### PR TITLE
Remove inline functions which prevent compile

### DIFF
--- a/lv_core/lv_style.c
+++ b/lv_core/lv_style.c
@@ -94,17 +94,17 @@ void lv_style_init(void)
     lv_style_scr.body.shadow.width = 0;
 
     lv_style_scr.text.opa = LV_OPA_COVER;
-    lv_style_scr.text.color = LV_COLOR_MAKE(0x30, 0x30, 0x30);
+    lv_style_scr.text.color = lv_color_make(0x30, 0x30, 0x30);
     lv_style_scr.text.font = LV_FONT_DEFAULT;
     lv_style_scr.text.letter_space = 2;
     lv_style_scr.text.line_space = 2;
 
     lv_style_scr.image.opa = LV_OPA_COVER;
-    lv_style_scr.image.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);
+    lv_style_scr.image.color = lv_color_make(0x20, 0x20, 0x20);
     lv_style_scr.image.intense = LV_OPA_TRANSP;
 
     lv_style_scr.line.opa = LV_OPA_COVER;
-    lv_style_scr.line.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);
+    lv_style_scr.line.color = lv_color_make(0x20, 0x20, 0x20);
     lv_style_scr.line.width = 2;
     lv_style_scr.line.rounded = 0;
 
@@ -117,32 +117,32 @@ void lv_style_init(void)
 
     /*Plain color style*/
     memcpy(&lv_style_plain_color, &lv_style_plain, sizeof(lv_style_t));
-    lv_style_plain_color.text.color = LV_COLOR_MAKE(0xf0, 0xf0, 0xf0);
-    lv_style_plain_color.image.color = LV_COLOR_MAKE(0xf0, 0xf0, 0xf0);
-    lv_style_plain_color.line.color = LV_COLOR_MAKE(0xf0, 0xf0, 0xf0);
-    lv_style_plain_color.body.main_color = LV_COLOR_MAKE(0x55, 0x96, 0xd8);
+    lv_style_plain_color.text.color = lv_color_make(0xf0, 0xf0, 0xf0);
+    lv_style_plain_color.image.color = lv_color_make(0xf0, 0xf0, 0xf0);
+    lv_style_plain_color.line.color = lv_color_make(0xf0, 0xf0, 0xf0);
+    lv_style_plain_color.body.main_color = lv_color_make(0x55, 0x96, 0xd8);
     lv_style_plain_color.body.grad_color = lv_style_plain_color.body.main_color;
 
     /*Pretty style */
     memcpy(&lv_style_pretty, &lv_style_plain, sizeof(lv_style_t));
-    lv_style_pretty.text.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);
-    lv_style_pretty.image.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);
-    lv_style_pretty.line.color = LV_COLOR_MAKE(0x20, 0x20, 0x20);
+    lv_style_pretty.text.color = lv_color_make(0x20, 0x20, 0x20);
+    lv_style_pretty.image.color = lv_color_make(0x20, 0x20, 0x20);
+    lv_style_pretty.line.color = lv_color_make(0x20, 0x20, 0x20);
     lv_style_pretty.body.main_color = LV_COLOR_WHITE;
     lv_style_pretty.body.grad_color = LV_COLOR_SILVER;
     lv_style_pretty.body.radius = LV_DPI / 15;
-    lv_style_pretty.body.border.color = LV_COLOR_MAKE(0x40, 0x40, 0x40);
+    lv_style_pretty.body.border.color = lv_color_make(0x40, 0x40, 0x40);
     lv_style_pretty.body.border.width = LV_DPI / 50 >= 1 ? LV_DPI / 50  : 1;
     lv_style_pretty.body.border.opa = LV_OPA_30;
 
     /*Pretty color style*/
     memcpy(&lv_style_pretty_color, &lv_style_pretty, sizeof(lv_style_t));
-    lv_style_pretty_color.text.color = LV_COLOR_MAKE(0xe0, 0xe0, 0xe0);
-    lv_style_pretty_color.image.color = LV_COLOR_MAKE(0xe0, 0xe0, 0xe0);
-    lv_style_pretty_color.line.color = LV_COLOR_MAKE(0xc0, 0xc0, 0xc0);
-    lv_style_pretty_color.body.main_color = LV_COLOR_MAKE(0x6b, 0x9a, 0xc7);
-    lv_style_pretty_color.body.grad_color = LV_COLOR_MAKE(0x2b, 0x59, 0x8b);
-    lv_style_pretty_color.body.border.color = LV_COLOR_MAKE(0x15, 0x2c, 0x42);
+    lv_style_pretty_color.text.color = lv_color_make(0xe0, 0xe0, 0xe0);
+    lv_style_pretty_color.image.color = lv_color_make(0xe0, 0xe0, 0xe0);
+    lv_style_pretty_color.line.color = lv_color_make(0xc0, 0xc0, 0xc0);
+    lv_style_pretty_color.body.main_color = lv_color_make(0x6b, 0x9a, 0xc7);
+    lv_style_pretty_color.body.grad_color = lv_color_make(0x2b, 0x59, 0x8b);
+    lv_style_pretty_color.body.border.color = lv_color_make(0x15, 0x2c, 0x42);
 
     /*Transparent style*/
     memcpy(&lv_style_transp, &lv_style_plain, sizeof(lv_style_t));
@@ -163,55 +163,55 @@ void lv_style_init(void)
 
     /*Button released style*/
     memcpy(&lv_style_btn_rel, &lv_style_plain, sizeof(lv_style_t));
-    lv_style_btn_rel.body.main_color = LV_COLOR_MAKE(0x76, 0xa2, 0xd0);
-    lv_style_btn_rel.body.grad_color = LV_COLOR_MAKE(0x19, 0x3a, 0x5d);
+    lv_style_btn_rel.body.main_color = lv_color_make(0x76, 0xa2, 0xd0);
+    lv_style_btn_rel.body.grad_color = lv_color_make(0x19, 0x3a, 0x5d);
     lv_style_btn_rel.body.radius = LV_DPI / 15;
     lv_style_btn_rel.body.padding.left= LV_DPI / 4;
     lv_style_btn_rel.body.padding.right = LV_DPI / 4;
     lv_style_btn_rel.body.padding.top = LV_DPI / 6;
     lv_style_btn_rel.body.padding.bottom = LV_DPI / 6;
     lv_style_btn_rel.body.padding.inner = LV_DPI / 10;
-    lv_style_btn_rel.body.border.color = LV_COLOR_MAKE(0x0b, 0x19, 0x28);
+    lv_style_btn_rel.body.border.color = lv_color_make(0x0b, 0x19, 0x28);
     lv_style_btn_rel.body.border.width = LV_DPI / 50 >= 1 ? LV_DPI / 50  : 1;
     lv_style_btn_rel.body.border.opa = LV_OPA_70;
     lv_style_btn_rel.body.shadow.color = LV_COLOR_GRAY;
     lv_style_btn_rel.body.shadow.width = 0;
-    lv_style_btn_rel.text.color = LV_COLOR_MAKE(0xff, 0xff, 0xff);
-    lv_style_btn_rel.image.color = LV_COLOR_MAKE(0xff, 0xff, 0xff);
+    lv_style_btn_rel.text.color = lv_color_make(0xff, 0xff, 0xff);
+    lv_style_btn_rel.image.color = lv_color_make(0xff, 0xff, 0xff);
 
     /*Button pressed style*/
     memcpy(&lv_style_btn_pr, &lv_style_btn_rel, sizeof(lv_style_t));
-    lv_style_btn_pr.body.main_color = LV_COLOR_MAKE(0x33, 0x62, 0x94);
-    lv_style_btn_pr.body.grad_color = LV_COLOR_MAKE(0x10, 0x26, 0x3c);
-    lv_style_btn_pr.text.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
-    lv_style_btn_pr.image.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
-    lv_style_btn_pr.line.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
+    lv_style_btn_pr.body.main_color = lv_color_make(0x33, 0x62, 0x94);
+    lv_style_btn_pr.body.grad_color = lv_color_make(0x10, 0x26, 0x3c);
+    lv_style_btn_pr.text.color = lv_color_make(0xa4, 0xb5, 0xc6);
+    lv_style_btn_pr.image.color = lv_color_make(0xa4, 0xb5, 0xc6);
+    lv_style_btn_pr.line.color = lv_color_make(0xa4, 0xb5, 0xc6);
 
     /*Button toggle released style*/
     memcpy(&lv_style_btn_tgl_rel, &lv_style_btn_rel, sizeof(lv_style_t));
