### PR TITLE
Correct style_tick_line in Mono theme

### DIFF
--- a/src/lv_draw/lv_draw_blend.c
+++ b/src/lv_draw/lv_draw_blend.c
@@ -815,11 +815,11 @@ static inline lv_color_t color_blend_true_color_additive(lv_color_t fg, lv_color
     fg.ch.red = LV_MATH_MIN(tmp, 255);
 #endif
 
+    tmp = bg.ch.green + fg.ch.green;
 #if LV_COLOR_DEPTH == 8
     fg.ch.green = LV_MATH_MIN(tmp, 7);
 #elif LV_COLOR_DEPTH == 16
 #if LV_COLOR_16_SWAP == 0
-    tmp = bg.ch.green + fg.ch.green;
     fg.ch.green = LV_MATH_MIN(tmp, 63);
 #else
     tmp = (bg.ch.green_h << 3) + bg.ch.green_l + (fg.ch.green_h << 3) + fg.ch.green_l;

--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -37,7 +37,6 @@ static lv_style_t style_btn;
 static lv_style_t style_round;
 static lv_style_t style_no_radius;
 static lv_style_t style_fg_color;
-static lv_style_t style_tick_line;
 static lv_style_t style_border_none;
 static lv_style_t style_big_line_space;       /*In roller or dropdownlist*/
 static lv_style_t style_pad_none;
@@ -71,6 +70,10 @@ static lv_style_t style_gauge_needle, style_gauge_major;
 
 #if LV_USE_PAGE
 static lv_style_t style_sb;
+#endif
+
+#if LV_USE_SPINNER
+static lv_style_t style_tick_line;
 #endif
 
 #if LV_USE_TEXTAREA


### PR DESCRIPTION
It should only be create if USE_SPINNER is defined