### PR TITLE
fix image demos on big endian systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v7.1.0 (planned on 07.07.2020)
 *Available in the `master` branch*
 - Change some lv_style_t methods to support big endian hardware.
+- Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying images on big endian systems.
 
 ### New features
 - Add `focus_parent` attribute to `lv_obj`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v7.1.0 (planned on 07.07.2020)
 *Available in the `master` branch*
-- Change some lv_style_t methods to support big endian hardware.
-- Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying images on big endian systems.
 
 ### New features
 - Add `focus_parent` attribute to `lv_obj`
@@ -16,6 +14,8 @@
 ### Bugfixes
 - `lv_img` fix invalidation area when angle or zoom changes
 - Update the style handling to support Big endian MCUs
+- Change some methods to support big endian hardware.
+- Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying images on big endian systems.
 
 ## v7.0.2 (16.06.2020)
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -222,6 +222,10 @@ typedef void * lv_img_decoder_user_data_t;
 /*=====================
  *  Compiler settings
  *====================*/
+
+/* For big endian systems set to 1 */
+#define LV_BIG_ENDIAN_SYSTEM    0
+
 /* Define a custom attribute to `lv_tick_inc` function */
 #define LV_ATTRIBUTE_TICK_INC
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -266,6 +266,11 @@
 #ifndef LV_USE_GPU_STM32_DMA2D
 #define LV_USE_GPU_STM32_DMA2D  0
 #endif
+/*If enabling LV_USE_GPU_STM32_DMA2D, LV_GPU_DMA2D_CMSIS_INCLUDE must be defined to include path of CMSIS header of target processor
+e.g. "stm32f769xx.h" or "stm32f429xx.h" */
+#ifndef LV_GPU_DMA2D_CMSIS_INCLUDE
+#define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
 
 /* 1: Enable file system (might be required for images */
 #ifndef LV_USE_FILESYSTEM
@@ -319,6 +324,12 @@
 /*=====================
  *  Compiler settings
  *====================*/
+
+/* For big endian systems set to 1 */
+#ifndef LV_BIG_ENDIAN_SYSTEM
+#define LV_BIG_ENDIAN_SYSTEM    0
+#endif
+
 /* Define a custom attribute to `lv_tick_inc` function */
 #ifndef LV_ATTRIBUTE_TICK_INC
 #define LV_ATTRIBUTE_TICK_INC
@@ -474,7 +485,7 @@
 
 /* The built-in fonts contains the ASCII range and some Symbols with  4 bit-per-pixel.
  * The symbols are available via `LV_SYMBOL_...` defines
- * More info about fonts: https://docs.lvgl.com/#Fonts
+ * More info about fonts: https://docs.lvgl.io/v7/en/html/overview/font.html
  * To create a new font go to: https://lvgl.com/ttf-font-to-c-array
  */
 
@@ -684,14 +695,14 @@
 #define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
 #endif
 
-/* The control character to use for signaling text recoloring. */
+/* The control character to use for signalling text recoloring. */
 #ifndef LV_TXT_COLOR_CMD
 #define LV_TXT_COLOR_CMD "#"
 #endif
 
 /* Support bidirectional texts.
  * Allows mixing Left-to-Right and Right-to-Left texts.
- * The direction will be processed according to the Unicode Bidirectional Algorithm:
+ * The direction will be processed according to the Unicode Bidirectioanl Algorithm:
  * https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
 #ifndef LV_USE_BIDI
 #define LV_USE_BIDI     0

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -702,7 +702,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h" */
 
 /* Support bidirectional texts.
  * Allows mixing Left-to-Right and Right-to-Left texts.
- * The direction will be processed according to the Unicode Bidirectioanl Algorithm:
+ * The direction will be processed according to the Unicode Bidirectional Algorithm:
  * https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
 #ifndef LV_USE_BIDI
 #define LV_USE_BIDI     0

--- a/src/lv_draw/lv_img_buf.h
+++ b/src/lv_draw/lv_img_buf.h
@@ -102,10 +102,26 @@ typedef uint8_t lv_img_cf_t;
 /**
  * LVGL image header
  */
+/* The first 8 bit is very important to distinguish the different source types.
+ * For more info see `lv_img_get_src_type()` in lv_img.c 
+ * On big endian systems the order is reversed so cf and always_zero must be at
+ * the end of the struct.
+ * */
+#if LV_BIG_ENDIAN_SYSTEM
 typedef struct {
 
-    /* The first 8 bit is very important to distinguish the different source types.
-     * For more info see `lv_img_get_src_type()` in lv_img.c */
+    uint32_t h : 11; /*Height of     the image map*/
+    uint32_t w : 11; /*Width of the image map*/
+    uint32_t reserved : 2; /*Reserved to be used later*/
+    uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
+                                 non-printable character*/
+    uint32_t cf : 5;          /* Color format: See `lv_img_color_format_t`*/
+
+
+} lv_img_header_t;
+#else
+typedef struct {
+
     uint32_t cf : 5;          /* Color format: See `lv_img_color_format_t`*/
     uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
                                  non-printable character*/
@@ -115,7 +131,7 @@ typedef struct {
     uint32_t w : 11; /*Width of the image map*/
     uint32_t h : 11; /*Height of     the image map*/
 } lv_img_header_t;
-
+#endif
 
 /** Image header it is compatible with
  * the result from image converter utility*/


### PR DESCRIPTION
Hi,
After figuring out the problem with the image demos and thinking a lot about how to solve it in a portable way I quit and added a flag to lv_conf.h...

The reason is that I couldn't figure out some way to keep the test in the first byte as it looks important for when the source is a file name... And the flag was the less intrusive option. It affects only code that is compiled with the flag turned on and the change was very small...

All 3 demos run in my big endian terminal and also in my simulator for windows. Tomorrow I'll try on my little endian terminal. 

The problem was that in `lv_img_src_get_type` it uses the first byte in the `src` void pointer because it could be a file name, a simbol or an internal variable. It must be the first byte so it's pointless to try to convert the data in big endian systems. Other solutions that I thought of would require some refactoring such as having different functions for each type and things like that (in order to use the img header struct names instead of byte position in the struct).

I hope that this suggestion it's acceptable for a hot fix. 


Thanks.
