### PR TITLE
lv_preload: add constant-speed loader

### DIFF
--- a/src/lv_objx/lv_preload.c
+++ b/src/lv_objx/lv_preload.c
@@ -220,9 +220,10 @@ void lv_preload_set_type(lv_obj_t * preload, lv_preload_type_t type)
             lv_anim_create(&b);
             break;
         }
+        case LV_PRELOAD_TYPE_CONSTANT_ARC:
         case LV_PRELOAD_TYPE_SPINNING_ARC:
         default: {
-            ext->anim_type = LV_PRELOAD_TYPE_SPINNING_ARC;
+            ext->anim_type = type;
             lv_anim_t a;
             a.var = preload;
             if(ext->anim_dir == LV_PRELOAD_DIR_FORWARD) {
@@ -234,7 +235,8 @@ void lv_preload_set_type(lv_obj_t * preload, lv_preload_type_t type)
                 a.end   = 360;
             }
             a.exec_cb        = (lv_anim_exec_xcb_t)lv_preload_spinner_anim;
-            a.path_cb        = lv_anim_path_ease_in_out;
+            a.path_cb        = (LV_PRELOAD_TYPE_CONSTANT_ARC == type ?
+                                lv_anim_path_linear : lv_anim_path_ease_in_out);
             a.ready_cb       = NULL;
             a.act_time       = 0;
             a.time           = ext->time;

--- a/src/lv_objx/lv_preload.h
+++ b/src/lv_objx/lv_preload.h
@@ -48,6 +48,7 @@ extern "C" {
 enum {
     LV_PRELOAD_TYPE_SPINNING_ARC,
     LV_PRELOAD_TYPE_FILLSPIN_ARC,
+    LV_PRELOAD_TYPE_CONSTANT_ARC,
 };
 typedef uint8_t lv_preload_type_t;
 
@@ -67,7 +68,7 @@ typedef struct
     /*New data for this type */
     lv_anim_value_t arc_length;      /*Length of the spinning indicator in degree*/
     uint16_t time;                   /*Time of one round*/
-    lv_preload_type_t anim_type : 1; /*Type of the arc animation*/
+    lv_preload_type_t anim_type : 2; /*Type of the arc animation*/
     lv_preload_dir_t anim_dir : 1;   /*Animation Direction*/
 } lv_preload_ext_t;
 


### PR DESCRIPTION
This adds a new `lv_preload` type `LV_PRELOAD_TYPE_CONSTANT_ARC`. It is similar to `LV_PRELOAD_TYPE_SPINNING_ARC`, but it spins the arc at a constant speed rather than slowing down at the top while still keeping the length of the arc constant.