### PR TITLE
Allow const lv_style_t objects

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -996,7 +996,7 @@ void lv_obj_set_auto_realign(lv_obj_t * obj, bool en)
  * @param obj pointer to an object
  * @param style_p pointer to the new style
  */
-void lv_obj_set_style(lv_obj_t * obj, lv_style_t * style)
+void lv_obj_set_style(lv_obj_t * obj, const lv_style_t * style)
 {
     obj->style_p = style;
 
@@ -1571,7 +1571,7 @@ lv_coord_t lv_obj_get_height(const lv_obj_t * obj)
  */
 lv_coord_t lv_obj_get_width_fit(lv_obj_t * obj)
 {
-    lv_style_t * style = lv_obj_get_style(obj);
+    const lv_style_t * style = lv_obj_get_style(obj);
 
     return lv_obj_get_width(obj) - style->body.padding.left - style->body.padding.right;
 }
@@ -1583,7 +1583,7 @@ lv_coord_t lv_obj_get_width_fit(lv_obj_t * obj)
  */
 lv_coord_t lv_obj_get_height_fit(lv_obj_t * obj)
 {
-    lv_style_t * style = lv_obj_get_style(obj);
+    const lv_style_t * style = lv_obj_get_style(obj);
 
     return lv_obj_get_height(obj) - style->body.padding.top - style->body.padding.bottom;
 }
@@ -1621,9 +1621,9 @@ bool lv_obj_get_auto_realign(lv_obj_t * obj)
  * @param obj pointer to an object
  * @return pointer to a style
  */
-lv_style_t * lv_obj_get_style(const lv_obj_t * obj)
+const lv_style_t * lv_obj_get_style(const lv_obj_t * obj)
 {
-    lv_style_t * style_act = obj->style_p;
+    const lv_style_t * style_act = obj->style_p;
     if(style_act == NULL) {
         lv_obj_t * par = obj->par;
 
@@ -1923,7 +1923,7 @@ static bool lv_obj_design(lv_obj_t * obj, const lv_area_t * mask_p, lv_design_mo
         if(lv_area_is_in(mask_p, &obj->coords) == false) return false;
 
         /*Can cover the area only if fully solid (no opacity)*/
-        lv_style_t * style = lv_obj_get_style(obj);
+        const lv_style_t * style = lv_obj_get_style(obj);
         if(style->body.opa != LV_OPA_COVER) return false;
 
         /* Because of the radius it is not sure the area is covered
@@ -1947,7 +1947,7 @@ static bool lv_obj_design(lv_obj_t * obj, const lv_area_t * mask_p, lv_design_mo
         if(lv_area_is_in(mask_p, &area_tmp) == false) return false;
 
     } else if(mode == LV_DESIGN_DRAW_MAIN) {
-        lv_style_t * style = lv_obj_get_style(obj);
+        const lv_style_t * style = lv_obj_get_style(obj);
         lv_draw_rect(&obj->coords, mask_p, style, lv_obj_get_opa_scale(obj));
     }
 
@@ -1967,7 +1967,7 @@ static lv_res_t lv_obj_signal(lv_obj_t * obj, lv_signal_t sign, void * param)
 
     lv_res_t res = LV_RES_OK;
 
-    lv_style_t * style = lv_obj_get_style(obj);
+    const lv_style_t * style = lv_obj_get_style(obj);
 
     lv_indev_t * indev_act = lv_indev_get_act();
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -189,7 +189,7 @@ typedef struct _lv_obj_t
     lv_design_cb_t design_cb; /*Object type specific design function*/
 
     void * ext_attr;      /*Object type specific extended data*/
-    lv_style_t * style_p; /*Pointer to the object's style*/
+    const lv_style_t * style_p; /*Pointer to the object's style*/
 
 #if LV_USE_GROUP != 0
     void * group_p; /*Pointer to the group of the object*/
@@ -407,7 +407,7 @@ void lv_obj_set_auto_realign(lv_obj_t * obj, bool en);
  * @param obj pointer to an object
  * @param style_p pointer to the new style
  */
-void lv_obj_set_style(lv_obj_t * obj, lv_style_t * style);
+void lv_obj_set_style(lv_obj_t * obj, const lv_style_t * style);
 
 /**
  * Notify an object about its style is modified
@@ -718,7 +718,7 @@ bool lv_obj_get_auto_realign(lv_obj_t * obj);
  * @param obj pointer to an object
  * @return pointer to a style
  */
-lv_style_t * lv_obj_get_style(const lv_obj_t * obj);
+const lv_style_t * lv_obj_get_style(const lv_obj_t * obj);
 
 /*-----------------
  * Attribute get

--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -412,7 +412,7 @@ static lv_obj_t * lv_refr_get_top_obj(const lv_area_t * area_p, lv_obj_t * obj)
 
         /*If no better children check this object*/
         if(found_p == NULL) {
-            lv_style_t * style = lv_obj_get_style(obj);
+            const lv_style_t * style = lv_obj_get_style(obj);
             if(style->body.opa == LV_OPA_COVER &&
                obj->design_cb(obj, area_p, LV_DESIGN_COVER_CHK) != false &&
                lv_obj_get_opa_scale(obj) == LV_OPA_COVER) {

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -158,7 +158,7 @@ lv_res_t lv_img_dsc_get_info(const char * src, lv_img_header_t * header)
  * @return color of the point
  */
 lv_color_t lv_img_buf_get_px_color(lv_img_dsc_t * dsc, lv_coord_t x, lv_coord_t y,
-                                   lv_style_t * style)
+                                   const lv_style_t * style)
 {
     lv_color_t p_color = LV_COLOR_BLACK;
     if(x >= dsc->header.w) {

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -174,7 +174,7 @@ void lv_img_decoder_set_custom(lv_img_decoder_info_f_t info_fp, lv_img_decoder_o
  * @return color of the point
  */
 lv_color_t lv_img_buf_get_px_color(lv_img_dsc_t * dsc, lv_coord_t x, lv_coord_t y,
-                                   lv_style_t * style);
+                                   const lv_style_t * style);
 /**
  * Get the alpha value of an image's pixel
  * @param dsc pointer to an image descriptor

--- a/src/lv_objx/lv_arc.c
+++ b/src/lv_objx/lv_arc.c
@@ -136,7 +136,7 @@ void lv_arc_set_angles(lv_obj_t * arc, uint16_t start, uint16_t end)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_arc_set_style(lv_obj_t * arc, lv_arc_style_t type, lv_style_t * style)
+void lv_arc_set_style(lv_obj_t * arc, lv_arc_style_t type, const lv_style_t * style)
 {
     switch(type) {
         case LV_ARC_STYLE_MAIN: lv_obj_set_style(arc, style); break;
@@ -177,9 +177,9 @@ uint16_t lv_arc_get_angle_end(lv_obj_t * arc)
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_arc_get_style(const lv_obj_t * arc, lv_arc_style_t type)
+const lv_style_t * lv_arc_get_style(const lv_obj_t * arc, lv_arc_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
 
     switch(type) {
         case LV_ARC_STYLE_MAIN: style = lv_obj_get_style(arc); break;
@@ -219,8 +219,8 @@ static bool lv_arc_design(lv_obj_t * arc, const lv_area_t * mask, lv_design_mode
     }
     /*Draw the object*/
     else if(mode == LV_DESIGN_DRAW_MAIN) {
-        lv_arc_ext_t * ext = lv_obj_get_ext_attr(arc);
-        lv_style_t * style = lv_arc_get_style(arc, LV_ARC_STYLE_MAIN);
+        lv_arc_ext_t * ext       = lv_obj_get_ext_attr(arc);
+        const lv_style_t * style = lv_arc_get_style(arc, LV_ARC_STYLE_MAIN);
 
         lv_coord_t r       = (LV_MATH_MIN(lv_obj_get_width(arc), lv_obj_get_height(arc))) / 2;
         lv_coord_t x       = arc->coords.x1 + lv_obj_get_width(arc) / 2;

--- a/src/lv_objx/lv_arc.h
+++ b/src/lv_objx/lv_arc.h
@@ -78,7 +78,7 @@ void lv_arc_set_angles(lv_obj_t * arc, uint16_t start, uint16_t end);
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_arc_set_style(lv_obj_t * arc, lv_arc_style_t type, lv_style_t * style);
+void lv_arc_set_style(lv_obj_t * arc, lv_arc_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -104,7 +104,7 @@ uint16_t lv_arc_get_angle_end(lv_obj_t * arc);
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_arc_get_style(const lv_obj_t * arc, lv_arc_style_t type);
+const lv_style_t * lv_arc_get_style(const lv_obj_t * arc, lv_arc_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_bar.c
+++ b/src/lv_objx/lv_bar.c
@@ -215,7 +215,7 @@ void lv_bar_set_sym(lv_obj_t * bar, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_bar_set_style(lv_obj_t * bar, lv_bar_style_t type, lv_style_t * style)
+void lv_bar_set_style(lv_obj_t * bar, lv_bar_style_t type, const lv_style_t * style)
 {
     lv_bar_ext_t * ext = lv_obj_get_ext_attr(bar);
 
@@ -286,9 +286,9 @@ bool lv_bar_get_sym(lv_obj_t * bar)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_bar_get_style(const lv_obj_t * bar, lv_bar_style_t type)
+const lv_style_t * lv_bar_get_style(const lv_obj_t * bar, lv_bar_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
     lv_bar_ext_t * ext = lv_obj_get_ext_attr(bar);
 
     switch(type) {
@@ -329,7 +329,7 @@ static bool lv_bar_design(lv_obj_t * bar, const lv_area_t * mask, lv_design_mode
          * At value = 100% the indicator can cover to whole background and the focused style won't
          * be visible*/
         if(lv_obj_is_focused(bar)) {
-            lv_style_t * style_bg = lv_bar_get_style(bar, LV_BAR_STYLE_BG);
+            const lv_style_t * style_bg = lv_bar_get_style(bar, LV_BAR_STYLE_BG);
             lv_style_t style_tmp;
             lv_style_copy(&style_tmp, style_bg);
             style_tmp.body.border.width = 0;
@@ -342,7 +342,7 @@ static bool lv_bar_design(lv_obj_t * bar, const lv_area_t * mask, lv_design_mode
 
         if(ext->cur_value != ext->min_value || ext->sym ||
            ext->anim_start != LV_BAR_ANIM_STATE_INV) {
-            lv_style_t * style_indic = lv_bar_get_style(bar, LV_BAR_STYLE_INDIC);
+            const lv_style_t * style_indic = lv_bar_get_style(bar, LV_BAR_STYLE_INDIC);
             lv_area_t indic_area;
             lv_area_copy(&indic_area, &bar->coords);
             indic_area.x1 += style_indic->body.padding.left;
@@ -431,7 +431,7 @@ static bool lv_bar_design(lv_obj_t * bar, const lv_area_t * mask, lv_design_mode
         /*Draw the border*/
         if(lv_obj_is_focused(bar)) {
             lv_opa_t opa_scale    = lv_obj_get_opa_scale(bar);
-            lv_style_t * style_bg = lv_bar_get_style(bar, LV_BAR_STYLE_BG);
+            const lv_style_t * style_bg = lv_bar_get_style(bar, LV_BAR_STYLE_BG);
             lv_style_t style_tmp;
             lv_style_copy(&style_tmp, style_bg);
             style_tmp.body.opa          = LV_OPA_TRANSP;
@@ -459,7 +459,7 @@ static lv_res_t lv_bar_signal(lv_obj_t * bar, lv_signal_t sign, void * param)
     if(res != LV_RES_OK) return res;
 
     if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
-        lv_style_t * style_indic = lv_bar_get_style(bar, LV_BAR_STYLE_INDIC);
+        const lv_style_t * style_indic = lv_bar_get_style(bar, LV_BAR_STYLE_INDIC);
         if(style_indic->body.shadow.width > bar->ext_size)
             bar->ext_size = style_indic->body.shadow.width;
     } else if(sign == LV_SIGNAL_GET_TYPE) {

--- a/src/lv_objx/lv_bar.h
+++ b/src/lv_objx/lv_bar.h
@@ -50,8 +50,8 @@ typedef struct
     int16_t anim_end;
     int16_t anim_state;
     uint16_t anim_time;
-    uint8_t sym : 1;          /*Symmetric: means the center is around zero value*/
-    lv_style_t * style_indic; /*Style of the indicator*/
+    uint8_t sym : 1;                /*Symmetric: means the center is around zero value*/
+    const lv_style_t * style_indic; /*Style of the indicator*/
 } lv_bar_ext_t;
 
 enum {
@@ -106,7 +106,7 @@ void lv_bar_set_sym(lv_obj_t * bar, bool en);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_bar_set_style(lv_obj_t * bar, lv_bar_style_t type, lv_style_t * style);
+void lv_bar_set_style(lv_obj_t * bar, lv_bar_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -146,7 +146,7 @@ bool lv_bar_get_sym(lv_obj_t * bar);
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_bar_get_style(const lv_obj_t * bar, lv_bar_style_t type);
+const lv_style_t * lv_bar_get_style(const lv_obj_t * bar, lv_bar_style_t type);
 
 /**********************
  *      MACROS

--- a/src/lv_objx/lv_btn.c
+++ b/src/lv_objx/lv_btn.c
@@ -254,7 +254,7 @@ void lv_btn_set_ink_out_time(lv_obj_t * btn, uint16_t time)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_btn_set_style(lv_obj_t * btn, lv_btn_style_t type, lv_style_t * style)
+void lv_btn_set_style(lv_obj_t * btn, lv_btn_style_t type, const lv_style_t * style)
 {
     lv_btn_ext_t * ext = lv_obj_get_ext_attr(btn);
 
@@ -350,9 +350,9 @@ uint16_t lv_btn_get_ink_out_time(const lv_obj_t * btn)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_btn_get_style(const lv_obj_t * btn, lv_btn_style_t type)
+const lv_style_t * lv_btn_get_style(const lv_obj_t * btn, lv_btn_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
     lv_btn_ext_t * ext = lv_obj_get_ext_attr(btn);
 
     switch(type) {

--- a/src/lv_objx/lv_btn.h
+++ b/src/lv_objx/lv_btn.h
@@ -54,7 +54,7 @@ typedef struct
 {
     lv_cont_ext_t cont; /*Ext. of ancestor*/
     /*New data for this type */
-    lv_style_t * styles[LV_BTN_STATE_NUM]; /*Styles in each state*/
+    const lv_style_t * styles[LV_BTN_STATE_NUM]; /*Styles in each state*/
     lv_btn_state_t state; /*Current state of the button from 'lv_btn_state_t' enum*/
 #if LV_BTN_INK_EFFECT
     uint16_t ink_in_time;   /*[ms] Time of ink fill effect (0: disable ink effect)*/
@@ -185,7 +185,7 @@ void lv_btn_set_ink_out_time(lv_obj_t * btn, uint16_t time);
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_btn_set_style(lv_obj_t * btn, lv_btn_style_t type, lv_style_t * style);
+void lv_btn_set_style(lv_obj_t * btn, lv_btn_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -282,7 +282,7 @@ uint16_t lv_btn_get_ink_out_time(const lv_obj_t * btn);
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_btn_get_style(const lv_obj_t * btn, lv_btn_style_t type);
+const lv_style_t * lv_btn_get_style(const lv_obj_t * btn, lv_btn_style_t type);
 
 /**********************
  *      MACROS

--- a/src/lv_objx/lv_btnm.c
+++ b/src/lv_objx/lv_btnm.c
@@ -164,7 +164,7 @@ void lv_btnm_set_map(const lv_obj_t * btnm, const char * map[])
     ext->map_p = map;
 
     /*Set size and positions of the buttons*/
-    lv_style_t * style_bg = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
+    const lv_style_t * style_bg = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
     lv_coord_t max_w =
         lv_obj_get_width(btnm) - style_bg->body.padding.left - style_bg->body.padding.right;
     lv_coord_t max_h =
@@ -303,7 +303,7 @@ void lv_btnm_set_pressed(const lv_obj_t * btnm, uint16_t id)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_btnm_set_style(lv_obj_t * btnm, lv_btnm_style_t type, lv_style_t * style)
+void lv_btnm_set_style(lv_obj_t * btnm, lv_btnm_style_t type, const lv_style_t * style)
 {
     lv_btnm_ext_t * ext = lv_obj_get_ext_attr(btnm);
 
@@ -530,9 +530,9 @@ bool lv_btnm_get_btn_ctrl(lv_obj_t * btnm, uint16_t btn_id, lv_btnm_ctrl_t ctrl)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_btnm_get_style(const lv_obj_t * btnm, lv_btnm_style_t type)
+const lv_style_t * lv_btnm_get_style(const lv_obj_t * btnm, lv_btnm_style_t type)
 {
-    lv_style_t * style  = NULL;
+    const lv_style_t * style  = NULL;
     lv_btnm_ext_t * ext = lv_obj_get_ext_attr(btnm);
 
     switch(type) {
@@ -586,8 +586,8 @@ static bool lv_btnm_design(lv_obj_t * btnm, const lv_area_t * mask, lv_design_mo
         ancestor_design_f(btnm, mask, mode);
 
         lv_btnm_ext_t * ext   = lv_obj_get_ext_attr(btnm);
-        lv_style_t * bg_style = lv_obj_get_style(btnm);
-        lv_style_t * btn_style;
+        const lv_style_t * bg_style = lv_obj_get_style(btnm);
+        const lv_style_t * btn_style;
         lv_opa_t opa_scale = lv_obj_get_opa_scale(btnm);
 
         lv_area_t area_btnm;
@@ -831,7 +831,7 @@ static lv_res_t lv_btnm_signal(lv_obj_t * btnm, lv_signal_t sign, void * param)
             ext->btn_id_act = ext->btn_id_pr;
             lv_obj_invalidate(btnm);
         } else if(c == LV_KEY_DOWN) {
-            lv_style_t * style = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
+            const lv_style_t * style = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
             /*Find the area below the the current*/
             if(ext->btn_id_pr == LV_BTNM_BTN_NONE) {
                 ext->btn_id_pr = 0;
@@ -853,7 +853,7 @@ static lv_res_t lv_btnm_signal(lv_obj_t * btnm, lv_signal_t sign, void * param)
             ext->btn_id_act = ext->btn_id_pr;
             lv_obj_invalidate(btnm);
         } else if(c == LV_KEY_UP) {
-            lv_style_t * style = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
+            const lv_style_t * style = lv_btnm_get_style(btnm, LV_BTNM_STYLE_BG);
             /*Find the area below the the current*/
             if(ext->btn_id_pr == LV_BTNM_BTN_NONE) {
                 ext->btn_id_pr = 0;

--- a/src/lv_objx/lv_btnm.h
+++ b/src/lv_objx/lv_btnm.h
@@ -54,7 +54,7 @@ typedef struct
     const char ** map_p;                       /*Pointer to the current map*/
     lv_area_t * button_areas;                  /*Array of areas of buttons*/
     lv_btnm_ctrl_t * ctrl_bits;                /*Array of control bytes*/
-    lv_style_t * styles_btn[LV_BTN_STATE_NUM]; /*Styles of buttons in each state*/
+    const lv_style_t * styles_btn[LV_BTN_STATE_NUM]; /*Styles of buttons in each state*/
     uint16_t btn_cnt;   /*Number of button in 'map_p'(Handled by the library)*/
     uint16_t btn_id_pr; /*Index of the currently pressed button or LV_BTNM_BTN_NONE*/
     uint16_t
@@ -131,7 +131,7 @@ void lv_btnm_set_pressed(const lv_obj_t * btnm, uint16_t id);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_btnm_set_style(lv_obj_t * btnm, lv_btnm_style_t type, lv_style_t * style);
+void lv_btnm_set_style(lv_obj_t * btnm, lv_btnm_style_t type, const lv_style_t * style);
 
 /**
  * Enable recoloring of button's texts
@@ -242,7 +242,7 @@ bool lv_btnm_get_btn_ctrl(lv_obj_t * btnm, uint16_t btn_id, lv_btnm_ctrl_t ctrl)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_btnm_get_style(const lv_obj_t * btnm, lv_btnm_style_t type);
+const lv_style_t * lv_btnm_get_style(const lv_obj_t * btnm, lv_btnm_style_t type);
 
 /**
  * Find whether "one toggle" mode is enabled.

--- a/src/lv_objx/lv_calendar.c
+++ b/src/lv_objx/lv_calendar.c
@@ -279,7 +279,7 @@ void lv_calendar_set_month_names(lv_obj_t * calendar, const char ** day_names)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_calendar_set_style(lv_obj_t * calendar, lv_calendar_style_t type, lv_style_t * style)
+void lv_calendar_set_style(lv_obj_t * calendar, lv_calendar_style_t type, const lv_style_t * style)
 {
     lv_calendar_ext_t * ext = lv_obj_get_ext_attr(calendar);
 
@@ -384,9 +384,9 @@ const char ** lv_calendar_get_month_names(const lv_obj_t * calendar)
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_calendar_get_style(const lv_obj_t * calendar, lv_calendar_style_t type)
+const lv_style_t * lv_calendar_get_style(const lv_obj_t * calendar, lv_calendar_style_t type)
 {
-    lv_style_t * style      = NULL;
+    const lv_style_t * style      = NULL;
     lv_calendar_ext_t * ext = lv_obj_get_ext_attr(calendar);
 
     switch(type) {
@@ -569,7 +569,7 @@ static bool calculate_touched_day(lv_obj_t * calendar, const lv_point_t * touche
 {
     lv_area_t days_area;
     lv_area_copy(&days_area, &calendar->coords);
-    lv_style_t * style_bg = lv_calendar_get_style(calendar, LV_CALENDAR_STYLE_BG);
+    const lv_style_t * style_bg = lv_calendar_get_style(calendar, LV_CALENDAR_STYLE_BG);
     days_area.x1 += style_bg->body.padding.left;
     days_area.x2 -= style_bg->body.padding.right;
     days_area.y1 = calendar->coords.y1 + get_header_height(calendar) +
@@ -670,7 +670,7 @@ static void draw_header(lv_obj_t * calendar, const lv_area_t * mask)
                   NULL, -1, -1);
 
     /*Add the left arrow*/
-    lv_style_t * arrow_style = ext->btn_pressing < 0 ? ext->style_header_pr : ext->style_header;
+    const lv_style_t * arrow_style = ext->btn_pressing < 0 ? ext->style_header_pr : ext->style_header;
     header_area.x1 += ext->style_header->body.padding.left;
     lv_draw_label(&header_area, mask, arrow_style, opa_scale, LV_SYMBOL_LEFT, LV_TXT_FLAG_NONE,
                   NULL, -1, -1);
@@ -719,8 +719,8 @@ static void draw_day_names(lv_obj_t * calendar, const lv_area_t * mask)
  */
 static void draw_days(lv_obj_t * calendar, const lv_area_t * mask)
 {
-    lv_calendar_ext_t * ext = lv_obj_get_ext_attr(calendar);
-    lv_style_t * style_bg   = lv_calendar_get_style(calendar, LV_CALENDAR_STYLE_BG);
+    lv_calendar_ext_t * ext     = lv_obj_get_ext_attr(calendar);
+    const lv_style_t * style_bg = lv_calendar_get_style(calendar, LV_CALENDAR_STYLE_BG);
     lv_area_t label_area;
     lv_opa_t opa_scale = lv_obj_get_opa_scale(calendar);
     label_area.y1      = calendar->coords.y1 + get_header_height(calendar) +
@@ -739,7 +739,7 @@ static void draw_days(lv_obj_t * calendar, const lv_area_t * mask)
     uint8_t day_cnt;
     uint8_t month_start_day = get_day_of_week(ext->showed_date.year, ext->showed_date.month, 1);
     day_draw_state_t draw_state; /*true: Not the prev. or next month is drawn*/
-    lv_style_t * act_style;
+    const lv_style_t * act_style;
 
     /*If starting with the first day of the week then the previous month is not visible*/
     if(month_start_day == 0) {
@@ -821,7 +821,7 @@ static void draw_days(lv_obj_t * calendar, const lv_area_t * mask)
             }
 
             /*Get the final style : highlighted/week box/today box/normal*/
-            lv_style_t * final_style;
+            const lv_style_t * final_style;
             if(draw_state == DAY_DRAW_PREV_MONTH &&
                is_highlighted(
                    calendar, ext->showed_date.year - (ext->showed_date.month == 1 ? 1 : 0),

--- a/src/lv_objx/lv_calendar.h
+++ b/src/lv_objx/lv_calendar.h
@@ -56,13 +56,13 @@ typedef struct
         month_names; /*Pointer to an array with the name of the month (NULL. use default names)*/
 
     /*Styles*/
-    lv_style_t * style_header;
-    lv_style_t * style_header_pr;
-    lv_style_t * style_day_names;
-    lv_style_t * style_highlighted_days;
-    lv_style_t * style_inactive_days;
-    lv_style_t * style_week_box;
-    lv_style_t * style_today_box;
+    const lv_style_t * style_header;
+    const lv_style_t * style_header_pr;
+    const lv_style_t * style_day_names;
+    const lv_style_t * style_highlighted_days;
+    const lv_style_t * style_inactive_days;
+    const lv_style_t * style_week_box;
+    const lv_style_t * style_today_box;
 } lv_calendar_ext_t;
 
 /*Styles*/
@@ -148,7 +148,7 @@ void lv_calendar_set_month_names(lv_obj_t * calendar, const char ** day_names);
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_calendar_set_style(lv_obj_t * calendar, lv_calendar_style_t type, lv_style_t * style);
+void lv_calendar_set_style(lv_obj_t * calendar, lv_calendar_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -209,7 +209,7 @@ const char ** lv_calendar_get_month_names(const lv_obj_t * calendar);
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_calendar_get_style(const lv_obj_t * calendar, lv_calendar_style_t type);
+const lv_style_t * lv_calendar_get_style(const lv_obj_t * calendar, lv_calendar_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_canvas.c
+++ b/src/lv_objx/lv_canvas.c
@@ -141,7 +141,7 @@ void lv_canvas_set_px(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_color_t 
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_canvas_set_style(lv_obj_t * canvas, lv_canvas_style_t type, lv_style_t * style)
+void lv_canvas_set_style(lv_obj_t * canvas, lv_canvas_style_t type, const lv_style_t * style)
 {
     switch(type) {
         case LV_CANVAS_STYLE_MAIN: lv_img_set_style(canvas, style); break;
@@ -161,8 +161,8 @@ void lv_canvas_set_style(lv_obj_t * canvas, lv_canvas_style_t type, lv_style_t *
  */
 lv_color_t lv_canvas_get_px(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y)
 {
-    lv_canvas_ext_t * ext = lv_obj_get_ext_attr(canvas);
-    lv_style_t * style    = lv_canvas_get_style(canvas, LV_CANVAS_STYLE_MAIN);
+    lv_canvas_ext_t * ext    = lv_obj_get_ext_attr(canvas);
+    const lv_style_t * style = lv_canvas_get_style(canvas, LV_CANVAS_STYLE_MAIN);
 
     return lv_img_buf_get_px_color(&ext->dsc, x, y, style);
 }
@@ -185,10 +185,10 @@ lv_img_dsc_t * lv_canvas_get_img(lv_obj_t * canvas)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_canvas_get_style(const lv_obj_t * canvas, lv_canvas_style_t type)
+const lv_style_t * lv_canvas_get_style(const lv_obj_t * canvas, lv_canvas_style_t type)
 {
     // lv_canvas_ext_t * ext = lv_obj_get_ext_attr(canvas);
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
 
     switch(type) {
         case LV_CANVAS_STYLE_MAIN: style = lv_img_get_style(canvas); break;
@@ -323,7 +323,7 @@ void lv_canvas_rotate(lv_obj_t * canvas, lv_img_dsc_t * img, int16_t angle, lv_c
                       lv_coord_t offset_y, int32_t pivot_x, int32_t pivot_y)
 {
     lv_canvas_ext_t * ext_dst = lv_obj_get_ext_attr(canvas);
-    lv_style_t * style        = lv_canvas_get_style(canvas, LV_CANVAS_STYLE_MAIN);
+    const lv_style_t * style  = lv_canvas_get_style(canvas, LV_CANVAS_STYLE_MAIN);
     int32_t sinma             = lv_trigo_sin(-angle);
     int32_t cosma             = lv_trigo_sin(-angle + 90); /* cos */
 

--- a/src/lv_objx/lv_canvas.h
+++ b/src/lv_objx/lv_canvas.h
@@ -92,7 +92,7 @@ void lv_canvas_set_px(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_color_t 
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_canvas_set_style(lv_obj_t * canvas, lv_canvas_style_t type, lv_style_t * style);
+void lv_canvas_set_style(lv_obj_t * canvas, lv_canvas_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -120,7 +120,7 @@ lv_img_dsc_t * lv_canvas_get_img(lv_obj_t * canvas);
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_canvas_get_style(const lv_obj_t * canvas, lv_canvas_style_t type);
+const lv_style_t * lv_canvas_get_style(const lv_obj_t * canvas, lv_canvas_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_cb.c
+++ b/src/lv_objx/lv_cb.c
@@ -149,7 +149,7 @@ void lv_cb_set_static_text(lv_obj_t * cb, const char * txt)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_cb_set_style(lv_obj_t * cb, lv_cb_style_t type, lv_style_t * style)
+void lv_cb_set_style(lv_obj_t * cb, lv_cb_style_t type, const lv_style_t * style)
 {
     lv_cb_ext_t * ext = lv_obj_get_ext_attr(cb);
 
@@ -194,10 +194,10 @@ const char * lv_cb_get_text(const lv_obj_t * cb)
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type)
+const lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type)
 {
-    lv_style_t * style = NULL;
-    lv_cb_ext_t * ext  = lv_obj_get_ext_attr(cb);
+    const lv_style_t * style = NULL;
+    lv_cb_ext_t * ext        = lv_obj_get_ext_attr(cb);
 
     switch(type) {
         case LV_CB_STYLE_BOX_REL: style = lv_btn_get_style(ext->bullet, LV_BTN_STYLE_REL); break;
@@ -271,10 +271,10 @@ static bool lv_bullet_design(lv_obj_t * bullet, const lv_area_t * mask, lv_desig
         /* If the check box is the active in a group and
          * the background is not visible (transparent)
          * then activate the style of the bullet*/
-        lv_style_t * style_ori  = lv_obj_get_style(bullet);
-        lv_obj_t * bg           = lv_obj_get_parent(bullet);
-        lv_style_t * style_page = lv_obj_get_style(bg);
-        lv_group_t * g          = lv_obj_get_group(bg);
+        const lv_style_t * style_ori  = lv_obj_get_style(bullet);
+        lv_obj_t * bg                 = lv_obj_get_parent(bullet);
+        const lv_style_t * style_page = lv_obj_get_style(bg);
+        lv_group_t * g                = lv_obj_get_group(bg);
         if(style_page->body.opa == LV_OPA_TRANSP) { /*Is the Background visible?*/
             if(lv_group_get_focused(g) == bg) {
                 lv_style_t * style_mod;
@@ -313,7 +313,7 @@ static lv_res_t lv_cb_signal(lv_obj_t * cb, lv_signal_t sign, void * param)
     lv_cb_ext_t * ext = lv_obj_get_ext_attr(cb);
 
     if(sign == LV_SIGNAL_STYLE_CHG) {
-        lv_style_t * label_style = lv_label_get_style(ext->label);
+        const lv_style_t * label_style = lv_label_get_style(ext->label);
         lv_obj_set_size(ext->bullet, lv_font_get_height(label_style->text.font),
                         lv_font_get_height(label_style->text.font));
         lv_btn_set_state(ext->bullet, lv_btn_get_state(cb));

--- a/src/lv_objx/lv_cb.h
+++ b/src/lv_objx/lv_cb.h
@@ -118,7 +118,7 @@ static inline void lv_cb_set_inactive(lv_obj_t * cb)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_cb_set_style(lv_obj_t * cb, lv_cb_style_t type, lv_style_t * style);
+void lv_cb_set_style(lv_obj_t * cb, lv_cb_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -147,7 +147,7 @@ static inline bool lv_cb_is_checked(const lv_obj_t * cb)
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type);
+const lv_style_t * lv_cb_get_style(const lv_obj_t * cb, lv_cb_style_t type);
 
 /**********************
  *      MACROS

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -611,9 +611,9 @@ static lv_res_t lv_chart_signal(lv_obj_t * chart, lv_signal_t sign, void * param
  */
 static void lv_chart_draw_div(lv_obj_t * chart, const lv_area_t * mask)
 {
-    lv_chart_ext_t * ext = lv_obj_get_ext_attr(chart);
-    lv_style_t * style   = lv_obj_get_style(chart);
-    lv_opa_t opa_scale   = lv_obj_get_opa_scale(chart);
+    lv_chart_ext_t * ext     = lv_obj_get_ext_attr(chart);
+    const lv_style_t * style = lv_obj_get_style(chart);
+    lv_opa_t opa_scale       = lv_obj_get_opa_scale(chart);
 
     uint8_t div_i;
     uint8_t div_i_end;

--- a/src/lv_objx/lv_chart.h
+++ b/src/lv_objx/lv_chart.h
@@ -206,7 +206,7 @@ void lv_chart_set_next(lv_obj_t * chart, lv_chart_series_t * ser, lv_coord_t y);
  * @param chart pointer to a chart object
  * @param style pointer to a style
  */
-static inline void lv_chart_set_style(lv_obj_t * chart, lv_style_t * style)
+static inline void lv_chart_set_style(lv_obj_t * chart, const lv_style_t * style)
 {
     lv_obj_set_style(chart, style);
 }
@@ -280,7 +280,7 @@ lv_opa_t lv_chart_get_series_darking(const lv_obj_t * chart);
  * @param chart pointer to an chart object
  * @return pointer to the chart's style
  */
-static inline lv_style_t * lv_chart_get_style(const lv_obj_t * chart)
+static inline const lv_style_t * lv_chart_get_style(const lv_obj_t * chart)
 {
     return lv_obj_get_style(chart);
 }

--- a/src/lv_objx/lv_cont.c
+++ b/src/lv_objx/lv_cont.c
@@ -303,7 +303,7 @@ static void lv_cont_layout_col(lv_obj_t * cont)
 
     /*Adjust margin and get the alignment type*/
     lv_align_t align;
-    lv_style_t * style = lv_obj_get_style(cont);
+    const lv_style_t * style = lv_obj_get_style(cont);
     lv_coord_t hpad_corr;
 
     switch(type) {
@@ -353,7 +353,7 @@ static void lv_cont_layout_row(lv_obj_t * cont)
 
     /*Adjust margin and get the alignment type*/
     lv_align_t align;
-    lv_style_t * style = lv_obj_get_style(cont);
+    const lv_style_t * style = lv_obj_get_style(cont);
     lv_coord_t vpad_corr;
 
     switch(type) {
@@ -400,9 +400,9 @@ static void lv_cont_layout_row(lv_obj_t * cont)
 static void lv_cont_layout_center(lv_obj_t * cont)
 {
     lv_obj_t * child;
-    lv_style_t * style = lv_obj_get_style(cont);
-    uint32_t obj_num   = 0;
-    lv_coord_t h_tot   = 0;
+    const lv_style_t * style = lv_obj_get_style(cont);
+    uint32_t obj_num         = 0;
+    lv_coord_t h_tot         = 0;
 
     LV_LL_READ(cont->child_ll, child)
     {
@@ -444,9 +444,9 @@ static void lv_cont_layout_pretty(lv_obj_t * cont)
     lv_obj_t * child_rs;  /* Row starter child */
     lv_obj_t * child_rc;  /* Row closer child */
     lv_obj_t * child_tmp; /* Temporary child */
-    lv_style_t * style = lv_obj_get_style(cont);
-    lv_coord_t w_obj   = lv_obj_get_width(cont);
-    lv_coord_t act_y   = style->body.padding.top;
+    const lv_style_t * style = lv_obj_get_style(cont);
+    lv_coord_t w_obj         = lv_obj_get_width(cont);
+    lv_coord_t act_y         = style->body.padding.top;
     /* Disable child change action because the children will be moved a lot
      * an unnecessary child change signals could be sent*/
 
@@ -545,12 +545,12 @@ static void lv_cont_layout_pretty(lv_obj_t * cont)
 static void lv_cont_layout_grid(lv_obj_t * cont)
 {
     lv_obj_t * child;
-    lv_style_t * style = lv_obj_get_style(cont);
-    lv_coord_t w_tot   = lv_obj_get_width(cont);
-    lv_coord_t w_obj   = lv_obj_get_width(lv_obj_get_child(cont, NULL));
-    lv_coord_t h_obj   = lv_obj_get_height(lv_obj_get_child(cont, NULL));
-    uint16_t obj_row   = (w_tot - style->body.padding.left - style->body.padding.right) /
-                       (w_obj + style->body.padding.inner); /*Obj. num. in a row*/
+    const lv_style_t * style = lv_obj_get_style(cont);
+    lv_coord_t w_tot         = lv_obj_get_width(cont);
+    lv_coord_t w_obj         = lv_obj_get_width(lv_obj_get_child(cont, NULL));
+    lv_coord_t h_obj         = lv_obj_get_height(lv_obj_get_child(cont, NULL));
+    uint16_t obj_row         = (w_tot - style->body.padding.left - style->body.padding.right) /
+                               (w_obj + style->body.padding.inner); /*Obj. num. in a row*/
     lv_coord_t x_ofs;
     if(obj_row > 1) {
         x_ofs = (w_obj + (w_tot - style->body.padding.left - style->body.padding.right) -
@@ -607,11 +607,11 @@ static void lv_cont_refr_autofit(lv_obj_t * cont)
 
     lv_area_t tight_area;
     lv_area_t ori;
-    lv_style_t * style = lv_obj_get_style(cont);
+    const lv_style_t * style = lv_obj_get_style(cont);
     lv_obj_t * child_i;
 
-    lv_obj_t * par         = lv_obj_get_parent(cont);
-    lv_style_t * par_style = lv_obj_get_style(par);
+    lv_obj_t * par               = lv_obj_get_parent(cont);
+    const lv_style_t * par_style = lv_obj_get_style(par);
     lv_area_t flood_area;
     lv_area_copy(&flood_area, &par->coords);
     flood_area.x1 += par_style->body.padding.left;

--- a/src/lv_objx/lv_cont.h
+++ b/src/lv_objx/lv_cont.h
@@ -129,7 +129,7 @@ static inline void lv_cont_set_fit(lv_obj_t * cont, lv_fit_t fit)
  * @param cont pointer to a container object
  * @param style pointer to the new style
  */
-static inline void lv_cont_set_style(lv_obj_t * cont, lv_style_t * style)
+static inline void lv_cont_set_style(lv_obj_t * cont, const lv_style_t * style)
 {
     lv_obj_set_style(cont, style);
 }
@@ -178,7 +178,7 @@ lv_fit_t lv_cont_get_fit_bottom(const lv_obj_t * cont);
  * @param cont pointer to a container object
  * @return pointer to the container's style
  */
-static inline lv_style_t * lv_cont_get_style(const lv_obj_t * cont)
+static inline const lv_style_t * lv_cont_get_style(const lv_obj_t * cont)
 {
     return lv_obj_get_style(cont);
 }

--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -280,7 +280,7 @@ void lv_ddlist_set_anim_time(lv_obj_t * ddlist, uint16_t anim_time)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_ddlist_set_style(lv_obj_t * ddlist, lv_ddlist_style_t type, lv_style_t * style)
+void lv_ddlist_set_style(lv_obj_t * ddlist, lv_ddlist_style_t type, const lv_style_t * style)
 {
     lv_ddlist_ext_t * ext = lv_obj_get_ext_attr(ddlist);
 
@@ -409,7 +409,7 @@ uint16_t lv_ddlist_get_anim_time(const lv_obj_t * ddlist)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_ddlist_get_style(const lv_obj_t * ddlist, lv_ddlist_style_t type)
+const lv_style_t * lv_ddlist_get_style(const lv_obj_t * ddlist, lv_ddlist_style_t type)
 {
     lv_ddlist_ext_t * ext = lv_obj_get_ext_attr(ddlist);
 
@@ -517,9 +517,9 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
         lv_opa_t opa_scale    = lv_obj_get_opa_scale(ddlist);
         /*If the list is opened draw a rectangle under the selected item*/
         if(ext->opened != 0 || ext->force_sel) {
-            lv_style_t * style     = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
-            const lv_font_t * font = style->text.font;
-            lv_coord_t font_h      = lv_font_get_height(font);
+            const lv_style_t * style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
+            const lv_font_t * font   = style->text.font;
+            lv_coord_t font_h        = lv_font_get_height(font);
 
             /*Draw the selected*/
             lv_area_t rect_area;
@@ -542,9 +542,9 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
 
         /*Redraw only in opened state*/
         if(ext->opened || ext->force_sel) {
-            lv_style_t * style     = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
-            const lv_font_t * font = style->text.font;
-            lv_coord_t font_h      = lv_font_get_height(font);
+            const lv_style_t * style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
+            const lv_font_t * font   = style->text.font;
+            lv_coord_t font_h        = lv_font_get_height(font);
 
             lv_area_t area_sel;
             area_sel.y1 = ext->label->coords.y1;
@@ -558,7 +558,7 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
             bool area_ok;
             area_ok = lv_area_intersect(&mask_sel, mask, &area_sel);
             if(area_ok) {
-                lv_style_t * sel_style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_SEL);
+                const lv_style_t * sel_style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_SEL);
                 lv_style_t new_style;
                 lv_style_copy(&new_style, style);
                 new_style.text.color = sel_style->text.color;
@@ -573,10 +573,10 @@ static bool lv_ddlist_design(lv_obj_t * ddlist, const lv_area_t * mask, lv_desig
         else {
             /*Draw a arrow in ddlist if enabled*/
             if(ext->draw_arrow) {
-                lv_style_t * style     = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
-                const lv_font_t * font = style->text.font;
-                lv_style_t * sel_style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
-                lv_coord_t font_h      = lv_font_get_height(font);
+                const lv_style_t * style     = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
+                const lv_font_t * font       = style->text.font;
+                const lv_style_t * sel_style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
+                lv_coord_t font_h            = lv_font_get_height(font);
                 lv_style_t new_style;
                 lv_style_copy(&new_style, style);
                 new_style.text.color = sel_style->text.color;
@@ -732,8 +732,8 @@ static lv_res_t lv_ddlist_scrl_signal(lv_obj_t * scrl, lv_signal_t sign, void * 
         /*TODO review this*/
         /* Because of the wider selected rectangle ext. size
          * In this way by dragging the scrollable part the wider rectangle area can be redrawn too*/
-        lv_style_t * style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
-        lv_coord_t hpad    = LV_MATH_MAX(style->body.padding.left, style->body.padding.right);
+        const lv_style_t * style = lv_ddlist_get_style(ddlist, LV_DDLIST_STYLE_BG);
+        lv_coord_t hpad          = LV_MATH_MAX(style->body.padding.left, style->body.padding.right);
         if(scrl->ext_size < hpad) scrl->ext_size = hpad;
     } else if(sign == LV_SIGNAL_RELEASED) {
         if(lv_indev_is_dragging(lv_indev_get_act()) == false) {
@@ -823,8 +823,8 @@ static void lv_ddlist_refr_size(lv_obj_t * ddlist, bool anim_en)
 #if LV_USE_ANIMATION == 0
     anim_en = false;
 #endif
-    lv_ddlist_ext_t * ext = lv_obj_get_ext_attr(ddlist);
-    lv_style_t * style    = lv_obj_get_style(ddlist);
+    lv_ddlist_ext_t * ext    = lv_obj_get_ext_attr(ddlist);
+    const lv_style_t * style = lv_obj_get_style(ddlist);
     lv_coord_t new_height;
     if(ext->opened) { /*Open the list*/
         if(ext->fix_height == 0)
@@ -834,10 +834,10 @@ static void lv_ddlist_refr_size(lv_obj_t * ddlist, bool anim_en)
             new_height = ext->fix_height;
 
     } else { /*Close the list*/
-        const lv_font_t * font   = style->text.font;
-        lv_style_t * label_style = lv_obj_get_style(ext->label);
-        lv_coord_t font_h        = lv_font_get_height(font);
-        new_height               = font_h + 2 * label_style->text.line_space;
+        const lv_font_t * font         = style->text.font;
+        const lv_style_t * label_style = lv_obj_get_style(ext->label);
+        lv_coord_t font_h              = lv_font_get_height(font);
+        new_height                     = font_h + 2 * label_style->text.line_space;
 
         lv_page_set_sb_mode(ddlist, LV_SB_MODE_HIDE);
     }
@@ -904,12 +904,12 @@ static void lv_ddlist_adjust_height(lv_obj_t * ddlist, int32_t height)
  */
 static void lv_ddlist_pos_current_option(lv_obj_t * ddlist)
 {
-    lv_ddlist_ext_t * ext    = lv_obj_get_ext_attr(ddlist);
-    lv_style_t * style       = lv_obj_get_style(ddlist);
-    const lv_font_t * font   = style->text.font;
-    lv_coord_t font_h        = lv_font_get_height(font);
-    lv_style_t * label_style = lv_obj_get_style(ext->label);
-    lv_obj_t * scrl          = lv_page_get_scrl(ddlist);
+    lv_ddlist_ext_t * ext          = lv_obj_get_ext_attr(ddlist);
+    const lv_style_t * style       = lv_obj_get_style(ddlist);
+    const lv_font_t * font         = style->text.font;
+    lv_coord_t font_h              = lv_font_get_height(font);
+    const lv_style_t * label_style = lv_obj_get_style(ext->label);
+    lv_obj_t * scrl                = lv_page_get_scrl(ddlist);
 
     lv_coord_t h       = lv_obj_get_height(ddlist);
     lv_coord_t line_y1 = ext->sel_opt_id * (font_h + label_style->text.line_space) +

--- a/src/lv_objx/lv_ddlist.h
+++ b/src/lv_objx/lv_ddlist.h
@@ -47,7 +47,7 @@ typedef struct
     lv_page_ext_t page; /*Ext. of ancestor*/
     /*New data for this type */
     lv_obj_t * label;        /*Label for the options*/
-    lv_style_t * sel_style;  /*Style of the selected option*/
+    const lv_style_t * sel_style;  /*Style of the selected option*/
     uint16_t option_cnt;     /*Number of options*/
     uint16_t sel_opt_id;     /*Index of the current option*/
     uint16_t sel_opt_id_ori; /*Store the original index on focus*/
@@ -148,7 +148,7 @@ void lv_ddlist_set_anim_time(lv_obj_t * ddlist, uint16_t anim_time);
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_ddlist_set_style(lv_obj_t * ddlist, lv_ddlist_style_t type, lv_style_t * style);
+void lv_ddlist_set_style(lv_obj_t * ddlist, lv_ddlist_style_t type, const lv_style_t * style);
 
 /**
  * Set the alignment of the labels in a drop down list
@@ -225,7 +225,7 @@ uint16_t lv_ddlist_get_anim_time(const lv_obj_t * ddlist);
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_ddlist_get_style(const lv_obj_t * ddlist, lv_ddlist_style_t type);
+const lv_style_t * lv_ddlist_get_style(const lv_obj_t * ddlist, lv_ddlist_style_t type);
 
 /**
  * Get the alignment of the labels in a drop down list

--- a/src/lv_objx/lv_gauge.c
+++ b/src/lv_objx/lv_gauge.c
@@ -272,9 +272,9 @@ static bool lv_gauge_design(lv_obj_t * gauge, const lv_area_t * mask, lv_design_
         /* Store the real pointer because of 'lv_group'
          * If the object is in focus 'lv_obj_get_style()' will give a pointer to tmp style
          * and to the real object style. It is important because of style change tricks below*/
-        lv_style_t * style_ori_p = gauge->style_p;
-        lv_style_t * style       = lv_obj_get_style(gauge);
-        lv_gauge_ext_t * ext     = lv_obj_get_ext_attr(gauge);
+        const lv_style_t * style_ori_p = gauge->style_p;
+        const lv_style_t * style       = lv_obj_get_style(gauge);
+        lv_gauge_ext_t * ext           = lv_obj_get_ext_attr(gauge);
 
         lv_gauge_draw_scale(gauge, mask);
 
@@ -347,9 +347,9 @@ static void lv_gauge_draw_scale(lv_obj_t * gauge, const lv_area_t * mask)
 {
     char scale_txt[16];
 
-    lv_gauge_ext_t * ext = lv_obj_get_ext_attr(gauge);
-    lv_style_t * style   = lv_obj_get_style(gauge);
-    lv_opa_t opa_scale   = lv_obj_get_opa_scale(gauge);
+    lv_gauge_ext_t * ext     = lv_obj_get_ext_attr(gauge);
+    const lv_style_t * style = lv_obj_get_style(gauge);
+    lv_opa_t opa_scale       = lv_obj_get_opa_scale(gauge);
     lv_coord_t r =
         lv_obj_get_width(gauge) / 2 - (3 * style->body.padding.left) - style->body.padding.inner;
     lv_coord_t x_ofs    = lv_obj_get_width(gauge) / 2 + gauge->coords.x1;
@@ -398,9 +398,9 @@ static void lv_gauge_draw_scale(lv_obj_t * gauge, const lv_area_t * mask)
 static void lv_gauge_draw_needle(lv_obj_t * gauge, const lv_area_t * mask)
 {
     lv_style_t style_needle;
-    lv_gauge_ext_t * ext = lv_obj_get_ext_attr(gauge);
-    lv_style_t * style   = lv_gauge_get_style(gauge);
-    lv_opa_t opa_scale   = lv_obj_get_opa_scale(gauge);
+    lv_gauge_ext_t * ext     = lv_obj_get_ext_attr(gauge);
+    const lv_style_t * style = lv_gauge_get_style(gauge);
+    lv_opa_t opa_scale       = lv_obj_get_opa_scale(gauge);
 
     lv_coord_t r      = lv_obj_get_width(gauge) / 2 - style->body.padding.left;
     lv_coord_t x_ofs  = lv_obj_get_width(gauge) / 2 + gauge->coords.x1;

--- a/src/lv_objx/lv_gauge.h
+++ b/src/lv_objx/lv_gauge.h
@@ -205,7 +205,7 @@ static inline uint16_t lv_gauge_get_scale_angle(const lv_obj_t * gauge)
  * @param gauge pointer to a gauge object
  * @return pointer to the gauge's style
  */
-static inline lv_style_t * lv_gauge_get_style(const lv_obj_t * gauge)
+static inline const lv_style_t * lv_gauge_get_style(const lv_obj_t * gauge)
 {
     return lv_obj_get_style(gauge);
 }

--- a/src/lv_objx/lv_img.c
+++ b/src/lv_objx/lv_img.c
@@ -176,7 +176,7 @@ void lv_img_set_src(lv_obj_t * img, const void * src_img)
 
     if(src_type == LV_IMG_SRC_SYMBOL) {
         /*`lv_img_dsc_get_info` couldn't set the with and height of a font so set it here*/
-        lv_style_t * style = lv_img_get_style(img);
+        const lv_style_t * style = lv_img_get_style(img);
         lv_point_t size;
         lv_txt_get_size(&size, src_img, style->text.font, style->text.letter_space,
                         style->text.line_space, LV_COORD_MAX, LV_TXT_FLAG_NONE);
@@ -342,7 +342,7 @@ lv_coord_t lv_img_get_offset_y(lv_obj_t * img)
  */
 static bool lv_img_design(lv_obj_t * img, const lv_area_t * mask, lv_design_mode_t mode)
 {
-    lv_style_t * style = lv_obj_get_style(img);
+    const lv_style_t * style = lv_obj_get_style(img);
     lv_img_ext_t * ext = lv_obj_get_ext_attr(img);
 
     if(mode == LV_DESIGN_COVER_CHK) {

--- a/src/lv_objx/lv_img.h
+++ b/src/lv_objx/lv_img.h
@@ -121,7 +121,7 @@ void lv_img_set_offset_y(lv_obj_t * img, lv_coord_t y);
  * @param img pointer to an image object
  * @param style pointer to a style
  */
-static inline void lv_img_set_style(lv_obj_t * img, lv_style_t * style)
+static inline void lv_img_set_style(lv_obj_t * img, const lv_style_t * style)
 {
     lv_obj_set_style(img, style);
 }
@@ -181,7 +181,7 @@ lv_coord_t lv_img_get_offset_y(lv_obj_t * img);
  * @param img pointer to an image object
  * @return pointer to the image's style
  */
-static inline lv_style_t * lv_img_get_style(const lv_obj_t * img)
+static inline const lv_style_t * lv_img_get_style(const lv_obj_t * img)
 {
     return lv_obj_get_style(img);
 }

--- a/src/lv_objx/lv_imgbtn.c
+++ b/src/lv_objx/lv_imgbtn.c
@@ -151,7 +151,7 @@ void lv_imgbtn_set_src(lv_obj_t * imgbtn, lv_btn_state_t state, const void * src
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_imgbtn_set_style(lv_obj_t * imgbtn, lv_imgbtn_style_t type, lv_style_t * style)
+void lv_imgbtn_set_style(lv_obj_t * imgbtn, lv_imgbtn_style_t type, const lv_style_t * style)
 {
     lv_btn_set_style(imgbtn, type, style);
 }
@@ -222,7 +222,7 @@ const void * lv_imgbtn_get_src_right(lv_obj_t * imgbtn, lv_btn_state_t state)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_imgbtn_get_style(const lv_obj_t * imgbtn, lv_imgbtn_style_t type)
+const lv_style_t * lv_imgbtn_get_style(const lv_obj_t * imgbtn, lv_imgbtn_style_t type)
 {
     return lv_btn_get_style(imgbtn, type);
 }
@@ -264,10 +264,10 @@ static bool lv_imgbtn_design(lv_obj_t * imgbtn, const lv_area_t * mask, lv_desig
     /*Draw the object*/
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         /*Just draw an image*/
-        lv_imgbtn_ext_t * ext = lv_obj_get_ext_attr(imgbtn);
-        lv_btn_state_t state  = lv_imgbtn_get_state(imgbtn);
-        lv_style_t * style    = lv_imgbtn_get_style(imgbtn, state);
-        lv_opa_t opa_scale    = lv_obj_get_opa_scale(imgbtn);
+        lv_imgbtn_ext_t * ext    = lv_obj_get_ext_attr(imgbtn);
+        lv_btn_state_t state     = lv_imgbtn_get_state(imgbtn);
+        const lv_style_t * style = lv_imgbtn_get_style(imgbtn, state);
+        lv_opa_t opa_scale       = lv_obj_get_opa_scale(imgbtn);
 
 #if LV_IMGBTN_TILED == 0
         const void * src = ext->img_src[state];

--- a/src/lv_objx/lv_imgbtn.h
+++ b/src/lv_objx/lv_imgbtn.h
@@ -143,7 +143,7 @@ static inline void lv_imgbtn_toggle(lv_obj_t * imgbtn)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_imgbtn_set_style(lv_obj_t * imgbtn, lv_imgbtn_style_t type, lv_style_t * style);
+void lv_imgbtn_set_style(lv_obj_t * imgbtn, lv_imgbtn_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -211,7 +211,7 @@ static inline bool lv_imgbtn_get_toggle(const lv_obj_t * imgbtn)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_imgbtn_get_style(const lv_obj_t * imgbtn, lv_imgbtn_style_t type);
+const lv_style_t * lv_imgbtn_get_style(const lv_obj_t * imgbtn, lv_imgbtn_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_kb.c
+++ b/src/lv_objx/lv_kb.c
@@ -228,7 +228,7 @@ void lv_kb_set_cursor_manage(lv_obj_t * kb, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_kb_set_style(lv_obj_t * kb, lv_kb_style_t type, lv_style_t * style)
+void lv_kb_set_style(lv_obj_t * kb, lv_kb_style_t type, const lv_style_t * style)
 {
     switch(type) {
         case LV_KB_STYLE_BG: lv_btnm_set_style(kb, LV_BTNM_STYLE_BG, style); break;
@@ -285,9 +285,9 @@ bool lv_kb_get_cursor_manage(const lv_obj_t * kb)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_kb_get_style(const lv_obj_t * kb, lv_kb_style_t type)
+const lv_style_t * lv_kb_get_style(const lv_obj_t * kb, lv_kb_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
 
     switch(type) {
         case LV_KB_STYLE_BG: style = lv_btnm_get_style(kb, LV_BTNM_STYLE_BG); break;

--- a/src/lv_objx/lv_kb.h
+++ b/src/lv_objx/lv_kb.h
@@ -135,7 +135,7 @@ static inline void lv_kb_set_ctrl_map(lv_obj_t * kb, const lv_btnm_ctrl_t ctrl_m
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_kb_set_style(lv_obj_t * kb, lv_kb_style_t type, lv_style_t * style);
+void lv_kb_set_style(lv_obj_t * kb, lv_kb_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -178,7 +178,7 @@ static inline const char ** lv_kb_get_map_array(const lv_obj_t * kb)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_kb_get_style(const lv_obj_t * kb, lv_kb_style_t type);
+const lv_style_t * lv_kb_get_style(const lv_obj_t * kb, lv_kb_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -419,16 +419,16 @@ uint16_t lv_label_get_anim_speed(const lv_obj_t * label)
  */
 void lv_label_get_letter_pos(const lv_obj_t * label, uint16_t index, lv_point_t * pos)
 {
-    const char * txt        = lv_label_get_text(label);
-    lv_label_ext_t * ext    = lv_obj_get_ext_attr(label);
-    uint32_t line_start     = 0;
-    uint32_t new_line_start = 0;
-    lv_coord_t max_w        = lv_obj_get_width(label);
-    lv_style_t * style      = lv_obj_get_style(label);
-    const lv_font_t * font  = style->text.font;
-    uint8_t letter_height   = lv_font_get_height(font);
-    lv_coord_t y            = 0;
-    lv_txt_flag_t flag      = LV_TXT_FLAG_NONE;
+    const char * txt         = lv_label_get_text(label);
+    lv_label_ext_t * ext     = lv_obj_get_ext_attr(label);
+    uint32_t line_start      = 0;
+    uint32_t new_line_start  = 0;
+    lv_coord_t max_w         = lv_obj_get_width(label);
+    const lv_style_t * style = lv_obj_get_style(label);
+    const lv_font_t * font   = style->text.font;
+    uint8_t letter_height    = lv_font_get_height(font);
+    lv_coord_t y             = 0;
+    lv_txt_flag_t flag       = LV_TXT_FLAG_NONE;
 
     if(ext->recolor != 0) flag |= LV_TXT_FLAG_RECOLOR;
     if(ext->expand != 0) flag |= LV_TXT_FLAG_EXPAND;
@@ -492,16 +492,16 @@ void lv_label_get_letter_pos(const lv_obj_t * label, uint16_t index, lv_point_t 
  */
 uint16_t lv_label_get_letter_on(const lv_obj_t * label, lv_point_t * pos)
 {
-    const char * txt        = lv_label_get_text(label);
-    lv_label_ext_t * ext    = lv_obj_get_ext_attr(label);
-    uint32_t line_start     = 0;
-    uint32_t new_line_start = 0;
-    lv_coord_t max_w        = lv_obj_get_width(label);
-    lv_style_t * style      = lv_obj_get_style(label);
-    const lv_font_t * font  = style->text.font;
-    uint8_t letter_height   = lv_font_get_height(font);
-    lv_coord_t y            = 0;
-    lv_txt_flag_t flag      = LV_TXT_FLAG_NONE;
+    const char * txt         = lv_label_get_text(label);
+    lv_label_ext_t * ext     = lv_obj_get_ext_attr(label);
+    uint32_t line_start      = 0;
+    uint32_t new_line_start  = 0;
+    lv_coord_t max_w         = lv_obj_get_width(label);
+    const lv_style_t * style = lv_obj_get_style(label);
+    const lv_font_t * font   = style->text.font;
+    uint8_t letter_height    = lv_font_get_height(font);
+    lv_coord_t y             = 0;
+    lv_txt_flag_t flag       = LV_TXT_FLAG_NONE;
 
     if(ext->recolor != 0) flag |= LV_TXT_FLAG_RECOLOR;
     if(ext->expand != 0) flag |= LV_TXT_FLAG_EXPAND;
@@ -566,16 +566,16 @@ uint16_t lv_label_get_letter_on(const lv_obj_t * label, lv_point_t * pos)
  */
 bool lv_label_is_char_under_pos(const lv_obj_t * label, lv_point_t * pos)
 {
-    const char * txt        = lv_label_get_text(label);
-    lv_label_ext_t * ext    = lv_obj_get_ext_attr(label);
-    uint32_t line_start     = 0;
-    uint32_t new_line_start = 0;
-    lv_coord_t max_w        = lv_obj_get_width(label);
-    lv_style_t * style      = lv_obj_get_style(label);
-    const lv_font_t * font  = style->text.font;
-    uint8_t letter_height   = lv_font_get_height(font);
-    lv_coord_t y            = 0;
-    lv_txt_flag_t flag      = LV_TXT_FLAG_NONE;
+    const char * txt         = lv_label_get_text(label);
+    lv_label_ext_t * ext     = lv_obj_get_ext_attr(label);
+    uint32_t line_start      = 0;
+    uint32_t new_line_start  = 0;
+    lv_coord_t max_w         = lv_obj_get_width(label);
+    const lv_style_t * style = lv_obj_get_style(label);
+    const lv_font_t * font   = style->text.font;
+    uint8_t letter_height    = lv_font_get_height(font);
+    lv_coord_t y             = 0;
+    lv_txt_flag_t flag       = LV_TXT_FLAG_NONE;
 
     if(ext->recolor != 0) flag |= LV_TXT_FLAG_RECOLOR;
     if(ext->expand != 0) flag |= LV_TXT_FLAG_EXPAND;
@@ -716,7 +716,7 @@ static bool lv_label_design(lv_obj_t * label, const lv_area_t * mask, lv_design_
         return false;
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         lv_area_t coords;
-        lv_style_t * style = lv_obj_get_style(label);
+        const lv_style_t * style = lv_obj_get_style(label);
         lv_opa_t opa_scale = lv_obj_get_opa_scale(label);
         lv_obj_get_coords(label, &coords);
 
@@ -826,11 +826,11 @@ static lv_res_t lv_label_signal(lv_obj_t * label, lv_signal_t sign, void * param
         }
     } else if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
         if(ext->body_draw) {
-            lv_style_t * style = lv_label_get_style(label);
-            label->ext_size    = LV_MATH_MAX(label->ext_size, style->body.padding.left);
-            label->ext_size    = LV_MATH_MAX(label->ext_size, style->body.padding.right);
-            label->ext_size    = LV_MATH_MAX(label->ext_size, style->body.padding.top);
-            label->ext_size    = LV_MATH_MAX(label->ext_size, style->body.padding.bottom);
+            const lv_style_t * style = lv_label_get_style(label);
+            label->ext_size = LV_MATH_MAX(label->ext_size, style->body.padding.left);
+            label->ext_size = LV_MATH_MAX(label->ext_size, style->body.padding.right);
+            label->ext_size = LV_MATH_MAX(label->ext_size, style->body.padding.top);
+            label->ext_size = LV_MATH_MAX(label->ext_size, style->body.padding.bottom);
         }
     } else if(sign == LV_SIGNAL_GET_TYPE) {
         lv_obj_type_t * buf = param;
@@ -854,9 +854,9 @@ static void lv_label_refr_text(lv_obj_t * label)
 
     if(ext->text == NULL) return;
 
-    lv_coord_t max_w       = lv_obj_get_width(label);
-    lv_style_t * style     = lv_obj_get_style(label);
-    const lv_font_t * font = style->text.font;
+    lv_coord_t max_w         = lv_obj_get_width(label);
+    const lv_style_t * style = lv_obj_get_style(label);
+    const lv_font_t * font   = style->text.font;
 
     /*If the width will be expanded set the max length to very big */
     if(ext->long_mode == LV_LABEL_LONG_EXPAND) {

--- a/src/lv_objx/lv_label.h
+++ b/src/lv_objx/lv_label.h
@@ -160,7 +160,7 @@ void lv_label_set_anim_speed(lv_obj_t * label, uint16_t anim_speed);
  * @param label pointer to an label object
  * @param style pointer to a style
  */
-static inline void lv_label_set_style(lv_obj_t * label, lv_style_t * style)
+static inline void lv_label_set_style(lv_obj_t * label, const lv_style_t * style)
 {
     lv_obj_set_style(label, style);
 }
@@ -241,7 +241,7 @@ bool lv_label_is_char_under_pos(const lv_obj_t * label, lv_point_t * pos);
  * @param label pointer to an label object
  * @return pointer to the label's style
  */
-static inline lv_style_t * lv_label_get_style(const lv_obj_t * label)
+static inline const lv_style_t * lv_label_get_style(const lv_obj_t * label)
 {
     return lv_obj_get_style(label);
 }

--- a/src/lv_objx/lv_led.c
+++ b/src/lv_objx/lv_led.c
@@ -187,12 +187,12 @@ static bool lv_led_design(lv_obj_t * led, const lv_area_t * mask, lv_design_mode
     } else if(mode == LV_DESIGN_DRAW_MAIN) {
         /*Make darker colors in a temporary style according to the brightness*/
         lv_led_ext_t * ext = lv_obj_get_ext_attr(led);
-        lv_style_t * style = lv_obj_get_style(led);
+        const lv_style_t * style = lv_obj_get_style(led);
 
         /* Store the real pointer because of 'lv_group'
          * If the object is in focus 'lv_obj_get_style()' will give a pointer to tmp style
          * and to the real object style. It is important because of style change tricks below*/
-        lv_style_t * style_ori_p = led->style_p;
+        const lv_style_t * style_ori_p = led->style_p;
 
         /*Create a temporal style*/
         lv_style_t leds_tmp;

--- a/src/lv_objx/lv_led.h
+++ b/src/lv_objx/lv_led.h
@@ -81,7 +81,7 @@ void lv_led_toggle(lv_obj_t * led);
  * @param led pointer to a led object
  * @param style pointer to a style
  */
-static inline void lv_led_set_style(lv_obj_t * led, lv_style_t * style)
+static inline void lv_led_set_style(lv_obj_t * led, const lv_style_t * style)
 {
     lv_obj_set_style(led, style);
 }
@@ -98,7 +98,7 @@ uint8_t lv_led_get_bright(const lv_obj_t * led);
  * @param led pointer to an led object
  * @return pointer to the led's style
  */
-static inline lv_style_t * lv_led_get_style(const lv_obj_t * led)
+static inline const lv_style_t * lv_led_get_style(const lv_obj_t * led)
 {
     return lv_obj_get_style(led);
 }

--- a/src/lv_objx/lv_line.c
+++ b/src/lv_objx/lv_line.c
@@ -121,7 +121,7 @@ void lv_line_set_points(lv_obj_t * line, const lv_point_t * point_a, uint16_t po
             ymax = LV_MATH_MAX(point_a[i].y, ymax);
         }
 
-        lv_style_t * style = lv_line_get_style(line);
+        const lv_style_t * style = lv_line_get_style(line);
         lv_obj_set_size(line, xmax + style->line.width, ymax + style->line.width);
     }
 
@@ -214,7 +214,7 @@ static bool lv_line_design(lv_obj_t * line, const lv_area_t * mask, lv_design_mo
 
         if(ext->point_num == 0 || ext->point_array == NULL) return false;
 
-        lv_style_t * style = lv_obj_get_style(line);
+        const lv_style_t * style = lv_obj_get_style(line);
         lv_opa_t opa_scale = lv_obj_get_opa_scale(line);
         lv_area_t area;
         lv_obj_get_coords(line, &area);
@@ -225,12 +225,12 @@ static bool lv_line_design(lv_obj_t * line, const lv_area_t * mask, lv_design_mo
         lv_coord_t h = lv_obj_get_height(line);
         uint16_t i;
 
-        lv_style_t circle_style; /*If rounded...*/
-        lv_style_copy(&circle_style, style);
-        circle_style.body.radius     = LV_RADIUS_CIRCLE;
-        circle_style.body.main_color = style->line.color;
-        circle_style.body.grad_color = style->line.color;
-        circle_style.body.opa        = style->line.opa;
+        lv_style_t circle_style_tmp; /*If rounded...*/
+        lv_style_copy(&circle_style_tmp, style);
+        circle_style_tmp.body.radius     = LV_RADIUS_CIRCLE;
+        circle_style_tmp.body.main_color = style->line.color;
+        circle_style_tmp.body.grad_color = style->line.color;
+        circle_style_tmp.body.opa        = style->line.opa;
         lv_area_t circle_area;
 
         /*Read all points and draw the lines*/
@@ -256,7 +256,7 @@ static bool lv_line_design(lv_obj_t * line, const lv_area_t * mask, lv_design_mo
                     p1.y - ((style->line.width - 1) >> 1) - ((style->line.width - 1) & 0x1);
                 circle_area.x2 = p1.x + ((style->line.width - 1) >> 1);
                 circle_area.y2 = p1.y + ((style->line.width - 1) >> 1);
-                lv_draw_rect(&circle_area, mask, &circle_style, opa_scale);
+                lv_draw_rect(&circle_area, mask, &circle_style_tmp, opa_scale);
             }
         }
 
@@ -268,7 +268,7 @@ static bool lv_line_design(lv_obj_t * line, const lv_area_t * mask, lv_design_mo
                 p2.y - ((style->line.width - 1) >> 1) - ((style->line.width - 1) & 0x1);
             circle_area.x2 = p2.x + ((style->line.width - 1) >> 1);
             circle_area.y2 = p2.y + ((style->line.width - 1) >> 1);
-            lv_draw_rect(&circle_area, mask, &circle_style, opa_scale);
+            lv_draw_rect(&circle_area, mask, &circle_style_tmp, opa_scale);
         }
     }
     return true;
@@ -296,7 +296,7 @@ static lv_res_t lv_line_signal(lv_obj_t * line, lv_signal_t sign, void * param)
         }
         buf->type[i] = "lv_line";
     } else if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
-        lv_style_t * style = lv_line_get_style(line);
+        const lv_style_t * style = lv_line_get_style(line);
         if(line->ext_size < style->line.width) line->ext_size = style->line.width;
     }
 

--- a/src/lv_objx/lv_line.h
+++ b/src/lv_objx/lv_line.h
@@ -91,7 +91,7 @@ void lv_line_set_y_invert(lv_obj_t * line, bool en);
  * @param line pointer to a line object
  * @param style pointer to a style
  */
-static inline void lv_line_set_style(lv_obj_t * line, lv_style_t * style)
+static inline void lv_line_set_style(lv_obj_t * line, const lv_style_t * style)
 {
     lv_obj_set_style(line, style);
 }
@@ -129,7 +129,7 @@ bool lv_line_get_y_invert(const lv_obj_t * line);
  * @param line pointer to an line object
  * @return pointer to the line's style
  */
-static inline lv_style_t * lv_line_get_style(const lv_obj_t * line)
+static inline const lv_style_t * lv_line_get_style(const lv_obj_t * line)
 {
     return lv_obj_get_style(line);
 }

--- a/src/lv_objx/lv_list.c
+++ b/src/lv_objx/lv_list.c
@@ -342,7 +342,7 @@ void lv_list_set_anim_time(lv_obj_t * list, uint16_t anim_time)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_list_set_style(lv_obj_t * list, lv_list_style_t type, lv_style_t * style)
+void lv_list_set_style(lv_obj_t * list, lv_list_style_t type, const lv_style_t * style)
 {
     lv_list_ext_t * ext           = lv_obj_get_ext_attr(list);
     lv_btn_style_t btn_style_refr = LV_BTN_STYLE_REL;
@@ -575,9 +575,9 @@ uint16_t lv_list_get_anim_time(const lv_obj_t * list)
  * @param type which style should be get
  * @return style pointer to a style
  *  */
-lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type)
+const lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type)
 {
-    lv_style_t * style  = NULL;
+    const lv_style_t * style  = NULL;
     lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
 
     switch(type) {

--- a/src/lv_objx/lv_list.h
+++ b/src/lv_objx/lv_list.h
@@ -52,11 +52,11 @@ typedef struct
 {
     lv_page_ext_t page; /*Ext. of ancestor*/
     /*New data for this type */
-    uint16_t anim_time;                        /*Scroll animation time*/
-    lv_style_t * styles_btn[LV_BTN_STATE_NUM]; /*Styles of the list element buttons*/
-    lv_style_t * style_img;                    /*Style of the list element images on buttons*/
-    uint32_t size;                             /*the number of items(buttons) in the list*/
-    bool single_mode;                          /* whether single selected mode is enabled */
+    uint16_t anim_time;                              /*Scroll animation time*/
+    const lv_style_t * styles_btn[LV_BTN_STATE_NUM]; /*Styles of the list element buttons*/
+    const lv_style_t * style_img;                    /*Style of the list element images on buttons*/
+    uint32_t size;                                   /*the number of items(buttons) in the list*/
+    bool single_mode;                                /* whether single selected mode is enabled */
 #if LV_USE_GROUP
     lv_obj_t *
         last_sel; /* The last selected button. It will be reverted when the list is focused again */
@@ -184,7 +184,7 @@ static inline void lv_list_set_edge_flash(lv_obj_t * list, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_list_set_style(lv_obj_t * list, lv_list_style_t type, lv_style_t * style);
+void lv_list_set_style(lv_obj_t * list, lv_list_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -299,7 +299,7 @@ static inline bool lv_list_get_edge_flash(lv_obj_t * list)
  * @param type which style should be get
  * @return style pointer to a style
  *  */
-lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type);
+const lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_lmeter.c
+++ b/src/lv_objx/lv_lmeter.c
@@ -250,7 +250,7 @@ static bool lv_lmeter_design(lv_obj_t * lmeter, const lv_area_t * mask, lv_desig
     /*Draw the object*/
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         lv_lmeter_ext_t * ext = lv_obj_get_ext_attr(lmeter);
-        lv_style_t * style    = lv_obj_get_style(lmeter);
+        const lv_style_t * style    = lv_obj_get_style(lmeter);
         lv_opa_t opa_scale    = lv_obj_get_opa_scale(lmeter);
         lv_style_t style_tmp;
         memcpy(&style_tmp, style, sizeof(lv_style_t));
@@ -342,7 +342,7 @@ static lv_res_t lv_lmeter_signal(lv_obj_t * lmeter, lv_signal_t sign, void * par
     } else if(sign == LV_SIGNAL_STYLE_CHG) {
         lv_obj_refresh_ext_size(lmeter);
     } else if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
-        lv_style_t * style = lv_lmeter_get_style(lmeter);
+        const lv_style_t * style = lv_lmeter_get_style(lmeter);
         lmeter->ext_size   = LV_MATH_MAX(lmeter->ext_size, style->line.width);
     } else if(sign == LV_SIGNAL_GET_TYPE) {
         lv_obj_type_t * buf = param;

--- a/src/lv_objx/lv_lmeter.h
+++ b/src/lv_objx/lv_lmeter.h
@@ -136,7 +136,7 @@ uint16_t lv_lmeter_get_scale_angle(const lv_obj_t * lmeter);
  * @param lmeter pointer to a line meter object
  * @return pointer to the line meter's style
  */
-static inline lv_style_t * lv_lmeter_get_style(const lv_obj_t * lmeter)
+static inline const lv_style_t * lv_lmeter_get_style(const lv_obj_t * lmeter)
 {
     return lv_obj_get_style(lmeter);
 }

--- a/src/lv_objx/lv_mbox.c
+++ b/src/lv_objx/lv_mbox.c
@@ -236,7 +236,7 @@ void lv_mbox_stop_auto_close(lv_obj_t * mbox)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_mbox_set_style(lv_obj_t * mbox, lv_mbox_style_t type, lv_style_t * style)
+void lv_mbox_set_style(lv_obj_t * mbox, lv_mbox_style_t type, const lv_style_t * style)
 {
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
 
@@ -336,9 +336,9 @@ uint16_t lv_mbox_get_anim_time(const lv_obj_t * mbox)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_mbox_get_style(const lv_obj_t * mbox, lv_mbox_style_t type)
+const lv_style_t * lv_mbox_get_style(const lv_obj_t * mbox, lv_mbox_style_t type)
 {
-    lv_style_t * style  = NULL;
+    const lv_style_t * style  = NULL;
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
 
     switch(type) {
@@ -473,7 +473,7 @@ static void mbox_realign(lv_obj_t * mbox)
 {
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
 
-    lv_style_t * style = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BG);
+    const lv_style_t * style = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BG);
     lv_coord_t w = lv_obj_get_width(mbox) - style->body.padding.left - style->body.padding.right;
 
     if(ext->text) {
@@ -481,9 +481,9 @@ static void mbox_realign(lv_obj_t * mbox)
     }
 
     if(ext->btnm) {
-        lv_style_t * btn_bg_style  = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BTN_BG);
-        lv_style_t * btn_rel_style = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BTN_REL);
-        lv_coord_t font_h          = lv_font_get_height(btn_rel_style->text.font);
+        const lv_style_t * btn_bg_style  = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BTN_BG);
+        const lv_style_t * btn_rel_style = lv_mbox_get_style(mbox, LV_MBOX_STYLE_BTN_REL);
+        lv_coord_t font_h                = lv_font_get_height(btn_rel_style->text.font);
         lv_obj_set_size(ext->btnm, w,
                         font_h + btn_rel_style->body.padding.top +
                             btn_rel_style->body.padding.bottom + btn_bg_style->body.padding.top +

--- a/src/lv_objx/lv_mbox.h
+++ b/src/lv_objx/lv_mbox.h
@@ -130,7 +130,7 @@ void lv_mbox_stop_auto_close(lv_obj_t * mbox);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_mbox_set_style(lv_obj_t * mbox, lv_mbox_style_t type, lv_style_t * style);
+void lv_mbox_set_style(lv_obj_t * mbox, lv_mbox_style_t type, const lv_style_t * style);
 
 /**
  * Set whether recoloring is enabled. Must be called after `lv_mbox_add_btns`.
@@ -179,7 +179,7 @@ uint16_t lv_mbox_get_anim_time(const lv_obj_t * mbox);
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_mbox_get_style(const lv_obj_t * mbox, lv_mbox_style_t type);
+const lv_style_t * lv_mbox_get_style(const lv_obj_t * mbox, lv_mbox_style_t type);
 
 /**
  * Get whether recoloring is enabled

--- a/src/lv_objx/lv_objx_templ.c
+++ b/src/lv_objx/lv_objx_templ.c
@@ -116,7 +116,7 @@ lv_obj_t * lv_templ_create(lv_obj_t * par, const lv_obj_t * copy)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_templ_set_style(lv_obj_t * templ, lv_templ_style_t type, lv_style_t * style)
+void lv_templ_set_style(lv_obj_t * templ, lv_templ_style_t type, const lv_style_t * style)
 {
     lv_templ_ext_t * ext = lv_obj_get_ext_attr(templ);
 

--- a/src/lv_objx/lv_objx_templ.h
+++ b/src/lv_objx/lv_objx_templ.h
@@ -77,7 +77,7 @@ lv_obj_t * lv_templ_create(lv_obj_t * par, const lv_obj_t * copy);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_templ_set_style(lv_obj_t * templ, lv_templ_style_t type, lv_style_t * style);
+void lv_templ_set_style(lv_obj_t * templ, lv_templ_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -624,7 +624,7 @@ static bool lv_page_design(lv_obj_t * page, const lv_area_t * mask, lv_design_mo
     /*Cache page bg style for temporary modification*/
     const lv_style_t * style = lv_page_get_style(page, LV_PAGE_STYLE_BG);
     lv_style_t style_tmp;
-    memcpy(&style_tmp, style, sizeof(lv_style_t));
+    lv_style_copy(&style_tmp, style);
 
     if(mode == LV_DESIGN_DRAW_MAIN) {
         /*Draw without border*/

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -243,7 +243,7 @@ void lv_page_set_edge_flash(lv_obj_t * page, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_page_set_style(lv_obj_t * page, lv_page_style_t type, lv_style_t * style)
+void lv_page_set_style(lv_obj_t * page, lv_page_style_t type, const lv_style_t * style)
 {
     lv_page_ext_t * ext = lv_obj_get_ext_attr(page);
 
@@ -329,8 +329,8 @@ bool lv_page_get_edge_flash(lv_obj_t * page)
  */
 lv_coord_t lv_page_get_fit_width(lv_obj_t * page)
 {
-    lv_style_t * bg_style   = lv_page_get_style(page, LV_PAGE_STYLE_BG);
-    lv_style_t * scrl_style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
+    const lv_style_t * bg_style   = lv_page_get_style(page, LV_PAGE_STYLE_BG);
+    const lv_style_t * scrl_style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
 
     return lv_obj_get_width(page) - bg_style->body.padding.left - bg_style->body.padding.right -
            scrl_style->body.padding.left - scrl_style->body.padding.right;
@@ -343,8 +343,8 @@ lv_coord_t lv_page_get_fit_width(lv_obj_t * page)
  */
 lv_coord_t lv_page_get_fit_height(lv_obj_t * page)
 {
-    lv_style_t * bg_style   = lv_page_get_style(page, LV_PAGE_STYLE_BG);
-    lv_style_t * scrl_style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
+    const lv_style_t * bg_style   = lv_page_get_style(page, LV_PAGE_STYLE_BG);
+    const lv_style_t * scrl_style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
 
     return lv_obj_get_height(page) - bg_style->body.padding.top - bg_style->body.padding.bottom -
            scrl_style->body.padding.top - scrl_style->body.padding.bottom;
@@ -356,9 +356,9 @@ lv_coord_t lv_page_get_fit_height(lv_obj_t * page)
  * @param type which style should be get
  * @return style pointer to a style
  *  */
-lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type)
+const lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type)
 {
-    lv_style_t * style  = NULL;
+    const lv_style_t * style  = NULL;
     lv_page_ext_t * ext = lv_obj_get_ext_attr(page);
 
     switch(type) {
@@ -384,8 +384,8 @@ lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type)
  */
 bool lv_page_on_edge(lv_obj_t * page, lv_page_edge_t edge)
 {
-    lv_style_t * page_style = lv_obj_get_style(page);
-    lv_obj_t * scrl         = lv_page_get_scrl(page);
+    const lv_style_t * page_style = lv_obj_get_style(page);
+    lv_obj_t * scrl               = lv_page_get_scrl(page);
     lv_area_t page_coords;
     lv_area_t scrl_coords;
 
@@ -441,8 +441,8 @@ void lv_page_focus(lv_obj_t * page, const lv_obj_t * obj, uint16_t anim_time)
     lv_anim_del(ext->scrl, (lv_anim_fp_t)lv_obj_set_pos);
 #endif
 
-    lv_style_t * style      = lv_page_get_style(page, LV_PAGE_STYLE_BG);
-    lv_style_t * style_scrl = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
+    const lv_style_t * style      = lv_page_get_style(page, LV_PAGE_STYLE_BG);
+    const lv_style_t * style_scrl = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
 
     /*If obj is higher then the page focus where the "error" is smaller*/
     lv_coord_t obj_y      = obj->coords.y1 - ext->scrl->coords.y1;
@@ -620,25 +620,22 @@ static bool lv_page_design(lv_obj_t * page, const lv_area_t * mask, lv_design_mo
 {
     if(mode == LV_DESIGN_COVER_CHK) {
         return ancestor_design(page, mask, mode);
-    } else if(mode == LV_DESIGN_DRAW_MAIN) {
+    }
+    /*Cache page bg style for temporary modification*/
+    const lv_style_t * style = lv_page_get_style(page, LV_PAGE_STYLE_BG);
+    lv_style_t style_tmp;
+    memcpy(&style_tmp, style, sizeof(lv_style_t));
+
+    if(mode == LV_DESIGN_DRAW_MAIN) {
         /*Draw without border*/
-        lv_style_t * style          = lv_page_get_style(page, LV_PAGE_STYLE_BG);
-        lv_coord_t border_width_tmp = style->body.border.width;
-        style->body.border.width    = 0;
-        lv_draw_rect(&page->coords, mask, style, lv_obj_get_opa_scale(page));
-        style->body.border.width = border_width_tmp;
+        style_tmp.body.border.width = 0;
+        lv_draw_rect(&page->coords, mask, &style_tmp, lv_obj_get_opa_scale(page));
 
     } else if(mode == LV_DESIGN_DRAW_POST) { /*Draw the scroll bars finally*/
-
         /*Draw only a border*/
-        lv_style_t * style          = lv_page_get_style(page, LV_PAGE_STYLE_BG);
-        lv_coord_t shadow_width_tmp = style->body.shadow.width;
-        lv_opa_t opa_tmp            = style->body.opa;
-        style->body.shadow.width    = 0;
-        style->body.opa             = LV_OPA_TRANSP;
-        lv_draw_rect(&page->coords, mask, style, lv_obj_get_opa_scale(page));
-        style->body.shadow.width = shadow_width_tmp;
-        style->body.opa          = opa_tmp;
+        style_tmp.body.shadow.width = 0;
+        style_tmp.body.opa          = LV_OPA_TRANSP;
+        lv_draw_rect(&page->coords, mask, &style_tmp, lv_obj_get_opa_scale(page));
 
         lv_page_ext_t * ext = lv_obj_get_ext_attr(page);
 
@@ -723,10 +720,10 @@ static bool lv_scrl_design(lv_obj_t * scrl, const lv_area_t * mask, lv_design_mo
         /* If the page is focused in a group and
          * the background object is not visible (transparent)
          * then "activate" the style of the scrollable*/
-        lv_style_t * style_scrl_ori = lv_obj_get_style(scrl);
-        lv_obj_t * page             = lv_obj_get_parent(scrl);
-        lv_style_t * style_page     = lv_obj_get_style(page);
-        lv_group_t * g              = lv_obj_get_group(page);
+        const lv_style_t * style_scrl_ori = lv_obj_get_style(scrl);
+        lv_obj_t * page                   = lv_obj_get_parent(scrl);
+        const lv_style_t * style_page     = lv_obj_get_style(page);
+        lv_group_t * g                    = lv_obj_get_group(page);
         if((style_page->body.opa == LV_OPA_TRANSP) &&
            style_page->body.border.width == 0) { /*Is the background visible?*/
             if(lv_group_get_focused(g) == page) {
@@ -780,7 +777,7 @@ static lv_res_t lv_page_signal(lv_obj_t * page, lv_signal_t sign, void * param)
                 child = lv_obj_get_child(page, child); /*Get the next child before move this*/
 
                 /*Reposition the child to take padding into account*/
-                lv_style_t * style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
+                const lv_style_t * style = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
                 tmp->coords.x1 += style->body.padding.left;
                 tmp->coords.x2 += style->body.padding.left;
                 tmp->coords.y1 += style->body.padding.top;
@@ -867,9 +864,9 @@ static lv_res_t lv_page_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, voi
     res = ancestor_signal(scrl, sign, param);
     if(res != LV_RES_OK) return res;
 
-    lv_obj_t * page          = lv_obj_get_parent(scrl);
-    lv_style_t * page_style  = lv_obj_get_style(page);
-    lv_page_ext_t * page_ext = lv_obj_get_ext_attr(page);
+    lv_obj_t * page                = lv_obj_get_parent(scrl);
+    const lv_style_t * page_style  = lv_obj_get_style(page);
+    lv_page_ext_t * page_ext       = lv_obj_get_ext_attr(page);
 
     if(sign == LV_SIGNAL_CORD_CHG) {
         /*Limit the position of the scrollable object to be always visible
@@ -1062,9 +1059,9 @@ static void scrl_def_event_cb(lv_obj_t * scrl, lv_event_t event)
  */
 static void lv_page_sb_refresh(lv_obj_t * page)
 {
-    lv_page_ext_t * ext = lv_obj_get_ext_attr(page);
-    lv_style_t * style  = lv_obj_get_style(page);
-    lv_obj_t * scrl     = ext->scrl;
+    lv_page_ext_t * ext      = lv_obj_get_ext_attr(page);
+    const lv_style_t * style = lv_obj_get_style(page);
+    lv_obj_t * scrl          = ext->scrl;
     lv_coord_t size_tmp;
     lv_coord_t scrl_w = lv_obj_get_width(scrl);
     lv_coord_t scrl_h = lv_obj_get_height(scrl);

--- a/src/lv_objx/lv_page.h
+++ b/src/lv_objx/lv_page.h
@@ -67,7 +67,7 @@ typedef struct
     lv_obj_t * scrl; /*The scrollable object on the background*/
     struct
     {
-        lv_style_t * style; /*Style of scrollbars*/
+        const lv_style_t * style; /*Style of scrollbars*/
         lv_area_t
             hor_area; /*Horizontal scrollbar area relative to the page. (Handled by the library) */
         lv_area_t
@@ -79,7 +79,7 @@ typedef struct
     struct
     {
         uint16_t state;      /*Store the current size of the edge flash effect*/
-        lv_style_t * style;  /*Style of edge flash effect (usually homogeneous circle)*/
+        const lv_style_t * style;  /*Style of edge flash effect (usually homogeneous circle)*/
         uint8_t enabled : 1; /*1: Show a flash animation on the edge*/
         uint8_t top_ip : 1; /*Used internally to show that top most position is reached (flash is In
                                Progress)*/
@@ -237,7 +237,7 @@ static inline void lv_page_set_scrl_layout(lv_obj_t * page, lv_layout_t layout)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_page_set_style(lv_obj_t * page, lv_page_style_t type, lv_style_t * style);
+void lv_page_set_style(lv_obj_t * page, lv_page_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -361,7 +361,7 @@ static inline lv_fit_t lv_page_get_scrl_fit_bottom(const lv_obj_t * page)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type);
+const lv_style_t * lv_page_get_style(const lv_obj_t * page, lv_page_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_preload.c
+++ b/src/lv_objx/lv_preload.c
@@ -154,7 +154,7 @@ void lv_preload_set_spin_time(lv_obj_t * preload, uint16_t time)
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, lv_style_t * style)
+void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, const lv_style_t * style)
 {
     switch(type) {
         case LV_PRELOAD_STYLE_MAIN: lv_arc_set_style(preload, LV_ARC_STYLE_MAIN, style); break;
@@ -261,9 +261,9 @@ uint16_t lv_preload_get_spin_time(const lv_obj_t * preload)
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type)
+const lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
 
     switch(type) {
         case LV_PRELOAD_STYLE_MAIN: style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN); break;
@@ -330,7 +330,7 @@ static bool lv_preload_design(lv_obj_t * preload, const lv_area_t * mask, lv_des
     else if(mode == LV_DESIGN_DRAW_MAIN) {
 
         /*Draw a circle as background*/
-        lv_style_t * style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
+        const lv_style_t * style = lv_arc_get_style(preload, LV_ARC_STYLE_MAIN);
         if(style->body.border.width > 0) {
             lv_coord_t r = (LV_MATH_MIN(lv_obj_get_width(preload), lv_obj_get_height(preload))) / 2;
             r -= LV_MATH_MIN(style->body.padding.left, style->body.padding.top);

--- a/src/lv_objx/lv_preload.h
+++ b/src/lv_objx/lv_preload.h
@@ -104,7 +104,7 @@ void lv_preload_set_spin_time(lv_obj_t * preload, uint16_t time);
  * @param type which style should be set
  * @param style pointer to a style
  *  */
-void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, lv_style_t * style);
+void lv_preload_set_style(lv_obj_t * preload, lv_preload_style_t type, const lv_style_t * style);
 
 /**
  * Set the animation type of a preloadeer.
@@ -135,7 +135,7 @@ uint16_t lv_preload_get_spin_time(const lv_obj_t * preload);
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type);
+const lv_style_t * lv_preload_get_style(const lv_obj_t * preload, lv_preload_style_t type);
 
 /**
  * Get the animation type of a preloadeer.

--- a/src/lv_objx/lv_roller.c
+++ b/src/lv_objx/lv_roller.c
@@ -199,9 +199,9 @@ void lv_roller_set_selected(lv_obj_t * roller, uint16_t sel_opt, bool anim_en)
  */
 void lv_roller_set_visible_row_count(lv_obj_t * roller, uint8_t row_cnt)
 {
-    lv_roller_ext_t * ext    = lv_obj_get_ext_attr(roller);
-    lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
-    uint8_t n_line_space     = (row_cnt > 1) ? row_cnt - 1 : 1;
+    lv_roller_ext_t * ext          = lv_obj_get_ext_attr(roller);
+    const lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
+    uint8_t n_line_space           = (row_cnt > 1) ? row_cnt - 1 : 1;
     lv_ddlist_set_fix_height(roller, lv_font_get_height(style_label->text.font) * row_cnt +
                                          style_label->text.line_space * n_line_space);
 }
@@ -212,7 +212,7 @@ void lv_roller_set_visible_row_count(lv_obj_t * roller, uint8_t row_cnt)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_roller_set_style(lv_obj_t * roller, lv_roller_style_t type, lv_style_t * style)
+void lv_roller_set_style(lv_obj_t * roller, lv_roller_style_t type, const lv_style_t * style)
 {
     switch(type) {
         case LV_ROLLER_STYLE_BG: lv_obj_set_style(roller, style); break;
@@ -269,7 +269,7 @@ bool lv_roller_get_hor_fit(const lv_obj_t * roller)
  * @param type which style should be get
  * @return style pointer to a style
  *  */
-lv_style_t * lv_roller_get_style(const lv_obj_t * roller, lv_roller_style_t type)
+const lv_style_t * lv_roller_get_style(const lv_obj_t * roller, lv_roller_style_t type)
 {
     switch(type) {
         case LV_ROLLER_STYLE_BG: return lv_obj_get_style(roller);
@@ -305,11 +305,11 @@ static bool lv_roller_design(lv_obj_t * roller, const lv_area_t * mask, lv_desig
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         draw_bg(roller, mask);
 
-        lv_style_t * style     = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
-        lv_opa_t opa_scale     = lv_obj_get_opa_scale(roller);
-        const lv_font_t * font = style->text.font;
-        lv_roller_ext_t * ext  = lv_obj_get_ext_attr(roller);
-        lv_coord_t font_h      = lv_font_get_height(font);
+        const lv_style_t * style = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
+        lv_opa_t opa_scale       = lv_obj_get_opa_scale(roller);
+        const lv_font_t * font   = style->text.font;
+        lv_roller_ext_t * ext    = lv_obj_get_ext_attr(roller);
+        lv_coord_t font_h        = lv_font_get_height(font);
         lv_area_t rect_area;
         rect_area.y1 = roller->coords.y1 + lv_obj_get_height(roller) / 2 - font_h / 2 -
                        style->text.line_space / 2;
@@ -323,11 +323,11 @@ static bool lv_roller_design(lv_obj_t * roller, const lv_area_t * mask, lv_desig
     }
     /*Post draw when the children are drawn*/
     else if(mode == LV_DESIGN_DRAW_POST) {
-        lv_style_t * style     = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
-        lv_roller_ext_t * ext  = lv_obj_get_ext_attr(roller);
-        const lv_font_t * font = style->text.font;
-        lv_coord_t font_h      = lv_font_get_height(font);
-        lv_opa_t opa_scale     = lv_obj_get_opa_scale(roller);
+        const lv_style_t * style = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
+        lv_roller_ext_t * ext    = lv_obj_get_ext_attr(roller);
+        const lv_font_t * font   = style->text.font;
+        lv_coord_t font_h        = lv_font_get_height(font);
+        lv_opa_t opa_scale       = lv_obj_get_opa_scale(roller);
 
         /*Redraw the text on the selected area with a different color*/
         lv_area_t rect_area;
@@ -342,7 +342,7 @@ static bool lv_roller_design(lv_obj_t * roller, const lv_area_t * mask, lv_desig
         bool area_ok;
         area_ok = lv_area_intersect(&mask_sel, mask, &rect_area);
         if(area_ok) {
-            lv_style_t * sel_style = lv_roller_get_style(roller, LV_ROLLER_STYLE_SEL);
+            const lv_style_t * sel_style = lv_roller_get_style(roller, LV_ROLLER_STYLE_SEL);
             lv_style_t new_style;
             lv_txt_flag_t txt_align = LV_TXT_FLAG_NONE;
 
@@ -503,9 +503,9 @@ static lv_res_t lv_roller_scrl_signal(lv_obj_t * roller_scrl, lv_signal_t sign, 
         return LV_RES_INV; /*On delete the ddlist signal deletes the label so nothing left to do
                               here*/
 
-    lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
-    const lv_font_t * font   = style_label->text.font;
-    lv_coord_t font_h        = lv_font_get_height(font);
+    const lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
+    const lv_font_t * font         = style_label->text.font;
+    lv_coord_t font_h              = lv_font_get_height(font);
 
     if(sign == LV_SIGNAL_DRAG_END) {
         /*If dragged then align the list to there be an element in the middle*/
@@ -550,7 +550,7 @@ static lv_res_t lv_roller_scrl_signal(lv_obj_t * roller_scrl, lv_signal_t sign, 
  */
 static void draw_bg(lv_obj_t * roller, const lv_area_t * mask)
 {
-    lv_style_t * style = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
+    const lv_style_t * style = lv_roller_get_style(roller, LV_ROLLER_STYLE_BG);
     lv_area_t half_mask;
     lv_area_t half_roller;
     lv_coord_t h = lv_obj_get_height(roller);
@@ -588,14 +588,11 @@ static void draw_bg(lv_obj_t * roller, const lv_area_t * mask)
     half_roller.y1 -= style->body.radius;
 
     if(union_ok) {
-        lv_color_t main_tmp = style->body.main_color;
-        lv_color_t grad_tmp = style->body.grad_color;
-
-        style->body.main_color = grad_tmp;
-        style->body.grad_color = main_tmp;
-        lv_draw_rect(&half_roller, &half_mask, style, lv_obj_get_opa_scale(roller));
-        style->body.main_color = main_tmp;
-        style->body.grad_color = grad_tmp;
+        lv_style_t style_tmp;
+        memcpy(&style_tmp, style, sizeof(lv_style_t));
+        style_tmp.body.main_color = style->body.grad_color;
+        style_tmp.body.grad_color = style->body.main_color;
+        lv_draw_rect(&half_roller, &half_mask, &style_tmp, lv_obj_get_opa_scale(roller));
     }
 }
 
@@ -609,12 +606,12 @@ static void refr_position(lv_obj_t * roller, bool anim_en)
 #if LV_USE_ANIMATION == 0
     anim_en = false;
 #endif
-    lv_obj_t * roller_scrl   = lv_page_get_scrl(roller);
-    lv_roller_ext_t * ext    = lv_obj_get_ext_attr(roller);
-    lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
-    const lv_font_t * font   = style_label->text.font;
-    lv_coord_t font_h        = lv_font_get_height(font);
-    lv_coord_t h             = lv_obj_get_height(roller);
+    lv_obj_t * roller_scrl         = lv_page_get_scrl(roller);
+    lv_roller_ext_t * ext          = lv_obj_get_ext_attr(roller);
+    const lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
+    const lv_font_t * font         = style_label->text.font;
+    lv_coord_t font_h              = lv_font_get_height(font);
+    lv_coord_t h                   = lv_obj_get_height(roller);
 
     /* Normally the animtaion's `end_cb` sets correct position of the roller is infinite.
      * But without animations do it manually*/
@@ -668,10 +665,10 @@ static void inf_normalize(void * scrl)
             (LV_ROLLER_INF_PAGES / 2) * real_id_cnt; /*Select the middle page*/
 
         /*Move to the new id*/
-        lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
-        const lv_font_t * font   = style_label->text.font;
-        lv_coord_t font_h        = lv_font_get_height(font);
-        lv_coord_t h             = lv_obj_get_height(roller);
+        const lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
+        const lv_font_t * font         = style_label->text.font;
+        lv_coord_t font_h              = lv_font_get_height(font);
+        lv_coord_t h                   = lv_obj_get_height(roller);
 
         lv_coord_t line_y1 = ext->ddlist.sel_opt_id * (font_h + style_label->text.line_space) +
                              ext->ddlist.label->coords.y1 - roller_scrl->coords.y1;

--- a/src/lv_objx/lv_roller.h
+++ b/src/lv_objx/lv_roller.h
@@ -123,7 +123,7 @@ static inline void lv_roller_set_anim_time(lv_obj_t * roller, uint16_t anim_time
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_roller_set_style(lv_obj_t * roller, lv_roller_style_t type, lv_style_t * style);
+void lv_roller_set_style(lv_obj_t * roller, lv_roller_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -187,7 +187,7 @@ bool lv_roller_get_hor_fit(const lv_obj_t * roller);
  * @param type which style should be get
  * @return style pointer to a style
  *  */
-lv_style_t * lv_roller_get_style(const lv_obj_t * roller, lv_roller_style_t type);
+const lv_style_t * lv_roller_get_style(const lv_obj_t * roller, lv_roller_style_t type);
 
 /**********************
  *      MACROS

--- a/src/lv_objx/lv_slider.c
+++ b/src/lv_objx/lv_slider.c
@@ -132,7 +132,7 @@ void lv_slider_set_knob_in(lv_obj_t * slider, bool in)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_slider_set_style(lv_obj_t * slider, lv_slider_style_t type, lv_style_t * style)
+void lv_slider_set_style(lv_obj_t * slider, lv_slider_style_t type, const lv_style_t * style)
 {
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
 
@@ -194,9 +194,9 @@ bool lv_slider_get_knob_in(const lv_obj_t * slider)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_slider_get_style(const lv_obj_t * slider, lv_slider_style_t type)
+const lv_style_t * lv_slider_get_style(const lv_obj_t * slider, lv_slider_style_t type)
 {
-    lv_style_t * style    = NULL;
+    const lv_style_t * style    = NULL;
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
 
     switch(type) {
@@ -233,9 +233,9 @@ static bool lv_slider_design(lv_obj_t * slider, const lv_area_t * mask, lv_desig
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
 
-        lv_style_t * style_bg    = lv_slider_get_style(slider, LV_SLIDER_STYLE_BG);
-        lv_style_t * style_knob  = lv_slider_get_style(slider, LV_SLIDER_STYLE_KNOB);
-        lv_style_t * style_indic = lv_slider_get_style(slider, LV_SLIDER_STYLE_INDIC);
+        const lv_style_t * style_bg    = lv_slider_get_style(slider, LV_SLIDER_STYLE_BG);
+        const lv_style_t * style_knob  = lv_slider_get_style(slider, LV_SLIDER_STYLE_KNOB);
+        const lv_style_t * style_indic = lv_slider_get_style(slider, LV_SLIDER_STYLE_INDIC);
 
         lv_opa_t opa_scale = lv_obj_get_opa_scale(slider);
 
@@ -536,8 +536,8 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
             slider->signal_cb(slider, LV_SIGNAL_REFR_EXT_SIZE, NULL);
         }
     } else if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
-        lv_style_t * style      = lv_slider_get_style(slider, LV_SLIDER_STYLE_BG);
-        lv_style_t * knob_style = lv_slider_get_style(slider, LV_SLIDER_STYLE_KNOB);
+        const lv_style_t * style      = lv_slider_get_style(slider, LV_SLIDER_STYLE_BG);
+        const lv_style_t * knob_style = lv_slider_get_style(slider, LV_SLIDER_STYLE_KNOB);
         lv_coord_t shadow_w     = knob_style->body.shadow.width;
         if(ext->knob_in == 0) {
             /* The smaller size is the knob diameter*/

--- a/src/lv_objx/lv_slider.h
+++ b/src/lv_objx/lv_slider.h
@@ -41,7 +41,7 @@ typedef struct
 {
     lv_bar_ext_t bar; /*Ext. of ancestor*/
     /*New data for this type */
-    lv_style_t * style_knob; /*Style of the knob*/
+    const lv_style_t * style_knob; /*Style of the knob*/
     int16_t
         drag_value; /*Store a temporal value during press until release (Handled by the library)*/
     uint8_t knob_in : 1; /*1: Draw the knob inside the bar*/
@@ -107,7 +107,7 @@ void lv_slider_set_knob_in(lv_obj_t * slider, bool in);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_slider_set_style(lv_obj_t * slider, lv_slider_style_t type, lv_style_t * style);
+void lv_slider_set_style(lv_obj_t * slider, lv_slider_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -161,7 +161,7 @@ bool lv_slider_get_knob_in(const lv_obj_t * slider);
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_slider_get_style(const lv_obj_t * slider, lv_slider_style_t type);
+const lv_style_t * lv_slider_get_style(const lv_obj_t * slider, lv_slider_style_t type);
 
 /**********************
  *      MACROS

--- a/src/lv_objx/lv_spinbox.h
+++ b/src/lv_objx/lv_spinbox.h
@@ -140,7 +140,7 @@ void lv_spinbox_set_padding_left(lv_obj_t * spinbox, uint8_t padding);
  * @param type which style should be get
  * @return style pointer to the style
  */
-static inline lv_style_t * lv_spinbox_get_style(lv_obj_t * spinbox, lv_spinbox_style_t type)
+static inline const lv_style_t * lv_spinbox_get_style(lv_obj_t * spinbox, lv_spinbox_style_t type)
 {
     return lv_ta_get_style(spinbox, type);
 }

--- a/src/lv_objx/lv_sw.c
+++ b/src/lv_objx/lv_sw.c
@@ -179,7 +179,7 @@ bool lv_sw_toggle(lv_obj_t * sw, bool anim)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_sw_set_style(lv_obj_t * sw, lv_sw_style_t type, lv_style_t * style)
+void lv_sw_set_style(lv_obj_t * sw, lv_sw_style_t type, const lv_style_t * style)
 {
     lv_sw_ext_t * ext = lv_obj_get_ext_attr(sw);
 
@@ -215,9 +215,9 @@ void lv_sw_set_anim_time(lv_obj_t * sw, uint16_t anim_time)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_sw_get_style(const lv_obj_t * sw, lv_sw_style_t type)
+const lv_style_t * lv_sw_get_style(const lv_obj_t * sw, lv_sw_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
     lv_sw_ext_t * ext  = lv_obj_get_ext_attr(sw);
 
     switch(type) {

--- a/src/lv_objx/lv_sw.h
+++ b/src/lv_objx/lv_sw.h
@@ -42,8 +42,8 @@ typedef struct
 {
     lv_slider_ext_t slider; /*Ext. of ancestor*/
     /*New data for this type */
-    lv_style_t * style_knob_off; /*Style of the knob when the switch is OFF*/
-    lv_style_t *
+    const lv_style_t * style_knob_off; /*Style of the knob when the switch is OFF*/
+    const lv_style_t *
         style_knob_on; /*Style of the knob when the switch is ON (NULL to use the same as OFF)*/
     lv_coord_t start_x;
     uint8_t changed : 1; /*Indicates the switch state explicitly changed by drag*/
@@ -105,7 +105,7 @@ bool lv_sw_toggle(lv_obj_t * sw, bool anim);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_sw_set_style(lv_obj_t * sw, lv_sw_style_t type, lv_style_t * style);
+void lv_sw_set_style(lv_obj_t * sw, lv_sw_style_t type, const lv_style_t * style);
 
 #if LV_USE_ANIMATION
 /**
@@ -137,7 +137,7 @@ static inline bool lv_sw_get_state(const lv_obj_t * sw)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_sw_get_style(const lv_obj_t * sw, lv_sw_style_t type);
+const lv_style_t * lv_sw_get_style(const lv_obj_t * sw, lv_sw_style_t type);
 
 /**
  * Get the animation time of the switch

--- a/src/lv_objx/lv_ta.c
+++ b/src/lv_objx/lv_ta.c
@@ -389,7 +389,7 @@ void lv_ta_del_char(lv_obj_t * ta)
 
     /*Don't let 'width == 0' because cursor will not be visible*/
     if(lv_obj_get_width(ext->label) == 0) {
-        lv_style_t * style = lv_obj_get_style(ext->label);
+        const lv_style_t * style = lv_obj_get_style(ext->label);
         lv_obj_set_width(ext->label, style->line.width);
     }
 
@@ -454,7 +454,7 @@ void lv_ta_set_text(lv_obj_t * ta, const char * txt)
 
     /*Don't let 'width == 0' because the cursor will not be visible*/
     if(lv_obj_get_width(ext->label) == 0) {
-        lv_style_t * style = lv_obj_get_style(ext->label);
+        const lv_style_t * style = lv_obj_get_style(ext->label);
         lv_obj_set_width(ext->label, lv_font_get_width(style->text.font, ' '));
     }
 
@@ -538,7 +538,7 @@ void lv_ta_set_cursor_pos(lv_obj_t * ta, int16_t pos)
     /*Position the label to make the cursor visible*/
     lv_obj_t * label_par = lv_obj_get_parent(ext->label);
     lv_point_t cur_pos;
-    lv_style_t * style       = lv_obj_get_style(ta);
+    const lv_style_t * style = lv_obj_get_style(ta);
     const lv_font_t * font_p = style->text.font;
     lv_area_t label_cords;
     lv_area_t ta_cords;
@@ -660,10 +660,10 @@ void lv_ta_set_one_line(lv_obj_t * ta, bool en)
     if(ext->one_line == en) return;
 
     if(en) {
-        lv_style_t * style_ta    = lv_obj_get_style(ta);
-        lv_style_t * style_scrl  = lv_obj_get_style(lv_page_get_scrl(ta));
-        lv_style_t * style_label = lv_obj_get_style(ext->label);
-        lv_coord_t font_h        = lv_font_get_height(style_label->text.font);
+        const lv_style_t * style_ta    = lv_obj_get_style(ta);
+        const lv_style_t * style_scrl  = lv_obj_get_style(lv_page_get_scrl(ta));
+        const lv_style_t * style_label = lv_obj_get_style(ext->label);
+        lv_coord_t font_h              = lv_font_get_height(style_label->text.font);
 
         ext->one_line = 1;
         lv_page_set_scrl_fit2(ta, LV_FIT_TIGHT, LV_FIT_FLOOD);
@@ -674,7 +674,7 @@ void lv_ta_set_one_line(lv_obj_t * ta, bool en)
         lv_obj_set_pos(lv_page_get_scrl(ta), style_ta->body.padding.left,
                        style_ta->body.padding.top);
     } else {
-        lv_style_t * style_ta = lv_obj_get_style(ta);
+        const lv_style_t * style_ta = lv_obj_get_style(ta);
 
         ext->one_line = 0;
         lv_page_set_scrl_fit2(ta, LV_FIT_FLOOD, LV_FIT_TIGHT);
@@ -768,7 +768,7 @@ void lv_ta_set_insert_replace(lv_obj_t * ta, const char * txt)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_ta_set_style(lv_obj_t * ta, lv_ta_style_t type, lv_style_t * style)
+void lv_ta_set_style(lv_obj_t * ta, lv_ta_style_t type, const lv_style_t * style)
 {
     lv_ta_ext_t * ext = lv_obj_get_ext_attr(ta);
 
@@ -923,9 +923,9 @@ uint16_t lv_ta_get_max_length(lv_obj_t * ta)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_ta_get_style(const lv_obj_t * ta, lv_ta_style_t type)
+const lv_style_t * lv_ta_get_style(const lv_obj_t * ta, lv_ta_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
     lv_ta_ext_t * ext  = lv_obj_get_ext_attr(ta);
 
     switch(type) {
@@ -1050,9 +1050,9 @@ void lv_ta_cursor_down(lv_obj_t * ta)
     lv_label_get_letter_pos(ext->label, lv_ta_get_cursor_pos(ta), &pos);
 
     /*Increment the y with one line and keep the valid x*/
-    lv_style_t * label_style = lv_obj_get_style(ext->label);
-    const lv_font_t * font_p = label_style->text.font;
-    lv_coord_t font_h        = lv_font_get_height(font_p);
+    const lv_style_t * label_style = lv_obj_get_style(ext->label);
+    const lv_font_t * font_p       = label_style->text.font;
+    lv_coord_t font_h              = lv_font_get_height(font_p);
     pos.y += font_h + label_style->text.line_space + 1;
     pos.x = ext->cursor.valid_x;
 
@@ -1081,9 +1081,9 @@ void lv_ta_cursor_up(lv_obj_t * ta)
     lv_label_get_letter_pos(ext->label, lv_ta_get_cursor_pos(ta), &pos);
 
     /*Decrement the y with one line and keep the valid x*/
-    lv_style_t * label_style = lv_obj_get_style(ext->label);
-    const lv_font_t * font   = label_style->text.font;
-    lv_coord_t font_h        = lv_font_get_height(font);
+    const lv_style_t * label_style = lv_obj_get_style(ext->label);
+    const lv_font_t * font         = label_style->text.font;
+    lv_coord_t font_h              = lv_font_get_height(font);
     pos.y -= font_h + label_style->text.line_space - 1;
     pos.x = ext->cursor.valid_x;
 
@@ -1219,13 +1219,13 @@ static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param)
         /* (The created label will be deleted automatically) */
     } else if(sign == LV_SIGNAL_STYLE_CHG) {
         if(ext->label) {
-            lv_obj_t * scrl         = lv_page_get_scrl(ta);
-            lv_style_t * style_ta   = lv_obj_get_style(ta);
-            lv_style_t * style_scrl = lv_obj_get_style(scrl);
+            lv_obj_t * scrl               = lv_page_get_scrl(ta);
+            const lv_style_t * style_ta   = lv_obj_get_style(ta);
+            const lv_style_t * style_scrl = lv_obj_get_style(scrl);
             if(ext->one_line) {
                 /*In one line mode refresh the Text Area height because 'vpad' can modify it*/
-                lv_style_t * style_label = lv_obj_get_style(ext->label);
-                lv_coord_t font_h        = lv_font_get_height(style_label->text.font);
+                const lv_style_t * style_label = lv_obj_get_style(ext->label);
+                lv_coord_t font_h              = lv_font_get_height(style_label->text.font);
                 lv_obj_set_height(
                     ta, font_h + style_ta->body.padding.top + style_ta->body.padding.bottom +
                             style_scrl->body.padding.top + style_scrl->body.padding.bottom);
@@ -1250,8 +1250,8 @@ static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param)
         if(ext->label) {
             if(lv_obj_get_width(ta) != lv_area_get_width(param) ||
                lv_obj_get_height(ta) != lv_area_get_height(param)) {
-                lv_obj_t * scrl         = lv_page_get_scrl(ta);
-                lv_style_t * style_scrl = lv_obj_get_style(scrl);
+                lv_obj_t * scrl               = lv_page_get_scrl(ta);
+                const lv_style_t * style_scrl = lv_obj_get_style(scrl);
                 lv_obj_set_width(ext->label, lv_page_get_fit_width(ta));
                 lv_obj_set_pos(ext->label, style_scrl->body.padding.left,
                                style_scrl->body.padding.top);
@@ -1264,8 +1264,8 @@ static lv_res_t lv_ta_signal(lv_obj_t * ta, lv_signal_t sign, void * param)
         if(ext->placeholder) {
             if(lv_obj_get_width(ta) != lv_area_get_width(param) ||
                lv_obj_get_height(ta) != lv_area_get_height(param)) {
-                lv_obj_t * scrl         = lv_page_get_scrl(ta);
-                lv_style_t * style_scrl = lv_obj_get_style(scrl);
+                lv_obj_t * scrl               = lv_page_get_scrl(ta);
+                const lv_style_t * style_scrl = lv_obj_get_style(scrl);
                 lv_obj_set_width(ext->placeholder, lv_page_get_fit_width(ta));
                 lv_obj_set_pos(ext->placeholder, style_scrl->body.padding.left,
                                style_scrl->body.padding.top);
@@ -1354,8 +1354,8 @@ static lv_res_t lv_ta_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void 
 
     if(sign == LV_SIGNAL_REFR_EXT_SIZE) {
         /*Set ext. size because the cursor might be out of this object*/
-        lv_style_t * style_label = lv_obj_get_style(ext->label);
-        lv_coord_t font_h        = lv_font_get_height(style_label->text.font);
+        const lv_style_t * style_label = lv_obj_get_style(ext->label);
+        lv_coord_t font_h              = lv_font_get_height(style_label->text.font);
         scrl->ext_size = LV_MATH_MAX(scrl->ext_size, style_label->text.line_space + font_h);
     } else if(sign == LV_SIGNAL_CORD_CHG) {
         /*Set the label width according to the text area width*/
@@ -1363,7 +1363,7 @@ static lv_res_t lv_ta_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void 
             if(lv_obj_get_width(ta) != lv_area_get_width(param) ||
                lv_obj_get_height(ta) != lv_area_get_height(param)) {
 
-                lv_style_t * style_scrl = lv_obj_get_style(scrl);
+                const lv_style_t * style_scrl = lv_obj_get_style(scrl);
                 lv_obj_set_width(ext->label, lv_page_get_fit_width(ta));
                 lv_obj_set_pos(ext->label, style_scrl->body.padding.left,
                                style_scrl->body.padding.top);
@@ -1478,8 +1478,8 @@ static bool char_is_accepted(lv_obj_t * ta, uint32_t c)
 
 static void get_cursor_style(lv_obj_t * ta, lv_style_t * style_res)
 {
-    lv_ta_ext_t * ext        = lv_obj_get_ext_attr(ta);
-    lv_style_t * label_style = lv_obj_get_style(ext->label);
+    lv_ta_ext_t * ext              = lv_obj_get_ext_attr(ta);
+    const lv_style_t * label_style = lv_obj_get_style(ext->label);
 
     if(ext->cursor.style) {
         lv_style_copy(style_res, ext->cursor.style);
@@ -1509,8 +1509,8 @@ static void get_cursor_style(lv_obj_t * ta, lv_style_t * style_res)
 
 static void refr_cursor_area(lv_obj_t * ta)
 {
-    lv_ta_ext_t * ext        = lv_obj_get_ext_attr(ta);
-    lv_style_t * label_style = lv_obj_get_style(ext->label);
+    lv_ta_ext_t * ext              = lv_obj_get_ext_attr(ta);
+    const lv_style_t * label_style = lv_obj_get_style(ext->label);
 
     lv_style_t cur_style;
     get_cursor_style(ta, &cur_style);
@@ -1616,8 +1616,8 @@ static void placeholder_update(lv_obj_t * ta)
 
     if(ta_text[0] == '\0') {
         /*Be sure the main label and the placeholder has the same coordinates*/
-        lv_obj_t * scrl         = lv_page_get_scrl(ta);
-        lv_style_t * style_scrl = lv_obj_get_style(scrl);
+        lv_obj_t * scrl               = lv_page_get_scrl(ta);
+        const lv_style_t * style_scrl = lv_obj_get_style(scrl);
         lv_obj_set_pos(ext->placeholder, style_scrl->body.padding.left,
                        style_scrl->body.padding.top);
         lv_obj_set_pos(ext->label, style_scrl->body.padding.left, style_scrl->body.padding.top);

--- a/src/lv_objx/lv_ta.h
+++ b/src/lv_objx/lv_ta.h
@@ -68,9 +68,9 @@ typedef struct
     uint8_t one_line : 1;        /*One line mode (ignore line breaks)*/
     struct
     {
-        lv_style_t * style; /*Style of the cursor (NULL to use label's style)*/
-        lv_coord_t valid_x; /*Used when stepping up/down in text area when stepping to a shorter
-                               line. (Handled by the library)*/
+        const lv_style_t * style; /*Style of the cursor (NULL to use label's style)*/
+        lv_coord_t valid_x;       /*Used when stepping up/down in text area when stepping to a shorter
+                                    line. (Handled by the library)*/
         uint16_t
             pos; /*The current cursor position (0: before 1. letter; 1: before 2. letter etc.)*/
         lv_area_t area;            /*Cursor area relative to the Text Area*/
@@ -255,7 +255,7 @@ static inline void lv_ta_set_edge_flash(lv_obj_t * ta, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_ta_set_style(lv_obj_t * ta, lv_ta_style_t type, lv_style_t * style);
+void lv_ta_set_style(lv_obj_t * ta, lv_ta_style_t type, const lv_style_t * style);
 
 /**
  * Enable/disable selection mode.
@@ -374,7 +374,7 @@ static inline bool lv_ta_get_edge_flash(lv_obj_t * ta)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_ta_get_style(const lv_obj_t * ta, lv_ta_style_t type);
+const lv_style_t * lv_ta_get_style(const lv_obj_t * ta, lv_ta_style_t type);
 
 /**
  * Get the selection index of the text area.

--- a/src/lv_objx/lv_table.c
+++ b/src/lv_objx/lv_table.c
@@ -365,7 +365,7 @@ void lv_table_set_cell_merge_right(lv_obj_t * table, uint16_t row, uint16_t col,
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_table_set_style(lv_obj_t * table, lv_table_style_t type, lv_style_t * style)
+void lv_table_set_style(lv_obj_t * table, lv_table_style_t type, const lv_style_t * style)
 {
     lv_table_ext_t * ext = lv_obj_get_ext_attr(table);
 
@@ -565,10 +565,10 @@ bool lv_table_get_cell_merge_right(lv_obj_t * table, uint16_t row, uint16_t col)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_table_get_style(const lv_obj_t * table, lv_table_style_t type)
+const lv_style_t * lv_table_get_style(const lv_obj_t * table, lv_table_style_t type)
 {
     lv_table_ext_t * ext = lv_obj_get_ext_attr(table);
-    lv_style_t * style   = NULL;
+    const lv_style_t * style   = NULL;
 
     switch(type) {
         case LV_TABLE_STYLE_BG: style = lv_obj_get_style(table); break;
@@ -606,9 +606,9 @@ static bool lv_table_design(lv_obj_t * table, const lv_area_t * mask, lv_design_
     else if(mode == LV_DESIGN_DRAW_MAIN) {
         ancestor_scrl_design(table, mask, mode);
 
-        lv_table_ext_t * ext  = lv_obj_get_ext_attr(table);
-        lv_style_t * bg_style = lv_obj_get_style(table);
-        lv_style_t * cell_style;
+        lv_table_ext_t * ext        = lv_obj_get_ext_attr(table);
+        const lv_style_t * bg_style = lv_obj_get_style(table);
+        const lv_style_t * cell_style;
         lv_coord_t h_row;
         lv_point_t txt_size;
         lv_area_t cell_area;
@@ -785,7 +785,7 @@ static void refr_size(lv_obj_t * table)
         h += get_row_height(table, i);
     }
 
-    lv_style_t * bg_style = lv_obj_get_style(table);
+    const lv_style_t * bg_style = lv_obj_get_style(table);
 
     w += bg_style->body.padding.left + bg_style->body.padding.right;
     h += bg_style->body.padding.top + bg_style->body.padding.bottom;
@@ -799,7 +799,7 @@ static lv_coord_t get_row_height(lv_obj_t * table, uint16_t row_id)
     lv_table_ext_t * ext = lv_obj_get_ext_attr(table);
     lv_point_t txt_size;
     lv_coord_t txt_w;
-    lv_style_t * cell_style;
+    const lv_style_t * cell_style;
 
     uint16_t row_start = row_id * ext->col_cnt;
     uint16_t cell;

--- a/src/lv_objx/lv_table.h
+++ b/src/lv_objx/lv_table.h
@@ -60,7 +60,7 @@ typedef struct
     uint16_t col_cnt;
     uint16_t row_cnt;
     char ** cell_data;
-    lv_style_t * cell_style[LV_TABLE_CELL_STYLE_CNT];
+    const lv_style_t * cell_style[LV_TABLE_CELL_STYLE_CNT];
     lv_coord_t col_w[LV_TABLE_COL_MAX];
 } lv_table_ext_t;
 
@@ -164,7 +164,7 @@ void lv_table_set_cell_merge_right(lv_obj_t * table, uint16_t row, uint16_t col,
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_table_set_style(lv_obj_t * table, lv_table_style_t type, lv_style_t * style);
+void lv_table_set_style(lv_obj_t * table, lv_table_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -244,7 +244,7 @@ bool lv_table_get_cell_merge_right(lv_obj_t * table, uint16_t row, uint16_t col)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_table_get_style(const lv_obj_t * table, lv_table_style_t type);
+const lv_style_t * lv_table_get_style(const lv_obj_t * table, lv_table_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_tabview.c
+++ b/src/lv_objx/lv_tabview.c
@@ -248,7 +248,7 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * tabview, const char * name)
     lv_btnm_set_btn_ctrl(ext->btns, ext->tab_cur, LV_BTNM_CTRL_NO_REPEAT, true);
 
     /*Modify the indicator size*/
-    lv_style_t * style_tabs = lv_obj_get_style(ext->btns);
+    const lv_style_t * style_tabs = lv_obj_get_style(ext->btns);
     lv_coord_t indic_width =
         (lv_obj_get_width(tabview) - style_tabs->body.padding.inner * (ext->tab_cnt - 1) -
          style_tabs->body.padding.left - style_tabs->body.padding.right) /
@@ -286,7 +286,7 @@ void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, bool anim_en)
 #endif
     lv_tabview_ext_t * ext = lv_obj_get_ext_attr(tabview);
 
-    lv_style_t * style = lv_obj_get_style(ext->content);
+    const lv_style_t * style = lv_obj_get_style(ext->content);
 
     lv_res_t res = LV_RES_OK;
     if(id >= ext->tab_cnt) id = ext->tab_cnt - 1;
@@ -322,8 +322,8 @@ void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, bool anim_en)
     }
 
     /*Move the indicator*/
-    lv_coord_t indic_width  = lv_obj_get_width(ext->indic);
-    lv_style_t * tabs_style = lv_obj_get_style(ext->btns);
+    lv_coord_t indic_width        = lv_obj_get_width(ext->indic);
+    const lv_style_t * tabs_style = lv_obj_get_style(ext->btns);
     lv_coord_t indic_x =
         indic_width * id + tabs_style->body.padding.inner * id + tabs_style->body.padding.left;
 
@@ -382,7 +382,7 @@ void lv_tabview_set_anim_time(lv_obj_t * tabview, uint16_t anim_time)
  * @param type which style should be set
  * @param style pointer to the new style
  */
-void lv_tabview_set_style(lv_obj_t * tabview, lv_tabview_style_t type, lv_style_t * style)
+void lv_tabview_set_style(lv_obj_t * tabview, lv_tabview_style_t type, const lv_style_t * style)
 {
     lv_tabview_ext_t * ext = lv_obj_get_ext_attr(tabview);
 
@@ -515,10 +515,10 @@ uint16_t lv_tabview_get_anim_time(const lv_obj_t * tabview)
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_tabview_get_style(const lv_obj_t * tabview, lv_tabview_style_t type)
+const lv_style_t * lv_tabview_get_style(const lv_obj_t * tabview, lv_tabview_style_t type)
 {
-    lv_style_t * style     = NULL;
-    lv_tabview_ext_t * ext = lv_obj_get_ext_attr(tabview);
+    const lv_style_t * style = NULL;
+    lv_tabview_ext_t * ext   = lv_obj_get_ext_attr(tabview);
 
     switch(type) {
         case LV_TABVIEW_STYLE_BG: style = lv_obj_get_style(tabview); break;
@@ -765,10 +765,10 @@ static void tabpage_pressing_handler(lv_obj_t * tabview, lv_obj_t * tabpage)
         ext->point_last.y = point_act.y;
 
         /*Move the indicator*/
-        lv_coord_t indic_width   = lv_obj_get_width(ext->indic);
-        lv_style_t * tabs_style  = lv_obj_get_style(ext->btns);
-        lv_style_t * indic_style = lv_obj_get_style(ext->indic);
-        lv_coord_t p             = ((tabpage->coords.x1 - tabview->coords.x1) *
+        lv_coord_t indic_width         = lv_obj_get_width(ext->indic);
+        const lv_style_t * tabs_style  = lv_obj_get_style(ext->btns);
+        const lv_style_t * indic_style = lv_obj_get_style(ext->indic);
+        lv_coord_t p                   = ((tabpage->coords.x1 - tabview->coords.x1) *
                         (indic_width + tabs_style->body.padding.inner)) /
                        lv_obj_get_width(tabview);
 
@@ -856,8 +856,8 @@ static void tabview_realign(lv_obj_t * tabview)
         lv_obj_set_hidden(ext->btns, false);
         lv_obj_set_hidden(ext->indic, false);
 
-        lv_style_t * style_btn_bg  = lv_tabview_get_style(tabview, LV_TABVIEW_STYLE_BTN_BG);
-        lv_style_t * style_btn_rel = lv_tabview_get_style(tabview, LV_TABVIEW_STYLE_BTN_REL);
+        const lv_style_t * style_btn_bg  = lv_tabview_get_style(tabview, LV_TABVIEW_STYLE_BTN_BG);
+        const lv_style_t * style_btn_rel = lv_tabview_get_style(tabview, LV_TABVIEW_STYLE_BTN_REL);
 
         /*Set the indicator widths*/
         lv_coord_t indic_width =

--- a/src/lv_objx/lv_tabview.h
+++ b/src/lv_objx/lv_tabview.h
@@ -142,7 +142,7 @@ void lv_tabview_set_anim_time(lv_obj_t * tabview, uint16_t anim_time);
  * @param type which style should be set
  * @param style pointer to the new style
  */
-void lv_tabview_set_style(lv_obj_t * tabview, lv_tabview_style_t type, lv_style_t * style);
+void lv_tabview_set_style(lv_obj_t * tabview, lv_tabview_style_t type, const lv_style_t * style);
 
 /**
  * Set the position of tab select buttons
@@ -203,7 +203,7 @@ uint16_t lv_tabview_get_anim_time(const lv_obj_t * tabview);
  * @param type which style should be get
  * @return style pointer to a style
  */
-lv_style_t * lv_tabview_get_style(const lv_obj_t * tabview, lv_tabview_style_t type);
+const lv_style_t * lv_tabview_get_style(const lv_obj_t * tabview, lv_tabview_style_t type);
 
 /**
  * Get position of tab select buttons

--- a/src/lv_objx/lv_tileview.c
+++ b/src/lv_objx/lv_tileview.c
@@ -249,7 +249,7 @@ void lv_tileview_set_tile_act(lv_obj_t * tileview, lv_coord_t x, lv_coord_t y, b
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_tileview_set_style(lv_obj_t * tileview, lv_tileview_style_t type, lv_style_t * style)
+void lv_tileview_set_style(lv_obj_t * tileview, lv_tileview_style_t type, const lv_style_t * style)
 {
 
     switch(type) {
@@ -271,9 +271,9 @@ void lv_tileview_set_style(lv_obj_t * tileview, lv_tileview_style_t type, lv_sty
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_tileview_get_style(const lv_obj_t * tileview, lv_tileview_style_t type)
+const lv_style_t * lv_tileview_get_style(const lv_obj_t * tileview, lv_tileview_style_t type)
 {
-    lv_style_t * style = NULL;
+    const lv_style_t * style = NULL;
     switch(type) {
         case LV_TILEVIEW_STYLE_BG: style = lv_obj_get_style(tileview); break;
         default: style = NULL;
@@ -339,8 +339,8 @@ static lv_res_t lv_tileview_scrl_signal(lv_obj_t * scrl, lv_signal_t sign, void 
     res = ancestor_scrl_signal(scrl, sign, param);
     if(res != LV_RES_OK) return res;
 
-    lv_obj_t * tileview   = lv_obj_get_parent(scrl);
-    lv_style_t * style_bg = lv_tileview_get_style(tileview, LV_TILEVIEW_STYLE_BG);
+    lv_obj_t * tileview         = lv_obj_get_parent(scrl);
+    const lv_style_t * style_bg = lv_tileview_get_style(tileview, LV_TILEVIEW_STYLE_BG);
 
     /*Apply constraint on moving of the tileview*/
     if(sign == LV_SIGNAL_CORD_CHG) {

--- a/src/lv_objx/lv_tileview.h
+++ b/src/lv_objx/lv_tileview.h
@@ -118,7 +118,7 @@ static inline void lv_tileview_set_edge_flash(lv_obj_t * tileview, bool en)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_tileview_set_style(lv_obj_t * tileview, lv_tileview_style_t type, lv_style_t * style);
+void lv_tileview_set_style(lv_obj_t * tileview, lv_tileview_style_t type, const lv_style_t * style);
 
 /*=====================
  * Getter functions
@@ -140,7 +140,7 @@ static inline bool lv_tileview_get_edge_flash(lv_obj_t * tileview)
  * @param type which style should be get
  * @return style pointer to the style
  */
-lv_style_t * lv_tileview_get_style(const lv_obj_t * tileview, lv_tileview_style_t type);
+const lv_style_t * lv_tileview_get_style(const lv_obj_t * tileview, lv_tileview_style_t type);
 
 /*=====================
  * Other functions

--- a/src/lv_objx/lv_win.c
+++ b/src/lv_objx/lv_win.c
@@ -261,7 +261,7 @@ void lv_win_set_sb_mode(lv_obj_t * win, lv_sb_mode_t sb_mode)
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_win_set_style(lv_obj_t * win, lv_win_style_t type, lv_style_t * style)
+void lv_win_set_style(lv_obj_t * win, lv_win_style_t type, const lv_style_t * style)
 {
     lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
 
@@ -391,9 +391,9 @@ lv_sb_mode_t lv_win_get_sb_mode(lv_obj_t * win)
  */
 lv_coord_t lv_win_get_width(lv_obj_t * win)
 {
-    lv_win_ext_t * ext      = lv_obj_get_ext_attr(win);
-    lv_obj_t * scrl         = lv_page_get_scrl(ext->page);
-    lv_style_t * style_scrl = lv_obj_get_style(scrl);
+    lv_win_ext_t * ext            = lv_obj_get_ext_attr(win);
+    lv_obj_t * scrl               = lv_page_get_scrl(ext->page);
+    const lv_style_t * style_scrl = lv_obj_get_style(scrl);
 
     return lv_obj_get_width(scrl) - style_scrl->body.padding.left - style_scrl->body.padding.right;
 }
@@ -404,10 +404,10 @@ lv_coord_t lv_win_get_width(lv_obj_t * win)
  * @param type which style window be get
  * @return style pointer to a style
  */
-lv_style_t * lv_win_get_style(const lv_obj_t * win, lv_win_style_t type)
+const lv_style_t * lv_win_get_style(const lv_obj_t * win, lv_win_style_t type)
 {
-    lv_style_t * style = NULL;
-    lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
+    const lv_style_t * style = NULL;
+    lv_win_ext_t * ext       = lv_obj_get_ext_attr(win);
 
     switch(type) {
         case LV_WIN_STYLE_BG: style = lv_obj_get_style(win); break;
@@ -513,7 +513,7 @@ static void lv_win_realign(lv_obj_t * win)
 
     if(ext->page == NULL || ext->header == NULL || ext->title == NULL) return;
 
-    lv_style_t * header_style = lv_win_get_style(win, LV_WIN_STYLE_HEADER);
+    const lv_style_t * header_style = lv_win_get_style(win, LV_WIN_STYLE_HEADER);
     lv_obj_set_size(ext->header, lv_obj_get_width(win),
                     ext->btn_size + header_style->body.padding.top +
                         header_style->body.padding.bottom);

--- a/src/lv_objx/lv_win.h
+++ b/src/lv_objx/lv_win.h
@@ -58,13 +58,13 @@ typedef struct
 {
     /*Ext. of ancestor*/
     /*New data for this type */
-    lv_obj_t * page;            /*Pointer to a page which holds the content*/
-    lv_obj_t * header;          /*Pointer to the header container of the window*/
-    lv_obj_t * title;           /*Pointer to the title label of the window*/
-    lv_style_t * style_header;  /*Style of the header container*/
-    lv_style_t * style_btn_rel; /*Control button releases style*/
-    lv_style_t * style_btn_pr;  /*Control button pressed style*/
-    lv_coord_t btn_size;        /*Size of the control buttons (square)*/
+    lv_obj_t * page;                  /*Pointer to a page which holds the content*/
+    lv_obj_t * header;                /*Pointer to the header container of the window*/
+    lv_obj_t * title;                 /*Pointer to the title label of the window*/
+    const lv_style_t * style_header;  /*Style of the header container*/
+    const lv_style_t * style_btn_rel; /*Control button releases style*/
+    const lv_style_t * style_btn_pr;  /*Control button pressed style*/
+    lv_coord_t btn_size;              /*Size of the control buttons (square)*/
 } lv_win_ext_t;
 
 enum {
@@ -154,7 +154,7 @@ void lv_win_set_sb_mode(lv_obj_t * win, lv_sb_mode_t sb_mode);
  * @param type which style should be set
  * @param style pointer to a style
  */
-void lv_win_set_style(lv_obj_t * win, lv_win_style_t type, lv_style_t * style);
+void lv_win_set_style(lv_obj_t * win, lv_win_style_t type, const lv_style_t * style);
 
 /**
  * Set drag status of a window. If set to 'true' window can be dragged like on a PC.
@@ -223,7 +223,7 @@ lv_coord_t lv_win_get_width(lv_obj_t * win);
  * @param type which style window be get
  * @return style pointer to a style
  */
-lv_style_t * lv_win_get_style(const lv_obj_t * win, lv_win_style_t type);
+const lv_style_t * lv_win_get_style(const lv_obj_t * win, lv_win_style_t type);
 
 /**
  * Get drag status of a window. If set to 'true' window can be dragged like on a PC.


### PR DESCRIPTION
Per #999, changes to allow for `const` `lv_style_t` objects.

Note that `lv_test_chart.c` lines [124-126](https://github.com/littlevgl/lv_examples/blob/0d84a023c6925cfa307dc1c7d5200481dc8f456d/lv_tests/lv_test_objx/lv_test_chart/lv_test_chart.c#L124-L126) in the `lv_examples` repo should be removed as they will trigger a warning post these changes and are currently dead code.