### PR TITLE
Small fix for bar/slider to make the fill more symmetric when near the min/max

### DIFF
--- a/lv_objx/lv_bar.c
+++ b/lv_objx/lv_bar.c
@@ -291,11 +291,11 @@ static bool lv_bar_design(lv_obj_t * bar, const lv_area_t * mask, lv_design_mode
         lv_coord_t h = lv_area_get_height(&indic_area);
 
 		if(w >= h) {
-		    indic_area.x2 = (int32_t) ((int32_t)w * (ext->cur_value - ext->min_value)) / (ext->max_value - ext->min_value);
-            indic_area.x2 = indic_area.x1 + indic_area.x2 - 1;
+		    indic_area.x2 = (int32_t) ((int32_t)w * (ext->cur_value - ext->min_value - 1)) / (ext->max_value - ext->min_value);
+            indic_area.x2 = indic_area.x1 + indic_area.x2;
 		} else {
-		    indic_area.y1 = (int32_t) ((int32_t)h * (ext->cur_value - ext->min_value)) / (ext->max_value - ext->min_value);
-            indic_area.y1 = indic_area.y2 - indic_area.y1 + 1;
+		    indic_area.y1 = (int32_t) ((int32_t)h * (ext->cur_value - ext->min_value - 1)) / (ext->max_value - ext->min_value);
+            indic_area.y1 = indic_area.y2 - indic_area.y1;
 		}
 
 		/*Draw the indicator*/

--- a/lv_objx/lv_slider.c
+++ b/lv_objx/lv_slider.c
@@ -320,12 +320,12 @@ static bool lv_slider_design(lv_obj_t * slider, const lv_area_t * mask, lv_desig
         if(ext->drag_value != LV_SLIDER_NOT_PRESSED) cur_value = ext->drag_value;
 
         if(slider_w >= slider_h) {
-            area_indic.x2 = (int32_t) ((int32_t)lv_area_get_width(&area_indic) * (cur_value - min_value)) / (max_value - min_value);
-            area_indic.x2 = area_indic.x1 + area_indic.x2 - 1;
+            area_indic.x2 = (int32_t) ((int32_t)(lv_area_get_width(&area_indic) - 1) * (cur_value - min_value)) / (max_value - min_value);
+            area_indic.x2 += area_indic.x1 + area_indic.x2;
 
         } else {
-            area_indic.y1 = (int32_t) ((int32_t)lv_area_get_height(&area_indic) * (cur_value - min_value)) / (max_value - min_value);
-            area_indic.y1 = area_indic.y2 - area_indic.y1 + 1;
+            area_indic.y1 = (int32_t) ((int32_t)(lv_area_get_height(&area_indic) - 1) * (cur_value - min_value)) / (max_value - min_value);
+            area_indic.y1 = area_indic.y2 - area_indic.y1;
         }
 
         if(cur_value != min_value) lv_draw_rect(&area_indic, mask, style_indic);
@@ -339,7 +339,7 @@ static bool lv_slider_design(lv_obj_t * slider, const lv_area_t * mask, lv_desig
                 knob_area.x1 = area_indic.x2 - slider_h / 2;
                 knob_area.x2 = knob_area.x1 + slider_h;
             } else {
-                knob_area.x1 = (int32_t) ((int32_t)(slider_w - slider_h) * (cur_value - min_value)) / (max_value - min_value);
+                knob_area.x1 = (int32_t) ((int32_t)(slider_w - slider_h - 1) * (cur_value - min_value)) / (max_value - min_value);
                 knob_area.x1 += slider->coords.x1;
                 knob_area.x2 = knob_area.x1 + slider_h;
             }
@@ -351,7 +351,7 @@ static bool lv_slider_design(lv_obj_t * slider, const lv_area_t * mask, lv_desig
                 knob_area.y1 = area_indic.y1 - slider_w / 2;
                 knob_area.y2 = knob_area.y1 + slider_w;
             } else {
-                knob_area.y2 = (int32_t) ((int32_t)(slider_h - slider_w) * (cur_value - min_value)) / (max_value - min_value);
+                knob_area.y2 = (int32_t) ((int32_t)(slider_h - slider_w - 1) * (cur_value - min_value)) / (max_value - min_value);
                 knob_area.y2 = slider->coords.y2 - knob_area.y2;
                 knob_area.y1 = knob_area.y2 - slider_w;
             }


### PR DESCRIPTION
As discussed in #175, this fixes the border getting drawn over when at max value, but also makes the inside fill more symmetric as it goes from min to max.
