### PR TITLE
New functions for Check Box and a minor bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,14 @@ Available in the `dev` branch
 - In `lv_init` test if the the strings are UTF-8 encoded.
 - Add `user_data` to themes
 - Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying images on big endian systems.
+- Add inline function lv_checkbox_get_state(const lv_obj_t * cb) to extend the checkbox functionality.
+- Add inline function lv_checkbox_set_state(const lv_obj_t * cb, lv_btn_state_t state ) to extend the checkbox functionality.
 
 ### Bugfixes
 - `lv_img` fix invalidation area when angle or zoom changes
 - Update the style handling to support Big endian MCUs
 - Change some methods to support big endian hardware.
+- remove use of c++ keyword 'new' in parameter of function lv_theme_set_base().
 
 ## v7.0.2 (16.06.2020)
 

--- a/src/lv_themes/lv_theme.c
+++ b/src/lv_themes/lv_theme.c
@@ -98,12 +98,12 @@ void lv_theme_copy(lv_theme_t * theme, const lv_theme_t * copy)
  * Set a base theme for a theme.
  * The styles from the base them will be added before the styles of the current theme.
  * Arbitrary long chain of themes can be created by setting base themes.
- * @param new pointer to theme which base should be set
+ * @param new_theme pointer to theme which base should be set
  * @param base pointer to the base theme
  */
-void lv_theme_set_base(lv_theme_t * new, lv_theme_t * base)
+void lv_theme_set_base(lv_theme_t * new_theme, lv_theme_t * base)
 {
-    new->base = base;
+    new_theme->base = base;
 }
 
 /**

--- a/src/lv_themes/lv_theme.h
+++ b/src/lv_themes/lv_theme.h
@@ -201,10 +201,10 @@ void lv_theme_copy(lv_theme_t * theme, const lv_theme_t * copy);
  * Set a base theme for a theme.
  * The styles from the base them will be added before the styles of the current theme.
  * Arbitrary long chain of themes can be created by setting base themes.
- * @param new pointer to theme which base should be set
+ * @param new_theme pointer to theme which base should be set
  * @param base pointer to the base theme
  */
-void lv_theme_set_base(lv_theme_t * new, lv_theme_t * base);
+void lv_theme_set_base(lv_theme_t * new_theme, lv_theme_t * base);
 
 /**
  * Set an apply callback for a theme.

--- a/src/lv_widgets/lv_checkbox.h
+++ b/src/lv_widgets/lv_checkbox.h
@@ -106,6 +106,15 @@ static inline void lv_checkbox_set_disabled(lv_obj_t * cb)
     lv_btn_set_state(cb, LV_BTN_STATE_DISABLED);
 }
 
+/**
+ * Set the state of a check box
+ * @param cb pointer to a check box object
+ * @param state the new state of the check box (from lv_btn_state_t enum)
+ */
+static inline void lv_checkbox_set_state(lv_obj_t * cb, lv_btn_state_t state)
+{
+	lv_btn_set_state(cb, state);
+}
 /*=====================
  * Getter functions
  *====================*/
@@ -137,6 +146,15 @@ static inline bool lv_checkbox_is_inactive(const lv_obj_t * cb)
     return lv_btn_get_state(cb) == LV_BTN_STATE_DISABLED ? true : false;
 }
 
+/**
+ * Get the current state of a check box
+ * @param cb pointer to a check box object
+ * @return the state of the check box (from lv_btn_state_t enum)
+ */
+static inline lv_btn_state_t lv_checkbox_get_state(const lv_obj_t * cb)
+{
+	return lv_btn_get_state(cb);
+}
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Remove use of c++ keyword 'new' from function parameter in
lv_theme_set_base() function.
Add function lv_checkbox_set_state(lv_obj_t * cb, lv_btn_state_t state).
Add function lv_checkbox_get_state(const lv_obj_t * cb).
Update Change log.