### PR TITLE
[Merged] 1.add gesture event;2.fixed draw arc round bug;

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -122,6 +122,13 @@ typedef int16_t lv_coord_t;
  * Time between `LV_EVENT_LONG_PRESSED_REPEAT */
 #define LV_INDEV_DEF_LONG_PRESS_REP_TIME  100
 
+
+/* Gesture threshold in pixels */
+#define LV_INDEV_DEF_GESTURE_LIMIT        50
+
+/* Gesture min velocity at release before swipe (pixels)*/
+#define LV_INDEV_DEF_GESTURE_MIN_VELOCITY 3
+
 /*==================
  * Feature usage
  *==================*/

--- a/src/lv_conf_checker.h
+++ b/src/lv_conf_checker.h
@@ -170,6 +170,17 @@
 #define LV_INDEV_DEF_LONG_PRESS_REP_TIME  100
 #endif
 
+
+/* Gesture threshold in pixels */
+#ifndef LV_INDEV_DEF_GESTURE_LIMIT
+#define LV_INDEV_DEF_GESTURE_LIMIT        50
+#endif
+
+/* Gesture min velocity at release before swipe (pixels)*/
+#ifndef LV_INDEV_DEF_GESTURE_MIN_VELOCITY
+#define LV_INDEV_DEF_GESTURE_MIN_VELOCITY 3
+#endif
+
 /*==================
  * Feature usage
  *==================*/
@@ -722,6 +733,11 @@
 /*Line meter (dependencies: *;)*/
 #ifndef LV_USE_LMETER
 #define LV_USE_LMETER   1
+#endif
+
+/*Mask (dependencies: -)*/
+#ifndef LV_USE_OBJMASK
+#define LV_USE_OBJMASK  0
 #endif
 
 /*Message box (dependencies: lv_rect, lv_btnm, lv_label)*/

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1366,7 +1366,6 @@ static void indev_gesture(lv_indev_proc_t * proc)
 	    (LV_MATH_ABS(proc->types.pointer.gesture_sum.y) > indev_act->driver.gesture_limit)){
 
 	    proc->types.pointer.gesture_sent = 1;
-	    proc->wait_until_release = 1;
 
 	    if (LV_MATH_ABS(proc->types.pointer.gesture_sum.x) > LV_MATH_ABS(proc->types.pointer.gesture_sum.y)){
 	        if (proc->types.pointer.gesture_sum.x > 0)

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1352,8 +1352,8 @@ static void indev_gesture(lv_indev_proc_t * proc)
 
 	if (gesture_obj == NULL) return;
 
-	if ((LV_MATH_ABS(proc->types.pointer.vect.x) < LV_INDEV_DEF_GESTURE_MIN_VELOCITY) &&
-		(LV_MATH_ABS(proc->types.pointer.vect.y) < LV_INDEV_DEF_GESTURE_MIN_VELOCITY)) {
+	if ((LV_MATH_ABS(proc->types.pointer.vect.x) < indev_act->driver.gesture_min_velocity) &&
+		(LV_MATH_ABS(proc->types.pointer.vect.y) < indev_act->driver.gesture_min_velocity)) {
 		proc->types.pointer.gesture_sum.x = 0;
 		proc->types.pointer.gesture_sum.y = 0;
 	}
@@ -1362,8 +1362,8 @@ static void indev_gesture(lv_indev_proc_t * proc)
 	proc->types.pointer.gesture_sum.x += proc->types.pointer.vect.x;
 	proc->types.pointer.gesture_sum.y += proc->types.pointer.vect.y;
 
-	if ((LV_MATH_ABS(proc->types.pointer.gesture_sum.x) > LV_INDEV_DEF_GESTURE_LIMIT) ||
-	    (LV_MATH_ABS(proc->types.pointer.gesture_sum.y) > LV_INDEV_DEF_GESTURE_LIMIT)){
+	if ((LV_MATH_ABS(proc->types.pointer.gesture_sum.x) > indev_act->driver.gesture_limit) ||
+	    (LV_MATH_ABS(proc->types.pointer.gesture_sum.y) > indev_act->driver.gesture_limit)){
 
 	    proc->types.pointer.gesture_sent = 1;
 

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1366,6 +1366,7 @@ static void indev_gesture(lv_indev_proc_t * proc)
 	    (LV_MATH_ABS(proc->types.pointer.gesture_sum.y) > indev_act->driver.gesture_limit)){
 
 	    proc->types.pointer.gesture_sent = 1;
+	    proc->wait_until_release = 1;
 
 	    if (LV_MATH_ABS(proc->types.pointer.gesture_sum.x) > LV_MATH_ABS(proc->types.pointer.gesture_sum.y)){
 	        if (proc->types.pointer.gesture_sum.x > 0)

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -43,6 +43,8 @@ static lv_obj_t * indev_search_obj(const lv_indev_proc_t * proc, lv_obj_t * obj)
 static void indev_drag(lv_indev_proc_t * proc);
 static void indev_drag_throw(lv_indev_proc_t * proc);
 static lv_obj_t * get_dragged_obj(lv_obj_t * obj);
+static void indev_gesture(lv_indev_proc_t * state);
+static void indev_gesture_judge(lv_indev_proc_t * proc);
 static bool indev_reset_check(lv_indev_proc_t * proc);
 
 /**********************
@@ -241,6 +243,16 @@ void lv_indev_get_point(const lv_indev_t * indev, lv_point_t * point)
         point->x = indev->proc.types.pointer.act_point.x;
         point->y = indev->proc.types.pointer.act_point.y;
     }
+}
+
+/**
+* Get the current gesture direct
+* @param indev pointer to an input device
+* @return current gesture direct
+*///zlm
+lv_gesture_dir_t lv_indev_get_gesture_dir(const lv_indev_t * indev)
+{
+    return indev->proc.types.pointer.gesture_dir;
 }
 
 /**
@@ -775,6 +787,8 @@ static void indev_proc_press(lv_indev_proc_t * proc)
             proc->types.pointer.drag_sum.x     = 0;
             proc->types.pointer.drag_sum.y     = 0;
             proc->types.pointer.drag_dir = LV_DRAG_DIR_NONE;
+            proc->types.pointer.gesture_sum.x  = 0;
+            proc->types.pointer.gesture_sum.y  = 0;
             proc->types.pointer.vect.x         = 0;
             proc->types.pointer.vect.y         = 0;
 
@@ -830,6 +844,7 @@ static void indev_proc_press(lv_indev_proc_t * proc)
         if(indev_act->proc.wait_until_release) return;
 
         indev_drag(proc);
+        indev_gesture(proc);
         if(indev_reset_check(proc)) return;
 
         /*If there is no drag then check for long press time*/
@@ -992,6 +1007,7 @@ static void indev_proc_release(lv_indev_proc_t * proc)
     /*The reset can be set in the signal function.
      * In case of reset query ignore the remaining parts.*/
     if(proc->types.pointer.last_obj != NULL && proc->reset_query == 0) {
+        indev_gesture_judge(proc);
         indev_drag_throw(proc);
         if(indev_reset_check(proc)) return;
     }
@@ -1020,6 +1036,8 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
         indev->proc.types.pointer.drag_dir = LV_DRAG_DIR_NONE;
         indev->proc.types.pointer.drag_throw_vect.x = 0;
         indev->proc.types.pointer.drag_throw_vect.y = 0;
+        indev->proc.types.pointer.gesture_sum.x     = 0;
+        indev->proc.types.pointer.gesture_sum.y     = 0;
         indev->proc.reset_query                     = 0;
         indev_obj_act                               = NULL;
     }
@@ -1315,6 +1333,80 @@ static lv_obj_t * get_dragged_obj(lv_obj_t * obj)
     return drag_obj;
 }
 
+
+/**
+* Handle the gesture of indev_proc_p->types.pointer.act_obj
+* @param indev pointer to a input device state
+*/
+static void indev_gesture(lv_indev_proc_t * state)
+{
+	lv_obj_t * gusture_obj = state->types.pointer.act_obj;
+	bool drag_just_started = false;
+
+	/*If gusture parent is active check recursively the drag_parent attribute*/
+	while (lv_obj_get_gesture_parent(gusture_obj) != false && gusture_obj != NULL) {
+		gusture_obj = lv_obj_get_parent(gusture_obj);
+	}
+
+	if (gusture_obj == NULL) return;
+
+	if (lv_obj_get_gesture(gusture_obj) == false) return;
+	if (state->types.pointer.gesture_in_prog) return;
+
+	if ((LV_MATH_ABS(state->types.pointer.vect.x) < LV_INDEV_DEF_GESTURE_MIN_VELOCITY) &&
+		(LV_MATH_ABS(state->types.pointer.vect.y) < LV_INDEV_DEF_GESTURE_MIN_VELOCITY)) {
+		state->types.pointer.gesture_sum.x = 0;
+		state->types.pointer.gesture_sum.y = 0;
+	}
+
+	/*Count the movement by gesture*/
+	state->types.pointer.gesture_sum.x += state->types.pointer.vect.x;
+	state->types.pointer.gesture_sum.y += state->types.pointer.vect.y;
+
+	if ((LV_MATH_ABS(state->types.pointer.gesture_sum.x) > LV_INDEV_DEF_GESTURE_LIMIT) || (LV_MATH_ABS(state->types.pointer.gesture_sum.y) > LV_INDEV_DEF_GESTURE_LIMIT)){
+		state->types.pointer.gesture_in_prog = 1;
+	}
+}
+
+/**
+* Handle judge by gesture if the gesture is ended
+* @param indev pointer to an input device state
+*/
+static void indev_gesture_judge(lv_indev_proc_t * proc)
+{
+	if (proc->types.pointer.gesture_in_prog == 0) return;
+
+	lv_obj_t * gesture_obj = proc->types.pointer.last_obj;
+
+	/*If drag parent is active check recursively the drag_parent attribute*/
+	while (lv_obj_get_gesture_parent(gesture_obj) != false && gesture_obj != NULL) {
+		gesture_obj = lv_obj_get_parent(gesture_obj);
+	}
+
+	if (gesture_obj == NULL) {
+		return;
+	}
+
+	proc->types.pointer.gesture_in_prog = 0;
+
+	if (LV_MATH_ABS(proc->types.pointer.gesture_sum.x) > LV_MATH_ABS(proc->types.pointer.gesture_sum.y)){
+		if (proc->types.pointer.gesture_sum.x > 0)
+			proc->types.pointer.gesture_dir = LV_GESTURE_DIR_RIGHT;
+		else
+			proc->types.pointer.gesture_dir = LV_GESTURE_DIR_LEFT;
+	}
+	else{
+		if (proc->types.pointer.gesture_sum.y > 0)
+			proc->types.pointer.gesture_dir = LV_GESTURE_DIR_BOTTOM;
+		else
+			proc->types.pointer.gesture_dir = LV_GESTURE_DIR_TOP;
+	}
+
+	gesture_obj->signal_cb(gesture_obj, LV_SIGNAL_GESTURE, indev_act);
+	if (indev_reset_check(proc)) return;
+	lv_event_send(gesture_obj, LV_EVENT_GESTURE, NULL);
+	if (indev_reset_check(proc)) return;
+}
 /**
  * Checks if the reset_query flag has been set. If so, perform necessary global indev cleanup actions
  * @param proc pointer to an input device 'proc'

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1345,7 +1345,7 @@ static void indev_gesture(lv_indev_proc_t * proc)
 
 	lv_obj_t * gesture_obj = proc->types.pointer.act_obj;
 
-	/*If gusture parent is active check recursively the drag_parent attribute*/
+	/*If gesture parent is active check recursively the drag_parent attribute*/
 	while (lv_obj_get_gesture_parent(gesture_obj) != false && gesture_obj != NULL) {
 		gesture_obj = lv_obj_get_parent(gesture_obj);
 	}
@@ -1384,7 +1384,6 @@ static void indev_gesture(lv_indev_proc_t * proc)
 	    if (indev_reset_check(proc)) return;
 	    lv_event_send(gesture_obj, LV_EVENT_GESTURE, NULL);
 	    if (indev_reset_check(proc)) return;
-
 	}
 }
 

--- a/src/lv_core/lv_indev.h
+++ b/src/lv_core/lv_indev.h
@@ -105,6 +105,13 @@ void lv_indev_set_button_points(lv_indev_t * indev, const lv_point_t * points);
 void lv_indev_get_point(const lv_indev_t * indev, lv_point_t * point);
 
 /**
+* Get the current gesture direct
+* @param indev pointer to an input device
+* @return current gesture direct
+*/
+lv_gesture_dir_t lv_indev_get_gesture_dir(const lv_indev_t * indev);
+
+/**
  * Get the last pressed key of an input device (for LV_INDEV_TYPE_KEYPAD)
  * @param indev pointer to an input device
  * @return the last pressed key (0 on error)

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -218,7 +218,6 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->base_dir     = LV_BIDI_DIR_LTR;
 #endif
 
-        new_obj->gesture      = 0;
         new_obj->gesture_parent = 0;
         new_obj->reserved     = 0;
 
@@ -316,7 +315,6 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->opa_scale_en = 0;
         new_obj->parent_event = 0;
-        new_obj->gesture = 0;
         new_obj->gesture_parent = 1;
         new_obj->reserved     = 0;
 
@@ -368,7 +366,6 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale_en = copy->opa_scale_en;
         new_obj->protect      = copy->protect;
         new_obj->opa_scale    = copy->opa_scale;
-        new_obj->gesture = copy->gesture;
         new_obj->gesture_parent = copy->gesture_parent;
 
         new_obj->style_p = copy->style_p;
@@ -1359,17 +1356,6 @@ void lv_obj_set_drag_parent(lv_obj_t * obj, bool en)
 }
 
 /**
-* Enable the gesture of an object
-* @param obj pointer to an object
-* @param en true: make the object gesture
-*/
-void lv_obj_set_gesture(lv_obj_t * obj, bool en)
-{
-    if (en == true) lv_obj_set_click(obj, true); /*gesture is useless without enabled clicking*/
-    obj->gesture = (en == true ? 1 : 0);
-}
-
-/**
 * Enable to use parent for gesture related operations.
 * If trying to gesture the object the parent will be moved instead
 * @param obj pointer to an object
@@ -2149,16 +2135,6 @@ bool lv_obj_get_drag_throw(const lv_obj_t * obj)
 bool lv_obj_get_drag_parent(const lv_obj_t * obj)
 {
     return obj->drag_parent == 0 ? false : true;
-}
-
-/**
-* Get the gesture enable attribute of an object
-* @param obj pointer to an object
-* @return true: the object is gesture
-*/
-bool lv_obj_get_gesture(const lv_obj_t * obj)
-{
-    return obj->gesture == 0 ? false : true;
 }
 
 /**

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -218,6 +218,8 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->base_dir     = LV_BIDI_DIR_LTR;
 #endif
 
+	new_obj->gesture      = 0;
+	new_obj->gesture_parent = 0;
         new_obj->reserved     = 0;
 
         new_obj->ext_attr = NULL;
@@ -314,6 +316,8 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->opa_scale_en = 0;
         new_obj->parent_event = 0;
+	new_obj->gesture = 0;
+	new_obj->gesture_parent = 0;
         new_obj->reserved     = 0;
 
         new_obj->ext_attr = NULL;
@@ -364,6 +368,8 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale_en = copy->opa_scale_en;
         new_obj->protect      = copy->protect;
         new_obj->opa_scale    = copy->opa_scale;
+        new_obj->gesture = copy->gesture;
+        new_obj->gesture_parent = copy->gesture_parent;
 
         new_obj->style_p = copy->style_p;
 
@@ -1353,6 +1359,28 @@ void lv_obj_set_drag_parent(lv_obj_t * obj, bool en)
 }
 
 /**
+* Enable the gesture of an object
+* @param obj pointer to an object
+* @param en true: make the object gesture
+*/
+void lv_obj_set_gesture(lv_obj_t * obj, bool en)
+{
+    if (en == true) lv_obj_set_click(obj, true); /*gesture is useless without enabled clicking*/
+    obj->gesture = (en == true ? 1 : 0);
+}
+
+/**
+* Enable to use parent for gesture related operations.
+* If trying to gesture the object the parent will be moved instead
+* @param obj pointer to an object
+* @param en true: enable the 'gesture parent' for the object
+*/
+void lv_obj_set_gesture_parent(lv_obj_t * obj, bool en)
+{
+    obj->gesture_parent = (en == true ? 1 : 0);
+}
+
+/**
  * Propagate the events to the parent too
  * @param obj pointer to an object
  * @param en true: enable the event propagation
@@ -2121,6 +2149,26 @@ bool lv_obj_get_drag_throw(const lv_obj_t * obj)
 bool lv_obj_get_drag_parent(const lv_obj_t * obj)
 {
     return obj->drag_parent == 0 ? false : true;
+}
+
+/**
+* Get the gesture enable attribute of an object
+* @param obj pointer to an object
+* @return true: the object is gesture
+*/
+bool lv_obj_get_gesture(const lv_obj_t * obj)
+{
+    return obj->gesture == 0 ? false : true;
+}
+
+/**
+* Get the gesture parent attribute of an object
+* @param obj pointer to an object
+* @return true: gesture parent is enabled
+*/
+bool lv_obj_get_gesture_parent(const lv_obj_t * obj)
+{
+    return obj->gesture_parent == 0 ? false : true;
 }
 
 /**

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -218,8 +218,8 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->base_dir     = LV_BIDI_DIR_LTR;
 #endif
 
-	new_obj->gesture      = 0;
-	new_obj->gesture_parent = 0;
+        new_obj->gesture      = 0;
+        new_obj->gesture_parent = 0;
         new_obj->reserved     = 0;
 
         new_obj->ext_attr = NULL;
@@ -316,8 +316,8 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->opa_scale    = LV_OPA_COVER;
         new_obj->opa_scale_en = 0;
         new_obj->parent_event = 0;
-	new_obj->gesture = 0;
-	new_obj->gesture_parent = 0;
+        new_obj->gesture = 0;
+        new_obj->gesture_parent = 1;
         new_obj->reserved     = 0;
 
         new_obj->ext_attr = NULL;

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -877,19 +877,18 @@ bool lv_obj_get_drag_parent(const lv_obj_t * obj);
 bool lv_obj_get_gesture(const lv_obj_t * obj);
 
 /**
-* Get the gesture parent attribute of an object
-* @param obj pointer to an object
-* @return true: gesture parent is enabled
-*/
-bool lv_obj_get_gesture_parent(const lv_obj_t * obj);
-
-/**
  * Get the drag parent attribute of an object
  * @param obj pointer to an object
  * @return true: drag parent is enabled
  */
 bool lv_obj_get_parent_event(const lv_obj_t * obj);
 
+/**
+* Get the gesture parent attribute of an object
+* @param obj pointer to an object
+* @return true: gesture parent is enabled
+*/
+bool lv_obj_get_gesture_parent(const lv_obj_t * obj);
 
 lv_bidi_dir_t lv_obj_get_base_dir(const lv_obj_t * obj);
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -514,12 +514,12 @@ void lv_obj_set_drag_throw(lv_obj_t * obj, bool en);
 void lv_obj_set_drag_parent(lv_obj_t * obj, bool en);
 
 /**
-* Enable to use parent for gusture related operations.
-* If trying to gusture the object the parent will be moved instead
+* Enable to use parent for gesture related operations.
+* If trying to gesture the object the parent will be moved instead
 * @param obj pointer to an object
-* @param en true: enable the 'gusture parent' for the object
+* @param en true: enable the 'gesture parent' for the object
 */
-void lv_obj_set_gusture_parent(lv_obj_t * obj, bool en);
+void lv_obj_set_gesture_parent(lv_obj_t * obj, bool en);
 
 /**
  * Propagate the events to the parent too

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -94,6 +94,7 @@ enum {
     LV_EVENT_DRAG_BEGIN,		  
     LV_EVENT_DRAG_END,
     LV_EVENT_DRAG_THROW_BEGIN,
+    LV_EVENT_GESTURE,			/**< The object has been getture*/
     LV_EVENT_KEY,
     LV_EVENT_FOCUSED,
     LV_EVENT_DEFOCUSED,
@@ -137,6 +138,7 @@ enum {
     LV_SIGNAL_DRAG_BEGIN,	
     LV_SIGNAL_DRAG_THROW_BEGIN,
     LV_SIGNAL_DRAG_END,                                   
+    LV_SIGNAL_GESTURE,			/**< The object has been getture*/
 
     /*Group related*/
     LV_SIGNAL_FOCUS,
@@ -225,7 +227,9 @@ typedef struct _lv_obj_t
     uint8_t parent_event : 1;   /**< 1: Send the object's events to the parent too. */
     lv_drag_dir_t drag_dir : 3; /**<  Which directions the object can be dragged in */
     lv_bidi_dir_t base_dir : 2; /**< Base direction of texts related to this object */
-    uint8_t reserved : 3;       /**<  Reserved for future use*/
+    uint8_t gesture : 1;        /**< 1: Enable the gesture*/
+    uint8_t gesture_parent : 1; /**< 1: Parent will be gesture instead*/
+    uint8_t reserved : 1;       /**<  Reserved for future use*/
     uint8_t protect;            /**< Automatically happening actions can be prevented. 'OR'ed values from
                                    `lv_protect_t`*/
     lv_opa_t opa_scale;         /**< Scale down the opacity by this factor. Effects all children as well*/
@@ -509,6 +513,21 @@ void lv_obj_set_drag_throw(lv_obj_t * obj, bool en);
  * @param en true: enable the 'drag parent' for the object
  */
 void lv_obj_set_drag_parent(lv_obj_t * obj, bool en);
+
+/**
+* Enable the gusture of an object
+* @param obj pointer to an object
+* @param en true: make the object gusture
+*/
+void lv_obj_set_gusture(lv_obj_t * obj, bool en);
+
+/**
+* Enable to use parent for gusture related operations.
+* If trying to gusture the object the parent will be moved instead
+* @param obj pointer to an object
+* @param en true: enable the 'gusture parent' for the object
+*/
+void lv_obj_set_gusture_parent(lv_obj_t * obj, bool en);
 
 /**
  * Propagate the events to the parent too
@@ -849,6 +868,20 @@ bool lv_obj_get_drag_throw(const lv_obj_t * obj);
  * @return true: drag parent is enabled
  */
 bool lv_obj_get_drag_parent(const lv_obj_t * obj);
+
+/**
+* Get the gesture enable attribute of an object
+* @param obj pointer to an object
+* @return true: the object is gesture
+*/
+bool lv_obj_get_gesture(const lv_obj_t * obj);
+
+/**
+* Get the gesture parent attribute of an object
+* @param obj pointer to an object
+* @return true: gesture parent is enabled
+*/
+bool lv_obj_get_gesture_parent(const lv_obj_t * obj);
 
 /**
  * Get the drag parent attribute of an object

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -227,9 +227,8 @@ typedef struct _lv_obj_t
     uint8_t parent_event : 1;   /**< 1: Send the object's events to the parent too. */
     lv_drag_dir_t drag_dir : 3; /**<  Which directions the object can be dragged in */
     lv_bidi_dir_t base_dir : 2; /**< Base direction of texts related to this object */
-    uint8_t gesture : 1;        /**< 1: Enable the gesture*/
     uint8_t gesture_parent : 1; /**< 1: Parent will be gesture instead*/
-    uint8_t reserved : 1;       /**<  Reserved for future use*/
+    uint8_t reserved : 2;       /**<  Reserved for future use*/
     uint8_t protect;            /**< Automatically happening actions can be prevented. 'OR'ed values from
                                    `lv_protect_t`*/
     lv_opa_t opa_scale;         /**< Scale down the opacity by this factor. Effects all children as well*/
@@ -515,13 +514,6 @@ void lv_obj_set_drag_throw(lv_obj_t * obj, bool en);
 void lv_obj_set_drag_parent(lv_obj_t * obj, bool en);
 
 /**
-* Enable the gusture of an object
-* @param obj pointer to an object
-* @param en true: make the object gusture
-*/
-void lv_obj_set_gusture(lv_obj_t * obj, bool en);
-
-/**
 * Enable to use parent for gusture related operations.
 * If trying to gusture the object the parent will be moved instead
 * @param obj pointer to an object
@@ -536,7 +528,9 @@ void lv_obj_set_gusture_parent(lv_obj_t * obj, bool en);
  */
 void lv_obj_set_parent_event(lv_obj_t * obj, bool en);
 
+
 void lv_obj_set_base_dir(lv_obj_t * obj, lv_bidi_dir_t dir);
+
 /**
  * Set the opa scale enable parameter (required to set opa_scale with `lv_obj_set_opa_scale()`)
  * @param obj pointer to an object
@@ -868,13 +862,6 @@ bool lv_obj_get_drag_throw(const lv_obj_t * obj);
  * @return true: drag parent is enabled
  */
 bool lv_obj_get_drag_parent(const lv_obj_t * obj);
-
-/**
-* Get the gesture enable attribute of an object
-* @param obj pointer to an object
-* @return true: the object is gesture
-*/
-bool lv_obj_get_gesture(const lv_obj_t * obj);
 
 /**
  * Get the drag parent attribute of an object

--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -107,8 +107,8 @@ static void get_rounded_area(int16_t angle, lv_coord_t radius, uint8_t tickness,
     const uint8_t ps = 8;
     const uint8_t pa = 127;
 
-    lv_coord_t thick_half = tickness / 2;
-    lv_coord_t thick_corr = tickness & 0x01 ? 0 : 1;
+    int32_t thick_half = tickness / 2;
+    int32_t thick_corr = tickness & 0x01 ? 0 : 1;
 
     lv_coord_t rx_corr;
     lv_coord_t ry_corr;
@@ -119,8 +119,8 @@ static void get_rounded_area(int16_t angle, lv_coord_t radius, uint8_t tickness,
     if(angle > 0 && angle < 180) ry_corr = 0;
     else  ry_corr = 0;
 
-    lv_coord_t cir_x;
-    lv_coord_t cir_y;
+    int32_t cir_x;
+    int32_t cir_y;
 
     cir_x = ((radius - rx_corr - thick_half) * lv_trigo_sin(90 - angle)) >> (LV_TRIGO_SHIFT - ps);
     cir_y = ((radius - ry_corr - thick_half) * lv_trigo_sin(angle)) >> (LV_TRIGO_SHIFT - ps);

--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -108,7 +108,7 @@ static void get_rounded_area(int16_t angle, lv_coord_t radius, uint8_t tickness,
     const uint8_t pa = 127;
 
     int32_t thick_half = tickness / 2;
-    int32_t thick_corr = tickness & 0x01 ? 0 : 1;
+    uint8_t thick_corr = tickness & 0x01 ? 0 : 1;
 
     lv_coord_t rx_corr;
     lv_coord_t ry_corr;

--- a/src/lv_hal/lv_hal_indev.c
+++ b/src/lv_hal/lv_hal_indev.c
@@ -53,11 +53,13 @@ void lv_indev_drv_init(lv_indev_drv_t * driver)
 {
     memset(driver, 0, sizeof(lv_indev_drv_t));
 
-    driver->type                = LV_INDEV_TYPE_NONE;
-    driver->drag_limit          = LV_INDEV_DEF_DRAG_LIMIT;
-    driver->drag_throw          = LV_INDEV_DEF_DRAG_THROW;
-    driver->long_press_time     = LV_INDEV_DEF_LONG_PRESS_TIME;
-    driver->long_press_rep_time = LV_INDEV_DEF_LONG_PRESS_REP_TIME;
+    driver->type                 = LV_INDEV_TYPE_NONE;
+    driver->drag_limit           = LV_INDEV_DEF_DRAG_LIMIT;
+    driver->drag_throw           = LV_INDEV_DEF_DRAG_THROW;
+    driver->long_press_time      = LV_INDEV_DEF_LONG_PRESS_TIME;
+    driver->long_press_rep_time  = LV_INDEV_DEF_LONG_PRESS_REP_TIME;
+    driver->gesture_limit        = LV_INDEV_DEF_GESTURE_LIMIT;
+    driver->gesture_min_velocity = LV_INDEV_DEF_GESTURE_MIN_VELOCITY;
 }
 
 /**

--- a/src/lv_hal/lv_hal_indev.h
+++ b/src/lv_hal/lv_hal_indev.h
@@ -65,6 +65,13 @@ enum {
 
 typedef uint8_t lv_drag_dir_t;
 
+enum {
+	LV_GESTURE_DIR_TOP,		/**< Gesture dir up. */
+	LV_GESTURE_DIR_BOTTOM,	/**< Gesture dir down. */
+	LV_GESTURE_DIR_LEFT,	/**< Gesture dir left. */
+	LV_GESTURE_DIR_RIGHT,	/**< Gesture dir right. */
+};
+typedef uint8_t lv_gesture_dir_t;
 
 /** Data structure passed to an input driver to fill */
 typedef struct
@@ -137,10 +144,13 @@ typedef struct _lv_indev_proc_t
                                                 other post-release event)*/
             struct _lv_obj_t * last_pressed; /*The lastly pressed object*/
 
+	    lv_gesture_dir_t gesture_dir;
+	    lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
             /*Flags*/
             uint8_t drag_limit_out : 1;
             uint8_t drag_in_prog : 1;
             lv_drag_dir_t drag_dir  : 3;
+	    uint8_t gesture_in_prog : 1;
         } pointer;
         struct
         { /*Keypad data*/

--- a/src/lv_hal/lv_hal_indev.h
+++ b/src/lv_hal/lv_hal_indev.h
@@ -150,7 +150,7 @@ typedef struct _lv_indev_proc_t
             uint8_t drag_limit_out : 1;
             uint8_t drag_in_prog : 1;
             lv_drag_dir_t drag_dir  : 3;
-	    uint8_t gesture_in_prog : 1;
+	    uint8_t gesture_sent : 1;
         } pointer;
         struct
         { /*Keypad data*/

--- a/src/lv_hal/lv_hal_indev.h
+++ b/src/lv_hal/lv_hal_indev.h
@@ -117,6 +117,12 @@ typedef struct _lv_indev_drv_t
     /**< Drag throw slow-down in [%]. Greater value means faster slow-down */
     uint8_t drag_throw;
 
+    /**< At least this difference should between two points to evaluate as gesture */
+    uint8_t gesture_min_velocity;
+
+    /**< At least this difference should be to send a gesture */
+    uint8_t gesture_limit;
+
     /**< Long press time in milliseconds*/
     uint16_t long_press_time;
 


### PR DESCRIPTION
Recently I have been busy porting littlevgl to stm32l4 and a few other things. Sorry for not coming and submitting the code.
1.add gesture event and use the sample:

```
...
lv_obj_t *obj = lv_obj_create(lv_disp_get_scr_act(NULL), NULL);
lv_obj_set_gusture(obj, true);
lv_obj_set_event_cb(obj , event_cb);
...
void event_cb(lv_obj_t * obj, lv_event_t event)
{
	lv_indev_t * pIndev = lv_indev_get_act();
	if (pIndev == NULL)
		return;

	switch (event){
	case LV_EVENT_GESTURE:{
                      lv_gesture_dir_t gesture_dir = lv_indev_get_gesture_dir(pIndev);
                      switch(gesture_dir ){
                      case 	LV_GESTURE_DIR_TOP:		/**< Gesture dir up. */
                          /*on led 1*/
                      break;
                      case 	LV_GESTURE_DIR_BOTTOM:	/**< Gesture dir down. */
                          /*on led 2*/
                      break;
                      case 	LV_GESTURE_DIR_LEFT:	/**< Gesture dir left. */
                          /*on led 3*/
                      break;
                      case 	LV_GESTURE_DIR_RIGHT:	/**< Gesture dir right. */
                          /*on led 4*/
                      break;
                     }
                }
		break;
	}
}
```
2.fixed draw arc round bug:in function
`static void get_rounded_area(int16_t angle, lv_coord_t radius, uint8_t tickness, lv_area_t * res_area);`
```
    lv_coord_tcir_x;
    lv_coord_tcir_y;

    cir_x = ((radius - rx_corr - thick_half) * lv_trigo_sin(90 - angle)) >> (LV_TRIGO_SHIFT - ps);
    cir_y = ((radius - ry_corr - thick_half) * lv_trigo_sin(angle)) >> (LV_TRIGO_SHIFT - ps);
```
Data of type lv_coord_t will overflow during calculation and be modified to int32_t;