### PR TITLE
fix warning/error with lv_conf.h option

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -184,7 +184,7 @@
 #define LV_LABEL_SCROLL_SPEED       25     /*Hor, or ver. scroll speed (px/sec) in 'LV_LABEL_LONG_SCROLL/ROLL' mode*/
 #endif
 
-/*Image (dependencies: lv_label*/
+/*Image (dependencies: lv_label, lv_filesystem*/
 #define USE_LV_IMG      1
 
 /*Line (dependencies: -*/
@@ -248,7 +248,7 @@
 /*Button matrix (dependencies: -)*/
 #define USE_LV_BTNM     1
 
-/*Keyboard (dependencies: lv_btnm)*/
+/*Keyboard (dependencies: lv_btnm, lv_ta)*/
 #define USE_LV_KB       1
 
 /*Check box (dependencies: lv_btn, lv_label)*/

--- a/lv_draw/lv_draw.c
+++ b/lv_draw/lv_draw.c
@@ -67,7 +67,9 @@ static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_colo
 #endif
 static void (*fill_fp)(const lv_area_t * coords, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) =  lv_vfill;
 static void (*letter_fp)(const lv_point_t * pos_p, const lv_area_t * mask, const lv_font_t * font_p, uint32_t letter, lv_color_t color, lv_opa_t opa) = lv_vletter;
+#if USE_LV_IMG
 static void (*map_fp)(const lv_area_t * coords, const lv_area_t * mask, const lv_color_t * map_p, lv_opa_t opa, bool transp, bool upscale, lv_color_t recolor, lv_opa_t recolor_opa) = lv_vmap;
+#endif
 #else
 //static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) = lv_rpx;
 static void (*fill_fp)(const lv_area_t * coords, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) =  lv_rfill;

--- a/lv_draw/lv_draw.c
+++ b/lv_draw/lv_draw.c
@@ -45,7 +45,7 @@ static void lv_draw_rect_main_mid(const lv_area_t * coords, const lv_area_t * ma
 static void lv_draw_rect_main_corner(const lv_area_t * coords, const lv_area_t * mask, const lv_style_t * style);
 static void lv_draw_rect_border_straight(const lv_area_t * coords, const lv_area_t * mask, const lv_style_t * style);
 static void lv_draw_rect_border_corner(const lv_area_t * coords, const lv_area_t * mask, const lv_style_t * style);
-#if USE_LV_SHADOW
+#if USE_LV_SHADOW && LV_VDB_SIZE
 static void lv_draw_rect_shadow(const lv_area_t * coords, const lv_area_t * mask, const lv_style_t * style);
 static void lv_draw_cont_shadow_full(const lv_area_t * coords, const lv_area_t * mask, const  lv_style_t * style);
 static void lv_draw_cont_shadow_bottom(const lv_area_t * coords, const lv_area_t * mask, const lv_style_t * style);
@@ -62,12 +62,14 @@ static void point_swap(lv_point_t * p1, lv_point_t * p2);
  *  STATIC VARIABLES
  **********************/
 #if LV_VDB_SIZE != 0
+#if USE_LV_SHADOW
 static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) = lv_vpx;
+#endif
 static void (*fill_fp)(const lv_area_t * coords, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) =  lv_vfill;
 static void (*letter_fp)(const lv_point_t * pos_p, const lv_area_t * mask, const lv_font_t * font_p, uint32_t letter, lv_color_t color, lv_opa_t opa) = lv_vletter;
 static void (*map_fp)(const lv_area_t * coords, const lv_area_t * mask, const lv_color_t * map_p, lv_opa_t opa, bool transp, bool upscale, lv_color_t recolor, lv_opa_t recolor_opa) = lv_vmap;
 #else
-static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) = lv_rpx;
+//static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) = lv_rpx;
 static void (*fill_fp)(const lv_area_t * coords, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) =  lv_rfill;
 static void (*letter_fp)(const lv_point_t * pos_p, const lv_area_t * mask, const lv_font_t * font_p, uint32_t letter, lv_color_t color, lv_opa_t opa) = lv_rletter;
 #if USE_LV_IMG

