### PR TITLE
Added new indev type LV_INDEV_TYPE_NAVIGATION

### DIFF
--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -35,6 +35,7 @@
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data);
+static void indev_navigation_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_proc_press(lv_indev_proc_t * proc);
 static void indev_proc_release(lv_indev_proc_t * proc);
@@ -114,6 +115,9 @@ void _lv_indev_read_task(lv_task_t * task)
         }
         else if(indev_act->driver.type == LV_INDEV_TYPE_ENCODER) {
             indev_encoder_proc(indev_act, &data);
+        }
+        else if(indev_act->driver.type == LV_INDEV_TYPE_NAVIGATION) {
+            indev_navigation_proc(indev_act, &data);
         }
         else if(indev_act->driver.type == LV_INDEV_TYPE_BUTTON) {
             indev_button_proc(indev_act, &data);
@@ -223,7 +227,7 @@ void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj)
  */
 void lv_indev_set_group(lv_indev_t * indev, lv_group_t * group)
 {
-    if(indev->driver.type == LV_INDEV_TYPE_KEYPAD || indev->driver.type == LV_INDEV_TYPE_ENCODER) {
+    if(indev->driver.type == LV_INDEV_TYPE_KEYPAD || indev->driver.type == LV_INDEV_TYPE_ENCODER || indev->driver.type == LV_INDEV_TYPE_NAVIGATION) {
         indev->group = group;
     }
 }
@@ -716,6 +720,184 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
         else if(editable && !g->editing && !i->proc.long_pr_sent) {
             lv_group_set_editing(g, true); /*Set edit mode*/
         }
+
+        i->proc.pr_timestamp = 0;
+        i->proc.long_pr_sent = 0;
+    }
+    indev_obj_act = NULL;
+#else
+    (void)data; /*Unused*/
+    (void)i;    /*Unused*/
+#endif
+}
+
+
+/**
+ * Process a new point from LV_INDEV_TYPE_NAVIGATION input device
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
+ */
+static void indev_navigation_proc(lv_indev_t * i, lv_indev_data_t * data)
+{
+#if LV_USE_GROUP
+
+    if(data->state == LV_INDEV_STATE_PR && i->proc.wait_until_release) return;
+
+    if(i->proc.wait_until_release) {
+        i->proc.wait_until_release      = 0;
+        i->proc.pr_timestamp            = 0;
+        i->proc.long_pr_sent            = 0;
+        i->proc.types.keypad.last_state = LV_INDEV_STATE_REL; /*To skip the processing of release*/
+    }
+
+    /* Save the last keys before anything else.
+     * They need to be already saved if the the function returns for any reason*/
+    lv_indev_state_t last_state     = i->proc.types.keypad.last_state;
+    i->proc.types.keypad.last_state = data->state;
+    i->proc.types.keypad.last_key   = data->key;
+
+    lv_group_t * g = i->group;
+    if(g == NULL) return;
+
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
+
+    /*Refresh the focused object. It might change due to lv_group_focus_prev/next*/
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
+
+    /*Button press happened*/
+    if(data->state == LV_INDEV_STATE_PR && last_state == LV_INDEV_STATE_REL) {
+
+        i->proc.pr_timestamp = lv_tick_get();
+
+
+    	if (data->key == LV_KEY_ENTER) {
+			bool editable = false;
+			indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_GET_EDITABLE, &editable);
+
+			/* If not editable send pressed signal */
+			if(editable == false) {
+				indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_PRESSED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+
+				lv_event_send(indev_obj_act, LV_EVENT_PRESSED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+			}
+		/* Process left key according to current mode */
+    	} else if (data->key == LV_KEY_LEFT) {
+	        if(lv_group_get_editing(g)) {
+	        	lv_group_send_data(g, LV_KEY_LEFT);
+	        }
+	        else {
+	        	lv_group_focus_prev(g);
+	        }
+		/* Process right key according to current mode */
+    	} else if (data->key == LV_KEY_RIGHT) {
+	        if(lv_group_get_editing(g)) {
+	        	lv_group_send_data(g, LV_KEY_RIGHT);
+	        }
+	        else {
+	        	lv_group_focus_next(g);
+	        }
+	    /* Pass other keys */
+    	} else lv_group_send_data(g, data->key);
+
+    }
+    /*Pressing*/
+    else if(data->state == LV_INDEV_STATE_PR && last_state == LV_INDEV_STATE_PR) {
+    	/*Long press*/
+        if(i->proc.long_pr_sent == 0 && lv_tick_elaps(i->proc.pr_timestamp) > i->driver.long_press_time) {
+
+
+        	/*left / right edit speed multiplier*/
+        	/* if pressed time is larger that 2x long_press_time move the value 2x faster */
+        	uint8_t m = (lv_tick_elaps(i->proc.pr_timestamp) / i->driver.long_press_time) > 2 ? 2 : 1;
+
+        	if (data->key == LV_KEY_ENTER) {
+
+        		/* Send a long press signal on enter*/
+				indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_LONG_PRESS, NULL);
+				if(indev_reset_check(&i->proc)) return;
+				lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+
+				i->proc.long_pr_sent = 1;
+
+			/* Repeat other keys */
+        	} else if (data->key == LV_KEY_LEFT) {
+				if(lv_group_get_editing(g)) {
+					while(m--) lv_group_send_data(g, LV_KEY_LEFT);;
+				}
+				else {
+					lv_group_focus_prev(g);
+				}
+			} else if (data->key == LV_KEY_RIGHT) {
+				if(lv_group_get_editing(g)) {
+					while(m--) lv_group_send_data(g, LV_KEY_RIGHT);
+				}
+				else {
+					lv_group_focus_next(g);
+				}
+			} else {
+				lv_group_send_data(g, data->key);
+				i->proc.pr_timestamp = lv_tick_get();
+			}
+        }
+    }
+    /*Release happened*/
+    else if(data->state == LV_INDEV_STATE_REL && last_state == LV_INDEV_STATE_PR) {
+
+    	if(data->key == LV_KEY_ENTER) {
+			bool editable = false;
+			indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_GET_EDITABLE, &editable);
+
+			/*The button was released on a non-editable object. Just send enter*/
+			if(editable == false) {
+				indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_RELEASED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+
+				if(i->proc.long_pr_sent == 0) lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+
+				lv_event_send(indev_obj_act, LV_EVENT_CLICKED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+
+				lv_event_send(indev_obj_act, LV_EVENT_RELEASED, NULL);
+				if(indev_reset_check(&i->proc)) return;
+			}
+			/*An object is being edited and the button is released. */
+			else if(g->editing) {
+				/*Ignore long pressed enter release because it comes from long press*/
+				if(!i->proc.long_pr_sent || _lv_ll_is_empty(&g->obj_ll)) {
+					indev_obj_act->signal_cb(indev_obj_act, LV_SIGNAL_RELEASED, NULL);
+					if(indev_reset_check(&i->proc)) return;
+
+					lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, NULL);
+					if(indev_reset_check(&i->proc)) return;
+
+					lv_event_send(indev_obj_act, LV_EVENT_CLICKED, NULL);
+					if(indev_reset_check(&i->proc)) return;
+
+					lv_event_send(indev_obj_act, LV_EVENT_RELEASED, NULL);
+					if(indev_reset_check(&i->proc)) return;
+
+					lv_group_send_data(g, LV_KEY_ENTER);
+					if(indev_reset_check(&i->proc)) return;
+
+					lv_group_set_editing(g, false); /*Exit edit mode*/
+				}
+			}
+			/*If the focused object is editable and now in navigate mode then on enter switch edit
+			   mode*/
+	        else if(editable && !g->editing && !i->proc.long_pr_sent) {
+	            lv_group_set_editing(g, true); /*Set edit mode*/
+	        }
+    	} else if (data->key == LV_KEY_ESC && g->editing) {
+    		if(_lv_ll_is_empty(&g->obj_ll) == false) {
+    			lv_group_set_editing(g, false); /*exit edit mode*/
+    		}
+    	}
 
         i->proc.pr_timestamp = 0;
         i->proc.long_pr_sent = 0;

