### PR TITLE
Compile warning in lv_spinbox_set_style.

### DIFF
--- a/src/lv_objx/lv_spinbox.h
+++ b/src/lv_objx/lv_spinbox.h
@@ -82,7 +82,7 @@ lv_obj_t * lv_spinbox_create(lv_obj_t * par, const lv_obj_t * copy);
  * @param type which style should be set
  * @param style pointer to a style
  */
-static inline void lv_spinbox_set_style(lv_obj_t * spinbox, lv_spinbox_style_t type, lv_style_t * style)
+static inline void lv_spinbox_set_style(lv_obj_t * spinbox, lv_spinbox_style_t type, const lv_style_t * style)
 {
     lv_ta_set_style(spinbox, type, style);
 }


### PR DESCRIPTION
discards 'const' qualifier from pointer