### PR TITLE
Fixes all functions reported in #513 and add a missing semicolon in #531

### DIFF
--- a/lv_core/lv_obj.c
+++ b/lv_core/lv_obj.c
@@ -1137,13 +1137,15 @@ lv_obj_t * lv_obj_get_parent(const lv_obj_t * obj)
  */
 lv_obj_t * lv_obj_get_child(const lv_obj_t * obj, const lv_obj_t * child)
 {
+    lv_obj_t * result = NULL;
+
     if(child == NULL) {
-        return lv_ll_get_head(&obj->child_ll);
+        result = lv_ll_get_head(&obj->child_ll);
     } else {
-        return lv_ll_get_next(&obj->child_ll, child);
+        result = lv_ll_get_next(&obj->child_ll, child);
     }
 
-    return NULL;
+    return result;
 }
 
 /**
@@ -1155,13 +1157,15 @@ lv_obj_t * lv_obj_get_child(const lv_obj_t * obj, const lv_obj_t * child)
  */
 lv_obj_t * lv_obj_get_child_back(const lv_obj_t * obj, const lv_obj_t * child)
 {
+    lv_obj_t * result = NULL;
+
     if(child == NULL) {
-        return lv_ll_get_tail(&obj->child_ll);
+        result = lv_ll_get_tail(&obj->child_ll);
     } else {
-        return lv_ll_get_prev(&obj->child_ll, child);
+        result = lv_ll_get_prev(&obj->child_ll, child);
     }
 
-    return NULL;
+    return result;
 }
 
 /**

--- a/lv_draw/lv_draw_img.c
+++ b/lv_draw/lv_draw_img.c
@@ -147,41 +147,48 @@ lv_res_t lv_img_dsc_get_info(const char * src, lv_img_header_t * header)
 
 uint8_t lv_img_color_format_get_px_size(lv_img_cf_t cf)
 {
+    uint8_t px_size = 0;
+
     switch(cf) {
         case LV_IMG_CF_UNKOWN:
         case LV_IMG_CF_RAW:
-            return 0;
+            px_size = 0;
+            break;
         case LV_IMG_CF_TRUE_COLOR:
         case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED:
-            return LV_COLOR_SIZE;
+            px_size = LV_COLOR_SIZE;
+            break;
         case LV_IMG_CF_TRUE_COLOR_ALPHA:
-            return LV_IMG_PX_SIZE_ALPHA_BYTE << 3;
-
+            px_size = LV_IMG_PX_SIZE_ALPHA_BYTE << 3;
+            break;
         case LV_IMG_CF_INDEXED_1BIT:
         case LV_IMG_CF_ALPHA_1BIT:
-            return 1;
-
+            px_size = 1;
+            break;
         case LV_IMG_CF_INDEXED_2BIT:
         case LV_IMG_CF_ALPHA_2BIT:
-            return 2;
-
+            px_size = 2;
+            break;
         case LV_IMG_CF_INDEXED_4BIT:
         case LV_IMG_CF_ALPHA_4BIT:
-            return 4;
-
+            px_size = 4;
+            break;
         case LV_IMG_CF_INDEXED_8BIT:
         case LV_IMG_CF_ALPHA_8BIT:
-            return 8;
-
+            px_size = 8;
+            break;
         default:
-            return 0;
+            px_size = 0;
+            break;
     }
 
-    return 0;
+    return px_size;
 }
 
 bool lv_img_color_format_is_chroma_keyed(lv_img_cf_t cf)
 {
+    bool is_chroma_keyed = false;
+
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED:
         case LV_IMG_CF_RAW_CHROMA_KEYED:
@@ -189,17 +196,21 @@ bool lv_img_color_format_is_chroma_keyed(lv_img_cf_t cf)
         case LV_IMG_CF_INDEXED_2BIT:
         case LV_IMG_CF_INDEXED_4BIT:
         case LV_IMG_CF_INDEXED_8BIT:
-            return true;
+            is_chroma_keyed = true;
+            break;
         default:
-            return false;
+            is_chroma_keyed = false;
+            break;
     }
 
-    return false;
+    return is_chroma_keyed;
 }
 
 
 bool lv_img_color_format_has_alpha(lv_img_cf_t cf)
 {
+    bool has_alpha = false;
+
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR_ALPHA:
         case LV_IMG_CF_RAW_ALPHA:
@@ -207,12 +218,14 @@ bool lv_img_color_format_has_alpha(lv_img_cf_t cf)
         case LV_IMG_CF_ALPHA_2BIT:
         case LV_IMG_CF_ALPHA_4BIT:
         case LV_IMG_CF_ALPHA_8BIT:
-            return true;
+            has_alpha = true;
+            break;
         default:
-            return false;
+            has_alpha = false;
+            break;
     }
 
-    return false;
+    return has_alpha;
 }
 
 /**

--- a/lv_draw/lv_draw_label.c
+++ b/lv_draw/lv_draw_label.c
@@ -209,28 +209,37 @@ void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, const lv_st
  */
 static uint8_t hex_char_to_num(char hex)
 {
+    uint8_t result = 0;
+
     if(hex >= '0' && hex <= '9') {
-        return hex - '0';
+        result = hex - '0';
     }
 
     if(hex >= 'a') hex -= 'a' - 'A';    /*Convert to upper case*/
 
     switch(hex) {
         case 'A':
-            return 10;
+            result = 10;
+            break;
         case 'B':
-            return 11;
+            result = 11;
+            break;
         case 'C':
-            return 12;
+            result = 12;
+            break;
         case 'D':
-            return 13;
+            result = 13;
+            break;
         case 'E':
-            return 14;
+            result = 14;
+            break;
         case 'F':
-            return 15;
+            result = 15;
+            break;
         default:
-            return 0;
+            result = 0;
+            break;
     }
 
-    return 0;
+    return result;
 }

