### PR TITLE
Improve preload animation

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -262,6 +262,7 @@
 #if USE_LV_PRELOAD != 0
 #define LV_PRELOAD_DEF_ARC_LENGTH   60      /*[deg]*/
 #define LV_PRELOAD_DEF_SPIN_TIME    1000    /*[ms]*/
+#define LV_PRELOAD_DEF_ANIM         LV_PRELOAD_TYPE_SPINNING_ARC
 #endif
 
 /*************************

--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -43,8 +43,8 @@
  * VDB makes the double buffering, you don't need to deal with it!
  * Typical size: ~1/10 screen */
 #define LV_VDB_SIZE         (30 * LV_HOR_RES)  /*Size of VDB in pixel count (1/10 screen size is good for first)*/
-#define LV_VDB_PX_BPP       LV_COLOR_SIZE     /*Bit-per-pixel of VDB. Useful for monochrome or non-standard color format displays. (Special formats are handles with `disp_drv->vdb_wr`)*/
-#define LV_VDB_ADR          0                 /*Place VDB to a specific address (e.g. in external RAM) (0: allocate automatically into RAM; LV_VDB_ADR_INV: to replace it later with `lv_vdb_set_adr()`)*/
+#define LV_VDB_PX_BPP       LV_COLOR_SIZE      /*Bit-per-pixel of VDB. Useful for monochrome or non-standard color format displays. (Special formats are handled with `disp_drv->vdb_wr`)*/
+#define LV_VDB_ADR          0                  /*Place VDB to a specific address (e.g. in external RAM) (0: allocate automatically into RAM; LV_VDB_ADR_INV: to replace it later with `lv_vdb_set_adr()`)*/
 
 /* Use two Virtual Display buffers (VDB) parallelize rendering and flushing (optional)
  * The flushing should use DMA to write the frame buffer in the background*/

--- a/lv_objx/lv_preload.c
+++ b/lv_objx/lv_preload.c
@@ -93,6 +93,7 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
     a.repeat_pause = 0;
     lv_anim_create(&a);
 
+#if LV_PRELOAD_DOUBLE_ANIM
     lv_anim_t b;
     b.var = new_preload;
     b.start = ext->arc_length;
@@ -107,7 +108,8 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
     b.repeat = 1;
     b.repeat_pause = 0;
     lv_anim_create(&b);
-#endif
+#endif // LV_PRELOAD_DOUBLE_ANIM
+#endif // USE_LV_ANIMATION
 
     /*Init the new pre loader pre loader*/
     if(copy == NULL) {

--- a/lv_objx/lv_preload.c
+++ b/lv_objx/lv_preload.c
@@ -24,6 +24,12 @@
 #ifndef LV_PRELOAD_DEF_SPIN_TIME
 # define LV_PRELOAD_DEF_SPIN_TIME   1000    /*[ms]*/
 #endif
+
+#ifndef LV_PRELOAD_DEF_ANIM
+# define LV_PRELOAD_DEF_ANIM        LV_PRELOAD_TYPE_SPINNING_ARC    /*animation type*/
+#endif
+
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -73,43 +79,12 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
 
     /*Initialize the allocated 'ext' */
     ext->arc_length = LV_PRELOAD_DEF_ARC_LENGTH;
+    ext->anim_type = LV_PRELOAD_DEF_ANIM;
 
     /*The signal and design functions are not copied so set them here*/
     lv_obj_set_signal_func(new_preload, lv_preload_signal);
     lv_obj_set_design_func(new_preload, lv_preload_design);
-#if USE_LV_ANIMATION
-    lv_anim_t a;
-    a.var = new_preload;
-    a.start = 0;
-    a.end = 360;
-    a.fp = (lv_anim_fp_t)lv_preload_spinner_animation;
-    a.path = lv_anim_path_ease_in_out;
-    a.end_cb = NULL;
-    a.act_time = 0;
-    a.time = LV_PRELOAD_DEF_SPIN_TIME;
-    a.playback = 0;
-    a.playback_pause = 0;
-    a.repeat = 1;
-    a.repeat_pause = 0;
-    lv_anim_create(&a);
 
-#if LV_PRELOAD_DOUBLE_ANIM
-    lv_anim_t b;
-    b.var = new_preload;
-    b.start = ext->arc_length;
-    b.end = 360 - ext->arc_length;
-    b.fp = (lv_anim_fp_t)lv_preload_set_arc_length;
-    b.path = lv_anim_path_ease_in_out;
-    b.end_cb = NULL;
-    b.act_time = 0;
-    b.time = LV_PRELOAD_DEF_SPIN_TIME;
-    b.playback = 1;
-    b.playback_pause = 0;
-    b.repeat = 1;
-    b.repeat_pause = 0;
-    lv_anim_create(&b);
-#endif // LV_PRELOAD_DOUBLE_ANIM
-#endif // USE_LV_ANIMATION
 
     /*Init the new pre loader pre loader*/
     if(copy == NULL) {
@@ -123,6 +98,8 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
             lv_obj_set_style(new_preload, &lv_style_pretty_color);
         }
 
+        ext->time = LV_PRELOAD_DEF_SPIN_TIME;
+
     }
     /*Copy an existing pre loader*/
     else {
@@ -132,6 +109,8 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
         /*Refresh the style with new signal function*/
         lv_obj_refresh_style(new_preload);
     }
