### PR TITLE
lv_label pause at beginning of LV_LABEL_LONG_ROLL animation.

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -353,6 +353,7 @@ typedef void * lv_obj_user_data_t;
 #if LV_USE_LABEL != 0
 /*Hor, or ver. scroll speed [px/sec] in 'LV_LABEL_LONG_ROLL/ROLL_CIRC' mode*/
 #  define LV_LABEL_DEF_SCROLL_SPEED       25
+#  define LV_LABEL_WAIT_CHAR_COUNT        3 /* Waiting period at beginning/end of animation cycle */
 #endif
 
 /*LED (dependencies: -)*/

--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -886,9 +886,7 @@ static void lv_label_refr_text(lv_obj_t * label)
         anim.path     = lv_anim_path_linear;
         anim.playback_pause =
             (((lv_font_get_width(style->text.font, ' ') + style->text.letter_space) * 1000) /
-             ext->anim_speed) *
-            LV_LABEL_WAIT_CHAR_COUNT;
-        ;
+             ext->anim_speed) * LV_LABEL_WAIT_CHAR_COUNT;
         anim.repeat_pause = anim.playback_pause;
         anim.act_time = -anim.playback_pause;
 
@@ -925,7 +923,9 @@ static void lv_label_refr_text(lv_obj_t * label)
         anim.repeat         = 1;
         anim.playback       = 0;
         anim.start          = 0;
-        anim.act_time       = 0;
+        anim.act_time       = 
+            -(((lv_font_get_width(style->text.font, ' ') + style->text.letter_space) * 1000) /
+             ext->anim_speed) * LV_LABEL_WAIT_CHAR_COUNT;
         anim.end_cb         = NULL;
         anim.path           = lv_anim_path_linear;
         anim.playback_pause = 0;

--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -23,8 +23,6 @@
 #define LV_LABEL_DEF_SCROLL_SPEED (25)
 #endif
 
-#define ANIM_WAIT_CHAR_COUNT 3
-
 #define LV_LABEL_DOT_END_INV 0xFFFF
 
 /**********************
@@ -774,7 +772,7 @@ static bool lv_label_design(lv_obj_t * label, const lv_area_t * mask, lv_design_
             /*Draw the text again next to the original to make an circular effect */
             if(size.x > lv_obj_get_width(label)) {
                 ofs.x = ext->offset.x + size.x +
-                        lv_font_get_width(style->text.font, ' ') * ANIM_WAIT_CHAR_COUNT;
+                        lv_font_get_width(style->text.font, ' ') * LV_LABEL_WAIT_CHAR_COUNT;
                 ofs.y = ext->offset.y;
                 lv_draw_label(&coords, mask, style, opa_scale, ext->text, flag, &ofs,
                               ext->selection_start, ext->selection_end);
@@ -884,15 +882,15 @@ static void lv_label_refr_text(lv_obj_t * label)
         anim.repeat   = 1;
         anim.playback = 1;
         anim.start    = 0;
-        anim.act_time = 0;
         anim.end_cb   = NULL;
         anim.path     = lv_anim_path_linear;
         anim.playback_pause =
             (((lv_font_get_width(style->text.font, ' ') + style->text.letter_space) * 1000) /
              ext->anim_speed) *
-            ANIM_WAIT_CHAR_COUNT;
+            LV_LABEL_WAIT_CHAR_COUNT;
         ;
         anim.repeat_pause = anim.playback_pause;
+        anim.act_time = -anim.playback_pause;
 
         bool hor_anim = false;
         if(size.x > lv_obj_get_width(label)) {
@@ -935,7 +933,7 @@ static void lv_label_refr_text(lv_obj_t * label)
 
         bool hor_anim = false;
         if(size.x > lv_obj_get_width(label)) {
-            anim.end  = -size.x - lv_font_get_width(font, ' ') * ANIM_WAIT_CHAR_COUNT;
+            anim.end  = -size.x - lv_font_get_width(font, ' ') * LV_LABEL_WAIT_CHAR_COUNT;
             anim.fp   = (lv_anim_fp_t)lv_label_set_offset_x;
             anim.time = lv_anim_speed_to_time(ext->anim_speed, anim.start, anim.end);
             lv_anim_create(&anim);


### PR DESCRIPTION
I think having the animation start immediately for LV_LABEL_LONG_ROLL animation is a bit jarring and can also cause a user to miss the first few characters, so I applied the same delay as at the end of the animation. I also exposed the macro to `lv_conf` for greater customization. Perhaps other animations like `LV_LABEL_LONG_ROLL_CIRC` should have this same initial delay.