--- a/src/lv_hal/lv_hal_indev.h
+++ b/src/lv_hal/lv_hal_indev.h
@@ -43,6 +43,7 @@ enum {
     LV_INDEV_TYPE_BUTTON,  /**< External (hardware button) which is assigned to a specific point of the
                               screen*/
     LV_INDEV_TYPE_ENCODER, /**< Encoder with only Left, Right turn and a Button*/
+    LV_INDEV_TYPE_NAVIGATION, /**< Keypad with ability to select and edit widget Left, Right, Enter required*/
 };
 typedef uint8_t lv_indev_type_t;
 

--- a/src/lv_widgets/lv_btnmatrix.c
+++ b/src/lv_widgets/lv_btnmatrix.c
@@ -814,7 +814,8 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
             }
         }
 #if LV_USE_GROUP
-        else if(indev_type == LV_INDEV_TYPE_KEYPAD || (indev_type == LV_INDEV_TYPE_ENCODER &&
+        else if(indev_type == LV_INDEV_TYPE_KEYPAD ||
+        		((indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) &&
                                                        lv_group_get_editing(lv_obj_get_group(btnm)))) {
             ext->btn_id_pr = ext->btn_id_focused;
             invalidate_button_area(btnm, ext->btn_id_focused);
@@ -835,7 +836,7 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
         /*Search the pressed area*/
         lv_indev_t * indev = lv_indev_get_act();
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
-        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_KEYPAD) return LV_RES_OK;
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_KEYPAD || indev_type == LV_INDEV_TYPE_NAVIGATION) return LV_RES_OK;
 
         lv_indev_get_point(indev, &p);
         btn_pr = get_button_from_point(btnm, &p);
@@ -880,7 +881,7 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
 
 
             lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_get_act());
