### PR TITLE
Added get_step function to lv_spinbox.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v7.9.2 (Planned for 02.02.2021)
 
 ### New features
-- feat(indev) allow input events to be passed to disabled objects 
+- feat(indev) allow input events to be passed to disabled objects
+- feat(spinbox) add inline get_step function for MicroPython support
 
 ### Bugfixes
 - fix(btnmatrix) fix lv_btnmatrix_get_active_btn_text() when used in a group

--- a/src/lv_widgets/lv_spinbox.h
+++ b/src/lv_widgets/lv_spinbox.h
@@ -142,8 +142,6 @@ int32_t lv_spinbox_get_value(lv_obj_t * spinbox);
  */
 static inline int32_t lv_spinbox_get_step(lv_obj_t * spinbox)
 {
-    LV_ASSERT_OBJ(spinbox, LV_OBJX_NAME);
-
     lv_spinbox_ext_t * ext = lv_obj_get_ext_attr(spinbox);
 
     return ext->step;

--- a/src/lv_widgets/lv_spinbox.h
+++ b/src/lv_widgets/lv_spinbox.h
@@ -135,6 +135,20 @@ bool lv_spinbox_get_rollover(lv_obj_t * spinbox);
  */
 int32_t lv_spinbox_get_value(lv_obj_t * spinbox);
 
+/**
+ * Get the spinbox step value (user has to convert to float according to its digit format)
+ * @param spinbox pointer to spinbox
+ * @return value integer step value of the spinbox
+ */
+static inline int32_t lv_spinbox_get_step(lv_obj_t * spinbox)
+{
+    LV_ASSERT_OBJ(spinbox, LV_OBJX_NAME);
+
+    lv_spinbox_ext_t * ext = lv_obj_get_ext_attr(spinbox);
+
+    return ext->step;
+}
+
 /*=====================
  * Other functions
  *====================*/


### PR DESCRIPTION
I have added a static inline function to allow access to the step parameter for the spinbox widget

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
