### PR TITLE
Add component.mk file for esp-idf make based commands

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,4 +1,14 @@
 # ESP-IDF component file for make based commands
 
+ifdef $(IDF_VER)
+
+$(info Adding LVGL as ESP-IDF component)
+
 COMPONENT_SRCDIRS := .
 COMPONENT_ADD_INCLUDEDIRS := .
+
+else
+
+$(info IDF_VER not defined)
+
+endif

--- a/component.mk
+++ b/component.mk
@@ -1,0 +1,4 @@
+# ESP-IDF component file for make based commands
+
+COMPONENT_SRCDIRS := .
+COMPONENT_ADD_INCLUDEDIRS := .

--- a/component.mk
+++ b/component.mk
@@ -2,13 +2,7 @@
 
 ifdef $(IDF_VER)
 
-$(info Adding LVGL as ESP-IDF component)
-
 COMPONENT_SRCDIRS := .
 COMPONENT_ADD_INCLUDEDIRS := .
-
-else
-
-$(info IDF_VER not defined)
 
 endif


### PR DESCRIPTION
### Description of the feature or fix

Adds the `component.mk` file to fix this issue https://github.com/lvgl/lv_port_esp32/issues/257

AFAIK when using make no symbol is defined, so there's no way to identify we're using esp-idf, but esp-idf search for this specific file name. If there's a way to identify the ESP-IDF framework when using make please let me know.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
