### PR TITLE
ESP-IDF: Let the user set or disable IRAM as LV_ATTRIBUTE_FAST_MEM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,10 @@ idf_component_register(SRCS ${SOURCES}
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_SKIP")
-target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
+
+if (CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
+endif()
 
 else()
 message(FATAL_ERROR "Unknown platform.")

--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,11 @@
 # Kconfig file for LVGL v7.7.1
 
 menu "LVGL configuration"
+    
+    config LV_ATTRIBUTE_FAST_MEM_USE_IRAM
+        bool "Set IRAM as LV_ATTRIBUTE_FAST_MEM"
+        help
+            Set this option to configure IRAM as LV_ATTRIBUTE_FAST_MEM
 
     config LV_CONF_MINIMAL
         bool "LVGL minimal configuration."


### PR DESCRIPTION
Tries to fix #1937 , against master because it fixes an compilation error.