### PR TITLE
[question]Calendar padding.

### DIFF
--- a/lv_objx/lv_calendar.c
+++ b/lv_objx/lv_calendar.c
@@ -800,8 +800,8 @@ static void draw_days(lv_obj_t * calendar, const lv_area_t * mask)
     lv_area_t label_area;
     lv_opa_t opa_scale = lv_obj_get_opa_scale(calendar);
     label_area.y1 = calendar->coords.y1 + get_header_height(calendar) +
-            ext->style_day_names->body.padding.ver + lv_font_get_height(ext->style_day_names->text.font) +
-            style_bg->body.padding.inner;
+            ext->style_day_names->body.padding.ver + lv_font_get_height(ext->style_day_names->text.font) + 
+            ext->style_day_names->body.padding.ver + style_bg->body.padding.inner;
     label_area.y2 = label_area.y1 + lv_font_get_height(style_bg->text.font);
 
     lv_coord_t w = lv_obj_get_width(calendar) - 2 * hpad;


### PR DESCRIPTION
Hi,
 I've noticed that setting day_names' pad.ver will not effect the vertical space between day_names & days.
![image](https://user-images.githubusercontent.com/19869728/48964108-ff020980-efdb-11e8-8364-aca9df4ac9b1.png)

 I checked the source code and found these in line 802-804: https://github.com/littlevgl/lvgl/blob/f317ff6d43f22bc4e90f2cf0f2f7ded6749cb35d/lv_objx/lv_calendar.c#L802
```
    label_area.y1 = calendar->coords.y1 + get_header_height(calendar) +
                    ext->style_day_names->body.padding.ver + lv_font_get_height(ext->style_day_names->text.font) +
                    style_bg->body.padding.inner;
```
The last adder is **style_bg->body.padding.inner**, why not **ext->style_day_names->body.padding.ver** or both? It's a little bit confusing...