### PR TITLE
Break long words immediately if word is longer than wrap width 2

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -109,6 +109,9 @@
 /*Text settings*/
 #define LV_TXT_UTF8             1                /*Enable UTF-8 coded Unicode character usage */
 #define LV_TXT_BREAK_CHARS     " ,.;:-_"         /*Can break texts on these chars*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 12 /* If a character is at least this long, will break wherever "prettiest" */
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 0 /* Minimum number of characters of a word to put on a line after a break */
 
 /*Feature usage*/
 #define USE_LV_ANIMATION        1               /*1: Enable all animations*/

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -13,6 +13,7 @@
  *      DEFINES
  *********************/
 #define NO_BREAK_FOUND  UINT32_MAX
+#define LV_TXT_LINE_BREAK_LONG_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
 
 /**********************
  *      TYPEDEFS

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -175,6 +175,28 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
 
             /*If the txt is too long then finish, this is the line end*/
             if(cur_w > max_width) {
+                /* Continue searching for next breakable character to see if the next word will fit */
+                uint32_t i_tmp = i;
+                cur_w = 0;
+                while(txt[i_tmp] != 0) {
+                    letter = lv_txt_encoded_next(txt, &i_tmp);
+                    /*Check for new line chars*/
+                    if(letter == '\n' || letter == '\r') {
+                        uint32_t i_tmp2 = i;
+                        uint32_t letter_next = lv_txt_encoded_next(txt, &i_tmp2);
+                        if(letter == '\r' &&  letter_next == '\n') i = i_tmp2;
+                        break;
+                    } 
+                    else if (is_break_char(letter)) {
+                        break;
+                    }
+                    lv_coord_t letter_width = lv_font_get_width(font, letter);
+                    cur_w += letter_width;
+                    if(cur_w > max_width) {
+                        return i;
+                    }
+                }
+
                 /*If this a break char then break here.*/
                 if(is_break_char(letter)) {
                     /* Now 'i' points to the next char because of txt_utf8_next()

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -15,7 +15,7 @@
 #define NO_BREAK_FOUND  UINT32_MAX
 #define LV_TXT_LINE_BREAK_LONG_LEN 12 /* If a character is at least this long, will break wherever "prettiest" */
 #define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
-#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3 /* Minimum number of characters of a word to put on a line after a break */
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 4 /* Minimum number of characters of a word to put on a line after a break */
 
 /**********************
  *      TYPEDEFS
@@ -187,7 +187,7 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
             if(cur_w > max_width) {
                 if( last_break != NO_BREAK_FOUND ) {
                     /* Continue searching for next breakable character to see if the next word will fit */
-                    uint32_t n_char_fit = n_char_since_last_break;
+                    uint32_t n_char_fit = n_char_since_last_break - 1;
                     if(  n_char_since_last_break <= LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN ) {
                         i = last_break;
                     }

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -13,9 +13,18 @@
  *      DEFINES
  *********************/
 #define NO_BREAK_FOUND  UINT32_MAX
+
+#ifndef LV_TXT_LINE_BREAK_LONG_LEN
 #define LV_TXT_LINE_BREAK_LONG_LEN 12 /* If a character is at least this long, will break wherever "prettiest" */
+#endif
+
+#ifndef LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
 #define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
+#endif
+
+#ifndef LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN
 #define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 0 /* Minimum number of characters of a word to put on a line after a break */
+#endif
 
 /**********************
  *      TYPEDEFS

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -15,7 +15,7 @@
 #define NO_BREAK_FOUND  UINT32_MAX
 #define LV_TXT_LINE_BREAK_LONG_LEN 12 /* If a character is at least this long, will break wherever "prettiest" */
 #define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
-#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 4 /* Minimum number of characters of a word to put on a line after a break */
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 0 /* Minimum number of characters of a word to put on a line after a break */
 
 /**********************
  *      TYPEDEFS

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -180,19 +180,16 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
             if(cur_w > max_width) {
                 if( last_break != NO_BREAK_FOUND ) {
                     /* Continue searching for next breakable character to see if the next word will fit */
-                    if( n_char_since_last_break <= LV_TXT_LINE_BREAK_LONG_MIN_LEN ) {
+                    if(  0 || n_char_since_last_break <= LV_TXT_LINE_BREAK_LONG_MIN_LEN ) {
                         i = last_break;
                     }
                     else {
                         uint32_t i_tmp = i;
-                        cur_w -= w_at_last_break;
+                        cur_w -= w_at_last_break + letter_space; /*ignore the first letter_space after the break char */
                         while(txt[i_tmp] != '\0') {
                             letter = lv_txt_encoded_next(txt, &i_tmp);
                             /*Check for new line chars*/
                             if(letter == '\n' || letter == '\r') {
-                                uint32_t i_tmp2 = i_tmp;
-                                uint32_t letter_next = lv_txt_encoded_next(txt, &i_tmp2);
-                                if(letter == '\r' &&  letter_next == '\n') i = i_tmp2;
                                 i = last_break;
                                 break;
                             } 
@@ -208,6 +205,9 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
                                 break;
                             }
                             cur_w += letter_space;
+                        }
+                        if(txt[i_tmp] == '\0') {
+                            i = last_break;
                         }
                     }
                 } else {

--- a/lv_misc/lv_txt.h
+++ b/lv_misc/lv_txt.h
@@ -28,6 +28,7 @@ extern "C" {
  *      DEFINES
  *********************/
 #define LV_TXT_COLOR_CMD  "#"
+#define LV_TXT_LINE_BREAK_LONG_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
 
 /**********************
  *      TYPEDEFS

--- a/lv_misc/lv_txt.h
+++ b/lv_misc/lv_txt.h
@@ -28,7 +28,6 @@ extern "C" {
  *      DEFINES
  *********************/
 #define LV_TXT_COLOR_CMD  "#"
-#define LV_TXT_LINE_BREAK_LONG_MIN_LEN 3 /* Minimum number of characters of a word to put on a line before a break */
 
 /**********************
  *      TYPEDEFS


### PR DESCRIPTION
Continued discussion of #703 ; separate PR because the original PR commit history got mangled.

Fixed the last character getting cut off in the `lv_test_kb_1()`.

I also added the functionality for long words (but still shorter than the display width, i.e. a single break will definitely solve the word-wrap issue) to break in a prettier place. Best to explain via example:
```
+----------------------+
|This is a test aaabbbc| // words >=12 long are broken
|ccddd                 |
+----------------------+
+----------------------+
|This is test aaabbbcc | // broken early to leave a
|cddd                  | // minimum of 4 trailing letters
+----------------------+

+----------------------+
|This is test123456 aaa| // 3 leading letters is fine
|bbbcccddd             | 
+----------------------+

+----------------------+
|This is test1234567   | // <3 leading letters is not
|aaabbbcccddd          | // this is a >=12 word that is < line_w
+----------------------+
```

