### PR TITLE
don't redefine _CRT_SECURE_NO_WARNINGS symbol if already defined

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -313,7 +313,7 @@
 /*************************
  * Non-user section
  *************************/
-#ifdef _MSC_VER                               /* Disable warnings for Visual Studio*/
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /* Disable warnings for Visual Studio*/
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 


### PR DESCRIPTION
This PR prevents "macro redefinition" warning under MSVC if the symbol `_CRT_SECURE_NO_WARNINGS ` is already defined (e.g. on project level).