### PR TITLE
Fix submodule checkout in both push and PR

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -21,11 +21,13 @@ jobs:
       run: git clone https://github.com/lvgl/lv_micropython.git .
     - name: Update submodules
       run: git submodule update --init --recursive
-    - name: Checkout lv_bindings
+    - name: Checkout LVGL submodule
       working-directory: ./lib/lv_bindings/lvgl
       run: |
-        git fetch
-        git checkout $GITHUB_SHA
+        git fetch --force ${{ github.event.repository.git_url }} "+refs/heads/*:refs/remotes/origin/*"
+        git fetch --force ${{ github.event.repository.git_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+        git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
+        git submodule update --init --recursive
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build the unix port


### PR DESCRIPTION
Fetch all needed refs to obtain the right SHA
Try to checkout either the commit SHA or the PR SHA

I think this should solve the false check failures we see on PRs.