### PR TITLE
Add note about origin of function

### DIFF
--- a/lv_objx/lv_canvas.c
+++ b/lv_objx/lv_canvas.c
@@ -328,6 +328,9 @@ void lv_canvas_draw_circle(lv_obj_t * canvas, lv_coord_t x0, lv_coord_t y0, lv_c
  * @param point2 end point of the line
  * @param color color of the line
  */
+/*
+ * NOTE: The lv_canvas_draw_line function originates from https://github.com/jb55/bresenham-line.c.
+ */
 void lv_canvas_draw_line(lv_obj_t * canvas, lv_point_t point1, lv_point_t point2, lv_color_t color)
 {
   lv_coord_t x0, y0, x1, y1;


### PR DESCRIPTION
As @seyyah stated in https://github.com/littlevgl/lvgl/issues/726#issuecomment-458542363, the `lv_canvas_draw_line` function is based on https://github.com/jb55/bresenham-line.c/blob/master/bresenham_line.c. I've added a note about that above the function.