### PR TITLE
Table cell styles 16

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -709,7 +709,12 @@ typedef void * lv_obj_user_data_t;
 #define LV_USE_TABLE    1
 #if LV_USE_TABLE
 #  define LV_TABLE_COL_MAX    12
+#  define LV_TABLE_CELL_STYLE_CNT 4
+#  if (LV_TABLE_CELL_STYLE_CNT > 16)
+#    error LV_TABLE_CELL_STYLE_CNT cannot exceed 16
+#  endif
 #endif
+
 
 /*Tab (dependencies: lv_page, lv_btnm)*/
 #define LV_USE_TABVIEW      1

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -710,9 +710,6 @@ typedef void * lv_obj_user_data_t;
 #if LV_USE_TABLE
 #  define LV_TABLE_COL_MAX    12
 #  define LV_TABLE_CELL_STYLE_CNT 4
-#  if (LV_TABLE_CELL_STYLE_CNT > 16)
-#    error LV_TABLE_CELL_STYLE_CNT cannot exceed 16
-#  endif
 #endif
 
 

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -4058,8 +4058,9 @@ static void report_style_mod_core(void * style, lv_obj_t * obj)
 
         uint8_t ci;
         for(ci = 0; ci < list->style_cnt; ci++) {
-            lv_style_t * class = lv_style_list_get_style(list, ci);
-            if(class == style || style == NULL) {
+            /* changed class to _class to allow compilation as c++ */
+            lv_style_t * _class = lv_style_list_get_style(list, ci);
+            if(_class == style || style == NULL) { 
                 lv_obj_refresh_style(obj, part, LV_STYLE_PROP_ALL);
                 break;
             }

--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -827,8 +827,9 @@ lv_res_t _lv_style_list_get_int(lv_style_list_t * list, lv_style_property_t prop
 
     int16_t ci;
     for(ci = 0; ci < list->style_cnt; ci++) {
-        lv_style_t * class = lv_style_list_get_style(list, ci);
-        int16_t weight_act = _lv_style_get_int(class, prop, &value_act);
+        /* changed class to _class to allow compilation as c++ */
+        lv_style_t * _class = lv_style_list_get_style(list, ci);
+        int16_t weight_act = _lv_style_get_int(_class, prop, &value_act);
 
         /*On perfect match return the value immediately*/
         if(weight_act == weight_goal) {
@@ -880,8 +881,8 @@ lv_res_t _lv_style_list_get_color(lv_style_list_t * list, lv_style_property_t pr
 
     int16_t ci;
     for(ci = 0; ci < list->style_cnt; ci++) {
-        lv_style_t * class = lv_style_list_get_style(list, ci);
-        int16_t weight_act = _lv_style_get_color(class, prop, &value_act);
+        lv_style_t * _class = lv_style_list_get_style(list, ci);
+        int16_t weight_act = _lv_style_get_color(_class, prop, &value_act);
         /*On perfect match return the value immediately*/
         if(weight_act == weight_goal) {
             *res = value_act;
@@ -930,8 +931,8 @@ lv_res_t _lv_style_list_get_opa(lv_style_list_t * list, lv_style_property_t prop
 
     int16_t ci;
     for(ci = 0; ci < list->style_cnt; ci++) {
-        lv_style_t * class = lv_style_list_get_style(list, ci);
-        int16_t weight_act = _lv_style_get_opa(class, prop, &value_act);
+        lv_style_t * _class = lv_style_list_get_style(list, ci);
+        int16_t weight_act = _lv_style_get_opa(_class, prop, &value_act);
         /*On perfect match return the value immediately*/
         if(weight_act == weight_goal) {
             *res = value_act;
@@ -980,8 +981,8 @@ lv_res_t _lv_style_list_get_ptr(lv_style_list_t * list, lv_style_property_t prop
 
     int16_t ci;
     for(ci = 0; ci < list->style_cnt; ci++) {
-        lv_style_t * class = lv_style_list_get_style(list, ci);
-        int16_t weight_act = _lv_style_get_ptr(class, prop, &value_act);
+        lv_style_t * _class = lv_style_list_get_style(list, ci);
+        int16_t weight_act = _lv_style_get_ptr(_class, prop, &value_act);
         /*On perfect match return the value immediately*/
         if(weight_act == weight_goal) {
             *res = value_act;

--- a/src/lv_themes/lv_theme_material.c
+++ b/src/lv_themes/lv_theme_material.c
@@ -1264,17 +1264,10 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL1);
-            _lv_style_list_add_style(list, &styles->table_cell);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL2);
-            _lv_style_list_add_style(list, &styles->table_cell);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL3);
-            _lv_style_list_add_style(list, &styles->table_cell);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL4);
-            _lv_style_list_add_style(list, &styles->table_cell);
+	    for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
+              list = lv_obj_get_style_list(obj, i);
+             _lv_style_list_add_style(list, &styles->table_cell);
+            }
             break;
 #endif
 

--- a/src/lv_themes/lv_theme_material.c
+++ b/src/lv_themes/lv_theme_material.c
@@ -1261,6 +1261,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 #endif
 #if LV_USE_TABLE
         case LV_THEME_TABLE:
+        {
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
@@ -1273,6 +1274,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
              _lv_style_list_add_style(list, &styles->table_cell);
             }
             break;
+        }
 #endif
 
 #if LV_USE_WIN

--- a/src/lv_themes/lv_theme_material.c
+++ b/src/lv_themes/lv_theme_material.c
@@ -1264,8 +1264,12 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-	    for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
-              list = lv_obj_get_style_list(obj, i);
+            int idx = 1; /* start value should be 1, not zero, since cell styles 
+                            start at 1 due to presence of LV_TABLE_PART_BG=0
+                            in the enum (lv_table.h) */ 
+                         /* declaring idx outside loop to work with older compilers */
+	    for (;idx <= LV_TABLE_CELL_STYLE_CNT; idx ++ ) {
+              list = lv_obj_get_style_list(obj, idx);
              _lv_style_list_add_style(list, &styles->table_cell);
             }
             break;

--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -890,8 +890,12 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-            for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
-              list = lv_obj_get_style_list(obj, i);
+            int idx = 1; /* start value should be 1, not zero, since cell styles
+                            start at 1 due to presence of LV_TABLE_PART_BG=0
+                            in the enum (lv_table.h) */
+                         /* declaring idx outside loop to work with older compilers */
+            for (; idx <= LV_TABLE_CELL_STYLE_CNT; idx ++ ) {
+              list = lv_obj_get_style_list(obj, idx);
               _lv_style_list_add_style(list, &styles->bg);
               _lv_style_list_add_style(list, &styles->no_radius);
             }

--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -887,6 +887,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 #endif
 #if LV_USE_TABLE
         case LV_THEME_TABLE:
+        {
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
@@ -899,8 +900,8 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
               _lv_style_list_add_style(list, &styles->bg);
               _lv_style_list_add_style(list, &styles->no_radius);
             }
-
             break;
+         }
 #endif
 
 #if LV_USE_WIN

--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -890,21 +890,12 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL1);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->no_radius);
+            for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
+              list = lv_obj_get_style_list(obj, i);
+              _lv_style_list_add_style(list, &styles->bg);
+              _lv_style_list_add_style(list, &styles->no_radius);
+            }
 
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL2);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->no_radius);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL3);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->no_radius);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL4);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->no_radius);
             break;
 #endif
 

