### PR TITLE
Add option to align title text in window

### DIFF
--- a/src/lv_widgets/lv_win.c
+++ b/src/lv_widgets/lv_win.c
@@ -364,6 +364,14 @@ void lv_win_set_drag(lv_obj_t * win, bool en)
     lv_obj_set_drag(win, en);
 }
 
+void lv_win_title_set_alignment(lv_obj_t * win, uint8_t alignment)
+{
+    lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
+
+    ext->title_txt_align = alignment;
+
+}
+
 /*=====================
  * Getter functions
  *====================*/
@@ -491,6 +499,14 @@ lv_coord_t lv_win_get_width(lv_obj_t * win)
 
     return lv_obj_get_width_fit(scrl) - left - right;
 }
+
+uint8_t lv_win_title_get_alignment(lv_obj_t * win)
+{
+    lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
+
+    return ext->title_txt_align;
+}
+
 
 /*=====================
  * Other functions

--- a/src/lv_widgets/lv_win.c
+++ b/src/lv_widgets/lv_win.c
@@ -92,6 +92,7 @@ lv_obj_t * lv_win_create(lv_obj_t * par, const lv_obj_t * copy)
     ext->page          = NULL;
     ext->header        = NULL;
     ext->title_txt    = lv_mem_alloc(strlen(DEF_TITLE) + 1);
+    ext->title_txt_align = LV_TXT_FLAG_NONE;
     strcpy(ext->title_txt, DEF_TITLE);
 
     /*Init the new window object*/