-    lv_style_btn_tgl_rel.body.main_color = LV_COLOR_MAKE(0x0a, 0x11, 0x22);
-    lv_style_btn_tgl_rel.body.grad_color = LV_COLOR_MAKE(0x37, 0x62, 0x90);
-    lv_style_btn_tgl_rel.body.border.color = LV_COLOR_MAKE(0x01, 0x07, 0x0d);
-    lv_style_btn_tgl_rel.text.color = LV_COLOR_MAKE(0xc8, 0xdd, 0xf4);
-    lv_style_btn_tgl_rel.image.color = LV_COLOR_MAKE(0xc8, 0xdd, 0xf4);
-    lv_style_btn_tgl_rel.line.color = LV_COLOR_MAKE(0xc8, 0xdd, 0xf4);
+    lv_style_btn_tgl_rel.body.main_color = lv_color_make(0x0a, 0x11, 0x22);
+    lv_style_btn_tgl_rel.body.grad_color = lv_color_make(0x37, 0x62, 0x90);
+    lv_style_btn_tgl_rel.body.border.color = lv_color_make(0x01, 0x07, 0x0d);
+    lv_style_btn_tgl_rel.text.color = lv_color_make(0xc8, 0xdd, 0xf4);
+    lv_style_btn_tgl_rel.image.color = lv_color_make(0xc8, 0xdd, 0xf4);
+    lv_style_btn_tgl_rel.line.color = lv_color_make(0xc8, 0xdd, 0xf4);
 
     /*Button toggle pressed style*/
     memcpy(&lv_style_btn_tgl_pr, &lv_style_btn_tgl_rel, sizeof(lv_style_t));
-    lv_style_btn_tgl_pr.body.main_color = LV_COLOR_MAKE(0x02, 0x14, 0x27);
-    lv_style_btn_tgl_pr.body.grad_color = LV_COLOR_MAKE(0x2b, 0x4c, 0x70);
-    lv_style_btn_tgl_pr.text.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
-    lv_style_btn_tgl_pr.image.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
-    lv_style_btn_tgl_pr.line.color = LV_COLOR_MAKE(0xa4, 0xb5, 0xc6);
+    lv_style_btn_tgl_pr.body.main_color = lv_color_make(0x02, 0x14, 0x27);
+    lv_style_btn_tgl_pr.body.grad_color = lv_color_make(0x2b, 0x4c, 0x70);
+    lv_style_btn_tgl_pr.text.color = lv_color_make(0xa4, 0xb5, 0xc6);
+    lv_style_btn_tgl_pr.image.color = lv_color_make(0xa4, 0xb5, 0xc6);
+    lv_style_btn_tgl_pr.line.color = lv_color_make(0xa4, 0xb5, 0xc6);
 
     /*Button inactive style*/
     memcpy(&lv_style_btn_ina, &lv_style_btn_rel, sizeof(lv_style_t));
-    lv_style_btn_ina.body.main_color = LV_COLOR_MAKE(0xd8, 0xd8, 0xd8);
-    lv_style_btn_ina.body.grad_color = LV_COLOR_MAKE(0xd8, 0xd8, 0xd8);
-    lv_style_btn_ina.body.border.color = LV_COLOR_MAKE(0x90, 0x90, 0x90);
-    lv_style_btn_ina.text.color = LV_COLOR_MAKE(0x70, 0x70, 0x70);
-    lv_style_btn_ina.image.color = LV_COLOR_MAKE(0x70, 0x70, 0x70);
-    lv_style_btn_ina.line.color = LV_COLOR_MAKE(0x70, 0x70, 0x70);
+    lv_style_btn_ina.body.main_color = lv_color_make(0xd8, 0xd8, 0xd8);
+    lv_style_btn_ina.body.grad_color = lv_color_make(0xd8, 0xd8, 0xd8);
+    lv_style_btn_ina.body.border.color = lv_color_make(0x90, 0x90, 0x90);
+    lv_style_btn_ina.text.color = lv_color_make(0x70, 0x70, 0x70);
+    lv_style_btn_ina.image.color = lv_color_make(0x70, 0x70, 0x70);
+    lv_style_btn_ina.line.color = lv_color_make(0x70, 0x70, 0x70);
 }
 
 

--- a/lv_draw/lv_draw_img.c
+++ b/lv_draw/lv_draw_img.c
@@ -439,7 +439,7 @@ static const uint8_t * lv_img_decoder_open(const void * src, const lv_style_t * 
 
         uint32_t i;
         for(i = 0; i < palette_size; i++) {
-            decoder_index_map[i] = LV_COLOR_MAKE(palette_p[i].ch.red, palette_p[i].ch.green, palette_p[i].ch.blue);
+            decoder_index_map[i] = lv_color_make(palette_p[i].ch.red, palette_p[i].ch.green, palette_p[i].ch.blue);
         }
         return NULL;
 #else

--- a/lv_draw/lv_draw_label.c
+++ b/lv_draw/lv_draw_label.c
@@ -161,7 +161,7 @@ void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, const lv_st
                             r = (hex_char_to_num(buf[0]) << 4) + hex_char_to_num(buf[1]);
                             g = (hex_char_to_num(buf[2]) << 4) + hex_char_to_num(buf[3]);
                             b = (hex_char_to_num(buf[4]) << 4) + hex_char_to_num(buf[5]);
-                            recolor = LV_COLOR_MAKE(r, g, b);
+                            recolor = lv_color_make(r, g, b);
                         } else {
                             recolor.full = style->text.color.full;
                         }

--- a/lv_misc/lv_color.c
+++ b/lv_misc/lv_color.c
@@ -57,7 +57,7 @@ lv_color_t lv_color_hsv_to_rgb(uint16_t h, uint8_t s, uint8_t v)
         r = v;
         g = v;
         b = v;
-        return LV_COLOR_MAKE(v, v, v);
+        return lv_color_make(v, v, v);
     }
 
     region = h / 43;
@@ -100,7 +100,7 @@ lv_color_t lv_color_hsv_to_rgb(uint16_t h, uint8_t s, uint8_t v)
             break;
     }
 
-    lv_color_t result = LV_COLOR_MAKE(r, g, b);
+    lv_color_t result = lv_color_make(r, g, b);
     return result;
 }
 

--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -364,9 +364,7 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
     return (uint16_t) bright >> 3;
 }
 
-/* The most simple macro to create a color from R,G and B values
- * The order of bit field is different on Big-endian and Little-endian machines*/
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+/* The most simple macro to create a color from R,G and B values */
 #if LV_COLOR_DEPTH == 1
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){(b8 >> 7 | g8 >> 7 | r8 >> 7)})
 static inline lv_color_t lv_color_make(int r8, int g8, int b8){
@@ -378,9 +376,9 @@ static inline lv_color_t lv_color_make(int r8, int g8, int b8){
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8 >> 6, g8 >> 5, r8 >> 5}})
 static inline lv_color_t lv_color_make(uint8_t r8, int g8, int b8){
     lv_color_t color;
-    color.blue  = b8 >> 6;
-    color.green = g8 >> 5;
-    color.red   = r8 >> 5;
+    color.ch.blue  = b8 >> 6;
+    color.ch.green = g8 >> 5;
+    color.ch.red   = r8 >> 5;
     return color;
 }
 #elif LV_COLOR_DEPTH == 16
@@ -388,19 +386,19 @@ static inline lv_color_t lv_color_make(uint8_t r8, int g8, int b8){
 #    define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8 >> 3, g8 >> 2, r8 >> 3}})
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
     lv_color_t color;
-    color.blue  = (uint16_t)(b8 >> 3);
-    color.green = (uint16_t)(g8 >> 2);
-    color.red   = (uint16_t)(r8 >> 3);
+    color.ch.blue  = (uint16_t)(b8 >> 3);
+    color.ch.green = (uint16_t)(g8 >> 2);
+    color.ch.red   = (uint16_t)(r8 >> 3);
     return color;
 }
 #  else
 #    define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{g8 >> 5, r8 >> 3, b8 >> 3, (g8 >> 2) & 0x7}})
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
     lv_color_t color;
-    color.green_h   = (uint16_t)(g8 >> 5);
-    color.red       = (uint16_t)(r8 >> 3);
-    color.blue      = (uint16_t)(b8 >> 3);
-    color.green_l   = (uint16_t)((g8 >> 2) & 0x7);
+    color.ch.green_h   = (uint16_t)(g8 >> 5);
+    color.ch.red       = (uint16_t)(r8 >> 3);
+    color.ch.blue      = (uint16_t)(b8 >> 3);
+    color.ch.green_l   = (uint16_t)((g8 >> 2) & 0x7);
     return color;
 }
 #  endif
@@ -408,34 +406,13 @@ static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8, g8, r8, 0xff}})            /*Fix 0xff alpha*/
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
     lv_color_t color;
-    color.blue  = b8;
-    color.green = g8;
-    color.red   = r8;
-    color.alpha = 0xff;
+    color.ch.blue  = b8;
+    color.ch.green = g8;
+    color.ch.red   = r8;
+    color.ch.alpha = 0xff;
     return color;
 }
 #endif
