### PR TITLE
Uninitialized pointer

### DIFF
--- a/src/lv_hal/lv_hal_disp.c
+++ b/src/lv_hal/lv_hal_disp.c
@@ -37,7 +37,7 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_disp_t * disp_def;
+static lv_disp_t * disp_def = NULL;
 
 /**********************
  *      MACROS


### PR DESCRIPTION
The disp_def pointer is used in lv_disp_drv_register line 131 without being sure that it is correctly initialized at startup.