### PR TITLE
Better rotation support (plus experimental software rotation)

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -69,6 +69,9 @@
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
 typedef int16_t lv_coord_t;
 
+/* Maximum buffer size to allocate for rotation. Only used if software rotation is enabled. */
+#define LV_DISP_ROT_MAX_BUF  (20U * 1024U)
+
 /*=========================
    Memory manager settings
  *=========================*/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -70,7 +70,7 @@
 typedef int16_t lv_coord_t;
 
 /* Maximum buffer size to allocate for rotation. Only used if software rotation is enabled. */
-#define LV_DISP_ROT_MAX_BUF  (20U * 1024U)
+#define LV_DISP_ROT_MAX_BUF  (10U * 1024U)
 
 /*=========================
    Memory manager settings

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -181,7 +181,7 @@
 #  ifdef CONFIG_LV_DISP_ROT_MAX_BUF
 #    define LV_DISP_ROT_MAX_BUF CONFIG_LV_DISP_ROT_MAX_BUF
 #  else
-#    define  LV_DISP_ROT_MAX_BUF  (20U * 1024U)
+#    define  LV_DISP_ROT_MAX_BUF  (10U * 1024U)
 #  endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -176,6 +176,15 @@
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
 
+/* Maximum buffer size to allocate for rotation. Only used if software rotation is enabled. */
+#ifndef LV_DISP_ROT_MAX_BUF
+#  ifdef CONFIG_LV_DISP_ROT_MAX_BUF
+#    define LV_DISP_ROT_MAX_BUF CONFIG_LV_DISP_ROT_MAX_BUF
+#  else
+#    define  LV_DISP_ROT_MAX_BUF  (20U * 1024U)
+#  endif
+#endif
+
 /*=========================
    Memory manager settings
  *=========================*/

