### PR TITLE
fix lv_obj_align_y and lv_obj_align_mid_y to align y and not x

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -984,7 +984,7 @@ void lv_obj_align_y(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align, lv_
 
     LV_ASSERT_OBJ(base, LV_OBJX_NAME);
 
-    obj_align_core(obj, base, align, true, false, 0, y_ofs);
+    obj_align_core(obj, base, align, false, true, 0, y_ofs);
 }
 
 /**
@@ -1058,7 +1058,7 @@ void lv_obj_align_mid_y(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align,
     LV_ASSERT_OBJ(base, LV_OBJX_NAME);
 
 
-    obj_align_mid_core(obj, base, align, true, false, 0, y_ofs);
+    obj_align_mid_core(obj, base, align, false, true, 0, y_ofs);
 }
 
 /**


### PR DESCRIPTION
Both lv_obj_align_y and lv_obj_aling_mid_y align x and not y.