### PR TITLE
Ability to enable passing of events to disabled objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v7.9.1 (Planned at 19.01.2020)
 
+### New features
+
+- feat(indev) allow input events to be passed to disabled objects 
+
 ### Bugfixes
 - fix(cpicker) fix division by zero
 - fix(dropdown) fix selecting options after the last one

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1148,7 +1148,7 @@ lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point)
                 hidden_i = lv_obj_get_parent(hidden_i);
             }
             /*No parent found with hidden == true*/
-            if (indev_obj_act->disabled_noevent == 1){
+            if(lv_obj_is_protected(indev_obj_act, LV_PROTECT_EVENT_TO_DISABLED) == false){
                 if(hidden_i == NULL && (lv_obj_get_state(obj, LV_OBJ_PART_MAIN) & LV_STATE_DISABLED) == false) found_p = obj;
             }
             else {

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -1148,7 +1148,12 @@ lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point)
                 hidden_i = lv_obj_get_parent(hidden_i);
             }
             /*No parent found with hidden == true*/
-            if(hidden_i == NULL && (lv_obj_get_state(obj, LV_OBJ_PART_MAIN) & LV_STATE_DISABLED) == false) found_p = obj;
+            if (indev_obj_act->disabled_noevent == 1){
+                if(hidden_i == NULL && (lv_obj_get_state(obj, LV_OBJ_PART_MAIN) & LV_STATE_DISABLED) == false) found_p = obj;
+            }
+            else {
+                if(hidden_i == NULL) found_p = obj;
+            }
         }
     }
 

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -378,6 +378,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
     new_obj->parent_event = 0;
     new_obj->gesture_parent = parent ? 1 : 0;
     new_obj->focus_parent  = 0;
+    new_obj->disabled_noevent = 1;
     new_obj->state = LV_STATE_DEFAULT;
 
     new_obj->ext_attr = NULL;
@@ -432,6 +433,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->hidden       = copy->hidden;
         new_obj->top          = copy->top;
         new_obj->parent_event = copy->parent_event;
+        new_obj->disabled_noevent = copy->disabled_noevent;
 
         new_obj->protect      = copy->protect;
         new_obj->gesture_parent = copy->gesture_parent;
@@ -1525,6 +1527,18 @@ void lv_obj_set_click(lv_obj_t * obj, bool en)
     LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
 
     obj->click = (en == true ? 1 : 0);
+}
+
+/**
+ * Enable or disable the passing of event of an object if it is disabled
+ * @param obj pointer to an object
+ * @param en true: make the object does not pass events if it is disabled
+ */
+void lv_obj_set_disabled_noevent(lv_obj_t * obj, bool en)
+{
+    LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
+
+    obj->disabled_noevent = (en == true ? 1 : 0);
 }
 
 /**
@@ -2948,6 +2962,18 @@ bool lv_obj_get_click(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
 
     return obj->click == 0 ? false : true;
+}
+
+**
+ * Get the passing of event of an object if it is disabled
+ * @param obj pointer to an object
+ * @param true: the object does not pass events if it is disabled
+ */
+bool lv_obj_get_disabled_noevent(lv_obj_t * obj, bool en)
+{
+    LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
+
+    return obj->disabled_noevent == 0 ? false : true;
 }
 
 /**

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -2964,7 +2964,7 @@ bool lv_obj_get_click(const lv_obj_t * obj)
     return obj->click == 0 ? false : true;
 }
 
-**
+/**
  * Get the passing of event of an object if it is disabled
  * @param obj pointer to an object
  * @param true: the object does not pass events if it is disabled

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -378,7 +378,6 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
     new_obj->parent_event = 0;
     new_obj->gesture_parent = parent ? 1 : 0;
     new_obj->focus_parent  = 0;
-    new_obj->disabled_noevent = 1;
     new_obj->state = LV_STATE_DEFAULT;
 
     new_obj->ext_attr = NULL;
@@ -433,7 +432,6 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent, const lv_obj_t * copy)
         new_obj->hidden       = copy->hidden;
         new_obj->top          = copy->top;
         new_obj->parent_event = copy->parent_event;
-        new_obj->disabled_noevent = copy->disabled_noevent;
 
         new_obj->protect      = copy->protect;
         new_obj->gesture_parent = copy->gesture_parent;
@@ -1527,18 +1525,6 @@ void lv_obj_set_click(lv_obj_t * obj, bool en)
     LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
 
     obj->click = (en == true ? 1 : 0);
-}
-
-/**
- * Enable or disable the passing of event of an object if it is disabled
- * @param obj pointer to an object
- * @param en true: make the object does not pass events if it is disabled
- */
-void lv_obj_set_disabled_noevent(lv_obj_t * obj, bool en)
-{
-    LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
-
-    obj->disabled_noevent = (en == true ? 1 : 0);
 }
 
 /**
@@ -2962,18 +2948,6 @@ bool lv_obj_get_click(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
 
     return obj->click == 0 ? false : true;
-}
-
-/**
- * Get the passing of event of an object if it is disabled
- * @param obj pointer to an object
- * @param true: the object does not pass events if it is disabled
- */
-bool lv_obj_get_disabled_noevent(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
-
-    return obj->disabled_noevent == 0 ? false : true;
 }
 
 /**

--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -2969,7 +2969,7 @@ bool lv_obj_get_click(const lv_obj_t * obj)
  * @param obj pointer to an object
  * @param true: the object does not pass events if it is disabled
  */
