### PR TITLE
lv_log: fix warnings

### DIFF
--- a/lv_misc/lv_log.c
+++ b/lv_misc/lv_log.c
@@ -54,7 +54,7 @@ void lv_log_register_print(void f(lv_log_level_t, const char *, uint32_t,  const
  * @param line line number in the source code where the log added
  * @param dsc description of the log
  */
-void lv_log_add(lv_log_level_t level, const char * file, uint32_t line, const char * dsc)
+void lv_log_add(lv_log_level_t level, const char * file, int line, const char * dsc)
 {
     if(level >= _LV_LOG_LEVEL_NUM) return;      /*Invalid level*/
 

--- a/lv_misc/lv_log.h
+++ b/lv_misc/lv_log.h
@@ -58,7 +58,7 @@ void lv_log_register_print(void f(lv_log_level_t, const char *, uint32_t,  const
  * @param line line number in the source code where the log added
  * @param dsc description of the log
  */
-void lv_log_add(lv_log_level_t level, const char * file, uint32_t line, const char * dsc);
+void lv_log_add(lv_log_level_t level, const char * file, int line, const char * dsc);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Just little fix warning for mismatch int printf argument