### PR TITLE
[Dev 7.0]  lv_arc  fix rounded-ending arc

### DIFF
--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -69,8 +69,34 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
 
     lv_draw_mask_remove_id(mask_angle_id);
 
+    // draw rounded-ending
     if(style->line.rounded) {
-        /*TODO*/
+      circle_style.body.main_color = style->line.color;
+      circle_style.body.grad_color = style->line.color;
+      circle_style.body.opa        = LV_OPA_COVER;
+      circle_style.body.border.width = 0;
+
+      lv_coord_t thick_half = style->line.width / 2;
+      lv_coord_t cir_x      = ((radius - thick_half + 1) * lv_trigo_sin(90 - start_angle) >> LV_TRIGO_SHIFT);
+      lv_coord_t cir_y      = ((radius - thick_half + 1) * lv_trigo_sin(start_angle) >> LV_TRIGO_SHIFT);
+  
+      lv_area_t round_area;
+        round_area.x1 = cir_x + center_x - thick_half + 1;
+        round_area.y1 = cir_y + center_y - thick_half + 1;
+        round_area.x2 = cir_x + center_x + thick_half;
+        round_area.y2 = cir_y + center_y + thick_half;
+      
+      lv_draw_rect(&round_area, clip_area, &circle_style, LV_OPA_COVER);
+ 
+      cir_x      = ((radius - thick_half + 1) * lv_trigo_sin(90 - end_angle) >> LV_TRIGO_SHIFT);
+      cir_y      = ((radius - thick_half + 1) * lv_trigo_sin(end_angle) >> LV_TRIGO_SHIFT);
+  
+        round_area.x1 = cir_x + center_x - thick_half + 1;
+        round_area.y1 = cir_y + center_y - thick_half + 1;
+        round_area.x2 = cir_x + center_x + thick_half;
+        round_area.y2 = cir_y + center_y + thick_half;
+  
+      lv_draw_rect(&round_area, clip_area, &circle_style, LV_OPA_COVER);
     }
 
 }

--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_draw_arc.h"
 #include "lv_draw_mask.h"