-#else
-#if LV_COLOR_DEPTH == 1
-#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){(r8 >> 7 | g8 >> 7 | b8 >> 7)})
-#elif LV_COLOR_DEPTH == 8
-#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{r8 >> 6, g8 >> 5, b8 >> 5}})
-#elif LV_COLOR_DEPTH == 16
-#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{r8 >> 3, g8 >> 2, b8 >> 3}})
-#elif LV_COLOR_DEPTH == 32
-#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{0xff, r8, g8, b8}})            /*Fix 0xff alpha*/
-#endif
-#endif
-
-
-#define LV_COLOR_HEX(c) LV_COLOR_MAKE((uint8_t) ((uint32_t)((uint32_t)c >> 16) & 0xFF), \
-                                (uint8_t) ((uint32_t)((uint32_t)c >> 8) & 0xFF), \
-                                (uint8_t) ((uint32_t) c & 0xFF))
-
-/*Usage LV_COLOR_HEX3(0x16C) which means LV_COLOR_HEX(0x1166CC)*/
-#define LV_COLOR_HEX3(c) LV_COLOR_MAKE((uint8_t) (((c >> 4) & 0xF0) | ((c >> 8) & 0xF)),   \
-                                (uint8_t) ((uint32_t)(c & 0xF0)     | ((c & 0xF0) >> 4)), \
-                                (uint8_t) ((uint32_t)(c & 0xF)      | ((c & 0xF) << 4)))
 
 static inline lv_color_t lv_color_hex(uint32_t c) {
     return lv_color_make((uint8_t) ((c >> 16) & 0xFF),
@@ -448,7 +425,6 @@ static inline lv_color_t lv_color_hex3(uint32_t c) {
                          (uint8_t) ((c & 0xF0)        | ((c & 0xF0) >> 4)),
                          (uint8_t) ((c & 0xF)         | ((c & 0xF) << 4)));
 }
-
 
 /**
  * Convert a HSV color to RGB

--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -402,7 +402,15 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
                                 (uint8_t) ((uint32_t)(c & 0xF0)     | ((c & 0xF0) >> 4)), \
                                 (uint8_t) ((uint32_t)(c & 0xF)      | ((c & 0xF) << 4)))
 
+static inline lv_color_t lv_color_hex(uint32_t c){		
+    return LV_COLOR_HEX(c);		
+}		
 
+static inline lv_color_t lv_color_hex3(uint32_t c){		
+    return LV_COLOR_HEX3(c);		
+}
+
+ 
 /**
  * Convert a HSV color to RGB
  * @param h hue [0..359]

--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -402,14 +402,6 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
                                 (uint8_t) ((uint32_t)(c & 0xF0)     | ((c & 0xF0) >> 4)), \
                                 (uint8_t) ((uint32_t)(c & 0xF)      | ((c & 0xF) << 4)))
 
-static inline lv_color_t lv_color_hex(uint32_t c){
-    return LV_COLOR_HEX(c);
-}
-
-static inline lv_color_t lv_color_hex3(uint32_t c){
-    return LV_COLOR_HEX3(c);
-}
-
 
 /**
  * Convert a HSV color to RGB

--- a/lv_misc/lv_color.h
+++ b/lv_misc/lv_color.h
@@ -369,16 +369,51 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #if LV_COLOR_DEPTH == 1
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){(b8 >> 7 | g8 >> 7 | r8 >> 7)})
+static inline lv_color_t lv_color_make(int r8, int g8, int b8){
+    lv_color_t color;
+    color.full = (b8 >> 7 | g8 >> 7 | r8 >> 7);
+    return color;
+}
 #elif LV_COLOR_DEPTH == 8
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8 >> 6, g8 >> 5, r8 >> 5}})
+static inline lv_color_t lv_color_make(uint8_t r8, int g8, int b8){
+    lv_color_t color;
+    color.blue  = b8 >> 6;
+    color.green = g8 >> 5;
+    color.red   = r8 >> 5;
+    return color;
+}
 #elif LV_COLOR_DEPTH == 16
 #  if LV_COLOR_16_SWAP == 0
 #    define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8 >> 3, g8 >> 2, r8 >> 3}})
+static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
+    lv_color_t color;
+    color.blue  = (uint16_t)(b8 >> 3);
+    color.green = (uint16_t)(g8 >> 2);
+    color.red   = (uint16_t)(r8 >> 3);
+    return color;
+}
 #  else
 #    define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{g8 >> 5, r8 >> 3, b8 >> 3, (g8 >> 2) & 0x7}})
+static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
+    lv_color_t color;
+    color.green_h   = (uint16_t)(g8 >> 5);
+    color.red       = (uint16_t)(r8 >> 3);
+    color.blue      = (uint16_t)(b8 >> 3);
+    color.green_l   = (uint16_t)((g8 >> 2) & 0x7);
+    return color;
+}
 #  endif
 #elif LV_COLOR_DEPTH == 32
 #define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){{b8, g8, r8, 0xff}})            /*Fix 0xff alpha*/
+static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8){
+    lv_color_t color;
+    color.blue  = b8;
+    color.green = g8;
+    color.red   = r8;
+    color.alpha = 0xff;
+    return color;
+}
 #endif
 #else
 #if LV_COLOR_DEPTH == 1
@@ -402,15 +437,19 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
                                 (uint8_t) ((uint32_t)(c & 0xF0)     | ((c & 0xF0) >> 4)), \
                                 (uint8_t) ((uint32_t)(c & 0xF)      | ((c & 0xF) << 4)))
 
