### PR TITLE
Added mirror option for line meters

### DIFF
--- a/src/lv_objx/lv_lmeter.c
+++ b/src/lv_objx/lv_lmeter.c
@@ -292,9 +292,9 @@ uint16_t lv_lmeter_get_angle_offset(lv_obj_t * lmeter)
 /**
  * get the mirror setting for the line meter
  * @param lmeter pointer to a line meter object
- * @return mirror (0 or 1)
+ * @return mirror (true or false)
  */
-uint16_t lv_lmeter_get_mirror(lv_obj_t * lmeter)
+bool lv_lmeter_get_mirror(lv_obj_t * lmeter)
 {
     lv_lmeter_ext_t * ext = lv_obj_get_ext_attr(lmeter);
 

--- a/src/lv_objx/lv_lmeter.c
+++ b/src/lv_objx/lv_lmeter.c
@@ -199,7 +199,7 @@ void lv_lmeter_set_angle_offset(lv_obj_t * lmeter, uint16_t angle)
  * @param lmeter pointer to a line meter object
  * @param mirror mirror setting
  */
-void lv_lmeter_set_mirror(lv_obj_t *lmeter, uint8_t mirror) {
+void lv_lmeter_set_mirror(lv_obj_t *lmeter, bool mirror) {
     lv_lmeter_ext_t * ext = lv_obj_get_ext_attr(lmeter);
     if(ext->mirrored == mirror) return;
 

--- a/src/lv_objx/lv_lmeter.c
+++ b/src/lv_objx/lv_lmeter.c
@@ -77,6 +77,7 @@ lv_obj_t * lv_lmeter_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->line_cnt    = 21;  /*Odd scale number looks better*/
     ext->scale_angle = 240; /*(scale_num - 1) * N looks better */
     ext->angle_ofs = 0;
+    ext->mirrored = 0;
 
     /*The signal and design functions are not copied so set them here*/
     lv_obj_set_signal_cb(new_lmeter, lv_lmeter_signal);
@@ -193,6 +194,20 @@ void lv_lmeter_set_angle_offset(lv_obj_t * lmeter, uint16_t angle)
     lv_obj_invalidate(lmeter);
 }
 
+/**
+ * Set the orientation of the meter growth, clockwise or counterclockwise (mirrored)
+ * @param lmeter pointer to a line meter object
+ * @param mirror mirror setting
+ */
+void lv_lmeter_set_mirror(lv_obj_t *lmeter, uint8_t mirror) {
+    lv_lmeter_ext_t * ext = lv_obj_get_ext_attr(lmeter);
+    if(ext->mirrored == mirror) return;
+
+    ext->mirrored = mirror;
+
+    lv_obj_invalidate(lmeter);
+}
+
 /*=====================
  * Getter functions
  *====================*/
@@ -273,6 +288,18 @@ uint16_t lv_lmeter_get_angle_offset(lv_obj_t * lmeter)
 
     return ext->angle_ofs;
 }
+
+/**
+ * get the mirror setting for the line meter
+ * @param lmeter pointer to a line meter object
+ * @return mirror (0 or 1)
+ */
+uint16_t lv_lmeter_get_mirror(lv_obj_t * lmeter)
+{
+    lv_lmeter_ext_t * ext = lv_obj_get_ext_attr(lmeter);
+
+    return ext->mirrored;
+}
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -315,7 +342,8 @@ static bool lv_lmeter_design(lv_obj_t * lmeter, const lv_area_t * mask, lv_desig
         lv_coord_t x_ofs  = lv_obj_get_width(lmeter) / 2 + lmeter->coords.x1;
         lv_coord_t y_ofs  = lv_obj_get_height(lmeter) / 2 + lmeter->coords.y1;
         int16_t angle_ofs = ext->angle_ofs + 90 + (360 - ext->scale_angle) / 2;
-        int16_t level =
+        int16_t level = ext->mirrored ?
+            (int32_t)((int32_t)(ext->max_value - ext->cur_value) * ext->line_cnt) / (ext->max_value - ext->min_value) :
             (int32_t)((int32_t)(ext->cur_value - ext->min_value) * ext->line_cnt) / (ext->max_value - ext->min_value);
         uint8_t i;
 
@@ -349,11 +377,12 @@ static bool lv_lmeter_design(lv_obj_t * lmeter, const lv_area_t * mask, lv_desig
             p1.x = x_out + x_ofs;
             p1.y = y_out + y_ofs;
 
-            if(i >= level)
+            uint16_t index = ext->mirrored ? ext->line_cnt - i : i;
+            if((!ext->mirrored && i >= level) || (ext->mirrored && i <= level))
                 style_tmp.line.color = style->line.color;
             else {
                 style_tmp.line.color =
-                    lv_color_mix(style->body.grad_color, style->body.main_color, (255 * i) / ext->line_cnt);
+                    lv_color_mix(style->body.grad_color, style->body.main_color, (255 * index) / ext->line_cnt);
             }
 
             lv_draw_line(&p1, &p2, mask, &style_tmp, opa_scale);

--- a/src/lv_objx/lv_lmeter.h
+++ b/src/lv_objx/lv_lmeter.h
@@ -102,7 +102,7 @@ void lv_lmeter_set_angle_offset(lv_obj_t * lmeter, uint16_t angle);
  * @param lmeter pointer to a line meter object
  * @param mirror mirror setting
  */
-void lv_lmeter_set_mirror(lv_obj_t *lmeter, uint8_t mirror);
+void lv_lmeter_set_mirror(lv_obj_t *lmeter, bool mirror);
 
 /**
  * Set the styles of a line meter
@@ -165,9 +165,9 @@ uint16_t lv_lmeter_get_angle_offset(lv_obj_t * lmeter);
 /**
  * get the mirror setting for the line meter
  * @param lmeter pointer to a line meter object
- * @return mirror (0 or 1)
+ * @return mirror (true or false)
  */
-uint16_t lv_lmeter_get_mirror(lv_obj_t * lmeter);
+bool lv_lmeter_get_mirror(lv_obj_t * lmeter);
 
 /**
  * Get the style of a line meter

--- a/src/lv_objx/lv_lmeter.h
+++ b/src/lv_objx/lv_lmeter.h
@@ -41,6 +41,7 @@ typedef struct
     int16_t cur_value;
     int16_t min_value;
     int16_t max_value;
+    uint8_t mirrored;
 } lv_lmeter_ext_t;
 
 /*Styles*/
@@ -95,6 +96,13 @@ void lv_lmeter_set_scale(lv_obj_t * lmeter, uint16_t angle, uint16_t line_cnt);
  * @param angle angle offset (0..360), rotates clockwise
  */
 void lv_lmeter_set_angle_offset(lv_obj_t * lmeter, uint16_t angle);
+
+/**
+ * Set the orientation of the meter growth, clockwise or counterclockwise (mirrored)
+ * @param lmeter pointer to a line meter object
+ * @param mirror mirror setting
+ */
+void lv_lmeter_set_mirror(lv_obj_t *lmeter, uint8_t mirror);
 
 /**
  * Set the styles of a line meter
@@ -153,6 +161,13 @@ uint16_t lv_lmeter_get_scale_angle(const lv_obj_t * lmeter);
  * @return angle offset (0..360)
  */
 uint16_t lv_lmeter_get_angle_offset(lv_obj_t * lmeter);
+
+/**
+ * get the mirror setting for the line meter
+ * @param lmeter pointer to a line meter object
+ * @return mirror (0 or 1)
+ */
+uint16_t lv_lmeter_get_mirror(lv_obj_t * lmeter);
 
 /**
  * Get the style of a line meter

--- a/src/lv_objx/lv_lmeter.h
+++ b/src/lv_objx/lv_lmeter.h
@@ -41,7 +41,7 @@ typedef struct
     int16_t cur_value;
     int16_t min_value;
     int16_t max_value;
-    uint8_t mirrored;
+    uint8_t mirrored :1;
 } lv_lmeter_ext_t;
 
 /*Styles*/


### PR DESCRIPTION
I want to display two aligned line meters that originate from a common center and grow apart from each other; in short, I need one of the two meters to be mirrored.
A previous pull request added the possibility to rotate the line meter; with this one I added a simple `mirrored` attribute that inverts the growth direction.

Result sample:
![scrot](https://user-images.githubusercontent.com/14563868/75557680-c0f65f80-5a40-11ea-8f86-d1e3c6f0cadc.png)