--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -401,6 +401,16 @@ lv_task_t * lv_indev_get_read_task(lv_disp_t * indev)
  */
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
+    lv_disp_t *disp = i->driver.disp;
+    if(disp->driver.rotated == LV_DISP_ROT_180 || disp->driver.rotated == LV_DISP_ROT_270) {
+        data->point.x = disp->driver.hor_res - data->point.x - 1;
+        data->point.y = disp->driver.ver_res - data->point.y - 1;
+    }
+    if(disp->driver.rotated == LV_DISP_ROT_90 || disp->driver.rotated == LV_DISP_ROT_270) {
+        lv_coord_t tmp = data->point.y;
+        data->point.y = data->point.x;
+        data->point.x = disp->driver.ver_res - tmp - 1;
+    }
     /*Move the cursor if set and moved*/
     if(i->cursor != NULL &&
        (i->proc.types.pointer.last_point.x != data->point.x || i->proc.types.pointer.last_point.y != data->point.y)) {

--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -799,6 +799,7 @@ static lv_color_t *lv_refr_vdb_rotate_pre(lv_disp_drv_t *drv, lv_area_t *area, l
 }
 
 static void lv_refr_vdb_rotate_post(lv_disp_drv_t *drv, lv_area_t *area, lv_color_t *color_p) {
+    LV_UNUSED(area);
     if(lv_disp_is_true_double_buf(disp_refr) && drv->sw_rotate)
         return;
     if(drv->rotated == LV_DISP_ROT_90 || drv->rotated == LV_DISP_ROT_270) {

--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -800,7 +800,7 @@ static void lv_refr_vdb_rotate(lv_area_t *area, lv_color_t *color_p) {
         lv_coord_t area_w = lv_area_get_width(area);
         lv_coord_t area_h = lv_area_get_height(area);
         /*Determine the maximum number of rows that can be rotated at a time*/
-        uint32_t max_row = LV_MATH_MIN((LV_DISP_ROT_MAX_BUF/sizeof(lv_color_t)) / area_w, area_h);
+        lv_coord_t max_row = LV_MATH_MIN((lv_coord_t)((LV_DISP_ROT_MAX_BUF/sizeof(lv_color_t)) / area_w), area_h);
         lv_coord_t init_y_off;
         init_y_off = area->y1;
         if(drv->rotated == LV_DISP_ROT_90) {
@@ -812,7 +812,7 @@ static void lv_refr_vdb_rotate(lv_area_t *area, lv_color_t *color_p) {
         }
         vdb->flushing = 0;
         /*Rotate the screen in chunks, flushing after each one*/
-        for(uint32_t row = 0; row < area_h; row += max_row) {
+        for(lv_coord_t row = 0; row < area_h; row += max_row) {
             lv_coord_t height = LV_MATH_MIN(max_row, area_h-row);
             lv_refr_vdb_rotate_90(drv->rotated == LV_DISP_ROT_270, area_w, height, color_p, rot_buf);
             vdb->flushing = 1;

--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -430,7 +430,11 @@ static void lv_refr_area(const lv_area_t * area_p)
         lv_coord_t y2 =
             area_p->y2 >= lv_disp_get_ver_res(disp_refr) ? lv_disp_get_ver_res(disp_refr) - 1 : area_p->y2;
 
-        int32_t max_row = (uint32_t)vdb->size / w;
+        int32_t max_row;
+        if(disp_refr->driver.sw_rotate && (disp_refr->driver.rotated == LV_DISP_ROT_90 || disp_refr->driver.rotated == LV_DISP_ROT_270)) {
+            max_row = (uint32_t)LV_MATH_MIN(vdb->size, LV_DISP_ROT_MAX_BUF / sizeof(lv_color_t)) / w;
+        } else
+            max_row = (uint32_t)vdb->size / w;
 
         if(max_row > h) max_row = h;
 
@@ -744,9 +748,9 @@ static void lv_refr_obj(lv_obj_t * obj, const lv_area_t * mask_ori_p)
 /**
  * Rotate the VDB to the display's native orientation.
  */
-static lv_color_t *lv_refr_vdb_rotate_pre(lv_disp_drv_t *drv, lv_area_t *area, lv_color_t *color_p) {
+static LV_ATTRIBUTE_FAST_MEM lv_color_t *lv_refr_vdb_rotate_pre(lv_disp_drv_t *drv, lv_area_t *area, lv_color_t *color_p) {
     if(lv_disp_is_true_double_buf(disp_refr) && drv->sw_rotate) {
-        LV_LOG_ERROR("lv_refr_vdb_rotate_pre: cannot rotate a true double-buffered display!");
+        LV_LOG_ERROR("cannot rotate a true double-buffered display!");
         return color_p;
     }
     lv_coord_t area_w = lv_area_get_width(area);

--- a/src/lv_hal/lv_hal_disp.c
+++ b/src/lv_hal/lv_hal_disp.c
@@ -191,14 +191,13 @@ void lv_disp_drv_update(lv_disp_t * disp, lv_disp_drv_t * new_drv)
      * This method is usually called upon orientation change, thus the screen is now a
      * different size.
      * The object invalidated its previous area. That area is now out of the screen area
-     * so we reset all invalidated areas and invalidate the object's new area only.
+     * so we reset all invalidated areas and invalidate the active screen's new area only.
      */
     _lv_memset_00(disp->inv_areas, sizeof(disp->inv_areas));
     _lv_memset_00(disp->inv_area_joined, sizeof(disp->inv_area_joined));
     disp->inv_p = 0;
-    _LV_LL_READ(disp->scr_ll, scr) {
-        lv_obj_invalidate(scr);
-    }
+    if(disp->act_scr != NULL)
+        lv_obj_invalidate(disp->act_scr);
 }
 
 /**

--- a/src/lv_hal/lv_hal_disp.h
+++ b/src/lv_hal/lv_hal_disp.h
@@ -60,6 +60,14 @@ typedef struct {
     volatile uint32_t last_part         : 1; /*1: the last part of the current area is being rendered*/
 } lv_disp_buf_t;
 
+
+typedef enum {
+    LV_DISP_ROT_NONE = 0,
+    LV_DISP_ROT_90,
+    LV_DISP_ROT_180,
+    LV_DISP_ROT_270
+} lv_disp_rot_t;
+
 /**
  * Display Driver structure to be registered by HAL
  */
@@ -75,7 +83,8 @@ typedef struct _disp_drv_t {
 #if LV_ANTIALIAS
     uint32_t antialiasing : 1; /**< 1: antialiasing is enabled on this display. */
 #endif
-    uint32_t rotated : 1; /**< 1: turn the display by 90 degree. @warning Does not update coordinates for you!*/
+    uint32_t rotated : 2;
+    uint32_t sw_rotate : 1; /**< 1: use software rotation (slower) */
 
 #if LV_COLOR_SCREEN_TRANSP
     /**Handle if the screen doesn't have a solid (opa == LV_OPA_COVER) background.
@@ -280,6 +289,20 @@ lv_coord_t lv_disp_get_dpi(lv_disp_t * disp);
  * @return LV_DISP_SIZE_SMALL/MEDIUM/LARGE/EXTRA_LARGE
  */
 lv_disp_size_t lv_disp_get_size_category(lv_disp_t * disp);
+
+/**
+ * Set the rotation of this display.
+ * @param disp pointer to a display (NULL to use the default display)
+ * @param rotation rotation angle
+ */
+void lv_disp_set_rotation(lv_disp_t * disp, lv_disp_rot_t rotation);
+
+/**
+ * Get the current rotation of this display.
+ * @param disp pointer to a display (NULL to use the default display)
+ * @return rotation angle
+ */
+lv_disp_rot_t lv_disp_get_rotation(lv_disp_t * disp);
 
 //! @cond Doxygen_Suppress
 


### PR DESCRIPTION
### Description of the feature or fix

This PR adds support for rotating the display to all 3 alternative orientations. The rotation can be done in hardware (like current versions) or can be done in software by enabling the `sw_rotate` flag on the display driver.

180 degree rotation done in software is extremely fast, at least on STM32F7, and I noticed little to no performance loss. 90 and 270 degree rotation, however, is considerably slower.

@kisvegabor Suggestions on how to optimize this would be appreciated if you have time to take a look.

Closes #2046.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [x] Update the documentation
