### PR TITLE
Add CmakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,6 @@ target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_SKIP")
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
 
+else()
+message(FATAL_ERROR "Unknown platform.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+if(ESP_PLATFORM)
+
+file(GLOB_RECURSE SOURCES src/*.c)
+
+idf_component_register(SRCS ${SOURCES}
+                       INCLUDE_DIRS . src)
+
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_SKIP")
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
+
+endif()


### PR DESCRIPTION
To make LVGL an ESP-IDF v4.x component it needs an CMakeLists.txt file, we check for ESP_PLATFORM to add the necessary commands.