### PR TITLE
Added functions to set multiple paddings and margins at once

### DIFF
--- a/src/lv_core/lv_obj_style_dec.h
+++ b/src/lv_core/lv_obj_style_dec.h
@@ -199,6 +199,99 @@ _LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_COLOR, scale_end_color, lv_color_t, _col
 
 #undef _LV_OBJ_STYLE_SET_GET_DECLARE
 
+
+static inline void lv_obj_set_style_local_pad_all(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_TOP | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_LEFT | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_style_set_pad_all(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_PAD_TOP | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_PAD_LEFT | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_PAD_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_obj_set_style_local_pad_hor(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_LEFT | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_style_set_pad_hor(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_PAD_LEFT | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_PAD_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_obj_set_style_local_pad_ver(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_TOP | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+}
+
+
+static inline void lv_style_set_pad_ver(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_PAD_TOP | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+}
+
+
+static inline void lv_obj_set_style_local_margin_all(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_TOP | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_LEFT | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_style_set_margin_all(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_MARGIN_TOP | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_MARGIN_LEFT | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_obj_set_style_local_margin_hor(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_LEFT | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_style_set_margin_hor(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_MARGIN_LEFT | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+}
+
+
+static inline void lv_obj_set_style_local_margin_ver(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
+{
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_TOP | (state << 8), value);
+    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+}
+
+
+static inline void lv_style_set_margin_ver(lv_style_t * style, lv_state_t state, lv_style_int_t value)
+{
+    _lv_style_set_int(style, LV_STYLE_MARGIN_TOP | (state << 8), value);
+    _lv_style_set_int(style, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+}
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/lv_core/lv_obj_style_dec.h
+++ b/src/lv_core/lv_obj_style_dec.h
@@ -202,93 +202,93 @@ _LV_OBJ_STYLE_SET_GET_DECLARE(SCALE_END_COLOR, scale_end_color, lv_color_t, _col
 
 static inline void lv_obj_set_style_local_pad_all(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_TOP | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_BOTTOM | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_LEFT | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_RIGHT | (state << 8), value);
+    lv_obj_set_style_local_pad_top(obj, part, state, value);
+    lv_obj_set_style_local_pad_bottom(obj, part, state, value);
+    lv_obj_set_style_local_pad_left(obj, part, state, value);
+    lv_obj_set_style_local_pad_right(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_pad_all(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_PAD_TOP | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_PAD_BOTTOM | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_PAD_LEFT | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_PAD_RIGHT | (state << 8), value);
+    lv_style_set_pad_top(style, state, value);
+    lv_style_set_pad_bottom(style, state, value);
+    lv_style_set_pad_left(style, state, value);
+    lv_style_set_pad_right(style, state, value);
 }
 
 
 static inline void lv_obj_set_style_local_pad_hor(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_LEFT | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_RIGHT | (state << 8), value);
+    lv_obj_set_style_local_pad_left(obj, part, state, value);
+    lv_obj_set_style_local_pad_right(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_pad_hor(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_PAD_LEFT | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_PAD_RIGHT | (state << 8), value);
+    lv_style_set_pad_left(style, state, value);
+    lv_style_set_pad_right(style, state, value);
 }
 
 
 static inline void lv_obj_set_style_local_pad_ver(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_TOP | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+    lv_obj_set_style_local_pad_top(obj, part, state, value);
+    lv_obj_set_style_local_pad_bottom(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_pad_ver(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_PAD_TOP | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_PAD_BOTTOM | (state << 8), value);
+    lv_style_set_pad_top(style, state, value);
+    lv_style_set_pad_bottom(style, state, value);
 }
 
 
 static inline void lv_obj_set_style_local_margin_all(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_TOP | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_LEFT | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+    lv_obj_set_style_local_margin_top(obj, part, state, value);
+    lv_obj_set_style_local_margin_bottom(obj, part, state, value);
+    lv_obj_set_style_local_margin_left(obj, part, state, value);
+    lv_obj_set_style_local_margin_right(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_margin_all(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_MARGIN_TOP | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_MARGIN_LEFT | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+    lv_style_set_margin_top(style, state, value);
+    lv_style_set_margin_bottom(style, state, value);
+    lv_style_set_margin_left(style, state, value);
+    lv_style_set_margin_right(style, state, value);
 }
 
 
 static inline void lv_obj_set_style_local_margin_hor(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_LEFT | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+    lv_obj_set_style_local_margin_left(obj, part, state, value);
+    lv_obj_set_style_local_margin_right(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_margin_hor(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_MARGIN_LEFT | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_MARGIN_RIGHT | (state << 8), value);
+    lv_style_set_margin_left(style, state, value);
+    lv_style_set_margin_right(style, state, value);
 }
 
 
 static inline void lv_obj_set_style_local_margin_ver(lv_obj_t * obj, uint8_t part, lv_state_t state, lv_style_int_t value)
 {
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_TOP | (state << 8), value);
-    _lv_obj_set_style_local_int(obj, part, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+    lv_obj_set_style_local_margin_top(obj, part, state, value);
+    lv_obj_set_style_local_margin_bottom(obj, part, state, value);
 }
 
 
 static inline void lv_style_set_margin_ver(lv_style_t * style, lv_state_t state, lv_style_int_t value)
 {
-    _lv_style_set_int(style, LV_STYLE_MARGIN_TOP | (state << 8), value);
-    _lv_style_set_int(style, LV_STYLE_MARGIN_BOTTOM | (state << 8), value);
+    lv_style_set_margin_top(style, state, value);
+    lv_style_set_margin_bottom(style, state, value);
 }
 
 


### PR DESCRIPTION
Hi,

here is my proposal to set multiple paddings / margins to a style or locally to an object, as discussed here: https://forum.lvgl.io/t/set-multiple-paddings-margins-at-once/2410/4

I hope this location (`src/lv_core/lv_obj_style_dec.h`) is good for them..