--- a/src/lv_themes/lv_theme_template.c
+++ b/src/lv_themes/lv_theme_template.c
@@ -42,7 +42,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_theme_t theme;
 
 static lv_theme_t theme;
 static theme_styles_t * styles;
@@ -732,8 +731,12 @@ void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-            for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
-              list = lv_obj_get_style_list(obj, i);
+            int idx = 1; /* start value should be 1, not zero, since cell styles
+                            start at 1 due to presence of LV_TABLE_PART_BG=0
+                            in the enum (lv_table.h) */
+                         /* declaring idx outside loop to work with older compilers */
+            for (; idx <= LV_TABLE_CELL_STYLE_CNT; idx ++ ) {
+              list = lv_obj_get_style_list(obj, idx);
               _lv_style_list_add_style(list, &styles->bg);
             }
 

--- a/src/lv_themes/lv_theme_template.c
+++ b/src/lv_themes/lv_theme_template.c
@@ -732,17 +732,11 @@ void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL1);
-            _lv_style_list_add_style(list, &styles->bg);
+            for (int i = i; i <= LV_TABLE_CELL_STYLE_CNT; i ++ ) {
+              list = lv_obj_get_style_list(obj, i);
+              _lv_style_list_add_style(list, &styles->bg);
+            }
 
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL2);
-            _lv_style_list_add_style(list, &styles->bg);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL3);
-            _lv_style_list_add_style(list, &styles->bg);
-
-            list = lv_obj_get_style_list(obj, LV_TABLE_PART_CELL4);
-            _lv_style_list_add_style(list, &styles->bg);
             break;
 #endif
 

