### PR TITLE
Fix lv_canvas_set_buffer document

### DIFF
--- a/src/lv_widgets/lv_canvas.h
+++ b/src/lv_widgets/lv_canvas.h
@@ -60,7 +60,7 @@ lv_obj_t * lv_canvas_create(lv_obj_t * par, const lv_obj_t * copy);
 /**
  * Set a buffer for the canvas.
  * @param buf a buffer where the content of the canvas will be.
- * The required size is (lv_img_color_format_get_px_size(cf) * w * h) / 8)
+ * The required size is (lv_img_color_format_get_px_size(cf) * w) / 8 * h)
  * It can be allocated with `lv_mem_alloc()` or
  * it can be statically allocated array (e.g. static lv_color_t buf[100*50]) or
  * it can be an address in RAM or external SRAM


### PR DESCRIPTION
Lines in canvas buffers are byte aligned so buffers might request larger size and contain unused bits.
The previous documented calc method would often result in a buffer size smaller than what was expected by LVGL, leading to memory corruption and program crash.