### PR TITLE
Strip logs at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ lv.scr_load(scr)
 Check out the [Documentation](https://docs.littlevgl.com/) for more!
 
 ### Contributing
-To ask questions please use the [Forum](https://forum.littlevgl.com).
+To ask questions please use the [Forum](https://forumtest.littlevgl.com).
 FOr development related things (bug reports, feature suggestions) use [GitHub's Issue tracker](https://github.com/littlevgl/lvgl/issues). 
 You can contribute in several ways:
 - **Answer other's question** in the Forum

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Choose a project with your favourite IDE:
 ### Porting to an embedded hardware
 In the most simple case you need to do these steps:
 1. Copy `lv_conf_templ.h` as `lv_conf.h` next to `lvgl` and set at least `LV_HOR_RES`, `LV_VER_RES` and `LV_COLOR_DEPTH`. 
-2. Call `lv_tick_inc(x)` every `x` milliseconds **in a Timer or Task** (`x` should be between 1 and 10). It is required for the internal timing of LittlevGL.
+2. Call `lv_tick_inc(x)` every `x` milliseconds **in a Timer or Task** (`x` should be between 1 and 10). It is required for the internal timing of LittlevGL. **It's very important that you don't call `lv_task_handler` in the same loop.**
 3. Call `lv_init()`
 4. Register a function which can **copy a pixel array** to an area of the screen:
 ```c
@@ -117,7 +117,7 @@ bool touchpad_read(lv_indev_data_t * data)
     return false; /*Return `false` because we are not buffering and no more data to read*/
 }
 ```
-6. Call `lv_task_handler()` periodically every few milliseconds in the main `while(1)` loop, in Timer interrupt or in an Operation system task. It will redraw the screen if required, handle input devices etc.
+6. Call `lv_task_handler()` periodically every few milliseconds in the main `while(1)` loop, in Timer interrupt or in an Operation system task. It will redraw the screen if required, handle input devices etc. **It's very important that you don't call `lv_tick_inc` in the same loop.**
 
 For a detailed description check the [Documentation](https://docs.littlevgl.com/#Porting) or the [Porting tutorial](https://github.com/littlevgl/lv_examples/blob/master/lv_tutorial/0_porting/lv_tutorial_porting.c)
  

--- a/lv_core/lv_group.c
+++ b/lv_core/lv_group.c
@@ -56,6 +56,7 @@ lv_group_t * lv_group_create(void)
     group->focus_cb = NULL;
     group->click_focus = 1;
     group->editing = 0;
+	group->wrap = 1;
 
     return group;
 }
@@ -366,7 +367,7 @@ static void lv_group_refocus(lv_group_t *g) {
 /**
  * Set whether focus next/prev will allow wrapping from first->last or last->first.
  * @param group pointer to group
- * @param en: true: enable `click_focus`
+ * @param en: true: enable `wrap`
  */
 void lv_group_set_wrap(lv_group_t * group, bool en)
 {

--- a/lv_core/lv_obj.c
+++ b/lv_core/lv_obj.c
@@ -309,7 +309,12 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const  lv_obj_t * copy)
         }
 #endif
 
-        lv_obj_set_pos(new_obj, lv_obj_get_x(copy), lv_obj_get_y(copy));
+        /*Set the same coordinates for non screen objects*/
+        if(lv_obj_get_parent(copy) != NULL && parent != NULL) {
+            lv_obj_set_pos(new_obj, lv_obj_get_x(copy), lv_obj_get_y(copy));
+        } else {
+            lv_obj_set_pos(new_obj, 0, 0);
+        }
 
         LV_LOG_INFO("Object create ready");
     }

--- a/lv_fonts/lv_font_builtin.c
+++ b/lv_fonts/lv_font_builtin.c
@@ -125,7 +125,7 @@ void lv_font_builtin_init(void)
 #if USE_LV_FONT_DEJAVU_30 != 0
     lv_font_add(&lv_font_symbol_30, &lv_font_dejavu_30);
 #else
-    lv_font_add(&lv_font_symbol_30_basic, NULL);
+    lv_font_add(&lv_font_symbol_30, NULL);
 #endif
 #endif
 

--- a/lv_misc/lv_log.h
+++ b/lv_misc/lv_log.h
@@ -64,10 +64,26 @@ void lv_log_add(lv_log_level_t level, const char * file, int line, const char * 
  *      MACROS
  **********************/
 
-#define LV_LOG_TRACE(dsc)   lv_log_add(LV_LOG_LEVEL_TRACE, __FILE__, __LINE__, dsc);
-#define LV_LOG_INFO(dsc)    lv_log_add(LV_LOG_LEVEL_INFO, __FILE__, __LINE__, dsc);
-#define LV_LOG_WARN(dsc)    lv_log_add(LV_LOG_LEVEL_WARN, __FILE__, __LINE__, dsc);
-#define LV_LOG_ERROR(dsc)   lv_log_add(LV_LOG_LEVEL_ERROR, __FILE__, __LINE__, dsc);
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_TRACE
+#  define LV_LOG_TRACE(dsc)   lv_log_add(LV_LOG_LEVEL_TRACE, __FILE__, __LINE__, dsc);
+#else
+#  define LV_LOG_TRACE(dsc)   {;}
+#endif
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+#  define LV_LOG_INFO(dsc)    lv_log_add(LV_LOG_LEVEL_INFO, __FILE__, __LINE__, dsc);
+#else
+#  define LV_LOG_INFO(dsc)    {;}
+#endif
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_WARN
+#  define LV_LOG_WARN(dsc)    lv_log_add(LV_LOG_LEVEL_WARN, __FILE__, __LINE__, dsc);
+#else
+#  define LV_LOG_WARN(dsc)    {;}
+#endif
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_ERROR
+#  define LV_LOG_ERROR(dsc)   lv_log_add(LV_LOG_LEVEL_ERROR, __FILE__, __LINE__, dsc);
+#else
+#  define LV_LOG_ERROR(dsc)   {;}
+#endif
 
 #else /*USE_LV_LOG*/
 

--- a/lv_misc/lv_txt.c
+++ b/lv_misc/lv_txt.c
@@ -324,7 +324,7 @@ lv_coord_t lv_txt_get_width(const char * txt, uint16_t length,
 
             lv_coord_t char_width = lv_font_get_width(font, letter);
             if(char_width > 0){
-                width += lv_font_get_width(font, letter);
+                width += char_width;
                 width += letter_space;
             }
         }

--- a/lv_objx/lv_canvas.c
+++ b/lv_objx/lv_canvas.c
@@ -351,11 +351,11 @@ void lv_canvas_mult_buf(lv_obj_t * canvas, void * to_copy, lv_coord_t w, lv_coor
 #  if LV_COLOR_16_SWAP == 0
             canvas_buf_color[j].green = (uint16_t) ((uint16_t) canvas_buf_color[j].green * copy_buf_color[j].green) >> 6;
 #  else
-            uint8_t green_canvas = (canvas_buf_color[j].ch.green_h << 3) + (canvas_buf_color[j].ch.green_l);
-            uint8_t green_buf = (copy_buf_color[j].ch.green_h << 3) + (copy_buf_color[j].ch.green_l);
+            uint8_t green_canvas = (canvas_buf_color[j].green_h << 3) + (canvas_buf_color[j].green_l);
+            uint8_t green_buf = (copy_buf_color[j].green_h << 3) + (copy_buf_color[j].green_l);
             uint8_t green_res = (uint16_t)((uint16_t)green_canvas * green_buf) >> 6;
-            canvas_buf_color[j].ch.green_h = (green_res >> 3) & 0x07;
-            canvas_buf_color[j].ch.green_l = green_res & 0x07;
+            canvas_buf_color[j].green_h = (green_res >> 3) & 0x07;
+            canvas_buf_color[j].green_l = green_res & 0x07;
 #  endif    /*LV_COLOR_16_SWAP*/
 
 #elif LV_COLOR_DEPTH == 8

--- a/lv_objx/lv_canvas.c
+++ b/lv_objx/lv_canvas.c
@@ -351,9 +351,11 @@ void lv_canvas_mult_buf(lv_obj_t * canvas, void * to_copy, lv_coord_t w, lv_coor
 #  if LV_COLOR_16_SWAP == 0
             canvas_buf_color[j].green = (uint16_t) ((uint16_t) canvas_buf_color[j].green * copy_buf_color[j].green) >> 6;
 #  else
-            canvas_buf_color[j].red = (uint16_t) ((uint16_t) canvas_buf_color[j].red * copy_buf_color[j].red) >> 6;
-            canvas_buf_color[j].blue = (uint16_t) ((uint16_t) canvas_buf_color[j].blue * copy_buf_color[j].blue) >> 6;
-            canvas_buf_color[j].red = (uint16_t) ((uint16_t) canvas_buf_color[j].red * copy_buf_color[j].red) >> 6;
+            uint8_t green_canvas = (canvas_buf_color[j].ch.green_h << 3) + (canvas_buf_color[j].ch.green_l);
+            uint8_t green_buf = (copy_buf_color[j].ch.green_h << 3) + (copy_buf_color[j].ch.green_l);
+            uint8_t green_res = (uint16_t)((uint16_t)green_canvas * green_buf) >> 6;
+            canvas_buf_color[j].ch.green_h = (green_res >> 3) & 0x07;
+            canvas_buf_color[j].ch.green_l = green_res & 0x07;
 #  endif    /*LV_COLOR_16_SWAP*/
 
 #elif LV_COLOR_DEPTH == 8

--- a/lv_objx/lv_cont.c
+++ b/lv_objx/lv_cont.c
@@ -210,7 +210,7 @@ lv_coord_t lv_cont_get_fit_height(lv_obj_t * cont)
 {
     lv_style_t * style = lv_cont_get_style(cont);
 
-    return lv_obj_get_width(cont) - 2 * style->body.padding.hor;
+    return lv_obj_get_height(cont) - 2 * style->body.padding.ver;
 }
 
 /**********************

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -39,6 +39,9 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param);
 static lv_res_t lv_list_btn_signal(lv_obj_t * btn, lv_signal_t sign, void * param);
 static void refr_btn_width(lv_obj_t * list);
 static void lv_list_btn_single_selected(lv_obj_t *btn);
+static bool lv_list_is_list_btn(lv_obj_t * list_btn);
+static bool lv_list_is_list_img(lv_obj_t * list_btn);
+static bool lv_list_is_list_label(lv_obj_t * list_btn);
 
 /**********************
  *  STATIC VARIABLES
@@ -430,7 +433,7 @@ lv_obj_t * lv_list_get_btn_label(const lv_obj_t * btn)
     lv_obj_t * label = lv_obj_get_child(btn, NULL);
     if(label == NULL) return NULL;
 
-    while(label->signal_func != label_signal) {
+    while(lv_list_is_list_label(label)) {
         label = lv_obj_get_child(btn, label);
         if(label == NULL) break;
     }
@@ -449,7 +452,7 @@ lv_obj_t * lv_list_get_btn_img(const lv_obj_t * btn)
     lv_obj_t * img = lv_obj_get_child(btn, NULL);
     if(img == NULL) return NULL;
 
-    while(img->signal_func != img_signal) {
+    while(lv_list_is_list_img(img)) {
         img = lv_obj_get_child(btn, img);
         if(img == NULL) break;
     }
@@ -477,7 +480,7 @@ lv_obj_t * lv_list_get_prev_btn(const lv_obj_t * list, lv_obj_t * prev_btn)
     btn = lv_obj_get_child(scrl, prev_btn);
     if(btn == NULL) return NULL;
 
-    while(btn->signal_func != lv_list_btn_signal) {
+    while(lv_list_is_list_btn(btn)) {
         btn = lv_obj_get_child(scrl, btn);
         if(btn == NULL) break;
     }
@@ -504,8 +507,8 @@ lv_obj_t * lv_list_get_next_btn(const lv_obj_t * list, lv_obj_t * prev_btn)
     btn = lv_obj_get_child_back(scrl, prev_btn);
     if(btn == NULL) return NULL;
 
-    while(btn->signal_func != lv_list_btn_signal) {
-        btn = lv_obj_get_child_back(scrl, btn);
+    while(lv_list_is_list_btn(btn)) {
+       btn = lv_obj_get_child_back(scrl, btn);
         if(btn == NULL) break;
     }
 
@@ -969,6 +972,60 @@ static void lv_list_btn_single_selected(lv_obj_t *btn)
         }
         e = lv_list_get_next_btn(list, e);
     } while (e != NULL);
+}
+
+/**
+ * Check if this is really a list button or another object.
+ * @param list_btn List button
+ */
+static bool lv_list_is_list_btn(lv_obj_t * list_btn)
+{
+    lv_obj_type_t type;
+
+    lv_obj_get_type(list_btn, &type);
+    uint8_t cnt;
+    for(cnt = 0; cnt < LV_MAX_ANCESTOR_NUM; cnt++) {
+        if(type.type[cnt] == NULL) break;
+        if(!strcmp(type.type[cnt], "lv_btn"))
+            return true;
+    }
+    return false;
+}
+
+/**
+ * Check if this is really a list label or another object.
+ * @param list_label List label
+ */
+static bool lv_list_is_list_label(lv_obj_t * list_label)
+{
+    lv_obj_type_t type;
+
+    lv_obj_get_type(list_label, &type);
+    uint8_t cnt;
+    for(cnt = 0; cnt < LV_MAX_ANCESTOR_NUM; cnt++) {
+        if(type.type[cnt] == NULL) break;
+        if(!strcmp(type.type[cnt], "lv_label"))
+            return true;
+    }
+    return false;
+}
+
+/**
+ * Check if this is really a list image or another object.
+ * @param list_image List image
+ */
+static bool lv_list_is_list_img(lv_obj_t * list_img)
+{
+    lv_obj_type_t type;
+
+    lv_obj_get_type(list_img, &type);
+    uint8_t cnt;
+    for(cnt = 0; cnt < LV_MAX_ANCESTOR_NUM; cnt++) {
+        if(type.type[cnt] == NULL) break;
+        if(!strcmp(type.type[cnt], "lv_img"))
+            return true;
+    }
+    return false;
 }
 
 #endif

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -591,10 +591,10 @@ lv_style_t * lv_list_get_style(const lv_obj_t * list, lv_list_style_t type)
             style = lv_page_get_style(list, LV_PAGE_STYLE_BG);
             break;
         case LV_LIST_STYLE_SCRL:
-            style = lv_page_get_style(list, LV_PAGE_STYLE_SB);
+            style = lv_page_get_style(list, LV_PAGE_STYLE_SCRL);
             break;
         case LV_LIST_STYLE_SB:
-            style = lv_page_get_style(list, LV_PAGE_STYLE_SCRL);
+            style = lv_page_get_style(list, LV_PAGE_STYLE_SB);
             break;
         case LV_LIST_STYLE_EDGE_FLASH:
             style = lv_page_get_style(list, LV_PAGE_STYLE_EDGE_FLASH);

--- a/lv_objx/lv_list.c
+++ b/lv_objx/lv_list.c
@@ -433,7 +433,7 @@ lv_obj_t * lv_list_get_btn_label(const lv_obj_t * btn)
     lv_obj_t * label = lv_obj_get_child(btn, NULL);
     if(label == NULL) return NULL;
 
-    while(lv_list_is_list_label(label)) {
+    while(lv_list_is_list_label(label) == false) {
         label = lv_obj_get_child(btn, label);
         if(label == NULL) break;
     }
@@ -452,7 +452,7 @@ lv_obj_t * lv_list_get_btn_img(const lv_obj_t * btn)
     lv_obj_t * img = lv_obj_get_child(btn, NULL);
     if(img == NULL) return NULL;
 
-    while(lv_list_is_list_img(img)) {
+    while(lv_list_is_list_img(img) == false) {
         img = lv_obj_get_child(btn, img);
         if(img == NULL) break;
     }
@@ -480,7 +480,7 @@ lv_obj_t * lv_list_get_prev_btn(const lv_obj_t * list, lv_obj_t * prev_btn)
     btn = lv_obj_get_child(scrl, prev_btn);
     if(btn == NULL) return NULL;
 
-    while(lv_list_is_list_btn(btn)) {
+    while(lv_list_is_list_btn(btn) == false) {
         btn = lv_obj_get_child(scrl, btn);
         if(btn == NULL) break;
     }
@@ -507,8 +507,8 @@ lv_obj_t * lv_list_get_next_btn(const lv_obj_t * list, lv_obj_t * prev_btn)
     btn = lv_obj_get_child_back(scrl, prev_btn);
     if(btn == NULL) return NULL;
 
-    while(lv_list_is_list_btn(btn)) {
-       btn = lv_obj_get_child_back(scrl, btn);
+    while(lv_list_is_list_btn(btn) == false) {
+        btn = lv_obj_get_child_back(scrl, btn);
         if(btn == NULL) break;
     }
 


### PR DESCRIPTION
This strips logs which level is lower than `LV_LOG_LEVEL` at compile time.
Besides reducing the executable size, it removes some unnecessary function calls.