### PR TITLE
Small fixes required for Micropython binding

### DIFF
--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -272,7 +272,7 @@ void lv_style_list_add_style(lv_style_list_t * list, lv_style_t * style);
  * @param style_list pointer to a style list
  * @param style pointer to a style to remove
  */
-void lv_style_list_remove_style(lv_style_list_t *, lv_style_t *);
+void lv_style_list_remove_style(lv_style_list_t * list, lv_style_t * style);
 
 /**
  * Remove all styles added from style list, clear the local style, transition style and free all allocated memories.

--- a/src/lv_widgets/lv_gauge.h
+++ b/src/lv_widgets/lv_gauge.h
@@ -35,7 +35,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef void (*lv_gauge_format_cb_t)(lv_obj_t * gauge, char buf[], int bufsize, int32_t value);
+typedef void (*lv_gauge_format_cb_t)(lv_obj_t * gauge, char * buf, int bufsize, int32_t value);
 
 /*Data of gauge*/
 typedef struct {


### PR DESCRIPTION
- Added missing argument names in `lv_style_list_remove_style` prototype 
- Changed `char buf[]` to `char * buf` on `lv_gauge_format_cb_t`, so that the binding would recognize this argument as a string, and not an array.