### PR TITLE
Highlight selected option if show_selected is false

### DIFF
--- a/src/lv_widgets/lv_dropdown.c
+++ b/src/lv_widgets/lv_dropdown.c
@@ -825,9 +825,7 @@ static lv_design_res_t lv_dropdown_page_design(lv_obj_t * page, const lv_area_t 
                     draw_box(ddlist, &clip_area_core, ext->pr_opt_id, LV_STATE_PRESSED);
                 }
 
-                if(ext->show_selected) {
-                    draw_box(ddlist, &clip_area_core, ext->sel_opt_id, LV_STATE_DEFAULT);
-                }
+                draw_box(ddlist, &clip_area_core, ext->sel_opt_id, LV_STATE_DEFAULT);
             }
         }
     }
@@ -853,9 +851,7 @@ static lv_design_res_t lv_dropdown_page_design(lv_obj_t * page, const lv_area_t 
                     draw_box_label(ddlist, &clip_area_core, ext->pr_opt_id, LV_STATE_PRESSED);
                 }
 
-                if(ext->show_selected) {
-                    draw_box_label(ddlist, &clip_area_core, ext->sel_opt_id, LV_STATE_DEFAULT);
-                }
+                draw_box_label(ddlist, &clip_area_core, ext->sel_opt_id, LV_STATE_DEFAULT);
             }
         }
     }


### PR DESCRIPTION
The current code disables highlighting of the selected option if _lv_dropdown_set_show_selected_ was called with _false_. This change keeps the highlighting  of the selected option.