### PR TITLE
Indev focus fix

### DIFF
--- a/src/lv_core/lv_group.c
+++ b/src/lv_core/lv_group.c
@@ -194,7 +194,7 @@ void lv_group_remove_obj(lv_obj_t * obj)
 }
 
 /**
- * remove all objects from a group
+ * Remove all objects from a group
  * @param group pointer to a group
  */
 void lv_group_remove_all_objs(lv_group_t * group)

--- a/src/lv_core/lv_group.c
+++ b/src/lv_core/lv_group.c
@@ -194,6 +194,28 @@ void lv_group_remove_obj(lv_obj_t * obj)
 }
 
 /**
+ * remove all objects from a group
+ * @param group pointer to a group
+ */
+void lv_group_remove_all_objs(lv_group_t * group)
+{
+	/*Defocus the the currently focused object*/
+	if(group->obj_focus != NULL) {
+		(*group->obj_focus)->signal_cb(*group->obj_focus, LV_SIGNAL_DEFOCUS, NULL);
+		lv_obj_invalidate(*group->obj_focus);
+		group->obj_focus = NULL;
+	}
+
+	/*Remove the objects from the group*/
+	lv_obj_t ** obj;
+	LV_LL_READ(group->obj_ll, obj) {
+		(*obj)->group_p = NULL;
+	}
+
+	lv_ll_clear(&(group->obj_ll));
+}
+
+/**
  * Focus on an object (defocus the current)
  * @param obj pointer to an object to focus on
  */

--- a/src/lv_core/lv_group.h
+++ b/src/lv_core/lv_group.h
@@ -114,7 +114,7 @@ void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj);
 void lv_group_remove_obj(lv_obj_t * obj);
 
 /**
- * remove all objects from a group
+ * Remove all objects from a group
  * @param group pointer to a group
  */
 void lv_group_remove_all_objs(lv_group_t * group);

--- a/src/lv_core/lv_group.h
+++ b/src/lv_core/lv_group.h
@@ -114,6 +114,12 @@ void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj);
 void lv_group_remove_obj(lv_obj_t * obj);
 
 /**
+ * remove all objects from a group
+ * @param group pointer to a group
+ */
+void lv_group_remove_all_objs(lv_group_t * group);
+    
+/**
  * Focus on an object (defocus the current)
  * @param obj pointer to an object to focus on
  */

--- a/src/lv_core/lv_indev.h
+++ b/src/lv_core/lv_indev.h
@@ -142,11 +142,11 @@ void lv_indev_wait_release(lv_indev_t * indev);
 lv_task_t * lv_indev_get_read_task(lv_disp_t * indev);
 
 /**
- * Gets a pointer to the currently handled object.
+ * Gets a pointer to the currently active object in indev proc functions.
  * NULL if no object is currently being handled or if groups aren't used.
  * @return pointer to currently focused object
  */
-lv_obj_t * lv_indev_get_obj_focused();
+lv_obj_t * lv_indev_get_obj_act( void );
 
 /**********************
  *      MACROS

--- a/src/lv_core/lv_indev.h
+++ b/src/lv_core/lv_indev.h
@@ -141,6 +141,13 @@ void lv_indev_wait_release(lv_indev_t * indev);
  */
 lv_task_t * lv_indev_get_read_task(lv_disp_t * indev);
 
+/**
+ * Gets a pointer to the currently handled object.
+ * NULL if no object is currently being handled or if groups aren't used.
+ * @return pointer to currently focused object
+ */
+lv_obj_t * lv_indev_get_obj_focused();
+
 /**********************
  *      MACROS
  **********************/

--- a/src/lv_core/lv_indev.h
+++ b/src/lv_core/lv_indev.h
@@ -144,7 +144,7 @@ lv_task_t * lv_indev_get_read_task(lv_disp_t * indev);
 /**
  * Gets a pointer to the currently active object in indev proc functions.
  * NULL if no object is currently being handled or if groups aren't used.
- * @return pointer to currently focused object
+ * @return pointer to currently active object
  */
 lv_obj_t * lv_indev_get_obj_act( void );
 

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -378,13 +378,8 @@ lv_res_t lv_obj_del(lv_obj_t * obj)
 
     /*Delete from the group*/
 #if LV_USE_GROUP
-    bool was_focused = false;
     lv_group_t * group = lv_obj_get_group(obj);
-
-    if(group) {
-        if(lv_group_get_focused(group) == obj) was_focused = true;
-        lv_group_remove_obj(obj);
-    }
+    if(group) lv_group_remove_obj(obj);
 #endif
 
     /*Remove the animations from this object*/
