### PR TITLE
Group refocus on deletion

### DIFF
--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -23,6 +23,7 @@
  **********************/
 static void style_mod_def(lv_style_t * style);
 static void style_mod_edit_def(lv_style_t * style);
+static void lv_group_refocus(lv_group_t *g);
 
 /**********************
  *  STATIC VARIABLES
@@ -92,7 +93,7 @@ void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj)
     /*If the object is already in a group and focused then defocuse it*/
     if(obj->group_p) {
         if(lv_obj_is_focused(obj)) {
-            lv_group_focus_next(obj->group_p);
+            lv_group_refocus(obj->group_p);
 
             LV_LOG_INFO("group: assign object to an other group");
         }
@@ -107,7 +108,7 @@ void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj)
     /* If the head and the tail is equal then there is only one object in the linked list.
      * In this case automatically activate it*/
     if(lv_ll_get_head(&group->obj_ll) == next) {
-        lv_group_focus_next(group);
+        lv_group_refocus(group);
     }
 }
 
@@ -122,7 +123,7 @@ void lv_group_remove_obj(lv_obj_t * obj)
     if(g->obj_focus == NULL) return;        /*Just to be sure (Not possible if there is at least one object in the group)*/
 
     if(*g->obj_focus == obj) {
-        lv_group_focus_next(g);
+        lv_group_refocus(g);
     }
 
     /* If the focuses object is still the same then it was the only object in the group but it will be deleted.
@@ -318,6 +319,17 @@ void lv_group_set_editing(lv_group_t * group, bool edit)
 void lv_group_set_click_focus(lv_group_t * group, bool en)
 {
     group->click_focus = en ? 1 : 0;
+}
+
+void lv_group_set_refocus_policy(lv_group_t * group, lv_group_refocus_policy_t policy) {
+    group->refocus_policy = policy & 0x01;
+}
+
+static void lv_group_refocus(lv_group_t *g) {
+	if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_NEXT)
+		lv_group_focus_next(g);
+	else if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_PREV)
+		lv_group_focus_prev(g);
 }
 
 /**

--- a/lv_core/lv_group.h
+++ b/lv_core/lv_group.h
@@ -56,7 +56,13 @@ typedef struct _lv_group_t
     uint8_t frozen          :1;             /*1: can't focus to new object*/
     uint8_t editing         :1;             /*1: Edit mode, 0: Navigate mode*/
     uint8_t click_focus     :1;             /*1: If an object in a group is clicked by an indev then it will be focused */
+    uint8_t refocus_policy  :1;             /*1: Focus prev if focused on deletion. 0: Focus prev if focused on deletion.*/
 } lv_group_t;
+
+typedef enum _lv_group_refocus_policy_t {
+    LV_GROUP_REFOCUS_POLICY_NEXT = 0,
+    LV_GROUP_REFOCUS_POLICY_PREV = 1
+} lv_group_refocus_policy_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -139,6 +145,13 @@ void lv_group_set_style_mod_edit_cb(lv_group_t * group, lv_group_style_mod_func_
  * @param focus_cb the call back function or NULL if unused
  */
 void lv_group_set_focus_cb(lv_group_t * group, lv_group_focus_cb_t focus_cb);
+
+/**
+ * Set whether the next or previous item in a group is focused if the currently focussed obj is deleted.
+ * @param group pointer to a group
+ * @param new refocus policy enum
+ */
+void lv_group_set_refocus_policy(lv_group_t * group, lv_group_refocus_policy_t policy);
 
 /**
  * Manually set the current mode (edit or navigate).


### PR DESCRIPTION
Added functionality so the user can specify how the next object should be selected in a group when the currently focused object is deleted. The old reselection policy (next in group) is default.

See #474