### PR TITLE
disable warning of unused param

### DIFF
--- a/src/lv_draw/lv_draw_label.c
+++ b/src/lv_draw/lv_draw_label.c
@@ -179,6 +179,7 @@ void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, const lv_st
         char *bidi_txt = lv_draw_get_buf(line_end - line_start + 1);
         lv_bidi_process_paragraph(txt + line_start, bidi_txt, line_end - line_start, bidi_dir, NULL, 0);
 #else
+        (void)bidir_dir;
         const char *bidi_txt = txt + line_start;
 #endif
 


### PR DESCRIPTION
If `LV_USE_BIDI` is not defined, than `bidi_dir` is not used and compiler generate warning.