### PR TITLE
Add Missing Right Curly Bracket

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -82,4 +82,8 @@ extern "C" {
  *      MACROS
  **********************/
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif /*LVGL_H*/


### PR DESCRIPTION
Add missing right curly bracket for `extern "C" {...}`.