### PR TITLE
lv_sys dir

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -57,7 +57,7 @@
    System settings
  *=================*/
 
-#define LV_SIGNALS                      1   /*Setup signal handlers (need a POSIX system)*/
+#define USE_POSIX_SIGNALS   1   /*Setup signal handlers (need a POSIX system)*/
 
 /*=================
    Misc. setting
@@ -260,4 +260,3 @@
 
 
 #endif /*Remove this to enable the content*/
-

--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -8,9 +8,9 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
-/*----------------
+/*===================
  * Dynamic memory
- *----------------*/
+ *===================*/
 
 /* Memory size which will be used by the library
  * to store the graphical objects and other data */
@@ -52,6 +52,12 @@
 /*Screen refresh settings*/
 #define LV_REFR_PERIOD      50    /*Screen refresh period in milliseconds*/
 #define LV_INV_FIFO_SIZE    32    /*The average count of objects on a screen */
+
+/*=================
+   System settings
+ *=================*/
+
+#define LV_SIGNALS                      1   /*Setup signal handlers (need a POSIX system)*/
 
 /*=================
    Misc. setting

--- a/lv_sys/lv_debug.h
+++ b/lv_sys/lv_debug.h
@@ -1,0 +1,113 @@
+/**
+ @file  :  lv_debug.h
+ @Summary:  Macros for debugging/logging
+
+ FULL_DUMP (enables dump globally) or DUMP (enables file-level dump) must be 
+ defined before including this header file for debug output to be enabled.
+
+ To be able to use the DBG macro do the following:
+ 1. Either add   '-DFULL_DUMP'  to your CFLAGS ...
+    (NOTE: This will enable all DBG macros found in the code!)
+
+     -=OR=-
+
+    add :
+     #define DUMP
+     #define TRACE
+     #include "lv_debug.h"
+   ... to the source file where you want to use the DBG macros.
+
+ 3. Then use the macros inside that file:
+      int func1(void)
+      {
+          TRACE_IN();
+          int err_code = func2();
+          if(err_code)
+          {
+              TRACE_RET();
+              return err_code;
+          }
+          TRACE_OUT();
+      }
+
+      int func2(void)
+      {
+          int err_code = 123;
+          DBG("errcode = 0x%x\n", err_code);
+          RETURN_ERR( err_code );
+      }
+ */
+
+#ifndef __LV_DEBUG_H
+#define __LV_DEBUG_H
+
+/*Enable lv_debug operation based if debugging or tracing is enabled.*/
+#if defined( DUMP ) || defined( FULL_DUMP ) || defined(TRACE) || defined(FULL_TRACE)
+
+#include <features.h>
+#include <stdio.h>
+
+/*disable this if you don't want to flush on every macro call*/
+#define flush_stdout()  fflush(stdout)
+
+/*The impl of the DBG and TRACE_... macros is system-dependent 
+  and is provided by one of the headers below. 
+  NOTE: We will use a generic impl for all *nixes for now, 
+  until the need arises to specialize some of them*/
+#if defined( __linux__ )
+#include "lvgl/lv_sys/posix/lv_debug_posix_generic.h"
+
+#elif defined( __unix__ )
+#include "lvgl/lv_sys/posix/lv_debug_posix_generic.h"
+
+#else
+#error   "Write a lv_debug impl for your system"
+#endif
+
+/*  The DBG_V macro is for "spammy" messages, which we usually don't want
+    to see, unless specifically enabled with DUMP_VERBOSE. In most cases 
+    these are DBG messages appearing in a loop... */
+#if defined( DUMP_VERBOSE )
+#define DBG_V           DBG
+#else
+#define DBG_V(fmt, args...)
+#endif
+
+/*  These macros are based on DBG and hence are not system-specific and can 
+    be defined here. The DBG macro is implemented in the system-specific headers 
+    included above (e.g. lv_debug_unix_generic.h)*/
+#define RETURN_ERR(e)   do{ DBG("ERROR 0x%x\n", (e)); return (e);}while(0)
+#define RETURN_ERR_V(e) do{ if(e) { DBG("ERROR 0x%x\n", (e)) } else { DBG("No error code when ERROR was expected!\n") }; return (e);}while(0)
+#define EXIT_ERR(e)     do{ DBG("ERROR 0x%x\n", (e)); return;}while(0)
+#define BREAK_ERR(e)    DBG("ERROR 0x%x\n", (e)); break;
+
+/*This var holds current indentation level for the TRACE macros*/
+#if defined(TRACE) || defined(FULL_TRACE)
+#if defined(TRACE_LEVEL_VAR_DEFINED)
+extern  int g_trace_lvl;
+#else
+#define TRACE_LEVEL_VAR_DEFINED
+int g_trace_lvl;
+#endif
+#endif
+
+
+#else  /*neither DUMP nor TRACE are defined --> all macros resolve to noop*/
+
+#define DBG(fmt, args...)
+#define DBG_V(fmt, args...)
+
+#define TRACE_IN()          {
+#define TRACE_IN_wFrom()    {
+#define TRACE_OUT()         }
+#define TRACE_RET()
+#define TRACE_MSG(fmt, args...)
+
+#define RETURN_ERR(e)
+#define RETURN_ERR_V(e)
+#define EXIT_ERR(e)
+#define BREAK_ERR(e)
+
+#endif /* defined( DUMP ) || defined( FULL_DUMP ) || defined(TRACE) || defined(FULL_TRACE) */
+
+#endif /* __LV_DEBUG_H */

