### PR TITLE
Fix crash on uninitialized field in text area

### DIFF
--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -108,6 +108,7 @@ lv_obj_t * lv_ta_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->cursor.valid_x = 0;
     ext->one_line = 0;
     ext->label = NULL;
+    ext->placeholder = NULL;
 
     lv_obj_set_signal_func(new_ta, lv_ta_signal);
     lv_obj_set_signal_func(lv_page_get_scrl(new_ta), lv_ta_scrollable_signal);


### PR DESCRIPTION
The `placeholder` field in text area is not initialized and the application will crash at runtime if the field contains garbage.