### PR TITLE
lv_label_set_text_id must be declared conditionally

### DIFF
--- a/lv_objx/lv_label.h
+++ b/lv_objx/lv_label.h
@@ -128,7 +128,9 @@ void lv_label_set_static_text(lv_obj_t * label, const char * text);
  * @param label pointer to a label object
  * @param txt_id ID of the text
  */
+#if USE_LV_MULTI_LANG
 void lv_label_set_text_id(lv_obj_t * label, uint32_t txt_id);
+#endif
 
 /**
  * Set the behavior of the label with longer text then the object size


### PR DESCRIPTION
Otherwise `lv_micropython` would create a wrapper to an undefined function.  

That's another case where a commit to lvgl breaks `lv_micropython` and could be prevented if we had proper CI, as discussed [here](https://github.com/littlevgl/lvgl/issues/768#issuecomment-458965961).