### PR TITLE
Guard USE AP prototypes with macro

### DIFF
--- a/src/lv_misc/lv_txt_ap.h
+++ b/src/lv_misc/lv_txt_ap.h
@@ -18,6 +18,8 @@ extern "C" {
 #include "lv_txt.h"
 #include "../lv_draw/lv_draw.h"
 
+#if LV_USE_ARABIC_PERSIAN_CHARS == 1
+
 /*********************
  *      DEFINES
  *********************/
@@ -49,6 +51,8 @@ void lv_txt_ap_proc(const char * txt, char * txt_out);
 /**********************
  *      MACROS
  **********************/
+
+#endif // LV_USE_ARABIC_PERSIAN_CHARS
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
It is required for Micropython to guard prototypes as well, otherwise the binding will try to call a function that is not defined when `LV_USE_ARABIC_PERSIAN_CHARS` is 0