### PR TITLE
Improve Arabic contextual analysis (lv_txt_ap.c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 - fix(indev) clear the indev's `act_obj` in `lv_indev_reset`
 - fix(text) fix out of bounds read in `_lv_txt_get_width`
+- fix(text) improve Arabic contextual analysis by adding hyphen processing and proper handling of lam-alef sequence
 
 ## v7.10.0
 

--- a/src/lv_misc/lv_txt_ap.c
+++ b/src/lv_misc/lv_txt_ap.c
@@ -58,6 +58,7 @@ const ap_chars_map_t ap_chars_map[] = {
     {22, 0xFEC6, 1, 2, -1,  {1, 1}},   // ظ
     {23, 0xFECA, 1, 2, -1,  {1, 1}},   // ع
     {24, 0xFECE, 1, 2, -1,  {1, 1}},   // غ
+    {30, 0x0640, 0, 0, 0,  {1, 1}},   // - (mad)
     {31, 0xFED2, 1, 2, -1,  {1, 1}},   // ف
     {32, 0xFED6, 1, 2, -1,  {1, 1}},   // ق
     {135, 0xFB8F, 1, 2, -1,  {1, 1}},  // ک
@@ -125,16 +126,35 @@ uint32_t _lv_txt_ap_calc_bytes_cnt(const char * txt)
     return chars_cnt + 1;
 }
 
+uint32_t _lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next)
+{
+	uint16_t ch_code = 0;
+	if (ap_chars_map[ch_curr].char_offset != 34) {
+		return 0;
+	}
+	if (ch_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
+		return 0;
+	}
+	ch_code = ap_chars_map[ch_next].char_offset + LV_AP_ALPHABET_BASE_CODE;
+	if (ch_code == 0x0622) { return 0xFEF5; } // mad
+	if (ch_code == 0x0623) { return 0xFEF7; } // top hamza
+	if (ch_code == 0x0625) { return 0xFEF9; } // bot hamza
+	if (ch_code == 0x0627) { return 0xFEFB; } // alef
+	return 0;
+}
+
 void _lv_txt_ap_proc(const char * txt, char * txt_out)
 {
     uint32_t txt_length = 0;
     uint32_t index_current, idx_next, idx_previous, i, j;
     uint32_t * ch_enc;
+    uint32_t * ch_fin;
     char * txt_out_temp;
 
     txt_length = _lv_txt_get_encoded_length(txt);
 
     ch_enc = (uint32_t *)lv_mem_alloc(sizeof(uint32_t) * (txt_length + 1));
+    ch_fin = (uint32_t *)lv_mem_alloc(sizeof(uint32_t) * (txt_length + 1));
 
     i = 0;
     j = 0;
@@ -144,12 +164,15 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
     ch_enc[j] = 0;
 
     i = 0;
+    j = 0;
     idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
     while(i < txt_length) {
         index_current = lv_ap_get_char_index(ch_enc[i]);
         idx_next = lv_ap_get_char_index(ch_enc[i + 1]);
 
         if(index_current == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
+        	ch_fin[j] = ch_enc[i];
+            j++;
             i++;
             idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
             continue;
@@ -160,17 +183,36 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
         uint8_t conjunction_to_next = ((i == txt_length - 1) ||
                                        idx_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) ? 0 : ap_chars_map[idx_next].ap_chars_conjunction.conj_to_previous;
 
+        uint32_t lam_alef = _lv_txt_lam_alef(index_current, idx_next);
+        if ( lam_alef ) {
+        	if (conjunction_to_previuse) {
+        		lam_alef ++;
+        	}
+        	ch_fin[j] = lam_alef;
+        	idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
+        	i += 2;
+        	j++;
+        	continue;
+        }
+
         if(conjunction_to_previuse && conjunction_to_next)
-            ch_enc[i] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_middle_form_offset;
+        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_middle_form_offset;
         else if(!conjunction_to_previuse && conjunction_to_next)
-            ch_enc[i] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_begining_form_offset;
+        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_begining_form_offset;
         else if(conjunction_to_previuse && !conjunction_to_next)
-            ch_enc[i] = ap_chars_map[index_current].char_end_form;
+        	ch_fin[j] = ap_chars_map[index_current].char_end_form;
         else
-            ch_enc[i] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_isolated_form_offset;
+        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_isolated_form_offset;
         idx_previous = index_current;
         i++;
+        j++;
     }
+    ch_fin[j] = 0;
+    for (i=0; i<txt_length; i++)
+    	ch_enc[i] = 0;
+    for (i=0; i<j; i++)
+    	ch_enc[i] = ch_fin[i];
+    lv_mem_free(ch_fin);
 
     txt_out_temp = txt_out;
     i = 0;

--- a/src/lv_misc/lv_txt_ap.c
+++ b/src/lv_misc/lv_txt_ap.c
@@ -155,7 +155,7 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
         idx_next = lv_ap_get_char_index(ch_enc[i + 1]);
 
         if(index_current == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
-        	ch_fin[j] = ch_enc[i];
+            ch_fin[j] = ch_enc[i];
             j++;
             i++;
             idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
@@ -169,33 +169,33 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
 
         uint32_t lam_alef = lv_txt_lam_alef(index_current, idx_next);
         if ( lam_alef ) {
-        	if (conjunction_to_previuse) {
-        		lam_alef ++;
-        	}
-        	ch_fin[j] = lam_alef;
-        	idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
-        	i += 2;
-        	j++;
-        	continue;
+            if (conjunction_to_previuse) {
+                lam_alef ++;
+            }
+            ch_fin[j] = lam_alef;
+            idx_previous = LV_UNDEF_ARABIC_PERSIAN_CHARS;
+            i += 2;
+            j++;
+            continue;
         }
 
         if(conjunction_to_previuse && conjunction_to_next)
-        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_middle_form_offset;
+            ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_middle_form_offset;
         else if(!conjunction_to_previuse && conjunction_to_next)
-        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_begining_form_offset;
+            ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_begining_form_offset;
         else if(conjunction_to_previuse && !conjunction_to_next)
-        	ch_fin[j] = ap_chars_map[index_current].char_end_form;
+            ch_fin[j] = ap_chars_map[index_current].char_end_form;
         else
-        	ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_isolated_form_offset;
+            ch_fin[j] = ap_chars_map[index_current].char_end_form + ap_chars_map[index_current].char_isolated_form_offset;
         idx_previous = index_current;
         i++;
         j++;
     }
     ch_fin[j] = 0;
     for (i=0; i<txt_length; i++)
-    	ch_enc[i] = 0;
+        ch_enc[i] = 0;
     for (i=0; i<j; i++)
-    	ch_enc[i] = ch_fin[i];
+        ch_enc[i] = ch_fin[i];
     lv_mem_free(ch_fin);
     
     txt_out_temp = txt_out;
@@ -247,19 +247,19 @@ static uint32_t lv_ap_get_char_index(uint16_t c)
 
 static uint32_t lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next)
 {
-	uint32_t ch_code = 0;
-	if (ap_chars_map[ch_curr].char_offset != 34) {
-		return 0;
-	}
-	if (ch_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
-		return 0;
-	}
-	ch_code = ap_chars_map[ch_next].char_offset + LV_AP_ALPHABET_BASE_CODE;
-	if (ch_code == 0x0622) { return 0xFEF5; } // (lam-alef) mad
-	if (ch_code == 0x0623) { return 0xFEF7; } // (lam-alef) top hamza
-	if (ch_code == 0x0625) { return 0xFEF9; } // (lam-alef) bot hamza
-	if (ch_code == 0x0627) { return 0xFEFB; } // (lam-alef) alef
-	return 0;
+    uint32_t ch_code = 0;
+    if (ap_chars_map[ch_curr].char_offset != 34) {
+        return 0;
+    }
+    if (ch_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
+        return 0;
+    }
+    ch_code = ap_chars_map[ch_next].char_offset + LV_AP_ALPHABET_BASE_CODE;
+    if (ch_code == 0x0622) { return 0xFEF5; } // (lam-alef) mad
+    if (ch_code == 0x0623) { return 0xFEF7; } // (lam-alef) top hamza
+    if (ch_code == 0x0625) { return 0xFEF9; } // (lam-alef) bot hamza
+    if (ch_code == 0x0627) { return 0xFEFB; } // (lam-alef) alef
+    return 0;
 }
 
 #endif

--- a/src/lv_misc/lv_txt_ap.c
+++ b/src/lv_misc/lv_txt_ap.c
@@ -25,6 +25,7 @@
  **********************/
 #if LV_USE_ARABIC_PERSIAN_CHARS == 1
 static uint32_t lv_ap_get_char_index(uint16_t c);
+static uint32_t lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next);
 
 /**********************
  *  STATIC VARIABLES
@@ -58,7 +59,7 @@ const ap_chars_map_t ap_chars_map[] = {
     {22, 0xFEC6, 1, 2, -1,  {1, 1}},   // ظ
     {23, 0xFECA, 1, 2, -1,  {1, 1}},   // ع
     {24, 0xFECE, 1, 2, -1,  {1, 1}},   // غ
-    {30, 0x0640, 0, 0, 0,  {1, 1}},   // - (mad)
+    {30, 0x0640, 0, 0, 0,  {1, 1}},   // - (mad, hyphen)
     {31, 0xFED2, 1, 2, -1,  {1, 1}},   // ف
     {32, 0xFED6, 1, 2, -1,  {1, 1}},   // ق
     {135, 0xFB8F, 1, 2, -1,  {1, 1}},  // ک
@@ -126,23 +127,6 @@ uint32_t _lv_txt_ap_calc_bytes_cnt(const char * txt)
     return chars_cnt + 1;
 }
 
-uint32_t _lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next)
-{
-	uint16_t ch_code = 0;
-	if (ap_chars_map[ch_curr].char_offset != 34) {
-		return 0;
-	}
-	if (ch_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
-		return 0;
-	}
-	ch_code = ap_chars_map[ch_next].char_offset + LV_AP_ALPHABET_BASE_CODE;
-	if (ch_code == 0x0622) { return 0xFEF5; } // mad
-	if (ch_code == 0x0623) { return 0xFEF7; } // top hamza
-	if (ch_code == 0x0625) { return 0xFEF9; } // bot hamza
-	if (ch_code == 0x0627) { return 0xFEFB; } // alef
-	return 0;
-}
-
 void _lv_txt_ap_proc(const char * txt, char * txt_out)
 {
     uint32_t txt_length = 0;
@@ -183,7 +167,7 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
         uint8_t conjunction_to_next = ((i == txt_length - 1) ||
                                        idx_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) ? 0 : ap_chars_map[idx_next].ap_chars_conjunction.conj_to_previous;
 
-        uint32_t lam_alef = _lv_txt_lam_alef(index_current, idx_next);
+        uint32_t lam_alef = lv_txt_lam_alef(index_current, idx_next);
         if ( lam_alef ) {
         	if (conjunction_to_previuse) {
         		lam_alef ++;
@@ -213,7 +197,7 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
     for (i=0; i<j; i++)
     	ch_enc[i] = ch_fin[i];
     lv_mem_free(ch_fin);
-
+    
     txt_out_temp = txt_out;
     i = 0;
 
@@ -259,6 +243,23 @@ static uint32_t lv_ap_get_char_index(uint16_t c)
         }
     }
     return LV_UNDEF_ARABIC_PERSIAN_CHARS;
+}
+
+static uint32_t lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next)
+{
+	uint32_t ch_code = 0;
+	if (ap_chars_map[ch_curr].char_offset != 34) {
+		return 0;
+	}
+	if (ch_next == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
+		return 0;
+	}
+	ch_code = ap_chars_map[ch_next].char_offset + LV_AP_ALPHABET_BASE_CODE;
+	if (ch_code == 0x0622) { return 0xFEF5; } // (lam-alef) mad
+	if (ch_code == 0x0623) { return 0xFEF7; } // (lam-alef) top hamza
+	if (ch_code == 0x0625) { return 0xFEF9; } // (lam-alef) bot hamza
+	if (ch_code == 0x0627) { return 0xFEFB; } // (lam-alef) alef
+	return 0;
 }
 
 #endif


### PR DESCRIPTION
### Description of the feature or fix

There are two proposed changes :
(1) there is an Arabic character that was not included in the (ap_chars_map) array. Arabs use, not frequently, this character to make the text appear longer. If it is not treated correctly, it will break the Arabic contextual analysis
(2) handling of letters (lam-alef) sequence. If letters alef (4 shapes, 0x0622/0x0623/0x0625/0x0627) comes after the letter lam (0x0644), the result will be a new single shape that combines both. In order not to break the code flow (current code is doing in-place editing), I created an new parallel array (ch_fin) that receives new contextual shapes. At the end I copied the resultant array back to ch_enc.

![lv_old](https://user-images.githubusercontent.com/6402214/107420118-9d310a00-6b29-11eb-86ea-12e3df6d2ab4.png)
![lv_new](https://user-images.githubusercontent.com/6402214/107420114-9c987380-6b29-11eb-9f41-37e9eb839676.png)

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [x] Update the documentation. No need since it supposed to be part of Arabic contextual analysis.