+
+    lv_preload_set_animation_type(new_preload, ext->anim_type);
 
 
     LV_LOG_INFO("preload created");
@@ -165,22 +144,7 @@ void lv_preload_set_spin_time(lv_obj_t * preload, uint16_t time)
     lv_preload_ext_t * ext = lv_obj_get_ext_attr(preload);
 
     ext->time = time;
-#if USE_LV_ANIMATION
-    lv_anim_t a;
-    a.var = preload;
-    a.start = 0;
-    a.end = 360;
-    a.fp = (lv_anim_fp_t)lv_preload_spinner_animation;
-    a.path = lv_anim_path_ease_in_out;
-    a.end_cb = NULL;
-    a.act_time = 0;
-    a.time = time;
-    a.playback = 0;
-    a.playback_pause = 0;
-    a.repeat = 1;
-    a.repeat_pause = 0;
-    lv_anim_create(&a);
-#endif
+    lv_preload_set_animation_type(preload, ext->anim_type);
 }
 /*=====================
  * Setter functions
@@ -195,10 +159,83 @@ void lv_preload_set_spin_time(lv_obj_t * preload, uint16_t time)
 void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, lv_style_t * style)
 {
     switch(type) {
-        case LV_PRELOAD_STYLE_MAIN:
-            lv_arc_set_style(preload, LV_ARC_STYLE_MAIN, style);
-            break;
+    case LV_PRELOAD_STYLE_MAIN:
+        lv_arc_set_style(preload, LV_ARC_STYLE_MAIN, style);
+        break;
     }
+}
+
+/**
+ * Set the animation type of a preloadeer.
+ * @param preload pointer to pre loader object
+ * @param type animation type of the preload
+ *  */
+void lv_preload_set_animation_type(lv_obj_t * preload, lv_preloader_type_t type)
+{
+#if USE_LV_ANIMATION
+    lv_preload_ext_t * ext = lv_obj_get_ext_attr(preload);
+
+    /*delete previous animation*/
+    //lv_anim_del(preload, NULL);
+    switch(type)
+    {
+    case LV_PRELOAD_TYPE_FILLSPIN_ARC:
+    {
+        ext->anim_type = LV_PRELOAD_TYPE_FILLSPIN_ARC;
+        lv_anim_t a;
+        a.var = preload;
+        a.start = 0;
+        a.end = 360;
+        a.fp = (lv_anim_fp_t)lv_preload_spinner_animation;
+        a.path = lv_anim_path_ease_in_out;
+        a.end_cb = NULL;
+        a.act_time = 0;
+        a.time = ext->time;
+        a.playback = 0;
+        a.playback_pause = 0;
+        a.repeat = 1;
+        a.repeat_pause = 0;
+        lv_anim_create(&a);
+
+        lv_anim_t b;
+        b.var = preload;
+        b.start = ext->arc_length;
+        b.end = 360 - ext->arc_length;
+        b.fp = (lv_anim_fp_t)lv_preload_set_arc_length;
+        b.path = lv_anim_path_ease_in_out;
+        b.end_cb = NULL;
+        b.act_time = 0;
+        b.time = ext->time;
+        b.playback = 1;
+        b.playback_pause = 0;
+        b.repeat = 1;
+        b.repeat_pause = 0;
+        lv_anim_create(&b);
+        break;
+    }
+    case LV_PRELOAD_TYPE_SPINNING_ARC:
+    default:
+    {
+        ext->anim_type = LV_PRELOAD_TYPE_SPINNING_ARC;
+        lv_anim_t a;
+        a.var = preload;
+        a.start = 0;
+        a.end = 360;
+        a.fp = (lv_anim_fp_t)lv_preload_spinner_animation;
+        a.path = lv_anim_path_ease_in_out;
+        a.end_cb = NULL;
+        a.act_time = 0;
+        a.time = ext->time;
+        a.playback = 0;
+        a.playback_pause = 0;
+        a.repeat = 1;
+        a.repeat_pause = 0;
+        lv_anim_create(&a);
+        break;
+    }
+    }
+
+#endif //USE_LV_ANIMATION
 }
 
 /*=====================
@@ -237,15 +274,26 @@ lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t t
     lv_style_t * style = NULL;
 
     switch(type) {
-        case LV_PRELOAD_STYLE_MAIN:
-            style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
-            break;
-        default:
-            style = NULL;
-            break;
+    case LV_PRELOAD_STYLE_MAIN:
+        style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
+        break;
+    default:
+        style = NULL;
+        break;
     }
 
     return style;
+}
+
+/**
+ * Get the animation type of a preloadeer.
+ * @param preload pointer to pre loader object
+ * @return animation type
+ *  */
+lv_preloader_type_t lv_preload_get_animation_type(lv_obj_t * preload)
+{
+    lv_preload_ext_t * ext = lv_obj_get_ext_attr(preload);
+    return ext->anim_type;
 }
 
 /*=====================

--- a/lv_objx/lv_preload.c
+++ b/lv_objx/lv_preload.c
@@ -92,6 +92,21 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
     a.repeat = 1;
     a.repeat_pause = 0;
     lv_anim_create(&a);
+
+    lv_anim_t b;
+    b.var = new_preload;
+    b.start = ext->arc_length;
+    b.end = 360;
+    b.fp = (lv_anim_fp_t)lv_preload_set_arc_length;
+    b.path = lv_anim_path_ease_in_out;
+    b.end_cb = NULL;
+    b.act_time = 0;
+    b.time = LV_PRELOAD_DEF_SPIN_TIME;
+    b.playback = 1;
+    b.playback_pause = 0;
+    b.repeat = 1;
+    b.repeat_pause = 100;
+    lv_anim_create(&b);
 #endif
 
     /*Init the new pre loader pre loader*/

