### PR TITLE
[Request for comment] Add a system time callback to be used without `lv_tick_inc`.

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -24,6 +24,11 @@
 #define LV_MEM_CUSTOM_ALLOC   malloc       /*Wrapper to malloc*/
 #define LV_MEM_CUSTOM_FREE    free         /*Wrapper to free*/
 #endif     /*LV_MEM_CUSTOM*/
+#define LV_TICK_CUSTOM     0               /*1: use a custom tick source (removing the need to manually update the tick with `lv_tick_inc`) */
+#if LV_TICK_CUSTOM == 1
+#define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"  /*Header for the sys time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())   /*Expression evaluating to current systime in ms*/
+#endif     /*LV_TICK_CUSTOM*/
 
 /*===================
    Graphical settings

--- a/lv_hal/lv_hal_tick.c
+++ b/lv_hal/lv_hal_tick.c
@@ -15,6 +15,10 @@
 #include "lv_hal_tick.h"
 #include <stddef.h>
 
+#if LV_TICK_CUSTOM == 1
+#include LV_TICK_CUSTOM_INCLUDE
+#endif
+
 /*********************
  *      DEFINES
  *********************/
@@ -57,6 +61,7 @@ LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
  */
 uint32_t lv_tick_get(void)
 {
+#if LV_TICK_CUSTOM == 0
     uint32_t result;
     do {
         tick_irq_flag = 1;
@@ -64,6 +69,9 @@ uint32_t lv_tick_get(void)
     } while(!tick_irq_flag);     /*'lv_tick_inc()' clears this flag which can be in an interrupt. Continue until make a non interrupted cycle */
 
     return result;
+#else
+    return LV_TICK_CUSTOM_SYS_TIME_EXPR;
+#endif
 }
 
 /**


### PR DESCRIPTION
This is really not tested, but I would like to know whether something like this can fit in the current vision for the library.

With a new configuration option one can now remove the need for
repeatedly calling `lv_tick_inc` for hardware that already provides
system time in another way.

The configuration example is set for an Arduino, but this was initially
developed for an nrf52 with the following config:

```
 #define LV_TICK_CUSTOM    1
 #if LV_TICK_CUSTOM == 1
 #define LV_TICK_CUSTOM_INCLUDE  "app_timer.h"
 #define LV_TICK_CUSTOM_SYS_TIME_CALL app_timer_cnt_get
 #define LV_TICK_CUSTOM_DIV           APP_TIMER_TICKS(1)
 #endif     /*LV_TICK_CUSTOM*/
```