### PR TITLE
Only start scrolling tabview horizontally if page is at edge

### DIFF
--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -6,6 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <stdio.h>
 #include "../lv_objx/lv_page.h"
 #if LV_USE_PAGE != 0
 
@@ -402,6 +403,10 @@ bool lv_page_on_edge(lv_obj_t *page, lv_page_edge_t edge) {
 	lv_obj_get_coords(scrl, &scrl_coords);
 	lv_obj_get_coords(page, &page_coords);
 
+	if(edge == LV_PAGE_EDGE_LEFT) {
+		printf("scrl_coords.x1 %d\n", scrl_coords.x1);
+		printf("page_coords.x1 + page_style->body.padding.left %d\n", page_coords.x1 + page_style->body.padding.left);
+	}
 	if(edge == LV_PAGE_EDGE_TOP && scrl_coords.y1 == page_coords.y1 + page_style->body.padding.top)
 		return true;
 	else if(edge == LV_PAGE_EDGE_BOTTOM && scrl_coords.y2 == page_coords.y2 - page_style->body.padding.bottom)

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -388,6 +388,33 @@ lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type)
  *====================*/
 
 /**
+ * Find whether the page has been scrolled to a certain edge.
+ * @param page Page object
+ * @param edge Edge to check
+ * @return true if the page is on the specified edge
+ */
+bool lv_page_on_edge(lv_obj_t *page, lv_page_edge_t edge) {
+	lv_style_t * page_style = lv_obj_get_style(page);
+	lv_obj_t * scrl = lv_page_get_scrl(page);
+	lv_area_t page_coords;
+	lv_area_t scrl_coords;
+
+	lv_obj_get_coords(scrl, &scrl_coords);
+	lv_obj_get_coords(page, &page_coords);
+
+	if(edge == LV_PAGE_EDGE_TOP && scrl_coords.y1 == page_coords.y1 + page_style->body.padding.top)
+		return true;
+	else if(edge == LV_PAGE_EDGE_BOTTOM && scrl_coords.y2 == page_coords.y2 - page_style->body.padding.bottom)
+		return true;
+	else if(edge == LV_PAGE_EDGE_LEFT && scrl_coords.x1 == page_coords.x1 + page_style->body.padding.left)
+		return true;
+	else if(edge == LV_PAGE_EDGE_RIGHT && scrl_coords.x2 == page_coords.x2 - page_style->body.padding.right)
+		return true;
+
+	return false;
+}
+
+/**
  * Glue the object to the page. After it the page can be moved (dragged) with this object too.
  * @param obj pointer to an object on a page
  * @param glue true: enable glue, false: disable glue

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -6,7 +6,6 @@
 /*********************
  *      INCLUDES
  *********************/
-#include <stdio.h>
 #include "../lv_objx/lv_page.h"
 #if LV_USE_PAGE != 0
 
@@ -403,10 +402,6 @@ bool lv_page_on_edge(lv_obj_t *page, lv_page_edge_t edge) {
 	lv_obj_get_coords(scrl, &scrl_coords);
 	lv_obj_get_coords(page, &page_coords);
 
-	if(edge == LV_PAGE_EDGE_LEFT) {
-		printf("scrl_coords.x1 %d\n", scrl_coords.x1);
-		printf("page_coords.x1 + page_style->body.padding.left %d\n", page_coords.x1 + page_style->body.padding.left);
-	}
 	if(edge == LV_PAGE_EDGE_TOP && scrl_coords.y1 == page_coords.y1 + page_style->body.padding.top)
 		return true;
 	else if(edge == LV_PAGE_EDGE_BOTTOM && scrl_coords.y2 == page_coords.y2 - page_style->body.padding.bottom)

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -944,7 +944,7 @@ static lv_res_t lv_page_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, voi
                 }
             }
             else if(scrl_coords.x1 > page_coords.x1 + page_style->body.padding.left) {
-                new_x = hpad;  /*Left align*/
+                new_x = page_style->body.padding.left;  /*Left align*/
                 refr_x = true;
                 if(page_ext->edge_flash.enabled &&
                         page_ext->edge_flash.left_ip == 0 && page_ext->edge_flash.right_ip == 0 &&
@@ -955,7 +955,7 @@ static lv_res_t lv_page_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, voi
             }
         }
 
