### PR TITLE
Fix build when LV_USE_GPU_NXP_PXP is enabled

### DIFF
--- a/src/lv_draw/lv_draw_blend.c
+++ b/src/lv_draw/lv_draw_blend.c
@@ -25,7 +25,6 @@
  *********************/
 #define GPU_SIZE_LIMIT      240
 
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -757,11 +756,10 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
 
         if(opa > LV_OPA_MAX) {
 #if LV_USE_GPU_NXP_PXP
-<<<<<<< HEAD
-        if (lv_area_get_size(draw_area) >= GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
-            lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
-            return;
-        }
+            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
+                lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
+                return;
+            }
 #elif (LV_USE_GPU_NXP_VG_LITE)
             if(lv_area_get_size(draw_area) >= LV_GPU_NXP_VG_LITE_BLIT_SIZE_LIMIT) {
 
@@ -792,17 +790,12 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(const lv_area_t * disp_area, lv_col
                     return;
                 }
                 /* Fall down to SW render in case of error */
-=======
-            if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_BLIT_SIZE_LIMIT) {
-                lv_gpu_nxp_pxp_blit(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h, opa);
-                return;
->>>>>>> 4c7a2ae0b7d8f564b22e7774039f6cbe5385926c
             }
 #elif LV_USE_GPU_STM32_DMA2D
-        if(lv_area_get_size(draw_area) >= 240) {
-            lv_gpu_stm32_dma2d_copy(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h);
-            return;
-        }
+            if(lv_area_get_size(draw_area) >= 240) {
+                lv_gpu_stm32_dma2d_copy(disp_buf_first, disp_w, map_buf_first, map_w, draw_area_w, draw_area_h);
+                return;
+            }
 #endif
 
             /*Software rendering*/

--- a/src/lv_draw/lv_draw_blend.c
+++ b/src/lv_draw/lv_draw_blend.c
@@ -70,7 +70,7 @@ static inline lv_color_t color_blend_true_color_subtractive(lv_color_t fg, lv_co
  *  STATIC VARIABLES
  **********************/
 
-#if LV_USE_GPU || LV_USE_GPU_STM32_DMA2D
+#if (LV_USE_GPU || LV_USE_GPU_STM32_DMA2D) && (LV_USE_GPU_NXP_PXP == 0) && (LV_USE_GPU_NXP_VG_LITE == 0)
     LV_ATTRIBUTE_DMA static lv_color_t blend_buf[LV_HOR_RES_MAX];
 #endif
 
@@ -336,12 +336,7 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(const lv_area_t * disp_area, lv_co
     /*Simple fill (maybe with opacity), no masking*/
     if(mask_res == LV_DRAW_MASK_RES_FULL_COVER) {
         if(opa > LV_OPA_MAX) {
-#if LV_USE_GPU
-            if(disp->driver.gpu_fill_cb && lv_area_get_size(draw_area) > GPU_SIZE_LIMIT) {
-                disp->driver.gpu_fill_cb(&disp->driver, disp_buf, disp_w, draw_area, color);
-                return;
-            }
-#elif LV_USE_GPU_NXP_PXP
+#if LV_USE_GPU_NXP_PXP
             if(lv_area_get_size(draw_area) >= LV_GPU_NXP_PXP_FILL_SIZE_LIMIT) {
                 lv_gpu_nxp_pxp_fill(disp_buf, disp_w, draw_area, color, opa);
                 return;
@@ -356,6 +351,11 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(const lv_area_t * disp_area, lv_co
 #elif LV_USE_GPU_STM32_DMA2D
             if(lv_area_get_size(draw_area) >= 240) {
                 lv_gpu_stm32_dma2d_fill(disp_buf_first, disp_w, color, draw_area_w, draw_area_h);
+                return;
+            }
+#elif LV_USE_GPU
+            if(disp->driver.gpu_fill_cb && lv_area_get_size(draw_area) > GPU_SIZE_LIMIT) {
+                disp->driver.gpu_fill_cb(&disp->driver, disp_buf, disp_w, draw_area, color);
                 return;
             }
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Build was failing when `LV_USE_GPU_NXP_PXP` was enabled from lv_conf.h
This was due to the definition `GPU_NXP_PXP_BLIT_SIZE_LIMIT` no including the `LV_` prefix.

Function `fill_normal` has an incorrect ordering of preprocessor checks that prevented PXP from being used.
In order to use PXP both `LV_USE_GPU` and `LV_USE_GPU_NXP_PXP` must be enabled. With the existing code and `LV_USE_GPU` enabled the PXP implementation was eliminated.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation 
