### PR TITLE
Correctly count text width

### DIFF
--- a/lv_core/lv_style.c
+++ b/lv_core/lv_style.c
@@ -95,7 +95,7 @@ void lv_style_init(void)
     lv_style_scr.text.color = LV_COLOR_MAKE(0x30, 0x30, 0x30);
     lv_style_scr.text.font = LV_FONT_DEFAULT;
     lv_style_scr.text.letter_space = 2;
-    lv_style_scr.text.line_space = 1;
+    lv_style_scr.text.line_space = 2;
 
     lv_style_scr.image.opa = LV_OPA_COVER;
     lv_style_scr.image.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);

--- a/lv_core/lv_style.c
+++ b/lv_core/lv_style.c
@@ -95,7 +95,7 @@ void lv_style_init(void)
     lv_style_scr.text.color = LV_COLOR_MAKE(0x30, 0x30, 0x30);
     lv_style_scr.text.font = LV_FONT_DEFAULT;
     lv_style_scr.text.letter_space = 2;
-    lv_style_scr.text.line_space = 2;
+    lv_style_scr.text.line_space = 1;
 
     lv_style_scr.image.opa = LV_OPA_COVER;
     lv_style_scr.image.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);

--- a/lv_draw/lv_draw_label.c
+++ b/lv_draw/lv_draw_label.c
@@ -185,7 +185,9 @@ void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, const lv_st
             letter_fp(&pos, mask, font, letter, color, opa);
             letter_w = lv_font_get_width(font, letter);
 
-            pos.x += letter_w + style->text.letter_space;
+            if(letter_w > 0){
+                pos.x += letter_w + style->text.letter_space;
+            }
         }
         /*Go to next line*/
         line_start = line_end;

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -212,7 +212,7 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
 /**
  * Give the length of a text with a given font
  * @param txt a '\0' terminate string
- * @param length length of 'txt' in character count and not bytes(UTF-8 can be 1,2,3 or 4 bytes long)
+ * @param length length of 'txt' in byte count and not characters (Á is 1 character but 2 bytes in UTF-8)
  * @param font pointer to a font
  * @param letter_space letter space
  * @param flags settings for the text from 'txt_flag_t' enum
@@ -224,13 +224,13 @@ lv_coord_t lv_txt_get_width(const char * txt, uint16_t length,
     if(txt == NULL) return 0;
     if(font == NULL) return 0;
 
-    uint32_t i = 0, j;
+    uint32_t i = 0;
     lv_coord_t width = 0;
     lv_txt_cmd_state_t cmd_state = LV_TXT_CMD_STATE_WAIT;
     uint32_t letter;
 
     if(length != 0) {
-        for(j=0; j< length; j++){
+        while(i< length){
             letter = lv_txt_encoded_next(txt, &i);
             if((flag & LV_TXT_FLAG_RECOLOR) != 0) {
                 if(lv_txt_is_cmd(&cmd_state, letter) != false) {

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -224,13 +224,13 @@ lv_coord_t lv_txt_get_width(const char * txt, uint16_t length,
     if(txt == NULL) return 0;
     if(font == NULL) return 0;
 
-    uint32_t i = 0;
+    uint32_t i = 0, j;
     lv_coord_t width = 0;
     lv_txt_cmd_state_t cmd_state = LV_TXT_CMD_STATE_WAIT;
     uint32_t letter;
 
     if(length != 0) {
-        while(i < length) {
+        for(j=0; j< length; j++){
             letter = lv_txt_encoded_next(txt, &i);
             if((flag & LV_TXT_FLAG_RECOLOR) != 0) {
                 if(lv_txt_is_cmd(&cmd_state, letter) != false) {
@@ -238,11 +238,16 @@ lv_coord_t lv_txt_get_width(const char * txt, uint16_t length,
                 }
             }
 
-            width += lv_font_get_width(font, letter);
-            width += letter_space;
+            lv_coord_t char_width = lv_font_get_width(font, letter);
+            if(char_width > 0){
+                width += lv_font_get_width(font, letter);
+                width += letter_space;
+            }
         }
 
-        width -= letter_space;  /*Trim the last letter space. Important if the text is center aligned */
+        if(width > 0) {
+            width -= letter_space;  /*Trim the last letter space. Important if the text is center aligned */
+        }
     }
 
     return width;

