### PR TITLE
lv_obj_count_children_recursive

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -206,6 +206,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale_en = 0;
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->parent_event = 0;
+        new_obj->reserved     = 0;
 
         new_obj->ext_attr = NULL;
 
@@ -1566,6 +1567,22 @@ uint16_t lv_obj_count_children(const lv_obj_t * obj)
     uint16_t cnt = 0;
 
     LV_LL_READ(obj->child_ll, i) cnt++;
+
+    return cnt;
+}
+
+/** Recursively count the children of an object
+ * @param obj pointer to an object
+ * @return children number of 'obj'
+ */
+uint16_t lv_obj_count_children_recursive(const lv_obj_t * obj){
+    lv_obj_t * i;
+    uint16_t cnt = 0;
+
+    LV_LL_READ(obj->child_ll, i) {
+        cnt++; // Count the child
+        cnt += lv_obj_count_children_recursive(i); // recursively count children's children
+    }
 
     return cnt;
 }

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -672,6 +672,12 @@ lv_obj_t * lv_obj_get_child_back(const lv_obj_t * obj, const lv_obj_t * child);
  */
 uint16_t lv_obj_count_children(const lv_obj_t * obj);
 
+/** Recursively count the children of an object
+ * @param obj pointer to an object
+ * @return children number of 'obj'
+ */
+uint16_t lv_obj_count_children_recursive(const lv_obj_t * obj);
+
 /*---------------------
  * Coordinate get
  *--------------------*/

--- a/src/lv_misc/lv_ll.c
+++ b/src/lv_misc/lv_ll.c
@@ -318,6 +318,22 @@ void * lv_ll_get_prev(const lv_ll_t * ll_p, const void * n_act)
     return prev;
 }
 
+/**
+ * Return the length of the linked list.
+ * @param ll_p pointer to linked list
+ * @return length of the linked list
+ */
+uint32_t lv_ll_get_len(const lv_ll_t *ll_p){
+    uint32_t len = 0;
+    void * node;
+
+    for(node=lv_ll_get_head(ll_p); node!=NULL; node=lv_ll_get_next(ll_p, node)) {
+        len++;
+    }
+
+    return len;
+}
+
 void lv_ll_swap(lv_ll_t * ll_p, void * n1_p, void * n2_p)
 {
     (void)(ll_p);

--- a/src/lv_misc/lv_ll.h
+++ b/src/lv_misc/lv_ll.h
@@ -125,6 +125,13 @@ void * lv_ll_get_next(const lv_ll_t * ll_p, const void * n_act);
 void * lv_ll_get_prev(const lv_ll_t * ll_p, const void * n_act);
 
 /**
+ * Return the length of the linked list.
+ * @param ll_p pointer to linked list
+ * @return length of the linked list
+ */
+uint32_t lv_ll_get_len(const lv_ll_t *ll_p);
+
+/**
  * Move a nodw before an other node in the same linked list
  * @param ll_p pointer to a linked list
  * @param n_act pointer to node to move


### PR DESCRIPTION
Add functions for recursively getting the number of children. Also added a function for getting the length of a linked list. Useful for debugging/profiling. For example, you can get the number of objects on a screen by `lv_obj_count_children_recursive(lv_scr_act())`