### PR TITLE
lv_chart: Fix division by zero issue when all points are equal

### DIFF
--- a/src/lv_widgets/lv_chart.c
+++ b/src/lv_widgets/lv_chart.c
@@ -1194,7 +1194,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
         lv_coord_t p_act = start_point;
         lv_coord_t p_prev = start_point;
         int32_t y_tmp = (int32_t)((int32_t)ser->points[p_prev] - ext->ymin[ser->y_axis]) * h;
-        y_tmp  = y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+        y_tmp  = y_tmp == 0 ? 1 : y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
         p2.y   = h - y_tmp + y_ofs;
 
         for(i = 0; i < ext->point_cnt; i++) {
@@ -1206,7 +1206,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
             p_act = (start_point + i) % ext->point_cnt;
 
             y_tmp = (int32_t)((int32_t)ser->points[p_act] - ext->ymin[ser->y_axis]) * h;
-            y_tmp = y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+            y_tmp = y_tmp == 0 ? 1 : y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
             p2.y  = h - y_tmp + y_ofs;
 
             /*Don't draw the first point. A second point is also required to draw the line*/

--- a/src/lv_widgets/lv_chart.c
+++ b/src/lv_widgets/lv_chart.c
@@ -333,7 +333,7 @@ void lv_chart_set_y_range(lv_obj_t * chart, lv_chart_axis_t axis, lv_coord_t ymi
     if(ext->ymin[axis] == ymin && ext->ymax[axis] == ymax) return;
 
     ext->ymin[axis] = ymin;
-    ext->ymax[axis] = ymax;
+    ext->ymax[axis] = (ymax == ymin ? ymax + 1 : ymax);
 
     lv_chart_refresh(chart);
 }
@@ -1194,8 +1194,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
         lv_coord_t p_act = start_point;
         lv_coord_t p_prev = start_point;
         int32_t y_tmp = (int32_t)((int32_t)ser->points[p_prev] - ext->ymin[ser->y_axis]) * h;
-        int32_t div_tmp = (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
-        y_tmp = y_tmp / (div_tmp == 0 ? 1 : div_tmp);
+        y_tmp = y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
         p2.y   = h - y_tmp + y_ofs;
 
         for(i = 0; i < ext->point_cnt; i++) {
@@ -1207,7 +1206,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
             p_act = (start_point + i) % ext->point_cnt;
 
             y_tmp = (int32_t)((int32_t)ser->points[p_act] - ext->ymin[ser->y_axis]) * h;
-            y_tmp = y_tmp / (div_tmp == 0 ? 1 : div_tmp);
+            y_tmp = (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
             p2.y  = h - y_tmp + y_ofs;
 
             /*Don't draw the first point. A second point is also required to draw the line*/

--- a/src/lv_widgets/lv_chart.c
+++ b/src/lv_widgets/lv_chart.c
@@ -1194,7 +1194,8 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
         lv_coord_t p_act = start_point;
         lv_coord_t p_prev = start_point;
         int32_t y_tmp = (int32_t)((int32_t)ser->points[p_prev] - ext->ymin[ser->y_axis]) * h;
-        y_tmp  = y_tmp == 0 ? 1 : y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+        int32_t div_tmp = (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+        y_tmp = y_tmp / (div_tmp == 0 ? 1 : div_tmp);
         p2.y   = h - y_tmp + y_ofs;
 
         for(i = 0; i < ext->point_cnt; i++) {
@@ -1206,7 +1207,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
             p_act = (start_point + i) % ext->point_cnt;
 
             y_tmp = (int32_t)((int32_t)ser->points[p_act] - ext->ymin[ser->y_axis]) * h;
-            y_tmp = y_tmp == 0 ? 1 : y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+            y_tmp = y_tmp / (div_tmp == 0 ? 1 : div_tmp);
             p2.y  = h - y_tmp + y_ofs;
 
             /*Don't draw the first point. A second point is also required to draw the line*/

--- a/src/lv_widgets/lv_chart.c
+++ b/src/lv_widgets/lv_chart.c
@@ -1206,7 +1206,7 @@ static void draw_series_line(lv_obj_t * chart, const lv_area_t * series_area, co
             p_act = (start_point + i) % ext->point_cnt;
 
             y_tmp = (int32_t)((int32_t)ser->points[p_act] - ext->ymin[ser->y_axis]) * h;
-            y_tmp = (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
+            y_tmp = y_tmp / (ext->ymax[ser->y_axis] - ext->ymin[ser->y_axis]);
             p2.y  = h - y_tmp + y_ofs;
 
             /*Don't draw the first point. A second point is also required to draw the line*/


### PR DESCRIPTION
As the title says, when all the points are equal, it attempts division by zero, and in some cases it can result in funny behavior.
Slightly kludgy fix, but not a significant performance impact.