### PR TITLE
Make several descriptor parameters const

### DIFF
--- a/src/lv_draw/lv_draw_arc.c
+++ b/src/lv_draw/lv_draw_arc.c
@@ -65,17 +65,18 @@ static void get_rounded_area(int16_t angle, lv_coord_t radius, uint8_t tickness,
  * @param mask the arc will be drawn only in this mask
  * @param start_angle the start angle of the arc (0 deg on the bottom, 90 deg on the right)
  * @param end_angle the end angle of the arc
- * @param style style of the arc (`body.thickness`, `body.main_color`, `body.opa` is used)
- * @param opa_scale scale down all opacities by the factor
+ * @param clip_area the arc will be drawn only in this area
+ * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uint16_t start_angle, uint16_t end_angle,
-                 const lv_area_t * clip_area, lv_draw_line_dsc_t * dsc)
+                 const lv_area_t * clip_area, const lv_draw_line_dsc_t * dsc)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
     if(dsc->width == 0) return;
     if(start_angle == end_angle) return;
 
-    if(dsc->width > radius) dsc->width = radius;
+    lv_style_int_t width = dsc->width;
+    if(width > radius) width = radius;
 
     lv_draw_rect_dsc_t cir_dsc;
     lv_draw_rect_dsc_init(&cir_dsc);
@@ -83,7 +84,7 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uin
     cir_dsc.bg_opa = LV_OPA_TRANSP;
     cir_dsc.border_opa = dsc->opa;
     cir_dsc.border_color = dsc->color;
-    cir_dsc.border_width = dsc->width;
+    cir_dsc.border_width = width;
     cir_dsc.border_blend_mode = dsc->blend_mode;
 
     lv_area_t area;
@@ -123,7 +124,7 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uin
         q_dsc.end_angle = end_angle;
         q_dsc.start_quarter = (start_angle / 90) & 0x3;
         q_dsc.end_quarter = (end_angle / 90) & 0x3;
-        q_dsc.width = dsc->width;
+        q_dsc.width = width;
         q_dsc.draw_dsc =  &cir_dsc;
         q_dsc.draw_area = &area;
         q_dsc.clip_area = clip_area;
@@ -146,7 +147,7 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uin
 
         lv_area_t round_area;
         if(dsc->round_start) {
-            get_rounded_area(start_angle, radius, dsc->width, &round_area);
+            get_rounded_area(start_angle, radius, width, &round_area);
             round_area.x1 += center_x;
             round_area.x2 += center_x;
             round_area.y1 += center_y;
@@ -156,7 +157,7 @@ void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uin
         }
 
         if(dsc->round_end) {
-            get_rounded_area(end_angle, radius, dsc->width, &round_area);
+            get_rounded_area(end_angle, radius, width, &round_area);
             round_area.x1 += center_x;
             round_area.x2 += center_x;
             round_area.y1 += center_y;

--- a/src/lv_draw/lv_draw_arc.h
+++ b/src/lv_draw/lv_draw_arc.h
@@ -35,11 +35,11 @@ extern "C" {
  * @param mask the arc will be drawn only in this mask
  * @param start_angle the start angle of the arc (0 deg on the bottom, 90 deg on the right)
  * @param end_angle the end angle of the arc
- * @param style style of the arc (`body.thickness`, `body.main_color`, `body.opa` is used)
- * @param opa_scale scale down all opacities by the factor
+ * @param clip_area the arc will be drawn only in this area
+ * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_draw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  uint16_t start_angle, uint16_t end_angle,
-                 const lv_area_t * clip_area, lv_draw_line_dsc_t * dsc);
+                 const lv_area_t * clip_area, const lv_draw_line_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -29,11 +29,11 @@
  **********************/
 LV_ATTRIBUTE_FAST_MEM static lv_res_t lv_img_draw_core(const lv_area_t * coords, const lv_area_t * clip_area,
                                                        const void * src,
-                                                       lv_draw_img_dsc_t * draw_dsc);
+                                                       const lv_draw_img_dsc_t * draw_dsc);
 
 LV_ATTRIBUTE_FAST_MEM static void lv_draw_map(const lv_area_t * map_area, const lv_area_t * clip_area,
                                               const uint8_t * map_p,
-                                              lv_draw_img_dsc_t * draw_dsc,
+                                              const lv_draw_img_dsc_t * draw_dsc,
                                               bool chroma_key, bool alpha_byte);
 
 static void show_error(const lv_area_t * coords, const lv_area_t * clip_area, const char * msg);
