### PR TITLE
Fix char insertion in textarea for big endian hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update the style handling to support Big endian MCUs
 - Change some methods to support big endian hardware.
 - Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying images on big endian systems.
+- Fix inserting chars in text area in big endian hardware.
 
 ## v7.0.2 (16.06.2020)
 

--- a/src/lv_misc/lv_txt.c
+++ b/src/lv_misc/lv_txt.c
@@ -534,6 +534,7 @@ static uint32_t lv_txt_unicode_to_utf8(uint32_t letter_uni)
  */
 static uint32_t lv_txt_utf8_conv_wc(uint32_t c)
 {
+#if LV_BIG_ENDIAN_SYSTEM == 0
     /*Swap the bytes (UTF-8 is big endian, but the MCUs are little endian)*/
     if((c & 0x80) != 0) {
         uint32_t swapped;
@@ -547,7 +548,7 @@ static uint32_t lv_txt_utf8_conv_wc(uint32_t c)
         }
         c = swapped;
     }
-
+#endif
     return c;
 }
 

--- a/src/lv_widgets/lv_textarea.c
+++ b/src/lv_widgets/lv_textarea.c
@@ -231,9 +231,17 @@ void lv_textarea_add_char(lv_obj_t * ta, uint32_t c)
 
     lv_textarea_ext_t * ext = lv_obj_get_ext_attr(ta);
 
-    uint32_t letter_buf[2];
-    letter_buf[0] = c;
-    letter_buf[1] = '\0';
+    const char *letter_buf;
+
+    uint32_t u32_buf[2];
+    u32_buf[0] = c;
+    u32_buf[1] = 0;
+    
+    letter_buf = (char*)&u32_buf;
+
+#if LV_BIG_ENDIAN_SYSTEM
+    if (c != 0) while (*letter_buf == 0) ++letter_buf;
+#endif
 
     ta_insert_replace = NULL;
     lv_event_send(ta, LV_EVENT_INSERT, letter_buf);
@@ -241,7 +249,7 @@ void lv_textarea_add_char(lv_obj_t * ta, uint32_t c)
         if(ta_insert_replace[0] == '\0') return; /*Drop this text*/
 
         /*Add the replaced text directly it's different from the original*/
-        if(strcmp(ta_insert_replace, (char *)letter_buf)) {
+        if(strcmp(ta_insert_replace, letter_buf)) {
             lv_textarea_add_text(ta, ta_insert_replace);
             return;
         }
@@ -272,7 +280,7 @@ void lv_textarea_add_char(lv_obj_t * ta, uint32_t c)
         if(txt[0] == '\0') lv_obj_invalidate(ta);
     }
 
-    lv_label_ins_text(ext->label, ext->cursor.pos, (const char *)letter_buf); /*Insert the character*/
+    lv_label_ins_text(ext->label, ext->cursor.pos, letter_buf); /*Insert the character*/
     lv_textarea_clear_selection(ta);                                                /*Clear selection*/
 
     if(ext->pwd_mode != 0) {


### PR DESCRIPTION
Hi,
It looks like `lv_textarea_add_char` is broken in big endian hardware as result of setting a `uint32_t letter_buffer[2]` and then casting it to `char *`, which is not portable as assumes char will be in the first byte. 

In the function the only place `letter_buffer` is not cast to `char *` is when it calls `lv_event_send` where it casts to `void *`.

Inspecting code that receives `letter_buffer` as `char *` made me suspect that it should be actually a char buffer. That's because there are calls to `strlen` for instance in the called functions.

I couldn't follow the examples to a place where the callback used the `letter_buffer` in the callback path, therefore I'm not sure if we should keep the code as it is or if this patch is safe.  I'm suggesting as a hotfix anyways because it works on the widgets demo app in all the devices I tested (this time I was able to test in 4 differrent devices). 

Please advise about the safety of this suggestion and if it's not safe on how could I change it to be an acceptable hotfix. 

If you consider that this change is not safe the 2 options I can think about are :
- declare letter_buf as `char letter_buf[8]` then memset it to zero and add c to the first byte. This will have the exact same memory as it has now in little endian systems for all calls (8 bytes where the first is the char), but it would break on big endian if the callback casts to `uint32_t *`.
- declare another letter_buf as the previous one and pass it only to the event function. This will keep current memory layout in little endian systems only for the event function and if some callback casts to `uint32_t` it will work on big endian systems.

Anyways, my impression by inspecting other code that uses `letter_buffer` is that it can be `char *` safely and it's a portable approach.