--- a/lv_misc/lv_txt.h
+++ b/lv_misc/lv_txt.h
@@ -82,7 +82,7 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
 /**
  * Give the length of a text with a given font
  * @param txt a '\0' terminate string
- * @param length length of 'txt' in character count and not bytes(UTF-8 can be 1,2,3 or 4 bytes long)
+ * @param length length of 'txt' in byte count and not characters (Á is 1 character but 2 bytes in UTF-8)
  * @param font pointer to a font
  * @param letter_space letter space
  * @param flags settings for the text from 'txt_flag_t' enum

--- a/lv_objx/lv_calendar.c
+++ b/lv_objx/lv_calendar.c
@@ -14,6 +14,7 @@
 #include "../lv_misc/lv_math.h"
 #include "../lv_core/lv_indev.h"
 #include "../lv_themes/lv_theme.h"
+#include <strings.h>
 
 /*********************
  *      DEFINES
@@ -756,7 +757,7 @@ static void draw_header(lv_obj_t * calendar, const lv_area_t * mask)
     /*Add the right arrow*/
     arrow_style = ext->btn_pressing > 0 ? ext->style_header_pr : ext->style_header;
     header_area.x1 = header_area.x2 - ext->style_header->body.padding.hor -
-            lv_txt_get_width(SYMBOL_RIGHT, 1, arrow_style->text.font,
+            lv_txt_get_width(SYMBOL_RIGHT, strlen(SYMBOL_RIGHT), arrow_style->text.font,
                     arrow_style->text.line_space, LV_TXT_FLAG_NONE);
     lv_draw_label(&header_area, mask, arrow_style, opa_scale, SYMBOL_RIGHT, LV_TXT_FLAG_NONE, NULL);
 

--- a/lv_objx/lv_ddlist.c
+++ b/lv_objx/lv_ddlist.c
@@ -16,6 +16,7 @@
 #include "../lv_themes/lv_theme.h"
 #include "../lv_misc/lv_symbol_def.h"
 #include "../lv_misc/lv_anim.h"
+#include <strings.h>
 
 /*********************
  *      DEFINES
@@ -579,7 +580,7 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
 				new_style.text.opa = sel_style->text.opa;
 				lv_area_t area_arrow;
 				area_arrow.x2 = ddlist->coords.x2 - style->body.padding.hor;
-				area_arrow.x1 = area_arrow.x2 - lv_txt_get_width(SYMBOL_DOWN, 1, sel_style->text.font, 0, 0);
+				area_arrow.x1 = area_arrow.x2 - lv_txt_get_width(strlen(SYMBOL_DOWN), 1, sel_style->text.font, 0, 0);
 
 				area_arrow.y1 = ddlist->coords.y1 + style->text.line_space;
 				area_arrow.y2 = area_arrow.y1 + font_h;

--- a/lv_objx/lv_ddlist.c
+++ b/lv_objx/lv_ddlist.c
@@ -580,7 +580,7 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
 				new_style.text.opa = sel_style->text.opa;
 				lv_area_t area_arrow;
 				area_arrow.x2 = ddlist->coords.x2 - style->body.padding.hor;
-				area_arrow.x1 = area_arrow.x2 - lv_txt_get_width(strlen(SYMBOL_DOWN), 1, sel_style->text.font, 0, 0);
+				area_arrow.x1 = area_arrow.x2 - lv_txt_get_width(SYMBOL_DOWN, (strlen(SYMBOL_DOWN), sel_style->text.font, 0, 0);
 
 				area_arrow.y1 = ddlist->coords.y1 + style->text.line_space;
 				area_arrow.y2 = area_arrow.y1 + font_h;

--- a/lv_objx/lv_label.c
+++ b/lv_objx/lv_label.c
@@ -446,21 +446,14 @@ void lv_label_get_letter_pos(const lv_obj_t * label, uint16_t index, lv_point_t 
     }
 
     /*Calculate the x coordinate*/
-    lv_coord_t x = lv_txt_get_width(&txt[line_start], index,
+    lv_coord_t x = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
                             font, style->text.letter_space, flag);
 
     if(ext->align == LV_LABEL_ALIGN_CENTER) {
-        lv_coord_t line_w;
-        line_w = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
-                                  font, style->text.letter_space, flag);
-        x += lv_obj_get_width(label) / 2 - line_w / 2;
+        x += lv_obj_get_width(label) / 2 - x / 2;
 
     } else if(ext->align == LV_LABEL_ALIGN_RIGHT) {
-        lv_coord_t line_w;
-        line_w = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
-                                  font, style->text.letter_space, flag);
-
-        x += lv_obj_get_width(label) - line_w;
+        x += lv_obj_get_width(label) - x;
     }
 
     pos->x = x;

