### PR TITLE
Minor fixes for compiler warnings/-Werrors

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -147,7 +147,6 @@ typedef void * lv_group_user_data_t;
 
 /*1: Add separate `user_data` for every callback*/
 #define LV_USE_USER_DATA_MULTI  0
-
 /*=====================
  *  Compiler settings
  *====================*/
@@ -156,6 +155,11 @@ typedef void * lv_group_user_data_t;
 
 /* Define a custom attribute to `lv_task_handler` function */
 #define LV_ATTRIBUTE_TASK_HANDLER
+
+/* With size optimization (-Os) the compiler might not align data to
+ * 4 or 8 byte boundary. This alignment will be explicitly applied where needed.*/
+#define LV_ATTRIBUTE_MEM_ALIGN               __attribute__((aligned(4)))  
+
 
 /* 1: Variable length array is supported*/
 #define LV_COMPILER_VLA_SUPPORTED            1
@@ -176,7 +180,7 @@ typedef void * lv_group_user_data_t;
 #endif   /*LV_TICK_CUSTOM*/
 
 typedef void * lv_disp_drv_user_data_t;             /*Type of user data in the display driver*/
-typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the display driver*/
+typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the input device driver*/
 
 /*================
  * Log settings
@@ -439,7 +443,6 @@ typedef void * lv_obj_user_data_t;
 /*==================
  * Non-user section
  *==================*/
-
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /* Disable warnings for Visual Studio*/
 #  define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -147,6 +147,7 @@ typedef void * lv_group_user_data_t;
 
 /*1: Add separate `user_data` for every callback*/
 #define LV_USE_USER_DATA_MULTI  0
+
 /*=====================
  *  Compiler settings
  *====================*/
@@ -443,6 +444,7 @@ typedef void * lv_obj_user_data_t;
 /*==================
  * Non-user section
  *==================*/
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /* Disable warnings for Visual Studio*/
 #  define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/src/lv_misc/lv_area.c
+++ b/src/lv_misc/lv_area.c
@@ -154,29 +154,6 @@ bool lv_area_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p)
     return is_on;
 }
 
-#if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
-/**
- * Check if a point is on an area
- * @param a_p pointer to an area
- * @param p_p pointer to a point
- * @param ext_hor extended horizontal padding
- * @param ext_ver extended horizontal padding
- * @return false:the point is out of the area
- */
-bool lv_area_ext_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p, uint8_t ext_hor, uint8_t ext_ver)
-{
-    bool is_on = false;
-
-    if(( (p_p->x + ext_hor) >= a_p->x1 && p_p->x <= (a_p->x2 + ext_hor) ) &&
-            ( (p_p->y + ext_ver) >= a_p->y1 && p_p->y <= (a_p->y2 + ext_ver)) ) {
-        is_on = true;
-    }
-
-    return is_on;
-}
-
-#endif
-
 /**
  * Check if two area has common parts
  * @param a1_p pointer to an area.

--- a/src/lv_misc/lv_area.c
+++ b/src/lv_misc/lv_area.c
@@ -154,7 +154,7 @@ bool lv_area_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p)
     return is_on;
 }
 
-#if LV_USE_EXTENDED_CLICK_AREA_TINY
+#if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
 /**
  * Check if a point is on an area
  * @param a_p pointer to an area

--- a/src/lv_misc/lv_area.h
+++ b/src/lv_misc/lv_area.h
@@ -28,10 +28,6 @@ extern "C" {
 #define LV_COORD_MAX (16383) /*To avoid overflow don't let the max [-32,32k] range */
 #define LV_COORD_MIN (-16384)
 
-#define LV_EXT_CLICK_AREA_OFF   0
-#define LV_EXT_CLICK_AREA_TINY  1
-#define LV_EXT_CLICK_AREA_FULL  2
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -148,18 +144,6 @@ void lv_area_join(lv_area_t * a_res_p, const lv_area_t * a1_p, const lv_area_t *
  * @return false:the point is out of the area
  */
 bool lv_area_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p);
