### PR TITLE
Adjusting min and max values to the number format

### DIFF
--- a/src/lv_misc/lv_math.c
+++ b/src/lv_misc/lv_math.c
@@ -198,6 +198,26 @@ uint32_t lv_sqrt(uint32_t num)
     return root;
 }
 
+/**
+ * Calculate the integer exponents.
+ * @param base
+ * @param power
+ * @return base raised to the power exponent
+ */
+int64_t lv_pow(int64_t base, int8_t exp)
+{
+	int64_t result = 1;
+    while (exp)
+    {
+        if (exp & 1)
+            result *= base;
+        exp >>= 1;
+        base *= base;
+    }
+
+    return result;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/lv_misc/lv_math.h
+++ b/src/lv_misc/lv_math.h
@@ -74,6 +74,14 @@ uint16_t lv_atan2(int x, int y);
  */
 uint32_t lv_sqrt(uint32_t num);
 
+/**
+ * Calculate the integer exponents.
+ * @param base
+ * @param power
+ * @return base raised to the power exponent
+ */
+int64_t lv_pow(int64_t base, int8_t exp);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/lv_objx/lv_spinbox.c
+++ b/src/lv_objx/lv_spinbox.c
@@ -154,6 +154,13 @@ void lv_spinbox_set_digit_format(lv_obj_t * spinbox, uint8_t digit_count, uint8_
 
     if(separator_position > LV_SPINBOX_MAX_DIGIT_COUNT) separator_position = LV_SPINBOX_MAX_DIGIT_COUNT;
 
+    if(digit_count < LV_SPINBOX_MAX_DIGIT_COUNT)
+    {
+        uint64_t max_val = lv_pow(10, digit_count);
+        if(ext->range_max > max_val - 1) ext->range_max = max_val - 1;
+        if(ext->range_min < - max_val  + 1) ext->range_min = - max_val  + 1;
+    }
+
     ext->digit_count   = digit_count;
     ext->dec_point_pos = separator_position;
 

--- a/src/lv_objx/lv_spinbox.h
+++ b/src/lv_objx/lv_spinbox.h
@@ -32,7 +32,7 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
-#define LV_SPINBOX_MAX_DIGIT_COUNT 16
+#define LV_SPINBOX_MAX_DIGIT_COUNT 10
 
 /**********************
  *      TYPEDEFS


### PR DESCRIPTION
Spinbox stores int32_t is only 10 digits.
Is it possible without "pow"?