### PR TITLE
Remove legacy control codes

### DIFF
--- a/src/lv_objx/lv_kb.c
+++ b/src/lv_objx/lv_kb.c
@@ -64,9 +64,9 @@ static const lv_btnm_ctrl_t kb_ctrl_spec_map[] = {
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2,
     2, 6, 2, 2};
 
-static const char * kb_map_num[] = {"1", "2", "3", "\202" LV_SYMBOL_CLOSE, "\n",
-                                    "4", "5", "6", "\202" LV_SYMBOL_OK, "\n",
-                                    "7", "8", "9", "\202Bksp", "\n",
+static const char * kb_map_num[] = {"1", "2", "3", LV_SYMBOL_CLOSE, "\n",
+                                    "4", "5", "6", LV_SYMBOL_OK, "\n",
+                                    "7", "8", "9", "Bksp", "\n",
                                     "+/-", "0", ".", LV_SYMBOL_LEFT, LV_SYMBOL_RIGHT, ""};
 
 static const lv_btnm_ctrl_t kb_ctrl_num_map[] = {1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 1};


### PR DESCRIPTION
Remove legacy control codes causing string match to fail in default keyboard event handler.