### PR TITLE
Fix lv_label_set_text() crash (issue #1498)

### DIFF
--- a/src/lv_objx/lv_label.c
+++ b/src/lv_objx/lv_label.c
@@ -188,7 +188,7 @@ void lv_label_set_text(lv_obj_t * label, const char * text)
 
     LV_ASSERT_STR(text);
 
-    if(ext->text == text) {
+    if(ext->text == text && ext->static_txt == 0) {
         /*If set its own text then reallocate it (maybe its size changed)*/
         ext->text = lv_mem_realloc(ext->text, strlen(ext->text) + 1);
         LV_ASSERT_MEM(ext->text);


### PR DESCRIPTION
This routine tried to optimize a special case of setting the label text to the same address as previously set, but it did not consider whether the prior set was static and tried to realloc non-allocated memory.