### PR TITLE
Remove from group before deleting children

### DIFF
--- a/lv_core/lv_obj.c
+++ b/lv_core/lv_obj.c
@@ -1920,6 +1920,14 @@ static void delete_children(lv_obj_t * obj)
     lv_obj_t * i;
     lv_obj_t * i_next;
     i = lv_ll_get_head(&(obj->child_ll));
+
+    /*Remove from the group; remove before transversing children so that 
+     * the object still has access to all children during the 
+     * LV_SIGNAL_DEFOCUS call*/
+#if USE_LV_GROUP
+    if(obj->group_p != NULL) lv_group_remove_obj(obj);
+#endif
+
     while(i != NULL) {
         /*Get the next object before delete this*/
         i_next = lv_ll_get_next(&(obj->child_ll), i);
@@ -1936,10 +1944,6 @@ static void delete_children(lv_obj_t * obj)
     lv_anim_del(obj, NULL);
 #endif
 
-    /*Delete from the group*/
-#if USE_LV_GROUP
-    if(obj->group_p != NULL) lv_group_remove_obj(obj);
-#endif
 
     /* Reset the input devices if
      * the currently pressed object is deleted*/


### PR DESCRIPTION
While deleting objects, this moves the `lv_group_remove_obj()` call before the children are recursively deleted. This is because some parent might modify its children in a `LV_SIGNAL_DEFOCUS` call, but they would have already have been deleted.