--- a/lv_sys/lv_sys.h
+++ b/lv_sys/lv_sys.h
@@ -1,0 +1,13 @@
+/**
+ @file  :   lv_sys.h
+ @Summary:  Initializes the system. OS/system dependent. Each system should 
+            provide its own impl. See dir posix for impl. of the POSIX 
+            system initialization.
+*/
+
+#ifndef __LV_SYS_H
+#define __LV_SYS_H
+
+void lv_sys_init(void (*exit_func_ptr)(void));
+
+#endif

--- a/lv_sys/lv_sys.mk
+++ b/lv_sys/lv_sys.mk
@@ -1,0 +1,5 @@
+
+DEPPATH += --dep-path lvgl/lv_sys
+VPATH += :lvgl/lv_sys
+
+CFLAGS += "-I$(LVGL_DIR)/lvgl/lv_sys"

--- a/lv_sys/posix/lv_debug_posix_generic.h
+++ b/lv_sys/posix/lv_debug_posix_generic.h
@@ -1,0 +1,141 @@
+/**
+ * @file  :  lv_debug.h
+ Summary:  Macros for debugging/logging
+
+ FULL_DUMP (enables dump globally) or DUMP (enables file-level dump) must be 
+ defined before including this header file for debug output to be enabled.
+
+ To be able to use the DBG macro do the following:
+ 1. Either add   '-DFULL_DUMP'  to your CFLAGS ...
+
+ 2. ... OR add 
+     #define DUMP
+     #include lv_debug.h
+   ... to the source file where you want to use the DBG macros
+
+ 3. Then use the macro in the code:
+      err_code = func();
+      DBG("errcode = 0x%x\n");
+         -= OR =- 
+      RETURN_ERR( errcode );
+ */
+
+#ifndef __LV_DEBUG_GENERIC_UNIX_H
+#define __LV_DEBUG_GENERIC_UNIX_H
+
+#include <stdio.h>
+
+/* Define several variants of the DBG macro */
+#if defined( DUMP ) || defined( FULL_DUMP )
+
+/* Variant 1. DBG macros print time stamp + location in code + user message */
+#if defined(PRINT_TIME_IN_DBG)
+#include <sys/timeb.h>
+#include <time.h>
+#define DBG(fmt, args...)    do{                    \
+            struct tm * p_tm;                       \
+            struct timeb var_timeb;                 \
+            ftime( &var_timeb );                    \
+            p_tm = localtime( &var_timeb.time );    \
+            printf("%02d:%02d:%03d [%s %s:%d] : " fmt, p_tm->tm_min, p_tm->tm_sec, var_timeb.millitm, __FUNCTION__,__FILE__, __LINE__, ##args);flush_stdout(); }while(0)
+
+/* Variant 2. DBG macros print caller thread + location in code + user message */
+#elif defined(PRINT_THREAD_IN_DBG)
+#include <pthread.h>
+#define DBG(fmt, args...)   printf("0x%lx [%s %s:%d]: " fmt, pthread_self(), __FUNCTION__, __FILE__, __LINE__, ##args);flush_stdout()
+
+
+/* Variant 3. DBG macros print location in code (func, file:line)  + user message */
+#elif defined(PRINT_FILE_IN_DBG)
+#define DBG(fmt, args...)   printf("[%s %s:%d]: " fmt, __FUNCTION__, __FILE__, __LINE__, ##args);fflush(NULL)
+
+/* Variant 4. DBG macros print originating func  + user message  [default if DUMP defined] */
+#else
+#define DBG(fmt, args...)   printf("[%s]: " fmt, __FUNCTION__, ##args);fflush(NULL)
+#endif  /* PRINT_TIME_IN_DBG */
+
+
+/* Variant 4. DBG macros disabled */
+#else
+
+#define DBG(fmt, args...)
+
+#endif   /* end of DBG macro variants */
+
+
+/* Define several variants of the TRACE_... macros */
+#if defined(TRACE) || defined(FULL_TRACE)
+
+/* Variant 1. TRACE macros print time stamp + location in code + user message */
+#if defined(PRINT_TIME_IN_TRACE)
+
+#include <sys/timeb.h>
+#include <time.h>
+#define TRACE_IN()      { do{                       \
+            struct tm * p_tm;                       \
+            struct timeb var_timeb;                 \
+            ftime( &var_timeb );                    \
+            p_tm = localtime( &var_timeb.time );    \
+            printf("TRACE IN  %*s> %s  [%02d:%02d:%03d] %s:%d\n", (++g_trace_lvl)*2, "", __FUNCTION__, p_tm->tm_min, p_tm->tm_sec, var_timeb.millitm, __FILE__, __LINE__);flush_stdout(); }while(0)
+
+#define TRACE_OUT()      do{                        \
+            struct tm * p_tm;                       \
+            struct timeb var_timeb;                 \
+            ftime( &var_timeb );                    \
+            p_tm = localtime( &var_timeb.time );    \
+            printf("TRACE OUT %*s< %s  [%02d:%02d:%03d] %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__, p_tm->tm_min, p_tm->tm_sec, var_timeb.millitm, __FILE__, __LINE__);flush_stdout(); }while(0); }
+
+#define TRACE_RET()      do{                        \
+            struct tm * p_tm;                       \
+            struct timeb var_timeb;                 \
+            ftime( &var_timeb );                    \
+            p_tm = localtime( &var_timeb.time );    \
+            printf("TRACE_RET %*s< %s  [%02d:%02d:%03d] %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__,  p_tm->tm_min,  p_tm->tm_sec, var_timeb.millitm, __FILE__, __LINE__);flush_stdout(); }while(0)
+
+#define TRACE_MSG(fmt, args...)    do{              \
+            struct tm * p_tm;                       \
+            struct timeb var_timeb;                 \
+            ftime( &var_timeb );                    \
+            p_tm = localtime( &var_timeb.time );    \
+            printf("TRACE msg %*s  %s  [%02d:%02d:%03d] %s:%d : " fmt, (g_trace_lvl)*2, "", __FUNCTION__,  p_tm->tm_min, p_tm->tm_sec, var_timeb.millitm, __FILE__, __LINE__, ##args);flush_stdout(); }while(0)
+
+/* Variant 2. TRACE macros print caller thread + location in code + user message */
+#elif defined(PRINT_THREAD_IN_TRACE)
+#include <pthread.h>
+#define TRACE_IN()          {   printf("TRACE IN  %*s> %s  [0x%lx] %s:%d\n", (++g_trace_lvl)*2, "", __FUNCTION__, pthread_self(),__FILE__, __LINE__);flush_stdout()
+#define TRACE_OUT()             printf("TRACE OUT %*s< %s  [0x%lx] %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__, pthread_self(),__FILE__, __LINE__);flush_stdout(); }
+#define TRACE_RET()             printf("TRACE_RET %*s< %s  [0x%lx] %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__, pthread_self(),__FILE__, __LINE__);flush_stdout()
+#define TRACE_MSG(fmt, args...) printf("TRACE msg %*s  %s  [0x%lx] %s:%d : " fmt, (g_trace_lvl)*2, "", __FUNCTION__, pthread_self(), __FILE__, __LINE__, ##args);flush_stdout()
+
+
+/* Variant 3. TRACE macros print location in code + user message */
+#elif defined(PRINT_FILE_IN_TRACE)
+#define TRACE_IN()          {   printf("TRACE IN  %*s> %s  %s:%d\n", (++g_trace_lvl)*2, "", __FUNCTION__, __FILE__, __LINE__);flush_stdout()
+#define TRACE_IN_wFrom()    {   printf("TRACE IN  %*s> %s  %s:%d   (from %s:%d)\n", (++g_trace_lvl)*2, "", __FUNCTION__, __FILE__, __LINE__, fiLe, LiNe);flush_stdout()
+#define TRACE_OUT()             printf("TRACE OUT %*s< %s  %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__, __FILE__, __LINE__);flush_stdout(); }
+#define TRACE_RET()             printf("TRACE_RET %*s< %s  %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__, __FILE__, __LINE__);flush_stdout()
+#define TRACE_MSG(fmt, args...) printf("TRACE msg %*s  %s  %s:%d : " fmt, (g_trace_lvl)*2, "", __FUNCTION__, __FILE__, __LINE__, ##args);flush_stdout()
+
+
+/* Variant 4. TRACE macros print short location in code + user message */
+#else
+#define TRACE_IN()          {   printf("TRACE IN  %*s> %s:%d\n", (++g_trace_lvl)*2, "", __FUNCTION__,    __LINE__);flush_stdout()
+#define TRACE_IN_wFrom()    {   printf("TRACE IN  %*s> %s:%d  (from %s:%d)\n", (++g_trace_lvl)*2, "", __FUNCTION__,    __LINE__, fiLe, LiNe);flush_stdout()
+#define TRACE_OUT()             printf("TRACE OUT %*s< %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__,  __LINE__);flush_stdout(); }
+#define TRACE_RET()             printf("TRACE_RET %*s< %s:%d\n", (--g_trace_lvl+1)*2, "", __FUNCTION__,  __LINE__);flush_stdout()
+#define TRACE_MSG(fmt, args...) printf("TRACE msg %*s  %s:%d : " fmt, (g_trace_lvl)*2, "", __FUNCTION__, __LINE__, ##args);flush_stdout()
+#endif  // PRINT_TIME_IN_TRACE
+
+
+/* Variant 5. TRACE macros disabled */
+#else
+
+#define TRACE_IN()          {
+#define TRACE_IN_wFrom()    {
+#define TRACE_OUT()         }
+#define TRACE_RET()
+#define TRACE_MSG(fmt, args...)
+
+#endif /* ... end of TRACE macro variants */
+
+#endif /* __LV_DEBUG_GENERIC_UNIX_H */

--- a/lv_sys/posix/lv_sys_posix_generic.c
+++ b/lv_sys/posix/lv_sys_posix_generic.c
@@ -1,0 +1,386 @@
+/**
+ * @file lv_sys_posix_generic.c
+ *
+ *  Initialize a POSIX system.
+ *  Provide a means to detect/debug/process signals.
+ */
+#include <features.h>
+#if !defined _POSIX_SOURCE
+#error This file should be included in builds of POSIX systems only!
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_conf.h"
+#include <assert.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+#ifndef     LV_SIGNALS
+#warning    "LV_SIGNALS not defined! Is lv_conf.h included?"
+#endif
+
+#define DBGSIGNALS      (LV_SIGNALS && 0)  /* && 0 to disable */
+#define DBGSIGNALS_V    (DBGSIGNALS && 0)  /* verbose */
+
+#ifdef  DBGSIGNALS
+#include <stdio.h>
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  GLOBAL PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+#if LV_SIGNALS
+static void sig_handler_func(int signum, siginfo_t * pinfo, void * p);
+#endif
+static void exit_func(void);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+volatile    char    exiting = 0;;
+static      void    (*user_deinit_func)(void);  /*Store deinit func provided by user*/
+
+#if defined(DBGSIGNALS) && DBGSIGNALS
+static  char        txt_buf[4*1024] = { 0 };
+
+const char * sig_names [] = {
+"SIGHUP",
+"SIGINT",
+"SIGQUIT",
+"SIGILL",
+"SIGTRAP",
+"SIGABRT",
+"SIGIOT",
+"SIGBUS",
+"SIGFPE",
+"SIGKILL",
+"SIGUSR1",
+"SIGSEGV",
+"SIGUSR2",
+"SIGPIPE",
+"SIGALRM",
+"SIGTERM",
+"SIGSTKFLT",
+"SIGCHLD",
+"SIGCONT",
+"SIGSTOP",
+"SIGTSTP",
+"SIGTTIN",
+"SIGTTOU",
+"SIGURG",
+"SIGXCPU",
+"SIGXFSZ",
+"SIGVTALRM",
+"SIGPROF",
+"SIGWINCH",
+"SIGIO/SIGPOLL",
+"SIGPWR",
+"SIGSYS/SIGUNUSED",
+};
+#endif
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL VARIABLES
+ **********************/
+
+/*********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+/**
+ * Init system: exit handler, signal handlers ...
+ */
+void lv_sys_init(void (*user_deinit_func_param)(void))
+{
+#if LV_SIGNALS
+    sigset_t set;
+    struct sigaction    siga = { 0 };
+
+#if DBGSIGNALS
+    {
+        pid_t p = getpid();
+        printf("\n\tPID:  %d\n\n", p); /*disp PID to test sending various signals to process*/
+    }
+#endif
+
+    sigfillset(&set); /* Block all other signals during execution of sig_handler_func */
+    siga.sa_sigaction = sig_handler_func;
+    siga.sa_mask = set;
+    siga.sa_flags = SA_SIGINFO; /* | SA_NODEFER  --> No! Multiple Ctrl-C keys will break the handler! */
+
+    sigaction(SIGINT, &siga, NULL);
+    sigaction(SIGQUIT, &siga, NULL);
+#endif
+
+    if( user_deinit_func_param )
+    {
+        user_deinit_func = user_deinit_func_param;
+    }
+
+    atexit(exit_func);
+}
+
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+static void exit_func(void)
+{
+#if defined(DBGSIGNALS) && DBGSIGNALS
+    if( *txt_buf )
+    {
+        puts( "Exiting due to signal:" );
+        puts( "-------------------------------" );
+        puts( txt_buf );
+        puts( "-------------------------------" );
+    }
+#endif
+
+    if( user_deinit_func )
+    {
+        user_deinit_func();
+    }
+}
+
+
+#if LV_SIGNALS
+/* TODO: Add proper signal handling during lv_init() and hal_init(), i.e.
+   Setup a signal halndler for error processing and block all signals
+      (some like SIGSKILL and possibly SEGV can not be masked)
+   Monitor progress of initialization to know what was initialized
+   If a signal is caught in the err handler - uninit app in reverse steps.
+   Once the system is initialized properly  setup a SIGINT (Ctrl-C) handler
+   and unblock all signals.
+*/
+#if defined(DBGSIGNALS) && DBGSIGNALS
+static void sig_handler_func(int signum, siginfo_t * pinfo, void * p)
+{
+    int             exit_app = 0;
+    int             have_err = -1;
+/*  ucontext_t *    pcontext = (ucontext_t *) p; */
+
+    if( SIGINT == signum || SIGQUIT == signum )
+    {
+        putchar('\n');
+        exit_app = 1;
+        have_err = 0;
+    }
+
+    if( SI_USER == pinfo->si_code || SI_QUEUE == pinfo->si_code )
+    {
+        sprintf(txt_buf,
+            "%s (%d / 0x%X)\n"      \
+            "si_errno        %d\n"  \
+            "si_code         %d\n"  \
+            "si_pid          %d\n"  \
+            "si_uid          %d\n"
+            , sig_names[ signum ]
+            , signum
+            , signum
+            , pinfo->si_errno
+            , pinfo->si_code
+            , pinfo->si_pid
+            , pinfo->si_uid
+        );
+        have_err = 0;
+    }
+    else
+    {
+        sprintf(txt_buf,
+            "%s \t(%d / 0x%X)\n" \
+            "si_errno \t%d\n"   \
+            "si_code  \t%d - "  \
+            , sig_names[ signum ]
+            , signum
+            , signum
+            , pinfo->si_errno
+            , pinfo->si_code
+        );
+
+        switch( pinfo->si_code )
+        {
+            case SI_KERNEL:
+                strcat(txt_buf,"\nSI_KERNEL: \tsent by kernel");
+                break;
+            case SI_TIMER:
+                strcat(txt_buf,"\nSI_TIMER: \tsent by timer expiration");
+                break;
+            case SI_MESGQ:
+                strcat(txt_buf,"\nSI_MESGQ: \tsent by real time mesq state change");
+                break;
+            case SI_ASYNCIO:
+                strcat(txt_buf,"\nSI_ASYNCIO: \tsent by AIO completion");
+                break;
+            case SI_SIGIO:
+                strcat(txt_buf,"\nSI_SIGIO: \tsent by queued SIGIO");
+                break;
+            case SI_TKILL:
+                strcat(txt_buf,"\nSI_TKILL: \tsent by tkill system call");
+                break;
+/*        case SI_DETHREAD:
+              strcat(txt_buf,"\nSI_DETHREAD: sent by execve() killing subsidiary threads");
+*/
+            default:
+                strcat(txt_buf,"\nSI_???: sent by ???");
+                break;
+        }
+
+        if( SIGSEGV == pinfo->si_signo )
+        {
+           switch( pinfo->si_code )
+           {
+               char segv_details[128];
+               case SEGV_MAPERR:
+                   sprintf(segv_details, "\nSEGV_MAPERR (__SI_FAULT|1)  address %p not mapped to object", pinfo->si_addr);
+                   strcat(txt_buf, segv_details);
+                   break;
+               case SEGV_ACCERR:
+                   sprintf(segv_details, "\nSEGV_ACCERR (__SI_FAULT|2)  invalid permissions for mapped object at address %p", pinfo->si_addr);
+                   strcat(txt_buf, segv_details);
+                   break;
+               default:
+                   strcat(txt_buf,"\nSEGV_???");
+           }
+
+           if( !pinfo->si_pid ) /* if is a real SEGV, sent by kernel */
+           {
+               exit_app = 1;
+           }
+        }
+        else if( SIGBUS == pinfo->si_signo )
+        {
+           switch( pinfo->si_code )
+           {
+               case BUS_ADRALN:
+                   strcat(txt_buf,"\nBUS_ADRALN (__SI_FAULT|1)  invalid address alignment" );
+                   break;
+               case BUS_ADRERR:
+                   strcat(txt_buf,"\nBUS_ADRERR (__SI_FAULT|2)  non-existent physical address" );
+                   break;
+               case BUS_OBJERR:
+                   strcat(txt_buf,"\nBUS_OBJERR (__SI_FAULT|3)  object specific hardware error/" );
+                   break;
+               default:
+                   strcat(txt_buf,"\nBUS_???");
+           }
+        }
+        else if( SIGTRAP == pinfo->si_signo )
+        {
+            switch( pinfo->si_code )
+            {
+#ifdef TRAP_BRKPT
+                case TRAP_BRKPT:
+                    strcat(txt_buf,"\nTRAP_BRKPT     process breakpoint" );
+                    break;
+#endif
+#ifdef TRAP_TRACE
+                case TRAP_TRACE:
+                    strcat(txt_buf,"\nTRAP_TRACE     process trace trap" );
+                    break;
+#endif
+#ifdef TRAP_BRANCH
+                case TRAP_BRANCH:
+                    strcat(txt_buf,"\nTRAP_BRANCH   process taken branch trap (since Linux 2.4)" );
+                    break;
+#endif
+#ifdef TRAP_HWBKPT
+                case TRAP_HWBKPT:
+                    strcat(txt_buf,"\nTRAP_HWBKPT   hardware breakpoint/watchpoint" );
+                    break;
+#endif
+                default:
+                    strcat(txt_buf,"\nTRAP_???");
+            }
+        }
+        else if( SIGPOLL == pinfo->si_signo )
+        {
+            strcat(txt_buf,"\nSIGPOLL:" );
+            switch( pinfo->si_code )
+            {
+                case POLL_IN:
+                    strcat(txt_buf,"\nPOLL_IN     data input available" );
+                    break;
+                case POLL_OUT:
+                    strcat(txt_buf,"\nPOLL_OUT    output buffers available" );
+                    break;
+                case POLL_MSG:
+                    strcat(txt_buf,"\nPOLL_MSG    input message available" );
+                    break;
+                case POLL_ERR:
+                    strcat(txt_buf,"\nPOLL_ERR    I/O error" );
+                    break;
+                case POLL_PRI:
+                    strcat(txt_buf,"\nPOLL_PRI    high priority input available" );
+                    break;
+                case POLL_HUP:
+                    strcat(txt_buf,"\nPOLL_HUP    high priority input available" );
+                    break;
+                default:
+                    strcat(txt_buf,"\nPOLL_???");
+            }
+        }
+        else if( SIGCHLD == pinfo->si_signo )
+        {
+            strcat(txt_buf,"\nSIGCHLD:" );
+        }
+    }
+
+#if DBGSIGNALS_V
+    /* Enable these if need more info about the signal caught */
+    sprintf(txt_buf, "pcontext        %p\n", pcontext);           /* ?? */
+    sprintf(txt_buf, "si_errno        %d\n", pinfo->si_errno);    /* An errno value - unused on Linux*/
+    sprintf(txt_buf, "si_pid          %d\n", pinfo->si_pid);      /* Sending process ID */
+    sprintf(txt_buf, "si_uid          %d\n", pinfo->si_uid);      /* Real user ID of sending process */
+    sprintf(txt_buf, "_rt.si_sigval   %d\n", pinfo->_sifields._rt.si_sigval);   /* Signal value */
+    sprintf(txt_buf, "si_status       %d\n", pinfo->si_status);   /* Exit value or signal */
+    sprintf(txt_buf, "si_utime        %ld\n",pinfo->si_utime);    /* User time consumed */
+    sprintf(txt_buf, "si_stime        %ld\n",pinfo->si_stime);    /* System time consumed */
+    sprintf(txt_buf, "si_value        %d\n", pinfo->si_value.sival_int);    /* Signal value */
+    sprintf(txt_buf, "si_int          %d\n", pinfo->si_int);      /* POSIX.1b signal */
+    sprintf(txt_buf, "si_ptr          %p\n", pinfo->si_ptr);      /* POSIX.1b signal */
+    sprintf(txt_buf, "si_overrun      %d\n", pinfo->si_overrun);  /* Timer overrun count; POSIX.1b timers */
+    sprintf(txt_buf, "si_timer        %d\n", pinfo->si_timerid);  /* Timer ID; POSIX.1b timers */
+    sprintf(txt_buf, "si_addr         %p\n", pinfo->si_addr);     /* Memory location which caused fault */
+    sprintf(txt_buf, "si_band         %ld\n",pinfo->si_band);     /* Band event (was int in
+                                                                     glibc 2.3.2 and earlier) */
+    sprintf(txt_buf, "si_fd           %d\n", pinfo->si_fd);       /* File descriptor */
+#endif
+
+    if( exit_app )
+    {
+        exit(have_err);
+    }
+}
+#else
+static void sig_handler_func(int signum, siginfo_t * pinfo, void * p)
+{
+    if( !exiting )
+    {
+        exiting = 1;
+        putchar(':');
+        putchar(')');
+        putchar('\n');
+        assert( SIGINT == signum || SIGQUIT == signum );
+        exit(0);
+    }
+}
+#endif /* DBGSIGNALS */
+#endif /* LV_SIGNALS */

--- a/lv_sys/posix/lv_sys_posix_generic.c
+++ b/lv_sys/posix/lv_sys_posix_generic.c
@@ -22,11 +22,11 @@
 /*********************
  *      DEFINES
  *********************/
-#ifndef     LV_SIGNALS
-#warning    "LV_SIGNALS not defined! Is lv_conf.h included?"
+#ifndef     USE_POSIX_SIGNALS
+#warning    "USE_POSIX_SIGNALS not defined! Is lv_conf.h up to date?"
 #endif
 
-#define DBGSIGNALS      (LV_SIGNALS && 0)  /* && 0 to disable */
+#define DBGSIGNALS      (USE_POSIX_SIGNALS && 0)  /* && 0 to disable */
 #define DBGSIGNALS_V    (DBGSIGNALS && 0)  /* verbose */
 
 #ifdef  DBGSIGNALS
@@ -44,7 +44,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-#if LV_SIGNALS
+#if USE_POSIX_SIGNALS
 static void sig_handler_func(int signum, siginfo_t * pinfo, void * p);
 #endif
 static void exit_func(void);
@@ -110,7 +110,7 @@ const char * sig_names [] = {
  */
 void lv_sys_init(void (*user_deinit_func_param)(void))
 {
-#if LV_SIGNALS
+#if USE_POSIX_SIGNALS
     sigset_t set;
     struct sigaction    siga = { 0 };
 
@@ -161,7 +161,7 @@ static void exit_func(void)
 }
 
 
-#if LV_SIGNALS
+#if USE_POSIX_SIGNALS
 /* TODO: Add proper signal handling during lv_init() and hal_init(), i.e.
    Setup a signal halndler for error processing and block all signals
       (some like SIGSKILL and possibly SEGV can not be masked)
@@ -383,4 +383,4 @@ static void sig_handler_func(int signum, siginfo_t * pinfo, void * p)
     }
 }
 #endif /* DBGSIGNALS */
-#endif /* LV_SIGNALS */
+#endif /* USE_POSIX_SIGNALS */

--- a/lv_sys/posix/lv_sys_posix_generic.mk
+++ b/lv_sys/posix/lv_sys_posix_generic.mk
@@ -1,0 +1,6 @@
+CSRCS += lv_sys_posix_generic.c
+
+DEPPATH += --dep-path lvgl/lv_sys/posix
+VPATH += :lvgl/lv_sys/posix
+
+CFLAGS += "-I$(LVGL_DIR)/lvgl/lv_sys/posix"


### PR DESCRIPTION
Adding lv_sys directory, providing an (operating-) system-dependent init framework and a generic POSIX system implementation of it. Adding in there:
 - a signals init and handling code for POSIX systems;
 - a set of debug/trace macros with a terminal-based implementation. Users could provide their own implementations of them (e.g. outputting to a remote system via syslog, etc.). The macros resolve to noop by default in release builds.