### PR TITLE
Dev 5.3  fix compilation errors on lv_mpy

### DIFF
--- a/lv_objx/lv_canvas.c
+++ b/lv_objx/lv_canvas.c
@@ -6,6 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <stdlib.h>
 #include "lv_canvas.h"
 #if USE_LV_CANVAS != 0
 


### PR DESCRIPTION
Added missing include to stdlib, needed for 'abs'