### PR TITLE
Remember list last selected

### DIFF
--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -718,13 +718,11 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param)
             }
 
             if(btn != NULL) {
+                lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
+                ext->last_sel = btn;
                 lv_action_t rel_action;
                 rel_action = lv_btn_get_action(btn, LV_BTN_ACTION_CLICK);
-                if(rel_action != NULL) {
-                    lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
-                    ext->last_sel = btn;
-                    rel_action(btn);
-                }
+                if(rel_action != NULL) rel_action(btn);
             }
         }
 #endif

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -655,8 +655,15 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param)
             if(last_clicked_btn) {
                 lv_list_set_btn_selected(list, last_clicked_btn);
             } else {
-                /*Get the first button and mark it as selected*/
-                lv_list_set_btn_selected(list, lv_list_get_next_btn(list, NULL));
+                lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
+                if(NULL != ext->last_sel) {
+                    /* Select the last used button */
+                    lv_list_set_btn_selected(list, ext->last_sel);
+                }
+                else {
+                    /*Get the first button and mark it as selected*/
+                    lv_list_set_btn_selected(list, lv_list_get_next_btn(list, NULL));
+                }
             }
         }
 #endif
@@ -712,7 +719,11 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param)
             if(btn != NULL) {
                 lv_action_t rel_action;
                 rel_action = lv_btn_get_action(btn, LV_BTN_ACTION_CLICK);
-                if(rel_action != NULL) rel_action(btn);
+                if(rel_action != NULL) {
+                    lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
+                    ext->last_sel = btn;
+                    rel_action(btn);
+                }
             }
         }
 #endif

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -90,6 +90,7 @@ lv_obj_t * lv_list_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->styles_btn[LV_BTN_STATE_INA] = &lv_style_btn_ina;
     ext->anim_time = LV_LIST_FOCUS_TIME;
 #if USE_LV_GROUP
+    ext->last_sel = NULL;
     ext->selected_btn = NULL;
 #endif
 

--- a/lv_objx/lv_list.h
+++ b/lv_objx/lv_list.h
@@ -57,6 +57,7 @@ typedef struct
     lv_style_t *styles_btn[LV_BTN_STATE_NUM];    /*Styles of the list element buttons*/
     lv_style_t *style_img;                       /*Style of the list element images on buttons*/
 #if USE_LV_GROUP
+    lv_obj_t * last_sel;                          /* Last btn selected */
     lv_obj_t * selected_btn;
 #endif
 } lv_list_ext_t;


### PR DESCRIPTION
While using Groups, this PR makes an `lv_list` remember the last selected button so that upon focus, the last used button is selected. For the majority of applications, I can imagine that this is the desired behavior of the developer. However, this differs from the original behavior. If default behavior is desired, we could set a flag in `ext` that determines whether to use original behavior (select first item in list) or new behavior (select last item used).

I wanted this action in `ext` as opposed to using global variables and `lv_list_set_btn_selected` because that approach requires redundant code for saving in every `lv_action_t`. A different global variable would also have to be specified for each `lv_list` which may not be known at compile time.