### PR TITLE
Fix gcc narrowing warning

### DIFF
--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -393,14 +393,14 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 #endif
 
 
-#define LV_COLOR_HEX(c) LV_COLOR_MAKE(((uint32_t)((uint32_t)c >> 16) & 0xFF), \
-                                ((uint32_t)((uint32_t)c >> 8) & 0xFF), \
-                                ((uint32_t) c & 0xFF))
+#define LV_COLOR_HEX(c) LV_COLOR_MAKE((uint8_t) ((uint32_t)((uint32_t)c >> 16) & 0xFF), \
+                                (uint8_t) ((uint32_t)((uint32_t)c >> 8) & 0xFF), \
+                                (uint8_t) ((uint32_t) c & 0xFF))
 
 /*Usage LV_COLOR_HEX3(0x16C) which means LV_COLOR_HEX(0x1166CC)*/
-#define LV_COLOR_HEX3(c) LV_COLOR_MAKE((((c >> 4) & 0xF0) | ((c >> 8) & 0xF)),   \
-                                ((uint32_t)(c & 0xF0)       | ((c & 0xF0) >> 4)), \
-                                ((uint32_t)(c & 0xF)         | ((c & 0xF) << 4)))
+#define LV_COLOR_HEX3(c) LV_COLOR_MAKE((uint8_t) (((c >> 4) & 0xF0) | ((c >> 8) & 0xF)),   \
+                                (uint8_t) ((uint32_t)(c & 0xF0)       | ((c & 0xF0) >> 4)), \
+                                (uint8_t) ((uint32_t)(c & 0xF)         | ((c & 0xF) << 4)))
 
 static inline lv_color_t lv_color_hex(uint32_t c){
     return LV_COLOR_HEX(c);

--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -399,8 +399,8 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 
 /*Usage LV_COLOR_HEX3(0x16C) which means LV_COLOR_HEX(0x1166CC)*/
 #define LV_COLOR_HEX3(c) LV_COLOR_MAKE((uint8_t) (((c >> 4) & 0xF0) | ((c >> 8) & 0xF)),   \
-                                (uint8_t) ((uint32_t)(c & 0xF0)       | ((c & 0xF0) >> 4)), \
-                                (uint8_t) ((uint32_t)(c & 0xF)         | ((c & 0xF) << 4)))
+                                (uint8_t) ((uint32_t)(c & 0xF0)     | ((c & 0xF0) >> 4)), \
+                                (uint8_t) ((uint32_t)(c & 0xF)      | ((c & 0xF) << 4)))
 
 static inline lv_color_t lv_color_hex(uint32_t c){
     return LV_COLOR_HEX(c);


### PR DESCRIPTION
When compiling LVGL 5.3 with a recent gcc in a C++ project, it output an integer narrowing warning because `LV_COLOR_HEX` and `LV_COLOR_HEX3` create three `uint32_t` values, passes them to `LV_COLOR_MAKE` which then initializes a struct containing `uint8_t` values with them without casting. This generates a warning in C++.

This pull request fixes the warnings by properly casting the values in `LV_COLOR_HEX` and `LV_COLOR_HEX3` so they are passed as `uint8_t`to `LV_COLOR_MAKE`.