### PR TITLE
Set alpha channel on return color in lv_color_to32

### DIFF
--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -390,7 +390,7 @@ static inline uint32_t lv_color_to32(lv_color_t color)
     LV_COLOR_SET_R32(ret, LV_COLOR_GET_R(color) * 36);     /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
     LV_COLOR_SET_G32(ret, LV_COLOR_GET_G(color) * 36); /*(2^8 - 1)/(2^3 - 1) = 255/7 = 36*/
     LV_COLOR_SET_B32(ret, LV_COLOR_GET_B(color) * 85);   /*(2^8 - 1)/(2^2 - 1) = 255/3 = 85*/
-    LV_COLOR_SET_A32(color, 0xFF);
+    LV_COLOR_SET_A32(ret, 0xFF);
     return ret.full;
 #elif LV_COLOR_DEPTH == 16
     /**


### PR DESCRIPTION
Set alpha channel on return color in lv_color_to32 for 8-bit to 32-bit
color conversions.