### PR TITLE
Reset flushing after setting the buffer content to fix race condition.

### DIFF
--- a/src/lv_hal/lv_hal_disp.c
+++ b/src/lv_hal/lv_hal_disp.c
@@ -267,14 +267,14 @@ bool lv_disp_get_antialiasing(lv_disp_t * disp)
  */
 LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
 {
-    disp_drv->buffer->flushing = 0;
-
     /*If the screen is transparent initialize it when the flushing is ready*/
 #if LV_COLOR_SCREEN_TRANSP
     if(disp_drv->screen_transp) {
         memset(disp_drv->buffer->buf_act, 0x00, disp_drv->buffer->size * sizeof(lv_color32_t));
     }
 #endif
+
+    disp_drv->buffer->flushing = 0;
 }
 
 /**


### PR DESCRIPTION
Flushing flag is used to wait for the finish of the transfer. If this
is reset to 0, the other parts of the code will start accessing the buf_act
(see src/lv_core/lv_refr.c:106) and thus may create a race condition. Exchanging
the resetting to 0 and memset will fix this issue.

REMARK: I found this by code inspection, while trying to figure out why my flushing does not work. This code is not used by myself (not using LV_COLOR_SCREEN_TRANSP) and it needs to be reviewed carefully. But I am really sure this needs to be exchanged.