### PR TITLE
calendar: add option to start week on Monday

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -536,6 +536,9 @@ typedef void * lv_obj_user_data_t;
 
 /*Calendar (dependencies: -)*/
 #define LV_USE_CALENDAR 1
+#if LV_USE_CALENDAR
+#  define LV_CALENDAR_WEEK_STARTS_MONDAY    0
+#endif
 
 /*Canvas (dependencies: lv_img)*/
 #define LV_USE_CANVAS   1

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -799,6 +799,11 @@
 #ifndef LV_USE_CALENDAR
 #define LV_USE_CALENDAR 1
 #endif
+#if LV_USE_CALENDAR
+#ifndef LV_CALENDAR_WEEK_STARTS_MONDAY
+#  define LV_CALENDAR_WEEK_STARTS_MONDAY    0
+#endif
+#endif
 
 /*Canvas (dependencies: lv_img)*/
 #ifndef LV_USE_CANVAS

--- a/src/lv_widgets/lv_calendar.c
+++ b/src/lv_widgets/lv_calendar.c
@@ -57,7 +57,11 @@ static uint8_t is_leap_year(uint32_t year);
  **********************/
 static lv_signal_cb_t ancestor_signal;
 static lv_design_cb_t ancestor_design;
+#if LV_CALENDAR_WEEK_STARTS_MONDAY != 0
+static const char * day_name[7]    = {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"};
+#else
 static const char * day_name[7]    = {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"};
+#endif
 static const char * month_name[12] = {"January", "February", "March",     "April",   "May",      "June",
                                       "July",    "August",   "September", "October", "November", "December"
                                      };
@@ -1057,14 +1061,18 @@ static uint8_t is_leap_year(uint32_t year)
  * @param year a year
  * @param month a  month
  * @param day a day
- * @return [0..6] which means [Sun..Sat]
+ * @return [0..6] which means [Sun..Sat] or [Mon..Sun] depending on LV_CALENDAR_WEEK_STARTS_MONDAY
  */
 static uint8_t get_day_of_week(uint32_t year, uint32_t month, uint32_t day)
 {
     uint32_t a = month < 3 ? 1 : 0;
     uint32_t b = year - a;
 
+    #if LV_CALENDAR_WEEK_STARTS_MONDAY
+    uint32_t day_of_week = (day + (31 * (month - 2 + 12 * a) / 12) + b + (b / 4) - (b / 100) + (b / 400) - 1) % 7;
+    #else
     uint32_t day_of_week = (day + (31 * (month - 2 + 12 * a) / 12) + b + (b / 4) - (b / 100) + (b / 400)) % 7;
+    #endif
 
     return day_of_week;
 }


### PR DESCRIPTION
Using define LV_CALENDAR_WEEK_STARTS_MONDAY.
Using a define it's not possible to change this configuration on the fly,
but it was the simplest approach and it doesn't change the API at all.

Thanks!