### PR TITLE
Removing inner struct 'ch' inside lv_color struct

### DIFF
--- a/src/lv_draw/lv_draw_basic.c
+++ b/src/lv_draw/lv_draw_basic.c
@@ -107,7 +107,7 @@ void lv_draw_px(lv_coord_t x, lv_coord_t y, const lv_area_t * mask_p, lv_color_t
             }
         } else {
 #if LV_COLOR_DEPTH == 32 && LV_COLOR_SCREEN_TRANSP
-            *vdb_px_p = color_mix_2_alpha(*vdb_px_p, (*vdb_px_p).ch.alpha, color, opa);
+            *vdb_px_p = color_mix_2_alpha(*vdb_px_p, vdb_px_p->alpha, color, opa);
 #endif
         }
     }
@@ -346,7 +346,7 @@ void lv_draw_letter(const lv_point_t * pos_p, const lv_area_t * mask_p, const lv
                             *vdb_buf_tmp = lv_color_mix(color, *vdb_buf_tmp, px_opa);
                         } else {
 #if LV_COLOR_DEPTH == 32 && LV_COLOR_SCREEN_TRANSP
-                            *vdb_buf_tmp = color_mix_2_alpha(*vdb_buf_tmp, (*vdb_buf_tmp).ch.alpha, color, px_opa);
+                            *vdb_buf_tmp = color_mix_2_alpha(*vdb_buf_tmp, vdb_buf_tmp->alpha, color, px_opa);
 #endif
                         }
                     }
@@ -538,7 +538,7 @@ void lv_draw_map(const lv_area_t * cords_p, const lv_area_t * mask_p, const uint
                                 vdb_buf_tmp[col] = lv_color_mix(px_color, vdb_buf_tmp[col], opa_result);
                             } else {
 #if LV_COLOR_DEPTH == 32 && LV_COLOR_SCREEN_TRANSP
-                                vdb_buf_tmp[col] = color_mix_2_alpha(vdb_buf_tmp[col], vdb_buf_tmp[col].ch.alpha,
+                                vdb_buf_tmp[col] = color_mix_2_alpha(vdb_buf_tmp[col], vdb_buf_tmp[col].alpha,
                                                                      px_color, opa_result);
 #endif
                             }
@@ -641,7 +641,7 @@ static void sw_color_fill(lv_color_t * mem, lv_coord_t mem_width, const lv_area_
 
                     } else {
 #if LV_COLOR_DEPTH == 32 && LV_COLOR_SCREEN_TRANSP
-                        mem[col] = color_mix_2_alpha(mem[col], mem[col].ch.alpha, color, opa);
+                        mem[col] = color_mix_2_alpha(mem[col], mem[col].alpha, color, opa);
 #endif
                     }
                 }
@@ -664,7 +664,7 @@ static inline lv_color_t color_mix_2_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
 {
     /* Pick the foreground if it's fully opaque or the Background is fully transparent*/
     if(fg_opa > LV_OPA_MAX || bg_opa <= LV_OPA_MIN) {
-        fg_color.ch.alpha = fg_opa;
+        fg_color.alpha = fg_opa;
         return fg_color;
     }
     /*Transparent foreground: use the Background*/
@@ -699,7 +699,7 @@ static inline lv_color_t color_mix_2_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
             }
             lv_opa_t ratio = (uint16_t)((uint16_t)fg_opa * 255) / alpha_res;
             c              = lv_color_mix(fg_color, bg_color, ratio);
