### PR TITLE
Fix a memory leak bug in function "lv_objmask_remove_mask" .

### DIFF
--- a/src/lv_widgets/lv_objmask.c
+++ b/src/lv_widgets/lv_objmask.c
@@ -171,6 +171,7 @@ void lv_objmask_remove_mask(lv_obj_t * objmask, lv_objmask_mask_t * mask)
     else {
         lv_mem_free(mask->param);
         _lv_ll_remove(&ext->mask_ll, mask);
+        lv_mem_free(mask);
     }
 
     lv_obj_invalidate(objmask);


### PR DESCRIPTION
There is a little memory leak When you call function "lv_objmask_remove_mask" to remove a specified mask.
It's need free the memory of list's node.