### PR TITLE
Bdf Converter Features and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ You can test the graphics library in a PC simulator, if you don't have an embedd
 
 There is a pre-configured PC project for **Eclipse CDT** in this repository: https://github.com/littlevgl/pc_simulator
 
+## Utilities
+Programs and scripts that assist the development of LittlevGL projects.
+
+### BDF Font Converter
+`utils/bdf_font_converter.py` converts [BDF](https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format) files into a LittlevGL compatible c file. This converter is useful for generating pixel-perfect fonts, especially for monochrome displays.
+
+Help can be printed out by:
+```
+python bdf_font_converter.py --help
+```
+
+Typical use case (generates `crox3hb.c`):
+```
+python bdf_font_converter.py win_crox3hb.bdf crox3hb
+```
 ## Related repositories
 * PC simulator: https://github.com/littlevgl/pc_simulator
 * Projects: https://github.com/littlevgl/lv_projects

--- a/utils/bdf_font_converter.py
+++ b/utils/bdf_font_converter.py
@@ -10,6 +10,8 @@ import math
 
 
 class Glyph:
+    pixel_art_0 = '.'
+    pixel_art_1 = '%'
     def __init__(self, props ):
         for k, v in props.items():
             setattr(self, k, v)
@@ -34,10 +36,19 @@ class Glyph:
         f.write('''/*Unicode: U+%04x ( %s ) , Width: %d */\n''' %
                 (self.encoding, self.name, self.dwidth[0]) )
         for line in self.bitmap:
+            pixel_art = '   //'
             for i in range(0, len(line), 2):
+                # Parse Pixel Art
+                bits = bin( int(line[i:i+2], 16) )[2:].zfill(8)
+                bits = bits.replace('0', self.pixel_art_0)
+                bits = bits.replace('1', self.pixel_art_1)
+                pixel_art += bits
+
+                # Parse Hex
                 f.write("0x%s," % line[i:i+2])
-                if(i > 0):
+                if i > 0:
                     f.write(" ")
+            f.write(pixel_art)
             f.write("\n")
         f.write("\n\n")
 

--- a/utils/bdf_font_converter.py
+++ b/utils/bdf_font_converter.py
@@ -36,7 +36,8 @@ class Glyph:
         f.write('''/*Unicode: U+%04x ( %s ) , Width: %d */\n''' %
                 (self.encoding, self.name, self.dwidth[0]) )
         for line in self.bitmap:
-            pixel_art = '   //'
+            pixel_art = ' //'
+            n_bytes = len(line) / 2
             for i in range(0, len(line), 2):
                 # Parse Pixel Art
                 bits = bin( int(line[i:i+2], 16) )[2:].zfill(8)
@@ -45,9 +46,7 @@ class Glyph:
                 pixel_art += bits
 
                 # Parse Hex
-                f.write("0x%s," % line[i:i+2])
-                if i > 0:
-                    f.write(" ")
+                f.write("0x%s, " % line[i:i+2])
             f.write(pixel_art)
             f.write("\n")
         f.write("\n\n")

--- a/utils/bdf_font_converter.py
+++ b/utils/bdf_font_converter.py
@@ -37,7 +37,6 @@ class Glyph:
                 (self.encoding, self.name, self.dwidth[0]) )
         for line in self.bitmap:
             pixel_art = ' //'
-            n_bytes = len(line) / 2
             for i in range(0, len(line), 2):
                 # Parse Pixel Art
                 bits = bin( int(line[i:i+2], 16) )[2:].zfill(8)
@@ -122,6 +121,8 @@ def parse_args():
             help='BDF Filename')
     parser.add_argument('font_name', type=str, default='font_name',
             help='Name of the font to be generated')
+    parser.add_argument('--toggle', '-t', action='store_true',
+            help='''Wrap entire file in "#if USE" macro''')
     args = parser.parse_args()
     dargs = vars(args)
     return (args, dargs)
@@ -139,6 +140,11 @@ def main():
     out.write('''
 #include "../lv_misc/lv_font.h"
 ''')
+
+    if args.toggle:
+        out.write('''
+#if USE_%s != 0  /*Can be enabled in lv_conf.h*/
+''' % args.font_name.upper())
 
     #################
     # WRITE BITMAPS #
@@ -196,6 +202,7 @@ lv_font_t %s =
     .monospace = 0,				/*Fix width (0: if not used)*/
     .next_page = NULL,		/*Pointer to a font extension*/
 };
+
 ''' % (args.font_name,
     glyphs[0].get_encoding(),
     glyphs[-1].get_encoding(),
@@ -205,6 +212,8 @@ lv_font_t %s =
     len(glyphs),
     ) )
 
+    if args.toggle:
+        out.write("#endif")
     out.close()
 
 if __name__=='__main__':


### PR DESCRIPTION
Updated main project README with a utils section.

Following features added to the BDF converter:

- Pixel Art is now generated as comments alongside glyph bitmap
- Added spaces between hex glyph bitmap values
- option `--toggle` to wrap the generated c file in a `#if USE_FONT_NAME != 0` statement