### PR TITLE
Pass disp->driver to rounder_cb in lv_inv_area

### DIFF
--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -115,7 +115,7 @@ void lv_inv_area(lv_disp_t * disp, const lv_area_t * area_p)
 
     /*The area is truncated to the screen*/
     if(suc != false) {
-        if(disp->driver.rounder_cb) disp->driver.rounder_cb(&disp_refr->driver, &com_area);
+        if(disp->driver.rounder_cb) disp->driver.rounder_cb(&disp->driver, &com_area);
 
         /*Save only if this area is not in one of the saved areas*/
         uint16_t i;


### PR DESCRIPTION
Pass pointer to disp->driver to rounder_cb in lv_inv_area instead of
pointer to disp_refr->driver as lv_inv_area is called when no refresh is
ongoing (lv_disp_drv_register).