### PR TITLE
Check for LV_CONF_INCLUDE_SIMPLE before defining it.

### DIFF
--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -12,7 +12,9 @@
 
 #if defined __has_include
 #  if __has_include("lv_conf.h")
+#   ifndef LV_CONF_INCLUDE_SIMPLE
 #    define LV_CONF_INCLUDE_SIMPLE
+#   endif
 #  endif
 #endif
 


### PR DESCRIPTION
I'm getting the following warning because I already defined the `LV_CONF_INCLUDE_SIMPLE` symbol on the project configuration.

```
In file included from ../components/lvgl/src/lv_misc/lv_log.h:16,
                 from ../components/lvgl/lvgl.h:26,
                 from ../main/blink.c:24:
../components/lvgl/src/lv_misc/../lv_conf_internal.h:19: warning: "LV_CONF_INCLUDE_SIMPLE" redefined
 #    define LV_CONF_INCLUDE_SIMPLE
<command-line>: note: this is the location of the previous definition
```