### PR TITLE
[7.0] Fix some warnings

### DIFF
--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -1007,126 +1007,86 @@ lv_opa_t _lv_obj_get_style_opa(const lv_obj_t * obj, uint8_t part, lv_style_prop
  */
 const void * _lv_obj_get_style_ptr(const lv_obj_t * obj, uint8_t part, lv_style_property_t prop);
 
-/**
- * Macro to declare the most important style set/get API functions.
- *
- * - Get the value of a style property from an object in the object's current state.
- *   If there is a transition animation in progress calculate the value accordingly.
- *   If the property is not set in the object's style check the parent(s) if the property can be inherited
- *   If still not found return a default value.
- *   For example:
- *      `lv_obj_get_style_border_width(btn1, LV_BTN_PART_MAIN);`
- *
- * - Set a local style property for an object in a given state
- *   For example:
- *      `lv_obj_set_style_border_width(btn1, LV_BTN_PART_MAIN, LV_STATE_PRESSED, 2);`
- *
- *  - Get the value from a style in a given state:
- *    For example
- *      `int16_t weight = lv_style_get_border_width(&style1, LV_STATE_PRESSED, &result);`
- *      `if(weight > 0) ...the property is found and loaded into result...`
- *
- *  - Set a value in a style in a given state
- *     For example
- *       `lv_style_set_border_width(&style1, LV_STATE_PRESSED, 2);`
- */
+#include "lv_obj_style_dec.h"
 
-#define _LV_OBJ_STYLE_SET_GET_DECLARE(prop_name, func_name, value_type, style_type)          \
-static inline value_type lv_obj_get_style_##func_name (const lv_obj_t * obj, uint8_t part)  \
-{                                                                                           \
-    return (value_type) _lv_obj_get_style##style_type (obj, part, LV_STYLE_##prop_name);     \
-}                                                                                           \
-static inline void lv_obj_set_style_##func_name (lv_obj_t * obj, uint8_t part, lv_state_t state, value_type value)  \
-{                                                                                           \
-    _lv_obj_set_style##style_type (obj, part, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), value);                  \
-}                                                                                           \
-static inline int16_t lv_style_get_##func_name (lv_style_t * style, lv_state_t state, void * res)             \
-{                                                                                           \
-    return _lv_style_get##style_type (style, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), res);                     \
-}                                                                                           \
-static inline void lv_style_set_##func_name (lv_style_t * style, lv_state_t state, value_type value)          \
-{                                                                                           \
-    _lv_style_set##style_type (style, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), value);                          \
-}                                                                                           \
-
-_LV_OBJ_STYLE_SET_GET_DECLARE(RADIUS, radius, lv_style_int_t,_int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(CLIP_CORNER, clip_corner, bool, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TRANSITION_TIME, transition_time, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SIZE, size, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OPA_SCALE, opa_scale, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_TOP, pad_top, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_BOTTOM, pad_bottom, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_LEFT, pad_left, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_RIGHT, pad_right, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_INNER, pad_inner, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_BLEND_MODE, bg_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_MAIN_STOP, bg_main_stop, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_STOP, bg_grad_stop, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_DIR, bg_grad_dir, lv_grad_dir_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_COLOR, bg_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_COLOR, bg_grad_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BG_OPA, bg_opa, lv_opa_t , _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_WIDTH, border_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_SIDE, border_side, lv_border_side_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_BLEND_MODE, border_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_POST, border_post, bool, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_COLOR, border_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_OPA, border_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_WIDTH, outline_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_PAD, outline_pad, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_BLEND_MODE, outline_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_COLOR, outline_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_OPA, outline_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_WIDTH, shadow_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OFFSET_X, shadow_offset_x, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OFFSET_Y, shadow_offset_y, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_SPREAD, shadow_spread, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_BLEND_MODE, shadow_blend_mode, lv_blend_mode_t, _int );
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_COLOR, shadow_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OPA, shadow_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_REPEAT, pattern_repeat, bool, _int );
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_BLEND_MODE, pattern_blend_mode, lv_blend_mode_t, _int );
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_RECOLOR, pattern_recolor, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_OPA, pattern_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_RECOLOR_OPA, pattern_recolor_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_IMAGE, pattern_image, const void *, _ptr);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_LETTER_SPACE, value_letter_space, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_LINE_SPACE, value_line_space, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_BLEND_MODE, value_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OFS_X, value_ofs_x, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OFS_Y, value_ofs_y, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_ALIGN, value_align, lv_align_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_COLOR, value_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OPA, value_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_FONT, value_font, const lv_font_t * , _ptr);
-_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_STR, value_str, const char * , _ptr);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_LETTER_SPACE, text_letter_space, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_LINE_SPACE, text_line_space, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_UNDERLINE, text_underline, bool, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_STRIKETHROUGH, text_strikethrough, bool, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_BLEND_MODE, text_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_COLOR, text_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_SEL_COLOR, text_sel_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_OPA, text_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_FONT, text_font, const lv_font_t * , _ptr);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_WIDTH, line_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_BLEND_MODE, line_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_DASH_WIDTH, line_dash_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_DASH_GAP, line_dash_gap, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_ROUNDED, line_rounded, bool, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_COLOR, line_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_OPA, line_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_BLEND_MODE, image_blend_mode, lv_blend_mode_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_RECOLOR, image_recolor, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_OPA, image_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_RECOLOR_OPA, image_recolor_opa, lv_opa_t, _opa);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_WIDTH, scale_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_BORDER_WIDTH, scale_border_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_BORDER_WIDTH, scale_end_border_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_LINE_WIDTH, scale_end_line_width, lv_style_int_t, _int);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_COLOR, scale_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_GRAD_COLOR, scale_grad_color, lv_color_t, _color);
-_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_COLOR, scale_end_color, lv_color_t, _color);
+_LV_OBJ_STYLE_SET_GET_DECLARE(RADIUS, radius, lv_style_int_t,_int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(CLIP_CORNER, clip_corner, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TRANSITION_TIME, transition_time, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SIZE, size, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OPA_SCALE, opa_scale, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_TOP, pad_top, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_BOTTOM, pad_bottom, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_LEFT, pad_left, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_RIGHT, pad_right, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PAD_INNER, pad_inner, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_BLEND_MODE, bg_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_MAIN_STOP, bg_main_stop, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_STOP, bg_grad_stop, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_DIR, bg_grad_dir, lv_grad_dir_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_COLOR, bg_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_GRAD_COLOR, bg_grad_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BG_OPA, bg_opa, lv_opa_t , _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_WIDTH, border_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_SIDE, border_side, lv_border_side_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_BLEND_MODE, border_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_POST, border_post, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_COLOR, border_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(BORDER_OPA, border_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_WIDTH, outline_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_PAD, outline_pad, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_BLEND_MODE, outline_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_COLOR, outline_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(OUTLINE_OPA, outline_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_WIDTH, shadow_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OFFSET_X, shadow_offset_x, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OFFSET_Y, shadow_offset_y, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_SPREAD, shadow_spread, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_BLEND_MODE, shadow_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_COLOR, shadow_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SHADOW_OPA, shadow_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_REPEAT, pattern_repeat, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_BLEND_MODE, pattern_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_RECOLOR, pattern_recolor, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_OPA, pattern_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_RECOLOR_OPA, pattern_recolor_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(PATTERN_IMAGE, pattern_image, const void *, _ptr, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_LETTER_SPACE, value_letter_space, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_LINE_SPACE, value_line_space, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_BLEND_MODE, value_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OFS_X, value_ofs_x, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OFS_Y, value_ofs_y, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_ALIGN, value_align, lv_align_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_COLOR, value_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_OPA, value_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_FONT, value_font, const lv_font_t * , _ptr, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(VALUE_STR, value_str, const char * , _ptr, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_LETTER_SPACE, text_letter_space, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_LINE_SPACE, text_line_space, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_UNDERLINE, text_underline, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_STRIKETHROUGH, text_strikethrough, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_BLEND_MODE, text_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_COLOR, text_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_SEL_COLOR, text_sel_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_OPA, text_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(TEXT_FONT, text_font, const lv_font_t * , _ptr, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_WIDTH, line_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_BLEND_MODE, line_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_DASH_WIDTH, line_dash_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_DASH_GAP, line_dash_gap, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_ROUNDED, line_rounded, bool, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_COLOR, line_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(LINE_OPA, line_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_BLEND_MODE, image_blend_mode, lv_blend_mode_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_RECOLOR, image_recolor, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_OPA, image_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(IMAGE_RECOLOR_OPA, image_recolor_opa, lv_opa_t, _opa, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_WIDTH, scale_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_BORDER_WIDTH, scale_border_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_BORDER_WIDTH, scale_end_border_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_LINE_WIDTH, scale_end_line_width, lv_style_int_t, _int, scalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_COLOR, scale_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_GRAD_COLOR, scale_grad_color, lv_color_t, _color, nonscalar)
+_LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_COLOR, scale_end_color, lv_color_t, _color, nonscalar)
 
 #undef _LV_OBJ_STYLE_SET_GET_DECLARE
 /*-----------------

--- a/src/lv_core/lv_obj_style_dec.h
+++ b/src/lv_core/lv_obj_style_dec.h
@@ -1,0 +1,74 @@
+
+/**
+ * @file lv_obj_style_dec.h
+ *
+ */
+
+#ifndef LV_OBJ_STYLE_DEC_H
+#define LV_OBJ_STYLE_DEC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**
+ * Macro to declare the most important style set/get API functions.
+ *
+ * - Get the value of a style property from an object in the object's current state.
+ *   If there is a transition animation in progress calculate the value accordingly.
+ *   If the property is not set in the object's style check the parent(s) if the property can be inherited
+ *   If still not found return a default value.
+ *   For example:
+ *      `lv_obj_get_style_border_width(btn1, LV_BTN_PART_MAIN);`
+ *
+ * - Set a local style property for an object in a given state
+ *   For example:
+ *      `lv_obj_set_style_border_width(btn1, LV_BTN_PART_MAIN, LV_STATE_PRESSED, 2);`
+ *
+ *  - Get the value from a style in a given state:
+ *    For example
+ *      `int16_t weight = lv_style_get_border_width(&style1, LV_STATE_PRESSED, &result);`
+ *      `if(weight > 0) ...the property is found and loaded into result...`
+ *
+ *  - Set a value in a style in a given state
+ *     For example
+ *       `lv_style_set_border_width(&style1, LV_STATE_PRESSED, 2);`
+ */
+
+
+#define _LV_OBJ_STYLE_DECLARE_GET_scalar(prop_name, func_name, value_type, style_type) \
+static inline value_type lv_obj_get_style_##func_name (const lv_obj_t * obj, uint8_t part)  \
+{                                                                                           \
+    return (value_type) _lv_obj_get_style##style_type (obj, part, LV_STYLE_##prop_name);     \
+}
+
+#define _LV_OBJ_STYLE_DECLARE_GET_nonscalar(prop_name, func_name, value_type, style_type) \
+static inline value_type lv_obj_get_style_##func_name (const lv_obj_t * obj, uint8_t part)  \
+{                                                                                           \
+    return _lv_obj_get_style##style_type (obj, part, LV_STYLE_##prop_name);     \
+}
+
+#define _LV_OBJ_STYLE_SET_GET_DECLARE(prop_name, func_name, value_type, style_type, scalar)          \
+_LV_OBJ_STYLE_DECLARE_GET_##scalar(prop_name, func_name, value_type, style_type) \
+static inline void lv_obj_set_style_##func_name (lv_obj_t * obj, uint8_t part, lv_state_t state, value_type value)  \
+{                                                                                           \
+    _lv_obj_set_style##style_type (obj, part, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), value);                  \
+}                                                                                           \
+static inline int16_t lv_style_get_##func_name (lv_style_t * style, lv_state_t state, void * res)             \
+{                                                                                           \
+    return _lv_style_get##style_type (style, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), res);                     \
+}                                                                                           \
+static inline void lv_style_set_##func_name (lv_style_t * style, lv_state_t state, value_type value)          \
+{                                                                                           \
+    _lv_style_set##style_type (style, LV_STYLE_##prop_name | (state << LV_STYLE_STATE_POS), value);                          \
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /*LV_OBJ_H*/

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -471,8 +471,9 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
  *         Higher number is means better fit
  *         -1 if the not found (`res` will be undefined)
  */
-int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, lv_style_int_t * res)
+int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, void * v_res)
 {
+    lv_style_int_t * res = (lv_style_int_t *)v_res;
     LV_ASSERT_STYLE(style);
 
     if(style == NULL) return -1;
@@ -505,8 +506,9 @@ int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, lv
  *       For example: `lv_style_get_border_opa()`
  * @note for performance reasons it's not checked if the property really has opacity type
  */
-int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, lv_opa_t * res)
+int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, void * v_res)
 {
+    lv_opa_t * res = (lv_opa_t *)v_res;
     LV_ASSERT_STYLE(style);
 
     if(style == NULL) return -1;
@@ -539,8 +541,9 @@ int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, lv
  *       For example: `lv_style_get_border_color()`
  * @note for performance reasons it's not checked if the property really has color type
  */
-int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, lv_color_t * res)
+int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, void * v_res)
 {
+    lv_color_t * res = (lv_color_t *)v_res;
     if(style == NULL) return -1;
     if(style->map == NULL) return -1;
     int32_t id = get_property_index(style, prop);
@@ -571,8 +574,9 @@ int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, 
  *       For example: `lv_style_get_text_font()`
  * @note for performance reasons it's not checked if the property really has pointer type
  */
-int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, void ** res)
+int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, void * v_res)
 {
+    void **res = (void *)v_res;
     if(style == NULL) return -1;
     if(style->map == NULL) return -1;
     int32_t id = get_property_index(style, prop);

--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -239,7 +239,7 @@ void lv_style_list_add_style(lv_style_list_t * list, lv_style_t * style);
  * @param style_list pointer to a style list
  * @param style pointer to a style to remove
  */
-void lv_style_list_remove_style(lv_style_list_t * list, lv_style_t * class);
+void lv_style_list_remove_style(lv_style_list_t *, lv_style_t *);
 
 /**
  * Remove all styles added from style list, clear the local style and free all allocated memories
@@ -335,7 +335,7 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
  *       For example: `lv_style_get_border_width()`
  * @note for performance reasons it's not checked if the property really has integer type
  */
-int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, lv_style_int_t * res);
+int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, void * res);
 
 /**
  * Get a color typed property from a style.
@@ -350,7 +350,7 @@ int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, lv
  *       For example: `lv_style_get_border_color()`
  * @note for performance reasons it's not checked if the property really has color type
  */
-int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, lv_color_t * res);
+int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, void * res);
 
 /**
  * Get an opacity typed property from a style.
@@ -365,7 +365,7 @@ int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, 
  *       For example: `lv_style_get_border_opa()`
  * @note for performance reasons it's not checked if the property really has opacity type
  */
