### PR TITLE
Update lv_disp.c

### DIFF
--- a/src/lv_core/lv_disp.c
+++ b/src/lv_core/lv_disp.c
@@ -217,7 +217,7 @@ void lv_scr_load_anim(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t
     lv_obj_t * act_scr = lv_scr_act();
 
 
-    if(d->del_prev && act_scr != d->scr_to_load) {
+    if(d->del_prev && act_scr != d->scr_to_load && d->scr_to_load) {
         lv_obj_del(act_scr);
         lv_disp_load_scr(d->scr_to_load);
         lv_anim_del(d->scr_to_load, NULL);


### PR DESCRIPTION
Check d->scr_to_load for not beeing NULL.

See forum post https://forum.lvgl.io/t/lv-scr-load-anim-does-not-work-properly/4057

The code sequence for if (...) should only be called if d->scr_to_load is not NULL, as this may lead to a NULL pointer exception.
