### PR TITLE
Bugfix/mgg 562 lvgl pxp symbol prefix missing include path update blit limit

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -200,9 +200,9 @@ void lv_init(void)
 #endif
 
 #if LV_USE_GPU_NXP_PXP && LV_USE_GPU_NXP_PXP_AUTO_INIT
-    if (lv_gpu_nxp_pxp_init(&pxp_default_cfg) != LV_RES_OK) {
+    if(lv_gpu_nxp_pxp_init(&pxp_default_cfg) != LV_RES_OK) {
         LV_LOG_ERROR("PXP init error. STOP.\n");
-        for ( ; ; ) ;
+        for(; ;) ;
     }
 #endif
 

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -28,8 +28,8 @@
 #include <string.h>
 
 #if LV_USE_GPU_NXP_PXP && LV_USE_GPU_NXP_PXP_AUTO_INIT
-    #include "lv_gpu/lv_gpu_nxp_pxp.h"
-    #include "lv_gpu/lv_gpu_nxp_pxp_osa.h"
+    #include "../lv_gpu/lv_gpu_nxp_pxp.h"
+    #include "../lv_gpu/lv_gpu_nxp_pxp_osa.h"
 #endif
 
 #if defined(LV_GC_INCLUDE)

--- a/src/lv_draw/lv_draw_blend.c
+++ b/src/lv_draw/lv_draw_blend.c
@@ -13,7 +13,7 @@
 #include "../lv_core/lv_refr.h"
 
 #if LV_USE_GPU_NXP_PXP
-#include "../lv_gpu/lv_gpu_nxp_pxp.h"
+    #include "../lv_gpu/lv_gpu_nxp_pxp.h"
 #elif LV_USE_GPU_STM32_DMA2D
 #include "../lv_gpu/lv_gpu_stm32_dma2d.h"
 #endif
@@ -741,10 +741,10 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
 
         if(opa > LV_OPA_MAX) {
 #if LV_USE_GPU_NXP_PXP
-        if (lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
-            lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
-            return;
-        }
+            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
+                lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
+                return;
+            }
 #elif LV_USE_GPU_STM32_DMA2D
         if(lv_area_get_size(draw_area) >= 240) {
             lv_gpu_stm32_dma2d_copy(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h);
@@ -761,7 +761,7 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
         }
         else {
 #if LV_USE_GPU_NXP_PXP
-            if (lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT) {
+            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT) {
                 lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
                 return;
             }

--- a/src/lv_draw/lv_draw_blend.c
+++ b/src/lv_draw/lv_draw_blend.c
@@ -341,7 +341,7 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(const lv_area_t * disp_area, lv_co
                 return;
             }
 #elif LV_USE_GPU_NXP_PXP
-            if(lv_area_get_size(draw_area) >= GPU_NXP_PXP_FILL_SIZE_LIMIT) {
+            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_FILL_SIZE_LIMIT) {
                 lv_gpu_nxp_pxp_fill(disp_buf, disp_w, draw_area, color, opa);
                 return;
             }
@@ -361,7 +361,7 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(const lv_area_t * disp_area, lv_co
         else {
 
 #if LV_USE_GPU_NXP_PXP
-            if(lv_area_get_size(draw_area) >= GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT) {
+            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT) {
                 lv_gpu_nxp_pxp_fill(disp_buf, disp_w, draw_area, color, opa);
                 return;
             }
@@ -741,7 +741,7 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
 
         if(opa > LV_OPA_MAX) {
 #if LV_USE_GPU_NXP_PXP
-        if (lv_area_get_size(draw_area) >= GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
+        if (lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
             lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
             return;
         }
@@ -761,7 +761,7 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
         }
         else {
 #if LV_USE_GPU_NXP_PXP
-            if (lv_area_get_size(draw_area) >= GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT) {
+            if (lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT) {
                 lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
                 return;
             }

--- a/src/lv_draw/lv_draw_img.c
+++ b/src/lv_draw/lv_draw_img.c
@@ -16,7 +16,7 @@
 #if LV_USE_GPU_STM32_DMA2D
 #include "../lv_gpu/lv_gpu_stm32_dma2d.h"
 #elif LV_USE_GPU_NXP_PXP
-#include "../lv_gpu/lv_gpu_nxp_pxp.h"
+    #include "../lv_gpu/lv_gpu_nxp_pxp.h"
 #endif
 
 /*********************
@@ -360,18 +360,19 @@ LV_ATTRIBUTE_FAST_MEM static void lv_draw_map(const lv_area_t * map_area, const 
     }
 #if LV_USE_GPU_NXP_PXP
     /* Simple case without masking and transformations */
-    else if (other_mask_cnt == 0 && draw_dsc->angle == 0 && draw_dsc->zoom == LV_IMG_ZOOM_NONE && alpha_byte == false &&
+    else if(other_mask_cnt == 0 && draw_dsc->angle == 0 && draw_dsc->zoom == LV_IMG_ZOOM_NONE && alpha_byte == false &&
             chroma_key == true && draw_dsc->recolor_opa == LV_OPA_TRANSP) { /* copy with color keying (+ alpha) */
-            lv_gpu_nxp_pxp_enable_color_key();
-            _lv_blend_map(clip_area, map_area, (lv_color_t *)map_p, NULL, LV_DRAW_MASK_RES_FULL_COVER, draw_dsc->opa,
-                         draw_dsc->blend_mode);
-            lv_gpu_nxp_pxp_disable_color_key();
-    } else if (other_mask_cnt == 0 && draw_dsc->angle == 0 && draw_dsc->zoom == LV_IMG_ZOOM_NONE && alpha_byte == false &&
+        lv_gpu_nxp_pxp_enable_color_key();
+        _lv_blend_map(clip_area, map_area, (lv_color_t *)map_p, NULL, LV_DRAW_MASK_RES_FULL_COVER, draw_dsc->opa,
+                      draw_dsc->blend_mode);
+        lv_gpu_nxp_pxp_disable_color_key();
+    }
+    else if(other_mask_cnt == 0 && draw_dsc->angle == 0 && draw_dsc->zoom == LV_IMG_ZOOM_NONE && alpha_byte == false &&
             chroma_key == false && draw_dsc->recolor_opa != LV_OPA_TRANSP) { /* copy with recolor (+ alpha) */
-            lv_gpu_nxp_pxp_enable_recolor(draw_dsc->recolor, draw_dsc->recolor_opa);
-            _lv_blend_map(clip_area, map_area, (lv_color_t *)map_p, NULL, LV_DRAW_MASK_RES_FULL_COVER, draw_dsc->opa,
-                         draw_dsc->blend_mode);
-            lv_gpu_nxp_pxp_disable_recolor();
+        lv_gpu_nxp_pxp_enable_recolor(draw_dsc->recolor, draw_dsc->recolor_opa);
+        _lv_blend_map(clip_area, map_area, (lv_color_t *)map_p, NULL, LV_DRAW_MASK_RES_FULL_COVER, draw_dsc->opa,
+                      draw_dsc->blend_mode);
+        lv_gpu_nxp_pxp_disable_recolor();
     }
 #endif
     /*In the other cases every pixel need to be checked one-by-one*/

--- a/src/lv_gpu/lv_gpu_nxp_pxp.c
+++ b/src/lv_gpu/lv_gpu_nxp_pxp.c
@@ -73,7 +73,8 @@ static void lv_gpu_nxp_pxp_run(void);
 static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width, const lv_color_t * src,
                                         lv_coord_t src_width,
                                         lv_coord_t copy_width, lv_coord_t copy_height, lv_opa_t opa, lv_color_t recolor, lv_opa_t recolorOpa);
-static void lv_gpu_nxp_invalidate_cache(uint32_t address, uint32_t width, uint32_t height, uint32_t stride, uint32_t pxSize);
+static void lv_gpu_nxp_invalidate_cache(uint32_t address, uint32_t width, uint32_t height, uint32_t stride,
+                                        uint32_t pxSize);
 
 /**********************
  *  STATIC VARIABLES
@@ -162,7 +163,8 @@ void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_
         .width          = fill_area->x2 - fill_area->x1 + 1,
         .height         = fill_area->y2 - fill_area->y1 + 1,
     };
-    lv_gpu_nxp_invalidate_cache(outputConfig.buffer0Addr, outputConfig.width, outputConfig.height, outputConfig.pitchBytes, sizeof(lv_color_t));
+    lv_gpu_nxp_invalidate_cache(outputConfig.buffer0Addr, outputConfig.width, outputConfig.height, outputConfig.pitchBytes,
+                                sizeof(lv_color_t));
     PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputConfig);
 
     if(opa > LV_OPA_MAX) {
@@ -182,7 +184,8 @@ void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_
         asBufferConfig.pitchBytes  = outputConfig.pitchBytes;
 
         PXP_SetAlphaSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &asBufferConfig);
-        PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, fill_area->x2 - fill_area->x1 + 1, fill_area->y2 - fill_area->y1 + 1);
+        PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, fill_area->x2 - fill_area->x1 + 1,
+                                    fill_area->y2 - fill_area->y1 + 1);
 
         /* Disable PS, use as color generator */
         PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
@@ -272,7 +275,8 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_colo
     PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
     PXP_SetAlphaSurfaceBlendConfig(LV_GPU_NXP_PXP_ID, &asBlendConfig);
 
-    lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes, sizeof(lv_color_t));
+    lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes,
+                                sizeof(lv_color_t));
 
     if(colorKeyEnabled) {
         PXP_SetAlphaSurfaceOverlayColorKey(LV_GPU_NXP_PXP_ID, colorKey, colorKey);
@@ -290,7 +294,8 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_colo
     outputBufferConfig.height         = copy_height;
     PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputBufferConfig);
 
-    lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height, outputBufferConfig.pitchBytes, sizeof(lv_color_t));
+    lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height,
+                                outputBufferConfig.pitchBytes, sizeof(lv_color_t));
 
     lv_gpu_nxp_pxp_run(); /* Start PXP task */
 }
@@ -395,7 +400,8 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
             PXP_SetAlphaSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &asBufferConfig);
             PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
 
-            lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes, sizeof(lv_color_t));
+            lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes,
+                                        sizeof(lv_color_t));
 
             /* Disable PS buffer, use as color generator */
             PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
