### PR TITLE
Replace lv_point_t* to lv_point_t[] to represent point array

### DIFF
--- a/src/lv_draw/lv_draw_triangle.c
+++ b/src/lv_draw/lv_draw_triangle.c
@@ -43,7 +43,7 @@ static void point_swap(lv_point_t * p1, lv_point_t * p2);
  * @param style style for of the triangle
  * @param opa_scale scale down all opacities by the factor (0..255)
  */
-void lv_draw_triangle(const lv_point_t * points, const lv_area_t * mask, const lv_style_t * style, lv_opa_t opa_scale)
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * mask, const lv_style_t * style, lv_opa_t opa_scale)
 {
     /*Return if the triangle is degenerated*/
     if(points[0].x == points[1].x && points[0].y == points[1].y) return;
@@ -85,7 +85,7 @@ void lv_draw_triangle(const lv_point_t * points, const lv_area_t * mask, const l
  * @param style style of the polygon
  * @param opa_scale scale down all opacities by the factor (0..255)
  */
-void lv_draw_polygon(const lv_point_t * points, uint32_t point_cnt, const lv_area_t * mask, const lv_style_t * style,
+void lv_draw_polygon(const lv_point_t points[], uint32_t point_cnt, const lv_area_t * mask, const lv_style_t * style,
                      lv_opa_t opa_scale)
 {
     if(point_cnt < 3) return;

--- a/src/lv_draw/lv_draw_triangle.h
+++ b/src/lv_draw/lv_draw_triangle.h
@@ -34,7 +34,7 @@ extern "C" {
  * @param style style for of the triangle
  * @param opa_scale scale down all opacities by the factor (0..255)
  */
-void lv_draw_triangle(const lv_point_t * points, const lv_area_t * mask, const lv_style_t * style, lv_opa_t opa_scale);
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * mask, const lv_style_t * style, lv_opa_t opa_scale);
 
 /**
  * Draw a polygon from triangles. Only convex polygons are supported
@@ -44,7 +44,7 @@ void lv_draw_triangle(const lv_point_t * points, const lv_area_t * mask, const l
  * @param style style of the polygon
  * @param opa_scale scale down all opacities by the factor (0..255)
  */
-void lv_draw_polygon(const lv_point_t * points, uint32_t point_cnt, const lv_area_t * mask, const lv_style_t * style,
+void lv_draw_polygon(const lv_point_t points[], uint32_t point_cnt, const lv_area_t * mask, const lv_style_t * style,
                      lv_opa_t opa_scale);
 
 /**********************

--- a/src/lv_objx/lv_canvas.c
+++ b/src/lv_objx/lv_canvas.c
@@ -658,7 +658,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param point_cnt number of points
  * @param style style of the line (`line` properties are used)
  */
-void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt, const lv_style_t * style)
+void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt, const lv_style_t * style)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
     LV_ASSERT_NULL(style);
@@ -742,7 +742,7 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t 
  * @param point_cnt number of points
  * @param style style of the polygon (`body.main_color` and `body.opa` is used)
  */
-void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt, const lv_style_t * style)
+void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt, const lv_style_t * style)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
     LV_ASSERT_NULL(style);

--- a/src/lv_objx/lv_canvas.h
+++ b/src/lv_objx/lv_canvas.h
@@ -213,7 +213,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param point_cnt number of points
  * @param style style of the line (`line` properties are used)
  */
-void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt, const lv_style_t * style);
+void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt, const lv_style_t * style);
 
 /**
  * Draw a polygon on the canvas
@@ -222,7 +222,7 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t * points, uint32_t 
  * @param point_cnt number of points
  * @param style style of the polygon (`body.main_color` and `body.opa` is used)
  */
-void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t * points, uint32_t point_cnt, const lv_style_t * style);
+void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt, const lv_style_t * style);
 
 /**
  * Draw an arc on the canvas


### PR DESCRIPTION
Needed for Micropython Bindings to identify the argument as an array instead of a pointer to a single `lv_point_t`
Same as https://github.com/lvgl/lvgl/pull/1495 for v6