### PR TITLE
lv_group: fix memory leak.

### DIFF
--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -52,6 +52,16 @@ lv_group_t * lv_group_create(void)
 }
 
 /**
+ * Delete a group object
+ * @param group pointer to a group
+ */
+void lv_group_del(lv_group_t * group)
+{
+    lv_ll_clear(&(group->obj_ll));
+    lv_mem_free(group);
+}
+
+/**
  * Add an object to a group
  * @param group pointer to a group
  * @param obj pointer to an object to add
@@ -83,8 +93,8 @@ void lv_group_remove_obj(lv_obj_t * obj)
     LL_READ(g->obj_ll, i) {
         if(*i == obj) {
             lv_ll_rem(&g->obj_ll, i);
+            lv_mem_free(i);
             obj->group_p = NULL;
-            break;
         }
     }
 


### PR DESCRIPTION
The items lack of memory deallocation
* `lv_group->obj_ll`
* `lv_group`

Although the pull request is based on v5.0, I found this issue and tested on v4.0 actually, so this patch maybe not so formal for v5.0. 

About `lv_group_add_obj`, because it doesn't check duplication when insert objects into linked-list, I remove `break` in order to remove all duplications at `lv_group_rem_obj`.

Congratulate for the new version v5.0.0!