@@ -65,13 +65,9 @@ void lv_draw_img_dsc_init(lv_draw_img_dsc_t * dsc)
  * @param coords the coordinates of the image
  * @param mask the image will be drawn only in this area
  * @param src pointer to a lv_color_t array which contains the pixels of the image
- * @param style style of the image
- * @param angle rotation angle of the image
- * @param center rotation center of the image
- * @param antialias anti-alias transformations (rotate, zoom) or not
- * @param opa_scale scale down all opacities by the factor
+ * @param dsc pointer to an initialized `lv_draw_img_dsc_t` variable
  */
-void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask, const void * src, lv_draw_img_dsc_t * dsc)
+void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask, const void * src, const lv_draw_img_dsc_t * dsc)
 {
     if(src == NULL) {
         LV_LOG_WARN("Image draw: src is NULL");
@@ -232,7 +228,7 @@ lv_img_src_t lv_img_src_get_type(const void * src)
 
 LV_ATTRIBUTE_FAST_MEM static lv_res_t lv_img_draw_core(const lv_area_t * coords, const lv_area_t * clip_area,
                                                        const void * src,
-                                                       lv_draw_img_dsc_t * draw_dsc)
+                                                       const lv_draw_img_dsc_t * draw_dsc)
 {
     if(draw_dsc->opa <= LV_OPA_MIN) return LV_RES_OK;
 
@@ -327,18 +323,14 @@ LV_ATTRIBUTE_FAST_MEM static lv_res_t lv_img_draw_core(const lv_area_t * coords,
  * @param cords_p coordinates the color map
  * @param mask_p the map will drawn only on this area  (truncated to VDB area)
  * @param map_p pointer to a lv_color_t array
- * @param opa opacity of the map
+ * @param draw_dsc pointer to an initialized `lv_draw_img_dsc_t` variable
  * @param chroma_keyed true: enable transparency of LV_IMG_LV_COLOR_TRANSP color pixels
  * @param alpha_byte true: extra alpha byte is inserted for every pixel
- * @param style style of the image
- * @param angle angle in degree
- * @param pivot center of rotation
- * @param zoom zoom factor
- * @param antialias anti-alias transformations (rotate, zoom) or not
  */
 LV_ATTRIBUTE_FAST_MEM static void lv_draw_map(const lv_area_t * map_area, const lv_area_t * clip_area,
                                               const uint8_t * map_p,
-                                              lv_draw_img_dsc_t * draw_dsc, bool chroma_key, bool alpha_byte)
+                                              const lv_draw_img_dsc_t * draw_dsc,
+                                              bool chroma_key, bool alpha_byte)
 {
     /* Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/lv_draw/lv_draw_img.h
+++ b/src/lv_draw/lv_draw_img.h
@@ -53,13 +53,9 @@ void lv_draw_img_dsc_init(lv_draw_img_dsc_t * dsc);
  * @param coords the coordinates of the image
  * @param mask the image will be drawn only in this area
  * @param src pointer to a lv_color_t array which contains the pixels of the image
- * @param style style of the image
- * @param angle rotation angle of the image
- * @param center rotation center of the image
- * @param antialias anti-alias transformations (rotate, zoom) or not
- * @param opa_scale scale down all opacities by the factor
+ * @param dsc pointer to an initialized `lv_draw_img_dsc_t` variable
  */
-void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask, const void * src, lv_draw_img_dsc_t * dsc);
+void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask, const void * src, const lv_draw_img_dsc_t * dsc);
 
 /**
  * Get the type of an image source

--- a/src/lv_draw/lv_draw_label.c
+++ b/src/lv_draw/lv_draw_label.c
@@ -111,8 +111,10 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc)
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the drawer to speed up the drawing of very long texts (thousands of lines).
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, lv_draw_label_dsc_t * dsc,
-                                         const char * txt, lv_draw_label_hint_t * hint)
+LV_ATTRIBUTE_FAST_MEM void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask,
+                                         const lv_draw_label_dsc_t * dsc,
+                                         const char * txt,
+                                         lv_draw_label_hint_t * hint)
 {
 
     if(dsc->opa <= LV_OPA_MIN) return;

--- a/src/lv_draw/lv_draw_label.h
+++ b/src/lv_draw/lv_draw_label.h
@@ -77,7 +77,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc);
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the drawer to speed up the drawing of very long texts (thousands of lines).
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask, lv_draw_label_dsc_t * dsc,
+LV_ATTRIBUTE_FAST_MEM void lv_draw_label(const lv_area_t * coords, const lv_area_t * mask,
+                                         const lv_draw_label_dsc_t * dsc,
                                          const char * txt, lv_draw_label_hint_t * hint);
 
 //! @endcond

--- a/src/lv_draw/lv_draw_line.c
+++ b/src/lv_draw/lv_draw_line.c
@@ -26,13 +26,13 @@
  **********************/
 LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(const lv_point_t * point1, const lv_point_t * point2,
                                                  const lv_area_t * clip,
-                                                 lv_draw_line_dsc_t * dsc);
+                                                 const lv_draw_line_dsc_t * dsc);
 LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(const lv_point_t * point1, const lv_point_t * point2,
                                                 const lv_area_t * clip,
-                                                lv_draw_line_dsc_t * dsc);
+                                                const lv_draw_line_dsc_t * dsc);
 LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(const lv_point_t * point1, const lv_point_t * point2,
                                                 const lv_area_t * clip,
-                                                lv_draw_line_dsc_t * dsc);
+                                                const lv_draw_line_dsc_t * dsc);
 
 /**********************
  *  STATIC VARIABLES
@@ -63,7 +63,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
  * @param opa_scale scale down all opacities by the factor
  */
 LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_point_t * point2, const lv_area_t * clip,
