### PR TITLE
fix 1bit lv_color compilation warnings/errors introduced by ...

### DIFF
--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -392,10 +392,10 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 
 /* The most simple macro to create a color from R,G and B values */
 #if LV_COLOR_DEPTH == 1
-#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){(b8 >> 7 | g8 >> 7 | r8 >> 7)})
+#define LV_COLOR_MAKE(r8, g8, b8) ((lv_color_t){.full = (b8 >> 7 | g8 >> 7 | r8 >> 7)})
 static inline lv_color_t lv_color_make(int r8, int g8, int b8)
 {
-    lv_color_t color;
+    lv_color_t color = { 0 };
     color.full = (b8 >> 7 | g8 >> 7 | r8 >> 7);
     return color;
 }


### PR DESCRIPTION
fix 1bit lv_color compilation warnings/errors introduced by 3da868a05ccbdafb4bbbf9c301d4f66eb2cf86.

I'm not sure if this impacts other bitdepths, but it was preventing me from compiling single bit color support. Both of the warnings don't really seem valid, but this fixes them.

The `.full` fixes the error `missing braces around initializer [-Werror=missing-braces]`

The ` = { 0 };` fixes `error: missing initializer for field 'green' of 'struct <anonymous>' [-Werror=missing-field-initializers]`