### PR TITLE
[v6.1] Add lv_img_buf_alloc and lv_img_buf_free functions

### DIFF
--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -467,6 +467,24 @@ void lv_img_buf_free(lv_img_dsc_t *dsc)
     }
 }
 
+uint32_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
+{
+    switch(cf) {
+        case LV_IMG_CF_TRUE_COLOR: return LV_IMG_BUF_SIZE_TRUE_COLOR(w, h);
+        case LV_IMG_CF_TRUE_COLOR_ALPHA: return LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h);
+        case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED: return LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h);
+        case LV_IMG_CF_ALPHA_1BIT: return LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h);
+        case LV_IMG_CF_ALPHA_2BIT: return LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h);
+        case LV_IMG_CF_ALPHA_4BIT: return LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h);
+        case LV_IMG_CF_ALPHA_8BIT: return LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h);
+        case LV_IMG_CF_INDEXED_1BIT: return LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h);
+        case LV_IMG_CF_INDEXED_2BIT: return LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h);
+        case LV_IMG_CF_INDEXED_4BIT: return LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h);
+        case LV_IMG_CF_INDEXED_8BIT: return LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h);
+        default: return 0;
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -427,15 +427,21 @@ lv_img_src_t lv_img_src_get_type(const void * src)
 
 lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
 {
-    /*Get the pixel size in bytes*/
-    uint8_t px_b = lv_img_color_format_get_px_size(cf) / 8;
-    
+    /* Allocate image descriptor */
     lv_img_dsc_t *dsc = lv_mem_alloc(sizeof(lv_img_dsc_t));
     if(dsc == NULL)
         return NULL;
     
     memset(dsc, 0, sizeof(lv_img_dsc_t));
-    dsc->data_size = px_b * w * h;
+    
+    /* Get image data size */
+    dsc->data_size = lv_img_buf_get_img_size(w, h, cf);
+    if(dsc->data_size == 0) {
+        lv_mem_free(dsc);
+        return NULL;
+    }
+    
+    /* Allocate raw buffer */
     dsc->data = lv_mem_alloc(dsc->data_size);
     if(dsc->data == NULL) {
         lv_mem_free(dsc);
@@ -443,6 +449,7 @@ lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
     }
     memset(dsc->data, 0, dsc->data_size);
     
+    /* Fill in header */
     dsc->header.always_zero = 0;
     dsc->header.w = w;
     dsc->header.h = h;

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -425,6 +425,41 @@ lv_img_src_t lv_img_src_get_type(const void * src)
     return img_src_type;
 }
 
+lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
+{
+    /*Get the pixel size in bytes*/
+    uint8_t px_b = lv_img_color_format_get_px_size(cf) / 8;
+    
+    lv_img_dsc_t *dsc = lv_mem_alloc(sizeof(lv_img_dsc_t));
+    if(dsc == NULL)
+        return NULL;
+    
+    memset(dsc, 0, sizeof(lv_img_dsc_t));
+    dsc->data_size = px_b * w * h;
+    dsc->data = lv_mem_alloc(dsc->data_size);
+    if(dsc->data == NULL) {
+        lv_mem_free(dsc);
+        return NULL;
+    }
+    memset(dsc->data, 0, dsc->data_size);
+    
+    dsc->header.always_zero = 0;
+    dsc->header.w = w;
+    dsc->header.h = h;
+    dsc->header.cf = cf;
+    return dsc;
+}
+
+void lv_img_buf_free(lv_img_dsc_t *dsc)
+{
+    if(dsc != NULL) {
+        if(dsc->data != NULL)
+            lv_mem_free(dsc->data);
+        
+        lv_mem_free(dsc);
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -162,7 +162,7 @@ void lv_img_buf_free(lv_img_dsc_t *dsc);
  * @param cf color format
  * @return size in bytes
  */
-static inline size_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
+static inline uint32_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
 {
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR: return LV_IMG_BUF_SIZE_TRUE_COLOR(w, h);

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -162,23 +162,7 @@ void lv_img_buf_free(lv_img_dsc_t *dsc);
  * @param cf color format
  * @return size in bytes
  */
-static inline uint32_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
-{
-    switch(cf) {
-        case LV_IMG_CF_TRUE_COLOR: return LV_IMG_BUF_SIZE_TRUE_COLOR(w, h);
-        case LV_IMG_CF_TRUE_COLOR_ALPHA: return LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h);
-        case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED: return LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h);
-        case LV_IMG_CF_ALPHA_1BIT: return LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h);
-        case LV_IMG_CF_ALPHA_2BIT: return LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h);
-        case LV_IMG_CF_ALPHA_4BIT: return LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h);
-        case LV_IMG_CF_ALPHA_8BIT: return LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h);
-        case LV_IMG_CF_INDEXED_1BIT: return LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h);
-        case LV_IMG_CF_INDEXED_2BIT: return LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h);
-        case LV_IMG_CF_INDEXED_4BIT: return LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h);
-        case LV_IMG_CF_INDEXED_8BIT: return LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h);
-        default: return 0;
-    }
-}
+uint32_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf);
 
 
 #ifdef __cplusplus

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -21,6 +21,26 @@ extern "C" {
  *********************/
 
 /**********************
+ *      MACROS
+ **********************/
+
+#define LV_IMG_BUF_SIZE_TRUE_COLOR(w, h) ((LV_COLOR_SIZE / 8) * w * h)
+#define LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h) ((LV_COLOR_SIZE / 8) * w * h)
+#define LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h) (LV_IMG_PX_SIZE_ALPHA_BYTE * w * h)
+
+/*+ 1: to be sure no fractional row*/
+#define LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h) ((((w / 8) + 1) * h))
+#define LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h) ((((w / 4) + 1) * h))
+#define LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h) ((((w / 2) + 1) * h))
+#define LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h) ((w * h))
+
+/*4 * X: for palette*/
+#define LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h) + 4 * 2)
+#define LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h) + 4 * 4)
+#define LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h) + 4 * 16)
+#define LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h) + 4 * 256)
+
+/**********************
  *      TYPEDEFS
  **********************/
 
@@ -135,10 +155,31 @@ lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf);
  */
 void lv_img_buf_free(lv_img_dsc_t *dsc);
 
+/**
+ * Get the memory consumption of a raw bitmap, given color format and dimensions.
+ * @param w width
+ * @param h height
+ * @param cf color format
+ * @return size in bytes
+ */
+static inline size_t lv_img_buf_get_img_size(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
+{
+    switch(cf) {
+        case LV_IMG_CF_TRUE_COLOR: return LV_IMG_BUF_SIZE_TRUE_COLOR(w, h);
+        case LV_IMG_CF_TRUE_COLOR_ALPHA: return LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h);
+        case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED: return LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h);
+        case LV_IMG_CF_ALPHA_1BIT: return LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h);
+        case LV_IMG_CF_ALPHA_2BIT: return LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h);
+        case LV_IMG_CF_ALPHA_4BIT: return LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h);
+        case LV_IMG_CF_ALPHA_8BIT: return LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h);
+        case LV_IMG_CF_INDEXED_1BIT: return LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h);
+        case LV_IMG_CF_INDEXED_2BIT: return LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h);
+        case LV_IMG_CF_INDEXED_4BIT: return LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h);
+        case LV_IMG_CF_INDEXED_8BIT: return LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h);
+        default: return 0;
+    }
+}
 
-/**********************
- *      MACROS
- **********************/
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -120,6 +120,22 @@ bool lv_img_color_format_is_chroma_keyed(lv_img_cf_t cf);
  */
 bool lv_img_color_format_has_alpha(lv_img_cf_t cf);
 
