### PR TITLE
Group focus mode

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -142,6 +142,10 @@ typedef void * lv_anim_user_data_t;
 #define LV_USE_GROUP            1
 #if LV_USE_GROUP
 typedef void * lv_group_user_data_t;
+
+/* 1: Enable to apply focus style to different object */
+#define LV_USE_GROUP_FOCUS_MODE 1
+
 #endif  /*LV_USE_GROUP*/
 
 /* 1: Enable GPU interface*/

--- a/src/lv_core/lv_group.c
+++ b/src/lv_core/lv_group.c
@@ -215,6 +215,22 @@ void lv_group_remove_all_objs(lv_group_t * group)
     lv_ll_clear(&(group->obj_ll));
 }
 
+#ifdef LV_USE_GROUP_FOCUS_MODE
+/**
+ * Set focus parent for the object (focus style will apply to parent, when child is focused)
+ * @param child Child object
+ * @param parent Parent object
+ */
+void lv_group_set_focus_parent(lv_obj_t * child, lv_obj_t * parent)
+{
+	child->group_focus_mode = LV_GROUP_FOCUS_CHILD;
+	child->group_focus_obj = parent;
+
+	parent->group_focus_mode = LV_GROUP_FOCUS_PARENT;
+	parent->group_focus_obj = child;
+}
+#endif
+
 /**
  * Focus on an object (defocus the current)
  * @param obj pointer to an object to focus on
@@ -362,6 +378,12 @@ void lv_group_set_editing(lv_group_t * group, bool edit)
         lv_res_t res = lv_event_send(*group->obj_focus, LV_EVENT_FOCUSED, NULL);
         if(res != LV_RES_OK) return;
     }
+
+#ifdef LV_USE_GROUP_FOCUS_MODE
+    if (focused->group_focus_mode == LV_GROUP_FOCUS_CHILD)  {
+		lv_obj_invalidate(focused->group_focus_obj);
+    }
+#endif
 
     lv_obj_invalidate(focused);
 }
@@ -673,9 +695,21 @@ static void focus_next_core(lv_group_t * group, void * (*begin)(const lv_ll_t *)
         lv_res_t res = lv_event_send(*group->obj_focus, LV_EVENT_DEFOCUSED, NULL);
         if(res != LV_RES_OK) return;
         lv_obj_invalidate(*group->obj_focus);
+
+#ifdef LV_USE_GROUP_FOCUS_MODE
+        if ((*group->obj_focus)->group_focus_mode == LV_GROUP_FOCUS_CHILD)  {
+    		lv_obj_invalidate((*group->obj_focus)->group_focus_obj);
+        }
+#endif
     }
 
     group->obj_focus = obj_next;
+
+#ifdef LV_USE_GROUP_FOCUS_MODE
+    if ((*group->obj_focus)->group_focus_mode == LV_GROUP_FOCUS_CHILD)  {
+		lv_obj_invalidate((*group->obj_focus)->group_focus_obj);
+    }
+#endif
 
     (*group->obj_focus)->signal_cb(*group->obj_focus, LV_SIGNAL_FOCUS, NULL);
     lv_res_t res = lv_event_send(*group->obj_focus, LV_EVENT_FOCUSED, NULL);

--- a/src/lv_core/lv_group.c
+++ b/src/lv_core/lv_group.c
@@ -229,6 +229,20 @@ void lv_group_set_focus_parent(lv_obj_t * child, lv_obj_t * parent)
 	parent->group_focus_mode = LV_GROUP_FOCUS_PARENT;
 	parent->group_focus_obj = child;
 }
+
+/**
+ * Remove focus mode from parent and child
+ * @param obj Child or Parent object
+ */
+void lv_group_remove_focus_mode(lv_obj_t * obj)
+{
+	obj->group_focus_mode = LV_GROUP_FOCUS_NORMAL;
+	obj->group_focus_obj->group_focus_mode = LV_GROUP_FOCUS_NORMAL;
+	obj->group_focus_obj->group_focus_obj = NULL;
+	obj->group_focus_obj = NULL;
+}
+
+
 #endif
 
 /**

--- a/src/lv_core/lv_group.h
+++ b/src/lv_core/lv_group.h
@@ -124,6 +124,13 @@ void lv_group_remove_obj(lv_obj_t * obj);
 void lv_group_remove_all_objs(lv_group_t * group);
 
 /**
+ * Set focus parent for the object (focus style will apply to parent, when child is focused)
+ * @param child Child object
+ * @param parent Parent object
+ */
+void lv_group_set_focus_parent(lv_obj_t * child, lv_obj_t * parent);
+
+/**
  * Focus on an object (defocus the current)
  * @param obj pointer to an object to focus on
  */

--- a/src/lv_core/lv_group.h
+++ b/src/lv_core/lv_group.h
@@ -123,12 +123,21 @@ void lv_group_remove_obj(lv_obj_t * obj);
  */
 void lv_group_remove_all_objs(lv_group_t * group);
 
+#ifdef LV_USE_GROUP_FOCUS_MODE
 /**
  * Set focus parent for the object (focus style will apply to parent, when child is focused)
  * @param child Child object
  * @param parent Parent object
  */
 void lv_group_set_focus_parent(lv_obj_t * child, lv_obj_t * parent);
