### PR TITLE
Change v5.3 to 5.3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"> LittlevGL - Open-source Embedded GUI Library</h1>
 <p align="center">
 <a href="https://github.com/littlevgl/lvgl/blob/master/LICENCE.txt"><img src="https://img.shields.io/badge/licence-MIT-blue.svg"></a>
-<a href="https://github.com/littlevgl/lvgl/releases/tag/v5.3"><img src="https://img.shields.io/badge/version-v5.3-blue.svg"></a>
+<a href="https://github.com/littlevgl/lvgl/releases/tag/v5.3"><img src="https://img.shields.io/badge/version-5.3-blue.svg"></a>
 <br>
 <img src="https://littlevgl.com/github/cover_ori_reduced_2.gif">
 </p>


### PR DESCRIPTION
When the badge already says 'version' it doesn't make sense to put the 'v' before the version number.