### PR TITLE
Add user pointer to indev driver for state storage between read() calls

### DIFF
--- a/lv_hal/lv_hal_indev.c
+++ b/lv_hal/lv_hal_indev.c
@@ -46,6 +46,7 @@ void lv_indev_drv_init(lv_indev_drv_t *driver)
 {
     driver->read = NULL;
     driver->type = LV_INDEV_TYPE_NONE;
+    driver->priv = NULL;
 }
 
 /**
@@ -107,6 +108,7 @@ bool lv_indev_read(lv_indev_t * indev, lv_indev_data_t *data)
     bool cont = false;
 
     if(indev->driver.read) {
+        data->priv = indev->driver.priv;
         cont = indev->driver.read(data);
     } else {
         memset(data, 0, sizeof(lv_indev_data_t));

--- a/lv_hal/lv_hal_indev.h
+++ b/lv_hal/lv_hal_indev.h
@@ -48,12 +48,14 @@ typedef struct {
         uint32_t key;          /*For INDEV_TYPE_KEYPAD*/
     };
     lv_indev_state_t state; /*LV_INDEV_EVENT_REL or LV_INDEV_EVENT_PR*/
+    void *priv;             /*'lv_indev_drv_t.priv' for this driver*/
 }lv_indev_data_t;
 
 /*Initialized by the user and registered by 'lv_indev_add()'*/
 typedef struct {
     lv_hal_indev_type_t type;                       /*Input device type*/
     bool (*read)(lv_indev_data_t *data);        /*Function pointer to read data. Return 'true' if there is still data to be read (buffered)*/
+    void *priv;                                    /*Opaque pointer for driver's use, passed in 'lv_indev_data_t' on read*/
 }lv_indev_drv_t;
 
 struct _lv_obj_t;


### PR DESCRIPTION
As discussed in #115, this adds a user pointer to be able to save driver state between indev calls to `read()`. This allows multiple indev instances to share the same code, such as for using the Linux input event device interface and having one for a keyboard, one for a mouse, one for a touchscreen all at the same time.