### PR TITLE
lvgl.h: Add lv_version functions

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -121,6 +121,29 @@ extern "C" {
  * */
 #define LV_VERSION_CHECK(x,y,z) (x == LVGL_VERSION_MAJOR && (y < LVGL_VERSION_MINOR || (y == LVGL_VERSION_MINOR && z <= LVGL_VERSION_PATCH)))
 
+/**
+ * Wrapper functions for VERSION macros
+ */
+
+static inline int lv_version_major()
+{
+    return LVGL_VERSION_MAJOR;
+}
+
+static inline int lv_version_minor()
+{
+    return LVGL_VERSION_MINOR;
+}
+
+static inline int lv_version_patch()
+{
+    return LVGL_VERSION_PATCH;
+}
+
+static inline const char *lv_version_info()
+{
+    return LVGL_VERSION_INFO;
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These static inline functions return the values of the VERSION macros, making them available for Micropython

See also https://github.com/lvgl/lv_examples/pull/85#issuecomment-749506978