@@ -411,7 +417,8 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
             outputBufferConfig.height         = copy_height;
             PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputBufferConfig);
 
-            lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height, outputBufferConfig.pitchBytes, sizeof(lv_color_t));
+            lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height,
+                                        outputBufferConfig.pitchBytes, sizeof(lv_color_t));
 
             pxp_porter_duff_config_t pdConfig;
 
@@ -460,11 +467,13 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
  * @param[in] stride stride in bytes
  * @param[in] pxSize pixel size in bytes
  */
-static void lv_gpu_nxp_invalidate_cache(uint32_t address, uint32_t width, uint32_t height, uint32_t stride, uint32_t pxSize) {
+static void lv_gpu_nxp_invalidate_cache(uint32_t address, uint32_t width, uint32_t height, uint32_t stride,
+                                        uint32_t pxSize)
+{
     int y;
 
-    for (y = 0; y < height; y++) {
-        DCACHE_CleanInvalidateByRange(address, width*pxSize);
+    for(y = 0; y < height; y++) {
+        DCACHE_CleanInvalidateByRange(address, width * pxSize);
         address += stride;
     }
 }

--- a/src/lv_gpu/lv_gpu_nxp_pxp.c
+++ b/src/lv_gpu/lv_gpu_nxp_pxp.c
@@ -48,9 +48,6 @@
  *      DEFINES
  *********************/
 
-/* PXP instance ID */
-#define PXP_ID PXP
-
 #if LV_COLOR_16_SWAP
     #error Color swap not implemented. Disable LV_COLOR_16_SWAP feature.
 #endif
@@ -135,7 +132,7 @@ void lv_gpu_nxp_pxp_deinit(void)
 {
     pxp_cfg.pxp_interrupt_deinit();
     PXP_DisableInterrupts(PXP, kPXP_CompleteInterruptEnable);
-    PXP_Deinit(PXP_ID);
+    PXP_Deinit(LV_GPU_NXP_PXP_ID);
 }
 
 
@@ -151,8 +148,8 @@ void lv_gpu_nxp_pxp_deinit(void)
 void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_area_t * fill_area, lv_color_t color,
                          lv_opa_t opa)
 {
-    PXP_Init(PXP_ID);
-    PXP_EnableCsc1(PXP_ID, false);     /* Disable CSC1, it is enabled by default. */
+    PXP_Init(LV_GPU_NXP_PXP_ID);
+    PXP_EnableCsc1(LV_GPU_NXP_PXP_ID, false);     /* Disable CSC1, it is enabled by default. */
     PXP_SetProcessBlockSize(PXP, kPXP_BlockSize16); /* Block size 16x16 for higher performance */
 
     /* OUT buffer configure */
@@ -166,13 +163,13 @@ void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_
         .height         = fill_area->y2 - fill_area->y1 + 1,
     };
     lv_gpu_nxp_invalidate_cache(outputConfig.buffer0Addr, outputConfig.width, outputConfig.height, outputConfig.pitchBytes, sizeof(lv_color_t));
-    PXP_SetOutputBufferConfig(PXP_ID, &outputConfig);
+    PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputConfig);
 
     if(opa > LV_OPA_MAX) {
         /* Simple color fill without opacity - AS disabled, PS as color generator */
-        PXP_SetAlphaSurfacePosition(PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U); /* Disable AS. */
-        PXP_SetProcessSurfacePosition(PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U); /* Disable PS. */
-        PXP_SetProcessSurfaceBackGroundColor(PXP_ID, lv_color_to32(color));
+        PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U); /* Disable AS. */
+        PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U); /* Disable PS. */
+        PXP_SetProcessSurfaceBackGroundColor(LV_GPU_NXP_PXP_ID, lv_color_to32(color));
     }
     else {
         /* Fill with opacity - AS used as source (same as OUT), PS used as color generator, blended together */
@@ -184,12 +181,12 @@ void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_
         asBufferConfig.bufferAddr  = (uint32_t)outputConfig.buffer0Addr;
         asBufferConfig.pitchBytes  = outputConfig.pitchBytes;
 
-        PXP_SetAlphaSurfaceBufferConfig(PXP_ID, &asBufferConfig);
-        PXP_SetAlphaSurfacePosition(PXP_ID, 0U, 0U, fill_area->x2 - fill_area->x1 + 1, fill_area->y2 - fill_area->y1 + 1);
+        PXP_SetAlphaSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &asBufferConfig);
+        PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, fill_area->x2 - fill_area->x1 + 1, fill_area->y2 - fill_area->y1 + 1);
 
         /* Disable PS, use as color generator */