--- a/lv_objx/lv_arc.c
+++ b/lv_objx/lv_arc.c
@@ -184,16 +184,18 @@ uint16_t lv_arc_get_angle_end(lv_obj_t * arc)
  *  */
 lv_style_t * lv_arc_get_style(const lv_obj_t * arc, lv_arc_style_t type)
 {
+    lv_style_t * style = NULL;
 
     switch(type) {
         case LV_ARC_STYLE_MAIN:
-            return lv_obj_get_style(arc);
+            style = lv_obj_get_style(arc);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /*=====================

--- a/lv_objx/lv_bar.c
+++ b/lv_objx/lv_bar.c
@@ -250,19 +250,22 @@ int16_t lv_bar_get_max_value(const lv_obj_t * bar)
  */
 lv_style_t * lv_bar_get_style(const lv_obj_t * bar, lv_bar_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_bar_ext_t * ext = lv_obj_get_ext_attr(bar);
 
     switch(type) {
         case LV_BAR_STYLE_BG:
-            return lv_obj_get_style(bar);
+            style = lv_obj_get_style(bar);
+            break;
         case LV_BAR_STYLE_INDIC:
-            return ext->style_indic;
+            style = ext->style_indic;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_btn.c
+++ b/lv_objx/lv_btn.c
@@ -403,25 +403,31 @@ uint16_t lv_btn_get_ink_out_time(const lv_obj_t * btn)
  */
 lv_style_t * lv_btn_get_style(const lv_obj_t * btn, lv_btn_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_btn_ext_t * ext = lv_obj_get_ext_attr(btn);
 
     switch(type) {
         case LV_BTN_STYLE_REL:
-            return ext->styles[LV_BTN_STATE_REL];
+            style = ext->styles[LV_BTN_STATE_REL];
+            break;
         case LV_BTN_STYLE_PR:
-            return ext->styles[LV_BTN_STATE_PR];
+            style = ext->styles[LV_BTN_STATE_PR];
+            break;
         case LV_BTN_STYLE_TGL_REL:
-            return ext->styles[LV_BTN_STATE_TGL_REL];
+            style = ext->styles[LV_BTN_STATE_TGL_REL];
+            break;
         case LV_BTN_STYLE_TGL_PR:
-            return ext->styles[LV_BTN_STATE_TGL_PR];
+            style = ext->styles[LV_BTN_STATE_TGL_PR];
+            break;
         case LV_BTN_STYLE_INA:
-            return ext->styles[LV_BTN_STATE_INA];
+            style = ext->styles[LV_BTN_STATE_INA];
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_btnm.c
+++ b/lv_objx/lv_btnm.c
@@ -361,27 +361,34 @@ uint16_t lv_btnm_get_toggled(const lv_obj_t * btnm)
  */
 lv_style_t * lv_btnm_get_style(const lv_obj_t * btnm, lv_btnm_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_btnm_ext_t * ext = lv_obj_get_ext_attr(btnm);
 
     switch(type) {
         case LV_BTNM_STYLE_BG:
-            return lv_obj_get_style(btnm);
+            style = lv_obj_get_style(btnm);
+            break;
         case LV_BTNM_STYLE_BTN_REL:
-            return ext->styles_btn[LV_BTN_STATE_REL];
+            style ext->styles_btn[LV_BTN_STATE_REL];
+            break;
         case LV_BTNM_STYLE_BTN_PR:
-            return ext->styles_btn[LV_BTN_STATE_PR];
+            style = ext->styles_btn[LV_BTN_STATE_PR];
+            break;
         case LV_BTNM_STYLE_BTN_TGL_REL:
-            return ext->styles_btn[LV_BTN_STATE_TGL_REL];
+            style = ext->styles_btn[LV_BTN_STATE_TGL_REL];
+            break;
         case LV_BTNM_STYLE_BTN_TGL_PR:
-            return ext->styles_btn[LV_BTN_STATE_TGL_PR];
+            style = ext->styles_btn[LV_BTN_STATE_TGL_PR];
+            break;
         case LV_BTNM_STYLE_BTN_INA:
-            return ext->styles_btn[LV_BTN_STATE_INA];
+            style = ext->styles_btn[LV_BTN_STATE_INA];
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_calendar.c
+++ b/lv_objx/lv_calendar.c
@@ -374,31 +374,40 @@ const char ** lv_calendar_get_month_names(const lv_obj_t * calendar)
  *  */
 lv_style_t * lv_calendar_get_style(const lv_obj_t * calendar, lv_calendar_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_calendar_ext_t * ext = lv_obj_get_ext_attr(calendar);
 
     switch(type) {
         case LV_CALENDAR_STYLE_BG:
-            return  lv_obj_get_style(calendar);
+            style = lv_obj_get_style(calendar);
+            break;
         case LV_CALENDAR_STYLE_HEADER:
-            return ext->style_header;
+            style = ext->style_header;
+            break;
         case LV_CALENDAR_STYLE_HEADER_PR:
-            return ext->style_header_pr;
+            style = ext->style_header_pr;
+            break;
         case LV_CALENDAR_STYLE_DAY_NAMES:
-            return ext->style_day_names;
+            style = ext->style_day_names;
+            break;
         case LV_CALENDAR_STYLE_HIGHLIGHTED_DAYS:
-            return ext->style_highlighted_days;
+            style = ext->style_highlighted_days;
+            break;
         case LV_CALENDAR_STYLE_INACTIVE_DAYS:
-            return ext->style_inactive_days;
+            style = ext->style_inactive_days;
+            break;
         case LV_CALENDAR_STYLE_WEEK_BOX:
-            return ext->style_week_box;
+            style = ext->style_week_box;
+            break;
         case LV_CALENDAR_STYLE_TODAY_BOX:
-            return ext->style_today_box;
+            style = ext->style_today_box;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /*=====================

--- a/lv_objx/lv_cb.c
+++ b/lv_objx/lv_cb.c
@@ -192,25 +192,31 @@ const char * lv_cb_get_text(const lv_obj_t * cb)
  *  */
 lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_cb_ext_t * ext = lv_obj_get_ext_attr(cb);
 
     switch(type) {
         case LV_CB_STYLE_BOX_REL:
-            return lv_btn_get_style(ext->bullet, LV_BTN_STYLE_REL);
+            style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_REL);
+            break;
         case LV_CB_STYLE_BOX_PR:
-            return lv_btn_get_style(ext->bullet, LV_BTN_STYLE_PR);
+            style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_PR);
+            break;
         case LV_CB_STYLE_BOX_TGL_REL:
-            return lv_btn_get_style(ext->bullet, LV_BTN_STYLE_TGL_REL);
+            style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_TGL_REL);
+            break;
         case LV_CB_STYLE_BOX_TGL_PR:
-            return lv_btn_get_style(ext->bullet, LV_BTN_STYLE_TGL_PR);
+            style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_TGL_PR);
+            break;
         case LV_CB_STYLE_BOX_INA:
-            return lv_btn_get_style(ext->bullet, LV_BTN_STYLE_INA);
+            style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_INA);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid awrning*/
-    return NULL;
+    return style;
 }
 
 /**********************
@@ -229,9 +235,11 @@ lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type)
  */
 static bool lv_cb_design(lv_obj_t * cb, const lv_area_t * mask, lv_design_mode_t mode)
 {
+    bool result = true;
+
     if(mode == LV_DESIGN_COVER_CHK) {
         /*Return false if the object is not covers the mask_p area*/
-        return ancestor_bg_design(cb, mask, mode);
+        result = ancestor_bg_design(cb, mask, mode);
     } else if(mode == LV_DESIGN_DRAW_MAIN || mode == LV_DESIGN_DRAW_POST) {
         lv_cb_ext_t * cb_ext = lv_obj_get_ext_attr(cb);
         lv_btn_ext_t * bullet_ext = lv_obj_get_ext_attr(cb_ext->bullet);
@@ -239,13 +247,13 @@ static bool lv_cb_design(lv_obj_t * cb, const lv_area_t * mask, lv_design_mode_t
         /*Be sure the state of the bullet is the same as the parent button*/
         bullet_ext->state = cb_ext->bg_btn.state;
 
-        return ancestor_bg_design(cb, mask, mode);
+        result = ancestor_bg_design(cb, mask, mode);
 
     } else {
-        return ancestor_bg_design(cb, mask, mode);
+        result = ancestor_bg_design(cb, mask, mode);
     }
 
-    return true;
+    return result;
 }
 
 /**

--- a/lv_objx/lv_ddlist.c
+++ b/lv_objx/lv_ddlist.c
@@ -366,21 +366,25 @@ uint16_t lv_ddlist_get_anim_time(const lv_obj_t * ddlist)
  */
 lv_style_t * lv_ddlist_get_style(const lv_obj_t * ddlist, lv_ddlist_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_ddlist_ext_t * ext = lv_obj_get_ext_attr(ddlist);
 
     switch(type) {
         case LV_DDLIST_STYLE_BG:
-            return lv_page_get_style(ddlist, LV_PAGE_STYLE_BG);
+            style = lv_page_get_style(ddlist, LV_PAGE_STYLE_BG);
+            break;
         case LV_DDLIST_STYLE_SB:
-            return lv_page_get_style(ddlist, LV_PAGE_STYLE_SB);
+            style = lv_page_get_style(ddlist, LV_PAGE_STYLE_SB);
+            break;
         case LV_DDLIST_STYLE_SEL:
-            return ext->sel_style;
+            style = ext->sel_style;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 /*=====================
  * Other functions

--- a/lv_objx/lv_kb.c
+++ b/lv_objx/lv_kb.c
@@ -330,25 +330,33 @@ lv_action_t lv_kb_get_hide_action(const lv_obj_t * kb)
  */
 lv_style_t * lv_kb_get_style(const lv_obj_t * kb, lv_kb_style_t type)
 {
+    lv_style_t * style = NULL;
+
     switch(type) {
         case LV_KB_STYLE_BG:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BG);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BG);
+            break;
         case LV_KB_STYLE_BTN_REL:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_REL);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_REL);
+            break;
         case LV_KB_STYLE_BTN_PR:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_PR);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_PR);
+            break;
         case LV_KB_STYLE_BTN_TGL_REL:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_TGL_REL);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_TGL_REL);
+            break;
         case LV_KB_STYLE_BTN_TGL_PR:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_TGL_PR);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_TGL_PR);
