### PR TITLE
Don't dirty heap if the lv_btn action deletes the button obj

### DIFF
--- a/lv_objx/lv_btn.c
+++ b/lv_objx/lv_btn.c
@@ -684,7 +684,7 @@ static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param)
                     res = ext->actions[LV_BTN_ACTION_CLICK](btn);
                 }
             }
-            if( LV_RES_INV != res ) {
+            if(res != LV_RES_INV) {
                 ext->long_pr_action_executed  = 0;
             }
         }

--- a/lv_objx/lv_btn.c
+++ b/lv_objx/lv_btn.c
@@ -684,7 +684,9 @@ static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param)
                     res = ext->actions[LV_BTN_ACTION_CLICK](btn);
                 }
             }
-            ext->long_pr_action_executed  = 0;
+            if( LV_RES_INV != res ) {
+                ext->long_pr_action_executed  = 0;
+            }
         }
     } else if(sign == LV_SIGNAL_CLEANUP) {
 #if USE_LV_ANIMATION && LV_BTN_INK_EFFECT


### PR DESCRIPTION
The `long_pr_action_executed` flag of the `lv_btn` object should not be set if the performed action returns `LV_RES_INV`. This now checks the action response. In the old configuration, it would dirty the heap in the event the button object was deleted.