### PR TITLE
Added overflow check while calculating label height

### DIFF
--- a/src/lv_misc/lv_math.h
+++ b/src/lv_misc/lv_math.h
@@ -22,6 +22,11 @@ extern "C" {
 #define LV_MATH_MAX(a, b) ((a) > (b) ? (a) : (b))
 #define LV_MATH_ABS(x) ((x) > 0 ? (x) : (-(x)))
 
+#define LV_IS_SIGNED(t) (((t)(-1)) < ((t) 0))
+#define LV_UMAX_OF(t) (((0x1ULL << ((sizeof(t) * 8ULL) - 1ULL)) - 1ULL) | (0xFULL << ((sizeof(t) * 8ULL) - 4ULL)))
+#define LV_SMAX_OF(t) (((0x1ULL << ((sizeof(t) * 8ULL) - 1ULL)) - 1ULL) | (0x7ULL << ((sizeof(t) * 8ULL) - 4ULL)))
+#define LV_MAX_OF(t) ((unsigned long) (LV_IS_SIGNED(t) ? LV_SMAX_OF(t) : LV_UMAX_OF(t)))
+
 #define LV_TRIGO_SIN_MAX 32767
 #define LV_TRIGO_SHIFT 15 /**<  >> LV_TRIGO_SHIFT to normalize*/
 

--- a/src/lv_misc/lv_txt.c
+++ b/src/lv_misc/lv_txt.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_txt.h"
 #include "lv_math.h"
+#include "lv_log.h"
 
 /*********************
  *      DEFINES
@@ -108,8 +109,14 @@ void lv_txt_get_size(lv_point_t * size_res, const char * text, const lv_font_t *
     /*Calc. the height and longest line*/
     while(text[line_start] != '\0') {
         new_line_start += lv_txt_get_next_line(&text[line_start], font, letter_space, max_width, flag);
-        size_res->y += letter_height;
-        size_res->y += line_space;
+
+        if ((unsigned long)size_res->y + (unsigned long)letter_height + (unsigned long)line_space > LV_MAX_OF(lv_coord_t)) {
+            LV_LOG_WARN("lv_txt_get_size: integer overflow while calculating text height");
+            return;
+        } else {
+            size_res->y += letter_height;
+            size_res->y += line_space;
+        }
 
         /*Calculate the the longest line*/
         act_line_length = lv_txt_get_width(&text[line_start], new_line_start - line_start, font, letter_space, flag);
@@ -118,7 +125,7 @@ void lv_txt_get_size(lv_point_t * size_res, const char * text, const lv_font_t *
         line_start  = new_line_start;
     }
 
-    /*Ma ke the text one line taller if the last character is '\n' or '\r'*/
+    /*Make the text one line taller if the last character is '\n' or '\r'*/
     if((line_start != 0) && (text[line_start - 1] == '\n' || text[line_start - 1] == '\r')) {
         size_res->y += letter_height + line_space;
     }


### PR DESCRIPTION
Simply added a warning log when the calculated height of a label overflows the designated data type for coordinates (most probably, running over 32767 while using `int16_t`).

The issue could arise with very long label texts, as per https://github.com/littlevgl/lvgl/issues/1375 .

The macros for data type max values are inspired from the second answer on this question https://stackoverflow.com/questions/2053843/min-and-max-value-of-data-type-in-c.

With this change in the event of an overflow the label is displayed with limited content and a warning is printed to the logs.