### PR TITLE
small fixes

### DIFF
--- a/src/lv_misc/lv_font.h
+++ b/src/lv_misc/lv_font.h
@@ -118,10 +118,21 @@ static inline uint8_t lv_font_get_line_height(const lv_font_t * font_p)
 
 #define LV_FONT_DECLARE(font_name) extern lv_font_t font_name;
 
+#if LV_FONT_ROBOTO_12
 LV_FONT_DECLARE(lv_font_roboto_12)
+#endif
+
+#if LV_FONT_ROBOTO_16
 LV_FONT_DECLARE(lv_font_roboto_16)
+#endif
+
+#if LV_FONT_ROBOTO_22
 LV_FONT_DECLARE(lv_font_roboto_22)
+#endif
+
+#if LV_FONT_ROBOTO_28
 LV_FONT_DECLARE(lv_font_roboto_28)
+#endif
 
 /*Declare the custom (user defined) fonts*/
 #ifdef LV_FONT_CUSTOM_DECLARE

--- a/src/lv_misc/lv_symbol_def.h
+++ b/src/lv_misc/lv_symbol_def.h
@@ -71,7 +71,7 @@ extern "C" {
 
 /*
  * following list is generated using
- * cat lv_symbol_def.h | sed -E -n 's/^#define\s+(SYMBOL_\w+).*$/    _LV_STR_\1,/p'
+ * cat src/lv_misc/lv_symbol_def.h | sed -E -n 's/^#define\s+(LV_SYMBOL_\w+).*"$/    _LV_STR_\1,/p'
  */
 enum {
     _LV_STR_SYMBOL_AUDIO,


### PR DESCRIPTION
Enable/disable font declarations according to font macros. This is required for Micropython otherwise we would get a declaration with a missing definition.

Updated sed line which generates _LV_STR enum for Micropython binding