### PR TITLE
Small zone user data

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -190,6 +190,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale_en = 0;
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->parent_event = 0;
+        new_obj->small_zone   = 0;
 
         new_obj->ext_attr = NULL;
 
@@ -260,6 +261,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->opa_scale_en = 0;
         new_obj->parent_event = 0;
+        new_obj->small_zone   = 0;
 
         new_obj->ext_attr = NULL;
     }
@@ -305,6 +307,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale_en = copy->opa_scale_en;
         new_obj->protect      = copy->protect;
         new_obj->opa_scale    = copy->opa_scale;
+        new_obj->small_zone   = copy->small_zone;
 
         new_obj->style_p = copy->style_p;
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -195,6 +195,11 @@ typedef struct _lv_obj_t
     void * group_p; /*Pointer to the group of the object*/
 #endif
     /*Attributes and states*/
+    uint8_t protect;          /*Automatically happening actions can be prevented. 'OR'ed values from
+                                 `lv_protect_t`*/
+    lv_opa_t opa_scale; /*Scale down the opacity by this factor. Effects all children as well*/
+    lv_coord_t ext_size; /*EXTtend the size of the object in every direction. E.g. for shadow drawing*/
+
     uint8_t click : 1;          /*1: Can be pressed by an input device*/
     uint8_t drag : 1;           /*1: Enable the dragging*/
     lv_drag_dir_t drag_dir : 2; /* Which directions the object can be dragged in */
@@ -204,12 +209,8 @@ typedef struct _lv_obj_t
     uint8_t top : 1; /*1: If the object or its children is clicked it goes to the foreground*/
     uint8_t opa_scale_en : 1; /*1: opa_scale is set*/
     uint8_t parent_event : 1; /*1: Send the object's events to the parent too. */
-    uint8_t protect;          /*Automatically happening actions can be prevented. 'OR'ed values from
-                                 `lv_protect_t`*/
-    lv_opa_t opa_scale; /*Scale down the opacity by this factor. Effects all children as well*/
+    uint32_t small_zone : 22;      /* Free space that user can use. May change in size */
 
-    lv_coord_t
-        ext_size; /*EXTtend the size of the object in every direction. E.g. for shadow drawing*/
 #if LV_OBJ_REALIGN
     lv_reailgn_t realign;
 #endif


### PR DESCRIPTION
This goes along with my RAM optimizations of #1020 , but i made it separate because it's sort of a new feature rather than a refactor.

This just sets a bitfield `small_zone` in `lv_obj` that takes up the remaining padding space in the object (currently 22 bits). Users could use this space in addition to `user_data`.

My reasoning for this: `user_data` might commonly be a 4-byte data type like a pointer, but the programmer may want to store a few extra flags or bits of data. This would unnecessarily inflate the size of every object by 4-bytes, which across hundreds of objects becomes significant. For example, an `lv_list` with 25 elements is ~51 objects, so utilizing the padding bits could save 204 bytes. The size of this field will change as more bits are added to the `lv_obj_t` bitfield, but I think thats fine as this is only intended for advanced programmers doing heavier optimizations.