### PR TITLE
Fix visual studio compile errors in lv_anim code

### DIFF
--- a/src/lv_misc/lv_anim.c
+++ b/src/lv_misc/lv_anim.c
@@ -529,11 +529,11 @@ static bool anim_ready_handler(lv_anim_t * a)
     }
     /*If the animation is not deleted then restart it*/
     else {
-        a->act_time = -a->repeat_delay; /*Restart the animation*/
+        a->act_time = -(int32_t)(a->repeat_delay); /*Restart the animation*/
         /*Swap the start and end values in play back mode*/
         if(a->playback_time != 0) {
             /*If now turning back use the 'playback_pause*/
-            if(a->playback_now == 0) a->act_time = -a->playback_delay;
+            if(a->playback_now == 0) a->act_time = -(int32_t)(a->playback_delay);
 
             /*Toggle the play back state*/
             a->playback_now = a->playback_now == 0 ? 1 : 0;

--- a/src/lv_misc/lv_anim.h
+++ b/src/lv_misc/lv_anim.h
@@ -160,7 +160,7 @@ static inline void lv_anim_set_time(lv_anim_t * a, uint32_t duration)
  */
 static inline void lv_anim_set_delay(lv_anim_t * a, uint32_t delay)
 {
-    a->act_time = (int32_t)(-delay);
+    a->act_time = -(int32_t)(delay);
 }
 
 /**


### PR DESCRIPTION
unary negation operator was being applied to an usigned int in three places.  I'm not sure what the other compilers are doing to accept the current code , but I have cast the unsigned ints to a signed one before applying the unary operator.

I have not done targeted testing on these changes.  But I have compiled and run my working copy of the lv_sim_visual_studio_sdl project with these changes and animations seem to work as you would expect.