-        /*scrollable height smaller then page height? -> align to left*/
+        /*scrollable height smaller then page height? -> align to top*/
         if(lv_area_get_height(&scrl_coords) + vpad <= lv_area_get_height(&page_coords)) {
             if(scrl_coords.y1 != page_coords.y1 + page_style->body.padding.top) {
                 new_y = page_style->body.padding.top;

--- a/src/lv_objx/lv_page.h
+++ b/src/lv_objx/lv_page.h
@@ -49,6 +49,17 @@ enum
 };
 typedef uint8_t lv_sb_mode_t;
 
+/*Edges: describes the four edges of the page*/
+
+enum
+{
+	LV_PAGE_EDGE_LEFT = 0x0,
+	LV_PAGE_EDGE_TOP = 0x1,
+	LV_PAGE_EDGE_RIGHT = 0x2,
+	LV_PAGE_EDGE_BOTTOM = 0x3
+};
+typedef uint8_t lv_page_edge_t;
+
 /*Data of page*/
 typedef struct
 {
@@ -348,6 +359,15 @@ lv_style_t * lv_page_get_style(const lv_obj_t *page, lv_page_style_t type);
 /*=====================
  * Other functions
  *====================*/
+
+
+/**
+ * Find whether the page has been scrolled to a certain edge.
+ * @param page Page object
+ * @param edge Edge to check
+ * @return true if the page is on the specified edge
+ */
+bool lv_page_on_edge(lv_obj_t *page, lv_page_edge_t edge);
 
 /**
  * Glue the object to the page. After it the page can be moved (dragged) with this object too.

--- a/src/lv_objx/lv_tabview.c
+++ b/src/lv_objx/lv_tabview.c
@@ -6,6 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <stdio.h>
 #include "lv_tabview.h"
 #if LV_USE_TABVIEW != 0
 
@@ -744,11 +745,13 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
 				ext->point_last.y = point_act.y;
 			}
 			ext->drag_hor = 1;
+			printf("Horizontal drag started\n");
 			lv_obj_set_drag(lv_page_get_scrl(tabpage), false);
 
 		} else if(ext->drag_hor == 0) {
 			ext->drag_hor = 0;
 		}
+		printf("%d %d\n", lv_page_on_edge(tabpage, LV_PAGE_EDGE_LEFT), lv_page_on_edge(tabpage, LV_PAGE_EDGE_RIGHT));
 	} else if(y_diff >= LV_INDEV_DRAG_LIMIT || y_diff <= -LV_INDEV_DRAG_LIMIT) {
 		ext->drag_hor = 0;
 		ext->draging = 1;

--- a/src/lv_objx/lv_tabview.c
+++ b/src/lv_objx/lv_tabview.c
@@ -6,7 +6,6 @@
 /*********************
  *      INCLUDES
  *********************/
-#include <stdio.h>
 #include "lv_tabview.h"
 #if LV_USE_TABVIEW != 0
 
@@ -745,13 +744,11 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
 				ext->point_last.y = point_act.y;
 			}
 			ext->drag_hor = 1;
-			printf("Horizontal drag started\n");
 			lv_obj_set_drag(lv_page_get_scrl(tabpage), false);
 
 		} else if(ext->drag_hor == 0) {
 			ext->drag_hor = 0;
 		}
