### PR TITLE
lv_slider: +1 feature, -1 bug

### DIFF
--- a/src/lv_widgets/lv_slider.c
+++ b/src/lv_widgets/lv_slider.c
@@ -260,8 +260,8 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
     if(res != LV_RES_OK) return res;
     if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
+    lv_slider_type_t type = lv_slider_get_type(slider);
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
-    lv_point_t p;
 
     /* Advanced hit testing: react only on dragging the knob(s) */
     if (LV_SIGNAL_HIT_TEST == sign) {
@@ -269,19 +269,21 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
 
         /* Ordinary slider: was the knob area hit? */
         info->result = _lv_area_is_point_on(&ext->right_knob_area, info->point, 0);
-        /* Range type has wwo knobs: check the other knob too */
-        if (lv_slider_get_type(slider) == LV_SLIDER_TYPE_RANGE) {
-            info->result |= _lv_area_is_point_on(&ext->left_knob_area, info->point, 0);
+
+        /* There's still a change we have a hit, if we have another knob */
+        if (false == info->result && LV_SLIDER_TYPE_RANGE == type) {
+            info->result = _lv_area_is_point_on(&ext->left_knob_area, info->point, 0);
         }
     }
 
+    lv_point_t p;
+
     if(sign == LV_SIGNAL_PRESSED) {
         ext->dragging = true;
-        if(lv_slider_get_type(slider) < LV_SLIDER_TYPE_RANGE) {
-            /* Normal and symmetrical types */
+        if(LV_SLIDER_TYPE_NORMAL == type || LV_SLIDER_TYPE_SYMMETRICAL == type) {
             ext->value_to_set = &ext->bar.cur_value;
         }
-        else if(lv_slider_get_type(slider) == LV_SLIDER_TYPE_RANGE) {
+        else if(LV_SLIDER_TYPE_RANGE == type) {
             lv_indev_get_point(param, &p);
             bool hor = lv_obj_get_width(slider) >= lv_obj_get_height(slider);
             lv_bidi_dir_t base_dir = lv_obj_get_base_dir(slider);

--- a/src/lv_widgets/lv_slider.c
+++ b/src/lv_widgets/lv_slider.c
@@ -263,9 +263,22 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
     lv_point_t p;
 
+    /* Advanced hit testing: react only on dragging the knob(s) */
+    if (LV_SIGNAL_HIT_TEST == sign) {
+        lv_hit_test_info_t *info = param;
+
+        /* Ordinary slider: was the knob area hit? */
+        info->result = _lv_area_is_point_on(&ext->right_knob_area, info->point, 0);
+        /* Range type has wwo knobs: check the other knob too */
+        if (lv_slider_get_type(slider) == LV_SLIDER_TYPE_RANGE) {
+            info->result |= _lv_area_is_point_on(&ext->left_knob_area, info->point, 0);
+        }
+    }
+
     if(sign == LV_SIGNAL_PRESSED) {
         ext->dragging = true;
-        if(lv_slider_get_type(slider) == LV_SLIDER_TYPE_NORMAL) {
+        if(lv_slider_get_type(slider) < LV_SLIDER_TYPE_RANGE) {
+            /* Normal and symmetrical types */
             ext->value_to_set = &ext->bar.cur_value;
         }
         else if(lv_slider_get_type(slider) == LV_SLIDER_TYPE_RANGE) {

--- a/src/lv_widgets/lv_slider.c
+++ b/src/lv_widgets/lv_slider.c
@@ -264,14 +264,14 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
     lv_slider_ext_t * ext = lv_obj_get_ext_attr(slider);
 
     /* Advanced hit testing: react only on dragging the knob(s) */
-    if (LV_SIGNAL_HIT_TEST == sign) {
+    if (sign == LV_SIGNAL_HIT_TEST) {
         lv_hit_test_info_t *info = param;
 
         /* Ordinary slider: was the knob area hit? */
         info->result = _lv_area_is_point_on(&ext->right_knob_area, info->point, 0);
 
         /* There's still a change we have a hit, if we have another knob */
-        if (false == info->result && LV_SLIDER_TYPE_RANGE == type) {
+        if ((info->result == false) && (type == LV_SLIDER_TYPE_RANGE)) {
             info->result = _lv_area_is_point_on(&ext->left_knob_area, info->point, 0);
         }
     }
@@ -280,10 +280,10 @@ static lv_res_t lv_slider_signal(lv_obj_t * slider, lv_signal_t sign, void * par
 
     if(sign == LV_SIGNAL_PRESSED) {
         ext->dragging = true;
-        if(LV_SLIDER_TYPE_NORMAL == type || LV_SLIDER_TYPE_SYMMETRICAL == type) {
+        if(type == LV_SLIDER_TYPE_NORMAL || type == LV_SLIDER_TYPE_SYMMETRICAL) {
             ext->value_to_set = &ext->bar.cur_value;
         }
-        else if(LV_SLIDER_TYPE_RANGE == type) {
+        else if(type == LV_SLIDER_TYPE_RANGE) {
             lv_indev_get_point(param, &p);
             bool hor = lv_obj_get_width(slider) >= lv_obj_get_height(slider);
             lv_bidi_dir_t base_dir = lv_obj_get_base_dir(slider);


### PR DESCRIPTION
An option to make slider act only to direct hit on the knob; not on the bar. As discussed in https://forum.lvgl.io/t/slider-object-make-it-react-only-to-knob-v7/2444

@embeddedt, now it works such that if the HIT TEST is enabled for a particular slider, this new feature kicks in. I.e, no separate setting flag etc.. Is it OK?

Then, the other one I found while testing this:
https://forum.lvgl.io/t/symmetrical-slider-not-possible-to-adjust-by-dragging-retake/2490

If this is NOT a proper bug, I'll drop it out and commit again.