### PR TITLE
Fix symbol font 30 for non-utf

### DIFF
--- a/lv_misc/lv_fonts/lv_font_symbol_30.c
+++ b/lv_misc/lv_fonts/lv_font_symbol_30.c
@@ -6838,8 +6838,13 @@ static const lv_font_glyph_dsc_t lv_font_symbol_30_glyph_dsc[] =
 };
 lv_font_t lv_font_symbol_30 = 
 {    
+#if LV_TXT_UTF8
     .unicode_first = 61440, /*First Unicode letter in this font*/
     .unicode_last = 62190,  /*Last Unicode letter in this font*/
+#else
+    .unicode_first = 192, /*First Unicode letter in this font*/
+    .unicode_last = 241,  /*Last Unicode letter in this font*/
+#endif
     .h_px = 30,             /*Font height in pixels*/
     .glyph_bitmap = lv_font_symbol_30_glyph_bitmap, /*Bitmap of glyphs*/
     .glyph_dsc = lv_font_symbol_30_glyph_dsc,       /*Description of glyphs*/


### PR DESCRIPTION
Hi,

There was a missing part in lv_font_symbol_30.c, that was included in other (10, 20, 40) sizes. This resulted in missing symbols in this font. This fixed the bug.