### PR TITLE
fixes #1671 lv_cont_layout_grid() fails to calculate available space in a row

### DIFF
--- a/src/lv_widgets/lv_cont.c
+++ b/src/lv_widgets/lv_cont.c
@@ -628,7 +628,7 @@ static void lv_cont_layout_grid(lv_obj_t * cont)
     _LV_LL_READ_BACK(cont->child_ll, child) {
         if(lv_obj_get_hidden(child) != false || lv_obj_is_protected(child, LV_PROTECT_POS) != false) continue;
         lv_coord_t obj_w = lv_obj_get_width(child);
-        if(act_x + inner + obj_w > w_fit) {
+        if(act_x + obj_w > w_fit + left) {
             act_x = left;
             act_y += y_ofs;
         }


### PR DESCRIPTION
  this issue results in space waste in right side of container
  the size of wasted space in each row is pad_left plus pad_inner

I want to clarify that I work on another repo copy in our enterprise github server. I tested code there other than directly on this folk in github.com. I did carefully reviewed the code to do my best to make sure it is same with my version. 