### PR TITLE
simplified join_area

### DIFF
--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -335,11 +335,11 @@ static void lv_refr_join_area(void)  {
               }
 
               /*Check if the areas are on each other*/
-              if(lv_area_is_on(&disp_refr->inv_areas[join_in], &disp_refr->inv_areas[join_from]) == false) {
+              if(_lv_area_is_on(&disp_refr->inv_areas[join_in], &disp_refr->inv_areas[join_from]) == false) {
                   continue;
               }
 
-              lv_area_join(&joined_area, &disp_refr->inv_areas[join_in], &disp_refr->inv_areas[join_from]);
+              _lv_area_join(&joined_area, &disp_refr->inv_areas[join_in], &disp_refr->inv_areas[join_from]);
 
               /*Join two area only if the joined area size is smaller*/
               if(lv_area_get_size(&joined_area) < (lv_area_get_size(&disp_refr->inv_areas[join_in]) +

--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -317,10 +317,11 @@ void _lv_disp_refr_task(lv_task_t * task)
 static void lv_refr_join_area(void)  {
       uint32_t join_from;
       uint32_t join_in;
-      uint32_t diff;  // a badly named variable, counting the number of joined areas within an outer cycle
+      uint32_t diff; /* a badly named variable, counting the number of joined areas within an outer cycle */
       lv_area_t joined_area;
 
-      if (disp_refr->inv_p == 0) return; // sanity
+      /* Sanity */
+      if (disp_refr->inv_p == 0) return;
 
       for(join_in = 0; join_in < disp_refr->inv_p - 1; join_in++) {
 
@@ -328,7 +329,7 @@ static void lv_refr_join_area(void)  {
           /*Check all areas to join them in 'join_in'*/
           for(join_from = join_in + 1; join_from < disp_refr->inv_p; join_from++) {
 
-              // move if there was some joining previously, to effectively remove the joined areas
+              /* Move if there was some joining previously, to effectively remove the joined areas */
               if (diff) {
                 lv_area_copy(&disp_refr->inv_areas[join_from - diff], &disp_refr->inv_areas[join_from]);
               }

--- a/src/lv_hal/lv_hal_disp.h
+++ b/src/lv_hal/lv_hal_disp.h
@@ -160,7 +160,6 @@ uint8_t del_prev  :
 
     /** Invalidated (marked to redraw) areas*/
     lv_area_t inv_areas[LV_INV_BUF_SIZE];
-    uint8_t inv_area_joined[LV_INV_BUF_SIZE];
     uint32_t inv_p : 10;
 
     /*Miscellaneous data*/


### PR DESCRIPTION
https://forum.lvgl.io/t/suggested-change-to-lv-refr-join-area/3082

lv_refr_join_area() is called just before a disp is to be refreshed, attempting to join areas which reasonably overlap. In doing so, originally it marked the removed (joined-in) areas by setting respective member of inv_area_joined[] to 1. The proposed change simply removes the joined-in areas from the refresh array, removing the need for inv_area_joined[] area and all references to it.
