### PR TITLE
lv_conf_checker syntax changes

### DIFF
--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -1,54 +1,56 @@
 '''
-Generates a chechker file for lv_conf.h from lv_conf_templ.h define all the not defined values
+Generates a checker file for lv_conf.h from lv_conf_templ.h define all the not defined values
 '''
 
 
 import re
 
-fin = open("../lv_conf_template.h", "r");
-fout = open("../src/lv_conf_checker.h", "w");
+fin = open("../lv_conf_template.h", "r")
+fout = open("../src/lv_conf_checker.h", "w")
 
 
 fout.write(
-'/**\n\
- * GENERATED FILE, DO NOT EDIT IT!\n\
- * @file lv_conf_checker.h\n\
- * Make sure all the defines of lv_conf.h have a default value\n\
-**/\n\
-\n\
-#ifndef LV_CONF_CHECKER_H\n\
-#define  LV_CONF_CHECKER_H\n\
-'
-)  
+'''/**
+ * GENERATED FILE, DO NOT EDIT IT!
+ * @file lv_conf_checker.h
+ * Make sure all the defines of lv_conf.h have a default value
+**/
 
-inlines = fin.read().splitlines();
+#ifndef LV_CONF_CHECKER_H
+#define LV_CONF_CHECKER_H
+'''
+)
 
 started = 0
 
-for i in inlines:
-  if(not started):
-    if('#define LV_CONF_H' in i):
-      started = 1 
+for i in fin.read().splitlines():
+  if not started:
+    if '#define LV_CONF_H' in i:
+      started = 1
       continue
     else:
       continue
-    
-  if('/*--END OF LV_CONF_H--*/' in i): break  
-    
-  if(re.search('^ *# *define .*$', i)): 
-    new = re.sub('^ *# *define', '#define ', i)       
-    new = re.sub(' +', ' ', new)                 #Remove extra white spaces
-    splitted = new.split(' ')
-    fout.write('#ifndef ' + splitted[1] + '\n')
-    fout.write(i + '\n') 
-    fout.write('#endif\n')
-  elif(re.search('^ *typedef .*;.*$', i)):
-    continue;   #igonre typedefs to avoide redeclaration
+
+  if '/*--END OF LV_CONF_H--*/' in i: break
+
+  r = re.search(r'^ *# *define ([^\s]+).*$', i)
+  if r:
+    fout.write(
+      f'#ifndef {r[1]}\n'
+      f'{i}\n'
+      '#endif\n'
+    )
+  elif re.search('^ *typedef .*;.*$', i):
+    continue   #ignore typedefs to avoide redeclaration
   else:
-    fout.write(i + '\n')  
-    
-    
+    fout.write(f'{i}\n')
+
+
 fout.write(
-'\n\
-#endif  /*LV_CONF_CHECKER_H*/\n\
-')
+'''
+#endif  /*LV_CONF_CHECKER_H*/
+'''
+)
+
+fin.close()
+fout.close()


### PR DESCRIPTION
A few syntax changes, the only functional change is that preprocessor tokens are matched with regex.