### PR TITLE
README.md: Update link to Micropython documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ void btn_event_cb(lv_obj_t * btn, lv_event_t event)
 ![LVGL button with label example](https://raw.githubusercontent.com/lvgl/docs/latest/misc/simple_button_example.gif)
 
 ### LVGL from Micropython
-Learn more about [Micropython](https://docs.lvgl.io/en/html/get-started/micropython).
+Learn more about [Micropython](https://docs.lvgl.io/latest/en/html/get-started/micropython.html).
 ```python
 # Create a Button and a Label
 scr = lv.obj()


### PR DESCRIPTION
The link to the LVGL Micropython documentation is broken. This commit updates the link to https://docs.lvgl.io/latest/en/html/get-started/micropython.html