### PR TITLE
Add wrap enable/disable for lv_group

### DIFF
--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -340,10 +340,15 @@ void lv_group_set_refocus_policy(lv_group_t * group, lv_group_refocus_policy_t p
 }
 
 static void lv_group_refocus(lv_group_t *g) {
-	if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_NEXT)
-		lv_group_focus_next(g);
-	else if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_PREV)
-		lv_group_focus_prev(g);
+    /*Refocus must temporarily allow wrapping to work correctly*/
+    uint8_t temp_wrap = g->wrap;
+
+    if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_NEXT)
+        lv_group_focus_next(g);
+    else if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_PREV)
+        lv_group_focus_prev(g);
+    /*Restore wrap property*/
+    g->wrap = temp_wrap;
 }
 
 /**

--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -204,7 +204,10 @@ void lv_group_focus_next(lv_group_t * group)
     if(group->obj_focus == NULL) obj_next = lv_ll_get_head(&group->obj_ll);
     else obj_next = lv_ll_get_next(&group->obj_ll, group->obj_focus);
 
-    if(obj_next == NULL) obj_next = lv_ll_get_head(&group->obj_ll);
+    if(obj_next == NULL) {
+        if(group->wrap) obj_next = lv_ll_get_head(&group->obj_ll);
+        else obj_next = lv_ll_get_tail(&group->obj_ll);
+    }
     group->obj_focus = obj_next;
 
     if(group->obj_focus) {
@@ -232,7 +235,10 @@ void lv_group_focus_prev(lv_group_t * group)
     if(group->obj_focus == NULL) obj_next = lv_ll_get_tail(&group->obj_ll);
     else obj_next = lv_ll_get_prev(&group->obj_ll, group->obj_focus);
 
-    if(obj_next == NULL) obj_next = lv_ll_get_tail(&group->obj_ll);
+    if(obj_next == NULL) {
+        if(group->wrap) obj_next = lv_ll_get_tail(&group->obj_ll);
+        else  obj_next = lv_ll_get_head(&group->obj_ll);
+    }
     group->obj_focus = obj_next;
 
     if(group->obj_focus != NULL) {
@@ -341,6 +347,16 @@ static void lv_group_refocus(lv_group_t *g) {
 }
 
 /**
+ * Set whether focus next/prev will allow wrapping from first->last or last->first.
+ * @param group pointer to group
+ * @param en: true: enable `click_focus`
+ */
+void lv_group_set_wrap(lv_group_t * group, bool en)
+{
+    group->wrap = en ? 1 : 0;
+}
+
+/**
  * Modify a style with the set 'style_mod' function. The input style remains unchanged.
  * @param group pointer to group
  * @param style pointer to a style to modify
@@ -426,6 +442,17 @@ bool lv_group_get_click_focus(const lv_group_t * group)
 {
     if(!group) return false;
     return group->click_focus ? true : false;
+}
+
+/**
+ * Get whether focus next/prev will allow wrapping from first->last or last->first object.
+ * @param group pointer to group
+ * @param en: true: wrapping enabled; false: wrapping disabled
+ */
+bool lv_group_get_wrap(lv_group_t * group)
+{
+    if(!group) return false;
+    return group->wrap ? true : false;
 }
 
 /**********************

--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -342,6 +342,7 @@ void lv_group_set_refocus_policy(lv_group_t * group, lv_group_refocus_policy_t p
 static void lv_group_refocus(lv_group_t *g) {
     /*Refocus must temporarily allow wrapping to work correctly*/
     uint8_t temp_wrap = g->wrap;
+    g->wrap = 1;
 
     if(g->refocus_policy == LV_GROUP_REFOCUS_POLICY_NEXT)
         lv_group_focus_next(g);

--- a/lv_core/lv_group.h
+++ b/lv_core/lv_group.h
@@ -58,6 +58,7 @@ typedef struct _lv_group_t
     uint8_t editing         :1;             /*1: Edit mode, 0: Navigate mode*/
     uint8_t click_focus     :1;             /*1: If an object in a group is clicked by an indev then it will be focused */
     uint8_t refocus_policy  :1;             /*1: Focus prev if focused on deletion. 0: Focus prev if focused on deletion.*/
+    uint8_t wrap            :1;             /*1: Focus next/prev can wrap at end of list. 0: Focus next/prev stops at end of list.*/
 } lv_group_t;
 
 typedef enum _lv_group_refocus_policy_t {
@@ -169,6 +170,13 @@ void lv_group_set_editing(lv_group_t * group, bool edit);
 void lv_group_set_click_focus(lv_group_t * group, bool en);
 
 /**
+ * Set whether focus next/prev will allow wrapping from first->last or last->first object.
+ * @param group pointer to group
+ * @param en: true: wrapping enabled; false: wrapping disabled
+ */
+void lv_group_set_wrap(lv_group_t * group, bool en);
+
+/**
  * Modify a style with the set 'style_mod' function. The input style remains unchanged.
  * @param group pointer to group
  * @param style pointer to a style to modify
@@ -218,6 +226,12 @@ bool lv_group_get_editing(const lv_group_t * group);
  */
 bool lv_group_get_click_focus(const lv_group_t * group);
 
+/**
+ * Get whether focus next/prev will allow wrapping from first->last or last->first object.
+ * @param group pointer to group
+ * @param en: true: wrapping enabled; false: wrapping disabled
+ */
+bool lv_group_get_wrap(lv_group_t * group);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Allows for controlling whether focus next/prev will wrap at the boundaries, or if they will stop at the boundaries.

Discussed in #627 