### PR TITLE
Fix issue with roller overrunning borders

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -1593,6 +1593,25 @@ void lv_obj_get_coords(const lv_obj_t * obj, lv_area_t * cords_p)
 }
 
 /**
+ * Adjust the coordinates retrieved from lv_obj_get_coords() according
+ * to the object's style.
+ */
+void lv_obj_adjust_coords(const lv_obj_t *obj, lv_area_t * cords_p)
+{
+	const lv_style_t *style = lv_obj_get_style(obj);
+	if(style->body.border.part & LV_BORDER_LEFT)
+		cords_p->x1 += style->body.border.width;
+
+	if(style->body.border.part & LV_BORDER_RIGHT)
+		cords_p->x2 -= style->body.border.width;
+	if(style->body.border.part & LV_BORDER_TOP)
+		cords_p->y1 += style->body.border.width;
+	if(style->body.border.part & LV_BORDER_BOTTOM)
+		cords_p->y2 -= style->body.border.width;
+}
+
+
+/**
  * Get the x coordinate of object
  * @param obj pointer to an object
  * @return distance of 'obj' from the left side of its parent

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -667,6 +667,12 @@ uint16_t lv_obj_count_children_recursive(const lv_obj_t * obj);
 void lv_obj_get_coords(const lv_obj_t * obj, lv_area_t * cords_p);
 
 /**
+ * Adjust the coordinates retrieved from lv_obj_get_coords() according
+ * to the object's style.
+ */
+void lv_obj_adjust_coords(const lv_obj_t *obj, lv_area_t * cords_p);
+
+/**
  * Get the x coordinate of object
  * @param obj pointer to an object
  * @return distance of 'obj' from the left side of its parent

--- a/src/lv_objx/lv_roller.c
+++ b/src/lv_objx/lv_roller.c
@@ -328,8 +328,12 @@ static bool lv_roller_design(lv_obj_t * roller, const lv_area_t * mask, lv_desig
         if((font_h & 0x1) && (style->text.line_space & 0x1))
             rect_area.y1--; /*Compensate the two rounding error*/
         rect_area.y2 = rect_area.y1 + font_h + style->text.line_space - 1;
-        rect_area.x1 = roller->coords.x1;
-        rect_area.x2 = roller->coords.x2;
+	lv_area_t roller_coords;
+	lv_obj_get_coords(roller, &roller_coords);
+	lv_obj_adjust_coords(roller, &roller_coords);
+
+        rect_area.x1 = roller_coords.x1;
+        rect_area.x2 = roller_coords.x2;
 
         lv_draw_rect(&rect_area, mask, ext->ddlist.sel_style, opa_scale);
     }


### PR DESCRIPTION
It is especially obvious on `lv_test_group_1`. When the roller is highlighted, the rectangle showing the selected item is drawn on top of the borders.

This pull request solves that issue by introducing a simple `lv_obj_adjust_coords` API that allows you to retrieve the object's "client area" (the area inside the borders). Additionally, the roller is updated to make use of this API.