### PR TITLE
lv_txt.c long word text wrapping initial commit (refactor).

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -297,6 +297,15 @@ typedef void * lv_font_user_data_t;
  /*Can break (wrap) texts on these chars*/
 #define LV_TXT_BREAK_CHARS                  " ,.;:-_"
 
+/* If a character is at least this long, will break wherever "prettiest" */
+#define LV_TXT_LINE_BREAK_LONG_LEN          12
+
+/* Minimum number of characters of a word to put on a line before a break */
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
+
+/* Minimum number of characters of a word to put on a line after a break */
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
 /*Change the built in (v)snprintf functions*/
 #define LV_SPRINTF_CUSTOM   0
 #if LV_SPRINTF_CUSTOM

--- a/src/lv_conf_checker.h
+++ b/src/lv_conf_checker.h
@@ -412,6 +412,21 @@
 #define LV_TXT_BREAK_CHARS                  " ,.;:-_"
 #endif
 
+/* If a character is at least this long, will break wherever "prettiest" */
+#ifndef LV_TXT_LINE_BREAK_LONG_LEN
+#define LV_TXT_LINE_BREAK_LONG_LEN          12
+#endif
+
+/* Minimum number of characters of a word to put on a line before a break */
+#ifndef LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
+#endif
+
+/* Minimum number of characters of a word to put on a line after a break */
+#ifndef LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+#endif
+
 /*Change the built in (v)snprintf functions*/
 #ifndef LV_SPRINTF_CUSTOM
 #define LV_SPRINTF_CUSTOM   0

--- a/src/lv_misc/lv_txt.c
+++ b/src/lv_misc/lv_txt.c
@@ -306,6 +306,11 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
         if(letter_next == '\0') i = tmp;
     }
 
+    /*Always step at least one to avoid infinite loops*/
+    if(i == 0) {
+        lv_txt_encoded_next(txt, &i);
+    }
+
     return i;
 }
 


### PR DESCRIPTION
I fixed all the merge conflicts and squashed all my commits into a single one for the long word text refactor. The diff is a bit ugly, just interpret it as `lv_txt_get_next_line` has been completely rewritten with an additional helper function `lv_txt_get_next_word`.