### PR TITLE
Fix typo in constant name

### DIFF
--- a/lv_draw/lv_draw_img.c
+++ b/lv_draw/lv_draw_img.c
@@ -124,7 +124,7 @@ lv_res_t lv_img_dsc_get_info(const char * src, lv_img_header_t * header)
         if(res != LV_FS_RES_OK || rn != sizeof(lv_img_header_t)) {
             header->w = LV_DPI;
             header->h = LV_DPI;
-            header->cf = LV_IMG_CF_UNKOWN;
+            header->cf = LV_IMG_CF_UNKNOWN;
         }
 
         lv_fs_close(&file);
@@ -150,7 +150,7 @@ uint8_t lv_img_color_format_get_px_size(lv_img_cf_t cf)
     uint8_t px_size = 0;
 
     switch(cf) {
-        case LV_IMG_CF_UNKOWN:
+        case LV_IMG_CF_UNKNOWN:
         case LV_IMG_CF_RAW:
             px_size = 0;
             break;
@@ -234,7 +234,7 @@ bool lv_img_color_format_has_alpha(lv_img_cf_t cf)
  *  - pointer to an 'lv_img_t' variable (image stored internally and compiled into the code)
  *  - a path to a file (e.g. "S:/folder/image.bin")
  *  - or a symbol (e.g. SYMBOL_CLOSE)
- * @return type of the image source LV_IMG_SRC_VARIABLE/FILE/SYMBOL/UNKOWN
+ * @return type of the image source LV_IMG_SRC_VARIABLE/FILE/SYMBOL/UNKNOWN
  */
 lv_img_src_t lv_img_src_get_type(const void * src)
 {

--- a/lv_draw/lv_draw_img.h
+++ b/lv_draw/lv_draw_img.h
@@ -41,7 +41,7 @@ typedef struct {
 
 /*Image color format*/
 enum {
-    LV_IMG_CF_UNKOWN = 0,
+    LV_IMG_CF_UNKNOWN = 0,
 
     LV_IMG_CF_RAW,                  /*Contains the file as it is. Needs custom decoder function*/
     LV_IMG_CF_RAW_ALPHA,            /*Contains the file as it is. The image has alpha. Needs custom decoder function*/
@@ -132,7 +132,7 @@ void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask,
  *  - pointer to an 'lv_img_t' variable (image stored internally and compiled into the code)
  *  - a path to a file (e.g. "S:/folder/image.bin")
  *  - or a symbol (e.g. SYMBOL_CLOSE)
- * @return type of the image source LV_IMG_SRC_VARIABLE/FILE/SYMBOL/UNKOWN
+ * @return type of the image source LV_IMG_SRC_VARIABLE/FILE/SYMBOL/UNKNOWN
  */
 lv_img_src_t lv_img_src_get_type(const void * src);
 

--- a/lv_objx/lv_img.c
+++ b/lv_objx/lv_img.c
@@ -74,7 +74,7 @@ lv_obj_t * lv_img_create(lv_obj_t * par, const lv_obj_t * copy)
 
     ext->src = NULL;
     ext->src_type = LV_IMG_SRC_UNKNOWN;
-    ext->cf = LV_IMG_CF_UNKOWN;
+    ext->cf = LV_IMG_CF_UNKNOWN;
     ext->w = lv_obj_get_width(new_img);
     ext->h = lv_obj_get_height(new_img);
     ext->auto_size = 1;

--- a/lv_objx/lv_imgbtn.c
+++ b/lv_objx/lv_imgbtn.c
@@ -69,7 +69,7 @@ lv_obj_t * lv_imgbtn_create(lv_obj_t * par, const lv_obj_t * copy)
     memset(ext->img_src_right, 0, sizeof(ext->img_src_right));
 #endif
 
-    ext->act_cf = LV_IMG_CF_UNKOWN;
+    ext->act_cf = LV_IMG_CF_UNKNOWN;
 
     /*The signal and design functions are not copied so set them here*/
     lv_obj_set_signal_func(new_imgbtn, lv_imgbtn_signal);
@@ -382,7 +382,7 @@ static void refr_img(lv_obj_t * imgbtn)
         lv_obj_set_height(imgbtn, header.h);
 #endif
     } else {
-        ext->act_cf = LV_IMG_CF_UNKOWN;
+        ext->act_cf = LV_IMG_CF_UNKNOWN;
     }
 
     lv_obj_invalidate(imgbtn);


### PR DESCRIPTION
Fixes typo in `lv_img_cf_t` constant (LV_IMG_CF_UNK**N**OWN).