### PR TITLE
lv_spinner: Replace remaining pre loader references with spinner

### DIFF
--- a/src/lv_widgets/lv_spinner.c
+++ b/src/lv_widgets/lv_spinner.c
@@ -56,22 +56,22 @@ static lv_design_cb_t ancestor_design;
  **********************/
 
 /**
- * Create a pre loader object
- * @param par pointer to an object, it will be the parent of the new pre loader
- * @param copy pointer to a pre loader object, if not NULL then the new object will be copied from
+ * Create a spinner object
+ * @param par pointer to an object, it will be the parent of the new spinner
+ * @param copy pointer to a spinner object, if not NULL then the new object will be copied from
  * it
- * @return pointer to the created pre loader
+ * @return pointer to the created spinner
  */
 lv_obj_t * lv_spinner_create(lv_obj_t * par, const lv_obj_t * copy)
 {
     LV_LOG_TRACE("spinner create started");
 
-    /*Create the ancestor of pre loader*/
+    /*Create the ancestor of spinner*/
     lv_obj_t * spinner = lv_arc_create(par, copy);
     LV_ASSERT_MEM(spinner);
     if(spinner == NULL) return NULL;
 
-    /*Allocate the pre loader type specific extended data*/
+    /*Allocate the spinner type specific extended data*/
     lv_spinner_ext_t * ext = lv_obj_allocate_ext_attr(spinner, sizeof(lv_spinner_ext_t));
     LV_ASSERT_MEM(ext);
     if(ext == NULL) {
@@ -154,7 +154,7 @@ void lv_spinner_set_spin_time(lv_obj_t * spinner, uint16_t time)
 
 /**
  * Set the animation type of a spinnereer.
- * @param spinner pointer to pre loader object
+ * @param spinner pointer to spinner object
  * @param type animation type of the spinner
  *  */
 void lv_spinner_set_type(lv_obj_t * spinner, lv_spinner_type_t type)
@@ -230,8 +230,8 @@ void lv_spinner_set_dir(lv_obj_t * spinner, lv_spinner_dir_t dir)
  *====================*/
 
 /**
- * Get the arc length [degree] of the a pre loader
- * @param spinner pointer to a pre loader object
+ * Get the arc length [degree] of the a spinner
+ * @param spinner pointer to a spinner object
  */
 lv_anim_value_t lv_spinner_get_arc_length(const lv_obj_t * spinner)
 {
@@ -243,7 +243,7 @@ lv_anim_value_t lv_spinner_get_arc_length(const lv_obj_t * spinner)
 
 /**
  * Get the spin time of the arc
- * @param spinner pointer to a pre loader object [milliseconds]
+ * @param spinner pointer to a spinner object [milliseconds]
  */
 uint16_t lv_spinner_get_spin_time(const lv_obj_t * spinner)
 {
@@ -255,7 +255,7 @@ uint16_t lv_spinner_get_spin_time(const lv_obj_t * spinner)
 
 /**
  * Get the animation type of a spinnereer.
- * @param spinner pointer to pre loader object
+ * @param spinner pointer to spinner object
  * @return animation type
  *  */
 lv_spinner_type_t lv_spinner_get_type(lv_obj_t * spinner)
@@ -301,8 +301,8 @@ void lv_spinner_anim_cb(void * ptr, lv_anim_value_t val)
  **********************/
 
 /**
- * Signal function of the pre loader
- * @param spinner pointer to a pre loader object
+ * Signal function of the spinner
+ * @param spinner pointer to a spinner object
  * @param sign a signal type from lv_signal_t enum
  * @param param pointer to a signal specific variable
  * @return LV_RES_OK: the object is not deleted in the function; LV_RES_INV: the object is deleted

--- a/src/lv_widgets/lv_spinner.h
+++ b/src/lv_widgets/lv_spinner.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_preload.h
+ * @file lv_spinner.h
  *
  */
 
@@ -19,11 +19,11 @@ extern "C" {
 
 /*Testing of dependencies*/
 #if LV_USE_ARC == 0
-#error "lv_preload: lv_arc is required. Enable it in lv_conf.h (LV_USE_ARC  1) "
+#error "lv_spinner: lv_arc is required. Enable it in lv_conf.h (LV_USE_ARC  1) "
 #endif
 
 #if LV_USE_ANIMATION == 0
-#error "lv_preload: animations are required. Enable it in lv_conf.h (LV_USE_ANIMATION  1) "
+#error "lv_spinner: animations are required. Enable it in lv_conf.h (LV_USE_ANIMATION  1) "
 #endif
 
 #include "../lv_core/lv_obj.h"
@@ -57,7 +57,7 @@ enum {
 };
 typedef uint8_t lv_spinner_dir_t;
 
-/*Data of pre loader*/
+/*Data of spinner*/
 typedef struct {
     lv_arc_ext_t arc; /*Ext. of ancestor*/
     /*New data for this type */
@@ -82,11 +82,11 @@ typedef uint8_t lv_spinner_style_t;
  **********************/
 
 /**
- * Create a pre loader objects
- * @param par pointer to an object, it will be the parent of the new pre loader
- * @param copy pointer to a pre loader object, if not NULL then the new object will be copied from
+ * Create a spinner object
+ * @param par pointer to an object, it will be the parent of the new spinner
+ * @param copy pointer to a spinner object, if not NULL then the new object will be copied from
  * it
- * @return pointer to the created pre loader
+ * @return pointer to the created spinner
  */
 lv_obj_t * lv_spinner_create(lv_obj_t * par, const lv_obj_t * copy);
 
@@ -96,17 +96,17 @@ lv_obj_t * lv_spinner_create(lv_obj_t * par, const lv_obj_t * copy);
 
 /**
  * Set the length of the spinning  arc in degrees
- * @param preload pointer to a preload object
+ * @param spinner pointer to a spinner object
  * @param deg length of the arc
  */
-void lv_spinner_set_arc_length(lv_obj_t * preload, lv_anim_value_t deg);
+void lv_spinner_set_arc_length(lv_obj_t * spinner, lv_anim_value_t deg);
 
 /**
  * Set the spin time of the arc
- * @param preload pointer to a preload object
+ * @param spinner pointer to a spinner object
  * @param time time of one round in milliseconds
  */
-void lv_spinner_set_spin_time(lv_obj_t * preload, uint16_t time);
+void lv_spinner_set_spin_time(lv_obj_t * spinner, uint16_t time);
 
 /*=====================
  * Setter functions
@@ -114,47 +114,47 @@ void lv_spinner_set_spin_time(lv_obj_t * preload, uint16_t time);
 
 /**
  * Set the animation type of a spinner.
- * @param preload pointer to pre loader object
- * @param type animation type of the preload
+ * @param spinner pointer to spinner object
+ * @param type animation type of the spinner
  *  */
-void lv_spinner_set_type(lv_obj_t * preload, lv_spinner_type_t type);
+void lv_spinner_set_type(lv_obj_t * spinner, lv_spinner_type_t type);
 
 /**
  * Set the animation direction of a spinner
- * @param preload pointer to pre loader object
- * @param direction animation direction of the preload
+ * @param spinner pointer to spinner object
+ * @param direction animation direction of the spinner
  */
-void lv_spinner_set_dir(lv_obj_t * preload, lv_spinner_dir_t dir);
+void lv_spinner_set_dir(lv_obj_t * spinner, lv_spinner_dir_t dir);
 
 /*=====================
  * Getter functions
  *====================*/
 
 /**
- * Get the arc length [degree] of the a pre loader
- * @param preload pointer to a pre loader object
+ * Get the arc length [degree] of the a spinner
+ * @param spinner pointer to a spinner object
  */
-lv_anim_value_t lv_spinner_get_arc_length(const lv_obj_t * preload);
+lv_anim_value_t lv_spinner_get_arc_length(const lv_obj_t * spinner);
 
 /**
  * Get the spin time of the arc
- * @param preload pointer to a pre loader object [milliseconds]
+ * @param spinner pointer to a spinner object [milliseconds]
  */
-uint16_t lv_spinner_get_spin_time(const lv_obj_t * preload);
+uint16_t lv_spinner_get_spin_time(const lv_obj_t * spinner);
 
 /**
  * Get the animation type of a spinner.
- * @param preload pointer to pre loader object
+ * @param spinner pointer to spinner object
  * @return animation type
  *  */
-lv_spinner_type_t lv_spinner_get_type(lv_obj_t * preload);
+lv_spinner_type_t lv_spinner_get_type(lv_obj_t * spinner);
 
 /**
  * Get the animation direction of a spinner
- * @param preload pointer to pre loader object
+ * @param spinner pointer to spinner object
  * @return animation direction
  */
-lv_spinner_dir_t lv_spinner_get_dir(lv_obj_t * preload);
+lv_spinner_dir_t lv_spinner_get_dir(lv_obj_t * spinner);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
Related to https://github.com/lvgl/docs/issues/116

**EDIT**
I've checked the lvgl documentation and I think the API on the docs are pulled from here, or should the docs be manually updated?