### PR TITLE
Remove assignment that clears parameter before using it

### DIFF
--- a/src/lv_objx/lv_mbox.c
+++ b/src/lv_objx/lv_mbox.c
@@ -199,7 +199,6 @@ void lv_mbox_set_anim_time(lv_obj_t * mbox, uint16_t anim_time)
 
 #if LV_USE_ANIMATION
     lv_mbox_ext_t * ext = lv_obj_get_ext_attr(mbox);
-    anim_time           = 0;
     ext->anim_time      = anim_time;
 #else
     (void)mbox;


### PR DESCRIPTION
It looks like there is an unwanted assignment statement in `lv_mbox_set_anim_time`. It clears the `anim_time` parameter before using it. The fix is to remove the assignment statement.

I tested it by adding a call to `lv_mbox_set_anim_time` to the `lv_mbox` example and observing the animation time on close with and without the fix:

```
    lv_obj_t * mbox1 = lv_mbox_create(lv_scr_act(), NULL);
    lv_mbox_set_text(mbox1, "A message box with two buttons.");
    lv_mbox_add_btns(mbox1, btns);
    lv_obj_set_width(mbox1, 200);
    lv_obj_align(mbox1, NULL, LV_ALIGN_CENTER, 0, 0); /*Align to the corner*/
    lv_mbox_set_anim_time(mbox1, 2000);
```