### PR TITLE
Add 8px and 10px fonts to build

### DIFF
--- a/src/lv_font/lv_font.mk
+++ b/src/lv_font/lv_font.mk
@@ -1,6 +1,8 @@
 CSRCS += lv_font.c
 CSRCS += lv_font_fmt_txt.c
 CSRCS += lv_font_loader.c
+CSRCS += lv_font_montserrat_8.c
+CSRCS += lv_font_montserrat_10.c
 CSRCS += lv_font_montserrat_12.c
 CSRCS += lv_font_montserrat_14.c
 CSRCS += lv_font_montserrat_16.c


### PR DESCRIPTION
Hi.

I was working with small OLED screen and noticed that small fonts are missing in the build (8px and 10px), so adding them.