### PR TITLE
Fix kconfig warnings

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -112,19 +112,19 @@ menu "LVGL configuration"
     config LV_MEM_CUSTOM_INCLUDE
         string
         prompt "Header to include for the custom memory function"
-        default stdlib.h
+        default "stdlib.h"
         depends on LV_MEM_CUSTOM
 
     config LV_MEM_CUSTOM_ALLOC
         string
         prompt "Wrapper to malloc"
-        default malloc 
+        default "malloc" 
         depends on LV_MEM_CUSTOM
 
     config LV_MEM_CUSTOM_FREE
         string
         prompt "Wrapper to free"
-        default free 
+        default "free" 
         depends on LV_MEM_CUSTOM
 
 	config LV_MEM_SIZE_BYTES
@@ -286,13 +286,13 @@ menu "LVGL configuration"
         config LV_TICK_CUSTOM_INCLUDE
             string
             prompt "Header for the system time function"
-            default Arduino.h
+            default "Arduino.h"
             depends on LV_TICK_CUSTOM
 
         config LV_TICK_CUSTOM_SYS_TIME_EXPR
             string
             prompt "Expression evaluating to current system time in ms"
-            default "(millis())"
+            default "millis\(\)"
             depends on LV_TICK_CUSTOM
     endmenu
 

--- a/Kconfig
+++ b/Kconfig
@@ -292,7 +292,7 @@ menu "LVGL configuration"
         config LV_TICK_CUSTOM_SYS_TIME_EXPR
             string
             prompt "Expression evaluating to current system time in ms"
-            default "millis\(\)"
+            default "millis()"
             depends on LV_TICK_CUSTOM
     endmenu
 


### PR DESCRIPTION
quote string defaults for Kconfig values to eliminate warnings 

Building for `esp32` using `esp-idf` generates warnings when default string values are not quoted on `Kconfig`
```
warning: style: quotes recommended around default value for string symbol LV_MEM_CUSTOM_INCLUDE (defined at components/lvgl/Kconfig:112)
warning: style: quotes recommended around default value for string symbol LV_MEM_CUSTOM_ALLOC (defined at components/lvgl/Kconfig:118)
warning: style: quotes recommended around default value for string symbol LV_MEM_CUSTOM_FREE (defined at components/lvgl/Kconfig:124)
warning: style: quotes recommended around default value for string symbol LV_TICK_CUSTOM_INCLUDE (defined at components/lvgl/Kconfig:286)
```
Note that the default values for `LV_TICK_CUSTOM_SYS_TIME_EXPR` contains `(` and `)` and these should be
escaped with a `\` on Linux and MacOS, I did not change this as I can not test on Windows and don't know if that
would cause any issues.

### Chekpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation 