--- a/src/lv_themes/lv_theme_template.c
+++ b/src/lv_themes/lv_theme_template.c
@@ -728,6 +728,7 @@ void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 #endif
 #if LV_USE_TABLE
         case LV_THEME_TABLE:
+        {
             list = lv_obj_get_style_list(obj, LV_TABLE_PART_BG);
             _lv_style_list_add_style(list, &styles->bg);
 
@@ -739,8 +740,8 @@ void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
               list = lv_obj_get_style_list(obj, idx);
               _lv_style_list_add_style(list, &styles->bg);
             }
-
             break;
+         }
 #endif
 
 #if LV_USE_WIN

--- a/src/lv_widgets/lv_chart.c
+++ b/src/lv_widgets/lv_chart.c
@@ -1358,7 +1358,8 @@ static void draw_y_ticks(lv_obj_t * chart, const lv_area_t * series_area, const 
                                  LV_COORD_MAX, LV_TXT_FLAG_CENTER);
 
                 /* set the area at some distance of the major tick len left of the tick */
-                lv_area_t a = {.y1 = p2.y - size.y / 2, .y2 = p2.y + size.y / 2};
+                /* changed to explicit member initialization to allow compilation as c++ */
+                lv_area_t a; a.y1 = p2.y - size.y / 2; a.y2 = p2.y + size.y / 2;
 
                 if(which_axis == LV_CHART_AXIS_PRIMARY_Y) {
                     a.x1 = p2.x - size.x - label_dist;

--- a/src/lv_widgets/lv_table.c
+++ b/src/lv_widgets/lv_table.c
@@ -947,6 +947,8 @@ static lv_style_list_t * lv_table_get_style(lv_obj_t * table, uint8_t part)
     LV_ASSERT_OBJ(table, LV_OBJX_NAME);
 
     lv_table_ext_t * ext = lv_obj_get_ext_attr(table);
+
+#if 0 /* OBSOLETE: retained in pull request to clarify the change */
     lv_style_list_t * style_dsc_p;
 
     switch(part) {
@@ -970,6 +972,16 @@ static lv_style_list_t * lv_table_get_style(lv_obj_t * table, uint8_t part)
     }
 
     return style_dsc_p;
+#else
+    /* Because of the presence of LV_TABLE_PART_BG, LV_TABLE_PART_CELL<i> has an integer value
+       of <i>. This comes in useful to extend above code with more cell types as follows */
+    if ( part == LV_TABLE_PART_BG ) {
+      return &table->style_list;
+    } else if (part >= 1 && part <= LV_TABLE_CELL_STYLE_CNT ) {
+      return &ext->cell_style[part-1];
+    }
+    return NULL;
+#endif
 }
 
 static void refr_size(lv_obj_t * table)

--- a/src/lv_widgets/lv_table.c
+++ b/src/lv_widgets/lv_table.c
@@ -948,31 +948,6 @@ static lv_style_list_t * lv_table_get_style(lv_obj_t * table, uint8_t part)
 
     lv_table_ext_t * ext = lv_obj_get_ext_attr(table);
 
-#if 0 /* OBSOLETE: retained in pull request to clarify the change */
-    lv_style_list_t * style_dsc_p;
-
-    switch(part) {
-        case LV_TABLE_PART_BG:
-            style_dsc_p = &table->style_list;
-            break;
-        case LV_TABLE_PART_CELL1:
-            style_dsc_p = &ext->cell_style[0];
-            break;
-        case LV_TABLE_PART_CELL2:
-            style_dsc_p = &ext->cell_style[1];
-            break;
-        case LV_TABLE_PART_CELL3:
-            style_dsc_p = &ext->cell_style[2];
-            break;
-        case LV_TABLE_PART_CELL4:
-            style_dsc_p = &ext->cell_style[3];
-            break;
-        default:
-            style_dsc_p = NULL;
-    }
-
-    return style_dsc_p;
-#else
     /* Because of the presence of LV_TABLE_PART_BG, LV_TABLE_PART_CELL<i> has an integer value
        of <i>. This comes in useful to extend above code with more cell types as follows */
     if ( part == LV_TABLE_PART_BG ) {
@@ -980,8 +955,8 @@ static lv_style_list_t * lv_table_get_style(lv_obj_t * table, uint8_t part)
     } else if (part >= 1 && part <= LV_TABLE_CELL_STYLE_CNT ) {
       return &ext->cell_style[part-1];
     }
+
     return NULL;
