### PR TITLE
Fix #1795: ensure switch/bar visual state matches logical state

### DIFF
--- a/src/lv_widgets/lv_bar.c
+++ b/src/lv_widgets/lv_bar.c
@@ -737,6 +737,7 @@ static void lv_bar_set_value_with_anim(lv_obj_t * bar, int16_t new_value, int16_
             anim_info->anim_start = anim_info->anim_end;
             anim_info->anim_end   = new_value;
         }
+        *value_ptr = new_value;
         /* Stop the previous animation if it exists */
         lv_anim_del(anim_info, NULL);
 

--- a/src/lv_widgets/lv_switch.c
+++ b/src/lv_widgets/lv_switch.c
@@ -127,7 +127,8 @@ void lv_switch_on(lv_obj_t * sw, lv_anim_enable_t anim)
     anim = LV_ANIM_OFF;
 #endif
     lv_switch_ext_t * ext = lv_obj_get_ext_attr(sw);
-    ext->state = 1;
+    if(lv_bar_get_value(sw) == 1)
+        return;
     lv_bar_set_value(sw, 1, anim);
     lv_obj_add_state(sw, LV_STATE_CHECKED);
 }
@@ -145,7 +146,8 @@ void lv_switch_off(lv_obj_t * sw, lv_anim_enable_t anim)
     anim = LV_ANIM_OFF;
 #endif
     lv_switch_ext_t * ext = lv_obj_get_ext_attr(sw);
-    ext->state = 0;
+    if(lv_bar_get_value(sw) == 0)
+        return;
     lv_bar_set_value(sw, 0, anim);
     lv_obj_clear_state(sw, LV_STATE_CHECKED);
 }

--- a/src/lv_widgets/lv_switch.c
+++ b/src/lv_widgets/lv_switch.c
@@ -126,7 +126,6 @@ void lv_switch_on(lv_obj_t * sw, lv_anim_enable_t anim)
 #if LV_USE_ANIMATION == 0
     anim = LV_ANIM_OFF;
 #endif
-    lv_switch_ext_t * ext = lv_obj_get_ext_attr(sw);
     if(lv_bar_get_value(sw) == 1)
         return;
     lv_bar_set_value(sw, 1, anim);
@@ -145,7 +144,6 @@ void lv_switch_off(lv_obj_t * sw, lv_anim_enable_t anim)
 #if LV_USE_ANIMATION == 0
     anim = LV_ANIM_OFF;
 #endif
-    lv_switch_ext_t * ext = lv_obj_get_ext_attr(sw);
     if(lv_bar_get_value(sw) == 0)
         return;
     lv_bar_set_value(sw, 0, anim);

--- a/src/lv_widgets/lv_switch.h
+++ b/src/lv_widgets/lv_switch.h
@@ -37,7 +37,6 @@ typedef struct {
     lv_bar_ext_t bar; /*Ext. of ancestor*/
     /*New data for this type */
     lv_style_list_t style_knob; /*Style of the knob*/
-    uint8_t state   : 1; /*The current state*/
 } lv_switch_ext_t;
 
 /**
@@ -112,8 +111,7 @@ static inline void lv_switch_set_anim_time(lv_obj_t * sw, uint16_t anim_time)
  */
 static inline bool lv_switch_get_state(const lv_obj_t * sw)
 {
-    lv_switch_ext_t * ext = (lv_switch_ext_t *)lv_obj_get_ext_attr(sw);
-    return ext->state ? true : false;
+    return lv_bar_get_value(sw) == 1 ? true : false;
 }
 
 /**


### PR DESCRIPTION
@HX2003 @hedyhefty If you could also test this fix that would be great.

Closes #1795.