### PR TITLE
Fix `lv_btnmatrix_set_one_check` not forcing one button to be checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix crash if `lv_table_set_col_cnt` is called before `lv_table_set_row_cnt` for the first time
 - Fix overflow in large image transformations
 - Limit extra button click area of button matrix's buttons. With large paddings it was counter intuitive. (Gaps are mapped to button when clicked).
+- Fix `lv_btnmatrix_set_one_check` not forcing exactly one button to be checked
 
 ## v7.3.0 (04.08.2020)
 

--- a/src/lv_widgets/lv_btnmatrix.c
+++ b/src/lv_widgets/lv_btnmatrix.c
@@ -912,7 +912,7 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
             /*Toggle the button if enabled*/
             if(button_is_tgl_enabled(ext->ctrl_bits[ext->btn_id_pr]) &&
                !button_is_inactive(ext->ctrl_bits[ext->btn_id_pr])) {
-                if(button_get_tgl_state(ext->ctrl_bits[ext->btn_id_pr])) {
+                if(button_get_tgl_state(ext->ctrl_bits[ext->btn_id_pr]) && !ext->one_check) {
                     ext->ctrl_bits[ext->btn_id_pr] &= (~LV_BTNMATRIX_CTRL_CHECK_STATE);
                 }
                 else {


### PR DESCRIPTION
As discussed [on the forum](https://forum.lvgl.io/t/expand-lv-btnmatrix-set-one-check-to-allow-radio-button-functionality/2962), this fix makes it so one button must be checked if you have enabled `lv_btnmatrix_set_one_check`.