### PR TITLE
lv_conf_checker.py: change requirement of python 3.6 to >=3.6

### DIFF
--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -1,11 +1,16 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 '''
 Generates a checker file for lv_conf.h from lv_conf_templ.h define all the not defined values
 '''
 
 
+import sys
 import re
+
+if sys.version_info < (3,6,0):
+  print("Python >=3.6 is required", file=sys.stderr)
+  exit(1)
 
 fin = open("../lv_conf_template.h", "r")
 fout = open("../src/lv_conf_internal.h", "w")


### PR DESCRIPTION
Many current OSes ship newer versions (e.g. 3.8) and they work OK
for this, so I don't think 3.6 is required specifically.
Versions older than 3.6 wouldn't work, though, since f-strings
are used.

Thanks!