### PR TITLE
fix(draw) overlap outline with background to prevent aliasing artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v7.10.1 (Planned for 16.02.2021)
 
 ### Bugfixes
+- fix(draw) overlap outline with background to prevent aliasing artifacts
 - fix(indev) clear the indev's `act_obj` in `lv_indev_reset`
 - fix(text) fix out of bounds read in `_lv_txt_get_width`
 - fix(delete) delete animation after the children are deleted

--- a/src/lv_draw/lv_draw_rect.c
+++ b/src/lv_draw/lv_draw_rect.c
@@ -1160,18 +1160,21 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const
     /*Get the inner radius*/
     lv_area_t area_inner;
     lv_area_copy(&area_inner, coords);
-    area_inner.x1 -= dsc->outline_pad;
-    area_inner.y1 -= dsc->outline_pad;
-    area_inner.x2 += dsc->outline_pad;
-    area_inner.y2 += dsc->outline_pad;
+
+    lv_coord_t pad = dsc->outline_pad - 1;
+    area_inner.x1 -= pad;
+    area_inner.y1 -= pad;
+    area_inner.x2 += pad;
+    area_inner.y2 += pad;
 
     lv_area_t area_outer;
     lv_area_copy(&area_outer, &area_inner);
 
-    area_outer.x1 -= dsc->outline_width;
-    area_outer.x2 += dsc->outline_width;
-    area_outer.y1 -= dsc->outline_width;
-    area_outer.y2 += dsc->outline_width;
+    lv_coord_t width = dsc->outline_width + 1;
+    area_outer.x1 -= width;
+    area_outer.x2 += width;
+    area_outer.y1 -= width;
+    area_outer.y2 += width;
 
     draw_full_border(&area_inner, &area_outer, clip, dsc->radius, true, dsc->outline_color, dsc->outline_opa,
                      dsc->outline_blend_mode);

--- a/src/lv_draw/lv_draw_rect.c
+++ b/src/lv_draw/lv_draw_rect.c
@@ -1161,7 +1161,8 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const
     lv_area_t area_inner;
     lv_area_copy(&area_inner, coords);
 
-    lv_coord_t pad = dsc->outline_pad - 1;
+    /*Extend the outline into the background area if it's overlapping the edge*/
+    lv_coord_t pad = (dsc->outline_pad == 0 ? (dsc->outline_pad - 1) : dsc->outline_pad);
     area_inner.x1 -= pad;
     area_inner.y1 -= pad;
     area_inner.x2 += pad;
@@ -1170,7 +1171,7 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const
     lv_area_t area_outer;
     lv_area_copy(&area_outer, &area_inner);
 
-    lv_coord_t width = dsc->outline_width + 1;
+    lv_coord_t width = (dsc->outline_pad == 0 ? (dsc->outline_width + 1) : dsc->outline_width);
     area_outer.x1 -= width;
     area_outer.x2 += width;
     area_outer.y1 -= width;


### PR DESCRIPTION
### Description of the feature or fix

Fixes #2064.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update CHANGELOG.md
- [ ] Update the documentation
