### PR TITLE
fixed compiler errors using LV_EXT_CLICK_AREA_TINY

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "../lv_misc/lv_gc.h"
+#include "../lv_misc/lv_math.h"
 
 #if defined(LV_GC_INCLUDE)
 #include LV_GC_INCLUDE
@@ -1073,20 +1074,6 @@ void lv_obj_set_auto_realign(lv_obj_t * obj, bool en)
 #endif
 }
 
-#if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
-/**
- * Set the size of an extended clickable area
- * @param obj pointer to an object
- * @param w extended width to both sides
- * @param h extended height to both sides
- */
-void lv_obj_set_ext_click_area(lv_obj_t * obj, uint8_t w, uint8_t h)
-{
-    obj->ext_click_pad_hor = w;
-    obj->ext_click_pad_ver = h;
-}
-#endif
-
 /**
  * Set the size of an extended clickable area
  * If TINY mode is used, only the largest of the horizontal and vertical padding
@@ -1780,7 +1767,7 @@ lv_coord_t lv_obj_get_ext_click_pad_top(const lv_obj_t * obj)
 lv_coord_t lv_obj_get_ext_click_pad_bottom(const lv_obj_t * obj)
 {
 #if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY
-    return obj->ext_click_pad_ver
+    return obj->ext_click_pad_ver;
 #elif LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_FULL
     return obj->ext_click_pad.y2;
 #else


### PR DESCRIPTION
fixed compiler errors when using #define LV_USE_EXT_CLICK_AREA  LV_EXT_CLICK_AREA_TINY

according to working commit https://github.com/littlevgl/lvgl/commit/d3d9fde2451d266aab9a4117e41eaa405116abf8
discussed in https://github.com/littlevgl/lv_gui_builder/issues/2#issuecomment-495246128