-        PXP_SetProcessSurfacePosition(PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
-        PXP_SetProcessSurfaceBackGroundColor(PXP_ID, lv_color_to32(color));
+        PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
+        PXP_SetProcessSurfaceBackGroundColor(LV_GPU_NXP_PXP_ID, lv_color_to32(color));
 
         /* Configure Porter-Duff blending - For RGB 565 only! */
         pdConfig.enable = 1;
@@ -203,7 +200,7 @@ void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_
         pdConfig.dstGlobalAlpha = 255 - opa;
         pdConfig.srcAlphaMode = kPXP_PorterDuffAlphaStraight; /* don't care */
         pdConfig.dstAlphaMode = kPXP_PorterDuffAlphaStraight; /* don't care */
-        PXP_SetPorterDuffConfig(PXP_ID, &pdConfig);
+        PXP_SetPorterDuffConfig(LV_GPU_NXP_PXP_ID, &pdConfig);
     }
 
     lv_gpu_nxp_pxp_run(); /* Start PXP task */
@@ -249,7 +246,7 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_colo
 
     if(opa >= LV_OPA_MAX && !colorKeyEnabled) {
         /* Simple blit, no effect - Disable PS buffer */
-        PXP_SetProcessSurfacePosition(PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
+        PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
     }
     else {
         /* Alpha blending or color keying enabled - PS must be enabled to fetch background pixels
@@ -263,24 +260,24 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_colo
             .pitchBytes  = dest_width * sizeof(lv_color_t)
         };
         asBlendConfig.alphaMode = kPXP_AlphaOverride;
-        PXP_SetProcessSurfaceBufferConfig(PXP_ID, &psBufferConfig);
-        PXP_SetProcessSurfacePosition(PXP_ID, 0U, 0U, copy_width - 1, copy_height - 1);
+        PXP_SetProcessSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &psBufferConfig);
+        PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, copy_width - 1, copy_height - 1);
     }
 
     /* AS buffer - source image */
     asBufferConfig.pixelFormat = PXP_AS_PIXEL_FORMAT;
     asBufferConfig.bufferAddr  = (uint32_t)src;
     asBufferConfig.pitchBytes  = src_width * sizeof(lv_color_t);
-    PXP_SetAlphaSurfaceBufferConfig(PXP_ID, &asBufferConfig);
-    PXP_SetAlphaSurfacePosition(PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
-    PXP_SetAlphaSurfaceBlendConfig(PXP_ID, &asBlendConfig);
+    PXP_SetAlphaSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &asBufferConfig);
+    PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
+    PXP_SetAlphaSurfaceBlendConfig(LV_GPU_NXP_PXP_ID, &asBlendConfig);
 
     lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes, sizeof(lv_color_t));
 
     if(colorKeyEnabled) {
-        PXP_SetAlphaSurfaceOverlayColorKey(PXP_ID, colorKey, colorKey);
+        PXP_SetAlphaSurfaceOverlayColorKey(LV_GPU_NXP_PXP_ID, colorKey, colorKey);
     }
-    PXP_EnableAlphaSurfaceOverlayColorKey(PXP_ID, colorKeyEnabled);
+    PXP_EnableAlphaSurfaceOverlayColorKey(LV_GPU_NXP_PXP_ID, colorKeyEnabled);
 
 
     /* Output buffer. */
@@ -291,7 +288,7 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_colo
     outputBufferConfig.pitchBytes     = dest_width * sizeof(lv_color_t);
     outputBufferConfig.width          = copy_width;
     outputBufferConfig.height         = copy_height;
-    PXP_SetOutputBufferConfig(PXP_ID, &outputBufferConfig);
+    PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputBufferConfig);
 
     lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height, outputBufferConfig.pitchBytes, sizeof(lv_color_t));
 