-static inline lv_color_t lv_color_hex(uint32_t c){		
-    return LV_COLOR_HEX(c);		
-}		
-
-static inline lv_color_t lv_color_hex3(uint32_t c){		
-    return LV_COLOR_HEX3(c);		
+static inline lv_color_t lv_color_hex(uint32_t c) {
+    return lv_color_make((uint8_t) ((c >> 16) & 0xFF),
+                         (uint8_t) ((c >> 8) & 0xFF),
+                         (uint8_t) (c & 0xFF));
 }
 
- 
+static inline lv_color_t lv_color_hex3(uint32_t c) {
+    return lv_color_make((uint8_t) (((c >> 4) & 0xF0) | ((c >> 8) & 0xF)),
+                         (uint8_t) ((c & 0xF0)        | ((c & 0xF0) >> 4)),
+                         (uint8_t) ((c & 0xF)         | ((c & 0xF) << 4)));
+}
+
+
 /**
  * Convert a HSV color to RGB
  * @param h hue [0..359]

--- a/lv_themes/lv_theme_alien.c
+++ b/lv_themes/lv_theme_alien.c
@@ -72,8 +72,8 @@ static void basic_init(void)
     def.body.opa = LV_OPA_COVER;
     def.glass = 0;
 
-    def.body.main_color = LV_COLOR_HEX3(0x222);
-    def.body.grad_color = LV_COLOR_HEX3(0x222);
+    def.body.main_color = lv_color_hex3(0x222);
+    def.body.grad_color = lv_color_hex3(0x222);
     def.body.radius = 0;
     def.body.padding.left = LV_DPI / 8;
     def.body.padding.right = LV_DPI / 8;
@@ -87,31 +87,31 @@ static void basic_init(void)
     def.body.shadow.width = 0;
     def.body.shadow.type = LV_SHADOW_FULL;
 
-    def.text.color = LV_COLOR_HEX3(0xDDD);
+    def.text.color = lv_color_hex3(0xDDD);
     def.text.font = _font;
     def.text.letter_space = 1;
     def.text.line_space = 2;
 
-    def.image.color = LV_COLOR_HEX3(0xDDD);
+    def.image.color = lv_color_hex3(0xDDD);
     def.image.intense = LV_OPA_TRANSP;
 
-    def.line.color = LV_COLOR_HEX3(0xDDD);
+    def.line.color = lv_color_hex3(0xDDD);
     def.line.width = 1;
 
     /*Background*/
     lv_style_copy(&bg, &def);
-    bg.body.main_color = LV_COLOR_HEX3(0x333);
-    bg.body.grad_color =  LV_COLOR_HEX3(0x333);
+    bg.body.main_color = lv_color_hex3(0x333);
+    bg.body.grad_color =  lv_color_hex3(0x333);
     bg.body.border.width = 2;
-    bg.body.border.color =  LV_COLOR_HEX3(0x666);
+    bg.body.border.color =  lv_color_hex3(0x666);
     bg.body.shadow.color = LV_COLOR_SILVER;
 
     /*Panel*/
     lv_style_copy(&panel, &def);
     panel.body.radius = LV_DPI / 10;
-    panel.body.main_color = LV_COLOR_HEX3(0x666);
-    panel.body.grad_color = LV_COLOR_HEX3(0x666);
-    panel.body.border.color = LV_COLOR_HEX3(0xccc);
+    panel.body.main_color = lv_color_hex3(0x666);
+    panel.body.grad_color = lv_color_hex3(0x666);
+    panel.body.border.color = lv_color_hex3(0xccc);
     panel.body.border.width = 2;
     panel.body.border.opa = LV_OPA_60;
     panel.text.color = lv_color_hsv_to_rgb(_hue, 8, 96);
@@ -341,8 +341,8 @@ static void sw_init(void)
     sw_bg.body.padding.right = -2 ;
     sw_bg.body.padding.top = -2 ;
     sw_bg.body.padding.bottom = -2 ;
-    sw_bg.body.main_color = LV_COLOR_HEX3(0x666);
-    sw_bg.body.grad_color = LV_COLOR_HEX3(0x999);
+    sw_bg.body.main_color = lv_color_hex3(0x666);
+    sw_bg.body.grad_color = lv_color_hex3(0x999);
     sw_bg.body.border.width = 2;
     sw_bg.body.border.opa = LV_OPA_50;
 
@@ -372,7 +372,7 @@ static void lmeter_init(void)
     lmeter_bg.body.grad_color = lv_color_hsv_to_rgb(_hue, 80, 80);
     lmeter_bg.body.padding.left = LV_DPI / 8;         /*Scale line length*/
     lmeter_bg.body.padding.right = LV_DPI / 8;         /*Scale line length*/
-    lmeter_bg.line.color = LV_COLOR_HEX3(0x222);
+    lmeter_bg.line.color = lv_color_hex3(0x222);
     lmeter_bg.line.width = 2;
 
     theme.style.lmeter = &lmeter_bg;
@@ -392,7 +392,7 @@ static void gauge_init(void)
     gauge_bg.body.padding.top = LV_DPI / 10;        /*Needle center size*/
     gauge_bg.body.padding.bottom = LV_DPI / 10;        /*Needle center size*/
     gauge_bg.body.padding.inner = LV_DPI / 12;      /*Label - scale distance*/
-    gauge_bg.body.border.color = LV_COLOR_HEX3(0x777);
+    gauge_bg.body.border.color = lv_color_hex3(0x777);
     gauge_bg.line.color = lv_color_hsv_to_rgb(_hue, 80, 75);
     gauge_bg.line.width = 2;
     gauge_bg.text.color = lv_color_hsv_to_rgb(_hue, 10, 90);
@@ -414,7 +414,7 @@ static void arc_init(void)
 
     /*For preloader*/
     arc.body.border.width = 2;
-    arc.body.border.color = LV_COLOR_HEX3(0x555);
+    arc.body.border.color = lv_color_hex3(0x555);
     arc.body.padding.left = 3;
     arc.body.padding.right = 3;
     arc.body.padding.top = 3;
@@ -698,8 +698,8 @@ static void roller_init(void)
     lv_style_copy(&roller_bg, &ddlist_bg);
     roller_bg.text.line_space = LV_DPI / 6;
     roller_bg.body.radius = LV_DPI / 20;
-    roller_bg.body.main_color = LV_COLOR_HEX3(0x222);
-    roller_bg.body.grad_color = LV_COLOR_HEX3(0x666);
+    roller_bg.body.main_color = lv_color_hex3(0x222);
+    roller_bg.body.grad_color = lv_color_hex3(0x666);
     roller_bg.body.border.opa = LV_OPA_30;
     roller_bg.text.opa = LV_OPA_70;
     roller_bg.text.color = lv_color_hsv_to_rgb(_hue, 20, 70);
@@ -721,8 +721,8 @@ static void tabview_init(void)
 #if LV_USE_TABVIEW != 0
     static lv_style_t tab_rel, tab_pr, tab_trel, tab_tpr, tab_indic;
     lv_style_copy(&tab_rel, &def);
-    tab_rel.body.main_color = LV_COLOR_HEX3(0x666);
-    tab_rel.body.grad_color = LV_COLOR_HEX3(0x666);
+    tab_rel.body.main_color = lv_color_hex3(0x666);
+    tab_rel.body.grad_color = lv_color_hex3(0x666);
     tab_rel.body.padding.left = 0;
     tab_rel.body.padding.right = 0;
     tab_rel.body.padding.top = LV_DPI / 6;
@@ -731,12 +731,12 @@ static void tabview_init(void)
     tab_rel.body.border.width = 1;
     tab_rel.body.border.color = LV_COLOR_SILVER;
     tab_rel.body.border.opa = LV_OPA_40;
-    tab_rel.text.color = LV_COLOR_HEX3(0xDDD);
+    tab_rel.text.color = lv_color_hex3(0xDDD);
     tab_rel.text.font = _font;
 
     lv_style_copy(&tab_pr, &tab_rel);
-    tab_pr.body.main_color = LV_COLOR_HEX3(0x444);
-    tab_pr.body.grad_color = LV_COLOR_HEX3(0x444);
+    tab_pr.body.main_color = lv_color_hex3(0x444);
+    tab_pr.body.grad_color = lv_color_hex3(0x444);
 
     lv_style_copy(&tab_trel, &def);
     tab_trel.body.opa = LV_OPA_TRANSP;

--- a/lv_themes/lv_theme_default.c
+++ b/lv_themes/lv_theme_default.c
@@ -61,7 +61,7 @@ static void basic_init(void)
 
     lv_style_copy(&plain_bordered, &lv_style_plain);
     plain_bordered.body.border.width = 2;
-    plain_bordered.body.border.color = LV_COLOR_HEX3(0xbbb);
+    plain_bordered.body.border.color = lv_color_hex3(0xbbb);
 
     theme.style.bg = &lv_style_plain;
     theme.style.panel = &lv_style_pretty;
@@ -87,9 +87,9 @@ static void label_init(void)
     lv_style_copy(&label_sec, &lv_style_plain);
     lv_style_copy(&label_hint, &lv_style_plain);
 
-    label_prim.text.color = LV_COLOR_HEX3(0x111);
-    label_sec.text.color = LV_COLOR_HEX3(0x888);
-    label_hint.text.color = LV_COLOR_HEX3(0xaaa);
+    label_prim.text.color = lv_color_hex3(0x111);
+    label_sec.text.color = lv_color_hex3(0x888);
+    label_hint.text.color = lv_color_hex3(0xaaa);
 
 
     theme.style.label.prim = &label_prim;
@@ -180,7 +180,7 @@ static void lmeter_init(void)
 #if LV_USE_LMETER != 0
 
     lv_style_copy(&lmeter, &lv_style_pretty_color);
-    lmeter.line.color = LV_COLOR_HEX3(0xddd);
+    lmeter.line.color = lv_color_hex3(0xddd);
     lmeter.line.width = 2;
     lmeter.body.main_color = lv_color_mix(lmeter.body.main_color, LV_COLOR_WHITE, LV_OPA_50);
     lmeter.body.grad_color = lv_color_mix(lmeter.body.grad_color, LV_COLOR_BLACK, LV_OPA_50);
@@ -196,9 +196,9 @@ static void gauge_init(void)
     lv_style_copy(&gauge, &lmeter);
     gauge.line.color = lmeter.body.grad_color;
     gauge.line.width = 2;
-    gauge.body.main_color = LV_COLOR_HEX3(0x888);
+    gauge.body.main_color = lv_color_hex3(0x888);
     gauge.body.grad_color = lmeter.body.main_color;
-    gauge.text.color = LV_COLOR_HEX3(0x888);
+    gauge.text.color = lv_color_hex3(0x888);
 
     theme.style.gauge = &gauge;
 #endif

--- a/lv_themes/lv_theme_material.c
+++ b/lv_themes/lv_theme_material.c
@@ -14,7 +14,7 @@
  *      DEFINES
  *********************/
 #define DEF_RADIUS           4
-#define DEF_SHADOW_COLOR     LV_COLOR_HEX3(0xaaa)
+#define DEF_SHADOW_COLOR     lv_color_hex3(0xaaa)
 
 /**********************
  *      TYPEDEFS
@@ -54,7 +54,7 @@ static void basic_init(void)
     def.body.radius = DEF_RADIUS;
 
     lv_style_copy(&bg, &def);
-    bg.body.main_color = LV_COLOR_HEX(0xf0f0f0);
+    bg.body.main_color = lv_color_hex(0xf0f0f0);
     bg.body.grad_color = bg.body.main_color;
     bg.body.radius = 0;
 
@@ -63,7 +63,7 @@ static void basic_init(void)
     panel.body.main_color = LV_COLOR_WHITE;
     panel.body.grad_color = LV_COLOR_WHITE;
     panel.body.border.width = 1;
-    panel.body.border.color = LV_COLOR_HEX3(0xbbb);
+    panel.body.border.color = lv_color_hex3(0xbbb);
     panel.body.border.opa = LV_OPA_COVER;
     panel.body.shadow.color = DEF_SHADOW_COLOR;
     panel.body.shadow.type = LV_SHADOW_BOTTOM;
@@ -73,8 +73,8 @@ static void basic_init(void)
     panel.body.padding.top = LV_DPI / 8;
     panel.body.padding.bottom = LV_DPI / 8;
     panel.body.padding.inner = LV_DPI / 12;
-    panel.text.color = LV_COLOR_HEX3(0x333);
-    panel.image.color = LV_COLOR_HEX3(0x333);
+    panel.text.color = lv_color_hex3(0x333);
+    panel.image.color = lv_color_hex3(0x333);
 
     lv_style_copy(&sb, &def);
     sb.body.main_color = LV_COLOR_BLACK;
@@ -134,7 +134,7 @@ static void btn_init(void)
     tgl_pr.body.shadow.width = 2;
 
     lv_style_copy(&ina, &rel);
-    ina.body.main_color = LV_COLOR_HEX3(0xccc);
+    ina.body.main_color = lv_color_hex3(0xccc);
     ina.body.grad_color = ina.body.main_color;
     ina.body.shadow.width = 0;
     ina.text.color = lv_color_hsv_to_rgb(_hue, 95, 5);
@@ -278,10 +278,10 @@ static void sw_init(void)
 
 
     lv_style_copy(&sw_knob_off, &sw_knob_on);
-    sw_knob_off.body.main_color = LV_COLOR_HEX(0xfafafa);
+    sw_knob_off.body.main_color = lv_color_hex(0xfafafa);
     sw_knob_off.body.grad_color = sw_knob_off.body.main_color;
     sw_knob_off.body.border.width = 1;
-    sw_knob_off.body.border.color = LV_COLOR_HEX3(0x999);
+    sw_knob_off.body.border.color = lv_color_hex3(0x999);
     sw_knob_off.body.border.opa = LV_OPA_COVER;
 
     theme.style.sw.bg = &sw_bg;
@@ -300,7 +300,7 @@ static void lmeter_init(void)
     lmeter.body.main_color = lv_color_hsv_to_rgb(_hue, 75, 90);
     lmeter.body.grad_color = lmeter.body.main_color;
     lmeter.body.padding.left = LV_DPI / 10;                       /*Scale line length*/
-    lmeter.line.color = LV_COLOR_HEX3(0x999);
+    lmeter.line.color = lv_color_hex3(0x999);
     lmeter.line.width = 2;
 
     theme.style.lmeter = &lmeter;
@@ -317,8 +317,8 @@ static void gauge_init(void)
     gauge.body.grad_color = gauge.body.main_color;
     gauge.body.padding.left = LV_DPI / 16;                       /*Scale line length*/
     gauge.body.padding.inner = LV_DPI / 8;
-    gauge.body.border.color = LV_COLOR_HEX3(0x999);
-    gauge.text.color = LV_COLOR_HEX3(0x333);
+    gauge.body.border.color = lv_color_hex3(0x999);
+    gauge.text.color = lv_color_hex3(0x333);
     gauge.line.width = 3;
     gauge.line.color = lv_color_hsv_to_rgb(_hue, 95, 70);
 
@@ -412,7 +412,7 @@ static void cb_init(void)
     rel.body.shadow.width = 3;
 
     lv_style_copy(&pr, &rel);
-    pr.body.main_color = LV_COLOR_HEX3(0xccc);
+    pr.body.main_color = lv_color_hex3(0xccc);
     pr.body.grad_color = pr.body.main_color;
     pr.body.shadow.width = 0;
 
@@ -450,18 +450,18 @@ static void btnm_init(void)
     bg.body.padding.top = 0;
     bg.body.padding.bottom = 0;
     bg.body.padding.inner = 0;
-    bg.text.color = LV_COLOR_HEX3(0x555);
+    bg.text.color = lv_color_hex3(0x555);
 
     lv_style_copy(&rel, theme.style.panel);
     rel.body.border.part = LV_BORDER_FULL | LV_BORDER_INTERNAL;
     rel.body.border.width = 1;
-    rel.body.border.color = LV_COLOR_HEX3(0xbbb);
+    rel.body.border.color = lv_color_hex3(0xbbb);
     rel.body.opa = LV_OPA_TRANSP;
     rel.body.shadow.width = 0;
 
     lv_style_copy(&pr, &rel);
     pr.glass = 0;
-    pr.body.main_color = LV_COLOR_HEX3(0xddd);
+    pr.body.main_color = lv_color_hex3(0xddd);
     pr.body.grad_color = pr.body.main_color;
     pr.body.border.width = 0;
     pr.body.opa = LV_OPA_COVER;
@@ -478,7 +478,7 @@ static void btnm_init(void)
     tgl_pr.body.border.width = 0;
 
     lv_style_copy(&ina, &pr);
-    ina.body.main_color = LV_COLOR_HEX3(0xccc);
+    ina.body.main_color = lv_color_hex3(0xccc);
     ina.body.grad_color = ina.body.main_color;
 
     theme.style.btnm.bg = &bg;
@@ -549,9 +549,9 @@ static void ta_init(void)
     oneline.body.radius = 0;
     oneline.body.border.part = LV_BORDER_BOTTOM;
     oneline.body.border.width = 3;
-    oneline.body.border.color = LV_COLOR_HEX3(0x333);
+    oneline.body.border.color = lv_color_hex3(0x333);
     oneline.body.border.opa = LV_OPA_COVER;
-    oneline.text.color = LV_COLOR_HEX3(0x333);
+    oneline.text.color = lv_color_hex3(0x333);
 
     theme.style.ta.area = theme.style.panel;
     theme.style.ta.oneline = &oneline;
@@ -588,13 +588,13 @@ static void list_init(void)
     rel.body.padding.top = LV_DPI / 6;
     rel.body.padding.bottom = LV_DPI / 6;
     rel.body.radius = 10;
-    rel.body.border.color = LV_COLOR_HEX3(0xbbb);
+    rel.body.border.color = lv_color_hex3(0xbbb);
     rel.body.border.width = 1;
     rel.body.border.part = LV_BORDER_BOTTOM;
 
     lv_style_copy(&pr, &rel);
     pr.glass = 0;
-    pr.body.main_color = LV_COLOR_HEX3(0xddd);
+    pr.body.main_color = lv_color_hex3(0xddd);
     pr.body.grad_color = pr.body.main_color;
     pr.body.border.width = 0;
     pr.body.opa = LV_OPA_COVER;
@@ -613,7 +613,7 @@ static void list_init(void)
     tgl_pr.body.border.width = 0;
 
     lv_style_copy(&ina, &pr);
-    ina.body.main_color = LV_COLOR_HEX3(0xccc);
+    ina.body.main_color = lv_color_hex3(0xccc);
     ina.body.grad_color = ina.body.main_color;
 
 
@@ -689,11 +689,11 @@ static void tabview_init(void)
     indic.body.padding.inner = LV_DPI / 20;
 
     lv_style_copy(&btn_bg, &def);
-    btn_bg.body.main_color = LV_COLOR_HEX3(0xccc);
+    btn_bg.body.main_color = lv_color_hex3(0xccc);
     btn_bg.body.grad_color = btn_bg.body.main_color;
     btn_bg.body.radius = 0;
     btn_bg.body.border.width = 1;
-    btn_bg.body.border.color = LV_COLOR_HEX3(0x888);
+    btn_bg.body.border.color = lv_color_hex3(0x888);
     btn_bg.body.border.part = LV_BORDER_BOTTOM;
     btn_bg.body.border.opa = LV_OPA_COVER;
     btn_bg.body.shadow.width = 5;
@@ -704,7 +704,7 @@ static void tabview_init(void)
     btn_bg.body.padding.right = 0;
     btn_bg.body.padding.top = 0;
     btn_bg.body.padding.bottom = 0;
-    btn_bg.text.color = LV_COLOR_HEX3(0x333);
+    btn_bg.text.color = lv_color_hex3(0x333);
 
 
     lv_style_copy(&rel, &lv_style_transp);
@@ -713,16 +713,16 @@ static void tabview_init(void)
     rel.text.font = _font;
 
     lv_style_copy(&pr, &def);
-    pr.body.main_color = LV_COLOR_HEX3(0xbbb);
+    pr.body.main_color = lv_color_hex3(0xbbb);
     pr.body.grad_color = pr.body.main_color;
     pr.body.border.width = 0;
     pr.body.opa = LV_OPA_COVER;
     pr.body.radius = 0;
     pr.body.border.width = 1;
-    pr.body.border.color = LV_COLOR_HEX3(0x888);
+    pr.body.border.color = lv_color_hex3(0x888);
     pr.body.border.part = LV_BORDER_BOTTOM;
     pr.body.border.opa = LV_OPA_COVER;
-    pr.text.color = LV_COLOR_HEX3(0x111);
+    pr.text.color = lv_color_hex3(0x111);
 
     lv_style_copy(&tgl_rel, &lv_style_transp);
     tgl_rel.glass = 0;
@@ -780,11 +780,11 @@ static void win_init(void)
     static lv_style_t header, pr;
 
     lv_style_copy(&header, &def);
-    header.body.main_color = LV_COLOR_HEX3(0xccc);
+    header.body.main_color = lv_color_hex3(0xccc);
     header.body.grad_color = header.body.main_color;
     header.body.radius = 0;
     header.body.border.width = 1;
-    header.body.border.color = LV_COLOR_HEX3(0xbbb);
+    header.body.border.color = lv_color_hex3(0xbbb);
     header.body.border.part = LV_BORDER_BOTTOM;
     header.body.border.opa = LV_OPA_COVER;
     header.body.padding.inner = 0;
@@ -792,17 +792,17 @@ static void win_init(void)
     header.body.padding.right = 0;
     header.body.padding.top = 0;
     header.body.padding.bottom = 0;
-    header.text.color = LV_COLOR_HEX3(0x333);
-    header.image.color = LV_COLOR_HEX3(0x333);
+    header.text.color = lv_color_hex3(0x333);
+    header.image.color = lv_color_hex3(0x333);
 
     lv_style_copy(&pr, &def);
-    pr.body.main_color = LV_COLOR_HEX3(0xbbb);
+    pr.body.main_color = lv_color_hex3(0xbbb);
     pr.body.grad_color = pr.body.main_color;
     pr.body.border.width = 0;
     pr.body.opa = LV_OPA_COVER;
     pr.body.radius = 0;
-    pr.text.color = LV_COLOR_HEX3(0x111);
-    pr.image.color = LV_COLOR_HEX3(0x111);
+    pr.text.color = lv_color_hex3(0x111);
+    pr.image.color = lv_color_hex3(0x111);
 
 
     theme.style.win.bg = theme.style.panel;

--- a/lv_themes/lv_theme_nemo.c
+++ b/lv_themes/lv_theme_nemo.c
@@ -75,8 +75,8 @@ static void basic_init(void)
     def.body.opa = LV_OPA_COVER;
     def.glass = 0;
 
-    def.body.main_color = LV_COLOR_HEX3(0x222);
-    def.body.grad_color = LV_COLOR_HEX3(0x222);
+    def.body.main_color = lv_color_hex3(0x222);
+    def.body.grad_color = lv_color_hex3(0x222);
     def.body.radius = 0;
     def.body.padding.left = LV_DPI / 8;
     def.body.padding.right = LV_DPI / 8;
@@ -90,31 +90,31 @@ static void basic_init(void)
     def.body.shadow.width = 0;
     def.body.shadow.type = LV_SHADOW_FULL;
 
-    def.text.color = LV_COLOR_HEX3(0xDDD);
+    def.text.color = lv_color_hex3(0xDDD);
     def.text.font = _font;
     def.text.letter_space = 1;
     def.text.line_space = 2;
 
-    def.image.color = LV_COLOR_HEX3(0xDDD);
+    def.image.color = lv_color_hex3(0xDDD);
     def.image.intense = LV_OPA_TRANSP;
 
-    def.line.color = LV_COLOR_HEX3(0xDDD);
+    def.line.color = lv_color_hex3(0xDDD);
     def.line.width = 1;
 
     /*Background*/
     lv_style_copy(&bg, &def);
-    bg.body.main_color = LV_COLOR_HEX3(0x005);
-    bg.body.grad_color =  LV_COLOR_HEX3(0x045);
+    bg.body.main_color = lv_color_hex3(0x005);
+    bg.body.grad_color =  lv_color_hex3(0x045);
     bg.body.border.width = 2;
-    bg.body.border.color =  LV_COLOR_HEX3(0x666);
+    bg.body.border.color =  lv_color_hex3(0x666);
     bg.body.shadow.color = LV_COLOR_SILVER;
 
     /*Panel*/
     lv_style_copy(&panel, &def);
     panel.body.radius = LV_DPI / 10;
-    panel.body.main_color = LV_COLOR_HEX3(0x500);
-    panel.body.grad_color = LV_COLOR_HEX3(0x505);
-    panel.body.border.color = LV_COLOR_HEX3(0xccc);
+    panel.body.main_color = lv_color_hex3(0x500);
+    panel.body.grad_color = lv_color_hex3(0x505);
+    panel.body.border.color = lv_color_hex3(0xccc);
     panel.body.border.width = 2;
     panel.body.border.opa = LV_OPA_60;
     panel.text.color = lv_color_hsv_to_rgb(_hue, 8, 96);
@@ -332,8 +332,8 @@ static void sw_init(void)
     sw_bg.body.padding.right = -2 ;
     sw_bg.body.padding.top = -2 ;
     sw_bg.body.padding.bottom = -2 ;
-    sw_bg.body.main_color = LV_COLOR_HEX3(0x666);
-    sw_bg.body.grad_color = LV_COLOR_HEX3(0x999);
+    sw_bg.body.main_color = lv_color_hex3(0x666);
+    sw_bg.body.grad_color = lv_color_hex3(0x999);
     sw_bg.body.border.width = 2;
     sw_bg.body.border.opa = LV_OPA_50;
 
@@ -362,7 +362,7 @@ static void lmeter_init(void)
     lmeter_bg.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 70);
     lmeter_bg.body.grad_color = lv_color_hsv_to_rgb(_hue, 80, 80);
     lmeter_bg.body.padding.left = LV_DPI / 8;         /*Scale line length*/
