### PR TITLE
Add arc antialiasing

### DIFF
--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -28,6 +28,10 @@ static void hor_line(lv_coord_t x, lv_coord_t y, const lv_area_t * mask, lv_coor
 static bool deg_test_norm(uint16_t deg, uint16_t start, uint16_t end);
 static bool deg_test_inv(uint16_t deg, uint16_t start, uint16_t end);
 
+#if LV_ANTIALIAS
+static uint32_t fast_sqrt(uint32_t op);
+#endif
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -57,6 +61,11 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
     lv_coord_t thickness = style->line.width;
     if(thickness > radius) thickness = radius;
 
+#if LV_ANTIALIAS
+    thickness--;
+    radius--;
+#endif
+
     lv_coord_t r_out = radius;
     lv_coord_t r_in  = r_out - thickness;
     int16_t deg_base;
@@ -73,17 +82,26 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
     else
         deg_test = deg_test_inv;
 
+    int middle_r_out = r_out;
+#if !LV_ANTIALIAS
+    thickness--;
+    middle_r_out = r_out - 1;
+#endif
     if(deg_test(270, start_angle, end_angle))
-        hor_line(center_x - r_out + 1, center_y, mask, thickness - 1, color, opa); /*Left Middle*/
+        hor_line(center_x - middle_r_out, center_y, mask, thickness, color, opa); /*Left Middle*/
     if(deg_test(90, start_angle, end_angle))
-        hor_line(center_x + r_in, center_y, mask, thickness - 1, color, opa); /*Right Middle*/
+        hor_line(center_x + r_in, center_y, mask, thickness, color, opa); /*Right Middle*/
     if(deg_test(180, start_angle, end_angle))
-        ver_line(center_x, center_y - r_out + 1, mask, thickness - 1, color, opa); /*Top Middle*/
+        ver_line(center_x, center_y - middle_r_out, mask, thickness, color, opa); /*Top Middle*/
     if(deg_test(0, start_angle, end_angle))
-        ver_line(center_x, center_y + r_in, mask, thickness - 1, color, opa); /*Bottom middle*/
+        ver_line(center_x, center_y + r_in, mask, thickness, color, opa); /*Bottom middle*/
 
     uint32_t r_out_sqr = r_out * r_out;
     uint32_t r_in_sqr  = r_in * r_in;
+#if LV_ANTIALIAS
+    uint32_t r_out_aa_sqr = (r_out + 1) * (r_out + 1);
+    uint32_t r_in_aa_sqr  = (r_in - 1) * (r_in - 1);
+#endif
     int16_t xi;
     int16_t yi;
     for(yi = -r_out; yi < 0; yi++) {
@@ -95,12 +113,55 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
         x_end[1]   = LV_COORD_MIN;
         x_end[2]   = LV_COORD_MIN;
         x_end[3]   = LV_COORD_MIN;
+        int xe     = 0;
         for(xi = -r_out; xi < 0; xi++) {
 
             uint32_t r_act_sqr = xi * xi + yi * yi;
+#if LV_ANTIALIAS
+            if(r_act_sqr > r_out_aa_sqr) {
+                continue;
+            }
+#else
             if(r_act_sqr > r_out_sqr) continue;
+#endif
 
             deg_base = fast_atan2(xi, yi) - 180;
+
+#if LV_ANTIALIAS
+            int opa = -1;
+            if(r_act_sqr > r_out_sqr) {
+                opa = LV_OPA_100 * (r_out + 1) - fast_sqrt(LV_OPA_100 * LV_OPA_100 * r_act_sqr);
+                if(opa < LV_OPA_0)
+                    opa = LV_OPA_0;
+                else if(opa > LV_OPA_100)
+                    opa = LV_OPA_100;
+            } else if(r_act_sqr < r_in_sqr) {
+                if(xe == 0) xe = xi;
+                opa = fast_sqrt(LV_OPA_100 * LV_OPA_100 * r_act_sqr) - LV_OPA_100 * (r_in - 1);
+                if(opa < LV_OPA_0)
+                    opa = LV_OPA_0;
+                else if(opa > LV_OPA_100)
+                    opa = LV_OPA_100;
+                if(r_act_sqr < r_in_aa_sqr)
+                    break; /*No need to continue the iteration in x once we found the inner edge of the
+                              arc*/
+            }
+            if(opa != -1) {
+                if(deg_test(180 + deg_base, start_angle, end_angle)) {
+                    lv_draw_px(center_x + xi, center_y + yi, mask, color, opa);
+                }
+                if(deg_test(360 - deg_base, start_angle, end_angle)) {
+                    lv_draw_px(center_x + xi, center_y - yi, mask, color, opa);
+                }
+                if(deg_test(180 - deg_base, start_angle, end_angle)) {
+                    lv_draw_px(center_x - xi, center_y + yi, mask, color, opa);
+                }
+                if(deg_test(deg_base, start_angle, end_angle)) {
+                    lv_draw_px(center_x - xi, center_y - yi, mask, color, opa);
+                }
+                continue;
+            }
+#endif
 
             deg = 180 + deg_base;
             if(deg_test(deg, start_angle, end_angle)) {
@@ -130,35 +191,32 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
                 x_end[3] = xi - 1;
             }
 
-            if(r_act_sqr < r_in_sqr)
+            if(r_act_sqr < r_in_sqr) {
+                xe = xi;
                 break; /*No need to continue the iteration in x once we found the inner edge of the
                           arc*/
+            }
         }
 
         if(x_start[0] != LV_COORD_MIN) {
-            if(x_end[0] == LV_COORD_MIN) x_end[0] = xi - 1;
+            if(x_end[0] == LV_COORD_MIN) x_end[0] = xe - 1;
             hor_line(center_x + x_start[0], center_y + yi, mask, x_end[0] - x_start[0], color, opa);
         }
 
         if(x_start[1] != LV_COORD_MIN) {
-            if(x_end[1] == LV_COORD_MIN) x_end[1] = xi - 1;
+            if(x_end[1] == LV_COORD_MIN) x_end[1] = xe - 1;
             hor_line(center_x + x_start[1], center_y - yi, mask, x_end[1] - x_start[1], color, opa);
         }
 
         if(x_start[2] != LV_COORD_MIN) {
-            if(x_end[2] == LV_COORD_MIN) x_end[2] = xi - 1;
+            if(x_end[2] == LV_COORD_MIN) x_end[2] = xe - 1;
             hor_line(center_x - x_end[2], center_y + yi, mask, LV_MATH_ABS(x_end[2] - x_start[2]), color, opa);
         }
 
         if(x_start[3] != LV_COORD_MIN) {
-            if(x_end[3] == LV_COORD_MIN) x_end[3] = xi - 1;
+            if(x_end[3] == LV_COORD_MIN) x_end[3] = xe - 1;
             hor_line(center_x - x_end[3], center_y - yi, mask, LV_MATH_ABS(x_end[3] - x_start[3]), color, opa);
         }
-
-#if LV_ANTIALIAS
-        /*TODO*/
-
-#endif
     }
 }
 
