### PR TITLE
Replace lv_point_t* to lv_point_t[] to represent point array

### DIFF
--- a/src/lv_draw/lv_draw_triangle.c
+++ b/src/lv_draw/lv_draw_triangle.c
@@ -40,7 +40,7 @@
  * @param clip_area the triangle will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_triangle(const lv_point_t * points, const lv_area_t * clip_area, lv_draw_rect_dsc_t * draw_dsc)
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip_area, lv_draw_rect_dsc_t * draw_dsc)
 {
     lv_draw_polygon(points, 3, clip_area, draw_dsc);
 }
@@ -52,7 +52,7 @@ void lv_draw_triangle(const lv_point_t * points, const lv_area_t * clip_area, lv
  * @param clip_area polygon will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_polygon(const lv_point_t * points, uint16_t point_cnt, const lv_area_t * clip_area,
+void lv_draw_polygon(const lv_point_t points[], uint16_t point_cnt, const lv_area_t * clip_area,
                      lv_draw_rect_dsc_t * draw_dsc)
 {
     if(point_cnt < 3) return;

--- a/src/lv_draw/lv_draw_triangle.h
+++ b/src/lv_draw/lv_draw_triangle.h
@@ -33,7 +33,7 @@ extern "C" {
  * @param clip_area the triangle will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_triangle(const lv_point_t * points, const lv_area_t * clip, lv_draw_rect_dsc_t * draw_dsc);
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip, lv_draw_rect_dsc_t * draw_dsc);
 
 /**
  * Draw a polygon. Only convex polygons are supported.
@@ -42,7 +42,7 @@ void lv_draw_triangle(const lv_point_t * points, const lv_area_t * clip, lv_draw
  * @param clip_area polygon will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_polygon(const lv_point_t * points, uint16_t point_cnt, const lv_area_t * mask,
+void lv_draw_polygon(const lv_point_t points[], uint16_t point_cnt, const lv_area_t * mask,
                      lv_draw_rect_dsc_t * draw_dsc);
 
 /**********************

--- a/src/lv_widgets/lv_canvas.c
+++ b/src/lv_widgets/lv_canvas.c
@@ -895,7 +895,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param point_cnt number of points
  * @param style style of the line (`line` properties are used)
  */
-void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt,
+void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                          lv_draw_line_dsc_t * line_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
@@ -958,7 +958,7 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t 
  * @param point_cnt number of points
  * @param style style of the polygon (`body.main_color` and `body.opa` is used)
  */
-void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt,
+void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                             lv_draw_rect_dsc_t * poly_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);

--- a/src/lv_widgets/lv_canvas.h
+++ b/src/lv_widgets/lv_canvas.h
@@ -214,7 +214,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param point_cnt number of points
  * @param style style of the line (`line` properties are used)
  */
-void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt,
+void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                          lv_draw_line_dsc_t * line_draw_dsc);
 
 /**
@@ -224,7 +224,7 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t 
  * @param point_cnt number of points
  * @param style style of the polygon (`body.main_color` and `body.opa` is used)
  */
-void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt,
+void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                             lv_draw_rect_dsc_t * poly_draw_dsc);
 
 /**


### PR DESCRIPTION
Needed for Micropython Bindings to identify the argument as an array instead of a pointer to a single lv_point_t