### PR TITLE
Workaround for stray 'free' macro

### DIFF
--- a/lv_misc/lv_fs.c
+++ b/lv_misc/lv_fs.c
@@ -21,6 +21,14 @@
  *      DEFINES
  *********************/
 
+/* "free" is used as a function pointer (in lv_fs_drv_t).
+ * We must make sure "free" was not defined to a platform specific
+ * free function, otherwise compilation would fail.
+ */
+#ifdef free
+#undef free
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
Related to littlevgl/lv_binding_micropython#11 'Build error for STM32 port due to 'free()' macro'