### PR TITLE
fix(linemeter): draw first critical needle with correct color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix(dropdown) arabic process the option in lv_dropdown_add_option
 - fix(textarea) buffer overflow in password mode with UTF-8 characters
 - fix(textarea) cursor position after hiding character in password mode
+- fix(linemeter) draw critical lines with correct color
 
 ## v7.8.1 (Plannad at 15.12.2020)
 

--- a/src/lv_widgets/lv_linemeter.c
+++ b/src/lv_widgets/lv_linemeter.c
@@ -447,7 +447,7 @@ void lv_linemeter_draw_scale(lv_obj_t * lmeter, const lv_area_t * clip_area, uin
         p1.y = y_out_extra;
 
         /* Set the color of the lines */
-        if((!ext->mirrored && i > level) || (ext->mirrored && i < level)) {
+        if((!ext->mirrored && i >= level) || (ext->mirrored && i <= level)) {
             line_dsc.color = end_color;
             line_dsc.width = end_line_width;
         }


### PR DESCRIPTION
### Description of the feature of fix

Fixes #1975.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update CHANGELOG.md
- [ ] Update the documentation 
