### PR TITLE
Change lv_group_send_data() return type to lv_res_t

### DIFF
--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -265,13 +265,14 @@ void lv_group_focus_freeze(lv_group_t * group, bool en)
  * Send a control character to the focuses object of a group
  * @param group pointer to a group
  * @param c a character (use LV_GROUP_KEY_.. to navigate)
+ * @return result of focused object in group.
  */
-void lv_group_send_data(lv_group_t * group, uint32_t c)
+lv_res_t lv_group_send_data(lv_group_t * group, uint32_t c)
 {
     lv_obj_t * act = lv_group_get_focused(group);
-    if(act == NULL) return;
+    if(act == NULL) return LV_RES_OK;
 
-    act->signal_func(act, LV_SIGNAL_CONTROLL, &c);
+    return act->signal_func(act, LV_SIGNAL_CONTROLL, &c);
 }
 
 /**

--- a/lv_core/lv_group.h
+++ b/lv_core/lv_group.h
@@ -124,8 +124,9 @@ void lv_group_focus_freeze(lv_group_t * group, bool en);
  * Send a control character to the focuses object of a group
  * @param group pointer to a group
  * @param c a character (use LV_GROUP_KEY_.. to navigate)
+ * @return result of focused object in group.
  */
-void lv_group_send_data(lv_group_t * group, uint32_t c);
+lv_res_t lv_group_send_data(lv_group_t * group, uint32_t c);
 
 /**
  * Set a function for a group which will modify the object's style if it is in focus


### PR DESCRIPTION
Changes the return type of `lv_group_send_data` from `void` to `lv_res_t`. It now returns the result of the focused object's `signal_func`. If there is no object, it returns `LV_RES_OK`.

#698 