### PR TITLE
Fix button matrix button width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 - Fix `lv_obj_del` and `lv_obj_clean` if the children list changed during deletion.
+- Adjust button matrix button width to include padding when spanning multiple units.
 
 
 ## v7.4.0 (01.09.2020)

--- a/src/lv_widgets/lv_btnmatrix.c
+++ b/src/lv_widgets/lv_btnmatrix.c
@@ -208,7 +208,7 @@ void lv_btnmatrix_set_map(lv_obj_t * btnm, const char * map[])
         /*Only deal with the non empty lines*/
         if(btn_cnt != 0) {
             /*Calculate the width of all units*/
-            lv_coord_t all_unit_w = max_w - ((btn_cnt - 1) * inner);
+            lv_coord_t all_unit_w = max_w - ((unit_cnt - 1) * inner);
 
             /*Set the button size and positions and set the texts*/
             uint16_t i;
@@ -216,19 +216,20 @@ void lv_btnmatrix_set_map(lv_obj_t * btnm, const char * map[])
 
             unit_act_cnt = 0;
             for(i = 0; i < btn_cnt; i++) {
+                uint8_t btn_unit_w = get_button_width(ext->ctrl_bits[btn_i]);
                 /* one_unit_w = all_unit_w / unit_cnt
                  * act_unit_w = one_unit_w * button_width
                  * do this two operations but the multiply first to divide a greater number */
-                lv_coord_t act_unit_w = (all_unit_w * get_button_width(ext->ctrl_bits[btn_i])) / unit_cnt;
+                lv_coord_t act_unit_w = (all_unit_w * btn_unit_w) / unit_cnt + inner * (btn_unit_w - 1);
                 act_unit_w--; /*-1 because e.g. width = 100 means 101 pixels (0..100)*/
 
                 /*Always recalculate act_x because of rounding errors */
                 if(base_dir == LV_BIDI_DIR_RTL)  {
-                    act_x = (unit_act_cnt * all_unit_w) / unit_cnt + i * inner;
+                    act_x = (unit_act_cnt * all_unit_w) / unit_cnt + unit_act_cnt * inner;
                     act_x = lv_obj_get_width(btnm) - right - act_x - act_unit_w - 1;
                 }
                 else {
-                    act_x = (unit_act_cnt * all_unit_w) / unit_cnt + i * inner +
+                    act_x = (unit_act_cnt * all_unit_w) / unit_cnt + unit_act_cnt * inner +
                             left;
                 }
                 /* Set the button's area.
@@ -243,7 +244,7 @@ void lv_btnmatrix_set_map(lv_obj_t * btnm, const char * map[])
                     lv_area_set(&ext->button_areas[btn_i], act_x, act_y, act_x + act_unit_w, act_y + btn_h);
                 }
 
-                unit_act_cnt += get_button_width(ext->ctrl_bits[btn_i]);
+                unit_act_cnt += btn_unit_w;
 
                 i_tot++;
                 btn_i++;


### PR DESCRIPTION
The button matrix doesn't include the padding between buttons in the size of each button when the button width is greater than one. This causes layouts like the numeric layout to be slightly offset.

It's not clearly visible with the default material theme as the padding is set fairly low (but it is there if you zoom in - the arrow buttons are offset by 1 px). It can be seen if you crank up the padding, i.e. `lv_style_set_pad_inner(&styles->kb_bg, LV_STATE_DEFAULT, LV_DPX(3*10));` in lv_theme_material.c, keyboard_init.

Here's the before:

![num_0_before_reg](https://user-images.githubusercontent.com/6849866/92009546-98795600-ed40-11ea-8c1e-dde1638b0f44.png)

And the after:

![num_3_after_reg](https://user-images.githubusercontent.com/6849866/92009552-9a431980-ed40-11ea-9944-5bfbd3b9d178.png)

Before with the inner padding cranked up - clearly visible:

![num_1_before](https://user-images.githubusercontent.com/6849866/92009562-9ca57380-ed40-11ea-94cb-396ea482e6b2.png)

After with the inner padding cranked up:

![num_2_after](https://user-images.githubusercontent.com/6849866/92009565-9dd6a080-ed40-11ea-9879-1dbacaf333fa.png)

The change is less obvious with the regular layout because there is no alignment expected.

Before with the regular keyboard layout:

![key_0_before_reg](https://user-images.githubusercontent.com/6849866/92009664-be9ef600-ed40-11ea-9442-fb9772b52089.png)

After with the regular keyboard layout:

![key_3_after_reg](https://user-images.githubusercontent.com/6849866/92009673-c1015000-ed40-11ea-8907-630387250727.png)

