### PR TITLE
Prevent crash when lv_init is called more than once.

### DIFF
--- a/lv_core/lv_obj.c
+++ b/lv_core/lv_obj.c
@@ -49,6 +49,8 @@ static lv_res_t lv_obj_signal(lv_obj_t * obj, lv_signal_t sign, void * param);
  *  STATIC VARIABLES
  **********************/
 
+static bool _lv_initialized = false;
+
 /**********************
  *      MACROS
  **********************/
@@ -62,6 +64,9 @@ static lv_res_t lv_obj_signal(lv_obj_t * obj, lv_signal_t sign, void * param);
  */
 void lv_init(void)
 {
+    if (_lv_initialized) return;
+    _lv_initialized = true;
+
     LV_GC_ROOT(_lv_def_scr) = NULL;
     LV_GC_ROOT(_lv_act_scr) = NULL;
     LV_GC_ROOT(_lv_top_layer) = NULL;

--- a/lv_core/lv_obj.c
+++ b/lv_core/lv_obj.c
@@ -64,9 +64,10 @@ static bool _lv_initialized = false;
  */
 void lv_init(void)
 {
-    if (_lv_initialized) return;
-    _lv_initialized = true;
-
+    /* Do nothing if already initialized */
+    if (_lv_initialized)
+         return;
+    
     LV_GC_ROOT(_lv_def_scr) = NULL;
     LV_GC_ROOT(_lv_act_scr) = NULL;
     LV_GC_ROOT(_lv_top_layer) = NULL;
@@ -116,7 +117,7 @@ void lv_init(void)
     lv_indev_init();
 #endif
 
-
+    _lv_initialized = true;
     LV_LOG_INFO("lv_init ready");
 }
 


### PR DESCRIPTION
Related: littlevgl/lv_binding_micropython#6:

> @amirgon We could just have a simple global boolean that is set to true upon initialization. If that boolean is true then `lv_init` would do nothing.
> 
> This would be backwards compatible and shouldn't really change much.