-            if(indev_type == LV_INDEV_TYPE_KEYPAD || indev_type == LV_INDEV_TYPE_ENCODER) {
+            if(indev_type == LV_INDEV_TYPE_KEYPAD || indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
                 ext->btn_id_focused = ext->btn_id_pr;
             }
 
@@ -920,7 +921,7 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
             indev_type = lv_indev_get_type(indev);
         }
 
-        if(indev_type == LV_INDEV_TYPE_ENCODER) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
             /*In navigation mode don't select any button but in edit mode select the fist*/
             if(lv_group_get_editing(lv_obj_get_group(btnm))) {
                 ext->btn_id_focused = 0;

--- a/src/lv_widgets/lv_cpicker.c
+++ b/src/lv_widgets/lv_cpicker.c
@@ -758,7 +758,7 @@ static lv_res_t lv_cpicker_signal(lv_obj_t * cpicker, lv_signal_t sign, void * p
 
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         lv_point_t p;
-        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_KEYPAD) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION || indev_type == LV_INDEV_TYPE_KEYPAD) {
             p.x = cpicker->coords.x1 + lv_obj_get_width(cpicker) / 2;
             p.y = cpicker->coords.y1 + lv_obj_get_height(cpicker) / 2;
         }

--- a/src/lv_widgets/lv_dropdown.c
+++ b/src/lv_widgets/lv_dropdown.c
@@ -916,7 +916,7 @@ static lv_res_t lv_dropdown_signal(lv_obj_t * ddlist, lv_signal_t sign, void * p
         lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_get_act());
 
         /*Encoders need special handling*/
-        if(indev_type == LV_INDEV_TYPE_ENCODER) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
             /*Open the list if editing*/
             if(editing) lv_dropdown_open(ddlist);
             /*Close the list if navigating*/
@@ -939,7 +939,7 @@ static lv_res_t lv_dropdown_signal(lv_obj_t * ddlist, lv_signal_t sign, void * p
                 }
 #if LV_USE_GROUP
                 lv_indev_type_t indev_type = lv_indev_get_type(indev);
-                if(indev_type == LV_INDEV_TYPE_ENCODER) {
+                if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
                     lv_group_set_editing(lv_obj_get_group(ddlist), false);
                 }
 #endif
@@ -1214,7 +1214,7 @@ static lv_res_t page_release_handler(lv_obj_t * page)
     lv_indev_t * indev = lv_indev_get_act();
 #if LV_USE_GROUP
     /*Leave edit mode once a new item is selected*/
