### PR TITLE
ddlist: fix ddlist width/padding not fitting text contents correctly

### DIFF
--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -108,7 +108,7 @@ lv_obj_t * lv_ddlist_create(lv_obj_t * par, const lv_obj_t * copy)
     if(copy == NULL) {
         lv_obj_t * scrl = lv_page_get_scrl(new_ddlist);
         lv_obj_set_drag(scrl, false);
-        lv_page_set_scrl_fit2(new_ddlist, LV_FIT_FILL, LV_FIT_TIGHT);
+        lv_page_set_scrl_fit2(new_ddlist, LV_FIT_TIGHT, LV_FIT_TIGHT);
 
         ext->label = lv_label_create(new_ddlist, NULL);
         lv_cont_set_fit2(new_ddlist, LV_FIT_TIGHT, LV_FIT_NONE);


### PR DESCRIPTION
Example:
```c
HOUR_DDLIST = lv_ddlist_create(page, NULL);
lv_obj_set_pos(HOUR_DDLIST, 134, 34);
lv_obj_set_top(HOUR_DDLIST, true);
lv_ddlist_set_options(HOUR_DDLIST, "12\n24");
```

Before the fix, dropdown is clearly not fitting the contents correctly, and the padding is super wonky:

![image](https://user-images.githubusercontent.com/32659164/56387617-9f4e0a00-61d9-11e9-92ff-b5b314ae60dd.png)

After the fix:

![image](https://user-images.githubusercontent.com/32659164/56387525-5d24c880-61d9-11e9-8d87-7b82bf1442d8.png)