@@ -538,11 +539,13 @@ static lv_design_res_t lv_win_header_design(lv_obj_t * header, const lv_area_t *
         lv_win_ext_t * ext = lv_obj_get_ext_attr(win);
 
         lv_style_int_t header_left = lv_obj_get_style_pad_left(win, LV_WIN_PART_HEADER);
+        lv_style_int_t header_right = lv_obj_get_style_pad_right(win, LV_WIN_PART_HEADER);
         lv_style_int_t header_inner = lv_obj_get_style_pad_inner(win, LV_WIN_PART_HEADER);
 
         lv_draw_label_dsc_t label_dsc;
         lv_draw_label_dsc_init(&label_dsc);
         lv_obj_init_draw_label_dsc(header, LV_OBJ_PART_MAIN, &label_dsc);
+        label_dsc.flag = ext->title_txt_align;
 
         lv_area_t txt_area;
         lv_point_t txt_size;
@@ -557,21 +560,41 @@ static lv_design_res_t lv_win_header_design(lv_obj_t * header, const lv_area_t *
 
         /*Get x position of the title (should be on the right of the buttons on the left)*/
 
-        lv_coord_t left_btn_offset = 0;
+        lv_coord_t btn_offset = 0;
         btn = lv_obj_get_child_back(ext->header, NULL);
         while(btn != NULL) {
             if(LV_WIN_BTN_ALIGN_LEFT == lv_win_btn_get_alignment(btn)) {
-                left_btn_offset += btn_w + header_inner;
+                btn_offset += btn_w + header_inner;
             }
 
             btn = lv_obj_get_child_back(header, btn);
         }
-
-        txt_area.x1 = header->coords.x1 + header_left + left_btn_offset;
-        txt_area.y1 = header->coords.y1 + (lv_obj_get_height(header) - txt_size.y) / 2;
-        txt_area.x2 = txt_area.x1 + txt_size.x  + left_btn_offset;
-        txt_area.y2 = txt_area.y1 + txt_size.y;
-
+        switch(label_dsc.flag) {
+            case LV_TXT_FLAG_CENTER:
+                txt_area.x1 = header->coords.x1 + header_left + btn_offset;
+                txt_area.x2 = header->coords.x2 - header_right - btn_offset;
+                txt_area.y1 = header->coords.y1 + (lv_obj_get_height(header) - txt_size.y) / 2;                                                 
+                txt_area.y2 = txt_area.y1 + txt_size.y;         
+                break;
+            case LV_TXT_FLAG_RIGHT:
+                txt_area.x1 = header->coords.x1;
+                txt_area.x2 = header->coords.x2 - header_right - btn_offset;
+                txt_area.y1 = header->coords.y1 + (lv_obj_get_height(header) - txt_size.y) / 2; 
+                txt_area.y2 = txt_area.y1 + txt_size.y;
+                break;                                         
+            case LV_TXT_FLAG_FIT || LV_TXT_FLAG_EXPAND:
+                txt_area.x1 = header->coords.x1;
+                txt_area.x2 = header->coords.x2;
+                txt_area.y1 = header->coords.y1 + (lv_obj_get_height(header) - txt_size.y) / 2; 
+                txt_area.y2 = txt_area.y1 + txt_size.y;
+                break;                                         
+            default:
+                txt_area.x1 = header->coords.x1 + header_left + btn_offset;
+                txt_area.x2 = txt_area.x1 + txt_size.x  + btn_offset;
+                txt_area.y1 = header->coords.y1 + (lv_obj_get_height(header) - txt_size.y) / 2;
+                txt_area.y2 = txt_area.y1 + txt_size.y;
+                break;
+        }
         lv_draw_label(&txt_area, clip_area, &label_dsc, ext->title_txt, NULL);
     }
     else if(mode == LV_DESIGN_DRAW_POST) {

--- a/src/lv_widgets/lv_win.h
+++ b/src/lv_widgets/lv_win.h
@@ -57,6 +57,7 @@ typedef struct {
     lv_obj_t * header;                /*Pointer to the header container of the window*/
     char * title_txt;                 /*Pointer to the title label of the window*/
     lv_coord_t btn_w;                 /*Width of the control buttons*/
+    uint8_t title_txt_align;          //Control the alignment of the header text
 } lv_win_ext_t;
 
 /** Window parts. */

--- a/src/lv_widgets/lv_win.h
+++ b/src/lv_widgets/lv_win.h
@@ -57,7 +57,7 @@ typedef struct {
     lv_obj_t * header;                /*Pointer to the header container of the window*/
     char * title_txt;                 /*Pointer to the title label of the window*/
     lv_coord_t btn_w;                 /*Width of the control buttons*/
-    uint8_t title_txt_align;          //Control the alignment of the header text
+    uint8_t title_txt_align;          /*Control the alignment of the header text*/
 } lv_win_ext_t;
 
 /** Window parts. */
@@ -176,6 +176,13 @@ void lv_win_set_anim_time(lv_obj_t * win, uint16_t anim_time);
  */
 void lv_win_set_drag(lv_obj_t * win, bool en);
 
+/**
+ * Set alignment of title text in window header. 
+ * @param win pointer to a window object
+ * @param alignment set the type of alignment with LV_TXT_FLAGS
+ */
+void lv_win_title_set_alignment(lv_obj_t * win, uint8_t alignment);
+
 /*=====================
  * Getter functions
  *====================*/
@@ -254,6 +261,12 @@ static inline bool lv_win_get_drag(const lv_obj_t * win)
 {
     return lv_obj_get_drag(win);
 }
+
+/**
+ * Get the current alignment of title text in window header. 
+ * @param win pointer to a window object
+ */
+uint8_t lv_win_title_get_alignment(lv_obj_t * win);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
I felt that i really needed a basic way to adjust the alignment of the title text, but since it is drawn directly it wasn't really possible. I therefore came up with this basic way of letting the user choose between the LV_TXT_FLAG's and changing the drawing bounds depending on said flag. Mind you that I'm very new to all of this so it might not be the most optimal way of doing it.
I have of course written the alignments as I felt was most suitable, but I shouldn't be the judge of that.
Current alignment boundaries: 

LV_TXT_FLAG_CENTER makes the text align in the center of the header but ensures it can’t overextend into to header button area;

LV_TXT_FLAG_RIGHT makes the text align at the right side, but takes the right side header buttons into account

LV_TXT_FLAG_FIT & LV_TXT_FLAG_EXPAND I wasn’t too sure about what to do so as of now it just aligns them as normal

LV_TXT_FLAG_NONE Is equal to no flag set by the user and therefore I have just set it to the default coords, like normal. The text then align at the left side.

Hope it works, and it's useful enough