### PR TITLE
lv_log: Fix type limits error

### DIFF
--- a/lv_misc/lv_log.h
+++ b/lv_misc/lv_log.h
@@ -32,7 +32,7 @@ extern "C" {
 #define LV_LOG_LEVEL_ERROR 3     /*Only critical issue, when the system may fail*/
 #define _LV_LOG_LEVEL_NUM  4
 
-typedef uint8_t lv_log_level_t;
+typedef int8_t lv_log_level_t;
 
 #if USE_LV_LOG
 /**********************


### PR DESCRIPTION
When building LittlevGL with a rather recent compiler (tested with GCC
7.3.1 provided by Arm), `-Wall`, `-Wextra` and `-Werror` activated and
`LV_LOG_LEVEL` set to `LV_LOG_LEVEL_TRACE`, compilation fails due to a
type limits error in lv_log.c

     if(level >= LV_LOG_LEVEL) {
              ^~

because the comparison is always true, since level is a `lv_log_level_t`
(that is a typedef for `uint8_t`) and `LV_LOG_LEVEL_TRACE` equals 0.

Fix that by making `lv_log_level_t` a typedef to `int8_t`.

Fixes #690