-		printf("%d %d\n", lv_page_on_edge(tabpage, LV_PAGE_EDGE_LEFT), lv_page_on_edge(tabpage, LV_PAGE_EDGE_RIGHT));
 	} else if(y_diff >= LV_INDEV_DRAG_LIMIT || y_diff <= -LV_INDEV_DRAG_LIMIT) {
 		ext->drag_hor = 0;
 		ext->draging = 1;

--- a/src/lv_objx/lv_tabview.c
+++ b/src/lv_objx/lv_tabview.c
@@ -82,6 +82,7 @@ lv_obj_t * lv_tabview_create(lv_obj_t * par, const lv_obj_t * copy)
     /*Initialize the allocated 'ext' */
     ext->drag_hor = 0;
     ext->draging = 0;
+    ext->scroll_ver = 0;
     ext->slide_enable = 1;
     ext->tab_cur = 0;
     ext->point_last.x = 0;
@@ -734,7 +735,7 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
     lv_coord_t y_diff = point_act.y - ext->point_last.y;
 
 
-	if(x_diff >= LV_INDEV_DRAG_LIMIT || x_diff <= -LV_INDEV_DRAG_LIMIT) {
+	if(!ext->scroll_ver && (x_diff >= LV_INDEV_DRAG_LIMIT || x_diff <= -LV_INDEV_DRAG_LIMIT)) {
 		ext->draging = 1;
 		/*Check if the page is on the edge */
 		if((lv_page_on_edge(tabpage, LV_PAGE_EDGE_LEFT) && x_diff > 0) ||
@@ -752,6 +753,7 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
 	} else if(y_diff >= LV_INDEV_DRAG_LIMIT || y_diff <= -LV_INDEV_DRAG_LIMIT) {
 		ext->drag_hor = 0;
 		ext->draging = 1;
+		ext->scroll_ver = 1;
 	} else
 		ext->draging = 0;
 
@@ -780,6 +782,7 @@ static void tabpage_press_lost_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
     lv_tabview_ext_t * ext = lv_obj_get_ext_attr(tabview);
     ext->drag_hor = 0;
     ext->draging = 0;
+    ext->scroll_ver = 0;
 
     lv_obj_set_drag(lv_page_get_scrl(tabpage), true);
 

--- a/src/lv_objx/lv_tabview.c
+++ b/src/lv_objx/lv_tabview.c
@@ -733,16 +733,28 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
     lv_coord_t x_diff = point_act.x - ext->point_last.x;
     lv_coord_t y_diff = point_act.y - ext->point_last.y;
 
-    if(ext->draging == 0) {
-        if(x_diff >= LV_INDEV_DRAG_LIMIT || x_diff <= -LV_INDEV_DRAG_LIMIT) {
-            ext->drag_hor = 1;
-            ext->draging = 1;
-            lv_obj_set_drag(lv_page_get_scrl(tabpage), false);
-        } else if(y_diff >= LV_INDEV_DRAG_LIMIT || y_diff <= -LV_INDEV_DRAG_LIMIT) {
-            ext->drag_hor = 0;
-            ext->draging = 1;
-        }
-    }
+
+	if(x_diff >= LV_INDEV_DRAG_LIMIT || x_diff <= -LV_INDEV_DRAG_LIMIT) {
+		ext->draging = 1;
+		/*Check if the page is on the edge */
+		if((lv_page_on_edge(tabpage, LV_PAGE_EDGE_LEFT) && x_diff > 0) ||
+		   (lv_page_on_edge(tabpage, LV_PAGE_EDGE_RIGHT) && x_diff < 0)) {
+			if(ext->drag_hor == 0) {
+				ext->point_last.x = point_act.x;
+				ext->point_last.y = point_act.y;
+			}
+			ext->drag_hor = 1;
+			lv_obj_set_drag(lv_page_get_scrl(tabpage), false);
+
+		} else if(ext->drag_hor == 0) {
+			ext->drag_hor = 0;
+		}
+	} else if(y_diff >= LV_INDEV_DRAG_LIMIT || y_diff <= -LV_INDEV_DRAG_LIMIT) {
+		ext->drag_hor = 0;
+		ext->draging = 1;
+	} else
+		ext->draging = 0;
+
     if(ext->drag_hor) {
         lv_obj_set_x(ext->content, lv_obj_get_x(ext->content) + point_act.x - ext->point_last.x);
         ext->point_last.x = point_act.x;

--- a/src/lv_objx/lv_tabview.h
+++ b/src/lv_objx/lv_tabview.h
@@ -64,6 +64,7 @@ typedef struct
     uint8_t slide_enable :1;    /*1: enable horizontal sliding by touch pad*/
     uint8_t draging :1;
     uint8_t drag_hor :1;
+    uint8_t scroll_ver :1;
     uint8_t btns_hide :1;
     lv_tabview_btns_pos_t btns_pos :1;
 } lv_tabview_ext_t;


### PR DESCRIPTION
Implements change suggested by @kisvegabor in https://github.com/littlevgl/lvgl/issues/967#issuecomment-475805132.

Also introduces a new API named `lv_page_on_edge` that can be used to find out whether a page object has been scrolled to one of the four edges.