### PR TITLE
lv_indev button release fix

### DIFF
--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -495,6 +495,7 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
 
             if(i->proc.long_pr_sent == 0) {
                 lv_event_send(focused, LV_EVENT_SHORT_CLICKED, NULL);
+                if(i->proc.reset_query) return; /*The object might be deleted*/
             }
 
             lv_event_send(focused, LV_EVENT_CLICKED, NULL);


### PR DESCRIPTION
There was a missing check to see if the object has been deleted.