### PR TITLE
Fixed implicit casting from void* in lv_imgbuf.h

### DIFF
--- a/src/lv_draw/lv_img_buf.h
+++ b/src/lv_draw/lv_img_buf.h
@@ -276,7 +276,7 @@ bool _lv_img_buf_transform_anti_alias(lv_img_transform_dsc_t * dsc);
  */
 static inline bool lv_img_buf_transform(lv_img_transform_dsc_t * dsc, lv_coord_t x, lv_coord_t y)
 {
-    const uint8_t * src_u8 = dsc->cfg.src;
+    const uint8_t * src_u8 = (const uint8_t*)dsc->cfg.src;
 
     /*Get the target point relative coordinates to the pivot*/
     int32_t xt = x - dsc->cfg.pivot_x;


### PR DESCRIPTION
While building C++ library with MSVC compiler got the following errors:
![image](https://user-images.githubusercontent.com/25596072/81809977-d6046a00-952a-11ea-83c4-a881302dd6b0.png)
Fixed, added explicit conversion.