### PR TITLE
lv_page: Fix build error when Animations disabled

### DIFF
--- a/lv_objx/lv_page.c
+++ b/lv_objx/lv_page.c
@@ -400,8 +400,8 @@ void lv_page_focus(lv_obj_t * page, lv_obj_t * obj, bool anim_en)
 			a.fp = (anim_fp_t) lv_obj_set_y;
 			anim_create(&a);
 		}
-	}
 #endif
+	}
 }
 
 /*=====================


### PR DESCRIPTION
defining LV_PAGE_ANIM_FOCUS_TIME as 0 cause build failure. This patch
fix the issue.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>