-bool lv_obj_get_disabled_noevent(lv_obj_t * obj, bool en)
+bool lv_obj_get_disabled_noevent(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, LV_OBJX_NAME);
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -225,6 +225,7 @@ typedef struct _lv_obj_t {
     uint8_t adv_hittest     : 1; /**< 1: Use advanced hit-testing (slower) */
     uint8_t gesture_parent  : 1; /**< 1: Parent will be gesture instead*/
     uint8_t focus_parent    : 1; /**< 1: Parent will be focused instead*/
+    uint8_t disabled_noevent: 1; /**< 1: Don't pass events if it is disabled*/
 
     lv_drag_dir_t drag_dir  : 3; /**<  Which directions the object can be dragged in */
     lv_bidi_dir_t base_dir  : 2; /**< Base direction of texts related to this object */
@@ -706,6 +707,13 @@ void lv_obj_set_adv_hittest(lv_obj_t * obj, bool en);
  * @param en true: make the object clickable
  */
 void lv_obj_set_click(lv_obj_t * obj, bool en);
+
+/**
+ * Enable or disable the passing of event of an object if it is disabled
+ * @param obj pointer to an object
+ * @param en true: make the object does not pass events if it is disabled
+ */
+void lv_obj_set_disabled_noevent(lv_obj_t * obj, bool en);
 
 /**
  * Enable to bring this object to the foreground if it
@@ -1230,6 +1238,13 @@ bool lv_obj_get_adv_hittest(const lv_obj_t * obj);
  * @return true: the object is clickable
  */
 bool lv_obj_get_click(const lv_obj_t * obj);
+
+/**
+ * Get the passing event of an object if it is disabled
+ * @param obj pointer to an object
+ * @param true: the object does not pass events if it is disabled
+ */
+bool lv_obj_get_disabled_noevent(lv_obj_t * obj, bool en);
 
 /**
  * Get the top enable attribute of an object

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -177,7 +177,7 @@ enum {
     LV_PROTECT_PRESS_LOST = 0x10,  /**< If the `indev` was pressing this object but swiped out while
                                       pressing do not search other object.*/
     LV_PROTECT_CLICK_FOCUS = 0x20, /**< Prevent focusing the object by clicking on it*/
-	LV_PROTECT_EVENT_TO_DISABLED = 0x40, /**< Pass events even to disabled objects*/
+    LV_PROTECT_EVENT_TO_DISABLED = 0x40, /**< Pass events even to disabled objects*/
 };
 typedef uint8_t lv_protect_t;
 

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -1244,7 +1244,7 @@ bool lv_obj_get_click(const lv_obj_t * obj);
  * @param obj pointer to an object
  * @param true: the object does not pass events if it is disabled
  */
-bool lv_obj_get_disabled_noevent(lv_obj_t * obj, bool en);
+bool lv_obj_get_disabled_noevent(lv_obj_t * obj);
 
 /**
  * Get the top enable attribute of an object

--- a/src/lv_core/lv_obj.h
+++ b/src/lv_core/lv_obj.h
@@ -177,6 +177,7 @@ enum {
     LV_PROTECT_PRESS_LOST = 0x10,  /**< If the `indev` was pressing this object but swiped out while
                                       pressing do not search other object.*/
     LV_PROTECT_CLICK_FOCUS = 0x20, /**< Prevent focusing the object by clicking on it*/
+	LV_PROTECT_EVENT_TO_DISABLED = 0x40, /**< Pass events even to disabled objects*/
 };
 typedef uint8_t lv_protect_t;
 
@@ -225,7 +226,6 @@ typedef struct _lv_obj_t {
     uint8_t adv_hittest     : 1; /**< 1: Use advanced hit-testing (slower) */
     uint8_t gesture_parent  : 1; /**< 1: Parent will be gesture instead*/
     uint8_t focus_parent    : 1; /**< 1: Parent will be focused instead*/
-    uint8_t disabled_noevent: 1; /**< 1: Don't pass events if it is disabled*/
 
     lv_drag_dir_t drag_dir  : 3; /**<  Which directions the object can be dragged in */
     lv_bidi_dir_t base_dir  : 2; /**< Base direction of texts related to this object */
@@ -707,13 +707,6 @@ void lv_obj_set_adv_hittest(lv_obj_t * obj, bool en);
  * @param en true: make the object clickable
  */
 void lv_obj_set_click(lv_obj_t * obj, bool en);
-
-/**
- * Enable or disable the passing of event of an object if it is disabled
- * @param obj pointer to an object
- * @param en true: make the object does not pass events if it is disabled
- */
-void lv_obj_set_disabled_noevent(lv_obj_t * obj, bool en);
 
 /**
  * Enable to bring this object to the foreground if it
@@ -1238,13 +1231,6 @@ bool lv_obj_get_adv_hittest(const lv_obj_t * obj);
  * @return true: the object is clickable
  */
 bool lv_obj_get_click(const lv_obj_t * obj);
-
-/**
- * Get the passing event of an object if it is disabled
- * @param obj pointer to an object
- * @param true: the object does not pass events if it is disabled
- */
-bool lv_obj_get_disabled_noevent(lv_obj_t * obj);
 
 /**
  * Get the top enable attribute of an object


### PR DESCRIPTION
### Description of the feature or fix

This pull adds an option to enable the passing of events to disabled objects, in order to be able to process them if needed.
By default the event is not triggered to the object, unless enabled by the user.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
