### PR TITLE
initialize variable to remove compiler warning

### DIFF
--- a/src/lv_objx/lv_cpicker.c
+++ b/src/lv_objx/lv_cpicker.c
@@ -759,7 +759,7 @@ static lv_area_t get_indic_area(lv_obj_t * cpicker)
     const lv_style_t * style_main = lv_cpicker_get_style(cpicker, LV_CPICKER_STYLE_MAIN);
     const lv_style_t * style_indic = lv_cpicker_get_style(cpicker, LV_CPICKER_STYLE_INDICATOR);
 
-    uint16_t r;
+    uint16_t r = 0;
     if(ext->type == LV_CPICKER_TYPE_DISC) r = style_main->line.width / 2;
     else if(ext->type == LV_CPICKER_TYPE_RECT) {
         lv_coord_t h = lv_obj_get_height(cpicker);


### PR DESCRIPTION
This code caused a compiler warning as `if-else if` case is considered not complete - `r` is undefined in some (impossible) cases.
```c
    uint16_t r;
    if(ext->type == LV_CPICKER_TYPE_DISC) r = style_main->line.width / 2;
    else if(ext->type == LV_CPICKER_TYPE_RECT) {
        lv_coord_t h = lv_obj_get_height(cpicker);
        r = h / 2;
    }
```
It caused problems in compilation of micropython where all warnings are treated as errors.