### PR TITLE
Fix lv_page_glue_obj() interface for lv_binding_micropython.

### DIFF
--- a/src/lv_objx/lv_list.c
+++ b/src/lv_objx/lv_list.c
@@ -202,7 +202,7 @@ lv_obj_t * lv_list_add_btn(lv_obj_t * list, const void * img_src, const char * t
     lv_btn_set_style(liste, LV_BTN_STYLE_TGL_PR, ext->styles_btn[LV_BTN_STATE_TGL_PR]);
     lv_btn_set_style(liste, LV_BTN_STYLE_INA, ext->styles_btn[LV_BTN_STATE_INA]);
 
-    lv_page_glue_obj(liste, true);
+    lv_page_glue_obj(list, liste, true);
     lv_btn_set_layout(liste, LV_LAYOUT_ROW_M);
 
     lv_layout_t list_layout = lv_list_get_layout(list);

--- a/src/lv_objx/lv_page.c
+++ b/src/lv_objx/lv_page.c
@@ -466,7 +466,7 @@ bool lv_page_on_edge(lv_obj_t * page, lv_page_edge_t edge)
  * @param obj pointer to an object on a page
  * @param glue true: enable glue, false: disable glue
  */
-void lv_page_glue_obj(lv_obj_t * obj, bool glue)
+void lv_page_glue_obj(lv_obj_t * page, lv_obj_t * obj, bool glue)
 {
     lv_obj_set_drag_parent(obj, glue);
     lv_obj_set_drag(obj, glue);

--- a/src/lv_objx/lv_page.h
+++ b/src/lv_objx/lv_page.h
@@ -373,7 +373,7 @@ bool lv_page_on_edge(lv_obj_t * page, lv_page_edge_t edge);
  * @param obj pointer to an object on a page
  * @param glue true: enable glue, false: disable glue
  */
-void lv_page_glue_obj(lv_obj_t * obj, bool glue);
+void lv_page_glue_obj(lv_obj_t * page, lv_obj_t * obj, bool glue);
 
 /**
  * Focus on an object. It ensures that the object will be visible on the page.


### PR DESCRIPTION
lv_page_glue_obj(lv_obj_t*, bool) doesn't contain page object as parameter like other methods.
This will lead to wrong Micropython binding generation.