--- a/lv_objx/lv_preload.c
+++ b/lv_objx/lv_preload.c
@@ -96,7 +96,7 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
     lv_anim_t b;
     b.var = new_preload;
     b.start = ext->arc_length;
-    b.end = 360;
+    b.end = 360 - ext->arc_length;
     b.fp = (lv_anim_fp_t)lv_preload_set_arc_length;
     b.path = lv_anim_path_ease_in_out;
     b.end_cb = NULL;
@@ -105,7 +105,7 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
     b.playback = 1;
     b.playback_pause = 0;
     b.repeat = 1;
-    b.repeat_pause = 100;
+    b.repeat_pause = 0;
     lv_anim_create(&b);
 #endif
 

--- a/lv_objx/lv_preload.h
+++ b/lv_objx/lv_preload.h
@@ -43,6 +43,7 @@ extern "C" {
 
 enum {
     LV_PRELOAD_TYPE_SPINNING_ARC,
+    LV_PRELOAD_TYPE_FILLSPIN_ARC,
 };
 typedef uint8_t lv_preloader_type_t;
 
@@ -52,6 +53,7 @@ typedef struct {
     /*New data for this type */
     uint16_t arc_length;            /*Length of the spinning indicator in degree*/
     uint16_t time;                  /*Time of one round*/
+    lv_preloader_type_t anim_type;  /*Type of the arc animation*/
 } lv_preload_ext_t;
 
 
@@ -103,6 +105,13 @@ void lv_preload_set_spin_time(lv_obj_t * preload, uint16_t time);
  *  */
 void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, lv_style_t *style);
 
