### PR TITLE
mem_max_size is only used on non custom mem

### DIFF
--- a/src/lv_misc/lv_mem.c
+++ b/src/lv_misc/lv_mem.c
@@ -85,7 +85,10 @@ typedef struct {
 #endif
 
 static uint32_t zero_mem; /*Give the address of this variable if 0 byte should be allocated*/
+
+#if LV_MEM_CUSTOM == 0
 static uint32_t mem_max_size; /*Tracks the maximum total size of memory ever used from the internal heap*/ 
+#endif
 
 static uint8_t mem_buf1_32[MEM_BUF_SMALL_SIZE];
 static uint8_t mem_buf2_32[MEM_BUF_SMALL_SIZE];


### PR DESCRIPTION
Disable it for custom mem to prevent warnings