### PR TITLE
Fix some more warnings in dev-7.0

### DIFF
--- a/src/lv_core/lv_debug.h
+++ b/src/lv_core/lv_debug.h
@@ -46,13 +46,13 @@ void lv_debug_log_error(const char * msg, uint64_t value);
 
 #ifndef LV_DEBUG_ASSERT
 #define LV_DEBUG_ASSERT(expr, msg, value)       \
-{                                               \
+do {                                            \
     if(!(expr)) {                               \
         LV_LOG_ERROR(__func__);                 \
         lv_debug_log_error(msg, (unsigned long int)value);         \
         while(1);                               \
     }                                           \
-}
+} while(0)
 #endif
 
 /*----------------

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -377,7 +377,8 @@ static void lv_draw_map(const lv_area_t * map_area, const lv_area_t * clip_area,
         }
 
 
-        lv_img_rotate_dsc_t rotate_dsc = {};
+        lv_img_rotate_dsc_t rotate_dsc;
+	memset(&rotate_dsc, 0, sizeof(lv_img_rotate_dsc_t));
         if(angle) {
             lv_img_cf_t cf = LV_IMG_CF_TRUE_COLOR;
             if(alpha_byte) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;

--- a/src/lv_draw/lv_draw_mask.c
+++ b/src/lv_draw/lv_draw_mask.c
@@ -9,6 +9,7 @@
 #include "lv_draw_mask.h"
 #include "../lv_misc/lv_math.h"
 #include "../lv_misc/lv_log.h"
+#include "../lv_core/lv_debug.h"
 
 /*********************
  *      DEFINES
@@ -222,6 +223,17 @@ void lv_draw_mask_angle_init(lv_draw_mask_param_t * param, lv_coord_t origo_x, l
     lv_draw_mask_line_side_t start_side;
     lv_draw_mask_line_side_t end_side;
 
+    /* Constrain the input angles */
+    if(start_angle < 0)
+        start_angle = 0;
+    else if(start_angle > 359)
+        start_angle = 359;
+    
+    if(end_angle < 0)
+        end_angle = 0;
+    else if(end_angle > 359)
+        end_angle = 359;
+
     if(end_angle < start_angle) {
         p->delta_deg = 360 - start_angle + end_angle;
     } else {
@@ -239,6 +251,8 @@ void lv_draw_mask_angle_init(lv_draw_mask_param_t * param, lv_coord_t origo_x, l
     }
     else if(start_angle >= 180 && start_angle < 360) {
         start_side = LV_DRAW_MASK_LINE_SIDE_RIGHT;
+    } else {
+        LV_DEBUG_ASSERT(false, "Unexpected start_angle", start_angle);
     }
 
     if(end_angle >= 0 && end_angle < 180) {
@@ -246,6 +260,8 @@ void lv_draw_mask_angle_init(lv_draw_mask_param_t * param, lv_coord_t origo_x, l
     }
     else if(end_angle >= 180 && end_angle < 360) {
         end_side = LV_DRAW_MASK_LINE_SIDE_LEFT;
+    } else {
+        LV_DEBUG_ASSERT(false, "Unexpected end_angle", end_angle);
     }
 
     lv_draw_mask_line_angle_init((lv_draw_mask_param_t*)&p->start_line, origo_x, origo_y, start_angle, start_side);

--- a/src/lv_draw/lv_img_buf.h
+++ b/src/lv_draw/lv_img_buf.h
@@ -154,7 +154,14 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-
+/**
+ * Allocate an image buffer in RAM
+ * @param w width of image
+ * @param h height of image
+ * @param cf a color format (`LV_IMG_CF_...`)
+ * @return an allocated image, or NULL on failure
+ */
+lv_img_dsc_t *lv_img_buf_alloc(lv_coord_t w, lv_coord_t h, lv_img_cf_t cf);
 
 /**
  * Get the color of an image's pixel


### PR DESCRIPTION
Fix part of #1248 .

Since `lv_coord_t` can logically store values outside the expected range, I think we should forcibly constrain the angles to be in the expected range. The assertions are just there in case the constraint doesn't work for some reason.

(By the way, it doesn't appear that assertions can ever be disabled for a release build. Is that an oversight or the intended behavior?)