+/**
+ * Set the animation type of a preloadeer.
+ * @param preload pointer to pre loader object
+ * @param type animation type of the preload
+ *  */
+void lv_preload_set_animation_type(lv_obj_t * preload, lv_preloader_type_t type);
+
 /*=====================
  * Getter functions
  *====================*/
@@ -126,6 +135,13 @@ uint16_t lv_preload_get_spin_time(const lv_obj_t * preload);
  * @return style pointer to the style
  *  */
 lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type);
+
+/**
+ * Get the animation type of a preloadeer.
+ * @param preload pointer to pre loader object
+ * @return animation type
+ *  */
+lv_preloader_type_t lv_preload_get_animation_type(lv_obj_t * preload);
 
 /*=====================
  * Other functions

--- a/lvgl.h
+++ b/lvgl.h
@@ -61,7 +61,7 @@ extern "C" {
  *********************/
 /*Current version of LittlevGL*/
 #define LVGL_VERSION_MAJOR   5
-#define LVGL_VERSION_MINOR   3
+#define LVGL_VERSION_MINOR   2
 #define LVGL_VERSION_PATCH   0
 #define LVGL_VERSION_INFO    ""
 

--- a/lvgl.h
+++ b/lvgl.h
@@ -61,9 +61,9 @@ extern "C" {
  *********************/
 /*Current version of LittlevGL*/
 #define LVGL_VERSION_MAJOR   5
-#define LVGL_VERSION_MINOR   2
+#define LVGL_VERSION_MINOR   3
 #define LVGL_VERSION_PATCH   0
-#define LVGL_VERSION_INFO    "rc"
+#define LVGL_VERSION_INFO    ""
 
 /**********************
  *      TYPEDEFS

--- a/lvgl.h
+++ b/lvgl.h
@@ -62,8 +62,8 @@ extern "C" {
 /*Current version of LittlevGL*/
 #define LVGL_VERSION_MAJOR   5
 #define LVGL_VERSION_MINOR   2
-#define LVGL_VERSION_PATCH   0
-#define LVGL_VERSION_INFO    ""
+#define LVGL_VERSION_PATCH   1
+#define LVGL_VERSION_INFO    "dev"
 
 /**********************
  *      TYPEDEFS


### PR DESCRIPTION
Hi,

This is a proposition for improving the animation of the lv_preload object : 

Current animation : 
![lv_preload-anim_current](https://user-images.githubusercontent.com/13847288/48497155-e2274280-e833-11e8-941a-1a8087e02b73.gif)

Improved animation : 
![lv_preload-anim_improvement](https://user-images.githubusercontent.com/13847288/48497165-e7848d00-e833-11e8-9aa0-92046f0da7f9.gif)

Let me know if I should make additional change.