### PR TITLE
single vdb macro fix for get_active and get_inactive

### DIFF
--- a/lv_core/lv_vdb.c
+++ b/lv_core/lv_vdb.c
@@ -158,7 +158,11 @@ LV_ATTRIBUTE_FLUSH_READY void lv_flush_ready(void)
  */
 lv_vdb_t * lv_vdb_get_active(void)
 {
+#if LV_VDB_DOUBLE == 0
+    return &vdb;
+#else
     return &vdb[vdb_active];
+#endif
 }
 
 /**
@@ -167,8 +171,11 @@ lv_vdb_t * lv_vdb_get_active(void)
  */
 lv_vdb_t * lv_vdb_get_inactive(void)
 {
+#if LV_VDB_DOUBLE == 0
+    return &vdb;
+#else
     return &vdb[(vdb_active + 1) & 0x1];
-
+#endif
 }
 
 /**


### PR DESCRIPTION
 Fixes compilation issues when not double buffering. Bug was introduced in 83cadc8abea8b13c3a94f3a2d2303022a7a79ccb