### PR TITLE
removed duplicated define in configuration template file

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -138,8 +138,6 @@
 /* More info about fonts: https://littlevgl.com/basics#fonts
  * To enable a built-in font use 1,2,4 or 8 values
  * which will determine the bit-per-pixel */
-#define LV_FONT_DEFAULT        &lv_font_dejavu_20     /*Always set a default font from the built-in fonts*/
-
 #define USE_LV_FONT_DEJAVU_10              0
 #define USE_LV_FONT_DEJAVU_10_LATIN_SUP    0
 #define USE_LV_FONT_DEJAVU_10_CYRILLIC     0


### PR DESCRIPTION
Hi,
The define LV_FONT_DEFAULT is present twice:
on line 141 (to be removed)
and on line 171.