### PR TITLE
Added POS1 and END support to lv_ta

### DIFF
--- a/lv_core/lv_group.h
+++ b/lv_core/lv_group.h
@@ -36,7 +36,7 @@ extern "C" {
 #define LV_GROUP_KEY_ENTER          10      /*0x0A, '\n'*/
 #define LV_GROUP_KEY_NEXT           9       /*0x09, '\t'*/
 #define LV_GROUP_KEY_PREV           11      /*0x0B, '*/
-#define LV_GROUP_KEY_POS1           2       /*0x02, STX*/
+#define LV_GROUP_KEY_HOME           2       /*0x02, STX*/
 #define LV_GROUP_KEY_END            3       /*0x03, ETX*/
 
 #if USE_LV_GROUP  != 0

--- a/lv_core/lv_group.h
+++ b/lv_core/lv_group.h
@@ -36,6 +36,8 @@ extern "C" {
 #define LV_GROUP_KEY_ENTER          10      /*0x0A, '\n'*/
 #define LV_GROUP_KEY_NEXT           9       /*0x09, '\t'*/
 #define LV_GROUP_KEY_PREV           11      /*0x0B, '*/
+#define LV_GROUP_KEY_POS1           2       /*0x02, STX*/
+#define LV_GROUP_KEY_END            3       /*0x03, ETX*/
 
 #if USE_LV_GROUP  != 0
 /**********************

--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -1063,7 +1063,7 @@ static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param)
         else if(c == LV_GROUP_KEY_DOWN) lv_ta_cursor_down(ta);
         else if(c == LV_GROUP_KEY_BACKSPACE) lv_ta_del_char(ta);
         else if(c == LV_GROUP_KEY_DEL)  lv_ta_del_char_forward(ta);
-        else if(c == LV_GROUP_KEY_POS1) lv_ta_set_cursor_pos(ta, 0);
+        else if(c == LV_GROUP_KEY_HOME) lv_ta_set_cursor_pos(ta, 0);
         else if(c == LV_GROUP_KEY_END)  lv_ta_set_cursor_pos(ta, LV_TA_CURSOR_LAST);
         else {
             lv_ta_add_char(ta, c);

--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -351,6 +351,17 @@ void lv_ta_del_char(lv_obj_t * ta)
     lv_ta_set_cursor_pos(ta, ext->cursor.pos - 1);
 }
 
+/**
+ * Delete the right character from the current cursor position
+ * @param ta pointer to a text area object
+ */
+void lv_ta_del_char_forward(lv_obj_t * ta)
+{
+	uint16_t cp = lv_ta_get_cursor_pos(ta);
+	lv_ta_set_cursor_pos(ta, cp + 1);
+	if(cp != lv_ta_get_cursor_pos(ta)) lv_ta_del_char(ta);
+}
+
 /*=====================
  * Setter functions
  *====================*/
@@ -1051,11 +1062,9 @@ static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param)
         else if(c == LV_GROUP_KEY_UP)   lv_ta_cursor_up(ta);
         else if(c == LV_GROUP_KEY_DOWN) lv_ta_cursor_down(ta);
         else if(c == LV_GROUP_KEY_BACKSPACE) lv_ta_del_char(ta);
-        else if(c == LV_GROUP_KEY_DEL)  {
-            uint16_t cp = lv_ta_get_cursor_pos(ta);
-            lv_ta_set_cursor_pos(ta, cp + 1);
-            if(cp != lv_ta_get_cursor_pos(ta)) lv_ta_del_char(ta);
-        }
+        else if(c == LV_GROUP_KEY_DEL)  lv_ta_del_char_forward(ta);
+        else if(c == LV_GROUP_KEY_POS1) lv_ta_set_cursor_pos(ta, 0);
+        else if(c == LV_GROUP_KEY_END)  lv_ta_set_cursor_pos(ta, LV_TA_CURSOR_LAST);
         else {
             lv_ta_add_char(ta, c);
         }

--- a/lv_objx/lv_ta.h
+++ b/lv_objx/lv_ta.h
@@ -122,6 +122,12 @@ void lv_ta_add_text(lv_obj_t * ta, const char * txt);
  */
 void lv_ta_del_char(lv_obj_t * ta);
 
+/**
+ * Delete the right character from the current cursor position
+ * @param ta pointer to a text area object
+ */
+void lv_ta_del_char_forward(lv_obj_t * ta);
+
 /*=====================
  * Setter functions
  *====================*/


### PR DESCRIPTION
Added POS1 and END keys to the LV_GROUP_KEY macros.
Added support for POS1 and END to lv_ta.
Moved deletion of the character on the right side of the cursor into the new lv_ta_del_char_forward function. 