### PR TITLE
Fix compilation errors when compiler does not support VLAs

### DIFF
--- a/lv_draw/lv_draw_img.c
+++ b/lv_draw/lv_draw_img.c
@@ -325,7 +325,7 @@ static lv_res_t lv_img_draw_core(const lv_area_t * coords, const lv_area_t * mas
 #if LV_COMPILER_VLA_SUPPORTED
         uint8_t buf[(lv_area_get_width(&mask_com) * ((LV_COLOR_DEPTH >> 3) + 1))];
 #else
-        uint8_t buf[LV_HOR_RES * ((LV_COLOR_DEPTH >> 3) + 1)];  /*+1 because of the possible alpha byte*/
+        uint8_t buf[LV_HOR_RES_MAX * ((LV_COLOR_DEPTH >> 3) + 1)];  /*+1 because of the possible alpha byte*/
 #endif
         lv_area_t line;
         lv_area_copy(&line, &mask_com);

--- a/lv_draw/lv_draw_rect.c
+++ b/lv_draw/lv_draw_rect.c
@@ -1089,9 +1089,9 @@ static void lv_draw_shadow_full(const lv_area_t * coords, const lv_area_t * mask
     lv_coord_t curve_x[radius + swidth + 1];     /*Stores the 'x' coordinates of a quarter circle.*/
 #else
 # if LV_HOR_RES > LV_VER_RES
-    lv_coord_t curve_x[LV_HOR_RES];
+    lv_coord_t curve_x[LV_HOR_RES_MAX];
 # else
-    lv_coord_t curve_x[LV_VER_RES];
+    lv_coord_t curve_x[LV_VER_RES_MAX];
 # endif
 #endif
     memset(curve_x, 0, sizeof(curve_x));
@@ -1110,9 +1110,9 @@ static void lv_draw_shadow_full(const lv_area_t * coords, const lv_area_t * mask
     uint32_t line_1d_blur[filter_width];
 #else
 # if LV_HOR_RES > LV_VER_RES
-    uint32_t line_1d_blur[LV_HOR_RES];
+    uint32_t line_1d_blur[LV_HOR_RES_MAX];
 # else
-    uint32_t line_1d_blur[LV_VER_RES];
+    uint32_t line_1d_blur[LV_VER_RES_MAX];
 # endif
 #endif
     /*1D Blur horizontally*/
@@ -1126,9 +1126,9 @@ static void lv_draw_shadow_full(const lv_area_t * coords, const lv_area_t * mask
     lv_opa_t line_2d_blur[radius + swidth + 1];
 #else
 # if LV_HOR_RES > LV_VER_RES
-    lv_opa_t line_2d_blur[LV_HOR_RES];
+    lv_opa_t line_2d_blur[LV_HOR_RES_MAX];
 # else
-    lv_opa_t line_2d_blur[LV_VER_RES];
+    lv_opa_t line_2d_blur[LV_VER_RES_MAX];
 # endif
 #endif
 
@@ -1247,9 +1247,9 @@ static void lv_draw_shadow_bottom(const lv_area_t * coords, const lv_area_t * ma
     lv_coord_t curve_x[radius + 1];             /*Stores the 'x' coordinates of a quarter circle.*/
 #else
 # if LV_HOR_RES > LV_VER_RES
-    lv_coord_t curve_x[LV_HOR_RES];
+    lv_coord_t curve_x[LV_HOR_RES_MAX];
 # else
-    lv_coord_t curve_x[LV_VER_RES];
+    lv_coord_t curve_x[LV_VER_RES_MAX];
 # endif
 #endif
     lv_point_t circ;
@@ -1266,9 +1266,9 @@ static void lv_draw_shadow_bottom(const lv_area_t * coords, const lv_area_t * ma
     lv_opa_t line_1d_blur[swidth];
 #else
 # if LV_HOR_RES > LV_VER_RES
-    lv_opa_t line_1d_blur[LV_HOR_RES];
+    lv_opa_t line_1d_blur[LV_HOR_RES_MAX];
 # else
-    lv_opa_t line_1d_blur[LV_VER_RES];
+    lv_opa_t line_1d_blur[LV_VER_RES_MAX];
 # endif
 #endif
 


### PR DESCRIPTION
Fixes compilation errors when `LV_COMPILER_VLA_SUPPORTED == 0`.