-
-#if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
-/**
- * Check if a point is on an area
- * @param a_p pointer to an area
- * @param p_p pointer to a point
- * @param ext_hor extended horizontal padding
- * @param ext_ver extended horizontal padding
- * @return false:the point is out of the area
- */
-bool lv_area_ext_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p, uint8_t ext_hor, uint8_t ext_ver);
-#endif
 
 /**
  * Check if two area has common parts

--- a/src/lv_misc/lv_area.h
+++ b/src/lv_misc/lv_area.h
@@ -28,6 +28,10 @@ extern "C" {
 #define LV_COORD_MAX (16383) /*To avoid overflow don't let the max [-32,32k] range */
 #define LV_COORD_MIN (-16384)
 
+#define LV_EXT_CLICK_AREA_OFF   0
+#define LV_EXT_CLICK_AREA_TINY  1
+#define LV_EXT_CLICK_AREA_FULL  2
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -145,7 +149,7 @@ void lv_area_join(lv_area_t * a_res_p, const lv_area_t * a1_p, const lv_area_t *
  */
 bool lv_area_is_point_on(const lv_area_t * a_p, const lv_point_t * p_p);
 
-#if LV_USE_EXTENDED_CLICK_AREA_TINY
+#if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
 /**
  * Check if a point is on an area
  * @param a_p pointer to an area

--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -97,7 +97,7 @@ lv_obj_t * lv_label_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->txt_sel_start = LV_LABEL_TEXT_SEL_OFF;
     ext->txt_sel_end   = LV_LABEL_TEXT_SEL_OFF;
 #endif
-    ext->dt.dot_tmp_ptr = NULL;
+    ext->dot.tmp_ptr = NULL;
     ext->dot_tmp_alloc = 0;
 
     lv_obj_set_design_cb(new_label, lv_label_design);
@@ -130,12 +130,12 @@ lv_obj_t * lv_label_create(lv_obj_t * par, const lv_obj_t * copy)
             memcpy(ext->text, copy_ext->text, lv_mem_get_size(copy_ext->text));
         }
 
-        if(copy_ext->dot_tmp_alloc && copy_ext->dt.dot_tmp_ptr ){
-            int len = strlen(copy_ext->dt.dot_tmp_ptr);
-            lv_label_set_dot_tmp(new_label, ext->dt.dot_tmp_ptr, len);
+        if(copy_ext->dot_tmp_alloc && copy_ext->dot.tmp_ptr ){
+            int len = strlen(copy_ext->dot.tmp_ptr);
+            lv_label_set_dot_tmp(new_label, ext->dot.tmp_ptr, len);
         }
         else{
-            memcpy(ext->dt.dot_tmp, copy_ext->dt.dot_tmp, sizeof(ext->dt.dot_tmp));
+            memcpy(ext->dot.tmp, copy_ext->dot.tmp, sizeof(ext->dot.tmp));
         }
         ext->dot_tmp_alloc = copy_ext->dot_tmp_alloc;
         ext->dot_end = copy_ext->dot_end;
@@ -1119,19 +1119,19 @@ static bool lv_label_set_dot_tmp(lv_obj_t *label, char *data, uint16_t len){
     if( len > sizeof(char *) ){
         /* Memory needs to be allocated. Allocates an additional byte
          * for a NULL-terminator so it can be copied. */
-        ext->dt.dot_tmp_ptr = lv_mem_alloc(len + 1);
-        if( ext->dt.dot_tmp_ptr == NULL ){
+        ext->dot.tmp_ptr = lv_mem_alloc(len + 1);
+        if( ext->dot.tmp_ptr == NULL ){
             LV_LOG_ERROR("Failed to allocate memory for dot_tmp_ptr");
             return false;
         }
-        memcpy(ext->dt.dot_tmp_ptr, data, len);
-        ext->dt.dot_tmp_ptr[len]='\0';
+        memcpy(ext->dot.tmp_ptr, data, len);
+        ext->dot.tmp_ptr[len]='\0';
         ext->dot_tmp_alloc = true;
     }
     else {
         /* Characters can be directly stored in object */
         ext->dot_tmp_alloc = false;
-        memcpy(ext->dt.dot_tmp, data, len);
+        memcpy(ext->dot.tmp, data, len);
     }
     return true;
 }