-#endif
 }
 
 static void refr_size(lv_obj_t * table)

--- a/src/lv_widgets/lv_table.h
+++ b/src/lv_widgets/lv_table.h
@@ -37,7 +37,12 @@ extern "C" {
    because of restriction of lv_table_cell_format_t.type to no more than
    4 bits so that lv_table_cell_format_t.s will not exceed 8 bits
 */
-#define LV_TABLE_CELL_STYLE_CNT 16
+#ifndef LV_TABLE_CELL_STYLE_CNT 
+#  define LV_TABLE_CELL_STYLE_CNT 4
+#endif
+#if (LV_TABLE_CELL_STYLE_CNT > 16)
+#  error LV_TABLE_CELL_STYLE_CNT cannot exceed 16
+#endif
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/lv_widgets/lv_table.h
+++ b/src/lv_widgets/lv_table.h
@@ -71,9 +71,9 @@ typedef struct {
 
 /*Parts of the table*/
 enum {
-    LV_TABLE_PART_BG,     /* Because of this member, LV_PART.*CELL1 has enum value of 1,
-    LV_TABLE_PART_CELL1,     LV_PART.*CELL2 has an enum value of 2 and so on upto the maximum
-    LV_TABLE_PART_CELL2,     number of styles specified by LV_TABLE_CELL_STYLE_CNT */
+    LV_TABLE_PART_BG,     /* Because of this member, LV_PART.*CELL1 has enum value of 1,        */
+    LV_TABLE_PART_CELL1,  /*   LV_PART.*CELL2 has an enum value of 2 and so on upto the maximum */
+    LV_TABLE_PART_CELL2,  /*   number of styles specified by LV_TABLE_CELL_STYLE_CNT            */
     LV_TABLE_PART_CELL3,
     LV_TABLE_PART_CELL4,  /* CELL 5-16 are not needed to be defined, the values in this enum
                              are there for backward compatibility */

--- a/src/lv_widgets/lv_table.h
+++ b/src/lv_widgets/lv_table.h
@@ -32,7 +32,12 @@ extern "C" {
 #define LV_TABLE_COL_MAX 12
 #endif
 
-#define LV_TABLE_CELL_STYLE_CNT 4
+/* 
+   Maximum allowable value of LV_TABLE_CELL_STYLE_CNT is 16 
+   because of restriction of lv_table_cell_format_t.type to no more than
+   4 bits so that lv_table_cell_format_t.s will not exceed 8 bits
+*/
+#define LV_TABLE_CELL_STYLE_CNT 16
 /**********************
  *      TYPEDEFS
  **********************/
@@ -46,7 +51,7 @@ typedef union {
     struct {
         uint8_t align : 2;
         uint8_t right_merge : 1;
-        uint8_t type : 2;
+        uint8_t type : 4; // upto 16 values
         uint8_t crop : 1;
     } s;
     uint8_t format_byte;
@@ -61,16 +66,17 @@ typedef struct {
     lv_coord_t * row_h;
     lv_style_list_t cell_style[LV_TABLE_CELL_STYLE_CNT];
     lv_coord_t col_w[LV_TABLE_COL_MAX];
-    uint8_t cell_types : 4; /*Keep track which cell types exists to avoid dealing with unused ones*/
+    uint16_t cell_types : LV_TABLE_CELL_STYLE_CNT; /*Keep track which cell types exists to avoid dealing with unused ones*/
 } lv_table_ext_t;
 
 /*Parts of the table*/
 enum {
-    LV_TABLE_PART_BG,
-    LV_TABLE_PART_CELL1,
-    LV_TABLE_PART_CELL2,
+    LV_TABLE_PART_BG,     /* Because of this member, LV_PART.*CELL1 has enum value of 1,
+    LV_TABLE_PART_CELL1,     LV_PART.*CELL2 has an enum value of 2 and so on upto the maximum
+    LV_TABLE_PART_CELL2,     number of styles specified by LV_TABLE_CELL_STYLE_CNT */
     LV_TABLE_PART_CELL3,
-    LV_TABLE_PART_CELL4,
+    LV_TABLE_PART_CELL4,  /* CELL 5-16 are not needed to be defined, the values in this enum
+                             are there for backward compatibility */
 };
 
 /**********************


### PR DESCRIPTION
This pull request extends the number of table cell types from 4 to 16, and also makes it easy to change the number of cell types
to any number between 4 and 16 (inclusive) by  modification in a single place (by simply changing the definition of LV_TABLE_CELL_STYLE_CNT).