+
+/**
+ * Remove focus mode from parent and child
+ * @param obj Child or Parent object
+ */
+void lv_group_remove_focus_mode(lv_obj_t * obj);
+
+#endif
 
 /**
  * Focus on an object (defocus the current)

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -211,6 +211,10 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
 
 #if LV_USE_GROUP
         new_obj->group_p = NULL;
+#if LV_USE_GROUP_FOCUS_MODE
+        new_obj->group_focus_mode = LV_GROUP_FOCUS_NORMAL;
+        new_obj->group_focus_obj = NULL;
+#endif
 #endif
         /*Set attributes*/
         new_obj->click        = 0;
@@ -2048,11 +2052,30 @@ const lv_style_t * lv_obj_get_style(const lv_obj_t * obj)
         }
     }
 #if LV_USE_GROUP
-    if(obj->group_p) {
-        if(lv_group_get_focused(obj->group_p) == obj) {
-            style_act = lv_group_mod_style(obj->group_p, style_act);
-        }
+
+#if LV_USE_GROUP_FOCUS_MODE
+    if (obj->group_focus_mode == LV_GROUP_FOCUS_NORMAL) {
+#endif
+		if(obj->group_p) {
+			if(lv_group_get_focused(obj->group_p) == obj)
+			{
+				style_act = lv_group_mod_style(obj->group_p, style_act);
+			}
+		}
+
+#if LV_USE_GROUP_FOCUS_MODE
     }
+
+    if (obj->group_focus_mode == LV_GROUP_FOCUS_PARENT) {
+    	lv_obj_t * cf = obj->group_focus_obj;
+		if(cf->group_p) {
+			if (lv_group_get_focused(cf->group_p) == cf) {
+				style_act = lv_group_mod_style(cf->group_p, style_act);
+			}
+		}
+    }
+#endif
+
 #endif
 
     if(style_act == NULL) style_act = &lv_style_plain;

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -424,6 +424,13 @@ lv_res_t lv_obj_del(lv_obj_t * obj)
 #if LV_USE_GROUP
     lv_group_t * group = lv_obj_get_group(obj);
     if(group) lv_group_remove_obj(obj);
+
+#if LV_USE_GROUP_FOCUS_MODE
+    if (obj->group_focus_mode != LV_GROUP_FOCUS_NORMAL) {
+    	lv_group_remove_focus_mode(obj);
+    }
+
+#endif
 #endif
 
         /*Remove the animations from this object*/

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -184,6 +184,13 @@ enum {
 
 typedef uint8_t lv_drag_dir_t;
 
+enum {
+    LV_GROUP_FOCUS_NORMAL = 0x0, /**< Normal focus mode. */
+    LV_GROUP_FOCUS_CHILD  = 0x1, /**< Child focus mode, do not apply the focus style */
+	LV_GROUP_FOCUS_PARENT = 0x2, /**< Parent focus mode, apply focus style when child is focused */
+};
+typedef uint8_t lv_focus_mode_t;
+
 typedef struct _lv_obj_t
 {
     struct _lv_obj_t * par; /**< Pointer to the parent object*/
@@ -200,6 +207,10 @@ typedef struct _lv_obj_t
 
 #if LV_USE_GROUP != 0
     void * group_p; /**< Pointer to the group of the object*/
+#if LV_USE_GROUP_FOCUS_MODE
+    lv_focus_mode_t group_focus_mode;   /**< Group focus mode. */
+    struct _lv_obj_t * group_focus_obj; /**< Pointer to child or parent object. */
+#endif
 #endif
 
 #if LV_USE_EXT_CLICK_AREA == LV_EXT_CLICK_AREA_TINY

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -494,6 +494,14 @@ void lv_page_focus(lv_obj_t * page, const lv_obj_t * obj, lv_anim_enable_t anim_
     const lv_style_t * style      = lv_page_get_style(page, LV_PAGE_STYLE_BG);
     const lv_style_t * style_scrl = lv_page_get_style(page, LV_PAGE_STYLE_SCRL);
 
+
+#ifdef LV_USE_GROUP_FOCUS_MODE
+    /*If object use focus mode then target parent*/
+    if (obj->group_focus_mode == LV_GROUP_FOCUS_CHILD) {
+    	obj = obj->group_focus_obj;
+    }
+#endif
+
     /*If obj is higher then the page focus where the "error" is smaller*/
     lv_coord_t obj_y      = obj->coords.y1 - ext->scrl->coords.y1;
     lv_coord_t obj_h      = lv_obj_get_height(obj);


### PR DESCRIPTION
Focus mode enables to set focus or edit style to by applied to another object

I want to have focused styled parent object of the actual focused/edited object.
More info https://forum.littlevgl.com/t/enhance-focus-behavior-for-touchless-interface/2266/2

The API was changed from this example:
`lv_group_set_focus_parent(slider, container);` the container will have select or edit style when slider is selected.
you also need to define `LV_USE_GROUP_FOCUS_MODE` to 1