+#include "../lv_misc/lv_math.h"  // LV_TRIGO_SHIFT
 
 /*********************
  *      DEFINES
@@ -69,7 +70,6 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius, cons
 
     lv_draw_mask_remove_id(mask_angle_id);
 
-    // draw rounded-ending
     if(style->line.rounded) {
       circle_style.body.main_color = style->line.color;
       circle_style.body.grad_color = style->line.color;

--- a/src/lv_objx/lv_arc.c
+++ b/src/lv_objx/lv_arc.c
@@ -239,37 +239,6 @@ static lv_design_res_t lv_arc_design(lv_obj_t * arc, const lv_area_t * clip_area
         lv_coord_t y       = arc->coords.y1 + lv_obj_get_height(arc) / 2;
         lv_opa_t opa_scale = lv_obj_get_opa_scale(arc);
         lv_draw_arc(x, y, r, clip_area, ext->angle_start, ext->angle_end, style, opa_scale);
-
-        /*Draw circle on the ends if enabled */
-        if(style->line.rounded) {
-            lv_coord_t thick_half = style->line.width / 2;
-            lv_coord_t cir_x      = ((r - thick_half + 1) * lv_trigo_sin(90 - ext->angle_start) >> LV_TRIGO_SHIFT);
-            lv_coord_t cir_y      = ((r - thick_half + 1) * lv_trigo_sin(ext->angle_start) >> LV_TRIGO_SHIFT);
-
-            lv_style_t cir_style;
-            lv_style_copy(&cir_style, &lv_style_plain);
-            cir_style.body.grad_color = style->line.color;
-            cir_style.body.main_color = cir_style.body.grad_color;
-            cir_style.body.radius     = LV_RADIUS_CIRCLE;
-            lv_area_t cir_area;
-            cir_area.x1 = cir_x + x - thick_half +1;
-            cir_area.y1 = cir_y + y - thick_half +1;
-            cir_area.x2 = cir_x + x + thick_half;
-            cir_area.y2 = cir_y + y + thick_half;
-
-            lv_draw_rect(&cir_area, clip_area, &cir_style, opa_scale);
-
-            cir_x = ((r - thick_half + 1) * lv_trigo_sin(90 - ext->angle_end) >> LV_TRIGO_SHIFT);
-            cir_y = ((r - thick_half + 1) * lv_trigo_sin(ext->angle_end) >> LV_TRIGO_SHIFT);
-
-            cir_area.x1 = cir_x + x - thick_half +1;
-            cir_area.y1 = cir_y + y - thick_half +1;
-            cir_area.x2 = cir_x + x + thick_half;
-            cir_area.y2 = cir_y + y + thick_half;
-
-            lv_draw_rect(&cir_area, clip_area, &cir_style, opa_scale);
-        }
-
     }
     /*Post draw when the children are drawn*/
     else if(mode == LV_DESIGN_DRAW_POST) {

--- a/src/lv_objx/lv_arc.c
+++ b/src/lv_objx/lv_arc.c
@@ -243,8 +243,8 @@ static lv_design_res_t lv_arc_design(lv_obj_t * arc, const lv_area_t * clip_area
         /*Draw circle on the ends if enabled */
         if(style->line.rounded) {
             lv_coord_t thick_half = style->line.width / 2;
-            lv_coord_t cir_x      = ((r - thick_half) * lv_trigo_sin(ext->angle_start) >> LV_TRIGO_SHIFT);
-            lv_coord_t cir_y      = ((r - thick_half) * lv_trigo_sin(ext->angle_start + 90) >> LV_TRIGO_SHIFT);
+            lv_coord_t cir_x      = ((r - thick_half + 1) * lv_trigo_sin(90 - ext->angle_start) >> LV_TRIGO_SHIFT);
+            lv_coord_t cir_y      = ((r - thick_half + 1) * lv_trigo_sin(ext->angle_start) >> LV_TRIGO_SHIFT);
 
             lv_style_t cir_style;
             lv_style_copy(&cir_style, &lv_style_plain);
@@ -252,18 +252,18 @@ static lv_design_res_t lv_arc_design(lv_obj_t * arc, const lv_area_t * clip_area
             cir_style.body.main_color = cir_style.body.grad_color;
             cir_style.body.radius     = LV_RADIUS_CIRCLE;
             lv_area_t cir_area;
-            cir_area.x1 = cir_x + x - thick_half;
-            cir_area.y1 = cir_y + y - thick_half;
+            cir_area.x1 = cir_x + x - thick_half +1;
+            cir_area.y1 = cir_y + y - thick_half +1;
             cir_area.x2 = cir_x + x + thick_half;
             cir_area.y2 = cir_y + y + thick_half;
 
             lv_draw_rect(&cir_area, clip_area, &cir_style, opa_scale);
 
-            cir_x = ((r - thick_half) * lv_trigo_sin(ext->angle_end) >> LV_TRIGO_SHIFT);
-            cir_y = ((r - thick_half) * lv_trigo_sin(ext->angle_end + 90) >> LV_TRIGO_SHIFT);
+            cir_x = ((r - thick_half + 1) * lv_trigo_sin(90 - ext->angle_end) >> LV_TRIGO_SHIFT);
+            cir_y = ((r - thick_half + 1) * lv_trigo_sin(ext->angle_end) >> LV_TRIGO_SHIFT);
 
-            cir_area.x1 = cir_x + x - thick_half;
-            cir_area.y1 = cir_y + y - thick_half;
+            cir_area.x1 = cir_x + x - thick_half +1;
+            cir_area.y1 = cir_y + y - thick_half +1;
             cir_area.x2 = cir_x + x + thick_half;
             cir_area.y2 = cir_y + y + thick_half;
 


### PR DESCRIPTION
I tried to fix rounded-ending of dev-7.0's lv_arc .

the result :

![capture_00052](https://user-images.githubusercontent.com/15370479/68071577-40836300-fdae-11e9-8d19-a32956dd65b0.png)
![capture_00053](https://user-images.githubusercontent.com/15370479/68071578-42e5bd00-fdae-11e9-9a0e-0244a86a94e0.png)
![capture_00054](https://user-images.githubusercontent.com/15370479/68071580-45e0ad80-fdae-11e9-88b7-07c63133f3eb.png)