-    lmeter_bg.line.color = LV_COLOR_HEX3(0x500);
+    lmeter_bg.line.color = lv_color_hex3(0x500);
     lmeter_bg.line.width = 2;
 
     theme.style.lmeter = &lmeter_bg;
@@ -382,7 +382,7 @@ static void gauge_init(void)
     gauge_bg.body.padding.top = LV_DPI / 20;        /*Needle center size*/
     gauge_bg.body.padding.bottom = LV_DPI / 20;        /*Needle center size*/
     gauge_bg.body.padding.inner = LV_DPI / 12;      /*Label - scale distance*/
-    gauge_bg.body.border.color = LV_COLOR_HEX3(0x500);
+    gauge_bg.body.border.color = lv_color_hex3(0x500);
     gauge_bg.line.color = lv_color_hsv_to_rgb(_hue, 80, 75);
     gauge_bg.line.width = 2;
     gauge_bg.text.color = lv_color_hsv_to_rgb(_hue, 10, 90);
@@ -676,8 +676,8 @@ static void roller_init(void)
     lv_style_copy(&roller_bg, &ddlist_bg);
     roller_bg.text.line_space = LV_DPI / 6;
     roller_bg.body.radius = LV_DPI / 20;
-    roller_bg.body.main_color = LV_COLOR_HEX3(0x500);
-    roller_bg.body.grad_color = LV_COLOR_HEX3(0x005);
+    roller_bg.body.main_color = lv_color_hex3(0x500);
+    roller_bg.body.grad_color = lv_color_hex3(0x005);
     roller_bg.body.border.opa = LV_OPA_30;
     roller_bg.text.opa = LV_OPA_70;
     roller_bg.text.color = lv_color_hsv_to_rgb(_hue, 20, 70);
