### PR TITLE
Updated lv_refr_area and lv_img_design to account for single pixel height/width objects.

### DIFF
--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -318,19 +318,20 @@ static void lv_refr_area(const lv_area_t * area_p)
             tmp.x2 = 0;
             tmp.y1 = 0;
 
-            lv_coord_t y_tmp = max_row - 1;
+            /* This method modified to account for single pixel areas (slateg1) */
+            lv_coord_t h_tmp = max_row;
             do {
-                tmp.y2 = y_tmp;
+                tmp.y2 = h_tmp - 1;
                 disp_refr->driver.rounder_cb(&disp_refr->driver, &tmp);
 
                 /*If this height fits into `max_row` then fine*/
                 if(lv_area_get_height(&tmp) <= max_row) break;
 
                 /*Decrement the height of the area until it fits into `max_row` after rounding*/
-                y_tmp--;
-            } while(y_tmp != 0);
+                h_tmp--;
+            } while(h_tmp > 0);
 
-            if(y_tmp == 0) {
+            if(h_tmp <= 0) {
                 LV_LOG_WARN("Can't set VDB height using the round function. (Wrong round_cb or to "
                             "small VDB)");
                 return;

--- a/src/lv_objx/lv_img.c
+++ b/src/lv_objx/lv_img.c
@@ -372,10 +372,10 @@ static bool lv_img_design(lv_obj_t * img, const lv_area_t * mask, lv_design_mode
             cords_tmp.y1 = coords.y1;
             cords_tmp.y2 = coords.y1 + ext->h - 1;
 
-            for(; cords_tmp.y1 < coords.y2; cords_tmp.y1 += ext->h, cords_tmp.y2 += ext->h) {
+            for(; cords_tmp.y1 <= coords.y2; cords_tmp.y1 += ext->h, cords_tmp.y2 += ext->h) {
                 cords_tmp.x1 = coords.x1;
                 cords_tmp.x2 = coords.x1 + ext->w - 1;
-                for(; cords_tmp.x1 < coords.x2; cords_tmp.x1 += ext->w, cords_tmp.x2 += ext->w) {
+                for(; cords_tmp.x1 <= coords.x2; cords_tmp.x1 += ext->w, cords_tmp.x2 += ext->w) {
                     lv_draw_img(&cords_tmp, mask, ext->src, style, opa_scale);
                 }
             }


### PR DESCRIPTION
lv_refr_area: Updated height for area refresh to correctly include areas that are a height of only 1 pixel.
lv_img_design: Updated draw loop to account for objects that are 1 pixel in height or width.