### PR TITLE
Remove unnecessary variable definition

### DIFF
--- a/lv_objx/lv_ta.c
+++ b/lv_objx/lv_ta.c
@@ -1213,7 +1213,6 @@ static lv_res_t lv_ta_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void 
         if(ext->label) {
             if(lv_obj_get_width(ta) != lv_area_get_width(param) ||
                     lv_obj_get_height(ta) != lv_area_get_height(param)) {
-                lv_obj_t * scrl = lv_page_get_scrl(ta);
                 lv_style_t * style_scrl = lv_obj_get_style(scrl);
                 lv_obj_set_width(ext->label, lv_obj_get_width(scrl) - 2 * style_scrl->body.padding.hor);
                 lv_obj_set_pos(ext->label, style_scrl->body.padding.hor, style_scrl->body.padding.ver);


### PR DESCRIPTION
The `scrl` variable definition/initialization hides the function argument with the same name (error under pedantic compilation). Moreover the variable is not necessary, since the argument receives the same value.