### PR TITLE
lv_roller_create cuases "divide by zero" via modulus operator for infinit scroll mode

### DIFF
--- a/src/lv_objx/lv_roller.c
+++ b/src/lv_objx/lv_roller.c
@@ -76,6 +76,7 @@ lv_obj_t * lv_roller_create(lv_obj_t * par, const lv_obj_t * copy)
     lv_mem_assert(ext);
     if(ext == NULL) return NULL;
     ext->ddlist.draw_arrow = 0; /*Do not draw arrow by default*/
+    ext->mode = LV_ROLLER_MODE_NORMAL;
 
     /*The signal and design functions are not copied so set them here*/
     lv_obj_set_signal_cb(new_roller, lv_roller_signal);


### PR DESCRIPTION
Thanks for the great work guys! Found an issue *I THINK*, which occurs because the roller controller doesn't assign default values to the extra attributes, random memory values can change the intended default of LV_ROLLER_MODE_NORMAL to LV_ROLLER_MODE_INFINITE, which can trigger an divide by zero error if not options are yet available to calculate the center, which does not yet exists because the issue arises before the options are assigned. If I can assign additional defaults, providing I diagnosed the issue correctly, just let me know. Thx.!

```c
static void inf_normalize(void * scrl)
{
    lv_obj_t * roller_scrl = (lv_obj_t *)scrl;
    lv_obj_t * roller      = lv_obj_get_parent(roller_scrl);
    lv_roller_ext_t * ext  = lv_obj_get_ext_attr(roller);

    if(ext->mode == LV_ROLLER_MODE_INIFINITE) {
        uint16_t real_id_cnt = ext->ddlist.option_cnt / LV_ROLLER_INF_PAGES;

        ext->ddlist.sel_opt_id = ext->ddlist.sel_opt_id % real_id_cnt; ////FIXME: SIGFPE (Arithmetic exception) here because real_id_cnt and sel_opt_id can be 0 

        ext->ddlist.sel_opt_id += (LV_ROLLER_INF_PAGES / 2) * real_id_cnt; /*Select the middle page*/

        /*Move to the new id*/
        const lv_style_t * style_label = lv_obj_get_style(ext->ddlist.label);
        const lv_font_t * font         = style_label->text.font;
        lv_coord_t font_h              = lv_font_get_line_height(font);
        lv_coord_t h                   = lv_obj_get_height(roller);

        lv_coord_t line_y1 = ext->ddlist.sel_opt_id * (font_h + style_label->text.line_space) +
                             ext->ddlist.label->coords.y1 - roller_scrl->coords.y1;
        lv_coord_t new_y = -line_y1 + (h - font_h) / 2;
        lv_obj_set_y(roller_scrl, new_y);
    }
}
```