### PR TITLE
lv_chart: Use circular buffer to avoid memcopy for every new data point

### DIFF
--- a/lv_objx/lv_chart.h
+++ b/lv_objx/lv_chart.h
@@ -53,9 +53,9 @@ typedef struct
     uint8_t type    :4;   /*Line, column or point chart (from 'lv_chart_type_t')*/
     struct {
         lv_coord_t width;  /*Line width or point radius*/
-        uint8_t num;   /*Number of data lines in dl_ll*/
-        lv_opa_t opa;     /*Opacity of data lines*/
-        lv_opa_t dark;    /*Dark level of the point/column bottoms*/
+        uint8_t num;       /*Number of data lines in dl_ll*/
+        lv_opa_t opa;      /*Opacity of data lines*/
+        lv_opa_t dark;     /*Dark level of the point/column bottoms*/
     } series;
 } lv_chart_ext_t;
 

--- a/lv_objx/lv_chart.h
+++ b/lv_objx/lv_chart.h
@@ -35,6 +35,7 @@ typedef struct
 {
     lv_coord_t * points;
     lv_color_t color;
+    uint16_t start_point;
 } lv_chart_series_t;
 
 /*Data of chart */


### PR DESCRIPTION
This pull request contains the implementation suggested in issue #594.

This makes the cost of adding a data point independent of array size.
Changing the array size is more complicated, but that will most likely
happen a lot less than adding a data point.