### PR TITLE
lv_ddlist: fix original selected option not restoring on escape

### DIFF
--- a/lv_objx/lv_ddlist.c
+++ b/lv_objx/lv_ddlist.c
@@ -701,6 +701,7 @@ static lv_res_t lv_ddlist_signal(lv_obj_t * ddlist, lv_signal_t sign, void * par
         } else if(c == LV_GROUP_KEY_ESC) {
             if(ext->opened) {
                 ext->opened = 0;
+                ext->sel_opt_id = ext->sel_opt_id_ori;
                 lv_ddlist_refr_size(ddlist, true);
             }
         }


### PR DESCRIPTION
Very simple fix. Drop down list was not restoring the original selected option when escape key was pressed. This would result in the drop down list showing an option selected (whatever happened to be highlighted when escape was pressed) that didn't actual match what was selected.