+            break;
         case LV_KB_STYLE_BTN_INA:
-            return lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_INA);
+            style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BTN_INA);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -474,31 +474,40 @@ uint16_t lv_list_get_anim_time(const lv_obj_t * list)
  *  */
 lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
 
     switch(type) {
         case LV_LIST_STYLE_BG:
-            return lv_page_get_style(list, LV_PAGE_STYLE_BG);
+            style = lv_page_get_style(list, LV_PAGE_STYLE_BG);
+            break;
         case LV_LIST_STYLE_SCRL:
-            return lv_page_get_style(list, LV_PAGE_STYLE_SB);
+            style = lv_page_get_style(list, LV_PAGE_STYLE_SB);
+            break;
         case LV_LIST_STYLE_SB:
-            return lv_page_get_style(list, LV_PAGE_STYLE_SCRL);
+            style = lv_page_get_style(list, LV_PAGE_STYLE_SCRL);
+            break;
         case LV_LIST_STYLE_BTN_REL:
-            return ext->styles_btn[LV_BTN_STATE_REL];
+            style = ext->styles_btn[LV_BTN_STATE_REL];
+            break;
         case LV_LIST_STYLE_BTN_PR:
-            return ext->styles_btn[LV_BTN_STATE_PR];
+            style = ext->styles_btn[LV_BTN_STATE_PR];
+            break;
         case LV_LIST_STYLE_BTN_TGL_REL:
-            return ext->styles_btn[LV_BTN_STATE_TGL_REL];
+            style = ext->styles_btn[LV_BTN_STATE_TGL_REL];
+            break;
         case LV_LIST_STYLE_BTN_TGL_PR:
-            return ext->styles_btn[LV_BTN_STATE_TGL_PR];
+            style = ext->styles_btn[LV_BTN_STATE_TGL_PR];
+            break;
         case LV_LIST_STYLE_BTN_INA:
-            return ext->styles_btn[LV_BTN_STATE_INA];
+            style = ext->styles_btn[LV_BTN_STATE_INA];
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 /*=====================
  * Other functions

--- a/lv_objx/lv_mbox.c
+++ b/lv_objx/lv_mbox.c
@@ -329,29 +329,37 @@ uint16_t lv_mbox_get_anim_time(const lv_obj_t * mbox)
  */
 lv_style_t * lv_mbox_get_style(const lv_obj_t * mbox, lv_mbox_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
 
     switch(type) {
         case LV_MBOX_STYLE_BG:
-            return lv_obj_get_style(mbox);
+            style = lv_obj_get_style(mbox);
+            break;
         case LV_MBOX_STYLE_BTN_BG:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BG);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BG);
+            break;
         case LV_MBOX_STYLE_BTN_REL:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_REL);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_REL);