--- a/lv_misc/lv_ufs.c
+++ b/lv_misc/lv_ufs.c
@@ -8,6 +8,7 @@
  *      INCLUDES
  *********************/
 #include "../../lv_conf.h"
+#if USE_LV_FILESYSTEM
 #include "lv_ufs.h"
 #include "lv_ll.h"
 #include <string.h>
@@ -499,4 +500,6 @@ static lv_ufs_ent_t* lv_ufs_ent_new(const char * fn)
     
     return new_ent;
 }
+
+#endif /*USE_LV_FILESYSTEM*/
 

--- a/lv_misc/lv_ufs.h
+++ b/lv_misc/lv_ufs.h
@@ -15,6 +15,10 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../../lv_conf.h"
+
+#if USE_LV_FILESYSTEM
+
 #include <stdbool.h>
 #include "lv_fs.h"
 #include "lv_mem.h"
@@ -196,6 +200,8 @@ lv_fs_res_t lv_ufs_free (uint32_t * total_p, uint32_t * free_p);
 /**********************
  *      MACROS
  **********************/
+
+#endif /*USE_LV_FILESYSTEM*/
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -44,7 +44,9 @@ static void refr_btn_width(lv_obj_t *list);
  *  STATIC VARIABLES
  **********************/
 static lv_signal_func_t btn_signal;
+#if USE_LV_IMG
 static lv_signal_func_t img_signal;
+#endif
 static lv_signal_func_t label_signal;
 static lv_signal_func_t ancestor_signal;
 
@@ -110,8 +112,10 @@ lv_obj_t * lv_list_create(lv_obj_t * par, lv_obj_t * copy)
         lv_obj_t *new_btn;
         while(copy_btn) {
             new_btn = lv_btn_create(new_list, copy_btn);
+#if USE_LV_IMG
             lv_obj_t *copy_img = lv_list_get_btn_img(copy_btn);
             if(copy_img) lv_img_create(new_btn, copy_img);
+#endif
             lv_label_create(new_btn, lv_list_get_btn_label(copy_btn));
             copy_btn = lv_obj_get_child_back(lv_page_get_scrl(copy), copy_btn);
         }

--- a/lv_objx/lv_mbox.c
+++ b/lv_objx/lv_mbox.c
@@ -198,9 +198,9 @@ void lv_mbox_set_anim_time(lv_obj_t * mbox, uint16_t time)
  */
 void lv_mbox_start_auto_close(lv_obj_t * mbox, uint16_t delay)
 {
+#if USE_LV_ANIMATION
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
 
-#if USE_LV_ANIMATION
     if(ext->anim_time != 0) {
         /*Add shrinking animations*/
         lv_obj_animate(mbox, LV_ANIM_GROW_H| LV_ANIM_OUT, ext->anim_time, delay, NULL);

--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -45,8 +45,10 @@ static bool lv_ta_design(lv_obj_t * ta, const lv_area_t * mask, lv_design_mode_t
 static bool lv_ta_scrollable_design(lv_obj_t * scrl, const lv_area_t * mask, lv_design_mode_t mode);
 static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param);
 static lv_res_t lv_ta_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void * param);
+#if USE_LV_ANIMATION
 static void cursor_blink_anim(lv_obj_t * ta, uint8_t show);
 static void pwd_char_hider_anim(lv_obj_t * ta, int32_t x);
+#endif
 static void pwd_char_hider(lv_obj_t * ta);
 
 /**********************
@@ -987,6 +989,8 @@ static lv_res_t lv_ta_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void 
     return res;
 }
 
+#if USE_LV_ANIMATION
+
 /**
  * Called to blink the cursor
  * @param ta pointer to a text area
@@ -1017,6 +1021,8 @@ static void pwd_char_hider_anim(lv_obj_t * ta, int32_t x)
     (void)ta;
     (void)x;
 }
+
+#endif
 
 /**
  * Hide all characters (convert them to '*')


### PR DESCRIPTION
I found some warning and i fix it when user change some settings in lv_conf.h

I discovered that this function seem do not be used (line 72):
`static void (*px_fp)(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_color_t color, lv_opa_t opa) = lv_rpx;`

It is WIP, don't merge now