### PR TITLE
Also making \r break lines in labels

### DIFF
--- a/src/lv_misc/lv_txt.c
+++ b/src/lv_misc/lv_txt.c
@@ -303,9 +303,9 @@ uint16_t lv_txt_get_next_line(const char * txt, const lv_font_t * font,
 
         i += advance;
 
-        if(txt[0] == '\n') break;
+        if(txt[0] == '\n' || txt[0] == '\r') break;
 
-        if(txt[i] == '\n'){
+        if(txt[i] == '\n' || txt[i] == '\r'){
             i++;  /* Include the following newline in the current line */
             break;
         }


### PR DESCRIPTION
An application I was working on used '\r' in label text to draw multi-line axis labels for a chart, as the '\n' character is already reserved to split labels in a chart's axis labels. This behaviour appears to have been changed in commit 29b145ffb29795d8d5f4e0835fec0792bcb1228c so that '\r' no longer causes a new line in a label. This PR restores that behaviour.