### PR TITLE
Fix page focus not focusing objects the same way when moving up or down the page

### DIFF
--- a/lv_objx/lv_page.c
+++ b/lv_objx/lv_page.c
@@ -303,9 +303,9 @@ void lv_page_focus(lv_obj_t * page, lv_obj_t * obj, uint16_t anim_time)
     else if((obj_h <= page_h && bot_err > 0) ||
             (obj_h > page_h && top_err >= bot_err)) {
         /*Calculate a new position and let some space below*/
-        scrlable_y = -obj_y;
-        scrlable_y += page_h - obj_h;
+        scrlable_y = -(obj_y + style_scrl->body.padding.ver + style->body.padding.ver);
         scrlable_y -= style_scrl->body.padding.ver;
+        scrlable_y += page_h - obj_h;
     } else {
         /*Already in focus*/
         return;


### PR DESCRIPTION
This simple fix makes it so the page focus behaves the same way when scrolling down vs. scrolling up.
Without this fix, you get results like this (this is a list):

**Starting point - notice padding between selected item and border**
![image](https://user-images.githubusercontent.com/32659164/41261670-a06383c6-6d91-11e8-80eb-6ed8530d3351.png)
**After scrolling down - notice selected item bumps into border**
![image](https://user-images.githubusercontent.com/32659164/41261717-e2024af6-6d91-11e8-8322-6797bbc9d280.png)

After the fix, it looks normal:
![image](https://user-images.githubusercontent.com/32659164/41261777-389b4746-6d92-11e8-9088-637e1c4ffb11.png)

