### PR TITLE
ddlist: fix animation complete not always clearing selection highlight

### DIFF
--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -847,8 +847,9 @@ static void lv_ddlist_refr_size(lv_obj_t * ddlist, bool anim_en)
         lv_ddlist_pos_current_option(ddlist);
         if(ext->opened) lv_page_set_sb_mode(ddlist, LV_SB_MODE_UNHIDE);
 #if LV_USE_ANIMATION
-        lv_anim_del(ddlist, (lv_anim_fp_t)lv_obj_set_height); /*If an animation is in progress then
+        lv_anim_del(ddlist, (lv_anim_fp_t)lv_ddlist_adjust_height); /*If an animation is in progress then
                                                                  it will overwrite this changes*/
+        lv_ddlist_anim_cb(ddlist); /*Force animation complete to fix highlight selection*/
     } else {
         lv_anim_t a;
         a.var            = ddlist;

--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -916,6 +916,7 @@ static void lv_ddlist_pos_current_option(lv_obj_t * ddlist)
                          ext->label->coords.y1 - scrl->coords.y1;
 
     lv_obj_set_y(scrl, -line_y1 + (h - font_h) / 2);
+    lv_obj_invalidate(ddlist);
 }
 
 #endif


### PR DESCRIPTION
This is the issue:

![lvgl_ddlist_animate](https://user-images.githubusercontent.com/32659164/56380596-758be780-61c7-11e9-9c5a-ddd9d7f93615.gif)

After fix:

![lvgl_ddlist_animate_fixed](https://user-images.githubusercontent.com/32659164/56380838-14b0df00-61c8-11e9-8cfa-a3590acd574a.gif)

If move over a ddlist then off again, depending on what seems like random timing, the end of the animation for closing the ddlist will not always remove the highlight like it is supposed to.

This change forces the ddlist to refresh.

There might be a deeper animation issue here. The manual invalidation should not be necessary, since the animation should result in a change that would refresh it. But somehow sometimes the last animation frame does not result in a refresh, and the highlight remains.