-    if(lv_indev_get_type(indev) == LV_INDEV_TYPE_ENCODER) {
+    if(lv_indev_get_type(indev) == LV_INDEV_TYPE_ENCODER || lv_indev_get_type(indev) == LV_INDEV_TYPE_NAVIGATION) {
         ext->sel_opt_id_orig = ext->sel_opt_id;
         lv_group_t * g      = lv_obj_get_group(ddlist);
         if(lv_group_get_editing(g)) {

--- a/src/lv_widgets/lv_list.c
+++ b/src/lv_widgets/lv_list.c
@@ -658,7 +658,7 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param)
         lv_indev_t * indev         = lv_indev_get_act();
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         if(indev_type == LV_INDEV_TYPE_KEYPAD ||
-           (indev_type == LV_INDEV_TYPE_ENCODER && lv_group_get_editing(lv_obj_get_group(list)))) {
+           ((indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) && lv_group_get_editing(lv_obj_get_group(list)))) {
             lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
 
             /*The page receives the key presses so the events should be propagated to the selected
@@ -706,7 +706,7 @@ static lv_res_t lv_list_signal(lv_obj_t * list, lv_signal_t sign, void * param)
         /*With ENCODER focus the button only in edit mode*/
         lv_group_t * g = lv_obj_get_group(list);
         if((indev_type == LV_INDEV_TYPE_KEYPAD) ||
-           (indev_type == LV_INDEV_TYPE_ENCODER && lv_group_get_editing(g))) {
+           ((indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_ENCODER) && lv_group_get_editing(g))) {
             lv_list_ext_t * ext = lv_obj_get_ext_attr(list);
             /* Select the last used button, or use the first no last button */
             if(ext->last_sel_btn) lv_list_focus_btn(list, ext->last_sel_btn);

--- a/src/lv_widgets/lv_msgbox.c
+++ b/src/lv_widgets/lv_msgbox.c
@@ -472,7 +472,7 @@ static lv_res_t lv_msgbox_signal(lv_obj_t * mbox, lv_signal_t sign, void * param
         if(sign == LV_SIGNAL_FOCUS) {
             lv_indev_t * indev         = lv_indev_get_act();
             lv_indev_type_t indev_type = lv_indev_get_type(indev);
-            if(indev_type == LV_INDEV_TYPE_ENCODER) {
+            if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
                 /*In navigation mode don't select any button but in edit mode select the fist*/
                 if(lv_group_get_editing(lv_obj_get_group(mbox))) lv_btnmatrix_set_focused_btn(ext->btnm, 0);
                 else lv_btnmatrix_set_focused_btn(ext->btnm, LV_BTNMATRIX_BTN_NONE);

--- a/src/lv_widgets/lv_roller.c
+++ b/src/lv_widgets/lv_roller.c
@@ -514,7 +514,7 @@ static lv_res_t lv_roller_signal(lv_obj_t * roller, lv_signal_t sign, void * par
         lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_get_act());
 
         /*Encoders need special handling*/
-        if(indev_type == LV_INDEV_TYPE_ENCODER) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
             /*In navigate mode revert the original value*/
             if(!editing) {
                 if(ext->sel_opt_id != ext->sel_opt_id_ori) {
@@ -787,10 +787,10 @@ static lv_res_t release_handler(lv_obj_t * roller)
 #if LV_USE_GROUP
     /*Leave edit mode once a new option is selected*/
     lv_indev_type_t indev_type = lv_indev_get_type(indev);
-    if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_KEYPAD) {
+    if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_KEYPAD || indev_type == LV_INDEV_TYPE_NAVIGATION) {
         ext->sel_opt_id_ori = ext->sel_opt_id;
 
-        if(indev_type == LV_INDEV_TYPE_ENCODER) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
             lv_group_t * g      = lv_obj_get_group(roller);
             if(lv_group_get_editing(g)) {
                 lv_group_set_editing(g, false);

--- a/src/lv_widgets/lv_slider.c
+++ b/src/lv_widgets/lv_slider.c
@@ -375,7 +375,7 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
         lv_group_t * g             = lv_obj_get_group(slider);
         bool editing               = lv_group_get_editing(g);
         lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_get_act());
-        if(indev_type == LV_INDEV_TYPE_ENCODER) {
+        if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) {
             if(editing) lv_group_set_editing(g, false);
         }
 #endif

--- a/src/lv_widgets/lv_spinbox.c
+++ b/src/lv_widgets/lv_spinbox.c
@@ -411,7 +411,8 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
         /*If released with an ENCODER then move to the next digit*/
         lv_spinbox_ext_t * ext = lv_obj_get_ext_attr(spinbox);
         lv_indev_t * indev = lv_indev_get_act();
-        if(lv_indev_get_type(indev) == LV_INDEV_TYPE_ENCODER) {
+        if(lv_indev_get_type(indev) == LV_INDEV_TYPE_ENCODER ||
+        		lv_indev_get_type(indev) == LV_INDEV_TYPE_NAVIGATION) {
 #if LV_USE_GROUP
             if(lv_group_get_editing(lv_obj_get_group(spinbox))) {
                 if(ext->step > 1) {
@@ -468,13 +469,13 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
 
         uint32_t c = *((uint32_t *)param); /*uint32_t because can be UTF-8*/
         if(c == LV_KEY_RIGHT) {
-            if(indev_type == LV_INDEV_TYPE_ENCODER)
+            if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION)
                 lv_spinbox_increment(spinbox);
             else
                 lv_spinbox_step_next(spinbox);
         }
         else if(c == LV_KEY_LEFT) {
-            if(indev_type == LV_INDEV_TYPE_ENCODER)
+            if(indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION)
                 lv_spinbox_decrement(spinbox);
             else
                 lv_spinbox_step_prev(spinbox);

--- a/src/lv_widgets/lv_tabview.c
+++ b/src/lv_widgets/lv_tabview.c
@@ -638,7 +638,7 @@ static lv_res_t lv_tabview_signal(lv_obj_t * tabview, lv_signal_t sign, void * p
         lv_indev_t * indev         = lv_indev_get_act();
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         if(indev_type == LV_INDEV_TYPE_KEYPAD ||
-           (indev_type == LV_INDEV_TYPE_ENCODER && lv_group_get_editing(lv_obj_get_group(tabview)))) {
+           ((indev_type == LV_INDEV_TYPE_ENCODER || indev_type == LV_INDEV_TYPE_NAVIGATION) && lv_group_get_editing(lv_obj_get_group(tabview)))) {
             lv_event_send(ext->btns, LV_EVENT_CLICKED, lv_event_get_data());
         }
 #endif
@@ -817,7 +817,7 @@ static void tab_btnm_event_cb(lv_obj_t * tab_btnm, lv_event_t event)
     if(id_prev != id_new) res = lv_event_send(tabview, LV_EVENT_VALUE_CHANGED, &id_new);
 
 #if LV_USE_GROUP
-    if(lv_indev_get_type(lv_indev_get_act()) == LV_INDEV_TYPE_ENCODER) {
+    if(lv_indev_get_type(lv_indev_get_act()) == LV_INDEV_TYPE_ENCODER || lv_indev_get_type(lv_indev_get_act()) == LV_INDEV_TYPE_NAVIGATION) {
         lv_group_set_editing(lv_obj_get_group(tabview), false);
     }
 #endif

--- a/src/lv_widgets/lv_textarea.c
+++ b/src/lv_widgets/lv_textarea.c
@@ -1798,7 +1798,8 @@ static void update_cursor_position_on_click(lv_obj_t * ta, lv_signal_t sign, lv_
     if(ext->cursor.hidden) return;
 
     if(lv_indev_get_type(click_source) == LV_INDEV_TYPE_KEYPAD ||
-       lv_indev_get_type(click_source) == LV_INDEV_TYPE_ENCODER) {
+       lv_indev_get_type(click_source) == LV_INDEV_TYPE_ENCODER ||
+	   lv_indev_get_type(click_source) == LV_INDEV_TYPE_NAVIGATION) {
         return;
     }
 


### PR DESCRIPTION
input type usable with small keypad
LV_KEY_LEFT and LV_KEY_RIGHT keys are used for navigation and value edit
LV_KEY_ENTER short click enter and leaves edit mode if focused object is editable
(optional) LV_KEY_ESC exit edit mode