### PR TITLE
lv_color1_t: Add 'ch' struct to union to fix 1bit color compilation error

### DIFF
--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -96,10 +96,13 @@ enum {
 
 typedef union
 {
-    uint8_t blue : 1;
-    uint8_t green : 1;
-    uint8_t red : 1;
-    uint8_t full : 1;
+    struct
+    {
+        uint8_t blue : 1;
+        uint8_t green : 1;
+        uint8_t red : 1;
+    } ch;
+    uint8_t full;
 } lv_color1_t;
 
 typedef union


### PR DESCRIPTION
lv_color.h:
Updated lv_color1_t union to include 'ch' structure. This fixes compilation errors when configured for 1bit color.