### PR TITLE
widget tableview: add new function lv_tabview_set_tab_name() to change a tab name during runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Available in the `dev` branch
 - Add `lv_theme_set_base()` to allow easy extension of built-in (or any) themes
 - Add `lv_obj_align_x()` and `lv_obj_align_y()` functions
 - Add `lv_obj_align_origo_x()` and `lv_obj_align_origo_y()` functions
+- Add `lv_tabview_set_tab_name()` function - used to change a tab's name
 
 ### Bugfixes
 - `tileview` fix navigation when not screen sized

--- a/src/lv_widgets/lv_tabview.c
+++ b/src/lv_widgets/lv_tabview.c
@@ -449,6 +449,36 @@ void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, lv_anim_enable_t an
 }
 
 /**
+ * Set the name of a tab.
+ * @param tabview pointer to Tab view object
+ * @param id index of a tab to load
+ * @param name new tab name
+ */
+void lv_tabview_set_tab_name(lv_obj_t *tabview, uint16_t id, char *name)
+{
+  LV_ASSERT_OBJ(tabview, LV_OBJX_NAME);
+
+  // get tabview's ext pointer which contains the tab name pointer list
+  lv_tabview_ext_t *ext = lv_obj_get_ext_attr(tabview);
+
+  // check for valid tab index
+  if (ext->tab_cnt > id)
+  {
+    // reallocate memory for new tab name (use reallocate due to mostly the size didn't change much)
+    char *str = lv_mem_realloc((void *)ext->tab_name_ptr[id], strlen(name) + 1);
+    LV_ASSERT_MEM(str);
+
+    // store new tab name at allocated memory
+    strcpy(str, name);
+    // update pointer
+    ext->tab_name_ptr[id] = str;
+
+    // force redrawing of the tab headers
+    lv_obj_invalidate(ext->btns);
+  }
+}
+
+/**
  * Set the animation time of tab view when a new tab is loaded
  * @param tabview pointer to Tab view object
  * @param anim_time_ms time of animation in milliseconds

--- a/src/lv_widgets/lv_tabview.c
+++ b/src/lv_widgets/lv_tabview.c
@@ -451,29 +451,29 @@ void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, lv_anim_enable_t an
 /**
  * Set the name of a tab.
  * @param tabview pointer to Tab view object
- * @param id index of a tab to load
+ * @param id index of the tab the name should be set
  * @param name new tab name
  */
 void lv_tabview_set_tab_name(lv_obj_t *tabview, uint16_t id, char *name)
 {
   LV_ASSERT_OBJ(tabview, LV_OBJX_NAME);
 
-  // get tabview's ext pointer which contains the tab name pointer list
+  /* get tabview's ext pointer which contains the tab name pointer list */
   lv_tabview_ext_t *ext = lv_obj_get_ext_attr(tabview);
 
-  // check for valid tab index
+  /* check for valid tab index */
   if (ext->tab_cnt > id)
   {
-    // reallocate memory for new tab name (use reallocate due to mostly the size didn't change much)
+    /* reallocate memory for new tab name (use reallocate due to mostly the size didn't change much) */
     char *str = lv_mem_realloc((void *)ext->tab_name_ptr[id], strlen(name) + 1);
     LV_ASSERT_MEM(str);
 
-    // store new tab name at allocated memory
+    /* store new tab name at allocated memory */
     strcpy(str, name);
-    // update pointer
+    /* update pointer  */
     ext->tab_name_ptr[id] = str;
 
-    // force redrawing of the tab headers
+    /* force redrawing of the tab headers */
     lv_obj_invalidate(ext->btns);
   }
 }

--- a/src/lv_widgets/lv_tabview.h
+++ b/src/lv_widgets/lv_tabview.h
@@ -120,6 +120,14 @@ void lv_tabview_clean_tab(lv_obj_t * tab);
 void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, lv_anim_enable_t anim);
 
 /**
+ * Set the name of a tab.
+ * @param tabview pointer to Tab view object
+ * @param id index of a tab to load
+ * @param name new tab name
+ */
+void lv_tabview_set_tab_name(lv_obj_t * tabview, uint16_t id, char * name);
+
+/**
  * Set the animation time of tab view when a new tab is loaded
  * @param tabview pointer to Tab view object
  * @param anim_time time of animation in milliseconds

--- a/src/lv_widgets/lv_tabview.h
+++ b/src/lv_widgets/lv_tabview.h
@@ -122,7 +122,7 @@ void lv_tabview_set_tab_act(lv_obj_t * tabview, uint16_t id, lv_anim_enable_t an
 /**
  * Set the name of a tab.
  * @param tabview pointer to Tab view object
- * @param id index of a tab to load
+ * @param id index of the tab the name should be set
  * @param name new tab name
  */
 void lv_tabview_set_tab_name(lv_obj_t * tabview, uint16_t id, char * name);


### PR DESCRIPTION
Hi !
I have a similar [use case](https://forum.lvgl.io/t/how-to-change-the-tab-name-in-a-tabview-and-update-the-screen-with-the-new-name/1254) and want to update the tab name dynamically during runtime.
But looking into `lv_tabview.c` code I realized that this could not be just a one-liner :smile: 

Because I'm not very familiar with the **lvgl** framework in detail there might be room for improvements ...