### PR TITLE
lv_group: fix lv_group_del not removing group from the group linked list

### DIFF
--- a/src/lv_core/lv_group.c
+++ b/src/lv_core/lv_group.c
@@ -110,6 +110,7 @@ void lv_group_del(lv_group_t * group)
     }
 
     lv_ll_clear(&(group->obj_ll));
+    lv_ll_rem(&LV_GC_ROOT(_lv_group_ll), group);
     lv_mem_free(group);
 }
 


### PR DESCRIPTION
After hours of debugging while trying to migrate to dev-6.0, I found that when you call `lv_group_del` it didn't actually remove the group from the group linked list, which resulted in all sorts of memory allocation related bugs.