### PR TITLE
Rename/move some defines

### DIFF
--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -733,8 +733,8 @@
 #endif
 
 /*Line meter (dependencies: *;)*/
-#ifndef LV_USE_LMETER
-#define LV_USE_LMETER   1
+#ifndef LV_USE_LINEMETER
+#define LV_USE_LINEMETER   1
 #endif
 
 /*Mask (dependencies: -)*/

--- a/src/lv_themes/lv_theme_material.h
+++ b/src/lv_themes/lv_theme_material.h
@@ -54,4 +54,4 @@ lv_theme_t * lv_theme_material_init(lv_color_t color_primary, lv_color_t color_s
 } /* extern "C" */
 #endif
 
-#endif /*LV_THEME_ALIEN_H*/
+#endif /*LV_THEME_MATERIAL_H*/

--- a/src/lv_widgets/lv_gauge.h
+++ b/src/lv_widgets/lv_gauge.h
@@ -18,8 +18,8 @@ extern "C" {
 #if LV_USE_GAUGE != 0
 
 /*Testing of dependencies*/
-#if LV_USE_LMETER == 0
-#error "lv_gauge: lv_linemeter is required. Enable it in lv_conf.h (LV_USE_LMETER  1) "
+#if LV_USE_LINEMETER == 0
+#error "lv_gauge: lv_linemeter is required. Enable it in lv_conf.h (LV_USE_LINEMETER  1) "
 #endif
 
 #include "../lv_core/lv_obj.h"

--- a/src/lv_widgets/lv_keyboard.c
+++ b/src/lv_widgets/lv_keyboard.c
@@ -19,8 +19,6 @@
  *********************/
 #define LV_OBJX_NAME "lv_keyboard"
 
-#define LV_KEYBOARD_CTRL_BTN_FLAGS (LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CLICK_TRIG)
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/lv_widgets/lv_keyboard.h
+++ b/src/lv_widgets/lv_keyboard.h
@@ -32,7 +32,8 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
-
+#define LV_KEYBOARD_CTRL_BTN_FLAGS (LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CLICK_TRIG)
+    
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/lv_widgets/lv_linemeter.h
+++ b/src/lv_widgets/lv_linemeter.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 
-#if LV_USE_LMETER != 0
+#if LV_USE_LINEMETER != 0
 
 #include "../lv_core/lv_obj.h"
 
@@ -146,7 +146,7 @@ void lv_linemeter_draw_scale(lv_obj_t * lmeter, const lv_area_t * clip_area, uin
  *      MACROS
  **********************/
 
-#endif /*LV_USE_LMETER*/
+#endif /*LV_USE_LINEMETER*/
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
LV_KEYBOARD_CTRL_BTN_FLAGS needs to be defined in the header because that flag is used in any externally created key maps passed to lv_keyboard_set_ctrl_map()

lv_linemeter.c and lv_gauge.c used LV_USE_LMETER but the conf template header used LV_USE_LINEMETER as well as lv_theme_material.c.  I changed them all the LV_USE_LINEMETER; users upgrading from 6.x will need to change their conf header.