### PR TITLE
Fix function name typo in btnm

### DIFF
--- a/src/lv_objx/lv_btnm.c
+++ b/src/lv_objx/lv_btnm.c
@@ -590,7 +590,7 @@ const char * lv_btnm_get_btn_text(const lv_obj_t * btnm, uint16_t btn_id)
  * @param btn_index the index a button not counting new line characters. (The return value of lv_btnm_get_pressed/released)
  * @return true: long press repeat is disabled; false: long press repeat enabled
  */
-bool lv_btnm_get_btn_no_repeate(lv_obj_t * btnm, uint16_t btn_id)
+bool lv_btnm_get_btn_no_repeat(lv_obj_t * btnm, uint16_t btn_id)
 {
     lv_btnm_ext_t * ext = lv_obj_get_ext_attr(btnm);
     return button_is_repeat_disabled(ext->ctrl_bits[btn_id]);

--- a/src/lv_objx/lv_btnm.h
+++ b/src/lv_objx/lv_btnm.h
@@ -264,7 +264,7 @@ const char * lv_btnm_get_btn_text(const lv_obj_t * btnm, uint16_t btn_id);
  * @param btn_index the index a button not counting new line characters. (The return value of lv_btnm_get_pressed/released)
  * @return true: long press repeat is disabled; false: long press repeat enabled
  */
-bool lv_btnm_get_btn_no_repeate(lv_obj_t * btnm, uint16_t btn_id);
+bool lv_btnm_get_btn_no_repeat(lv_obj_t * btnm, uint16_t btn_id);
 
 /**
  * Check whether a button for a button is hidden or not.


### PR DESCRIPTION
lv_btnm_get_btn_no_repeat**e** (complement to lv_btnm_set_btn_no_repeat)