### PR TITLE
Fix big endian pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.1.0 (planned on 07.07.2020)
 *Available in the `master` branch*
+- Change some lv_style_t methods to support big endian hardware.
 
 ### New features
 - Add `focus_parent` attribute to `lv_obj`

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -2441,7 +2441,7 @@ lv_style_int_t _lv_obj_get_style_int(const lv_obj_t * obj, uint8_t part, lv_styl
     lv_style_property_t prop_ori = prop;
 
     lv_style_attr_t attr;
-    attr.full = prop_ori >> 8;
+    attr = prop_ori >> 8;
 
     lv_style_int_t value_act;
     lv_res_t res = LV_RES_INV;
@@ -2455,7 +2455,7 @@ lv_style_int_t _lv_obj_get_style_int(const lv_obj_t * obj, uint8_t part, lv_styl
         res = _lv_style_list_get_int(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(LV_ATTR_INHERIT(attr.full) == 0) break;
+        if(LV_STYLE_ATTR_GET_INHERIT(attr) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2504,7 +2504,7 @@ lv_color_t _lv_obj_get_style_color(const lv_obj_t * obj, uint8_t part, lv_style_
     lv_style_property_t prop_ori = prop;
 
     lv_style_attr_t attr;
-    attr.full = prop_ori >> 8;
+    attr = prop_ori >> 8;
 
     lv_color_t value_act;
     lv_res_t res = LV_RES_INV;
@@ -2518,7 +2518,7 @@ lv_color_t _lv_obj_get_style_color(const lv_obj_t * obj, uint8_t part, lv_style_
         res = _lv_style_list_get_color(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(LV_ATTR_INHERIT(attr.full) == 0) break;
+        if(LV_STYLE_ATTR_GET_INHERIT(attr) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2560,7 +2560,7 @@ lv_opa_t _lv_obj_get_style_opa(const lv_obj_t * obj, uint8_t part, lv_style_prop
     lv_style_property_t prop_ori = prop;
 
     lv_style_attr_t attr;
-    attr.full = prop_ori >> 8;
+    attr = prop_ori >> 8;
 
     lv_opa_t value_act;
     lv_res_t res = LV_RES_INV;
@@ -2574,7 +2574,7 @@ lv_opa_t _lv_obj_get_style_opa(const lv_obj_t * obj, uint8_t part, lv_style_prop
         res = _lv_style_list_get_opa(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(LV_ATTR_INHERIT(attr.full) == 0) break;
+        if(LV_STYLE_ATTR_GET_INHERIT(attr) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2617,7 +2617,7 @@ const void * _lv_obj_get_style_ptr(const lv_obj_t * obj, uint8_t part, lv_style_
     lv_style_property_t prop_ori = prop;
 
     lv_style_attr_t attr;
-    attr.full = prop_ori >> 8;
+    attr = prop_ori >> 8;
 
     const void * value_act;
     lv_res_t res = LV_RES_INV;
@@ -2631,7 +2631,7 @@ const void * _lv_obj_get_style_ptr(const lv_obj_t * obj, uint8_t part, lv_style_
         res = _lv_style_list_get_ptr(dsc, prop, &value_act);
         if(res == LV_RES_OK)  return value_act;
 
-        if(LV_ATTR_INHERIT(attr.full) == 0) break;
+        if(LV_STYLE_ATTR_GET_INHERIT(attr) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -2455,7 +2455,7 @@ lv_style_int_t _lv_obj_get_style_int(const lv_obj_t * obj, uint8_t part, lv_styl
         res = _lv_style_list_get_int(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(attr.bits.inherit == 0) break;
+        if(LV_ATTR_INHERIT(attr.full) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2518,7 +2518,7 @@ lv_color_t _lv_obj_get_style_color(const lv_obj_t * obj, uint8_t part, lv_style_
         res = _lv_style_list_get_color(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(attr.bits.inherit == 0) break;
+        if(LV_ATTR_INHERIT(attr.full) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2574,7 +2574,7 @@ lv_opa_t _lv_obj_get_style_opa(const lv_obj_t * obj, uint8_t part, lv_style_prop
         res = _lv_style_list_get_opa(dsc, prop, &value_act);
         if(res == LV_RES_OK) return value_act;
 
-        if(attr.bits.inherit == 0) break;
+        if(LV_ATTR_INHERIT(attr.full) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -2631,7 +2631,7 @@ const void * _lv_obj_get_style_ptr(const lv_obj_t * obj, uint8_t part, lv_style_
         res = _lv_style_list_get_ptr(dsc, prop, &value_act);
         if(res == LV_RES_OK)  return value_act;
 
-        if(attr.bits.inherit == 0) break;
+        if(LV_ATTR_INHERIT(attr.full) == 0) break;
 
         /*If not found, check the `MAIN` style first*/
         if(part != LV_OBJ_PART_MAIN) {
@@ -4137,4 +4137,3 @@ static bool obj_valid_child(const lv_obj_t * parent, const lv_obj_t * obj_to_fin
 
     return false;
 }
-

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -36,6 +36,12 @@
  **********************/
 LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t * style, lv_style_property_t prop);
 static lv_style_t * get_alloc_local_style(lv_style_list_t * list);
+static void style_resize(lv_style_t *style, size_t sz);
+static lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx);
+static uint8_t get_style_prop_id(const lv_style_t *style, size_t idx);
+static uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx);
+static size_t get_prop_size(uint8_t prop_id);
+static size_t get_next_prop_index(uint8_t prop_id, size_t id);
 
 /**********************
  *  GLOABAL VARIABLES
@@ -102,16 +108,12 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_property_t prop)
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = *(style->map + id + 1);
+        attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
         if(attr_found.bits.state == attr_goal.bits.state) {
             uint32_t map_size = _lv_style_get_mem_size(style);
-            uint8_t prop_size = sizeof(lv_style_property_t);
-            if((prop & 0xF) < LV_STYLE_ID_COLOR) prop_size += sizeof(lv_style_int_t);
-            else if((prop & 0xF) < LV_STYLE_ID_OPA) prop_size += sizeof(lv_color_t);
-            else if((prop & 0xF) < LV_STYLE_ID_PTR) prop_size += sizeof(lv_opa_t);
-            else prop_size += sizeof(const void *);
+            uint8_t prop_size = get_prop_size(prop);
 
             /*Move the props to fill the space of the property to delete*/
             uint32_t i;
@@ -119,7 +121,7 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_property_t prop)
                 style->map[i] = style->map[i + prop_size];
             }
 
-            style->map = lv_mem_realloc(style->map, map_size - prop_size);
+            style_resize(style, map_size - prop_size);
 
             return true;
         }
@@ -328,23 +330,17 @@ void lv_style_reset(lv_style_t * style)
  * @param style pointer to a style
  * @return size of the properties in bytes
  */
-uint16_t _lv_style_get_mem_size(const lv_style_t * style)
+uint16_t
+_lv_style_get_mem_size(const lv_style_t *style)
 {
     LV_ASSERT_STYLE(style);
 
     if(style->map == NULL) return 0;
-
     size_t i = 0;
-    while(style->map[i] != _LV_STYLE_CLOSEING_PROP) {
-        /*Go to the next property*/
-        if((style->map[i] & 0xF) < LV_STYLE_ID_COLOR) i += sizeof(lv_style_int_t);
-        else if((style->map[i] & 0xF) < LV_STYLE_ID_OPA) i += sizeof(lv_color_t);
-        else if((style->map[i] & 0xF) < LV_STYLE_ID_PTR) i += sizeof(lv_opa_t);
-        else i += sizeof(const void *);
-
-        i += sizeof(lv_style_property_t);
+    uint8_t prop_id;
+    while((prop_id = get_style_prop_id(style, i)) != _LV_STYLE_CLOSEING_PROP) {
+        i = get_next_prop_index(prop_id, i);
     }
-
     return i + sizeof(lv_style_property_t);
 }
 
@@ -368,7 +364,7 @@ void _lv_style_set_int(lv_style_t * style, lv_style_property_t prop, lv_style_in
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = *(style->map + id + 1);
+        attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
         if(attr_found.bits.state == attr_goal.bits.state) {
@@ -385,7 +381,7 @@ void _lv_style_set_int(lv_style_t * style, lv_style_property_t prop, lv_style_in
     uint16_t size = _lv_style_get_mem_size(style);
     if(size == 0) size += end_mark_size;
     size += sizeof(lv_style_property_t) + sizeof(lv_style_int_t);
-    style->map = lv_mem_realloc(style->map, size);
+    style_resize(style, size);
     LV_ASSERT_MEM(style->map);
     if(style == NULL) return;
 
@@ -414,7 +410,7 @@ void _lv_style_set_color(lv_style_t * style, lv_style_property_t prop, lv_color_
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = *(style->map + id + 1);
+        attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
         if(attr_found.bits.state == attr_goal.bits.state) {
@@ -432,7 +428,7 @@ void _lv_style_set_color(lv_style_t * style, lv_style_property_t prop, lv_color_
     if(size == 0) size += end_mark_size;
 
     size += sizeof(lv_style_property_t) + sizeof(lv_color_t);
-    style->map = lv_mem_realloc(style->map, size);
+    style_resize(style, size);
     LV_ASSERT_MEM(style->map);
     if(style == NULL) return;
 
@@ -461,7 +457,7 @@ void _lv_style_set_opa(lv_style_t * style, lv_style_property_t prop, lv_opa_t op
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = *(style->map + id + 1);
+        attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
         if(attr_found.bits.state == attr_goal.bits.state) {
@@ -479,7 +475,7 @@ void _lv_style_set_opa(lv_style_t * style, lv_style_property_t prop, lv_opa_t op
     if(size == 0) size += end_mark_size;
 
     size += sizeof(lv_style_property_t) + sizeof(lv_opa_t);
-    style->map = lv_mem_realloc(style->map, size);
+    style_resize(style, size);
     LV_ASSERT_MEM(style->map);
     if(style == NULL) return;
 
@@ -508,7 +504,7 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = *(style->map + id + 1);
+        attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
         if(attr_found.bits.state == attr_goal.bits.state) {
@@ -526,7 +522,7 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
     if(size == 0) size += end_mark_size;
 
     size += sizeof(lv_style_property_t) + sizeof(const void *);
-    style->map = lv_mem_realloc(style->map, size);
+    style_resize(style, size);
     LV_ASSERT_MEM(style->map);
     if(style == NULL) return;
 
@@ -560,7 +556,7 @@ int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_style_int_t));
         lv_style_attr_t attr_act;
-        attr_act.full = style->map[id + 1];
+        attr_act.full = get_style_prop_attr(style, id + 1);
 
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
@@ -597,7 +593,7 @@ int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_opa_t));
         lv_style_attr_t attr_act;
-        attr_act.full = style->map[id + 1];
+        attr_act.full = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
@@ -631,7 +627,7 @@ int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, 
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_color_t));
         lv_style_attr_t attr_act;
-        attr_act.full = style->map[id + 1];
+        attr_act.full = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
@@ -666,7 +662,7 @@ int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(const void *));
         lv_style_attr_t attr_act;
-        attr_act.full = style->map[id + 1];
+        attr_act.full = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
@@ -1067,10 +1063,12 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
     int16_t id_guess = -1;
 
     size_t i = 0;
-    while(style->map[i] != _LV_STYLE_CLOSEING_PROP) {
-        if(style->map[i] == id_to_find) {
+    
+    uint8_t prop_id;    
+    while((prop_id = get_style_prop_id(style, i)) != _LV_STYLE_CLOSEING_PROP) {
+        if(prop_id == id_to_find) {
             lv_style_attr_t attr_i;
-            attr_i.full = style->map[i + 1];
+            attr_i.full = get_style_prop_attr(style, i);
 
             /*If the state perfectly matches return this property*/
             if(attr_i.bits.state == attr.bits.state) {
@@ -1088,13 +1086,8 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
             }
         }
 
-        /*Go to the next property*/
-        if((style->map[i] & 0xF) < LV_STYLE_ID_COLOR) i += sizeof(lv_style_int_t);
-        else if((style->map[i] & 0xF) < LV_STYLE_ID_OPA) i += sizeof(lv_color_t);
-        else if((style->map[i] & 0xF) < LV_STYLE_ID_PTR) i += sizeof(lv_opa_t);
-        else i += sizeof(const void *);
+        i = get_next_prop_index(prop_id, i);
 
-        i += sizeof(lv_style_property_t);
     }
 
     return id_guess;
@@ -1124,4 +1117,80 @@ static lv_style_t * get_alloc_local_style(lv_style_list_t * list)
     list->has_local = 1;
 
     return local_style;
+}
+
+/**
+ * Resizes a style map. Useful entry point for debugging.
+ * @param style pointer to the style to be resized.
+ * @param size new size
+ */
+static void style_resize(lv_style_t *style, size_t sz)
+{
+    style->map = lv_mem_realloc(style->map, sz);
+}
+
+/**
+ * Get style property in index.
+ * @param style pointer to style.
+ * @param idx index of the style in style->map
+ * @return property in style->map + idx
+ */
+static lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx)
+{
+    lv_style_property_t prop;
+    uint8_t *prop_p = (uint8_t*)&prop;
+    prop_p[0] = style->map[idx];
+    prop_p[1] = style->map[idx + 1];
+    return prop;
+}
+
+/**
+ * Get style property id in index.
+ * @param style pointer to style.
+ * @param idx index of the style in style->map
+ * @return id of property in style->map + idx
+ */
+static uint8_t get_style_prop_id(const lv_style_t *style, size_t idx)
+{
+    return get_style_prop(style, idx) & 0xFF;
+}
+
+/**
+ * Get style property attributes for index.
+ * @param style pointer to style.
+ * @param idx index of the style in style->map
+ * @return attribute of property in style->map + idx
+ */
+static uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx)
+{
+    return ((get_style_prop(style, idx) >> 8) & 0xFFU);
+}
+
+
+/**
+ * Get property size.
+ * @param prop_id property id.
+ * @param idx index of the style in style->map
+ * @return attribute of property in style->map + idx
+ */
+static size_t get_prop_size(uint8_t prop_id)
+{
+    prop_id &= 0xF;
+    size_t size = sizeof(lv_style_property_t);
+    if(prop_id < LV_STYLE_ID_COLOR) size += sizeof(lv_style_int_t);
+    else if(prop_id < LV_STYLE_ID_OPA) size += sizeof(lv_color_t);
+    else if(prop_id < LV_STYLE_ID_PTR) size += sizeof(lv_opa_t);
+    else size += sizeof(const void *);
+    return size;
+}
+
+/**
+ * Get next property index, given current property and index.
+ * @param prop_id property id.
+ * @param idx index of the style in style->map
+ * @return index of next property in style->map
+ */
+static size_t get_next_prop_index(uint8_t prop_id, size_t idx)
+{
+    return idx + get_prop_size(prop_id);
 }

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -111,7 +111,7 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_property_t prop)
         attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
-        if(attr_found.bits.state == attr_goal.bits.state) {
+        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
             uint32_t map_size = _lv_style_get_mem_size(style);
             uint8_t prop_size = get_prop_size(prop);
 
@@ -368,7 +368,7 @@ void _lv_style_set_int(lv_style_t * style, lv_style_property_t prop, lv_style_in
         attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
-        if(attr_found.bits.state == attr_goal.bits.state) {
+        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &value, sizeof(lv_style_int_t));
             return;
         }
@@ -414,7 +414,7 @@ void _lv_style_set_color(lv_style_t * style, lv_style_property_t prop, lv_color_
         attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
-        if(attr_found.bits.state == attr_goal.bits.state) {
+        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &color, sizeof(lv_color_t));
             return;
         }
@@ -461,7 +461,7 @@ void _lv_style_set_opa(lv_style_t * style, lv_style_property_t prop, lv_opa_t op
         attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
-        if(attr_found.bits.state == attr_goal.bits.state) {
+        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &opa, sizeof(lv_opa_t));
             return;
         }
@@ -508,7 +508,7 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
         attr_found.full = get_style_prop_attr(style, id);
         attr_goal.full = (prop >> 8) & 0xFFU;
 
-        if(attr_found.bits.state == attr_goal.bits.state) {
+        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &p, sizeof(const void *));
             return;
         }
@@ -562,7 +562,7 @@ int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, vo
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
 
-        return attr_act.bits.state & attr_goal.bits.state;
+        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
     }
 }
 
@@ -599,7 +599,7 @@ int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, vo
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
 
-        return attr_act.bits.state & attr_goal.bits.state;
+        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
     }
 }
 
@@ -633,7 +633,7 @@ int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, 
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
 
-        return attr_act.bits.state & attr_goal.bits.state;
+        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
     }
 }
 
@@ -668,7 +668,7 @@ int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, vo
         lv_style_attr_t attr_goal;
         attr_goal.full = (prop >> 8) & 0xFF;
 
-        return attr_act.bits.state & attr_goal.bits.state;
+        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
     }
 }
 
@@ -1072,16 +1072,16 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
             attr_i.full = get_style_prop_attr(style, i);
 
             /*If the state perfectly matches return this property*/
-            if(attr_i.bits.state == attr.bits.state) {
+            if(LV_ATTR_STATE(attr_i.full) == LV_ATTR_STATE(attr.full)) {
                 return i;
             }
             /* Be sure the property not specifies other state than the requested.
              * E.g. For HOVER+PRESS, HOVER only is OK, but HOVER+FOCUS not*/
-            else if((attr_i.bits.state & (~attr.bits.state)) == 0) {
+            else if((LV_ATTR_STATE(attr_i.full) & (~LV_ATTR_STATE(attr.full))) == 0) {
                 /* Use this property if it describes better the requested state than the current candidate.
                  * E.g. for HOVER+FOCUS+PRESS prefer HOVER+FOCUS over FOCUS*/
-                if(attr_i.bits.state > weight) {
-                    weight = attr_i.bits.state;
+                if(LV_ATTR_STATE(attr_i.full) > weight) {
+                    weight = LV_ATTR_STATE(attr_i.full);
                     id_guess = i;
                 }
             }

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -108,10 +108,10 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_property_t prop)
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = get_style_prop_attr(style, id);
-        attr_goal.full = (prop >> 8) & 0xFFU;
+        attr_found = get_style_prop_attr(style, id);
+        attr_goal = (prop >> 8) & 0xFFU;
 
-        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
+        if(LV_STYLE_ATTR_GET_STATE(attr_found) == LV_STYLE_ATTR_GET_STATE(attr_goal)) {
             uint32_t map_size = _lv_style_get_mem_size(style);
             uint8_t prop_size = get_prop_size(prop);
 
@@ -365,10 +365,10 @@ void _lv_style_set_int(lv_style_t * style, lv_style_property_t prop, lv_style_in
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = get_style_prop_attr(style, id);
-        attr_goal.full = (prop >> 8) & 0xFFU;
+        attr_found = get_style_prop_attr(style, id);
+        attr_goal = (prop >> 8) & 0xFFU;
 
-        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
+        if(LV_STYLE_ATTR_GET_STATE(attr_found) == LV_STYLE_ATTR_GET_STATE(attr_goal)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &value, sizeof(lv_style_int_t));
             return;
         }
@@ -411,10 +411,10 @@ void _lv_style_set_color(lv_style_t * style, lv_style_property_t prop, lv_color_
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = get_style_prop_attr(style, id);
-        attr_goal.full = (prop >> 8) & 0xFFU;
+        attr_found = get_style_prop_attr(style, id);
+        attr_goal = (prop >> 8) & 0xFFU;
 
-        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
+        if(LV_STYLE_ATTR_GET_STATE(attr_found) == LV_STYLE_ATTR_GET_STATE(attr_goal)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &color, sizeof(lv_color_t));
             return;
         }
@@ -458,10 +458,10 @@ void _lv_style_set_opa(lv_style_t * style, lv_style_property_t prop, lv_opa_t op
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = get_style_prop_attr(style, id);
-        attr_goal.full = (prop >> 8) & 0xFFU;
+        attr_found = get_style_prop_attr(style, id);
+        attr_goal = (prop >> 8) & 0xFFU;
 
-        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
+        if(LV_STYLE_ATTR_GET_STATE(attr_found) == LV_STYLE_ATTR_GET_STATE(attr_goal)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &opa, sizeof(lv_opa_t));
             return;
         }
@@ -505,10 +505,10 @@ void _lv_style_set_ptr(lv_style_t * style, lv_style_property_t prop, const void 
         lv_style_attr_t attr_found;
         lv_style_attr_t attr_goal;
 
-        attr_found.full = get_style_prop_attr(style, id);
-        attr_goal.full = (prop >> 8) & 0xFFU;
+        attr_found = get_style_prop_attr(style, id);
+        attr_goal = (prop >> 8) & 0xFFU;
 
-        if(LV_ATTR_STATE(attr_found.full) == LV_ATTR_STATE(attr_goal.full)) {
+        if(LV_STYLE_ATTR_GET_STATE(attr_found) == LV_STYLE_ATTR_GET_STATE(attr_goal)) {
             _lv_memcpy_small(style->map + id + sizeof(lv_style_property_t), &p, sizeof(const void *));
             return;
         }
@@ -557,12 +557,12 @@ int16_t _lv_style_get_int(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_style_int_t));
         lv_style_attr_t attr_act;
-        attr_act.full = get_style_prop_attr(style, id + 1);
+        attr_act = get_style_prop_attr(style, id + 1);
 
         lv_style_attr_t attr_goal;
-        attr_goal.full = (prop >> 8) & 0xFF;
+        attr_goal = (prop >> 8) & 0xFF;
 
-        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
+        return LV_STYLE_ATTR_GET_STATE(attr_act) & LV_STYLE_ATTR_GET_STATE(attr_goal);
     }
 }
 
@@ -594,12 +594,12 @@ int16_t _lv_style_get_opa(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_opa_t));
         lv_style_attr_t attr_act;
-        attr_act.full = get_style_prop_attr(style, id);
+        attr_act = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
-        attr_goal.full = (prop >> 8) & 0xFF;
+        attr_goal = (prop >> 8) & 0xFF;
 
-        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
+        return LV_STYLE_ATTR_GET_STATE(attr_act) & LV_STYLE_ATTR_GET_STATE(attr_goal);
     }
 }
 
@@ -628,12 +628,12 @@ int16_t _lv_style_get_color(const lv_style_t * style, lv_style_property_t prop, 
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(lv_color_t));
         lv_style_attr_t attr_act;
-        attr_act.full = get_style_prop_attr(style, id);
+        attr_act = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
-        attr_goal.full = (prop >> 8) & 0xFF;
+        attr_goal = (prop >> 8) & 0xFF;
 
-        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
+        return LV_STYLE_ATTR_GET_STATE(attr_act) & LV_STYLE_ATTR_GET_STATE(attr_goal);
     }
 }
 
@@ -663,12 +663,12 @@ int16_t _lv_style_get_ptr(const lv_style_t * style, lv_style_property_t prop, vo
     else {
         _lv_memcpy_small(res, &style->map[id + sizeof(lv_style_property_t)], sizeof(const void *));
         lv_style_attr_t attr_act;
-        attr_act.full = get_style_prop_attr(style, id);
+        attr_act = get_style_prop_attr(style, id);
 
         lv_style_attr_t attr_goal;
-        attr_goal.full = (prop >> 8) & 0xFF;
+        attr_goal = (prop >> 8) & 0xFF;
 
-        return LV_ATTR_STATE(attr_act.full) & LV_ATTR_STATE(attr_goal.full);
+        return LV_STYLE_ATTR_GET_STATE(attr_act) & LV_STYLE_ATTR_GET_STATE(attr_goal);
     }
 }
 
@@ -816,8 +816,8 @@ lv_res_t _lv_style_list_get_int(lv_style_list_t * list, lv_style_property_t prop
     if(list->style_list == NULL) return LV_RES_INV;
 
     lv_style_attr_t attr;
-    attr.full = prop >> 8;
-    int16_t weight_goal = attr.full;
+    attr = prop >> 8;
+    int16_t weight_goal = attr;
 
     int16_t weight = -1;
 
@@ -868,8 +868,8 @@ lv_res_t _lv_style_list_get_color(lv_style_list_t * list, lv_style_property_t pr
     if(list->style_list == NULL) return LV_RES_INV;
 
     lv_style_attr_t attr;
-    attr.full = prop >> 8;
-    int16_t weight_goal = attr.full;
+    attr = prop >> 8;
+    int16_t weight_goal = attr;
 
     int16_t weight = -1;
 
@@ -918,8 +918,8 @@ lv_res_t _lv_style_list_get_opa(lv_style_list_t * list, lv_style_property_t prop
     if(list->style_list == NULL) return LV_RES_INV;
 
     lv_style_attr_t attr;
-    attr.full = prop >> 8;
-    int16_t weight_goal = attr.full;
+    attr = prop >> 8;
+    int16_t weight_goal = attr;
 
     int16_t weight = -1;
 
@@ -968,8 +968,8 @@ lv_res_t _lv_style_list_get_ptr(lv_style_list_t * list, lv_style_property_t prop
     if(list->style_list == NULL) return LV_RES_INV;
 
     lv_style_attr_t attr;
-    attr.full = prop >> 8;
-    int16_t weight_goal = attr.full;
+    attr = prop >> 8;
+    int16_t weight_goal = attr;
 
     int16_t weight = -1;
 
@@ -1058,7 +1058,7 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
 
     uint8_t id_to_find = prop & 0xFF;
     lv_style_attr_t attr;
-    attr.full = (prop >> 8) & 0xFF;
+    attr = (prop >> 8) & 0xFF;
 
     int16_t weight = -1;
     int16_t id_guess = -1;
@@ -1069,19 +1069,19 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
     while((prop_id = get_style_prop_id(style, i)) != _LV_STYLE_CLOSEING_PROP) {
         if(prop_id == id_to_find) {
             lv_style_attr_t attr_i;
-            attr_i.full = get_style_prop_attr(style, i);
+            attr_i = get_style_prop_attr(style, i);
 
             /*If the state perfectly matches return this property*/
-            if(LV_ATTR_STATE(attr_i.full) == LV_ATTR_STATE(attr.full)) {
+            if(LV_STYLE_ATTR_GET_STATE(attr_i) == LV_STYLE_ATTR_GET_STATE(attr)) {
                 return i;
             }
             /* Be sure the property not specifies other state than the requested.
              * E.g. For HOVER+PRESS, HOVER only is OK, but HOVER+FOCUS not*/
-            else if((LV_ATTR_STATE(attr_i.full) & (~LV_ATTR_STATE(attr.full))) == 0) {
+            else if((LV_STYLE_ATTR_GET_STATE(attr_i) & (~LV_STYLE_ATTR_GET_STATE(attr))) == 0) {
                 /* Use this property if it describes better the requested state than the current candidate.
                  * E.g. for HOVER+FOCUS+PRESS prefer HOVER+FOCUS over FOCUS*/
-                if(LV_ATTR_STATE(attr_i.full) > weight) {
-                    weight = LV_ATTR_STATE(attr_i.full);
+                if(LV_STYLE_ATTR_GET_STATE(attr_i) > weight) {
+                    weight = LV_STYLE_ATTR_GET_STATE(attr_i);
                     id_guess = i;
                 }
             }

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -35,13 +35,13 @@
  *  STATIC PROTOTYPES
  **********************/
 LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t * style, lv_style_property_t prop);
-static lv_style_t * get_alloc_local_style(lv_style_list_t * list);
-static void style_resize(lv_style_t *style, size_t sz);
-static lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx);
-static uint8_t get_style_prop_id(const lv_style_t *style, size_t idx);
-static uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx);
-static size_t get_prop_size(uint8_t prop_id);
-static size_t get_next_prop_index(uint8_t prop_id, size_t id);
+static inline lv_style_t * get_alloc_local_style(lv_style_list_t * list);
+static inline void style_resize(lv_style_t *style, size_t sz);
+static inline lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx);
+static inline uint8_t get_style_prop_id(const lv_style_t *style, size_t idx);
+static inline uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx);
+static inline size_t get_prop_size(uint8_t prop_id);
+static inline size_t get_next_prop_index(uint8_t prop_id, size_t id);
 
 /**********************
  *  GLOABAL VARIABLES
@@ -1098,7 +1098,7 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
  * @param list pointer to a style list
  * @return pointer to the local style
  */
-static lv_style_t * get_alloc_local_style(lv_style_list_t * list)
+static inline lv_style_t * get_alloc_local_style(lv_style_list_t * list)
 {
     LV_ASSERT_STYLE_LIST(list);
 
@@ -1124,7 +1124,7 @@ static lv_style_t * get_alloc_local_style(lv_style_list_t * list)
  * @param style pointer to the style to be resized.
  * @param size new size
  */
-static void style_resize(lv_style_t *style, size_t sz)
+static inline void style_resize(lv_style_t *style, size_t sz)
 {
     style->map = lv_mem_realloc(style->map, sz);
 }
@@ -1135,7 +1135,7 @@ static void style_resize(lv_style_t *style, size_t sz)
  * @param idx index of the style in style->map
  * @return property in style->map + idx
  */
-static lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx)
+static inline lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx)
 {
     lv_style_property_t prop;
     uint8_t *prop_p = (uint8_t*)&prop;
@@ -1150,7 +1150,7 @@ static lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx)
  * @param idx index of the style in style->map
  * @return id of property in style->map + idx
  */
-static uint8_t get_style_prop_id(const lv_style_t *style, size_t idx)
+static inline uint8_t get_style_prop_id(const lv_style_t *style, size_t idx)
 {
     return get_style_prop(style, idx) & 0xFF;
 }
@@ -1161,7 +1161,7 @@ static uint8_t get_style_prop_id(const lv_style_t *style, size_t idx)
  * @param idx index of the style in style->map
  * @return attribute of property in style->map + idx
  */
-static uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx)
+static inline uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx)
 {
     return ((get_style_prop(style, idx) >> 8) & 0xFFU);
 }
@@ -1173,7 +1173,7 @@ static uint8_t get_style_prop_attr(const lv_style_t *style, size_t idx)
  * @param idx index of the style in style->map
  * @return attribute of property in style->map + idx
  */
-static size_t get_prop_size(uint8_t prop_id)
+static inline size_t get_prop_size(uint8_t prop_id)
 {
     prop_id &= 0xF;
     size_t size = sizeof(lv_style_property_t);
@@ -1190,7 +1190,7 @@ static size_t get_prop_size(uint8_t prop_id)
  * @param idx index of the style in style->map
  * @return index of next property in style->map
  */
-static size_t get_next_prop_index(uint8_t prop_id, size_t idx)
+static inline size_t get_next_prop_index(uint8_t prop_id, size_t idx)
 {
     return idx + get_prop_size(prop_id);
 }

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -35,7 +35,7 @@
  *  STATIC PROTOTYPES
  **********************/
 LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t * style, lv_style_property_t prop);
-static inline lv_style_t * get_alloc_local_style(lv_style_list_t * list);
+static lv_style_t * get_alloc_local_style(lv_style_list_t * list);
 static inline void style_resize(lv_style_t *style, size_t sz);
 static inline lv_style_property_t get_style_prop(const lv_style_t *style, size_t idx);
 static inline uint8_t get_style_prop_id(const lv_style_t *style, size_t idx);
@@ -330,17 +330,18 @@ void lv_style_reset(lv_style_t * style)
  * @param style pointer to a style
  * @return size of the properties in bytes
  */
-uint16_t
-_lv_style_get_mem_size(const lv_style_t *style)
+uint16_t _lv_style_get_mem_size(const lv_style_t * style)
 {
     LV_ASSERT_STYLE(style);
 
     if(style->map == NULL) return 0;
+
     size_t i = 0;
     uint8_t prop_id;
     while((prop_id = get_style_prop_id(style, i)) != _LV_STYLE_CLOSEING_PROP) {
         i = get_next_prop_index(prop_id, i);
     }
+
     return i + sizeof(lv_style_property_t);
 }
 
@@ -1063,7 +1064,7 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
     int16_t id_guess = -1;
 
     size_t i = 0;
-    
+
     uint8_t prop_id;    
     while((prop_id = get_style_prop_id(style, i)) != _LV_STYLE_CLOSEING_PROP) {
         if(prop_id == id_to_find) {
@@ -1087,7 +1088,6 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
         }
 
         i = get_next_prop_index(prop_id, i);
-
     }
 
     return id_guess;
@@ -1098,7 +1098,7 @@ LV_ATTRIBUTE_FAST_MEM static inline int32_t get_property_index(const lv_style_t 
  * @param list pointer to a style list
  * @return pointer to the local style
  */
-static inline lv_style_t * get_alloc_local_style(lv_style_list_t * list)
+static lv_style_t * get_alloc_local_style(lv_style_list_t * list)
 {
     LV_ASSERT_STYLE_LIST(list);
 

--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -81,14 +81,10 @@ enum {
 
 typedef uint8_t lv_text_decor_t;
 
-typedef struct {
-    uint8_t full;
-} lv_style_attr_t;
+typedef uint8_t lv_style_attr_t;
 
-//typedef uint8_t lv_style_attr_t;
-
-#define LV_ATTR_INHERIT(f) ((f)&0xA0)
-#define LV_ATTR_STATE(f) ((f)&0x3F)
+#define LV_STYLE_ATTR_GET_INHERIT(f) ((f)&0xA0)
+#define LV_STYLE_ATTR_GET_STATE(f) ((f)&0x3F)
 
 #define LV_STYLE_ID_VALUE 0x0   /*max 9 pcs*/
 #define LV_STYLE_ID_COLOR 0x9   /*max 3 pcs*/

--- a/src/lv_core/lv_style.h
+++ b/src/lv_core/lv_style.h
@@ -81,13 +81,14 @@ enum {
 
 typedef uint8_t lv_text_decor_t;
 
-typedef union {
-    struct {
-        uint8_t state       : 7; /* To which state the property refers to*/
-        uint8_t inherit     : 1; /*1: The property can be inherited*/
-    } bits;
+typedef struct {
     uint8_t full;
 } lv_style_attr_t;
+
+//typedef uint8_t lv_style_attr_t;
+
+#define LV_ATTR_INHERIT(f) ((f)&0xA0)
+#define LV_ATTR_STATE(f) ((f)&0x3F)
 
 #define LV_STYLE_ID_VALUE 0x0   /*max 9 pcs*/
 #define LV_STYLE_ID_COLOR 0x9   /*max 3 pcs*/

--- a/src/lv_font/lv_font_fmt_txt.c
+++ b/src/lv_font/lv_font_fmt_txt.c
@@ -214,7 +214,8 @@ static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter)
             glyph_id = fdsc->cmaps[i].glyph_id_start + gid_ofs_8[rcp];
         }
         else if(fdsc->cmaps[i].type == LV_FONT_FMT_TXT_CMAP_SPARSE_TINY) {
-            uint8_t * p = _lv_utils_bsearch(&rcp, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
+            uint16_t key = rcp;
+            uint8_t * p = _lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
                                             sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
 
             if(p) {
@@ -224,7 +225,8 @@ static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter)
             }
         }
         else if(fdsc->cmaps[i].type == LV_FONT_FMT_TXT_CMAP_SPARSE_FULL) {
-            uint8_t * p = _lv_utils_bsearch(&rcp, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
+            uint16_t key = rcp;
+            uint8_t * p = _lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
                                             sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
 
             if(p) {


### PR DESCRIPTION
Hi,
I couldn't run the `lv_demo_widgets` example  in [one of my devices](https://www.verifone.com/search?keys=VX%20690) which is big endian.

After some investigation I've found that usage of `style->map + idx`,  `style->map[idx]` and `style->map[idx+1]` is not compatible with big endian hardware. 

Please consider the suggestion in this PR.

I tested in the problematic device with the `lv_demo_widgets` and also in my [POS simulator for windows](http://www.muxi.com/posweb/) and with [this little endian POS](https://www.castlestech.com/products/vega3000countertop/) and it run fine.

Thanks.

 