@@ -395,14 +392,14 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
             asBufferConfig.pixelFormat = PXP_AS_PIXEL_FORMAT;
             asBufferConfig.bufferAddr  = (uint32_t)src;
             asBufferConfig.pitchBytes  = src_width * sizeof(lv_color_t);
-            PXP_SetAlphaSurfaceBufferConfig(PXP_ID, &asBufferConfig);
-            PXP_SetAlphaSurfacePosition(PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
+            PXP_SetAlphaSurfaceBufferConfig(LV_GPU_NXP_PXP_ID, &asBufferConfig);
+            PXP_SetAlphaSurfacePosition(LV_GPU_NXP_PXP_ID, 0U, 0U, copy_width - 1U, copy_height - 1U);
 
             lv_gpu_nxp_invalidate_cache(asBufferConfig.bufferAddr, copy_width, copy_height, asBufferConfig.pitchBytes, sizeof(lv_color_t));
 
             /* Disable PS buffer, use as color generator */
-            PXP_SetProcessSurfacePosition(PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
-            PXP_SetProcessSurfaceBackGroundColor(PXP_ID, lv_color_to32(recolor));
+            PXP_SetProcessSurfacePosition(LV_GPU_NXP_PXP_ID, 0xFFFFU, 0xFFFFU, 0U, 0U);
+            PXP_SetProcessSurfaceBackGroundColor(LV_GPU_NXP_PXP_ID, lv_color_to32(recolor));
 
             /* Output buffer */
             outputBufferConfig.pixelFormat    = (pxp_output_pixel_format_t)PXP_OUT_PIXEL_FORMAT;
@@ -412,7 +409,7 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
             outputBufferConfig.pitchBytes     = dest_width * sizeof(lv_color_t);
             outputBufferConfig.width          = copy_width;
             outputBufferConfig.height         = copy_height;
-            PXP_SetOutputBufferConfig(PXP_ID, &outputBufferConfig);
+            PXP_SetOutputBufferConfig(LV_GPU_NXP_PXP_ID, &outputBufferConfig);
 
             lv_gpu_nxp_invalidate_cache(outputBufferConfig.buffer0Addr, outputBufferConfig.width, outputBufferConfig.height, outputBufferConfig.pitchBytes, sizeof(lv_color_t));
 
@@ -430,7 +427,7 @@ static void lv_gpu_nxp_pxp_blit_recolor(lv_color_t * dest, lv_coord_t dest_width
             pdConfig.dstGlobalAlpha = 255 - recolorOpa;
             pdConfig.srcAlphaMode = kPXP_PorterDuffAlphaStraight; /* don't care */
             pdConfig.dstAlphaMode = kPXP_PorterDuffAlphaStraight; /* don't care */
-            PXP_SetPorterDuffConfig(PXP_ID, &pdConfig);
+            PXP_SetPorterDuffConfig(LV_GPU_NXP_PXP_ID, &pdConfig);
 
             lv_gpu_nxp_pxp_run(); /* Start PXP task */
 

--- a/src/lv_gpu/lv_gpu_nxp_pxp.h
+++ b/src/lv_gpu/lv_gpu_nxp_pxp.h
@@ -107,7 +107,7 @@ typedef struct {
  *
  * @return LV_RES_OK: PXP init ok; LV_RES_INV: init error. See error log for more information.
  */
-lv_res_t lv_gpu_nxp_pxp_init(lv_nxp_pxp_cfg_t *cfg);
+lv_res_t lv_gpu_nxp_pxp_init(lv_nxp_pxp_cfg_t * cfg);
 
 /**
  * Disable PXP device. Should be called during display deinit sequence.
@@ -123,7 +123,8 @@ void lv_gpu_nxp_pxp_deinit(void);
  * @param[in] color color
  * @param[in] opa transparency of the color
  */
-void lv_gpu_nxp_pxp_fill(lv_color_t *dest_buf, lv_coord_t dest_width, const lv_area_t *fill_area, lv_color_t color, lv_opa_t opa);
+void lv_gpu_nxp_pxp_fill(lv_color_t * dest_buf, lv_coord_t dest_width, const lv_area_t * fill_area, lv_color_t color,
+                         lv_opa_t opa);
 
 
 
@@ -143,7 +144,8 @@ void lv_gpu_nxp_pxp_fill(lv_color_t *dest_buf, lv_coord_t dest_width, const lv_a
  * @param[in] copy_h height of area to be copied from src to dest
  * @param[in] opa opacity of the result
  */
-void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_color_t * src, lv_coord_t src_width, lv_coord_t copy_width, lv_coord_t copy_height, lv_opa_t opa);
+void lv_gpu_nxp_pxp_blit(lv_color_t * dest, lv_coord_t dest_width, const lv_color_t * src, lv_coord_t src_width,
+                         lv_coord_t copy_width, lv_coord_t copy_height, lv_opa_t opa);
 
 
 /**

--- a/src/lv_gpu/lv_gpu_nxp_pxp.h
+++ b/src/lv_gpu/lv_gpu_nxp_pxp.h
@@ -45,30 +45,30 @@ extern "C" {
  *      DEFINES
  *********************/
 
-/* PXP module instance to use */
-#define PXP_ID PXP
+/** PXP module instance to use */
+#define LV_GPU_NXP_PXP_ID PXP
 
-/* PXP interrupt line ID  */
-#define PXP_IRQ_ID PXP_IRQn
+/** PXP interrupt line ID  */
+#define LV_GPU_NXP_PXP_IRQ_ID PXP_IRQn
 
-/* Minimum area for image copy with 100% opacity to be handled by PXP */
-#ifndef GPU_NXP_PXP_BLIT_SIZE_LIMIT
-#define GPU_NXP_PXP_BLIT_SIZE_LIMIT 1
+#ifndef LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT
+/** Minimum area (in pixels) for image copy with 100% opacity to be handled by PXP */
+#define LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT 32
 #endif
 
-/* Minimum area for image copy with transparency to be handled by PXP */
-#ifndef GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT
-#define GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT 16
+#ifndef LV_GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT
+/** Minimum area (in pixels) for image copy with transparency to be handled by PXP */
+#define LV_GPU_NXP_PXP_BLIT_OPA_SIZE_LIMIT 16
 #endif
 
-/* Minimum area to be filled by PXP with 100% opacity */
-#ifndef GPU_NXP_PXP_FILL_SIZE_LIMIT
-#define GPU_NXP_PXP_FILL_SIZE_LIMIT 64
+#ifndef LV_GPU_NXP_PXP_FILL_SIZE_LIMIT
+/** Minimum area (in pixels) to be filled by PXP with 100% opacity */
+#define LV_GPU_NXP_PXP_FILL_SIZE_LIMIT 64
 #endif
 
-/* Minimum area to be filled by PXP with transparency */
-#ifndef GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT
-#define GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT 32
+#ifndef LV_GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT
+/** Minimum area (in pixels) to be filled by PXP with transparency */
+#define LV_GPU_NXP_PXP_FILL_OPA_SIZE_LIMIT 32
 #endif
 
 /**********************

--- a/src/lv_gpu/lv_gpu_nxp_pxp_osa.c
+++ b/src/lv_gpu/lv_gpu_nxp_pxp_osa.c
@@ -86,8 +86,8 @@ void PXP_IRQHandler(void)
     BaseType_t taskAwake = pdFALSE;
 #endif
 
-    if(kPXP_CompleteFlag & PXP_GetStatusFlags(PXP_ID)) {
-        PXP_ClearStatusFlags(PXP_ID, kPXP_CompleteFlag);
+    if(kPXP_CompleteFlag & PXP_GetStatusFlags(LV_GPU_NXP_PXP_ID)) {
+        PXP_ClearStatusFlags(LV_GPU_NXP_PXP_ID, kPXP_CompleteFlag);
 #if defined(FSL_RTOS_FREE_RTOS)
         xSemaphoreGiveFromISR(s_pxpIdle, &taskAwake);
         portYIELD_FROM_ISR(taskAwake);
@@ -113,12 +113,12 @@ static lv_res_t _lv_gpu_nxp_pxp_interrupt_init(void)
         return LV_RES_INV;
     }
 
-    NVIC_SetPriority(PXP_IRQ_ID, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1);
+    NVIC_SetPriority(LV_GPU_NXP_PXP_IRQ_ID, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1);
 #else
     s_pxpIdle = true;
 #endif
 
-    NVIC_EnableIRQ(PXP_IRQ_ID);
+    NVIC_EnableIRQ(LV_GPU_NXP_PXP_IRQ_ID);
 
     return LV_RES_OK;
 }
@@ -128,7 +128,7 @@ static lv_res_t _lv_gpu_nxp_pxp_interrupt_init(void)
  */
 static void _lv_gpu_nxp_pxp_interrupt_deinit(void)
 {
-    NVIC_DisableIRQ(PXP_IRQ_ID);
+    NVIC_DisableIRQ(LV_GPU_NXP_PXP_IRQ_ID);
 #if defined(FSL_RTOS_FREE_RTOS)
     vSemaphoreDelete(s_pxpIdle);
 #endif
@@ -143,8 +143,8 @@ static void _lv_gpu_nxp_pxp_run(void)
     s_pxpIdle = false;
 #endif
 
-    PXP_EnableInterrupts(PXP_ID, kPXP_CompleteInterruptEnable);
-    PXP_Start(PXP_ID);
+    PXP_EnableInterrupts(LV_GPU_NXP_PXP_ID, kPXP_CompleteInterruptEnable);
+    PXP_Start(LV_GPU_NXP_PXP_ID);
 
 #if defined(FSL_RTOS_FREE_RTOS)
     if(xSemaphoreTake(s_pxpIdle, portMAX_DELAY) != pdTRUE) {


### PR DESCRIPTION
Hi, 
I'm sending small update for PXP - aligned symbol names (LV_ prefix), fixed threshold and code formatting. Ready to merge, no more work planned on this PR. 