### PR TITLE
feature(lv_conf): use clock() to inc tick

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -143,8 +143,8 @@
 /*HAL settings*/
 #define LV_TICK_CUSTOM     0                        /*1: use a custom tick source (removing the need to manually update the tick with `lv_tick_inc`) */
 #if LV_TICK_CUSTOM == 1
-#define LV_TICK_CUSTOM_INCLUDE  "something.h"         /*Header for the sys time function*/
-#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current systime in ms*/
+#define LV_TICK_CUSTOM_INCLUDE  <time.h>         /*Header for the sys time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR ((uint32_t)clock())     /*Expression evaluating to current systime in ms*/
 #endif     /*LV_TICK_CUSTOM*/
 
 


### PR DESCRIPTION
* Many times, we can use the standard clock() function to get the milliseconds of the system running.