### PR TITLE
Fix a crash with null indev input in lv_indev_wait_release()

### DIFF
--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -297,6 +297,7 @@ void lv_indev_get_vect(const lv_indev_t * indev, lv_point_t * point)
  */
 void lv_indev_wait_release(lv_indev_t * indev)
 {
+    if(indev == NULL)return;
     indev->proc.wait_until_release = 1;
 }
 


### PR DESCRIPTION
Will crash on calling while no indev returned conditions, such as delayed for an deletion of objects automatically when idle(no interactive inputs).
Perhaps we will think of that it is "your" responsibility to check before calling. well, I think it may not be easy for the one who does not familar with the library(they usually trust it I think), and I stucked here and debug for hours.