### PR TITLE
Chart improvements: add secondary Y axis and ability to put labels in reverse oder

### DIFF
--- a/src/lv_draw/lv_draw_label.c
+++ b/src/lv_draw/lv_draw_label.c
@@ -60,6 +60,13 @@ void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, const lv_st
 {
     const lv_font_t * font = style->text.font;
     lv_coord_t w;
+
+    /*No need to waste processor time if string is empty*/
+    if (txt[0] == '\0')
+    {
+        return;
+    }
+
     if((flag & LV_TXT_FLAG_EXPAND) == 0) {
         /*Normally use the label's width as width*/
         w = lv_area_get_width(coords);

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -1223,7 +1223,11 @@ static void lv_chart_draw_y_ticks(lv_obj_t * chart, const lv_area_t * mask, uint
 
         for(i = 0; i < (num_scale_ticks + 1); i++) { /* one extra loop - it may not exist in the list, empty label */
                                                      /* first point of the tick */
-            p1.x = x_ofs - 1;
+            p1.x = x_ofs;
+            if (which_axis == LV_CHART_AXIS_PRIMARY_Y)
+                p1.x--;
+            else
+                p1.x++;
 
             /* second point of the tick */
             if((num_of_labels != 0) && (i == 0 || i % y_axis->num_tick_marks == 0))

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -1334,6 +1334,7 @@ static void lv_chart_draw_x_ticks(lv_obj_t * chart, const lv_area_t * mask)
         uint8_t num_of_labels;
         uint8_t num_scale_ticks;
         uint8_t major_tick_len, minor_tick_len;
+        label_iterator_t iter;
         lv_point_t p1;
         lv_point_t p2;
         lv_coord_t x_ofs = chart->coords.x1;
@@ -1353,16 +1354,9 @@ static void lv_chart_draw_x_ticks(lv_obj_t * chart, const lv_area_t * mask)
         else
             minor_tick_len = ext->x_axis.minor_tick_len;
 
-        /* count the '\n'-s to determine the number of options */
-        list_index    = 0;
-        num_of_labels = 0;
-        if(ext->x_axis.list_of_values != NULL) {
-            for(j = 0; ext->x_axis.list_of_values[j] != '\0'; j++) {
-                if(ext->x_axis.list_of_values[j] == '\n') num_of_labels++;
-            }
-
-            num_of_labels++; /* last option in the at row*/
-        }
+        /*determine the number of options */
+        iter = lv_chart_create_label_iter(ext->x_axis.list_of_values, LV_CHART_LABEL_ITERATOR_FORWARD);
+        num_of_labels = iter.items_left + 1;
 
         /* we can't have string labels without ticks step, set to 1 if not specified */
         if(ext->x_axis.num_tick_marks == 0) ext->x_axis.num_tick_marks = 1;
@@ -1394,23 +1388,8 @@ static void lv_chart_draw_x_ticks(lv_obj_t * chart, const lv_area_t * mask)
             /* draw values if available */
             if(num_of_labels != 0) {
                 /* add text only to major tick */
-                if(i == 0 || i % ext->x_axis.num_tick_marks == 0) {
-                    /* search for tick string */
-                    j = 0;
-                    while(ext->x_axis.list_of_values[list_index] != '\n' &&
-                          ext->x_axis.list_of_values[list_index] != '\0') {
-                        /* do not overflow the buffer, but move to the end of the current label */
-                        if(j < LV_CHART_AXIS_TICK_LABEL_MAX_LEN)
-                            buf[j++] = ext->x_axis.list_of_values[list_index++];
-                        else
-                            list_index++;
-                    }
-
-                    /* this was a string, but not end of the list, so jump to the next string */
-                    if(ext->x_axis.list_of_values[list_index] == '\n') list_index++;
-
-                    /* terminate the string */
-                    buf[j] = '\0';
+                if(lv_chart_is_tick_with_label(i, &(ext->x_axis))) {
+                    lv_chart_get_next_label(&iter, buf);
 
                     /* reserve appropriate area */
                     lv_point_t size;

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -38,7 +38,7 @@ typedef struct {
     const char * current_pos;
     uint8_t items_left;
     uint8_t is_reverse_iter;
-} label_iterator_t;
+} lv_chart_label_iterator_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -55,9 +55,9 @@ static void lv_chart_draw_axes(lv_obj_t * chart, const lv_area_t * mask);
 static void lv_chart_inv_lines(lv_obj_t * chart, uint16_t i);
 static void lv_chart_inv_points(lv_obj_t * chart, uint16_t i);
 static void lv_chart_inv_cols(lv_obj_t * chart, uint16_t i);
-static void lv_chart_get_next_label(label_iterator_t * iterator, char * buf);
+static void lv_chart_get_next_label(lv_chart_label_iterator_t * iterator, char * buf);
 static inline bool lv_chart_is_tick_with_label(uint8_t tick_num, lv_chart_axis_cfg_t * axis);
-static label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t iterator_dir);
+static lv_chart_label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t iterator_dir);
 
 /**********************
  *  STATIC VARIABLES
@@ -1100,11 +1100,11 @@ static void lv_chart_draw_areas(lv_obj_t * chart, const lv_area_t * mask)
  * Create iterator for newline-separated list
  * @param list pointer to newline-separated labels list
  * @param iterator_dir LV_CHART_ITERATOR_FORWARD or LV_CHART_LABEL_ITERATOR_REVERSE
- * @return label_iterator_t
+ * @return lv_chart_label_iterator_t
  */
-static label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t iterator_dir)
+static lv_chart_label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t iterator_dir)
 {
-    label_iterator_t iterator = {0};
+    lv_chart_label_iterator_t iterator = {0};
     uint8_t j;
 
     iterator.list_start = list;
@@ -1132,7 +1132,7 @@ static label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t it
  * @param iterator iterator to get label from
  * @param[out] buf buffer to point next label to
  */
-static void lv_chart_get_next_label(label_iterator_t * iterator, char * buf)
+static void lv_chart_get_next_label(lv_chart_label_iterator_t * iterator, char * buf)
 {
     uint8_t label_len = 0;
     if (iterator->is_reverse_iter) {
@@ -1182,7 +1182,7 @@ static void lv_chart_get_next_label(label_iterator_t * iterator, char * buf)
             label_len = LV_CHART_AXIS_TICK_LABEL_MAX_LEN;
         }
 
-        if(*(iterator->current_pos) == '\n') iterator->current_pos++;
+        if(*iterator->current_pos == '\n') iterator->current_pos++;
     }
 
     /* terminate the string */
@@ -1221,7 +1221,7 @@ static void lv_chart_draw_y_ticks(lv_obj_t * chart, const lv_area_t * mask, uint
         lv_point_t p1;
         lv_point_t p2;
         lv_coord_t x_ofs;
-        label_iterator_t iter;
+        lv_chart_label_iterator_t iter;
         lv_coord_t y_ofs = chart->coords.y1;
         lv_coord_t h     = lv_obj_get_height(chart);
         lv_coord_t w     = lv_obj_get_width(chart);
@@ -1343,7 +1343,7 @@ static void lv_chart_draw_x_ticks(lv_obj_t * chart, const lv_area_t * mask)
         uint8_t num_of_labels;
         uint8_t num_scale_ticks;
         uint8_t major_tick_len, minor_tick_len;
-        label_iterator_t iter;
+        lv_chart_label_iterator_t iter;
         lv_point_t p1;
         lv_point_t p2;
         lv_coord_t x_ofs = chart->coords.x1;

--- a/src/lv_objx/lv_chart.c
+++ b/src/lv_objx/lv_chart.c
@@ -1122,11 +1122,8 @@ static label_iterator_t lv_chart_create_label_iter(const char * list, uint8_t it
         iterator.is_reverse_iter = 1;
         // -1 to skip '\0' at the end of the string
         iterator.current_pos = list + j - 1;
-
-        if(*iterator.current_pos == '\n'){
-            iterator.current_pos--;
-        }
     }
+    iterator.items_left++;
     return iterator;
 }
 
@@ -1172,7 +1169,7 @@ static void lv_chart_get_next_label(label_iterator_t * iterator, char * buf)
     }
 
     /* terminate the string */
-    buf[label_len] = '\0';
+    buf[label_len] = '\0'; //TODO: in case with forward iterator will cause UB
     iterator->items_left--;
 }
 
@@ -1185,11 +1182,7 @@ static void lv_chart_get_next_label(label_iterator_t * iterator, char * buf)
  */
 static bool lv_chart_is_tick_with_label(uint8_t tick_num, lv_chart_axis_cfg_t * axis)
 {
-    if(axis->options & LV_CHART_AXIS_INVERSE_LABELS_ORDER) {
-        return ((tick_num != 0) && ((tick_num % axis->num_tick_marks) == 0));
-    } else {
-        return ((tick_num == 0) || ((tick_num % axis->num_tick_marks) == 0));
-    }
+    return ((tick_num == 0) || ((tick_num % axis->num_tick_marks) == 0));
 }
 
 static void lv_chart_draw_y_ticks(lv_obj_t * chart, const lv_area_t * mask, uint8_t which_axis)
@@ -1245,7 +1238,7 @@ static void lv_chart_draw_y_ticks(lv_obj_t * chart, const lv_area_t * mask, uint
         iter = lv_chart_create_label_iter(y_axis->list_of_values, iter_dir);
 
         /*determine the number of options */
-        num_of_labels = iter.items_left + 1;
+        num_of_labels = iter.items_left;
 
         /* we can't have string labels without ticks step, set to 1 if not specified */
         if(y_axis->num_tick_marks == 0) y_axis->num_tick_marks = 1;
@@ -1356,7 +1349,7 @@ static void lv_chart_draw_x_ticks(lv_obj_t * chart, const lv_area_t * mask)
 
         /*determine the number of options */
         iter = lv_chart_create_label_iter(ext->x_axis.list_of_values, LV_CHART_LABEL_ITERATOR_FORWARD);
-        num_of_labels = iter.items_left + 1;
+        num_of_labels = iter.items_left;
 
         /* we can't have string labels without ticks step, set to 1 if not specified */
         if(ext->x_axis.num_tick_marks == 0) ext->x_axis.num_tick_marks = 1;

--- a/src/lv_objx/lv_chart.h
+++ b/src/lv_objx/lv_chart.h
@@ -65,8 +65,9 @@ typedef struct
 
 /** Data of axis */
 enum {
-    LV_CHART_AXIS_SKIP_LAST_TICK = 0x00,    /**< don't draw the last tick */
-    LV_CHART_AXIS_DRAW_LAST_TICK = 0x01     /**< draw the last tick */
+    LV_CHART_AXIS_SKIP_LAST_TICK = 0x00,            /**< don't draw the last tick */
+    LV_CHART_AXIS_DRAW_LAST_TICK = 0x01,            /**< draw the last tick */
+    LV_CHART_AXIS_INVERSE_LABELS_ORDER = 0x02       /**< draw tick labels in an inversed order*/
 };
 typedef uint8_t lv_chart_axis_options_t;
 

--- a/src/lv_objx/lv_chart.h
+++ b/src/lv_objx/lv_chart.h
@@ -261,6 +261,16 @@ void lv_chart_set_x_tick_length(lv_obj_t * chart, uint8_t major_tick_len, uint8_
 void lv_chart_set_y_tick_length(lv_obj_t * chart, uint8_t major_tick_len, uint8_t minor_tick_len);
 
 /**
+ * Set the length of the tick marks on the secondary y axis
+ * @param chart pointer to the chart
+ * @param major_tick_len the length of the major tick or `LV_CHART_TICK_LENGTH_AUTO` to set automatically
+ *                       (where labels are added)
+ * @param minor_tick_len the length of the minor tick, `LV_CHART_TICK_LENGTH_AUTO` to set automatically
+ *                       (where no labels are added)
+ */
+void lv_chart_set_secondary_y_tick_length(lv_obj_t * chart, uint8_t major_tick_len, uint8_t minor_tick_len);
+
+/**
  * Set the x-axis tick count and labels of a chart
  * @param chart             pointer to a chart object
  * @param list_of_values    list of string values, terminated with \n, except the last
@@ -270,6 +280,17 @@ void lv_chart_set_y_tick_length(lv_obj_t * chart, uint8_t major_tick_len, uint8_
  */
 void lv_chart_set_x_tick_texts(lv_obj_t * chart, const char * list_of_values, uint8_t num_tick_marks,
                                lv_chart_axis_options_t options);
+
+/**
+ * Set the secondary y-axis tick count and labels of a chart
+ * @param chart             pointer to a chart object
+ * @param list_of_values    list of string values, terminated with \n, except the last
+ * @param num_tick_marks    if list_of_values is NULL: total number of ticks per axis
+ *                          else number of ticks between two value labels
+ * @param options           extra options
+ */
+void lv_chart_set_secondary_y_tick_texts(lv_obj_t * chart, const char * list_of_values, uint8_t num_tick_marks,
+                                        lv_chart_axis_options_t options);
 
 /**
  * Set the y-axis tick count and labels of a chart

--- a/src/lv_objx/lv_chart.h
+++ b/src/lv_objx/lv_chart.h
@@ -93,6 +93,7 @@ typedef struct
     lv_chart_type_t type; /*Line, column or point chart (from 'lv_chart_type_t')*/
     lv_chart_axis_cfg_t y_axis;
     lv_chart_axis_cfg_t x_axis;
+    lv_chart_axis_cfg_t secondary_y_axis;
     uint16_t margin;
     uint8_t update_mode : 1;
     struct


### PR DESCRIPTION
This PR adds extra functionality discussed int this thread: https://forum.littlevgl.com/t/add-secondary-axis-support-for-chart-and-y-axis-inversion/424/2
These are functions lv_chart_set_secondary_y_tick_texts() and lv_chart_set_secondary_y_tick_length() which work the same way as  lv_chart_set_y_tick_texts() and lv_chart_set_y_tick_length(). Also flag LV_CHART_AXIS_INVERSE_LABELS_ORDER has been added. It can be passed to lv_chart_set_y_tick_texts() or lv_chart_set_secondary_y_tick_texts(). This  functionality is demonstrated by following snippet:
```
   lv_obj_t * chart;
 ...      
    lv_obj_set_pos(chart, 30, 50);
    lv_obj_set_size(chart, 430, 210);
    lv_chart_set_x_tick_texts(chart, "1\n2\n3\n4\n5\n6\n7", 2, LV_CHART_AXIS_DRAW_LAST_TICK);
    lv_chart_set_x_tick_length(chart, 5, 8);
    lv_chart_set_y_tick_texts(chart, "123\n456\n789\n5a\n", 2, LV_CHART_AXIS_DRAW_LAST_TICK | LV_CHART_AXIS_INVERSE_LABELS_ORDER);
    lv_chart_set_y_tick_length(chart, 5, 8);
    lv_chart_set_secondary_y_tick_texts(chart, "a0\nb0\nc0\nd2\nc", 2, LV_CHART_AXIS_SKIP_LAST_TICK);
    lv_chart_set_secondary_y_tick_length(chart, 5, 8);
...
```
Snippet above is the part of the code that draws following screen:
![lvgl_scr](https://user-images.githubusercontent.com/5807480/64928331-5dc09a00-d81f-11e9-951c-4998c89a0230.png)
Looking forward your comments.
