### PR TITLE
lv_font: Fix compiler warning when compressed fonts are disabled

### DIFF
--- a/src/lv_font/lv_font_fmt_txt.c
+++ b/src/lv_font/lv_font_fmt_txt.c
@@ -42,22 +42,26 @@ static int32_t unicode_list_compare(const void * ref, const void * element);
 static int32_t kern_pair_8_compare(const void * ref, const void * element);
 static int32_t kern_pair_16_compare(const void * ref, const void * element);
 
+#if LV_USE_FONT_COMPRESSED
 static void decompress(const uint8_t * in, uint8_t * out, lv_coord_t w, lv_coord_t h, uint8_t bpp, bool prefilter);
 static inline void decompress_line(uint8_t * out, lv_coord_t w);
 static inline uint8_t get_bits(const uint8_t * in, uint32_t bit_pos, uint8_t len);
 static inline void bits_write(uint8_t * out, uint32_t bit_pos, uint8_t val, uint8_t len);
 static inline void rle_init(const uint8_t * in,  uint8_t bpp);
 static inline uint8_t rle_next(void);
+#endif /* LV_USE_FONT_COMPRESSED */
 
 /**********************
  *  STATIC VARIABLES
  **********************/
+#if LV_USE_FONT_COMPRESSED
 static uint32_t rle_rdp;
 static const uint8_t * rle_in;
 static uint8_t rle_bpp;
 static uint8_t rle_prev_v;
 static uint8_t rle_cnt;
 static rle_state_t rle_state;
+#endif /* LV_USE_FONT_COMPRESSED */
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -338,6 +342,7 @@ static int32_t kern_pair_16_compare(const void * ref, const void * element)
     else return (int32_t) ref16_p[1] - element16_p[1];
 }
 
+#if LV_USE_FONT_COMPRESSED
 /**
  * The compress a glyph's bitmap
  * @param in the compressed bitmap
@@ -567,6 +572,7 @@ static inline uint8_t rle_next(void)
 
     return ret;
 }
+#endif /* LV_USE_FONT_COMPRESSED */
 
 /** Code Comparator.
  *


### PR DESCRIPTION
Fixes a compiler warning in lv_font_fmt_txt.c when compressed fonts are
disabled (LV_USE_FONT_COMPRESSED=0):

/home/maureen/zephyrproject/modules/lib/gui/lvgl/src/lv_font/lv_font_fmt_txt.c:349:13: warning: 'decompress' defined but not used [-Wunused-function]
  349 | static void decompress(const uint8_t * in, uint8_t * out, lv_coord_t w, lv_coord_t h, uint8_t bpp, bool prefilter)
      |             ^~~~~~~~~~

This was found after upgrading Zephyr to use LVGL v7.6.1.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

See zephyrproject-rtos/zephyr#29720

cc: @galak @vanwinkeljan