-            c.ch.alpha     = alpha_res;
+            c.alpha        = alpha_res;
         }
         return c;
     }

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -102,7 +102,7 @@ lv_color_t lv_img_buf_get_px_color(lv_img_dsc_t * dsc, lv_coord_t x, lv_coord_t 
         uint32_t px     = dsc->header.w * y * px_size + x * px_size;
         memcpy(&p_color, &buf_u8[px], sizeof(lv_color_t));
 #if LV_COLOR_SIZE == 32
-        p_color.ch.alpha = 0xFF; /*Only the color should be get so use a deafult alpha value*/
+        p_color.alpha = 0xFF; /*Only the color should be get so use a deafult alpha value*/
 #endif
     } else if(dsc->header.cf == LV_IMG_CF_INDEXED_1BIT) {
         buf_u8 += 4 * 2;
@@ -431,16 +431,16 @@ lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
     lv_img_dsc_t *dsc = lv_mem_alloc(sizeof(lv_img_dsc_t));
     if(dsc == NULL)
         return NULL;
-    
+
     memset(dsc, 0, sizeof(lv_img_dsc_t));
-    
+
     /* Get image data size */
     dsc->data_size = lv_img_buf_get_img_size(w, h, cf);
     if(dsc->data_size == 0) {
         lv_mem_free(dsc);
         return NULL;
     }
-    
+
     /* Allocate raw buffer */
     dsc->data = lv_mem_alloc(dsc->data_size);
     if(dsc->data == NULL) {
@@ -448,7 +448,7 @@ lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf)
         return NULL;
     }
     memset(dsc->data, 0, dsc->data_size);
-    
+
     /* Fill in header */
     dsc->header.always_zero = 0;
     dsc->header.w = w;
@@ -462,7 +462,7 @@ void lv_img_buf_free(lv_img_dsc_t *dsc)
     if(dsc != NULL) {
         if(dsc->data != NULL)
             lv_mem_free(dsc->data);
-        
+
         lv_mem_free(dsc);
     }
 }

--- a/src/lv_draw/lv_img_decoder.c
+++ b/src/lv_draw/lv_img_decoder.c
@@ -398,7 +398,7 @@ lv_res_t lv_img_decoder_built_in_open(lv_img_decoder_t * decoder, lv_img_decoder
 
             uint32_t i;
             for(i = 0; i < palette_size; i++) {
-                user_data->palette[i] = lv_color_make(palette_p[i].ch.red, palette_p[i].ch.green, palette_p[i].ch.blue);
+                user_data->palette[i] = lv_color_make(palette_p[i].red, palette_p[i].green, palette_p[i].blue);
             }
         }
 

--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -109,7 +109,7 @@ typedef union
         uint8_t blue : 2;
         uint8_t green : 3;
         uint8_t red : 3;
-    } ch;
+    };
     uint8_t full;
 } lv_color8_t;
 
@@ -127,7 +127,7 @@ typedef union
         uint16_t blue : 5;
         uint16_t green_l : 3;
 #endif
-    } ch;
+    };
     uint16_t full;
 } lv_color16_t;
 
@@ -139,7 +139,7 @@ typedef union
         uint8_t green;
         uint8_t red;
         uint8_t alpha;
-    } ch;
+    };
     uint32_t full;
 } lv_color32_t;
 
@@ -191,24 +191,24 @@ static inline uint8_t lv_color_to1(lv_color_t color)
 #if LV_COLOR_DEPTH == 1
     return color.full;
 #elif LV_COLOR_DEPTH == 8
