### PR TITLE
add lv_cb_set_static_text function, fix incorrect kb_ctrl_num_map

### DIFF
--- a/lv_objx/lv_cb.c
+++ b/lv_objx/lv_cb.c
@@ -120,14 +120,26 @@ lv_obj_t * lv_cb_create(lv_obj_t * par, const lv_obj_t * copy)
  *====================*/
 
 /**
- * Set the text of a check box
+ * Set the text of a check box. `txt` will be copied and may be deallocated
+ * after this function returns.
  * @param cb pointer to a check box
- * @param txt the text of the check box
+ * @param txt the text of the check box. NULL to refresh with the current text.
  */
 void lv_cb_set_text(lv_obj_t * cb, const char * txt)
 {
     lv_cb_ext_t * ext = lv_obj_get_ext_attr(cb);
     lv_label_set_text(ext->label, txt);
+}
+
+/**
+ * Set the text of a check box. `txt` must not be deallocated during the life
+ * of this checkbox.
+ * @param cb pointer to a check box
+ * @param txt the text of the check box. NULL to refresh with the current text.
+ */
+void lv_cb_set_static_text(lv_obj_t * cb, const char * txt) {
+    lv_cb_ext_t * ext = lv_obj_get_ext_attr(cb);
+    lv_label_set_static_text(ext->label, txt);
 }
 
 /**

--- a/lv_objx/lv_cb.h
+++ b/lv_objx/lv_cb.h
@@ -78,11 +78,20 @@ lv_obj_t * lv_cb_create(lv_obj_t * par, const lv_obj_t * copy);
  *====================*/
 
 /**
- * Set the text of a check box
+ * Set the text of a check box. `txt` will be copied and may be deallocated
+ * after this function returns.
  * @param cb pointer to a check box
- * @param txt the text of the check box
+ * @param txt the text of the check box. NULL to refresh with the current text.
  */
 void lv_cb_set_text(lv_obj_t * cb, const char * txt);
+
+/**
+ * Set the text of a check box. `txt` must not be deallocated during the life
+ * of this checkbox.
+ * @param cb pointer to a check box
+ * @param txt the text of the check box. NULL to refresh with the current text.
+ */
+void lv_cb_set_static_text(lv_obj_t * cb, const char * txt);
 
 /**
  * Set the state of the check box

--- a/lv_objx/lv_kb.c
+++ b/lv_objx/lv_kb.c
@@ -84,6 +84,7 @@ static const char * kb_map_num[] = {
 static const lv_btnm_ctrl_t kb_ctrl_num_map[] = {
      1, 1, 1, 2,
      1, 1, 1, 2,
+     1, 1, 1, 2,
      1, 1, 1, 1, 1
 };
 /**********************


### PR DESCRIPTION
Add set static text functionality to the checkbox object. This is a straight passthrough to the existing functionality of the  underlying label object.

Fix missing row in kb_ctrl_num_map