+/**
+ * Allocate an image buffer in RAM
+ * @param w width of image
+ * @param h height of image
+ * @param cf a color format (`LV_IMG_CF_...`)
+ * @return an allocated image, or NULL on failure
+ */
+lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf);
+
+/**
+ * Free an allocated image buffer
+ * @param dsc image buffer to free
+ */
+void lv_img_buf_free(lv_img_dsc_t *dsc);
+
+
 /**********************
  *      MACROS
  **********************/

--- a/src/lv_objx/lv_canvas.h
+++ b/src/lv_objx/lv_canvas.h
@@ -23,6 +23,7 @@ extern "C" {
 
 #include "../lv_core/lv_obj.h"
 #include "../lv_objx/lv_img.h"
+#include "../lv_draw/lv_draw_img.h"
 
 /*********************
  *      DEFINES
@@ -239,21 +240,21 @@ void lv_canvas_draw_arc(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_
 /**********************
  *      MACROS
  **********************/
-#define LV_CANVAS_BUF_SIZE_TRUE_COLOR(w, h) ((LV_COLOR_SIZE / 8) * w * h)
-#define LV_CANVAS_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h) ((LV_COLOR_SIZE / 8) * w * h)
-#define LV_CANVAS_BUF_SIZE_TRUE_COLOR_ALPHA(w, h) (LV_IMG_PX_SIZE_ALPHA_BYTE * w * h)
+#define LV_CANVAS_BUF_SIZE_TRUE_COLOR(w, h) LV_IMG_BUF_SIZE_TRUE_COLOR(w, h)
+#define LV_CANVAS_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h) LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h)
+#define LV_CANVAS_BUF_SIZE_TRUE_COLOR_ALPHA(w, h) LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h)
 
 /*+ 1: to be sure no fractional row*/
-#define LV_CANVAS_BUF_SIZE_ALPHA_1BIT(w, h) ((((w / 8) + 1) * h))
-#define LV_CANVAS_BUF_SIZE_ALPHA_2BIT(w, h) ((((w / 4) + 1) * h))
-#define LV_CANVAS_BUF_SIZE_ALPHA_4BIT(w, h) ((((w / 2) + 1) * h))
-#define LV_CANVAS_BUF_SIZE_ALPHA_8BIT(w, h) ((w * h))
+#define LV_CANVAS_BUF_SIZE_ALPHA_1BIT(w, h) LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_ALPHA_2BIT(w, h) LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_ALPHA_4BIT(w, h) LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_ALPHA_8BIT(w, h) LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h)
 
 /*4 * X: for palette*/
-#define LV_CANVAS_BUF_SIZE_INDEXED_1BIT(w, h) (LV_CANVAS_BUF_SIZE_ALPHA_1BIT(w, h) + 4 * 2)
-#define LV_CANVAS_BUF_SIZE_INDEXED_2BIT(w, h) (LV_CANVAS_BUF_SIZE_ALPHA_2BIT(w, h) + 4 * 4)
-#define LV_CANVAS_BUF_SIZE_INDEXED_4BIT(w, h) (LV_CANVAS_BUF_SIZE_ALPHA_4BIT(w, h) + 4 * 16)
-#define LV_CANVAS_BUF_SIZE_INDEXED_8BIT(w, h) (LV_CANVAS_BUF_SIZE_ALPHA_8BIT(w, h) + 4 * 256)
+#define LV_CANVAS_BUF_SIZE_INDEXED_1BIT(w, h) LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_INDEXED_2BIT(w, h) LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_INDEXED_4BIT(w, h) LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h)
+#define LV_CANVAS_BUF_SIZE_INDEXED_8BIT(w, h) LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h)
 
 #endif /*LV_USE_CANVAS*/
 


### PR DESCRIPTION
This adds an API that will allocate an image buffer and descriptor of appropriate size in RAM, given the width, height, and color format.

An example usecase is with the `lv_canvas` object, where previously (from what I can tell) it was your responsibility to allocate the buffer and calculate the proper size.