### PR TITLE
Write to logfile before setting the log callback to NULL

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -171,16 +171,16 @@ void lv_init(void)
 void lv_deinit(void)
 {
     _lv_gc_clear_roots();
-#if LV_USE_LOG
-    lv_log_register_print_cb(NULL);
-#endif
+	
     lv_disp_set_default(NULL);
     _lv_mem_deinit();
     lv_initialized = false;
+	
+    LV_LOG_INFO("lv_deinit done");
+	
 #if LV_USE_LOG
     lv_log_register_print_cb(NULL);
 #endif
-    LV_LOG_INFO("lv_deinit done");
 }
 #endif
 


### PR DESCRIPTION
In lv_deinit the log callback is first set to NULL and then the "lv_deinit done" message is logged.
I propose that the log message should be written with the log callback in place even if it is not the real end of the method. Since lv_log_register_print_cb is simply setting the value to NULL there should be no issues.