### PR TITLE
Fixing C standard related error, formatting lv_conf_templ.h

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -18,7 +18,7 @@
 
 /* Memory size which will be used by the library
  * to store the graphical objects and other data */
-#define LV_MEM_CUSTOM      0                /*1: use custom malloc/free, 0: use the built-in lv_mem_alloc/lv_mem_free*/
+#define LV_MEM_CUSTOM       0               /*1: use custom malloc/free, 0: use the built-in lv_mem_alloc/lv_mem_free*/
 #if LV_MEM_CUSTOM == 0
 #define LV_MEM_SIZE    (32U * 1024U)        /*Size memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
 #define LV_MEM_ATTR                         /*Complier prefix for big array declaration*/
@@ -73,7 +73,7 @@
 /*Color settings*/
 #define LV_COLOR_DEPTH     16                     /*Color depth: 1/8/16/32*/
 #define LV_COLOR_16_SWAP   0                      /*Swap the 2 bytes of RGB565 color. Useful if the display has a 8 bit interface (e.g. SPI)*/
-#define LV_COLOR_SCREEN_TRANSP        0           /*1: Enable screen transparency. Useful for OSD or other overlapping GUIs. Requires ARGB8888 colors*/
+#define LV_COLOR_SCREEN_TRANSP          0         /*1: Enable screen transparency. Useful for OSD or other overlapping GUIs. Requires ARGB8888 colors*/
 #define LV_COLOR_TRANSP    LV_COLOR_LIME          /*Images pixels with this color will not be drawn (with chroma keying)*/
 
 /*Text settings*/
@@ -101,7 +101,6 @@
 #define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the sys time function*/
 #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current systime in ms*/
 #endif     /*LV_TICK_CUSTOM*/
-
 
 /*Log settings*/
 #define USE_LV_LOG      1   /*Enable/disable the log module*/
@@ -228,7 +227,7 @@
 #endif
 
 /*Tileview (dependencies: lv_page) */
-#define USE_LV_TILEVIEW    1
+#define USE_LV_TILEVIEW     1
 #if USE_LV_TILEVIEW
 #define LV_TILEVIEW_ANIM_TIME   300     /*Time of slide animation [ms] (0: no animation)*/
 #endif

--- a/lv_draw/lv_draw_vbasic.c
+++ b/lv_draw/lv_draw_vbasic.c
@@ -680,7 +680,7 @@ static inline lv_color_t color_mix_2_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
         /*Save the parameters and the result. If they will be asked again don't compute again*/
         static lv_opa_t fg_opa_save = 0;
         static lv_opa_t bg_opa_save = 0;
-        static lv_color_t c = {0};
+        static lv_color_t c = {{0}};
 
         if(fg_opa != fg_opa_save || bg_opa != bg_opa_save) {
             fg_opa_save = fg_opa;


### PR DESCRIPTION
Regarding lv_conf_templ: I saw that most definitions in it are aligned to 4-space positions, so I fixed those few which were not.