### PR TITLE
lv_indev: init data before calling of indev_read

### DIFF
--- a/lv_hal/lv_hal_indev.c
+++ b/lv_hal/lv_hal_indev.c
@@ -110,6 +110,8 @@ bool lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
     bool cont = false;
 
     if(indev->driver.read) {
+        memset(data, 0, sizeof(data));
+        data->state = LV_INDEV_STATE_REL;
         data->user_data = indev->driver.user_data;
 
         LV_LOG_TRACE("idnev read started");


### PR DESCRIPTION
Based on issue: https://github.com/littlevgl/lvgl/issues/469#issuecomment-439565304

The `indev_read` function should set the `data` variables in every case. However, to be sure, the library should initialize it.

@TMarkivULCRobotics please test it!