@@ -699,8 +699,8 @@ static void tabview_init(void)
 #if LV_USE_TABVIEW != 0
     static lv_style_t tab_rel, tab_pr, tab_trel, tab_tpr, tab_indic;
     lv_style_copy(&tab_rel, &def);
-    tab_rel.body.main_color = LV_COLOR_HEX3(0x500);
-    tab_rel.body.grad_color = LV_COLOR_HEX3(0x005);
+    tab_rel.body.main_color = lv_color_hex3(0x500);
+    tab_rel.body.grad_color = lv_color_hex3(0x005);
     tab_rel.body.padding.left = 0;
     tab_rel.body.padding.right = 0;
     tab_rel.body.padding.top = LV_DPI / 6;
@@ -709,12 +709,12 @@ static void tabview_init(void)
     tab_rel.body.border.width = 1;
     tab_rel.body.border.color = LV_COLOR_SILVER;
     tab_rel.body.border.opa = LV_OPA_40;
-    tab_rel.text.color = LV_COLOR_HEX3(0xDDD);
+    tab_rel.text.color = lv_color_hex3(0xDDD);
     tab_rel.text.font = _font;
 
     lv_style_copy(&tab_pr, &tab_rel);
-    tab_pr.body.main_color = LV_COLOR_HEX3(0x005);
-    tab_pr.body.grad_color = LV_COLOR_HEX3(0x500);
+    tab_pr.body.main_color = lv_color_hex3(0x005);
+    tab_pr.body.grad_color = lv_color_hex3(0x500);
 
     lv_style_copy(&tab_trel, &def);
     tab_trel.body.opa = LV_OPA_TRANSP;

--- a/lv_themes/lv_theme_night.c
+++ b/lv_themes/lv_theme_night.c
@@ -105,7 +105,7 @@ static void btn_init(void)
     lv_style_copy(&btn_rel, &def);
     btn_rel.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 40);
     btn_rel.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 20);
-    btn_rel.body.border.color = LV_COLOR_HEX3(0x111);
+    btn_rel.body.border.color = lv_color_hex3(0x111);
     btn_rel.body.border.width = 1;
     btn_rel.body.border.opa = LV_OPA_70;
     btn_rel.body.padding.left = LV_DPI / 4;
@@ -113,10 +113,10 @@ static void btn_init(void)
     btn_rel.body.padding.top = LV_DPI / 8;
     btn_rel.body.padding.bottom = LV_DPI / 8;
     btn_rel.body.shadow.type = LV_SHADOW_BOTTOM;
-    btn_rel.body.shadow.color = LV_COLOR_HEX3(0x111);
+    btn_rel.body.shadow.color = lv_color_hex3(0x111);
     btn_rel.body.shadow.width = LV_DPI / 30;
-    btn_rel.text.color = LV_COLOR_HEX3(0xeee);
-    btn_rel.image.color  = LV_COLOR_HEX3(0xeee);
+    btn_rel.text.color = lv_color_hex3(0xeee);
+    btn_rel.image.color  = lv_color_hex3(0xeee);
 
     lv_style_copy(&btn_pr, &btn_rel);
     btn_pr.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 30);
@@ -126,22 +126,22 @@ static void btn_init(void)
     btn_tgl_rel.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 20);
     btn_tgl_rel.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 40);
     btn_tgl_rel.body.shadow.width = LV_DPI / 40;
-    btn_tgl_rel.text.color = LV_COLOR_HEX3(0xddd);
-    btn_tgl_rel.image.color = LV_COLOR_HEX3(0xddd);
+    btn_tgl_rel.text.color = lv_color_hex3(0xddd);
+    btn_tgl_rel.image.color = lv_color_hex3(0xddd);
 
     lv_style_copy(&btn_tgl_pr, &btn_rel);
     btn_tgl_pr.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 10);
     btn_tgl_pr.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 30);
     btn_tgl_pr.body.shadow.width = LV_DPI / 30;
