### PR TITLE
Send LV_EVENT_APPLY when pressing enter in a one line textarea

### DIFF
--- a/src/lv_widgets/lv_textarea.c
+++ b/src/lv_widgets/lv_textarea.c
@@ -1468,6 +1468,8 @@ static lv_res_t lv_textarea_signal(lv_obj_t * ta, lv_signal_t sign, void * param
             lv_textarea_set_cursor_pos(ta, 0);
         else if(c == LV_KEY_END)
             lv_textarea_set_cursor_pos(ta, LV_TEXTAREA_CURSOR_LAST);
+        else if(c == LV_KEY_ENTER && lv_textarea_get_one_line(ta))
+            lv_event_send(ta, LV_EVENT_APPLY, NULL);
         else {
             lv_textarea_add_char(ta, c);
         }


### PR DESCRIPTION
Send the the LV_EVENT_APPLY event, when LV_KEY_ENTER is sent to a textare which is in one line mode.
A usecase for this would be a username password dialog where most users would expect to trigger the login once the press enter in the password field.