### PR TITLE
lv_conf_checker: Update lv_conf_checker so it is ESP-IDF aware.

### DIFF
--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -27,13 +27,16 @@ fout.write(
 #define LV_CONF_INTERNAL_H
 /* clang-format off */
 
-/*Handle special Kconfig options*/
-#include "lv_conf_kconfig.h"
-
 #include <stdint.h>
 
+#if defined (ESP_PLATFORM)
+#include "sdkconfig.h"
+#include "esp_attr.h"
+#include "lv_conf_kconfig.h"
+#endif
+
 /*If lv_conf.h is not skipped include it*/
-#if !defined(LV_CONF_SKIP) && !defined(CONFIG_LV_CONF_SKIP)
+#if !defined(LV_CONF_SKIP)
 #  if defined(LV_CONF_PATH)											/*If there is a path defined for lv_conf.h use it*/
 #    define __LV_TO_STR_AUX(x) #x
 #    define __LV_TO_STR(x) __LV_TO_STR_AUX(x)
@@ -97,7 +100,7 @@ fout.write(
 '''
 
 /*If running without lv_conf.h add typdesf with default value*/
-#if defined(LV_CONF_SKIP) || defined(CONFIG_LV_CONF_SKIP)
+#if defined(LV_CONF_SKIP)
 
   /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
   typedef int16_t lv_coord_t;

--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -32,8 +32,9 @@ fout.write(
 #if defined (ESP_PLATFORM)
 #include "sdkconfig.h"
 #include "esp_attr.h"
-#include "lv_conf_kconfig.h"
 #endif
+
+#include "lv_conf_kconfig.h"
 
 /*If lv_conf.h is not skipped include it*/
 #if !defined(LV_CONF_SKIP)


### PR DESCRIPTION
This is part of the work being done to make LVGL an ESP-IDF component. I've decided to break the changes into smaller PRs so they can be easier to review.

Include ESP-IDF headers and lv_conf_kconfig.h when using the ESP-IDF framework. Also remove the CONFIG_LV_CONF_SKIP as it is not generated by the Kconfig file.

NOTE: I'm a bit confused against what branch should the PR be done, please let me know if I should make it against `dev` or `dev-v8` instead, got more PRs coming.