### PR TITLE
Proposed fix for roller widget crash when LV_USE_GROUP=0

### DIFF
--- a/src/lv_widgets/lv_roller.c
+++ b/src/lv_widgets/lv_roller.c
@@ -584,17 +584,16 @@ static lv_res_t lv_roller_signal(lv_obj_t * roller, lv_signal_t sign, void * par
     }
 
     /* Include the ancient signal function */
-    if(sign == LV_SIGNAL_CHILD_CHG || sign == LV_SIGNAL_GET_TYPE) {
-        res = ancestor_signal(roller, sign, param);
-        if(res != LV_RES_OK) return res;
-        if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
-    }
-    else if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
 #if LV_USE_GROUP
+    if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
+#else
+    if(sign == LV_SIGNAL_CHILD_CHG || sign == LV_SIGNAL_GET_TYPE) {
+#endif
         res = ancestor_signal(roller, sign, param);
         if(res != LV_RES_OK) return res;
-#endif
     }
+
+    if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
     lv_roller_ext_t * ext = lv_obj_get_ext_attr(roller);
     LV_UNUSED(ext);

--- a/src/lv_widgets/lv_roller.c
+++ b/src/lv_widgets/lv_roller.c
@@ -584,11 +584,7 @@ static lv_res_t lv_roller_signal(lv_obj_t * roller, lv_signal_t sign, void * par
     }
 
     /* Include the ancient signal function */
-#if LV_USE_GROUP
     if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
-#else
-    if(sign == LV_SIGNAL_CHILD_CHG || sign == LV_SIGNAL_GET_TYPE) {
-#endif
         res = ancestor_signal(roller, sign, param);
         if(res != LV_RES_OK) return res;
     }

--- a/src/lv_widgets/lv_roller.c
+++ b/src/lv_widgets/lv_roller.c
@@ -584,14 +584,17 @@ static lv_res_t lv_roller_signal(lv_obj_t * roller, lv_signal_t sign, void * par
     }
 
     /* Include the ancient signal function */
-    if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
+    if(sign == LV_SIGNAL_CHILD_CHG || sign == LV_SIGNAL_GET_TYPE) {
+        res = ancestor_signal(roller, sign, param);
+        if(res != LV_RES_OK) return res;
+        if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
+    }
+    else if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
 #if LV_USE_GROUP
         res = ancestor_signal(roller, sign, param);
         if(res != LV_RES_OK) return res;
 #endif
     }
-
-    if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
     lv_roller_ext_t * ext = lv_obj_get_ext_attr(roller);
     LV_UNUSED(ext);

--- a/src/lv_widgets/lv_spinbox.c
+++ b/src/lv_widgets/lv_spinbox.c
@@ -389,13 +389,17 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
     }
 
     /* Include the ancient signal function */
+    if(sign == LV_SIGNAL_GET_TYPE) {
+        res = ancestor_signal(spinbox, sign, param);
+        if(res != LV_RES_OK) return res;
+        return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
+    }
     if(sign != LV_SIGNAL_CONTROL) {
 #if LV_USE_GROUP
         res = ancestor_signal(spinbox, sign, param);
         if(res != LV_RES_OK) return res;
 #endif
     }
-    if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
 
     if(sign == LV_SIGNAL_CLEANUP) {

--- a/src/lv_widgets/lv_spinbox.c
+++ b/src/lv_widgets/lv_spinbox.c
@@ -389,11 +389,7 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
     }
 
     /* Include the ancient signal function */
-#if LV_USE_GROUP
-    if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
-#else
-    if(sign == LV_SIGNAL_GET_TYPE) {
-#endif
+    if(sign != LV_SIGNAL_CONTROL) {
         res = ancestor_signal(spinbox, sign, param);
         if(res != LV_RES_OK) return res;
     }

--- a/src/lv_widgets/lv_spinbox.c
+++ b/src/lv_widgets/lv_spinbox.c
@@ -389,17 +389,15 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
     }
 
     /* Include the ancient signal function */
-    if(sign == LV_SIGNAL_GET_TYPE) {
-        res = ancestor_signal(spinbox, sign, param);
-        if(res != LV_RES_OK) return res;
-        return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
-    }
-    if(sign != LV_SIGNAL_CONTROL) {
 #if LV_USE_GROUP
+    if(sign != LV_SIGNAL_CONTROL) { /*Don't let the page to scroll on keys*/
+#else
+    if(sign == LV_SIGNAL_GET_TYPE) {
+#endif
         res = ancestor_signal(spinbox, sign, param);
         if(res != LV_RES_OK) return res;
-#endif
     }
+    if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
 
     if(sign == LV_SIGNAL_CLEANUP) {


### PR DESCRIPTION
Issue #1760
LV_SIGNAL_CHILD_CHG and LV_SIGNAL_GET_TYPE signals are propagated back to ancestor independent on LV_USE_GROUP value.

Tested on PC simulator and Nucleo board.