### PR TITLE
first periodic mistake at lv_task_set_period

### DIFF
--- a/src/lv_misc/lv_task.c
+++ b/src/lv_misc/lv_task.c
@@ -290,7 +290,8 @@ void lv_task_set_prio(lv_task_t * task, lv_task_prio_t prio)
  * @param period the new period
  */
 void lv_task_set_period(lv_task_t * task, uint32_t period)
-{
+{     
+    task->last_run = lv_tick_get();
     task->period = period;
 }
 

--- a/src/lv_misc/lv_task.c
+++ b/src/lv_misc/lv_task.c
@@ -291,7 +291,7 @@ void lv_task_set_prio(lv_task_t * task, lv_task_prio_t prio)
  */
 void lv_task_set_period(lv_task_t * task, uint32_t period)
 {     
-    task->last_run = lv_tick_get();
+    lv_task_reset(task);
     task->period = period;
 }
 


### PR DESCRIPTION
Hi,
When we set the period, because of the 'task->last_run' isn't updated we can't know and contol the first period time.