### PR TITLE
Update build_micropython.yml

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -25,7 +25,7 @@ jobs:
       working-directory: ./lib/lv_bindings/lvgl
       run: |
         git fetch --force ${{ github.event.repository.git_url }} "+refs/heads/*:refs/remotes/origin/*"
-        git fetch --force ${{ github.event.repository.git_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+        git fetch --force ${{ github.event.repository.git_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
         git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
         git submodule update --init --recursive
     - name: Build mpy-cross


### PR DESCRIPTION
Fetch both head and merge commits of "pull" refs.  
This would allow the CI script to first try checkout the merge commit (which is `github.sha` on PR) and only if that fails, default to checking out the PR head.