### PR TITLE
Spinbox object - Cursor need shift to left after merge pull request #1220

### DIFF
--- a/src/lv_objx/lv_spinbox.c
+++ b/src/lv_objx/lv_spinbox.c
@@ -405,11 +405,15 @@ static void lv_spinbox_updatevalue(lv_obj_t * spinbox)
     char buf[LV_SPINBOX_MAX_DIGIT_COUNT + 8];
     memset(buf, 0, sizeof(buf));
     char * buf_p = buf;
+    uint8_t cur_shift_left = 0;
 
     if (ext->range_min < 0) { // hide sign if there are only positive values
         /*Add the sign*/
         (*buf_p) = ext->value >= 0 ? '+' : '-';
         buf_p++;
+    } else {
+    	/*Cursor need shift to left*/
+    	cur_shift_left++;
     }
 
     int32_t i;
@@ -467,7 +471,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * spinbox)
 
     if(cur_pos > intDigits) cur_pos++; /*Skip teh decimal point*/
 
-    cur_pos += ext->digit_padding_left;
+    cur_pos += (ext->digit_padding_left - cur_shift_left);
 
     lv_ta_set_cursor_pos(spinbox, cur_pos);
 }


### PR DESCRIPTION
The cursor position is incorrect when the character is hidden. When sign is hidden, we need shift cursor to the left.

Example code:
I was used encoder to skipt to next cursor position
```
    obj = lv_spinbox_create(win, NULL);
    lv_obj_set_event_cb(obj, general_event_handler);
    lv_spinbox_set_digit_format(obj, 3, 0);
    lv_spinbox_set_range(obj, 20,800);
    lv_spinbox_set_step(obj,10);
    lv_spinbox_set_value(obj, 320);
```

