### PR TITLE
Revert semicolon removal from f4498fd0. This semicolon is necessary f…

### DIFF
--- a/lv_misc/lv_font.h
+++ b/lv_misc/lv_font.h
@@ -171,7 +171,7 @@ int16_t lv_font_get_width_sparse(const lv_font_t * font, uint32_t unicode_letter
  *      MACROS
  **********************/
 
-#define LV_FONT_DECLARE(font_name) extern lv_font_t font_name
+#define LV_FONT_DECLARE(font_name) extern lv_font_t font_name;
 
 
 /**********************


### PR DESCRIPTION
…or more natural, less error prone custom font declaration in lv_conf.h