### PR TITLE
Initializing lv_color_t::green_l when LV_COLOR_16_SWAP==1

### DIFF
--- a/src/lv_misc/lv_color.h
+++ b/src/lv_misc/lv_color.h
@@ -267,7 +267,11 @@ typedef lv_color8_t lv_color_t;
 #elif LV_COLOR_DEPTH == 16
 typedef uint16_t lv_color_int_t;
 typedef lv_color16_t lv_color_t;
-#define _LV_COLOR_ZERO_INITIALIZER {{0x00, 0x00, 0x00}}
+# if LV_COLOR_16_SWAP == 0
+#  define _LV_COLOR_ZERO_INITIALIZER {{0x00, 0x00, 0x00}}
+# else
+#  define _LV_COLOR_ZERO_INITIALIZER {{0x00, 0x00, 0x00, 0x00}}
+# endif
 #elif LV_COLOR_DEPTH == 32
 typedef uint32_t lv_color_int_t;
 typedef lv_color32_t lv_color_t;


### PR DESCRIPTION
lv_color_t has four components when LV_COLOR_16_SWAP != 0 and
green_l was not being initialized (creating a compile warning).