### PR TITLE
Make drop down list more aesthetic

### DIFF
--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -841,7 +841,6 @@ static void lv_ddlist_refr_size(lv_obj_t * ddlist, bool anim_en)
                 style->body.padding.top + style->body.padding.bottom;
         else new_height = ext->fix_height;
 
-        lv_page_set_sb_mode(ddlist, LV_SB_MODE_UNHIDE);
     } else { /*Close the list*/
         const lv_font_t * font = style->text.font;
         lv_style_t * label_style = lv_obj_get_style(ext->label);
@@ -854,6 +853,7 @@ static void lv_ddlist_refr_size(lv_obj_t * ddlist, bool anim_en)
     if(anim_en == 0) {
         lv_obj_set_height(ddlist, new_height);
         lv_ddlist_pos_current_option(ddlist);
+        if(ext->opened) lv_page_set_sb_mode(ddlist, LV_SB_MODE_UNHIDE);
 #if LV_USE_ANIMATION
         lv_anim_del(ddlist, (lv_anim_fp_t)lv_obj_set_height);  /*If an animation is in progress then it will overwrite this changes*/
     } else {
@@ -888,6 +888,8 @@ static void lv_ddlist_anim_cb(lv_obj_t * ddlist) {
 	lv_ddlist_pos_current_option(ddlist);
 
 	ext->force_sel = 0; /*Turn off drawing of selection*/
+
+    if(ext->opened) lv_page_set_sb_mode(ddlist, LV_SB_MODE_UNHIDE);
 }
 
 /**

--- a/src/lv_objx/lv_ddlist.h
+++ b/src/lv_objx/lv_ddlist.h
@@ -53,6 +53,7 @@ typedef struct
     uint16_t sel_opt_id_ori;             /*Store the original index on focus*/
     uint16_t anim_time;                  /*Open/Close animation time [ms]*/
     uint8_t opened :1;                   /*1: The list is opened (handled by the library)*/
+    uint8_t force_sel :1;				 /*1: Keep the selection highlight even if the list is closed*/
     uint8_t draw_arrow :1;               /*1: Draw arrow*/
     uint8_t stay_open :1;              /*1: Don't close the list when a new item is selected*/
     lv_coord_t fix_height;               /*Height of the ddlist when opened. (0: auto-size)*/


### PR DESCRIPTION
This does two things:

1. The selection rectangle remains drawn until the drop down list is fully closed. Before, it would disappear as soon as the list started closing, which looks strange to me.
2. As the list is closing, it continually repositions itself to keep the option centered on the screen. Again, this was necessary for proper visual effects. Without that, the selection rectangle would be cut off as the list got smaller.

I've tested this on STM32 and the PC simulator and I haven't noticed any significant performance drops.