-                                        lv_draw_line_dsc_t * dsc)
+                                        const lv_draw_line_dsc_t * dsc)
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -120,7 +120,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_poin
 
 LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(const lv_point_t * point1, const lv_point_t * point2,
                                                 const lv_area_t * clip,
-                                                lv_draw_line_dsc_t * dsc)
+                                                const lv_draw_line_dsc_t * dsc)
 {
     lv_opa_t opa = dsc->opa;
 
@@ -221,7 +221,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(const lv_point_t * point1, const
 
 LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(const lv_point_t * point1, const lv_point_t * point2,
                                                 const lv_area_t * clip,
-                                                lv_draw_line_dsc_t * dsc)
+                                                const lv_draw_line_dsc_t * dsc)
 {
     lv_opa_t opa = dsc->opa;
 
@@ -316,7 +316,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(const lv_point_t * point1, const
 
 LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(const lv_point_t * point1, const lv_point_t * point2,
                                                  const lv_area_t * clip,
-                                                 lv_draw_line_dsc_t * dsc)
+                                                 const lv_draw_line_dsc_t * dsc)
 {
     /*Keep the great y in p1*/
     lv_point_t p1;

--- a/src/lv_draw/lv_draw_line.c
+++ b/src/lv_draw/lv_draw_line.c
@@ -58,9 +58,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
  * Draw a line
  * @param point1 first point of the line
  * @param point2 second point of the line
- * @param mask the line will be drawn only on this area
- * @param style pointer to a line's style
- * @param opa_scale scale down all opacities by the factor
+ * @param clip the line will be drawn only in this area
+ * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_point_t * point2, const lv_area_t * clip,
                                         const lv_draw_line_dsc_t * dsc)

--- a/src/lv_draw/lv_draw_line.h
+++ b/src/lv_draw/lv_draw_line.h
@@ -48,7 +48,7 @@ typedef struct {
  * @param opa_scale scale down all opacities by the factor
  */
 LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_point_t * point2, const lv_area_t * mask,
-                                        lv_draw_line_dsc_t * dsc);
+                                        const lv_draw_line_dsc_t * dsc);
 
 LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
 

--- a/src/lv_draw/lv_draw_line.h
+++ b/src/lv_draw/lv_draw_line.h
@@ -43,11 +43,10 @@ typedef struct {
  * Draw a line
  * @param point1 first point of the line
  * @param point2 second point of the line
- * @param mask the line will be drawn only on this area
- * @param style pointer to a line's style
- * @param opa_scale scale down all opacities by the factor
+ * @param clip the line will be drawn only in this area
+ * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_point_t * point2, const lv_area_t * mask,
+LV_ATTRIBUTE_FAST_MEM void lv_draw_line(const lv_point_t * point1, const lv_point_t * point2, const lv_area_t * clip,
                                         const lv_draw_line_dsc_t * dsc);
 
 LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);

--- a/src/lv_draw/lv_draw_rect.c
+++ b/src/lv_draw/lv_draw_rect.c
@@ -27,20 +27,21 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-LV_ATTRIBUTE_FAST_MEM static void draw_bg(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc);
+LV_ATTRIBUTE_FAST_MEM static void draw_bg(const lv_area_t * coords, const lv_area_t * clip,
+                                          const lv_draw_rect_dsc_t * dsc);
 LV_ATTRIBUTE_FAST_MEM static void draw_border(const lv_area_t * coords, const lv_area_t * clip,
-                                              lv_draw_rect_dsc_t * dsc);
-static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc);
-LV_ATTRIBUTE_FAST_MEM static inline lv_color_t grad_get(lv_draw_rect_dsc_t * dsc, lv_coord_t s, lv_coord_t i);
+                                              const lv_draw_rect_dsc_t * dsc);
+static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc);
+LV_ATTRIBUTE_FAST_MEM static inline lv_color_t grad_get(const lv_draw_rect_dsc_t * dsc, lv_coord_t s, lv_coord_t i);
 #if LV_USE_SHADOW
 LV_ATTRIBUTE_FAST_MEM static void draw_shadow(const lv_area_t * coords, const lv_area_t * clip,
-                                              lv_draw_rect_dsc_t * dsc);
+                                              const lv_draw_rect_dsc_t * dsc);
 LV_ATTRIBUTE_FAST_MEM static void shadow_draw_corner_buf(const lv_area_t * coords,  uint16_t * sh_buf, lv_coord_t s,
                                                          lv_coord_t r);
 LV_ATTRIBUTE_FAST_MEM static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf);
 #endif