@@ -234,6 +292,27 @@ static uint16_t fast_atan2(int x, int y)
     }
     return degree;
 }
+
+#if LV_ANTIALIAS
+// http://www.codecodex.com/wiki/Calculate_an_integer_square_root#C
+static uint32_t fast_sqrt(uint32_t num)
+{
+    uint32_t root = 0;
+    uint32_t remainder = num;
+    uint32_t place      = 0x40000000;
+
+    while(place > num) place >>= 2;
+    while(place) {
+        if(num >= root + place) {
+            num  -= root + place;
+            root += (place << 1);
+        }
+        root  >>= 1;
+        place >>= 2;
+    }
+    return root;
+}
+#endif
 
 /**********************
  *   STATIC FUNCTIONS


### PR DESCRIPTION
This doesn't currently antialias the ends of the arcs, just the curve itself. The way it works is that pixels within 1 px of the outer radius (`r_out_aa_sqr`) or 1 px of the inner radius (`r_in_aa_sqr`) are colored according to their distance from the radius: `LV_OPA_100 * (r_out + 1) - fast_sqrt(LV_OPA_100 * LV_OPA_100 * r_act_sqr)`. Radius squared is pre-multiplied by LV_OPA_100 to use integer sqrt.

This doesn't currently play too nice with `style.line.rounded = 1` (see demo). I haven't changed how the rounded end caps are drawn - the issue with the line cap end drawing code is just more obvious when you have properly anti-aliased curves.

On an unrelated note, I think there definitely lots of scope for curve drawing algorithm optimization. The algorithm currently checks nearly every pixel in a square around the curve. I can imagine a more efficient algorithm would start at the middle of one of the sides and follow the outside of the curve.

Demo:

![image](https://user-images.githubusercontent.com/6849866/67075974-2d547e80-f184-11e9-88e3-e622ef515588.png)
