### PR TITLE
Improved ESP-IDF integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,26 @@ if(ESP_PLATFORM)
 file(GLOB_RECURSE SOURCES src/*.c)
 
 idf_component_register(SRCS ${SOURCES}
-                       INCLUDE_DIRS . src)
+                       INCLUDE_DIRS . src
+                       REQUIRES main)
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
-target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_SKIP")
+
+if (CONFIG_LV_MEM_CUSTOM)
+    if (CONFIG_LV_MEM_CUSTOM_ALLOC)
+        target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_MEM_CUSTOM_ALLOC=${CONFIG_LV_MEM_CUSTOM_ALLOC}")
+    endif()
+
+    if (CONFIG_LV_MEM_CUSTOM_FREE)
+        target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_MEM_CUSTOM_FREE=${CONFIG_LV_MEM_CUSTOM_FREE}")
+    endif()
+endif()
+
+if (CONFIG_LV_TICK_CUSTOM)
+    if (CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR)
+        target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_TICK_CUSTOM_SYS_TIME_EXPR=${CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR}")
+    endif()
+endif()
 
 if (CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
     target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ if (CONFIG_LV_TICK_CUSTOM)
     endif()
 endif()
 
+if (CONFIG_LV_USER_DATA_FREE)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_USER_DATA_FREE=${CONFIG_LV_USER_DATA_FREE}")
+endif()
+
 if (CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
     target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
 endif()

--- a/Kconfig
+++ b/Kconfig
@@ -105,11 +105,40 @@ menu "LVGL configuration"
             displays.
     
     menu "Memory manager settings"
+    config LV_MEM_CUSTOM
+	    bool
+	    prompt "If true use custom malloc/free, otherwise use the built-in `lv_mem_alloc` and `lv_mem_free`"
+	    default false
+
+    config LV_MEM_CUSTOM_INCLUDE
+        string
+        prompt "Header to include for the custom memory function"
+        default stdlib.h
+        depends on LV_MEM_CUSTOM
+
+    config LV_MEM_CUSTOM_ALLOC
+        string
+        prompt "Wrapper to malloc"
+        default malloc 
+        depends on LV_MEM_CUSTOM
+
+    config LV_MEM_CUSTOM_FREE
+        string
+        prompt "Wrapper to free"
+        default free 
+        depends on LV_MEM_CUSTOM
+
 	config LV_MEM_SIZE_BYTES
 	    int
 	    prompt "Size of the memory used by `lv_mem_alloc` in kilobytes (>= 2kB)"
 	    range 2 128
-	    default 32
+        default 32
+        depends on !LV_MEM_CUSTOM
+
+    config LV_MEMCPY_MEMSET_STD
+        bool
+        prompt "Use the standard memcpy and memset instead of LVGL's own functions"
+        default false 
     endmenu
     
     menu "Indev device settings"
@@ -235,9 +264,28 @@ menu "LVGL configuration"
                 LV_IMG_CACHE_DEF_SIZE must be >= 1
     endmenu
 
-    menu "Compiler settings"
+    menu "Compiler Settings"
         config LV_BIG_ENDIAN_SYSTEM
             bool "For big endian systems set to 1"
+    endmenu
+
+    menu "HAL Settings"
+        config LV_TICK_CUSTOM
+            bool 
+            prompt "Use a custom tick source"
+            default false
+
+        config LV_TICK_CUSTOM_INCLUDE
+            string
+            prompt "Header for the system time function"
+            default Arduino.h
+            depends on LV_TICK_CUSTOM
+
+        config LV_TICK_CUSTOM_SYS_TIME_EXPR
+            string
+            prompt "Expression evaluating to current system time in ms"
+            default "(millis())"
+            depends on LV_TICK_CUSTOM
     endmenu
 
     menu "Log Settings"

--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,4 @@
-# Kconfig file for LVGL v7.7.1
+# Kconfig file for LVGL v7.8.1
 
 menu "LVGL configuration"
     
@@ -108,7 +108,6 @@ menu "LVGL configuration"
     config LV_MEM_CUSTOM
 	    bool
 	    prompt "If true use custom malloc/free, otherwise use the built-in `lv_mem_alloc` and `lv_mem_free`"
-	    default false
 
     config LV_MEM_CUSTOM_INCLUDE
         string
@@ -138,7 +137,6 @@ menu "LVGL configuration"
     config LV_MEMCPY_MEMSET_STD
         bool
         prompt "Use the standard memcpy and memset instead of LVGL's own functions"
-        default false 
     endmenu
     
     menu "Indev device settings"
@@ -273,7 +271,6 @@ menu "LVGL configuration"
         config LV_TICK_CUSTOM
             bool 
             prompt "Use a custom tick source"
-            default false
 
         config LV_TICK_CUSTOM_INCLUDE
             string

--- a/Kconfig
+++ b/Kconfig
@@ -231,6 +231,17 @@ menu "LVGL configuration"
             default y if !LV_CONF_MINIMAL
         config LV_USE_USER_DATA
             bool "Add a 'user_data' to drivers and objects."
+        config LV_USE_USER_DATA_FREE
+            bool "Free the user data field upon object deletion"
+            depends on LV_USE_USER_DATA
+        config LV_USER_DATA_FREE_INCLUDE
+            string "Header for user data free function"
+            default "something.h"
+            depends on LV_USE_USER_DATA_FREE
+        config LV_USER_DATA_FREE
+            string "Invoking for user data free function. It has the lv_obj_t pointer as single parameter."
+            default "(user_data_free)"
+            depends on LV_USE_USER_DATA_FREE
         config LV_USE_PERF_MONITOR
             bool "Show CPU usage and FPS count in the right bottom corner."
         config LV_USE_API_EXTENSION_V6
@@ -931,26 +942,6 @@ menu "LVGL configuration"
     endmenu
 
     menu "Widgets"
-        menu "User Data"
-            config LV_USE_USER_DATA
-                bool "Add a void* field to drivers and objects."
-
-            config LV_USE_USER_DATA_FREE
-                bool "Free the user data field upon object deletion"
-                depends on LV_USE_USER_DATA
-
-            config LV_USER_DATA_FREE_INCLUDE
-                string "Header for user data free function"
-                default "something.h"
-                depends on LV_USE_USER_DATA_FREE
-
-            config LV_USER_DATA_FREE
-                string "Invoking for user data free function. It has the lv_obj_t pointer as single parameter."
-                default "(user_data_free)"
-                depends on LV_USE_USER_DATA_FREE
-
-        endmenu
-
         config LV_USE_OBJ_REALIGN
             bool "Enable `lv_obj_realign()` based on `lv_obj_align()` parameters."
             default y if !LV_CONF_MINIMAL

--- a/Kconfig
+++ b/Kconfig
@@ -931,6 +931,26 @@ menu "LVGL configuration"
     endmenu
 
     menu "Widgets"
+        menu "User Data"
+            config LV_USE_USER_DATA
+                bool "Add a void* field to drivers and objects."
+
+            config LV_USE_USER_DATA_FREE
+                bool "Free the user data field upon object deletion"
+                depends on LV_USE_USER_DATA
+
+            config LV_USER_DATA_FREE_INCLUDE
+                string "Header for user data free function"
+                default "something.h"
+                depends on LV_USE_USER_DATA_FREE
+
+            config LV_USER_DATA_FREE
+                string "Invoking for user data free function. It has the lv_obj_t pointer as single parameter."
+                default "(user_data_free)"
+                depends on LV_USE_USER_DATA_FREE
+
+        endmenu
+
         config LV_USE_OBJ_REALIGN
             bool "Enable `lv_obj_realign()` based on `lv_obj_align()` parameters."
             default y if !LV_CONF_MINIMAL


### PR DESCRIPTION
I removed a duplicate definition of `LV_CONF_SKIP`, present both as a command line macro and as a KConfig implicit option (this caused a redefinition warning).

I also added some KConfig options for custom memory allocation (`malloc`/`free`) and custom millisecond counting, both readily present in ESP-IDF projects.

I had to remove quotes from some KConfig strings by unwrapping them in the CMake config file.

The most invasive change is requiring the `main` component when registering the lvgl component; I needed this to define my own `millis` function and allowing the component to access the necessary header file.