### PR TITLE
lv_img_decoder.c Wrap filesystem calls in LV_USE_FILESYSTEM macro

### DIFF
--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -7,6 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_draw_img.h"
+#include "lv_log.h"
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
I don't use the lv filesystem, so i cannot verify this correctness; but i just wrapped all the fs-related called in LV_USE_FILESYSTEM. Should be fine. Also fixed misc compiler warnings/errors.