-int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, lv_opa_t * res);
+int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, void * res);
 
 /**
  * Get a pointer typed property from a style.
@@ -380,7 +380,7 @@ int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, lv
  *       For example: `lv_style_get_text_font()`
  * @note for performance reasons it's not checked if the property really has pointer type
  */
-int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, void ** res);
+int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, void * res);
 
 /**
  * Set a local integer typed property in a style list.

--- a/src/lv_misc/lv_mem.c
+++ b/src/lv_misc/lv_mem.c
@@ -353,6 +353,7 @@ void lv_mem_defrag(void)
 
 lv_res_t lv_mem_test(void)
 {
+#if LV_MEM_CUSTOM == 0
     lv_mem_ent_t * e;
     e = ent_get_next(NULL);
     while(e) {
@@ -362,7 +363,7 @@ lv_res_t lv_mem_test(void)
         }
         e = ent_get_next(e);
     }
-
+#endif
     return LV_RES_OK;
 }
 

--- a/src/lv_widgets/lv_btnmatrix.c
+++ b/src/lv_widgets/lv_btnmatrix.c
@@ -799,12 +799,15 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
             /*Search the pressed area*/
             lv_indev_get_point(param, &p);
             btn_pr = get_button_from_point(btnm, &p);
-            if(button_is_inactive(ext->ctrl_bits[btn_pr]) == false &&
-               button_is_hidden(ext->ctrl_bits[btn_pr]) == false) {
-                invalidate_button_area(btnm, ext->btn_id_pr) /*Invalidate the old area*/;
-                ext->btn_id_pr = btn_pr;
-                ext->btn_id_act = btn_pr;
-                invalidate_button_area(btnm, ext->btn_id_pr); /*Invalidate the new area*/
+            /*Handle the case where there is no button there*/
+            if(btn_pr != LV_BTNMATRIX_BTN_NONE) {
+                if(button_is_inactive(ext->ctrl_bits[btn_pr]) == false &&
+                button_is_hidden(ext->ctrl_bits[btn_pr]) == false) {
+                    invalidate_button_area(btnm, ext->btn_id_pr) /*Invalidate the old area*/;
+                    ext->btn_id_pr = btn_pr;
+                    ext->btn_id_act = btn_pr;
+                    invalidate_button_area(btnm, ext->btn_id_pr); /*Invalidate the new area*/
+                }
             }
         }
 #if LV_USE_GROUP
