### PR TITLE
add lv_obj_set_user_data function

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -1875,6 +1875,16 @@ lv_obj_user_data_t * lv_obj_get_user_data(lv_obj_t * obj)
 {
     return &obj->user_data;
 }
+
+/**
+ * Set the objet's user data
+ * @param obj pointer to an object
+ * @param data user data
+ */
+void lv_obj_set_user_data(lv_obj_t * obj, lv_obj_user_data_t data)
+{
+    obj->user_data = data;
+}
 #endif
 
 #if LV_USE_GROUP

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -1877,13 +1877,13 @@ lv_obj_user_data_t * lv_obj_get_user_data(lv_obj_t * obj)
 }
 
 /**
- * Set the objet's user data
+ * Set the object's user data. The data will be copied.
  * @param obj pointer to an object
  * @param data user data
  */
 void lv_obj_set_user_data(lv_obj_t * obj, lv_obj_user_data_t data)
 {
-    obj->user_data = data;
+    memcpy(&obj->user_data, &data, sizeof(lv_obj_user_data_t));
 }
 #endif
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -859,7 +859,7 @@ void lv_obj_get_type(lv_obj_t * obj, lv_obj_type_t * buf);
 lv_obj_user_data_t * lv_obj_get_user_data(lv_obj_t * obj);
 
 /**
- * Set the objet's user data
+ * Set the object's user data. The data will be copied.
  * @param obj pointer to an object
  * @param data user data
  */

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -857,6 +857,14 @@ void lv_obj_get_type(lv_obj_t * obj, lv_obj_type_t * buf);
  * @return pointer to the user data
  */
 lv_obj_user_data_t * lv_obj_get_user_data(lv_obj_t * obj);
+
+/**
+ * Set the objet's user data
+ * @param obj pointer to an object
+ * @param data user data
+ */
+void lv_obj_set_user_data(lv_obj_t * obj, lv_obj_user_data_t data);
+
 #endif
 
 #if LV_USE_GROUP


### PR DESCRIPTION
The new v6.0 `user_data` mechanism includes a `lv_obj_get_user_data` function, but the set data function was missing.

I'm not sure if this is an oversight, or if the user is expected to set the data directly via the object pointer. I presume the former, since the get function was implemented and the other `lv_obj_t` members have set/get function pairs.