### PR TITLE
Add missing lv_font_montserrat_34

### DIFF
--- a/src/lv_font/lv_font.h
+++ b/src/lv_font/lv_font.h
@@ -171,6 +171,10 @@ LV_FONT_DECLARE(lv_font_montserrat_30)
 LV_FONT_DECLARE(lv_font_montserrat_32)
 #endif
 
+#if LV_FONT_MONTSERRAT_34
+LV_FONT_DECLARE(lv_font_montserrat_34)
+#endif
+   
 #if LV_FONT_MONTSERRAT_36
 LV_FONT_DECLARE(lv_font_montserrat_36)
 #endif


### PR DESCRIPTION
if you do not mind me asking, and on matters of fonts why was Roboto changed to Montserrat when V7 was released ?