### PR TITLE
fix(gauge,linemeter) draw critical sections/end value in correct spot

### DIFF
--- a/src/lv_widgets/lv_gauge.h
+++ b/src/lv_widgets/lv_gauge.h
@@ -112,7 +112,7 @@ static inline void lv_gauge_set_range(lv_obj_t * gauge, int32_t min, int32_t max
  */
 static inline void lv_gauge_set_critical_value(lv_obj_t * gauge, int32_t value)
 {
-    lv_linemeter_set_value(gauge, value);
+    lv_linemeter_set_value(gauge, value-1);
 }
 
 /**

--- a/src/lv_widgets/lv_linemeter.c
+++ b/src/lv_widgets/lv_linemeter.c
@@ -446,7 +446,7 @@ void lv_linemeter_draw_scale(lv_obj_t * lmeter, const lv_area_t * clip_area, uin
         p1.y = y_out_extra;
 
         /* Set the color of the lines */
-        if((!ext->mirrored && i >= level) || (ext->mirrored && i <= level)) {
+        if((!ext->mirrored && i > level) || (ext->mirrored && i < level)) {
             line_dsc.color = end_color;
             line_dsc.width = end_line_width;
         }
@@ -465,12 +465,12 @@ void lv_linemeter_draw_scale(lv_obj_t * lmeter, const lv_area_t * clip_area, uin
     lv_draw_mask_remove_id(mask_out_id);
 #endif
 
-    if(part == LV_LINEMETER_PART_MAIN && level < ext->line_cnt - 1) {
+    if(part == LV_LINEMETER_PART_MAIN && level + 1 < ext->line_cnt - 1) {
         lv_style_int_t border_width = lv_obj_get_style_scale_border_width(lmeter, part);
         lv_style_int_t end_border_width = lv_obj_get_style_scale_end_border_width(lmeter, part);
 
         if(border_width || end_border_width) {
-            int16_t end_angle = ((level) * ext->scale_angle) / (ext->line_cnt - 1) + angle_ofs;
+            int16_t end_angle = ((level + 1) * ext->scale_angle) / (ext->line_cnt - 1) + angle_ofs;
             lv_draw_line_dsc_t arc_dsc;
             lv_draw_line_dsc_init(&arc_dsc);
             lv_obj_init_draw_line_dsc(lmeter, part, &arc_dsc);


### PR DESCRIPTION
### Description of the feature or fix

The previous fixes I introduced for this problem cause the standalone linemeter's line colors to be off by one, resulting in bugs like [this](https://forum.lvgl.io/t/how-to-set-the-line-meter-parameter/4506).

I have thus reverted the fixes to the linemeter and instead done the adjustment in the gauge itself.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