-static void draw_pattern(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc);
-static void draw_value(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc);
+static void draw_pattern(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc);
+static void draw_value(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc);
 
 /**********************
  *  STATIC VARIABLES
@@ -85,9 +86,9 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc)
  * Draw a rectangle
  * @param coords the coordinates of the rectangle
  * @param mask the rectangle will be drawn only in this mask
- * @param style pointer to a style
+ * @param dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_rect(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc)
+void lv_draw_rect(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
 {
     if(lv_area_get_height(coords) < 1 || lv_area_get_width(coords) < 1) return;
 #if LV_USE_SHADOW
@@ -142,7 +143,8 @@ void lv_draw_px(const lv_point_t * point, const lv_area_t * clip_area, const lv_
  *   STATIC FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static void draw_bg(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc)
+LV_ATTRIBUTE_FAST_MEM static void draw_bg(const lv_area_t * coords, const lv_area_t * clip,
+                                          const lv_draw_rect_dsc_t * dsc)
 {
     if(dsc->bg_opa <= LV_OPA_MIN) return;
 
@@ -364,7 +366,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_bg(const lv_area_t * coords, const lv_are
 }
 
 LV_ATTRIBUTE_FAST_MEM static void draw_border(const lv_area_t * coords, const lv_area_t * clip,
-                                              lv_draw_rect_dsc_t * dsc)
+                                              const lv_draw_rect_dsc_t * dsc)
 {
     if(dsc->border_opa <= LV_OPA_MIN) return;
     if(dsc->border_width == 0) return;
@@ -581,7 +583,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_border(const lv_area_t * coords, const lv
     _lv_mem_buf_release(mask_buf);
 }
 
-LV_ATTRIBUTE_FAST_MEM static inline lv_color_t grad_get(lv_draw_rect_dsc_t * dsc, lv_coord_t s, lv_coord_t i)
+LV_ATTRIBUTE_FAST_MEM static inline lv_color_t grad_get(const lv_draw_rect_dsc_t * dsc, lv_coord_t s, lv_coord_t i)
 {
     int32_t min = (dsc->bg_main_color_stop * s) >> 8;
     if(i <= min) return dsc->bg_color;
@@ -598,7 +600,7 @@ LV_ATTRIBUTE_FAST_MEM static inline lv_color_t grad_get(lv_draw_rect_dsc_t * dsc
 
 #if LV_USE_SHADOW
 LV_ATTRIBUTE_FAST_MEM static void draw_shadow(const lv_area_t * coords, const lv_area_t * clip,
-                                              lv_draw_rect_dsc_t * dsc)
+                                              const lv_draw_rect_dsc_t * dsc)
 {
     /*Check whether the shadow is visible*/
     if(dsc->shadow_width == 0) return;