-    btn_tgl_pr.text.color = LV_COLOR_HEX3(0xddd);
-    btn_tgl_pr.image.color = LV_COLOR_HEX3(0xddd);
+    btn_tgl_pr.text.color = lv_color_hex3(0xddd);
+    btn_tgl_pr.image.color = lv_color_hex3(0xddd);
 
     lv_style_copy(&btn_ina, &btn_rel);
     btn_ina.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 20);
     btn_ina.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 20);
     btn_ina.body.shadow.width = 0;
-    btn_ina.text.color = LV_COLOR_HEX3(0xaaa);
-    btn_ina.image.color = LV_COLOR_HEX3(0xaaa);
+    btn_ina.text.color = lv_color_hex3(0xaaa);
+    btn_ina.image.color = lv_color_hex3(0xaaa);
 
     theme.style.btn.rel = &btn_rel;
     theme.style.btn.pr = &btn_pr;
@@ -269,10 +269,10 @@ static void lmeter_init(void)
     lmeter_bg.body.grad_color = lv_color_hsv_to_rgb(_hue, 95, 90);
     lmeter_bg.body.padding.left = LV_DPI / 10;           /*Scale line length*/
     lmeter_bg.body.padding.inner = LV_DPI / 10;         /*Text padding*/
-    lmeter_bg.body.border.color = LV_COLOR_HEX3(0x333);
-    lmeter_bg.line.color = LV_COLOR_HEX3(0x555);
+    lmeter_bg.body.border.color = lv_color_hex3(0x333);
+    lmeter_bg.line.color = lv_color_hex3(0x555);
     lmeter_bg.line.width = 1;
-    lmeter_bg.text.color = LV_COLOR_HEX3(0xddd);
+    lmeter_bg.text.color = lv_color_hex3(0xddd);
 
     theme.style.lmeter = &lmeter_bg;
 #endif
@@ -287,7 +287,7 @@ static void gauge_init(void)
     gauge_bg.body.grad_color = gauge_bg.body.main_color;
     gauge_bg.line.color = lv_color_hsv_to_rgb(_hue, 80, 75);
     gauge_bg.line.width = 1;
-    gauge_bg.text.color = LV_COLOR_HEX3(0xddd);
+    gauge_bg.text.color = lv_color_hex3(0xddd);
 
     theme.style.gauge = &gauge_bg;
 #endif
@@ -337,7 +337,7 @@ static void calendar_init(void)
     lv_style_copy(&cal_bg, &bg);
     cal_bg.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 40);
     cal_bg.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 40);
-    cal_bg.body.border.color = LV_COLOR_HEX3(0x333);
+    cal_bg.body.border.color = lv_color_hex3(0x333);
     cal_bg.body.border.width = 1;
     cal_bg.body.radius = LV_DPI / 20;
     cal_bg.body.padding.left = LV_DPI / 10;
@@ -351,7 +351,7 @@ static void calendar_init(void)
     cal_header.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 20);
     cal_header.body.radius = 0;
     cal_header.body.border.width = 1;
-    cal_header.body.border.color = LV_COLOR_HEX3(0x333);
+    cal_header.body.border.color = lv_color_hex3(0x333);
     cal_header.body.padding.left = LV_DPI / 10;
     cal_header.body.padding.right = LV_DPI / 10;
     cal_header.body.padding.top = LV_DPI / 10;
@@ -427,8 +427,8 @@ static void cb_init(void)
     tgl_pr.body.border.width = 1;;
 
     lv_style_copy(&ina, &rel);
-    ina.body.main_color = LV_COLOR_HEX3(0x777);
-    ina.body.grad_color = LV_COLOR_HEX3(0x777);
+    ina.body.main_color = lv_color_hex3(0x777);
+    ina.body.grad_color = lv_color_hex3(0x777);
     ina.body.border.width = 0;
 
     theme.style.cb.bg = &lv_style_transp;
@@ -511,7 +511,7 @@ static void mbox_init(void)
     mbox_bg.body.border.color =  lv_color_hsv_to_rgb(_hue, 11, 20);
     mbox_bg.body.border.width = 1;
     mbox_bg.body.shadow.width = LV_DPI / 10;
-    mbox_bg.body.shadow.color = LV_COLOR_HEX3(0x222);
+    mbox_bg.body.shadow.color = lv_color_hex3(0x222);
     mbox_bg.body.radius = LV_DPI / 20;
     theme.style.mbox.bg = &mbox_bg;
     theme.style.mbox.btn.bg = &lv_style_transp;
@@ -528,7 +528,7 @@ static void page_init(void)
     lv_style_copy(&page_scrl, &bg);
     page_scrl.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 40);
     page_scrl.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 40);
-    page_scrl.body.border.color = LV_COLOR_HEX3(0x333);
+    page_scrl.body.border.color = lv_color_hex3(0x333);
     page_scrl.body.border.width = 1;
     page_scrl.body.radius = LV_DPI / 20;
 
@@ -697,7 +697,7 @@ static void win_init(void)
 #if LV_USE_WIN != 0
     static lv_style_t win_bg;
     lv_style_copy(&win_bg, &bg);
-    win_bg.body.border.color = LV_COLOR_HEX3(0x333);
+    win_bg.body.border.color = lv_color_hex3(0x333);
     win_bg.body.border.width = 1;
 
     static lv_style_t win_header;
@@ -714,8 +714,8 @@ static void win_init(void)
     lv_style_copy(&win_btn_pr, &def);
     win_btn_pr.body.main_color = lv_color_hsv_to_rgb(_hue, 10, 10);
     win_btn_pr.body.grad_color = lv_color_hsv_to_rgb(_hue, 10, 10);
-    win_btn_pr.text.color = LV_COLOR_HEX3(0xaaa);
-    win_btn_pr.image.color = LV_COLOR_HEX3(0xaaa);
+    win_btn_pr.text.color = lv_color_hex3(0xaaa);
+    win_btn_pr.image.color = lv_color_hex3(0xaaa);
 
     theme.style.win.bg = &win_bg;
     theme.style.win.sb = &sb;

--- a/lv_themes/lv_theme_zen.c
+++ b/lv_themes/lv_theme_zen.c
@@ -51,8 +51,8 @@ static void basic_init(void)
     lv_style_copy(&def, &lv_style_pretty);  /*Initialize the default style*/
     def.body.border.opa = LV_OPA_COVER;
     def.text.font = _font;
-    def.text.color = LV_COLOR_HEX3(0x444);
-    def.image.color = LV_COLOR_HEX3(0x444);
+    def.text.color = lv_color_hex3(0x444);
+    def.image.color = lv_color_hex3(0x444);
 
     lv_style_copy(&bg, &def);
     bg.body.main_color = LV_COLOR_WHITE;
@@ -67,7 +67,7 @@ static void basic_init(void)
     panel.body.border.color = lv_color_hsv_to_rgb(_hue, 30, 90);
     panel.body.border.opa = LV_OPA_COVER;
     panel.body.shadow.width = 4;
-    panel.body.shadow.color = LV_COLOR_HEX3(0xddd);
+    panel.body.shadow.color = lv_color_hex3(0xddd);
     panel.body.padding.left = LV_DPI / 6;
     panel.body.padding.right = LV_DPI / 6;
     panel.body.padding.top = LV_DPI / 8;
@@ -105,7 +105,7 @@ static void btn_init(void)
     rel.body.border.color = lv_color_hsv_to_rgb(_hue, 40, 90);
     rel.body.border.opa = LV_OPA_COVER;
     rel.body.shadow.width = 4;
-    rel.body.shadow.color = LV_COLOR_HEX3(0xddd);
+    rel.body.shadow.color = lv_color_hex3(0xddd);
     rel.body.padding.left = LV_DPI / 4;
     rel.body.padding.right = LV_DPI / 4;
     rel.body.padding.top = LV_DPI / 8;
@@ -125,9 +125,9 @@ static void btn_init(void)
     tgl_pr.image.color = lv_color_hsv_to_rgb(_hue, 40, 50);
 
     lv_style_copy(&ina, &tgl_pr);
-    ina.body.border.color = LV_COLOR_HEX3(0xbbb);
-    ina.text.color = LV_COLOR_HEX3(0xbbb);
-    ina.image.color = LV_COLOR_HEX3(0xbbb);
+    ina.body.border.color = lv_color_hex3(0xbbb);
+    ina.text.color = lv_color_hex3(0xbbb);
+    ina.image.color = lv_color_hex3(0xbbb);
 
     theme.style.btn.rel = &rel;
     theme.style.btn.pr = &pr;
@@ -145,7 +145,7 @@ static void label_init(void)
     lv_style_copy(&sec, &def);
     lv_style_copy(&hint, &def);
 
-    prim.text.color = LV_COLOR_HEX3(0x555);
+    prim.text.color = lv_color_hex3(0x555);
     sec.text.color = lv_color_hsv_to_rgb(_hue, 50, 80);
     hint.text.color = lv_color_hsv_to_rgb(_hue, 25, 85);
 
@@ -276,7 +276,7 @@ static void lmeter_init(void)
     static lv_style_t lmeter;
 
     lv_style_copy(&lmeter, &def);