@@ -432,7 +427,7 @@ lv_res_t lv_obj_del(lv_obj_t * obj)
         }
 
 #if LV_USE_GROUP
-        if(indev->group == group && was_focused) {
+        if(indev->group == group && obj == lv_indev_get_obj_focused() ) {
             lv_indev_reset(indev);
         }
 #endif
@@ -2197,14 +2192,10 @@ static void delete_children(lv_obj_t * obj)
      * the object still has access to all children during the
      * LV_SIGNAL_DEFOCUS call*/
 #if LV_USE_GROUP
-    bool was_focused = false;
     lv_group_t * group = lv_obj_get_group(obj);
-
-    if(group) {
-        if(lv_group_get_focused(obj->group_p) == obj) was_focused = true;
-        lv_group_remove_obj(obj);
-    }
+    if(group) lv_group_remove_obj(obj);
 #endif
+
 
     while(i != NULL) {
         /*Get the next object before delete this*/
@@ -2239,7 +2230,7 @@ static void delete_children(lv_obj_t * obj)
             indev->proc.types.pointer.last_pressed = NULL;
         }
 #if LV_USE_GROUP
-        if(indev->group == group && was_focused) {
+        if(indev->group == group && obj == lv_indev_get_obj_focused() ) {
             lv_indev_reset(indev);
         }
 #endif

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -427,7 +427,7 @@ lv_res_t lv_obj_del(lv_obj_t * obj)
         }
 
 #if LV_USE_GROUP
-        if(indev->group == group && obj == lv_indev_get_obj_focused() ) {
+        if(indev->group == group && obj == lv_indev_get_obj_act() ) {
             lv_indev_reset(indev);
         }
 #endif
@@ -2230,7 +2230,7 @@ static void delete_children(lv_obj_t * obj)
             indev->proc.types.pointer.last_pressed = NULL;
         }
 #if LV_USE_GROUP
-        if(indev->group == group && obj == lv_indev_get_obj_focused() ) {
+        if(indev->group == group && obj == lv_indev_get_obj_act() ) {
             lv_indev_reset(indev);
         }
 #endif

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -31,7 +31,7 @@
  *  STATIC PROTOTYPES
  **********************/
 #if LV_USE_ANIMATION
-static void style_animator(lv_style_anim_dsc_t * dsc, int32_t val);
+static void style_animator(lv_style_anim_dsc_t * dsc, int16_t val);
 static void style_animation_common_end_cb(lv_anim_t * a);
 #endif
 
@@ -316,9 +316,9 @@ void lv_style_anim_set_styles(lv_anim_t * a, lv_style_t * to_anim, const lv_styl
 /**
  * Used by the style animations to set the values of a style according to start and end style.
  * @param dsc the 'animated variable' set by lv_style_anim_create()
- * @param val the current state of the animation between 0 and LV_STYLE_ANIM_RES
+ * @param val the current state of the animation between 0 and LV_ANIM_RESOLUTION
  */
-static void style_animator(lv_style_anim_dsc_t * dsc, int32_t val)
+static void style_animator(lv_style_anim_dsc_t * dsc, int16_t val)
 {
     const lv_style_t * start = &dsc->style_start;
     const lv_style_t * end   = &dsc->style_end;

--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -264,7 +264,7 @@ static inline lv_anim_user_data_t * lv_style_anim_get_user_data_ptr(lv_anim_t * 
  */
 static inline void lv_style_anim_create(lv_anim_t * a)
 {
-    return lv_anim_create(a);
+    lv_anim_create(a);
 }
 
 #endif

--- a/src/lv_draw/lv_img_decoder.c
+++ b/src/lv_draw/lv_img_decoder.c
@@ -421,7 +421,7 @@ static lv_res_t lv_img_decoder_built_in_read_line(lv_img_decoder_t * decoder,  l
             dsc->header.cf == LV_IMG_CF_TRUE_COLOR_ALPHA ||
             dsc->header.cf == LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED)
     {
-        /* For TRUE_COLOE images read line required only for files.
+        /* For TRUE_COLOR images read line required only for files.
          * For variables the image data was returned in `open`*/
         if(dsc->src_type == LV_IMG_SRC_FILE) {
             res = lv_img_decoder_built_in_line_true_color(dsc, x, y, len, buf);

--- a/src/lv_fonts/lv_font_builtin.c
+++ b/src/lv_fonts/lv_font_builtin.c
@@ -125,7 +125,7 @@ void lv_font_builtin_init(void)
 #if LV_USE_FONT_DEJAVU_30 != 0
     lv_font_add(&lv_font_symbol_30, &lv_font_dejavu_30);
 #else
-    lv_font_add(&lv_font_symbol_30_basic, NULL);
+    lv_font_add(&lv_font_symbol_30, NULL);
 #endif
 #endif
 

--- a/src/lv_objx/lv_bar.c
+++ b/src/lv_objx/lv_bar.c
@@ -30,7 +30,7 @@
 static bool lv_bar_design(lv_obj_t * bar, const lv_area_t * mask, lv_design_mode_t mode);
 static lv_res_t lv_bar_signal(lv_obj_t * bar, lv_signal_t sign, void * param);
 
-static void lv_bar_animate(void * bar, int32_t value);
+static void lv_bar_anim(void * bar, int16_t value);
 static void lv_bar_anim_ready(lv_anim_t * a);
 
 /**********************
@@ -158,9 +158,9 @@ void lv_bar_set_value(lv_obj_t * bar, int16_t value, bool anim)
         a.var            = bar;
         a.start          = LV_BAR_ANIM_STATE_START;
         a.end            = LV_BAR_ANIM_STATE_END;
-        a.exec_cb             = (lv_anim_exec_cb_t)lv_bar_animate;
-        a.path_cb           = lv_anim_path_linear;
-        a.ready_cb         = lv_bar_anim_ready;
+        a.exec_cb        = (lv_anim_exec_cb_t)lv_bar_anim;
+        a.path_cb        = lv_anim_path_linear;
+        a.ready_cb       = lv_bar_anim_ready;
         a.act_time       = 0;
         a.time           = ext->anim_time;
         a.playback       = 0;
@@ -475,7 +475,7 @@ static lv_res_t lv_bar_signal(lv_obj_t * bar, lv_signal_t sign, void * param)
     return res;
 }
 
-static void lv_bar_animate(void * bar, int32_t value)
+static void lv_bar_anim(void * bar, int16_t value)
 {
     lv_bar_ext_t * ext = lv_obj_get_ext_attr(bar);
     ext->anim_state    = value;

--- a/src/lv_objx/lv_btn.c
+++ b/src/lv_objx/lv_btn.c
@@ -35,7 +35,7 @@ static bool lv_btn_design(lv_obj_t * btn, const lv_area_t * mask, lv_design_mode
 static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param);
 
 #if LV_USE_ANIMATION && LV_BTN_INK_EFFECT
-static void lv_btn_ink_effect_anim(lv_obj_t * btn, int32_t val);
+static void lv_btn_ink_effect_anim(lv_obj_t * btn, int16_t val);
 static void lv_btn_ink_effect_anim_ready(lv_anim_t * a);
 #endif
 
@@ -517,9 +517,9 @@ static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param)
             a.var            = btn;
             a.start          = 0;
             a.end            = LV_BTN_INK_VALUE_MAX;
-            a.exec_cb             = (lv_anim_exec_cb_t)lv_btn_ink_effect_anim;
-            a.path_cb           = lv_anim_path_linear;
-            a.ready_cb         = lv_btn_ink_effect_anim_ready;
+            a.exec_cb        = (lv_anim_exec_cb_t)lv_btn_ink_effect_anim;
+            a.path_cb        = lv_anim_path_linear;
+            a.ready_cb       = lv_btn_ink_effect_anim_ready;
             a.act_time       = 0;
             a.time           = ext->ink_in_time;
             a.playback       = 0;
@@ -586,9 +586,9 @@ static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param)
             a.var            = ink_obj;
             a.start          = LV_BTN_INK_VALUE_MAX;
             a.end            = 0;
-            a.exec_cb             = (lv_anim_exec_cb_t)lv_btn_ink_effect_anim;
-            a.path_cb           = lv_anim_path_linear;
-            a.ready_cb         = lv_btn_ink_effect_anim_ready;
+            a.exec_cb        = (lv_anim_exec_cb_t)lv_btn_ink_effect_anim;
+            a.path_cb        = lv_anim_path_linear;
+            a.ready_cb       = lv_btn_ink_effect_anim_ready;
             a.act_time       = 0;
             a.time           = ext->ink_out_time;
             a.playback       = 0;
@@ -632,7 +632,7 @@ static lv_res_t lv_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param)
  * @param btn pointer to the animated button
  * @param val the new radius
  */
-static void lv_btn_ink_effect_anim(lv_obj_t * btn, int32_t val)
+static void lv_btn_ink_effect_anim(lv_obj_t * btn, int16_t val)
 {
     if(btn) {
         ink_act_value = val;

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -860,12 +860,15 @@ static void lv_chart_draw_cols(lv_obj_t * chart, const lv_area_t * mask)
         LV_LL_READ_BACK(ext->series_ll, ser) {
             lv_coord_t start_point = ext->update_mode == LV_CHART_UPDATE_MODE_SHIFT ? ser->start_point : 0;
 
-            rects.body.main_color = ser->color;
-            rects.body.grad_color = lv_color_mix(LV_COLOR_BLACK, ser->color, ext->series.dark);
             col_a.x1              = x_act;
             col_a.x2              = col_a.x1 + col_w;
             x_act += col_w;
 
+            if(col_a.x2 < mask->x1) continue;
+            if(col_a.x1 > mask->x2) break;
+
+            rects.body.main_color = ser->color;
+            rects.body.grad_color = lv_color_mix(LV_COLOR_BLACK, ser->color, ext->series.dark);
 
             lv_coord_t p_act = (start_point + i) % ext->point_cnt;
             y_tmp = (int32_t)((int32_t) ser->points[p_act] - ext->ymin) * h;

--- a/src/lv_objx/lv_ddlist.c
+++ b/src/lv_objx/lv_ddlist.c
@@ -46,7 +46,7 @@ static void lv_ddlist_pos_current_option(lv_obj_t * ddlist);
 static void lv_ddlist_refr_width(lv_obj_t* ddlist);
 static void lv_ddlist_anim_ready_cb(lv_anim_t * a);
 static void lv_ddlist_anim_finish(lv_obj_t* ddlist);
-static void lv_ddlist_adjust_height(lv_obj_t * ddlist, int32_t height);
+static void lv_ddlist_adjust_height(lv_obj_t * ddlist, int16_t height);
 
 /**********************
  *  STATIC VARIABLES
@@ -937,7 +937,7 @@ static void lv_ddlist_anim_finish(lv_obj_t* ddlist)
  * @param ddlist Drop down list object
  * @param height New drop down list height
  */
-static void lv_ddlist_adjust_height(lv_obj_t * ddlist, int32_t height)
+static void lv_ddlist_adjust_height(lv_obj_t * ddlist, int16_t height)
 {
     lv_obj_set_height(ddlist, height);
     lv_ddlist_pos_current_option(ddlist);

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -40,7 +40,7 @@ static bool lv_page_design(lv_obj_t * page, const lv_area_t * mask, lv_design_mo
 static bool lv_scrl_design(lv_obj_t * scrl, const lv_area_t * mask, lv_design_mode_t mode);
 static lv_res_t lv_page_signal(lv_obj_t * page, lv_signal_t sign, void * param);
 static lv_res_t lv_page_scrollable_signal(lv_obj_t * scrl, lv_signal_t sign, void * param);
-static void edge_flash_anim(void * page, int32_t v);
+static void edge_flash_anim(void * page, int16_t v);
 static void edge_flash_anim_end(lv_anim_t * a);
 static void scrl_def_event_cb(lv_obj_t * scrl, lv_event_t event);
 
@@ -435,10 +435,8 @@ void lv_page_focus(lv_obj_t * page, const lv_obj_t * obj, uint16_t anim_time)
      * because it can overide the current changes*/
     lv_anim_del(page, (lv_anim_exec_cb_t)lv_obj_set_x);
     lv_anim_del(page, (lv_anim_exec_cb_t)lv_obj_set_y);
-    lv_anim_del(page, (lv_anim_exec_cb_t)lv_obj_set_pos);
     lv_anim_del(ext->scrl, (lv_anim_exec_cb_t)lv_obj_set_x);
     lv_anim_del(ext->scrl, (lv_anim_exec_cb_t)lv_obj_set_y);
-    lv_anim_del(ext->scrl, (lv_anim_exec_cb_t)lv_obj_set_pos);
 #endif
 
     const lv_style_t * style      = lv_page_get_style(page, LV_PAGE_STYLE_BG);
@@ -1195,7 +1193,7 @@ static void lv_page_sb_refresh(lv_obj_t * page)
     }
 }
 
-static void edge_flash_anim(void * page, int32_t v)
+static void edge_flash_anim(void * page, int16_t v)
 {
     lv_page_ext_t * ext   = lv_obj_get_ext_attr(page);
     ext->edge_flash.state = v;

--- a/src/lv_objx/lv_preload.c
+++ b/src/lv_objx/lv_preload.c
@@ -127,7 +127,7 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy)
  * @param preload pointer to a preload object
  * @param deg length of the arc
  */
-void lv_preload_set_arc_length(lv_obj_t * preload, uint16_t deg)
+void lv_preload_set_arc_length(lv_obj_t * preload, int16_t deg)
 {
     lv_preload_ext_t * ext = lv_obj_get_ext_attr(preload);
 
@@ -189,9 +189,9 @@ void lv_preload_set_anim_type(lv_obj_t * preload, lv_preload_type_t type)
                 a.start      = 0;
                 a.end        = 360;
             }
-            a.exec_cb             = (lv_anim_exec_cb_t)lv_preload_spinner_anim;
-            a.path_cb           = lv_anim_path_ease_in_out;
-            a.ready_cb         = NULL;
+            a.exec_cb        = (lv_anim_exec_cb_t)lv_preload_spinner_anim;
+            a.path_cb        = lv_anim_path_ease_in_out;
+            a.ready_cb       = NULL;
             a.act_time       = 0;
             a.time           = ext->time;
             a.playback       = 0;
@@ -211,9 +211,9 @@ void lv_preload_set_anim_type(lv_obj_t * preload, lv_preload_type_t type)
                 b.start      = ext->arc_length;
                 b.end        = 360 - ext->arc_length;
             }
-            b.exec_cb             = (lv_anim_exec_cb_t)lv_preload_set_arc_length;
-            b.path_cb           = lv_anim_path_ease_in_out;
-            b.ready_cb         = NULL;
+            b.exec_cb        = (lv_anim_exec_cb_t)lv_preload_set_arc_length;
+            b.path_cb        = lv_anim_path_ease_in_out;
+            b.ready_cb       = NULL;
             b.act_time       = 0;
             b.time           = ext->time;
             b.playback       = 1;
@@ -237,9 +237,9 @@ void lv_preload_set_anim_type(lv_obj_t * preload, lv_preload_type_t type)
                 a.start      = 0;
                 a.end        = 360;
             }
-            a.exec_cb             = (lv_anim_exec_cb_t)lv_preload_spinner_anim;
-            a.path_cb           = lv_anim_path_ease_in_out;
-            a.ready_cb         = NULL;
+            a.exec_cb        = (lv_anim_exec_cb_t)lv_preload_spinner_anim;
+            a.path_cb        = lv_anim_path_ease_in_out;
+            a.ready_cb       = NULL;
             a.act_time       = 0;
             a.time           = ext->time;
             a.playback       = 0;
@@ -328,7 +328,7 @@ lv_preload_dir_t lv_preload_get_anim_dir(lv_obj_t * preload) {
  * @param ptr pointer to preloader
  * @param val the current desired value [0..360]
  */
-void lv_preload_spinner_anim(void * ptr, int32_t val)
+void lv_preload_spinner_anim(void * ptr, int16_t val)
 {
     lv_obj_t * preload     = ptr;
     lv_preload_ext_t * ext = lv_obj_get_ext_attr(preload);

--- a/src/lv_objx/lv_preload.h
+++ b/src/lv_objx/lv_preload.h
@@ -92,7 +92,7 @@ lv_obj_t * lv_preload_create(lv_obj_t * par, const lv_obj_t * copy);
  * @param preload pointer to a preload object
  * @param deg length of the arc
  */
-void lv_preload_set_arc_length(lv_obj_t * preload, uint16_t deg);
+void lv_preload_set_arc_length(lv_obj_t * preload, int16_t deg);
 
 /**
  * Set the spin time of the arc
@@ -175,7 +175,7 @@ lv_preload_dir_t lv_preload_get_anim_dir(lv_obj_t * preload);
  * @param type which style should be get
  * @return style pointer to the style
  *  */
-void lv_preload_spinner_anim(void * ptr, int32_t val);
+void lv_preload_spinner_anim(void * ptr, int16_t val);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Previously, the following actions would cause undesireable effects (indev query not properly reseting, causing deleted objects' callbacks to be called).

1. Create an object `objA` in a group
2. Click `objA`.
3. Within the `short_clicked` callback:
    a. Create a new object `objB` in the same group
    b. Focus on `objB` object
    c. Delete `objA`

Since the currently focused object is `objB`, deleting `objA` wouldn't trigger `proc.reset_query`, so other signals (like `LV_EVENT_CLICKED`) would be sent to the deleted `objA`'s callback.

This PR explicitly stores the object pointer that `indev` is sending signals to, and `lv_obj_del` explicitly checks if this is the object being deleted to trigger `proc.reset_query`. 

I only fixed this for the `KEYPAD` device since this is what I use and am most familiar with. Other devices (`POINTER`, `ENCODER`, `BUTTON`) may need a similar fix.

Other things:

1. I think `lv_obj_del` and `delete_children` should be refactored as they contain a lot of duplicate code.

Sorry that this includes #1069 , we can cherry pick if we want to clean this up.