### PR TITLE
Fix hardfault when DCache is disabled with no callback

### DIFF
--- a/src/lv_gpu/lv_gpu_stm32_dma2d.c
+++ b/src/lv_gpu/lv_gpu_stm32_dma2d.c
@@ -241,7 +241,7 @@ static void invalidate_cache(void)
     if(disp->driver.clean_dcache_cb) disp->driver.clean_dcache_cb(&disp->driver);
     else {
 #if __CORTEX_M >= 0x07
-    	if((SCB->CCR) & (1<<((uint32_t)SCB_CCR_DC_Msk)))
+    	if((SCB->CCR) & (uint32_t)SCB_CCR_DC_Msk)
     		SCB_CleanInvalidateDCache();
 #endif
     }

--- a/src/lv_gpu/lv_gpu_stm32_dma2d.c
+++ b/src/lv_gpu/lv_gpu_stm32_dma2d.c
@@ -241,7 +241,8 @@ static void invalidate_cache(void)
     if(disp->driver.clean_dcache_cb) disp->driver.clean_dcache_cb(&disp->driver);
     else {
 #if __CORTEX_M >= 0x07
-        SCB_CleanInvalidateDCache();
+    	if((SCB->CCR) & (1<<((uint32_t)SCB_CCR_DC_Msk)))
+    		SCB_CleanInvalidateDCache();
 #endif
     }
 }


### PR DESCRIPTION
On line 244, SCB_CleanInvalidateDCache() runs indiscriminately of whether DCache is actually enabled, and when it's disabled, it causes a hardfault.
It's going to be near impossible to push this into CMSIS, so I'm creating a pull request here instead. Simple one-line fix.