-    if((color.ch.red & 0x4) || (color.ch.green & 0x4) || (color.ch.blue & 0x2)) {
+    if((color.red & 0x4) || (color.green & 0x4) || (color.blue & 0x2)) {
         return 1;
     } else {
         return 0;
     }
 #elif LV_COLOR_DEPTH == 16
 #if LV_COLOR_16_SWAP == 0
-    if((color.ch.red & 0x10) || (color.ch.green & 0x20) || (color.ch.blue & 0x10)) {
+    if((color.red & 0x10) || (color.green & 0x20) || (color.blue & 0x10)) {
         return 1;
 #else
-    if((color.ch.red & 0x10) || (color.ch.green_h & 0x20) || (color.ch.blue & 0x10)) {
+    if((color.red & 0x10) || (color.green_h & 0x20) || (color.blue & 0x10)) {
         return 1;
 #endif
     } else {
         return 0;
     }
 #elif LV_COLOR_DEPTH == 32
-    if((color.ch.red & 0x80) || (color.ch.green & 0x80) || (color.ch.blue & 0x80)) {
+    if((color.red & 0x80) || (color.green & 0x80) || (color.blue & 0x80)) {
         return 1;
     } else {
         return 0;
@@ -229,22 +229,22 @@ static inline uint8_t lv_color_to8(lv_color_t color)
 
 #if LV_COLOR_16_SWAP == 0
     lv_color8_t ret;
-    ret.ch.red   = color.ch.red >> 2;   /* 5 - 3  = 2*/
-    ret.ch.green = color.ch.green >> 3; /* 6 - 3  = 3*/
-    ret.ch.blue  = color.ch.blue >> 3;  /* 5 - 2  = 3*/
+    ret.red   = color.red >> 2;   /* 5 - 3  = 2*/
+    ret.green = color.green >> 3; /* 6 - 3  = 3*/
+    ret.blue  = color.blue >> 3;  /* 5 - 2  = 3*/
     return ret.full;
 #else
     lv_color8_t ret;
-    ret.ch.red   = color.ch.red >> 2;  /* 5 - 3  = 2*/
-    ret.ch.green = color.ch.green_h;   /* 6 - 3  = 3*/
-    ret.ch.blue  = color.ch.blue >> 3; /* 5 - 2  = 3*/
+    ret.red   = color.red >> 2;  /* 5 - 3  = 2*/
+    ret.green = color.green_h;   /* 6 - 3  = 3*/
+    ret.blue  = color.blue >> 3; /* 5 - 2  = 3*/
     return ret.full;
 #endif
 #elif LV_COLOR_DEPTH == 32
     lv_color8_t ret;
-    ret.ch.red   = color.ch.red >> 5;   /* 8 - 3  = 5*/
-    ret.ch.green = color.ch.green >> 5; /* 8 - 3  = 5*/
-    ret.ch.blue  = color.ch.blue >> 6;  /* 8 - 2  = 6*/
+    ret.red   = color.red >> 5;   /* 8 - 3  = 5*/
+    ret.green = color.green >> 5; /* 8 - 3  = 5*/
+    ret.blue  = color.blue >> 6;  /* 8 - 2  = 6*/
     return ret.full;
 #endif
 }
@@ -259,15 +259,15 @@ static inline uint16_t lv_color_to16(lv_color_t color)
 #elif LV_COLOR_DEPTH == 8
     lv_color16_t ret;
 #if LV_COLOR_16_SWAP == 0
-    ret.ch.red = color.ch.red * 4;     /*(2^5 - 1)/(2^3 - 1) = 31/7 = 4*/
-    ret.ch.green = color.ch.green * 9; /*(2^6 - 1)/(2^3 - 1) = 63/7 = 9*/
-    ret.ch.blue = color.ch.blue * 10;  /*(2^5 - 1)/(2^2 - 1) = 31/3 = 10*/
+    ret.red = color.red * 4;     /*(2^5 - 1)/(2^3 - 1) = 31/7 = 4*/
+    ret.green = color.green * 9; /*(2^6 - 1)/(2^3 - 1) = 63/7 = 9*/
+    ret.blue = color.blue * 10;  /*(2^5 - 1)/(2^2 - 1) = 31/3 = 10*/
 #else
-    ret.red        = color.ch.red * 4;
-    uint8_t g_tmp  = color.ch.green * 9;
-    ret.ch.green_h = (g_tmp & 0x1F) >> 3;
-    ret.ch.green_l = g_tmp & 0x07;
-    ret.ch.blue    = color.ch.blue * 10;
+    ret.red        = color.red * 4;
+    uint8_t g_tmp  = color.green * 9;
+    ret.green_h = (g_tmp & 0x1F) >> 3;
+    ret.green_l = g_tmp & 0x07;
+    ret.blue    = color.blue * 10;
 #endif
     return ret.full;
 #elif LV_COLOR_DEPTH == 16
@@ -275,14 +275,14 @@ static inline uint16_t lv_color_to16(lv_color_t color)
 #elif LV_COLOR_DEPTH == 32
     lv_color16_t ret;
 #if LV_COLOR_16_SWAP == 0
-    ret.ch.red   = color.ch.red >> 3;   /* 8 - 5  = 3*/
-    ret.ch.green = color.ch.green >> 2; /* 8 - 6  = 2*/
-    ret.ch.blue  = color.ch.blue >> 3;  /* 8 - 5  = 3*/
+    ret.red   = color.red >> 3;   /* 8 - 5  = 3*/
+    ret.green = color.green >> 2; /* 8 - 6  = 2*/
+    ret.blue  = color.blue >> 3;  /* 8 - 5  = 3*/
 #else
-    ret.ch.red     = color.ch.red >> 3;
-    ret.ch.green_h = (color.ch.green & 0xE0) >> 5;
-    ret.ch.green_l = (color.ch.green & 0x1C) >> 2;
-    ret.ch.blue    = color.ch.blue >> 3;
+    ret.red     = color.red >> 3;
+    ret.green_h = (color.green & 0xE0) >> 5;
+    ret.green_l = (color.green & 0x1C) >> 2;
+    ret.blue    = color.blue >> 3;
 #endif
     return ret.full;
 #endif
@@ -297,25 +297,25 @@ static inline uint32_t lv_color_to32(lv_color_t color)
         return 0xFFFFFFFF;
 #elif LV_COLOR_DEPTH == 8
     lv_color32_t ret;
-    ret.ch.red = color.ch.red * 36;     /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
-    ret.ch.green = color.ch.green * 36; /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
-    ret.ch.blue = color.ch.blue * 85;   /*(2^8 - 1)/(2^2 - 1) = 255/3 = 85*/
-    ret.ch.alpha = 0xFF;
+    ret.red = color.red * 36;     /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
+    ret.green = color.green * 36; /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
+    ret.blue = color.blue * 85;   /*(2^8 - 1)/(2^2 - 1) = 255/3 = 85*/
+    ret.alpha = 0xFF;
     return ret.full;
 #elif LV_COLOR_DEPTH == 16
 #if LV_COLOR_16_SWAP == 0
     lv_color32_t ret;
-    ret.ch.red   = color.ch.red * 8;   /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
-    ret.ch.green = color.ch.green * 4; /*(2^8 - 1)/(2^6 - 1) = 255/63 = 4*/
-    ret.ch.blue  = color.ch.blue * 8;  /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
-    ret.ch.alpha = 0xFF;
+    ret.red   = color.red * 8;   /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
+    ret.green = color.green * 4; /*(2^8 - 1)/(2^6 - 1) = 255/63 = 4*/
+    ret.blue  = color.blue * 8;  /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
+    ret.alpha = 0xFF;
     return ret.full;
 #else
     lv_color32_t ret;
-    ret.ch.red   = color.ch.red * 8;                                 /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
-    ret.ch.green = ((color.ch.green_h << 3) + color.ch.green_l) * 4; /*(2^8 - 1)/(2^6 - 1) = 255/63 = 4*/
-    ret.ch.blue  = color.ch.blue * 8;                                /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
-    ret.ch.alpha = 0xFF;
+    ret.red   = color.red * 8;                                 /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
+    ret.green = ((color.green_h << 3) + color.green_l) * 4; /*(2^8 - 1)/(2^6 - 1) = 255/63 = 4*/
+    ret.blue  = color.blue * 8;                                /*(2^8 - 1)/(2^5 - 1) = 255/31 = 8*/
+    ret.alpha = 0xFF;
     return ret.full;
 #endif
 #elif LV_COLOR_DEPTH == 32
@@ -328,20 +328,20 @@ static inline lv_color_t lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix)
     lv_color_t ret;
 #if LV_COLOR_DEPTH != 1
     /*LV_COLOR_DEPTH == 8, 16 or 32*/
-    ret.ch.red = (uint16_t)((uint16_t)c1.ch.red * mix + (c2.ch.red * (255 - mix))) >> 8;
+    ret.red = (uint16_t)((uint16_t)c1.red * mix + (c2.red * (255 - mix))) >> 8;
 #if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP
     /*If swapped Green is in 2 parts*/
-    uint16_t g_1   = (c1.ch.green_h << 3) + c1.ch.green_l;
-    uint16_t g_2   = (c2.ch.green_h << 3) + c2.ch.green_l;
+    uint16_t g_1   = (c1.green_h << 3) + c1.green_l;
+    uint16_t g_2   = (c2.green_h << 3) + c2.green_l;
     uint16_t g_out = (uint16_t)((uint16_t)g_1 * mix + (g_2 * (255 - mix))) >> 8;
-    ret.ch.green_h = g_out >> 3;
-    ret.ch.green_l = g_out & 0x7;
+    ret.green_h = g_out >> 3;
+    ret.green_l = g_out & 0x7;
 #else
-    ret.ch.green = (uint16_t)((uint16_t)c1.ch.green * mix + (c2.ch.green * (255 - mix))) >> 8;
+    ret.green = (uint16_t)((uint16_t)c1.green * mix + (c2.green * (255 - mix))) >> 8;
 #endif
-    ret.ch.blue = (uint16_t)((uint16_t)c1.ch.blue * mix + (c2.ch.blue * (255 - mix))) >> 8;
+    ret.blue = (uint16_t)((uint16_t)c1.blue * mix + (c2.blue * (255 - mix))) >> 8;
 #if LV_COLOR_DEPTH == 32
-    ret.ch.alpha = 0xFF;
+    ret.alpha = 0xFF;
 #endif
 #else
     /*LV_COLOR_DEPTH == 1*/
@@ -360,7 +360,7 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 {
     lv_color32_t c32;
     c32.full        = lv_color_to32(color);
-    uint16_t bright = 3 * c32.ch.red + c32.ch.blue + 4 * c32.ch.green;
+    uint16_t bright = 3 * c32.red + c32.blue + 4 * c32.green;
     return (uint16_t)bright >> 3;
 }
 
@@ -378,9 +378,9 @@ static inline lv_color_t lv_color_make(int r8, int g8, int b8)
 static inline lv_color_t lv_color_make(uint8_t r8, int g8, int b8)
 {
     lv_color_t color;
-    color.ch.blue = b8 >> 6;
-    color.ch.green = g8 >> 5;
-    color.ch.red = r8 >> 5;
+    color.blue = b8 >> 6;
+    color.green = g8 >> 5;
+    color.red = r8 >> 5;
     return color;
 }
 #elif LV_COLOR_DEPTH == 16
@@ -389,9 +389,9 @@ static inline lv_color_t lv_color_make(uint8_t r8, int g8, int b8)
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8)
 {
     lv_color_t color;
-    color.ch.blue  = (uint16_t)(b8 >> 3);
-    color.ch.green = (uint16_t)(g8 >> 2);
-    color.ch.red   = (uint16_t)(r8 >> 3);
+    color.blue  = (uint16_t)(b8 >> 3);
+    color.green = (uint16_t)(g8 >> 2);
+    color.red   = (uint16_t)(r8 >> 3);
     return color;
 }
 #else
@@ -399,10 +399,10 @@ static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8)
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8)
 {
     lv_color_t color;
-    color.ch.green_h = (uint16_t)(g8 >> 5);
-    color.ch.red = (uint16_t)(r8 >> 3);
-    color.ch.blue = (uint16_t)(b8 >> 3);
-    color.ch.green_l = (uint16_t)((g8 >> 2) & 0x7);
+    color.green_h = (uint16_t)(g8 >> 5);
+    color.red = (uint16_t)(r8 >> 3);
+    color.blue = (uint16_t)(b8 >> 3);
+    color.green_l = (uint16_t)((g8 >> 2) & 0x7);
     return color;
 }
 #endif
@@ -411,10 +411,10 @@ static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8)
 static inline lv_color_t lv_color_make(uint8_t r8, uint8_t g8, uint8_t b8)
 {
     lv_color_t color;
-    color.ch.blue  = b8;
-    color.ch.green = g8;
-    color.ch.red   = r8;
-    color.ch.alpha = 0xff;
+    color.blue  = b8;
+    color.green = g8;
+    color.red   = r8;
+    color.alpha = 0xff;
     return color;
 }
 #endif


### PR DESCRIPTION
Removing inner struct 'ch' inside lv_color struct. This change introduced in 6.x. causes the following problems :

 - breaks backward compatibility with 5.x code and hence makes porting from 5x to 6x harder;
 - imposes inconsistent naming of the lv_color struct fields between lv_color1_t and the other lv_color flavors;
 - and finally - it is simply not necessary and requires more typing without providing any advantage.
