### PR TITLE
lv_btnm make individual buttons use focus style mod

### DIFF
--- a/src/lv_objx/lv_btnm.c
+++ b/src/lv_objx/lv_btnm.c
@@ -913,7 +913,10 @@ static lv_res_t lv_btnm_signal(lv_obj_t * btnm, lv_signal_t sign, void * param)
                 res        = lv_event_send(btnm, LV_EVENT_VALUE_CHANGED, &b);
             }
         }
-    } else if(sign == LV_SIGNAL_PRESS_LOST || sign == LV_SIGNAL_DEFOCUS) {
+    } else if(sign == LV_SIGNAL_PRESS_LOST) {
+        ext->btn_id_pr  = LV_BTNM_BTN_NONE;
+        invalidate_button_area(btnm, ext->btn_id_act);
+    } else if(sign == LV_SIGNAL_DEFOCUS) {
         ext->btn_id_pr  = LV_BTNM_BTN_NONE;
 #if LV_USE_GROUP
         /*Restore style mod cb to group*/

--- a/src/lv_objx/lv_btnm.h
+++ b/src/lv_objx/lv_btnm.h
@@ -56,14 +56,11 @@ typedef struct
     uint16_t btn_cnt;                                 /*Number of button in 'map_p'(Handled by the library)*/
     uint16_t btn_id_pr;                               /*Index of the currently pressed button or LV_BTNM_BTN_NONE*/
     uint16_t btn_id_act;    /*Index of the active button (being pressed/released etc) or LV_BTNM_BTN_NONE */
+    uint8_t recolor : 1;    /*Enable button recoloring*/
+    uint8_t one_toggle : 1; /*Single button toggled at once*/
 #if LV_USE_GROUP
-    uint8_t recolor : 1,    /*Enable button recoloring*/
-            one_toggle : 1, /*Single button toggled at once*/
-            act_style : 1;  /*Enable style mod for last active button*/
+    uint8_t act_style : 1;                            /*Enable style mod for last active button*/
     lv_group_style_mod_cb_t style_mod_cb;             /*Style mod cb for focusing buttons*/
-#else
-    uint8_t recolor : 1,    /*Enable button recoloring*/
-            one_toggle : 1; /*Single button toggled at once*/
 #endif
 } lv_btnm_ext_t;
 

--- a/src/lv_objx/lv_btnm.h
+++ b/src/lv_objx/lv_btnm.h
@@ -56,8 +56,15 @@ typedef struct
     uint16_t btn_cnt;                                 /*Number of button in 'map_p'(Handled by the library)*/
     uint16_t btn_id_pr;                               /*Index of the currently pressed button or LV_BTNM_BTN_NONE*/
     uint16_t btn_id_act;    /*Index of the active button (being pressed/released etc) or LV_BTNM_BTN_NONE */
-    uint8_t recolor : 1;    /*Enable button recoloring*/
-    uint8_t one_toggle : 1; /*Single button toggled at once*/
+#if LV_USE_GROUP
+    uint8_t recolor : 1,    /*Enable button recoloring*/
+            one_toggle : 1, /*Single button toggled at once*/
+            act_style : 1;  /*Enable style mod for last active button*/
+    lv_group_style_mod_cb_t style_mod_cb;             /*Style mod cb for focusing buttons*/
+#else
+    uint8_t recolor : 1,    /*Enable button recoloring*/
+            one_toggle : 1; /*Single button toggled at once*/
+#endif
 } lv_btnm_ext_t;
 
 enum {


### PR DESCRIPTION
The old way of highlighting the active button with the button pressed style means there is no actual click feedback for keypad users. The group focus style mod is also applied to the whole button matrix, which muddles with the button matrix's style of its own.

This change makes click feedback for keypad users possible, and also doesn't interfere with the button matrix's overall style.