### PR TITLE
Rework lv_conf_checker.py to ignore certain items

### DIFF
--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 '''
 Generates a chechker file for lv_conf.h from lv_conf_templ.h define all the not defined values
 '''
@@ -5,50 +7,60 @@ Generates a chechker file for lv_conf.h from lv_conf_templ.h define all the not 
 
 import re
 
-fin = open("../lv_conf_template.h", "r");
-fout = open("../src/lv_conf_checker.h", "w");
+fin = open("../lv_conf_template.h", "r")
+fout = open("../src/lv_conf_checker.h", "w")
 
+ignored = (
+  "LV_OBJ_FREE_NUM_TYPE"
+)
 
 fout.write(
-'/**\n\
- * GENERATED FILE, DO NOT EDIT IT!\n\
- * @file lv_conf_checker.h\n\
- * Make sure all the defines of lv_conf.h have a default value\n\
-**/\n\
-\n\
-#ifndef LV_CONF_CHECKER_H\n\
-#define  LV_CONF_CHECKER_H\n\
-'
-)  
+'''/**
+ * GENERATED FILE, DO NOT EDIT IT!
+ * @file lv_conf_checker.h
+ * Make sure all the defines of lv_conf.h have a default value
+**/
 
-inlines = fin.read().splitlines();
+#ifndef LV_CONF_CHECKER_H
+#define LV_CONF_CHECKER_H
+'''
+)
+
+inlines = fin.read().splitlines()
 
 started = 0
 
 for i in inlines:
-  if(not started):
-    if('#define LV_CONF_H' in i):
-      started = 1 
+  if not started:
+    if '#define LV_CONF_H' in i:
+      started = 1
       continue
     else:
       continue
-    
-  if('/*--END OF LV_CONF_H--*/' in i): break  
-    
-  if(re.search('^ *# *define .*$', i)): 
-    new = re.sub('^ *# *define', '#define ', i)       
+
+  if '/*--END OF LV_CONF_H--*/' in i: break
+
+  r = re.search('^ *# *define *([^ ]+).*$', i)
+
+  if r and r[1] in ignored: continue
+
+  if r:
+    new = re.sub('^ *# *define', '#define ', i)
     new = re.sub(' +', ' ', new)                 #Remove extra white spaces
     splitted = new.split(' ')
     fout.write('#ifndef ' + splitted[1] + '\n')
-    fout.write(i + '\n') 
+    fout.write(i + '\n')
     fout.write('#endif\n')
-  elif(re.search('^ *typedef .*;.*$', i)):
+  elif re.search('^ *typedef .*;.*$', i):
     continue;   #igonre typedefs to avoide redeclaration
   else:
-    fout.write(i + '\n')  
-    
-    
+    fout.write(i + '\n')
+
+
 fout.write(
-'\n\
-#endif  /*LV_CONF_CHECKER_H*/\n\
-')
+'''
+#endif  /*LV_CONF_CHECKER_H*/
+''')
+
+fin.close()
+fout.close()


### PR DESCRIPTION
This allows certain items (namely LV_OBJ_FREE_NUM_TYPE) to be ignored when defining defaults. Currently commenting out this, as suggested in lv_conf.h, results in an uint32_t free num.
I also reworked the syntax a little bit to be more PEP8-compliant.