### PR TITLE
Fix `lv_mbox_create` for Micropython Binding

### DIFF
--- a/src/lv_misc/lv_log.h
+++ b/src/lv_misc/lv_log.h
@@ -33,6 +33,12 @@ extern "C" {
 #define LV_LOG_LEVEL_NONE 4 /**< Do not log anything*/
 #define _LV_LOG_LEVEL_NUM 5 /**< Number of log levels */
 
+LV_EXPORT_CONST_INT(LV_LOG_LEVEL_TRACE);
+LV_EXPORT_CONST_INT(LV_LOG_LEVEL_INFO);
+LV_EXPORT_CONST_INT(LV_LOG_LEVEL_WARN);
+LV_EXPORT_CONST_INT(LV_LOG_LEVEL_ERROR);
+LV_EXPORT_CONST_INT(LV_LOG_LEVEL_NONE);
+
 typedef int8_t lv_log_level_t;
 
 #if LV_USE_LOG

--- a/src/lv_objx/lv_mbox.c
+++ b/src/lv_objx/lv_mbox.c
@@ -139,7 +139,7 @@ lv_obj_t * lv_mbox_create(lv_obj_t * par, const lv_obj_t * copy)
  * @param btn_map button descriptor (button matrix map).
  *                E.g.  a const char *txt[] = {"ok", "close", ""} (Can not be local variable)
  */
-void lv_mbox_add_btns(lv_obj_t * mbox, const char ** btn_map)
+void lv_mbox_add_btns(lv_obj_t * mbox, const char * btn_map[])
 {
     LV_ASSERT_OBJ(mbox, LV_OBJX_NAME);
     LV_ASSERT_NULL(btn_map);

--- a/src/lv_objx/lv_mbox.h
+++ b/src/lv_objx/lv_mbox.h
@@ -94,7 +94,7 @@ lv_obj_t * lv_mbox_create(lv_obj_t * par, const lv_obj_t * copy);
  * @param btn_map button descriptor (button matrix map).
  *                E.g.  a const char *txt[] = {"ok", "close", ""} (Can not be local variable)
  */
-void lv_mbox_add_btns(lv_obj_t * mbox, const char ** btn_mapaction);
+void lv_mbox_add_btns(lv_obj_t * mbox, const char * btn_mapaction[]);
 
 /*=====================
  * Setter functions


### PR DESCRIPTION
When passing array of strings, the parameter should be defined as const char *[], and not const char **