### PR TITLE
Fix -Wconversion warnings

### DIFF
--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -196,7 +196,7 @@ void lv_style_anim_set_styles(lv_anim_t * a, lv_style_t * to_anim, const lv_styl
  * @param duration duration of the animation in milliseconds
  * @param delay delay before the animation in milliseconds
  */
-static inline void lv_style_anim_set_time(lv_anim_t * a, uint16_t duration, uint16_t delay)
+static inline void lv_style_anim_set_time(lv_anim_t * a, uint16_t duration, int16_t delay)
 {
     lv_anim_set_time(a, duration, delay);
 }

--- a/src/lv_misc/lv_anim.h
+++ b/src/lv_misc/lv_anim.h
@@ -129,10 +129,10 @@ static inline void lv_anim_set_exec_cb(lv_anim_t * a, void * var, lv_anim_exec_x
  * @param duration duration of the animation in milliseconds
  * @param delay delay before the animation in milliseconds
  */
-static inline void lv_anim_set_time(lv_anim_t * a, uint16_t duration, uint16_t delay)
+static inline void lv_anim_set_time(lv_anim_t * a, uint16_t duration, int16_t delay)
 {
     a->time     = duration;
-    a->act_time = -delay;
+    a->act_time = (int16_t)(-delay);
 }
 
 /**

--- a/src/lv_misc/lv_area.h
+++ b/src/lv_misc/lv_area.h
@@ -85,7 +85,7 @@ inline static void lv_area_copy(lv_area_t * dest, const lv_area_t * src)
  */
 static inline lv_coord_t lv_area_get_width(const lv_area_t * area_p)
 {
-    return area_p->x2 - area_p->x1 + 1;
+    return (lv_coord_t)(area_p->x2 - area_p->x1 + 1);
 }
 
 /**
@@ -95,7 +95,7 @@ static inline lv_coord_t lv_area_get_width(const lv_area_t * area_p)
  */
 static inline lv_coord_t lv_area_get_height(const lv_area_t * area_p)
 {
-    return area_p->y2 - area_p->y1 + 1;
+    return (lv_coord_t)(area_p->y2 - area_p->y1 + 1);
 }
 
 /**

--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -94,9 +94,9 @@ enum {
  * Macros for all existing  color depths
  * to set/get values of the color channels
  *------------------------------------------*/
-# define LV_COLOR_SET_R1(c, v) (c).ch.red = (v) & 0x1;
-# define LV_COLOR_SET_G1(c, v) (c).ch.green = (v) & 0x1;
-# define LV_COLOR_SET_B1(c, v) (c).ch.blue = (v) & 0x1;
+# define LV_COLOR_SET_R1(c, v) (c).ch.red = (uint8_t)((v) & 0x1);
+# define LV_COLOR_SET_G1(c, v) (c).ch.green = (uint8_t)((v) & 0x1);
+# define LV_COLOR_SET_B1(c, v) (c).ch.blue = (uint8_t)((v) & 0x1);
 # define LV_COLOR_SET_A1(c, v)
 
 # define LV_COLOR_GET_R1(c) (c).ch.red
@@ -104,21 +104,21 @@ enum {
 # define LV_COLOR_GET_B1(c) (c).ch.blue
 # define LV_COLOR_GET_A1(c) 1
 
-# define LV_COLOR_SET_R8(c, v) (c).ch.red = (v) & 0x7;
-# define LV_COLOR_SET_G8(c, v) (c).ch.green = (v) & 0x7;
-# define LV_COLOR_SET_B8(c, v) (c).ch.blue = (v) & 0x3;
-# define LV_COLOR_SET_A8(c, v)
+# define LV_COLOR_SET_R8(c, v) (c).ch.red = (uint8_t)((v) & 0x7);
+# define LV_COLOR_SET_G8(c, v) (c).ch.green = (uint8_t)((v) & 0x7);
+# define LV_COLOR_SET_B8(c, v) (c).ch.blue = (uint8_t)((v) & 0x3);
+# define LV_COLOR_SET_A8(c, v) do {} while(0)
 
 # define LV_COLOR_GET_R8(c) (c).ch.red
 # define LV_COLOR_GET_G8(c) (c).ch.green
 # define LV_COLOR_GET_B8(c) (c).ch.blue
 # define LV_COLOR_GET_A8(c) 0xFF
 
-# define LV_COLOR_SET_R16(c, v) (c).ch.red = (v) & 0x1F;
-# define LV_COLOR_SET_G16(c, v) (c).ch.green = (v) & 0x3F;
-# define LV_COLOR_SET_G16_SWAP(c, v) {(c).ch.green_h = ((v) >> 3) & 0x7; (c).ch.green_l = (v) & 0x7;}
-# define LV_COLOR_SET_B16(c, v) (c).ch.blue = (v) & 0x1F;
-# define LV_COLOR_SET_A16(c, v)
+# define LV_COLOR_SET_R16(c, v) (c).ch.red = (uint16_t)((v) & 0x1F);
+# define LV_COLOR_SET_G16(c, v) (c).ch.green = (uint16_t)((v) & 0x3F);
+# define LV_COLOR_SET_G16_SWAP(c, v) {(c).ch.green_h = (uint16_t)(((v) >> 3) & 0x7); (c).ch.green_l = (uint16_t)((v) & 0x7);}
+# define LV_COLOR_SET_B16(c, v) (c).ch.blue = (uint16_t)((v) & 0x1F);
+# define LV_COLOR_SET_A16(c, v) do {} while(0)
 
 # define LV_COLOR_GET_R16(c) (c).ch.red
 # define LV_COLOR_GET_G16(c) (c).ch.green
@@ -126,10 +126,10 @@ enum {
 # define LV_COLOR_GET_B16(c) (c).ch.blue
 # define LV_COLOR_GET_A16(c) 0xFF
 
-# define LV_COLOR_SET_R32(c, v) (c).ch.red = (v) & 0xFF;
-# define LV_COLOR_SET_G32(c, v) (c).ch.green = (v) & 0xFF;
-# define LV_COLOR_SET_B32(c, v) (c).ch.blue = (v) & 0xFF;
-# define LV_COLOR_SET_A32(c, v) (c).ch.alpha = (v) & 0xFF;
+# define LV_COLOR_SET_R32(c, v) (c).ch.red = (uint32_t)((v) & 0xFF);
+# define LV_COLOR_SET_G32(c, v) (c).ch.green = (uint32_t)((v) & 0xFF);
+# define LV_COLOR_SET_B32(c, v) (c).ch.blue = (uint32_t)((v) & 0xFF);
+# define LV_COLOR_SET_A32(c, v) (c).ch.alpha = (uint32_t)((v) & 0xFF);
 
 # define LV_COLOR_GET_R32(c) (c).ch.red
 # define LV_COLOR_GET_G32(c) (c).ch.green
@@ -458,8 +458,8 @@ static inline uint8_t lv_color_brightness(lv_color_t color)
 {
     lv_color32_t c32;
     c32.full        = lv_color_to32(color);
-    uint16_t bright = 3 * LV_COLOR_GET_R32(c32) + LV_COLOR_GET_B32(c32) + 4 * LV_COLOR_GET_G32(c32);
-    return (uint16_t)bright >> 3;
+    uint16_t bright = (uint16_t)(3u * LV_COLOR_GET_R32(c32) + LV_COLOR_GET_B32(c32) + 4u * LV_COLOR_GET_G32(c32));
+    return (uint8_t)(bright >> 3);
 }
 
 /* The most simple macro to create a color from R,G and B values */


### PR DESCRIPTION
I changed two inline helper functions to use `int16_t` instead of `uint16_t`. I don't think it's a big issue because using an out-of-range value wouldn't have worked properly anyways.

This should fix #1213.