@@ -1144,10 +1144,10 @@ static bool lv_label_set_dot_tmp(lv_obj_t *label, char *data, uint16_t len){
 static char * lv_label_get_dot_tmp(lv_obj_t *label){
     lv_label_ext_t * ext = lv_obj_get_ext_attr(label);
     if( ext->dot_tmp_alloc ){
-        return ext->dt.dot_tmp_ptr;
+        return ext->dot.tmp_ptr;
     }
     else{
-        return ext->dt.dot_tmp;
+        return ext->dot.tmp;
     }
 }
 
@@ -1158,11 +1158,11 @@ static char * lv_label_get_dot_tmp(lv_obj_t *label){
  */
 static void lv_label_dot_tmp_free(lv_obj_t *label){
     lv_label_ext_t * ext = lv_obj_get_ext_attr(label);
-    if( ext->dot_tmp_alloc && ext->dt.dot_tmp_ptr ){
-        lv_mem_free(ext->dt.dot_tmp_ptr);
+    if( ext->dot_tmp_alloc && ext->dot.tmp_ptr ){
+        lv_mem_free(ext->dot.tmp_ptr);
     }
     ext->dot_tmp_alloc = false;
-    ext->dt.dot_tmp_ptr = NULL;
+    ext->dot.tmp_ptr = NULL;
 }
 
 #endif

--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -97,7 +97,7 @@ lv_obj_t * lv_label_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->txt_sel_start = LV_LABEL_TEXT_SEL_OFF;
     ext->txt_sel_end   = LV_LABEL_TEXT_SEL_OFF;
 #endif
-    ext->dot_tmp_ptr = NULL;
+    ext->dt.dot_tmp_ptr = NULL;
     ext->dot_tmp_alloc = 0;
 
     lv_obj_set_design_cb(new_label, lv_label_design);
@@ -130,12 +130,12 @@ lv_obj_t * lv_label_create(lv_obj_t * par, const lv_obj_t * copy)
             memcpy(ext->text, copy_ext->text, lv_mem_get_size(copy_ext->text));
         }
 
-        if(copy_ext->dot_tmp_alloc && copy_ext->dot_tmp_ptr ){
-            int len = strlen(copy_ext->dot_tmp_ptr);
-            lv_label_set_dot_tmp(new_label, ext->dot_tmp_ptr, len);
+        if(copy_ext->dot_tmp_alloc && copy_ext->dt.dot_tmp_ptr ){
+            int len = strlen(copy_ext->dt.dot_tmp_ptr);
+            lv_label_set_dot_tmp(new_label, ext->dt.dot_tmp_ptr, len);
         }
         else{
-            memcpy(ext->dot_tmp, copy_ext->dot_tmp, sizeof(ext->dot_tmp));
+            memcpy(ext->dt.dot_tmp, copy_ext->dt.dot_tmp, sizeof(ext->dt.dot_tmp));
         }
         ext->dot_tmp_alloc = copy_ext->dot_tmp_alloc;
         ext->dot_end = copy_ext->dot_end;
@@ -1119,19 +1119,19 @@ static bool lv_label_set_dot_tmp(lv_obj_t *label, char *data, uint16_t len){
     if( len > sizeof(char *) ){
         /* Memory needs to be allocated. Allocates an additional byte
          * for a NULL-terminator so it can be copied. */
-        ext->dot_tmp_ptr = lv_mem_alloc(len + 1);
-        if( ext->dot_tmp_ptr == NULL ){
+        ext->dt.dot_tmp_ptr = lv_mem_alloc(len + 1);
+        if( ext->dt.dot_tmp_ptr == NULL ){
             LV_LOG_ERROR("Failed to allocate memory for dot_tmp_ptr");
             return false;
         }
-        memcpy(ext->dot_tmp_ptr, data, len);
-        ext->dot_tmp_ptr[len]='\0';
+        memcpy(ext->dt.dot_tmp_ptr, data, len);
+        ext->dt.dot_tmp_ptr[len]='\0';
         ext->dot_tmp_alloc = true;
     }
     else {
         /* Characters can be directly stored in object */
         ext->dot_tmp_alloc = false;
-        memcpy(ext->dot_tmp, data, len);
+        memcpy(ext->dt.dot_tmp, data, len);
     }
     return true;
 }
@@ -1144,10 +1144,10 @@ static bool lv_label_set_dot_tmp(lv_obj_t *label, char *data, uint16_t len){
 static char * lv_label_get_dot_tmp(lv_obj_t *label){
     lv_label_ext_t * ext = lv_obj_get_ext_attr(label);
     if( ext->dot_tmp_alloc ){
-        return ext->dot_tmp_ptr;
+        return ext->dt.dot_tmp_ptr;
     }
     else{
-        return ext->dot_tmp;
+        return ext->dt.dot_tmp;
     }
 }
 
@@ -1158,11 +1158,11 @@ static char * lv_label_get_dot_tmp(lv_obj_t *label){
  */
 static void lv_label_dot_tmp_free(lv_obj_t *label){
     lv_label_ext_t * ext = lv_obj_get_ext_attr(label);
-    if( ext->dot_tmp_alloc && ext->dot_tmp_ptr ){
-        lv_mem_free(ext->dot_tmp_ptr);
+    if( ext->dot_tmp_alloc && ext->dt.dot_tmp_ptr ){
+        lv_mem_free(ext->dt.dot_tmp_ptr);
     }
     ext->dot_tmp_alloc = false;
-    ext->dot_tmp_ptr = NULL;
+    ext->dt.dot_tmp_ptr = NULL;
 }
 
 #endif

--- a/src/lv_objx/lv_label.h
+++ b/src/lv_objx/lv_label.h
@@ -66,7 +66,7 @@ typedef struct
     union{
         char * dot_tmp_ptr; /* Pointer to the allocated memory containing the character which are replaced by dots (Handled by the library)*/
         char dot_tmp[ sizeof(char *) ];    /* Directly store the characters if <=4 characters */
-    };
+    } dt;
     uint16_t dot_end;       /*The text end position in dot mode (Handled by the library)*/
     uint16_t anim_speed;    /*Speed of scroll and roll animation in px/sec unit*/
     lv_point_t offset;      /*Text draw position offset*/

--- a/src/lv_objx/lv_label.h
+++ b/src/lv_objx/lv_label.h
@@ -64,9 +64,9 @@ typedef struct
     /*New data for this type */
     char * text;                    /*Text of the label*/
     union{
-        char * dot_tmp_ptr; /* Pointer to the allocated memory containing the character which are replaced by dots (Handled by the library)*/
-        char dot_tmp[ sizeof(char *) ];    /* Directly store the characters if <=4 characters */
-    } dt;
+        char * tmp_ptr; /* Pointer to the allocated memory containing the character which are replaced by dots (Handled by the library)*/
+        char tmp[ sizeof(char *) ];    /* Directly store the characters if <=4 characters */
+    } dot;
     uint16_t dot_end;       /*The text end position in dot mode (Handled by the library)*/
     uint16_t anim_speed;    /*Speed of scroll and roll animation in px/sec unit*/
     lv_point_t offset;      /*Text draw position offset*/


### PR DESCRIPTION
* Name the unnamed union in `lv_label_ext_t`
* Add `LV_ATTRIBUTE_MEM_ALIGN` to `lv_conf_template.h`
* Replace incorrect `LV_USE_EXTENDED_CLICK_AREA_TINY` check with `LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY`
* Move `LV_EXT_CLICK_AREA` defines to `lv_area.h` - because they are now needed in there 