### PR TITLE
Replace nonstandard <strings.h> with standard <string.h> header

### DIFF
--- a/lv_objx/lv_calendar.c
+++ b/lv_objx/lv_calendar.c
@@ -14,7 +14,7 @@
 #include "../lv_misc/lv_math.h"
 #include "../lv_core/lv_indev.h"
 #include "../lv_themes/lv_theme.h"
-#include <strings.h>
+#include <string.h>
 
 /*********************
  *      DEFINES

--- a/lv_objx/lv_ddlist.c
+++ b/lv_objx/lv_ddlist.c
@@ -16,7 +16,7 @@
 #include "../lv_themes/lv_theme.h"
 #include "../lv_misc/lv_symbol_def.h"
 #include "../lv_misc/lv_anim.h"
-#include <strings.h>
+#include <string.h>
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
Introduced in commit d3fab62, nonstandard header <strings.h> has been #included to access declaration of `strlen` function. This header might not be available on all platforms (my Visual C++ compiler does not have one). This patch replaces the <strings.h> header with <string.h> which is the standard one and is already being used in multiple locations in the code base.

Trivia: [Difference between string.h and strings.h](https://stackoverflow.com/questions/4291149/difference-between-string-h-and-strings-h)