--- a/lv_objx/lv_label.c
+++ b/lv_objx/lv_label.c
@@ -446,22 +446,8 @@ void lv_label_get_letter_pos(const lv_obj_t * label, uint16_t index, lv_point_t 
     }
 
     /*Calculate the x coordinate*/
-    lv_coord_t x = 0;
-    uint32_t i = line_start;
-    uint32_t cnt = line_start;                      /*Count the letter (in UTF-8 1 letter not 1 byte)*/
-    lv_txt_cmd_state_t cmd_state = LV_TXT_CMD_STATE_WAIT;
-    uint32_t letter;
-    while(cnt < index) {
-        cnt += lv_txt_encoded_size(&txt[i]);
-        letter = lv_txt_encoded_next(txt, &i);
-        /*Handle the recolor command*/
-        if((flag & LV_TXT_FLAG_RECOLOR) != 0) {
-            if(lv_txt_is_cmd(&cmd_state, txt[i]) != false) {
-                continue; /*Skip the letter is it is part of a command*/
-            }
-        }
-        x += lv_font_get_width(font, letter) + style->text.letter_space;
-    }
+    lv_coord_t x = lv_txt_get_width(&txt[line_start], index,
+                            font, style->text.letter_space, flag);
 
     if(ext->align == LV_LABEL_ALIGN_CENTER) {
         lv_coord_t line_w;

--- a/lv_objx/lv_label.c
+++ b/lv_objx/lv_label.c
@@ -440,22 +440,32 @@ void lv_label_get_letter_pos(const lv_obj_t * label, uint16_t index, lv_point_t 
     }
 
     /*If the last character is line break then go to the next line*/
-    if((txt[index - 1] == '\n' || txt[index - 1] == '\r') && txt[index] == '\0') {
-        y += letter_height + style->text.line_space;
-        line_start = index;
+    if(index > 0) {
+        if((txt[index - 1] == '\n' || txt[index - 1] == '\r') && txt[index] == '\0') {
+            y += letter_height + style->text.line_space;
+            line_start = index;
+        }
     }
 
     /*Calculate the x coordinate*/
-    lv_coord_t x = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
+    lv_coord_t x = lv_txt_get_width(&txt[line_start], index - line_start,
                             font, style->text.letter_space, flag);
 
+    if(index != line_start) x += style->text.letter_space;
+
     if(ext->align == LV_LABEL_ALIGN_CENTER) {
-        x += lv_obj_get_width(label) / 2 - x / 2;
+        lv_coord_t line_w;
+        line_w = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
+                                  font, style->text.letter_space, flag);
+        x += lv_obj_get_width(label) / 2 - line_w / 2;
 
     } else if(ext->align == LV_LABEL_ALIGN_RIGHT) {
-        x += lv_obj_get_width(label) - x;
-    }
+        lv_coord_t line_w;
+        line_w = lv_txt_get_width(&txt[line_start], new_line_start - line_start,
+                                  font, style->text.letter_space, flag);
 
+        x += lv_obj_get_width(label) - line_w;
+    }
     pos->x = x;
     pos->y = y;
 }

--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -1281,7 +1281,7 @@ static void refr_cursor_area(lv_obj_t * ta)
     lv_label_get_letter_pos(ext->label, cur_pos, &letter_pos);
 
     /*If the cursor is out of the text (most right) draw it to the next line*/
-    if(letter_pos.x + ext->label->coords.x1 + letter_w > ext->label->coords.x2 && ext->one_line == 0) {
+    if(letter_pos.x + ext->label->coords.x1 + letter_w > ext->label->coords.x2 && ext->one_line == 0 && lv_label_get_align(ext->label) != LV_LABEL_ALIGN_RIGHT) {
         letter_pos.x = 0;
         letter_pos.y += letter_h + label_style->text.line_space;
 


### PR DESCRIPTION
The txt get width function was adding a letter_space for every 0-width character. I noticed this because my labels were not perfectly centered (turns out it was a letrer_space from a `\n`). I also believe it was iterating over the txt the wrong number of times (tracking bytes rather than characters), so I fixed that as well. This fix solved my alignment issues.

I assume there might be bugs elsewhere. Will investigate in additional commits.