-    lmeter.line.color = LV_COLOR_HEX3(0xddd);
+    lmeter.line.color = lv_color_hex3(0xddd);
     lmeter.line.width = 2;
     lmeter.body.main_color = lv_color_hsv_to_rgb(_hue, 80, 70);
     lmeter.body.grad_color = lmeter.body.main_color;
@@ -295,11 +295,11 @@ static void gauge_init(void)
     lv_style_copy(&gauge, &def);
     gauge.line.color = lv_color_hsv_to_rgb(_hue, 50, 70);
     gauge.line.width = 1;
-    gauge.body.main_color = LV_COLOR_HEX3(0x999);
+    gauge.body.main_color = lv_color_hex3(0x999);
     gauge.body.grad_color = gauge.body.main_color;
     gauge.body.padding.left = LV_DPI / 16;
     gauge.body.padding.right = LV_DPI / 16;
-    gauge.body.border.color = LV_COLOR_HEX3(0x666);     /*Needle middle color*/
+    gauge.body.border.color = lv_color_hex3(0x666);     /*Needle middle color*/
 
     theme.style.gauge = &gauge;
 #endif
@@ -375,7 +375,7 @@ static void cb_init(void)
     rel.body.border.width = 3;
     rel.body.border.opa = LV_OPA_COVER;
     rel.body.border.color = lv_color_hsv_to_rgb(_hue, 35, 80);
-    rel.body.main_color = LV_COLOR_HEX3(0xfff);
+    rel.body.main_color = lv_color_hex3(0xfff);
     rel.body.grad_color = rel.body.main_color;
 
 
@@ -395,7 +395,7 @@ static void cb_init(void)
 
 
     lv_style_copy(&ina, &rel);
-    ina.body.border.color = LV_COLOR_HEX3(0xaaa);
+    ina.body.border.color = lv_color_hex3(0xaaa);
 
 
     theme.style.cb.bg = &lv_style_transp;
@@ -446,9 +446,9 @@ static void btnm_init(void)
     tgl_pr.body.grad_color = tgl_pr.body.main_color;
 
     lv_style_copy(&ina, &pr);
-    ina.body.main_color = LV_COLOR_HEX3(0x888);
+    ina.body.main_color = lv_color_hex3(0x888);
     ina.body.grad_color = tgl_pr.body.main_color;
-    ina.text.color = LV_COLOR_HEX3(0x888);;
+    ina.text.color = lv_color_hex3(0x888);;
 
     theme.style.btnm.bg = &bg;
     theme.style.btnm.btn.rel = &rel;
@@ -464,7 +464,7 @@ static void kb_init(void)
 #if LV_USE_KB
     static lv_style_t bg, rel, pr, tgl_rel, tgl_pr, ina;
     lv_style_copy(&bg, &def);
-    bg.body.main_color = LV_COLOR_HEX3(0x666);
+    bg.body.main_color = lv_color_hex3(0x666);
     bg.body.grad_color = bg.body.main_color;
     bg.body.padding.left = 0;
     bg.body.padding.right = 0;
@@ -478,34 +478,34 @@ static void kb_init(void)
     rel.body.opa = LV_OPA_COVER;
     rel.body.radius = 0;
     rel.body.border.width = 1;
-    rel.body.border.color = LV_COLOR_HEX3(0x888);
+    rel.body.border.color = lv_color_hex3(0x888);
     rel.body.border.opa = LV_OPA_COVER;
     rel.text.color = LV_COLOR_WHITE;
 
     lv_style_copy(&pr, &def);
-    pr.body.main_color = LV_COLOR_HEX3(0xeee);
+    pr.body.main_color = lv_color_hex3(0xeee);
     pr.body.grad_color = pr.body.main_color;
-    pr.body.border.color = LV_COLOR_HEX3(0x888);
+    pr.body.border.color = lv_color_hex3(0x888);
     pr.body.border.width = 1;
     pr.body.border.opa = LV_OPA_COVER;
     pr.body.radius = 0;
-    pr.text.color = LV_COLOR_HEX3(0x666);
+    pr.text.color = lv_color_hex3(0x666);
 
     lv_style_copy(&tgl_rel, &pr);
-    tgl_rel.body.main_color = LV_COLOR_HEX3(0x999);
+    tgl_rel.body.main_color = lv_color_hex3(0x999);
     tgl_rel.body.grad_color = tgl_rel.body.main_color;
     tgl_rel.text.color = LV_COLOR_WHITE;
 
 
     lv_style_copy(&tgl_pr, &pr);
-    tgl_pr.body.main_color = LV_COLOR_HEX3(0xbbb);
+    tgl_pr.body.main_color = lv_color_hex3(0xbbb);
     tgl_pr.body.grad_color = tgl_pr.body.main_color;
-    tgl_pr.text.color = LV_COLOR_HEX3(0xddd);
+    tgl_pr.text.color = lv_color_hex3(0xddd);
 
     lv_style_copy(&ina, &pr);
-    ina.body.main_color = LV_COLOR_HEX3(0x777);
+    ina.body.main_color = lv_color_hex3(0x777);
     ina.body.grad_color = ina.body.main_color;
-    ina.text.color = LV_COLOR_HEX3(0xbbb);
+    ina.text.color = lv_color_hex3(0xbbb);
 
     theme.style.kb.bg = &bg;
     theme.style.kb.btn.rel = &rel;
@@ -608,8 +608,8 @@ static void list_init(void)
     rel.body.padding.right = LV_DPI / 8;
     rel.body.padding.top = LV_DPI / 8;
     rel.body.padding.bottom = LV_DPI / 8;
-    rel.text.color = LV_COLOR_HEX3(0x666);
-    rel.image.color = LV_COLOR_HEX3(0x666);
+    rel.text.color = lv_color_hex3(0x666);
+    rel.image.color = lv_color_hex3(0x666);
 
     lv_style_copy(&pr, &rel);
     pr.text.color = theme.style.btn.pr->text.color;
@@ -647,7 +647,7 @@ static void ddlist_init(void)
     bg.body.padding.right = LV_DPI / 6;
     bg.body.padding.top = LV_DPI / 8;
     bg.body.padding.bottom = LV_DPI / 8;
-    bg.text.color = LV_COLOR_HEX3(0x666);
+    bg.text.color = lv_color_hex3(0x666);
 
     lv_style_copy(&sel, &def);
     sel.body.opa = LV_OPA_TRANSP;
@@ -668,7 +668,7 @@ static void roller_init(void)
     bg.body.border.width = 0;
     bg.body.opa = LV_OPA_TRANSP;
     bg.text.line_space = LV_DPI / 6;
-    bg.text.color = LV_COLOR_HEX3(0x999);
+    bg.text.color = lv_color_hex3(0x999);
 
     lv_style_copy(&sel, theme.style.panel);
     sel.body.radius = LV_RADIUS_CIRCLE;
@@ -700,11 +700,11 @@ static void tabview_init(void)
     lv_style_copy(&rel, &def);
     rel.body.opa = LV_OPA_TRANSP;
     rel.body.border.width = 0;
-    rel.text.color = LV_COLOR_HEX3(0x999);
+    rel.text.color = lv_color_hex3(0x999);
 
 
     lv_style_copy(&pr, &rel);
-    pr.text.color = LV_COLOR_HEX3(0x777);
+    pr.text.color = lv_color_hex3(0x777);
 
     lv_style_copy(&tgl_rel, &rel);
     tgl_rel.text.color = lv_color_hsv_to_rgb(_hue, 50, 80);
@@ -759,18 +759,18 @@ static void win_init(void)
     header.body.border.width = 2;
     header.body.border.part = LV_BORDER_BOTTOM;
     header.body.border.color = lv_color_hsv_to_rgb(_hue, 10, 90);
-    header.text.color = LV_COLOR_HEX3(0x666);
-    header.image.color = LV_COLOR_HEX3(0x666);
+    header.text.color = lv_color_hex3(0x666);
+    header.image.color = lv_color_hex3(0x666);
 
     lv_style_copy(&rel, &def);
     rel.body.opa = LV_OPA_TRANSP;
     rel.body.border.width = 0;
-    rel.text.color =  LV_COLOR_HEX3(0x666);
-    rel.image.color =  LV_COLOR_HEX3(0x666);
+    rel.text.color =  lv_color_hex3(0x666);
+    rel.image.color =  lv_color_hex3(0x666);
 
     lv_style_copy(&pr, &rel);
-    pr.text.color = LV_COLOR_HEX3(0x333);
-    pr.image.color = LV_COLOR_HEX3(0x333);
+    pr.text.color = lv_color_hex3(0x333);
+    pr.image.color = lv_color_hex3(0x333);
 
     theme.style.win.bg = theme.style.panel;
     theme.style.win.sb = &sb;


### PR DESCRIPTION
## Error

Using the esp32_ili9431 example with a C++ compiler, I was getting __narrowing errors__. I saw this error was supposed to have been resolved in #817 but I was still getting __narrowing errors__ errors.

## Source of error

The errors came from the inline functions `lv_color_hex` and `lv_color_hex3` which don't seem to be used anywhere else in the project after being added in 652809d0059e57320c2b58102c47dbde3622d6b0. 

## Solution

Removing them makes the library compile.