### PR TITLE
Add missing gc root

### DIFF
--- a/src/lv_misc/lv_gc.h
+++ b/src/lv_misc/lv_gc.h
@@ -40,7 +40,8 @@ extern "C" {
     prefix lv_ll_t _lv_group_ll;                                                                                       \
     prefix lv_ll_t _lv_img_defoder_ll;                                                                                 \
     prefix lv_img_cache_entry_t * _lv_img_cache_array;                                                                 \
-    prefix void * _lv_task_act;
+    prefix void * _lv_task_act;                                                                                        \
+    prefix void * _lv_draw_buf; 
 
 #define LV_NO_PREFIX
 #define LV_ROOTS LV_GC_ROOTS(LV_NO_PREFIX)


### PR DESCRIPTION
I just found a missing gc root: `draw_buf` (found it the hard way... :confused:)  

If you think of any other example of -

- global pointer (possibly `static`)
- allocated dynamically by lvgl
- not marked as gc root

Please let me know!