@@ -827,15 +830,16 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
         /*Search the pressed area*/
         lv_indev_get_point(param, &p);
         btn_pr = get_button_from_point(btnm, &p);
-        /*Invalidate to old and the new areas*/;
-        if(btn_pr != ext->btn_id_pr &&
-                button_is_inactive(ext->ctrl_bits[btn_pr]) == false &&
-                button_is_hidden(ext->ctrl_bits[btn_pr]) == false) {
-            lv_indev_reset_long_press(param); /*Start the log press time again on the new button*/
+        /*Invalidate to old and the new areas*/
+        if(btn_pr != ext->btn_id_pr) {
             if(ext->btn_id_pr != LV_BTNMATRIX_BTN_NONE) {
                 invalidate_button_area(btnm, ext->btn_id_pr);
             }
-            if(btn_pr != LV_BTNMATRIX_BTN_NONE) {
+            lv_indev_reset_long_press(param); /*Start the log press time again on the new button*/
+            if(btn_pr != LV_BTNMATRIX_BTN_NONE &&
+               button_is_inactive(ext->ctrl_bits[btn_pr]) == false &&
+               button_is_hidden(ext->ctrl_bits[btn_pr]) == false) {
+                /* Send VALUE_CHANGED for the newly pressed button */
                 uint32_t b = ext->btn_id_act;
                 res        = lv_event_send(btnm, LV_EVENT_VALUE_CHANGED, &b);
                 if(res == LV_RES_OK) {

--- a/src/lv_widgets/lv_roller.c
+++ b/src/lv_widgets/lv_roller.c
@@ -434,7 +434,7 @@ static lv_design_res_t lv_roller_design(lv_obj_t * roller, const lv_area_t * cli
  */
 static lv_res_t lv_roller_signal(lv_obj_t * roller, lv_signal_t sign, void * param)
 {
-    lv_res_t res;
+    lv_res_t res = LV_RES_OK;
     if(sign == LV_SIGNAL_GET_STYLE) {
         lv_get_style_info_t * info = param;
         info->result = lv_roller_get_style(roller, info->part);


### PR DESCRIPTION
For trivial fixes (i.e. a missing cast) I typically just commit directly to `dev-7.0`, but I wanted to get your feedback on this changeset.

Because the diff is a bit unwieldy, I'll try to summarize it below:

* The trailing semicolons were removed on the `_LV_OBJ_STYLE_SET_GET_DECLARE` lines. They aren't necessary and ISO C doesn't allow them.
* I split the definition of `_LV_OBJ_STYLE_SET_GET_DECLARE` out into a separate file to make it more manageable.
* I modified `_LV_OBJ_STYLE_SET_GET_DECLARE` to take an extra parameter that describes whether the value type is scalar or not. ISO C forbids casting of scalar types (even to themselves) so this unfortunately ugly hack seems to be necessary. 
* I changed all the `_lv_style_get_` functions to use `void *` for their type. Again, this was quite ugly, but C++ doesn't allow implicit casting of `void *`, so I either had to do that or add yet another parameter to `_LV_OBJ_STYLE_SET_GET_DECLARE` to be able to use an explicit cast. I chose the former for simplicity, because it doesn't appear that the `_lv_style_get` are intended for consumption by anything other than the macro.
* Lastly, `lv_mem_test` will always succeed if `LV_MEM_CUSTOM == 1` (because the necessary size information isn't available). 
