### PR TITLE
Update lv_gpu_stm32_dma2d.c

### DIFF
--- a/src/lv_gpu/lv_gpu_stm32_dma2d.c
+++ b/src/lv_gpu/lv_gpu_stm32_dma2d.c
@@ -63,7 +63,13 @@ static void dma2d_wait(void);
 void lv_gpu_stm32_dma2d_init(void)
 {
     /* Enable DMA2D clock */
+#if defined(STM32F4) || defined(STM32F7)
     RCC->AHB1ENR |= RCC_AHB1ENR_DMA2DEN;
+#elif  defined(STM32H7)
+    RCC->AHB3ENR |= RCC_AHB3ENR_DMA2DEN;
+#else
+# warning "LVGL can't enable the clock of DMA2D"
+#endif    
 
     /* Delay after setting peripheral clock */
     volatile uint32_t temp = RCC->AHB1ENR;


### PR DESCRIPTION
Fix issue #1798: On STM32H7xx family the DMA2D RCC enable flag is in RCC->AHB3ENR.