@@ -1226,7 +1228,7 @@ LV_ATTRIBUTE_FAST_MEM static void shadow_blur_corner(lv_coord_t size, lv_coord_t
 
 #endif
 
-static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc)
+static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
 {
     if(dsc->outline_opa <= LV_OPA_MIN) return;
     if(dsc->outline_width == 0) return;
@@ -1424,7 +1426,7 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, lv_dr
     _lv_mem_buf_release(mask_buf);
 }
 
-static void draw_pattern(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc)
+static void draw_pattern(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
 {
     if(dsc->pattern_image == NULL) return;
     if(dsc->pattern_opa <= LV_OPA_MIN) return;
@@ -1526,7 +1528,7 @@ static void draw_pattern(const lv_area_t * coords, const lv_area_t * clip, lv_dr
 }
 
 
-static void draw_value(const lv_area_t * coords, const lv_area_t * clip, lv_draw_rect_dsc_t * dsc)
+static void draw_value(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
 {
     if(dsc->value_str == NULL) return;
     if(dsc->value_opa <= LV_OPA_MIN) return;

--- a/src/lv_draw/lv_draw_rect.h
+++ b/src/lv_draw/lv_draw_rect.h
@@ -92,9 +92,9 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc);
  * Draw a rectangle
  * @param coords the coordinates of the rectangle
  * @param mask the rectangle will be drawn only in this mask
- * @param style pointer to a style
+ * @param dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_rect(const lv_area_t * coords, const lv_area_t * mask, lv_draw_rect_dsc_t * dsc);
+void lv_draw_rect(const lv_area_t * coords, const lv_area_t * mask, const lv_draw_rect_dsc_t * dsc);
 
 /**
  * Draw a pixel

--- a/src/lv_draw/lv_draw_triangle.c
+++ b/src/lv_draw/lv_draw_triangle.c
@@ -40,7 +40,7 @@
  * @param clip_area the triangle will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip_area, lv_draw_rect_dsc_t * draw_dsc)
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip_area, const lv_draw_rect_dsc_t * draw_dsc)
 {
     lv_draw_polygon(points, 3, clip_area, draw_dsc);
 }
@@ -53,7 +53,7 @@ void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip_area, lv
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
 void lv_draw_polygon(const lv_point_t points[], uint16_t point_cnt, const lv_area_t * clip_area,
-                     lv_draw_rect_dsc_t * draw_dsc)
+                     const lv_draw_rect_dsc_t * draw_dsc)
 {
     if(point_cnt < 3) return;
     if(points == NULL) return;

--- a/src/lv_draw/lv_draw_triangle.h
+++ b/src/lv_draw/lv_draw_triangle.h
@@ -33,7 +33,7 @@ extern "C" {
  * @param clip_area the triangle will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip, lv_draw_rect_dsc_t * draw_dsc);
+void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip, const lv_draw_rect_dsc_t * draw_dsc);
 
 /**
  * Draw a polygon. Only convex polygons are supported.
@@ -43,7 +43,7 @@ void lv_draw_triangle(const lv_point_t points[], const lv_area_t * clip, lv_draw
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
 void lv_draw_polygon(const lv_point_t points[], uint16_t point_cnt, const lv_area_t * mask,
-                     lv_draw_rect_dsc_t * draw_dsc);
+                     const lv_draw_rect_dsc_t * draw_dsc);
 
 /**********************
  *      MACROS

--- a/src/lv_draw/lv_img_buf.c
+++ b/src/lv_draw/lv_img_buf.c
@@ -468,7 +468,7 @@ void _lv_img_buf_transform_init(lv_img_transform_dsc_t * dsc)
  * @param pivot x,y pivot coordinates of rotation
  */
 void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, int16_t angle, uint16_t zoom,
-                                      lv_point_t * pivot)
+                                      const lv_point_t * pivot)
 {
 #if LV_USE_IMG_TRANSFORM
     if(angle == 0 && zoom == LV_IMG_ZOOM_NONE) {

--- a/src/lv_draw/lv_img_buf.h
+++ b/src/lv_draw/lv_img_buf.h
@@ -380,7 +380,7 @@ static inline bool _lv_img_buf_transform(lv_img_transform_dsc_t * dsc, lv_coord_
  * @param pivot x,y pivot coordinates of rotation
  */
 void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, int16_t angle, uint16_t zoom,
-                                      lv_point_t * pivot);
+                                      const lv_point_t * pivot);
 
 /**********************
  *      MACROS

--- a/src/lv_draw/lv_img_decoder.c
+++ b/src/lv_draw/lv_img_decoder.c
@@ -559,7 +559,7 @@ static lv_res_t lv_img_decoder_built_in_line_true_color(lv_img_decoder_dsc_t * d
     }
     uint32_t btr = len * (px_size >> 3);
     uint32_t br  = 0;
-    lv_fs_read(user_data->f, buf, btr, &br);
+    res = lv_fs_read(user_data->f, buf, btr, &br);
     if(res != LV_FS_RES_OK || btr != br) {
         LV_LOG_WARN("Built-in image decoder read failed");
         return LV_RES_INV;

--- a/src/lv_widgets/lv_canvas.c
+++ b/src/lv_widgets/lv_canvas.c
@@ -909,7 +909,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param style style of the line (`line` properties are used)
  */
 void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
-                         lv_draw_line_dsc_t * line_draw_dsc)
+                         const lv_draw_line_dsc_t * line_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
 

--- a/src/lv_widgets/lv_canvas.c
+++ b/src/lv_widgets/lv_canvas.c
@@ -657,6 +657,7 @@ void lv_canvas_blur_ver(lv_obj_t * canvas, const lv_area_t * area, uint16_t r)
  * Fill the canvas with color
  * @param canvas pointer to a canvas
  * @param color the background color
+ * @param opa the desired opacity
  */
 void lv_canvas_fill_bg(lv_obj_t * canvas, lv_color_t color, lv_opa_t opa)
 {
@@ -694,10 +695,10 @@ void lv_canvas_fill_bg(lv_obj_t * canvas, lv_color_t color, lv_opa_t opa)
  * @param y top coordinate of the rectangle
  * @param w width of the rectangle
  * @param h height of the rectangle
- * @param style style of the rectangle (`body` properties are used except `padding`)
+ * @param rect_dsc descriptor of the rectangle
  */
 void lv_canvas_draw_rect(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h,
-                         lv_draw_rect_dsc_t * rect_dsc)
+                         const lv_draw_rect_dsc_t * rect_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
 
@@ -763,7 +764,7 @@ void lv_canvas_draw_rect(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
  * @param x left coordinate of the text
  * @param y top coordinate of the text
  * @param max_w max width of the text. The text will be wrapped to fit into this size
- * @param style style of the text (`text` properties are used)
+ * @param label_draw_dsc pointer to a valid label descriptor `lv_draw_label_dsc_t`
  * @param txt text to display
  * @param align align of the text (`LV_LABEL_ALIGN_LEFT/RIGHT/CENTER`)
  */
@@ -841,10 +842,10 @@ void lv_canvas_draw_text(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
  * Draw an image on the canvas
  * @param canvas pointer to a canvas object
  * @param src image source. Can be a pointer an `lv_img_dsc_t` variable or a path an image.
- * @param style style of the image (`image` properties are used)
+ * @param img_draw_dsc pointer to a valid label descriptor `lv_draw_img_dsc_t`
  */
 void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const void * src,
-                        lv_draw_img_dsc_t * img_draw_dsc)
+                        const lv_draw_img_dsc_t * img_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
 
@@ -906,7 +907,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param canvas pointer to a canvas object
  * @param points point of the line
  * @param point_cnt number of points
- * @param style style of the line (`line` properties are used)
+ * @param line_draw_dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                          const lv_draw_line_dsc_t * line_draw_dsc)
@@ -969,10 +970,10 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t 
  * @param canvas pointer to a canvas object
  * @param points point of the polygon
  * @param point_cnt number of points
- * @param style style of the polygon (`body.main_color` and `body.opa` is used)
+ * @param poly_draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
 void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
-                            lv_draw_rect_dsc_t * poly_draw_dsc)
+                            const lv_draw_rect_dsc_t * poly_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
 
@@ -1033,10 +1034,10 @@ void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32
  * @param r radius of the arc
  * @param start_angle start angle in degrees
  * @param end_angle end angle in degrees
- * @param style style of the polygon (`body.main_color` and `body.opa` is used)
+ * @param arc_draw_dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_canvas_draw_arc(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_t r, int32_t start_angle,
-                        int32_t end_angle, lv_draw_line_dsc_t * arc_draw_dsc)
+                        int32_t end_angle, const lv_draw_line_dsc_t * arc_draw_dsc)
 {
     LV_ASSERT_OBJ(canvas, LV_OBJX_NAME);
 

--- a/src/lv_widgets/lv_canvas.h
+++ b/src/lv_widgets/lv_canvas.h
@@ -153,6 +153,7 @@ void lv_canvas_transform(lv_obj_t * canvas, lv_img_dsc_t * img, int16_t angle, u
 /**
  * Apply horizontal blur on the canvas
  * @param canvas pointer to a canvas object
+ * @param area the area to blur. If `NULL` the whole canvas will be blurred.
  * @param r radius of the blur
  */
 void lv_canvas_blur_hor(lv_obj_t * canvas, const lv_area_t * area, uint16_t r);
@@ -169,6 +170,7 @@ void lv_canvas_blur_ver(lv_obj_t * canvas, const lv_area_t * area, uint16_t r);
  * Fill the canvas with color
  * @param canvas pointer to a canvas
  * @param color the background color
+ * @param opa the desired opacity
  */
 void lv_canvas_fill_bg(lv_obj_t * canvas, lv_color_t color, lv_opa_t opa);
 
@@ -179,10 +181,10 @@ void lv_canvas_fill_bg(lv_obj_t * canvas, lv_color_t color, lv_opa_t opa);
  * @param y top coordinate of the rectangle
  * @param w width of the rectangle
  * @param h height of the rectangle
- * @param style style of the rectangle (`body` properties are used except `padding`)
+ * @param rect_dsc descriptor of the rectangle
  */
 void lv_canvas_draw_rect(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h,
-                         lv_draw_rect_dsc_t * rect_dsc);
+                         const lv_draw_rect_dsc_t * rect_dsc);
 
 /**
  * Draw a text on the canvas.
@@ -190,7 +192,7 @@ void lv_canvas_draw_rect(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
  * @param x left coordinate of the text
  * @param y top coordinate of the text
  * @param max_w max width of the text. The text will be wrapped to fit into this size
- * @param style style of the text (`text` properties are used)
+ * @param label_draw_dsc pointer to a valid label descriptor `lv_draw_label_dsc_t`
  * @param txt text to display
  * @param align align of the text (`LV_LABEL_ALIGN_LEFT/RIGHT/CENTER`)
  */
@@ -201,18 +203,20 @@ void lv_canvas_draw_text(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
 /**
  * Draw an image on the canvas
  * @param canvas pointer to a canvas object
+ * @param x left coordinate of the image
+ * @param y top coordinate of the image
  * @param src image source. Can be a pointer an `lv_img_dsc_t` variable or a path an image.
- * @param style style of the image (`image` properties are used)
+ * @param img_draw_dsc pointer to a valid label descriptor `lv_draw_img_dsc_t`
  */
 void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const void * src,
-                        lv_draw_img_dsc_t * img_draw_dsc);
+                        const lv_draw_img_dsc_t * img_draw_dsc);
 
 /**
  * Draw a line on the canvas
  * @param canvas pointer to a canvas object
  * @param points point of the line
  * @param point_cnt number of points
- * @param style style of the line (`line` properties are used)
+ * @param line_draw_dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
                          const lv_draw_line_dsc_t * line_draw_dsc);
@@ -222,10 +226,10 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t 
  * @param canvas pointer to a canvas object
  * @param points point of the polygon
  * @param point_cnt number of points
- * @param style style of the polygon (`body.main_color` and `body.opa` is used)
+ * @param poly_draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
 void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
-                            lv_draw_rect_dsc_t * poly_draw_dsc);
+                            const lv_draw_rect_dsc_t * poly_draw_dsc);
 
 /**
  * Draw an arc on the canvas
@@ -235,10 +239,10 @@ void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32
  * @param r radius of the arc
  * @param start_angle start angle in degrees
  * @param end_angle end angle in degrees
- * @param style style of the polygon (`body.main_color` and `body.opa` is used)
+ * @param arc_draw_dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_canvas_draw_arc(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_t r, int32_t start_angle,
-                        int32_t end_angle, lv_draw_line_dsc_t * arc_draw_dsc);
+                        int32_t end_angle, const lv_draw_line_dsc_t * arc_draw_dsc);
 
 /**********************
  *      MACROS

--- a/src/lv_widgets/lv_canvas.h
+++ b/src/lv_widgets/lv_canvas.h
@@ -215,7 +215,7 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
  * @param style style of the line (`line` properties are used)
  */
 void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t point_cnt,
-                         lv_draw_line_dsc_t * line_draw_dsc);
+                         const lv_draw_line_dsc_t * line_draw_dsc);
 
 /**
  * Draw a polygon on the canvas


### PR DESCRIPTION
I made several descriptor parameters const. This allows to use statically initialized variables. I also updated several function docs.

There is one line in src/lv_draw/lv_draw_label.c:219 I am not sure whats is the intention. I think this is relict from testing?
`dsc->decor  = LV_TEXT_DECOR_UNDERLINE;`