### PR TITLE
use margin in the header part of calendar.

### DIFF
--- a/src/lv_themes/lv_theme_material.c
+++ b/src/lv_themes/lv_theme_material.c
@@ -549,10 +549,12 @@ static void calendar_init(void)
 #if LV_USE_CALENDAR
 
     style_init_reset(&styles->calendar_header);
-    lv_style_set_pad_top(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
+    lv_style_set_pad_top(&styles->calendar_header, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_left(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_right(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
-    lv_style_set_pad_bottom(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
+    lv_style_set_pad_bottom(&styles->calendar_header, LV_STATE_DEFAULT, 0);
+    lv_style_set_margin_top(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
+    lv_style_set_margin_bottom(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_text_color(&styles->calendar_header, LV_STATE_PRESSED, IS_LIGHT ? lv_color_hex(0x888888) : LV_COLOR_WHITE);
 
     style_init_reset(&styles->calendar_daynames);

--- a/src/lv_widgets/lv_calendar.c
+++ b/src/lv_widgets/lv_calendar.c
@@ -650,8 +650,10 @@ static bool calculate_touched_day(lv_obj_t * calendar, const lv_point_t * touche
 static lv_coord_t get_header_height(lv_obj_t * calendar)
 {
     const lv_font_t * font = lv_obj_get_style_text_font(calendar, LV_CALENDAR_PART_HEADER);
-    lv_style_int_t top = lv_obj_get_style_pad_top(calendar, LV_CALENDAR_PART_HEADER);
-    lv_style_int_t bottom = lv_obj_get_style_pad_bottom(calendar, LV_CALENDAR_PART_HEADER);
+    lv_style_int_t top = lv_obj_get_style_margin_top(calendar, LV_CALENDAR_PART_HEADER) +
+    		lv_obj_get_style_pad_top(calendar, LV_CALENDAR_PART_HEADER);
+    lv_style_int_t bottom = lv_obj_get_style_margin_bottom(calendar, LV_CALENDAR_PART_HEADER) +
+    		lv_obj_get_style_pad_bottom(calendar, LV_CALENDAR_PART_HEADER);
 
     return lv_font_get_line_height(font) + top + bottom;
 }
@@ -677,7 +679,6 @@ static lv_coord_t get_day_names_height(lv_obj_t * calendar)
  */
 static void draw_header(lv_obj_t * calendar, const lv_area_t * mask)
 {
-    lv_style_int_t header_top = lv_obj_get_style_pad_top(calendar, LV_CALENDAR_PART_HEADER);
     lv_style_int_t header_left = lv_obj_get_style_pad_left(calendar, LV_CALENDAR_PART_HEADER);
     lv_style_int_t header_right = lv_obj_get_style_pad_right(calendar, LV_CALENDAR_PART_HEADER);
     const lv_font_t * font = lv_obj_get_style_text_font(calendar, LV_CALENDAR_PART_HEADER);
@@ -687,8 +688,9 @@ static void draw_header(lv_obj_t * calendar, const lv_area_t * mask)
     lv_area_t header_area;
     header_area.x1 = calendar->coords.x1;
     header_area.x2 = calendar->coords.x2;
-    header_area.y1 = calendar->coords.y1 + header_top;
-    header_area.y2 = header_area.y1 + lv_font_get_line_height(font);
+    header_area.y1 = calendar->coords.y1 + lv_obj_get_style_margin_top(calendar, LV_CALENDAR_PART_HEADER);
+    header_area.y2 = header_area.y1 + lv_obj_get_style_pad_top(calendar, LV_CALENDAR_PART_HEADER) +
+    		lv_font_get_line_height(font) + lv_obj_get_style_pad_bottom(calendar, LV_CALENDAR_PART_HEADER);
 
     lv_draw_rect_dsc_t header_rect_dsc;
     lv_draw_rect_dsc_init(&header_rect_dsc);
@@ -711,6 +713,8 @@ static void draw_header(lv_obj_t * calendar, const lv_area_t * mask)
     lv_draw_label_dsc_init(&label_dsc);
     lv_obj_init_draw_label_dsc(calendar, LV_CALENDAR_PART_HEADER, &label_dsc);
     label_dsc.flag = LV_TXT_FLAG_CENTER;
+    header_area.y1 += lv_obj_get_style_pad_top(calendar, LV_CALENDAR_PART_HEADER);
+    header_area.y2 -= lv_obj_get_style_pad_bottom(calendar, LV_CALENDAR_PART_HEADER);
     lv_draw_label(&header_area, mask, &label_dsc, txt_buf, NULL);
 
     calendar->state = state_ori;    /*Restore the state*/


### PR DESCRIPTION
Hi
As I discussed [here](https://forum.lvgl.io/t/increase-the-header-part-of-calendar/3028), I think it's a good idea to use the top margin for setting the distance between the header and the top of the calendar and bottom margin for the header and the start of day names part. 
Padding can also be used for increasing the colorful part of the header.
So now we can have a calendar like this:
![calendar](https://user-images.githubusercontent.com/9710249/94340863-e6b50880-0011-11eb-994b-4378c1542303.jpeg)

`
lv_obj_set_style_local_clip_corner(calendar_date, LV_CALENDAR_PART_BG, LV_STATE_DEFAULT, true);
		lv_obj_set_style_local_clip_corner(calendar_date, LV_CALENDAR_PART_BG, LV_STATE_FOCUSED, true);
		lv_obj_set_style_local_text_color(calendar_date, LV_CALENDAR_PART_DATE, LV_STATE_DISABLED, LV_COLOR_GRAY);
		lv_obj_set_style_local_margin_top(calendar_date, LV_CALENDAR_PART_HEADER, LV_STATE_DEFAULT, 0);
		lv_obj_set_style_local_margin_bottom(calendar_date, LV_CALENDAR_PART_HEADER, LV_STATE_DEFAULT, 10);
		lv_obj_set_style_local_pad_ver(calendar_date, LV_CALENDAR_PART_HEADER, LV_STATE_DEFAULT, 20);
		lv_obj_set_style_local_bg_color(calendar_date, LV_CALENDAR_PART_HEADER, LV_STATE_DEFAULT, lv_color_hex3(0xddd));
		lv_obj_set_style_local_bg_opa(calendar_date, LV_CALENDAR_PART_HEADER, LV_STATE_DEFAULT, LV_OPA_COVER);
`
