### PR TITLE
Repair infinite loop in label refresh.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.7.2 (Planned to 28.11.2020)
 ### Bugfixes
+- label: Repair calculate back `dot` character logical error which cause infinite loop.
 
 ## v7.7.1 (04.11.2020)
 ### Bugfixes

--- a/src/lv_widgets/lv_label.c
+++ b/src/lv_widgets/lv_label.c
@@ -1191,7 +1191,7 @@ void lv_label_refr_text(lv_obj_t * label)
             size_t txt_len = strlen(ext->text);
             uint32_t byte_id     = _lv_txt_encoded_get_byte_id(ext->text, letter_id);
             while(byte_id + LV_LABEL_DOT_NUM > txt_len) {
-                byte_id -= _lv_txt_encoded_size(&ext->text[byte_id]);
+                _lv_txt_encoded_prev(ext->text, &byte_id);
                 letter_id--;
             }
 


### PR DESCRIPTION
When find back `dot` character postion, move `byte_id` to previous character index, not subtract current character length. 

Thus, it will broken `byte_id` ,  makes it point to UTF8 sequence middle, so it will stuck at `_lv_txt_encoded_size`.


The following condition is used to reappear the issue.
1、`_lv_txt_encoded_size` founded index for `dot` named 'index'.
2、It need additional character to store 'dot' character.
3、The character behind 'index' is short than character length before `index`.