+            break;
         case LV_MBOX_STYLE_BTN_PR:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_PR);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_PR);
+            break;
         case LV_MBOX_STYLE_BTN_TGL_REL:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_TGL_REL);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_TGL_REL);
+            break;
         case LV_MBOX_STYLE_BTN_TGL_PR:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_TGL_PR);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_TGL_PR);
+            break;
         case LV_MBOX_STYLE_BTN_INA:
-            return lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_INA);
+            style = lv_btnm_get_style(ext->btnm, LV_BTNM_STYLE_BTN_INA);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 

--- a/lv_objx/lv_page.c
+++ b/lv_objx/lv_page.c
@@ -340,21 +340,25 @@ lv_coord_t lv_page_get_fit_height(lv_obj_t * page)
  *  */
 lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_page_ext_t * ext = lv_obj_get_ext_attr(page);
 
     switch(type) {
         case LV_PAGE_STYLE_BG:
-            return lv_obj_get_style(page);
+            style = lv_obj_get_style(page);
+            break;
         case LV_PAGE_STYLE_SCRL:
-            return lv_obj_get_style(ext->scrl);
+            style = lv_obj_get_style(ext->scrl);
+            break;
         case LV_PAGE_STYLE_SB:
-            return ext->sb.style;
+            style = ext->sb.style;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /*=====================

--- a/lv_objx/lv_preload.c
+++ b/lv_objx/lv_preload.c
@@ -217,16 +217,18 @@ uint16_t lv_preload_get_spin_time(const lv_obj_t * preload)
  *  */
 lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type)
 {
+    lv_style_t * style = NULL;
 
     switch(type) {
         case LV_PRELOAD_STYLE_MAIN:
-            return lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
+            style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /*=====================

--- a/lv_objx/lv_roller.c
+++ b/lv_objx/lv_roller.c
@@ -192,17 +192,21 @@ bool lv_roller_get_hor_fit(const lv_obj_t * roller)
  *  */
 lv_style_t * lv_roller_get_style(const lv_obj_t * roller, lv_roller_style_t type)
 {
+    lv_style_t * style = NULL;
+
     switch(type) {
         case LV_ROLLER_STYLE_BG:
-            return lv_obj_get_style(roller);
+            style = lv_obj_get_style(roller);
+            break;
         case LV_ROLLER_STYLE_SEL:
-            return lv_ddlist_get_style(roller, LV_DDLIST_STYLE_SEL);
+            style = lv_ddlist_get_style(roller, LV_DDLIST_STYLE_SEL);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_slider.c
+++ b/lv_objx/lv_slider.c
@@ -223,21 +223,25 @@ bool lv_slider_get_knob_in(const lv_obj_t * slider)
  */
 lv_style_t * lv_slider_get_style(const lv_obj_t * slider, lv_slider_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
 
     switch(type) {
         case LV_SLIDER_STYLE_BG:
-            return lv_bar_get_style(slider, LV_BAR_STYLE_BG);
+            style = lv_bar_get_style(slider, LV_BAR_STYLE_BG);
+            break;
         case LV_SLIDER_STYLE_INDIC:
-            return lv_bar_get_style(slider, LV_BAR_STYLE_INDIC);
+            style = lv_bar_get_style(slider, LV_BAR_STYLE_INDIC);
+            break;
         case LV_SLIDER_STYLE_KNOB:
-            return ext->style_knob;
+            style = ext->style_knob;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**********************

--- a/lv_objx/lv_sw.c
+++ b/lv_objx/lv_sw.c
@@ -177,23 +177,28 @@ void lv_sw_set_style(lv_obj_t * sw, lv_sw_style_t type, lv_style_t * style)
  */
 lv_style_t * lv_sw_get_style(const lv_obj_t * sw, lv_sw_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_sw_ext_t * ext = lv_obj_get_ext_attr(sw);
 
     switch(type) {
         case LV_SW_STYLE_BG:
-            return lv_slider_get_style(sw, LV_SLIDER_STYLE_BG);
+            style = lv_slider_get_style(sw, LV_SLIDER_STYLE_BG);
+            break;
         case LV_SW_STYLE_INDIC:
-            return lv_slider_get_style(sw, LV_SLIDER_STYLE_INDIC);
+            style = lv_slider_get_style(sw, LV_SLIDER_STYLE_INDIC);
+            break;
         case LV_SW_STYLE_KNOB_OFF:
-            return ext->style_knob_off;
+            style = ext->style_knob_off;
+            break;
         case LV_SW_STYLE_KNOB_ON:
-            return ext->style_knob_on;
+            style = ext->style_knob_on;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 /**********************
  *   STATIC FUNCTIONS

--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -765,10 +765,9 @@ lv_style_t * lv_ta_get_style(const lv_obj_t * ta, lv_ta_style_t type)
             break;
         default:
             style = NULL;
-            break
+            break;
     }
 
-    /*To avoid warning*/
     return style;
 }
 

--- a/lv_objx/lv_tabview.c
+++ b/lv_objx/lv_tabview.c
@@ -511,27 +511,34 @@ uint16_t lv_tabview_get_anim_time(const lv_obj_t * tabview)
  */
 lv_style_t * lv_tabview_get_style(const lv_obj_t * tabview, lv_tabview_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_tabview_ext_t * ext = lv_obj_get_ext_attr(tabview);
 
     switch(type) {
         case LV_TABVIEW_STYLE_BG:
-            return lv_obj_get_style(tabview);
+            style = lv_obj_get_style(tabview);
+            break;
         case LV_TABVIEW_STYLE_BTN_BG:
-            return lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BG);
+            style = lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BG);
+            break;
         case LV_TABVIEW_STYLE_BTN_REL:
-            return lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_REL);
+            style = lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_REL);
+            break;
         case LV_TABVIEW_STYLE_BTN_PR:
-            return lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_PR);
+            style = lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_PR);
+            break;
         case LV_TABVIEW_STYLE_BTN_TGL_REL:
-            return lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_TGL_REL);
+            style = lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_TGL_REL);
+            break;
         case LV_TABVIEW_STYLE_BTN_TGL_PR:
-            return lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_TGL_PR);
+            style = lv_btnm_get_style(ext->btns, LV_BTNM_STYLE_BTN_TGL_PR);
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /**

--- a/lv_objx/lv_win.c
+++ b/lv_objx/lv_win.c
@@ -395,29 +395,37 @@ lv_coord_t lv_win_get_width(lv_obj_t * win)
  */
 lv_style_t * lv_win_get_style(const lv_obj_t * win, lv_win_style_t type)
 {
+    lv_style_t * style = NULL;
     lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
 
     switch(type) {
         case LV_WIN_STYLE_BG:
-            return lv_obj_get_style(win);
+            style = lv_obj_get_style(win);
+            break;
         case LV_WIN_STYLE_CONTENT_BG:
-            return lv_page_get_style(ext->page, LV_PAGE_STYLE_BG);
+            style = lv_page_get_style(ext->page, LV_PAGE_STYLE_BG);
+            break;
         case LV_WIN_STYLE_CONTENT_SCRL:
-            return lv_page_get_style(ext->page, LV_PAGE_STYLE_SCRL);
+            style = lv_page_get_style(ext->page, LV_PAGE_STYLE_SCRL);
+            break;
         case LV_WIN_STYLE_SB:
-            return lv_page_get_style(ext->page, LV_PAGE_STYLE_SB);
+            style = lv_page_get_style(ext->page, LV_PAGE_STYLE_SB);
+            break;
         case LV_WIN_STYLE_HEADER:
-            return lv_obj_get_style(ext->header);
+            style = lv_obj_get_style(ext->header);
+            break;
         case LV_WIN_STYLE_BTN_REL:
-            return ext->style_btn_rel;
+            style = ext->style_btn_rel;
+            break;
         case LV_WIN_STYLE_BTN_PR:
-            return ext->style_btn_pr;
+            style = ext->style_btn_pr;
+            break;
         default:
-            return NULL;
+            style = NULL;
+            break;
     }
 
-    /*To avoid warning*/
-    return NULL;
+    return style;
 }
 
 /*=====================


### PR DESCRIPTION
Fixes all warnings reported in #513, modified functions:
```
lv_ta_get_style
lv_arc_get_style
lv_bar_get_style
lv_btn_get_style
lv_calendar_get_style
lv_btnm_get_style
lv_cb_get_style
lv_cb_design
lv_ddlist_get_style
lv_kb_get_style
lv_list_get_style
lv_mbox_get_style
lv_preload_get_style
lv_page_get_style
lv_slider_get_style
lv_roller_get_style
lv_sw_get_style
lv_tabview_get_style
lv_win_get_style
lv_obj_get_child
lv_obj_get_child_back
hex_char_to_num
lv_img_color_format_get_px_size
lv_img_color_format_is_chroma_keyed
lv_img_color_format_has_alpha
```

And also add the missing semicolon reported in #531.