### PR TITLE
fix(theme): fix the memory leak when lv_theme_xxx_init is called twice

### DIFF
--- a/src/lv_core/lv_style.c
+++ b/src/lv_core/lv_style.c
@@ -321,10 +321,8 @@ void _lv_style_list_reset(lv_style_list_t * list)
  */
 void lv_style_reset(lv_style_t * style)
 {
-    LV_ASSERT_STYLE(style);
-
     lv_mem_free(style->map);
-    style->map = NULL;
+    lv_style_init(style);
 }
 
 /**

--- a/src/lv_themes/lv_theme.c
+++ b/src/lv_themes/lv_theme.c
@@ -91,7 +91,6 @@ void lv_theme_copy(lv_theme_t * theme, const lv_theme_t * copy)
         theme->apply_cb = copy->apply_cb;
         theme->apply_xcb = copy->apply_xcb;
     }
-
 }
 
 /**
@@ -471,5 +470,4 @@ static void clear_styles(lv_obj_t * obj, lv_theme_style_t name)
         default:
             break;
     }
-
 }

--- a/src/lv_themes/lv_theme.h
+++ b/src/lv_themes/lv_theme.h
@@ -1,10 +1,10 @@
 /**
- *@file lv_themes.h
+ *@file lv_theme.h
  *
  */
 
-#ifndef LV_THEMES_H
-#define LV_THEMES_H
+#ifndef LV_THEME_H
+#define LV_THEME_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -272,4 +272,4 @@ uint32_t lv_theme_get_flags(void);
 } /* extern "C" */
 #endif
 
-#endif /*LV_THEMES_H*/
+#endif /*LV_THEME_H*/

--- a/src/lv_themes/lv_theme_empty.c
+++ b/src/lv_themes/lv_theme_empty.c
@@ -95,8 +95,8 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 {
     LV_UNUSED(th);
     if(name == LV_THEME_SCR) {
-        lv_obj_clean_style_list(obj, LV_OBJ_PART_MAIN);
         lv_obj_add_style(obj, LV_OBJ_PART_MAIN, &styles->opa_cover);
+        lv_obj_refresh_style(obj, LV_OBJ_PART_ALL, LV_STYLE_PROP_ALL);
     }
 }
 

--- a/src/lv_themes/lv_theme_empty.c
+++ b/src/lv_themes/lv_theme_empty.c
@@ -6,7 +6,6 @@
 /*********************
  *      INCLUDES
  *********************/
-#include <stdint.h>
 #include "../../lvgl.h" /*To see all the widgets*/
 
 #if LV_USE_THEME_EMPTY

--- a/src/lv_themes/lv_theme_empty.h
+++ b/src/lv_themes/lv_theme_empty.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_theme_material.h
+ * @file lv_theme_empty.h
  *
  */
 
@@ -53,4 +53,4 @@ lv_theme_t * lv_theme_empty_init(lv_color_t color_primary, lv_color_t color_seco
 } /* extern "C" */
 #endif
 
-#endif /*LV_THEME_ALIEN_H*/
+#endif /*LV_THEME_EMPTY_H*/

--- a/src/lv_themes/lv_theme_material.c
+++ b/src/lv_themes/lv_theme_material.c
@@ -175,15 +175,12 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name);
-static void style_init_reset(lv_style_t * style);
 
 /**********************
  *  STATIC VARIABLES
  **********************/
 static lv_theme_t theme;
 static theme_styles_t * styles;
-
-static bool inited;
 
 /**********************
  *      MACROS
@@ -195,7 +192,7 @@ static bool inited;
 
 static void basic_init(void)
 {
-    style_init_reset(&styles->scr);
+    lv_style_reset(&styles->scr);
     lv_style_set_bg_opa(&styles->scr, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->scr, LV_STATE_DEFAULT, COLOR_SCR);
     lv_style_set_text_color(&styles->scr, LV_STATE_DEFAULT, COLOR_SCR_TEXT);
@@ -204,7 +201,7 @@ static void basic_init(void)
     lv_style_set_text_sel_bg_color(&styles->scr, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_value_font(&styles->scr, LV_STATE_DEFAULT, theme.font_normal);
 
-    style_init_reset(&styles->bg);
+    lv_style_reset(&styles->bg);
     lv_style_set_radius(&styles->bg, LV_STATE_DEFAULT, LV_DPX(8));
     lv_style_set_bg_opa(&styles->bg, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->bg, LV_STATE_DEFAULT, COLOR_BG);
@@ -228,7 +225,7 @@ static void basic_init(void)
     lv_style_set_transition_time(&styles->bg, LV_STATE_DEFAULT, TRANSITION_TIME);
     lv_style_set_transition_prop_6(&styles->bg, LV_STATE_DEFAULT, LV_STYLE_BORDER_COLOR);
 
-    style_init_reset(&styles->bg_sec);
+    lv_style_reset(&styles->bg_sec);
     lv_style_copy(&styles->bg_sec, &styles->bg);
     lv_style_set_bg_color(&styles->bg_sec, LV_STATE_DEFAULT, COLOR_BG_SEC);
     lv_style_set_border_color(&styles->bg_sec, LV_STATE_DEFAULT, COLOR_BG_SEC_BORDER);
@@ -237,7 +234,7 @@ static void basic_init(void)
     lv_style_set_image_recolor(&styles->bg_sec, LV_STATE_DEFAULT, COLOR_BG_SEC_TEXT);
     lv_style_set_line_color(&styles->bg_sec, LV_STATE_DEFAULT, COLOR_BG_SEC_TEXT);
 
-    style_init_reset(&styles->bg_click);
+    lv_style_reset(&styles->bg_click);
     lv_style_set_bg_color(&styles->bg_click, LV_STATE_PRESSED, COLOR_BG_PR);
     lv_style_set_bg_color(&styles->bg_click, LV_STATE_CHECKED, COLOR_BG_CHK);
     lv_style_set_bg_color(&styles->bg_click, LV_STATE_PRESSED | LV_STATE_CHECKED, COLOR_BG_PR_CHK);
@@ -259,7 +256,7 @@ static void basic_init(void)
     lv_style_set_image_recolor(&styles->bg_click, LV_STATE_DISABLED, COLOR_BG_TEXT_DIS);
     lv_style_set_transition_prop_5(&styles->bg_click, LV_STATE_DEFAULT, LV_STYLE_BG_COLOR);
 
-    style_init_reset(&styles->btn);
+    lv_style_reset(&styles->btn);
     lv_style_set_radius(&styles->btn, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
     lv_style_set_bg_opa(&styles->btn, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->btn, LV_STATE_DEFAULT, COLOR_BTN);
@@ -309,12 +306,12 @@ static void basic_init(void)
     lv_style_set_transition_delay(&styles->btn, LV_STATE_DEFAULT, TRANSITION_TIME);
     lv_style_set_transition_delay(&styles->btn, LV_STATE_PRESSED, 0);
 
-    style_init_reset(&styles->pad_inner);
+    lv_style_reset(&styles->pad_inner);
 
     lv_style_set_pad_inner(&styles->pad_inner, LV_STATE_DEFAULT,
                            lv_disp_get_size_category(NULL) <= LV_DISP_SIZE_MEDIUM ? LV_DPX(20) : LV_DPX(40));
 
-    style_init_reset(&styles->pad_small);
+    lv_style_reset(&styles->pad_small);
     lv_style_int_t pad_small_value = lv_disp_get_size_category(NULL) <= LV_DISP_SIZE_MEDIUM ? LV_DPX(10) : LV_DPX(20);
     lv_style_set_pad_left(&styles->pad_small, LV_STATE_DEFAULT,  pad_small_value);
     lv_style_set_pad_right(&styles->pad_small, LV_STATE_DEFAULT, pad_small_value);
@@ -347,7 +344,7 @@ static void label_init(void)
 static void bar_init(void)
 {
 #if LV_USE_BAR
-    style_init_reset(&styles->bar_bg);
+    lv_style_reset(&styles->bar_bg);
     lv_style_set_radius(&styles->bar_bg, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
     lv_style_set_bg_opa(&styles->bar_bg, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->bar_bg, LV_STATE_DEFAULT, COLOR_BG_SEC);
@@ -360,7 +357,7 @@ static void bar_init(void)
     lv_style_set_transition_time(&styles->bar_bg, LV_STATE_DEFAULT, TRANSITION_TIME);
     lv_style_set_transition_prop_6(&styles->bar_bg, LV_STATE_DEFAULT, LV_STYLE_OUTLINE_OPA);
 
-    style_init_reset(&styles->bar_indic);
+    lv_style_reset(&styles->bar_indic);
     lv_style_set_bg_opa(&styles->bar_indic, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_radius(&styles->bar_indic, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
     lv_style_set_bg_color(&styles->bar_indic, LV_STATE_DEFAULT, theme.color_primary);
@@ -386,7 +383,7 @@ static void line_init(void)
 static void led_init(void)
 {
 #if LV_USE_LED != 0
-    style_init_reset(&styles->led);
+    lv_style_reset(&styles->led);
     lv_style_set_bg_opa(&styles->led, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->led, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_border_width(&styles->led, LV_STATE_DEFAULT, 2);
@@ -402,7 +399,7 @@ static void led_init(void)
 static void slider_init(void)
 {
 #if LV_USE_SLIDER != 0
-    style_init_reset(&styles->slider_knob);
+    lv_style_reset(&styles->slider_knob);
     lv_style_set_bg_opa(&styles->slider_knob, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->slider_knob, LV_STATE_DEFAULT, IS_LIGHT ? theme.color_primary : LV_COLOR_WHITE);
     lv_style_set_value_color(&styles->slider_knob, LV_STATE_DEFAULT, IS_LIGHT ? lv_color_hex(0x31404f) : LV_COLOR_WHITE);
@@ -412,7 +409,7 @@ static void slider_init(void)
     lv_style_set_pad_top(&styles->slider_knob, LV_STATE_DEFAULT, LV_DPX(7));
     lv_style_set_pad_bottom(&styles->slider_knob, LV_STATE_DEFAULT, LV_DPX(7));
 
-    style_init_reset(&styles->slider_bg);
+    lv_style_reset(&styles->slider_bg);
     lv_style_set_margin_left(&styles->slider_bg, LV_STATE_DEFAULT, LV_DPX(10));
     lv_style_set_margin_right(&styles->slider_bg, LV_STATE_DEFAULT, LV_DPX(10));
     lv_style_set_margin_top(&styles->slider_bg, LV_STATE_DEFAULT, LV_DPX(10));
@@ -424,7 +421,7 @@ static void slider_init(void)
 static void switch_init(void)
 {
 #if LV_USE_SWITCH != 0
-    style_init_reset(&styles->sw_knob);
+    lv_style_reset(&styles->sw_knob);
     lv_style_set_bg_opa(&styles->sw_knob, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->sw_knob, LV_STATE_DEFAULT, LV_COLOR_WHITE);
     lv_style_set_radius(&styles->sw_knob, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
@@ -438,7 +435,7 @@ static void switch_init(void)
 static void linemeter_init(void)
 {
 #if LV_USE_LINEMETER != 0
-    style_init_reset(&styles->lmeter);
+    lv_style_reset(&styles->lmeter);
     lv_style_set_radius(&styles->lmeter, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
     lv_style_set_pad_left(&styles->lmeter, LV_STATE_DEFAULT, LV_DPX(20));
     lv_style_set_pad_right(&styles->lmeter, LV_STATE_DEFAULT, LV_DPX(20));
@@ -457,7 +454,7 @@ static void linemeter_init(void)
 static void gauge_init(void)
 {
 #if LV_USE_GAUGE != 0
-    style_init_reset(&styles->gauge_main);
+    lv_style_reset(&styles->gauge_main);
     lv_style_set_line_color(&styles->gauge_main, LV_STATE_DEFAULT, lv_color_hex3(0x888));
     lv_style_set_scale_grad_color(&styles->gauge_main, LV_STATE_DEFAULT, lv_color_hex3(0x888));
     lv_style_set_scale_end_color(&styles->gauge_main, LV_STATE_DEFAULT, theme.color_primary);
@@ -471,7 +468,7 @@ static void gauge_init(void)
     lv_style_set_scale_width(&styles->gauge_main, LV_STATE_DEFAULT, LV_DPX(15));
     lv_style_set_radius(&styles->gauge_main, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->gauge_strong);
+    lv_style_reset(&styles->gauge_strong);
     lv_style_set_line_color(&styles->gauge_strong, LV_STATE_DEFAULT, lv_color_hex3(0x888));
     lv_style_set_scale_grad_color(&styles->gauge_strong, LV_STATE_DEFAULT, lv_color_hex3(0x888));
     lv_style_set_scale_end_color(&styles->gauge_strong, LV_STATE_DEFAULT, theme.color_primary);
@@ -479,7 +476,7 @@ static void gauge_init(void)
     lv_style_set_scale_end_line_width(&styles->gauge_strong, LV_STATE_DEFAULT, LV_DPX(8));
     lv_style_set_scale_width(&styles->gauge_strong, LV_STATE_DEFAULT, LV_DPX(25));
 
-    style_init_reset(&styles->gauge_needle);
+    lv_style_reset(&styles->gauge_needle);
     lv_style_set_line_color(&styles->gauge_needle, LV_STATE_DEFAULT, IS_LIGHT ? lv_color_hex(0x464b5b) : LV_COLOR_WHITE);
     lv_style_set_line_width(&styles->gauge_needle, LV_STATE_DEFAULT, LV_DPX(8));
     lv_style_set_bg_opa(&styles->gauge_needle, LV_STATE_DEFAULT, LV_OPA_COVER);
@@ -493,17 +490,17 @@ static void gauge_init(void)
 static void arc_init(void)
 {
 #if LV_USE_ARC != 0
-    style_init_reset(&styles->arc_indic);
+    lv_style_reset(&styles->arc_indic);
     lv_style_set_line_color(&styles->arc_indic, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_line_width(&styles->arc_indic, LV_STATE_DEFAULT, LV_DPX(25));
     lv_style_set_line_rounded(&styles->arc_indic, LV_STATE_DEFAULT, true);
 
-    style_init_reset(&styles->arc_bg);
+    lv_style_reset(&styles->arc_bg);
     lv_style_set_line_color(&styles->arc_bg, LV_STATE_DEFAULT, COLOR_BG_SEC);
     lv_style_set_line_width(&styles->arc_bg, LV_STATE_DEFAULT, LV_DPX(25));
     lv_style_set_line_rounded(&styles->arc_bg, LV_STATE_DEFAULT, true);
 
-    style_init_reset(&styles->arc_knob);
+    lv_style_reset(&styles->arc_knob);
     lv_style_set_radius(&styles->arc_knob, LV_STATE_DEFAULT,   LV_RADIUS_CIRCLE);
     lv_style_set_pad_top(&styles->arc_knob, LV_STATE_DEFAULT,  LV_DPX(0));
     lv_style_set_pad_bottom(&styles->arc_knob, LV_STATE_DEFAULT,  LV_DPX(0));
@@ -522,16 +519,16 @@ static void spinner_init(void)
 static void chart_init(void)
 {
 #if LV_USE_CHART
-    style_init_reset(&styles->chart_bg);
+    lv_style_reset(&styles->chart_bg);
     lv_style_set_text_color(&styles->chart_bg, LV_STATE_DEFAULT, IS_LIGHT ? COLOR_BG_TEXT_DIS : lv_color_hex(0xa1adbd));
 
-    style_init_reset(&styles->chart_series_bg);
+    lv_style_reset(&styles->chart_series_bg);
     lv_style_set_line_width(&styles->chart_series_bg, LV_STATE_DEFAULT, LV_DPX(1));
     lv_style_set_line_dash_width(&styles->chart_series_bg, LV_STATE_DEFAULT, LV_DPX(10));
     lv_style_set_line_dash_gap(&styles->chart_series_bg, LV_STATE_DEFAULT, LV_DPX(10));
     lv_style_set_line_color(&styles->chart_series_bg, LV_STATE_DEFAULT, COLOR_BG_BORDER);
 
-    style_init_reset(&styles->chart_series);
+    lv_style_reset(&styles->chart_series);
     lv_style_set_line_width(&styles->chart_series, LV_STATE_DEFAULT, LV_DPX(3));
     lv_style_set_size(&styles->chart_series, LV_STATE_DEFAULT, LV_DPX(4));
     lv_style_set_pad_inner(&styles->chart_series, LV_STATE_DEFAULT, LV_DPX(2));     /*Space between columns*/
@@ -544,7 +541,7 @@ static void calendar_init(void)
 {
 #if LV_USE_CALENDAR
 
-    style_init_reset(&styles->calendar_header);
+    lv_style_reset(&styles->calendar_header);
     lv_style_set_pad_top(&styles->calendar_header, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_left(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_right(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
@@ -553,14 +550,14 @@ static void calendar_init(void)
     lv_style_set_margin_bottom(&styles->calendar_header, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_text_color(&styles->calendar_header, LV_STATE_PRESSED, IS_LIGHT ? lv_color_hex(0x888888) : LV_COLOR_WHITE);
 
-    style_init_reset(&styles->calendar_daynames);
+    lv_style_reset(&styles->calendar_daynames);
     lv_style_set_text_color(&styles->calendar_daynames, LV_STATE_DEFAULT,
                             IS_LIGHT ? lv_color_hex(0x31404f) : lv_color_hex3(0xeee));
     lv_style_set_pad_left(&styles->calendar_daynames, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_right(&styles->calendar_daynames, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_bottom(&styles->calendar_daynames, LV_STATE_DEFAULT, PAD_DEF);
 
-    style_init_reset(&styles->calendar_date_nums);
+    lv_style_reset(&styles->calendar_date_nums);
     lv_style_set_radius(&styles->calendar_date_nums, LV_STATE_DEFAULT, LV_DPX(4));
     lv_style_set_text_color(&styles->calendar_date_nums, LV_STATE_CHECKED,
                             IS_LIGHT ? lv_color_hex(0x31404f) : LV_COLOR_WHITE);
@@ -586,14 +583,14 @@ static void calendar_init(void)
 static void cpicker_init(void)
 {
 #if LV_USE_CPICKER
-    style_init_reset(&styles->cpicker_bg);
+    lv_style_reset(&styles->cpicker_bg);
     lv_style_set_scale_width(&styles->cpicker_bg, LV_STATE_DEFAULT, LV_DPX(30));
     lv_style_set_bg_opa(&styles->cpicker_bg, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->cpicker_bg, LV_STATE_DEFAULT, COLOR_SCR);
     lv_style_set_pad_inner(&styles->cpicker_bg, LV_STATE_DEFAULT, LV_DPX(20));
     lv_style_set_radius(&styles->cpicker_bg, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->cpicker_indic);
+    lv_style_reset(&styles->cpicker_indic);
     lv_style_set_radius(&styles->cpicker_indic, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
     lv_style_set_bg_color(&styles->cpicker_indic, LV_STATE_DEFAULT, LV_COLOR_WHITE);
     lv_style_set_bg_opa(&styles->cpicker_indic, LV_STATE_DEFAULT, LV_OPA_COVER);
@@ -611,7 +608,7 @@ static void cpicker_init(void)
 static void checkbox_init(void)
 {
 #if LV_USE_CHECKBOX != 0
-    style_init_reset(&styles->cb_bg);
+    lv_style_reset(&styles->cb_bg);
     lv_style_set_radius(&styles->cb_bg, LV_STATE_DEFAULT, LV_DPX(4));
     lv_style_set_pad_inner(&styles->cb_bg, LV_STATE_DEFAULT, LV_DPX(10));
     lv_style_set_outline_color(&styles->cb_bg, LV_STATE_DEFAULT, theme.color_primary);
@@ -622,7 +619,7 @@ static void checkbox_init(void)
     lv_style_set_transition_time(&styles->cb_bg, LV_STATE_DEFAULT, TRANSITION_TIME);
     lv_style_set_transition_prop_6(&styles->cb_bg, LV_STATE_DEFAULT, LV_STYLE_OUTLINE_OPA);
 
-    style_init_reset(&styles->cb_bullet);
+    lv_style_reset(&styles->cb_bullet);
     lv_style_set_outline_opa(&styles->cb_bullet, LV_STATE_FOCUSED, LV_OPA_TRANSP);
     lv_style_set_radius(&styles->cb_bullet, LV_STATE_DEFAULT, LV_DPX(4));
     lv_style_set_pattern_image(&styles->cb_bullet, LV_STATE_CHECKED, LV_SYMBOL_OK);
@@ -645,7 +642,7 @@ static void btnmatrix_init(void)
 static void keyboard_init(void)
 {
 #if LV_USE_KEYBOARD
-    style_init_reset(&styles->kb_bg);
+    lv_style_reset(&styles->kb_bg);
     lv_style_set_radius(&styles->kb_bg, LV_STATE_DEFAULT, 0);
     lv_style_set_border_width(&styles->kb_bg, LV_STATE_DEFAULT, LV_DPX(4));
     lv_style_set_border_side(&styles->kb_bg, LV_STATE_DEFAULT, LV_BORDER_SIDE_TOP);
@@ -662,7 +659,7 @@ static void keyboard_init(void)
 static void msgbox_init(void)
 {
 #if LV_USE_MSGBOX
-    style_init_reset(&styles->mbox_bg);
+    lv_style_reset(&styles->mbox_bg);
     lv_style_set_shadow_width(&styles->mbox_bg, LV_STATE_DEFAULT, LV_DPX(50));
     lv_style_set_shadow_color(&styles->mbox_bg, LV_STATE_DEFAULT, IS_LIGHT ? LV_COLOR_SILVER : lv_color_hex3(0x999));
 
@@ -672,7 +669,7 @@ static void msgbox_init(void)
 static void page_init(void)
 {
 #if LV_USE_PAGE
-    style_init_reset(&styles->sb);
+    lv_style_reset(&styles->sb);
     lv_style_set_bg_opa(&styles->sb, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->sb, LV_STATE_DEFAULT, (IS_LIGHT ? lv_color_hex(0xcccfd1) : lv_color_hex(0x777f85)));
     lv_style_set_radius(&styles->sb, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
@@ -681,7 +678,7 @@ static void page_init(void)
     lv_style_set_pad_bottom(&styles->sb, LV_STATE_DEFAULT,  LV_DPX(7));
 
 #if LV_USE_ANIMATION
-    style_init_reset(&styles->edge_flash);
+    lv_style_reset(&styles->edge_flash);
     lv_style_set_bg_opa(&styles->edge_flash, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->edge_flash, LV_STATE_DEFAULT,  lv_color_hex3(0x888));
 #endif
@@ -691,13 +688,13 @@ static void page_init(void)
 static void textarea_init(void)
 {
 #if LV_USE_TEXTAREA
-    style_init_reset(&styles->ta_cursor);
+    lv_style_reset(&styles->ta_cursor);
     lv_style_set_border_color(&styles->ta_cursor, LV_STATE_DEFAULT, COLOR_BG_SEC_TEXT);
     lv_style_set_border_width(&styles->ta_cursor, LV_STATE_DEFAULT, LV_DPX(2));
     lv_style_set_pad_left(&styles->ta_cursor, LV_STATE_DEFAULT, LV_DPX(1));
     lv_style_set_border_side(&styles->ta_cursor, LV_STATE_DEFAULT, LV_BORDER_SIDE_LEFT);
 
-    style_init_reset(&styles->ta_placeholder);
+    lv_style_reset(&styles->ta_placeholder);
     lv_style_set_text_color(&styles->ta_placeholder, LV_STATE_DEFAULT,
                             IS_LIGHT ? COLOR_BG_TEXT_DIS : lv_color_hex(0xa1adbd));
 #endif
@@ -707,7 +704,7 @@ static void spinbox_init(void)
 {
 #if LV_USE_SPINBOX
 
-    style_init_reset(&styles->spinbox_cursor);
+    lv_style_reset(&styles->spinbox_cursor);
     lv_style_set_bg_opa(&styles->spinbox_cursor, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->spinbox_cursor, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_text_color(&styles->spinbox_cursor, LV_STATE_DEFAULT, LV_COLOR_WHITE);
@@ -720,7 +717,7 @@ static void spinbox_init(void)
 static void list_init(void)
 {
 #if LV_USE_LIST != 0
-    style_init_reset(&styles->list_bg);
+    lv_style_reset(&styles->list_bg);
     lv_style_set_clip_corner(&styles->list_bg, LV_STATE_DEFAULT, true);
     lv_style_set_pad_left(&styles->list_bg, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_right(&styles->list_bg, LV_STATE_DEFAULT, 0);
@@ -728,7 +725,7 @@ static void list_init(void)
     lv_style_set_pad_bottom(&styles->list_bg, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_inner(&styles->list_bg, LV_STATE_DEFAULT, 0);
 
-    style_init_reset(&styles->list_btn);
+    lv_style_reset(&styles->list_btn);
     lv_style_set_bg_opa(&styles->list_btn, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->list_btn, LV_STATE_DEFAULT, COLOR_BG);
     lv_style_set_bg_color(&styles->list_btn, LV_STATE_PRESSED, COLOR_BG_PR);
@@ -775,11 +772,11 @@ static void ddlist_init(void)
 {
 #if LV_USE_DROPDOWN != 0
 
-    style_init_reset(&styles->ddlist_page);
+    lv_style_reset(&styles->ddlist_page);
     lv_style_set_text_line_space(&styles->ddlist_page, LV_STATE_DEFAULT, LV_DPX(20));
     lv_style_set_clip_corner(&styles->ddlist_page, LV_STATE_DEFAULT, true);
 
-    style_init_reset(&styles->ddlist_sel);
+    lv_style_reset(&styles->ddlist_sel);
     lv_style_set_bg_opa(&styles->ddlist_sel, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->ddlist_sel, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_text_color(&styles->ddlist_sel, LV_STATE_DEFAULT, IS_LIGHT ? lv_color_hex3(0xfff) : lv_color_hex3(0xfff));
@@ -791,10 +788,10 @@ static void ddlist_init(void)
 static void roller_init(void)
 {
 #if LV_USE_ROLLER != 0
-    style_init_reset(&styles->roller_bg);
+    lv_style_reset(&styles->roller_bg);
     lv_style_set_text_line_space(&styles->roller_bg, LV_STATE_DEFAULT, LV_DPX(25));
 
-    style_init_reset(&styles->roller_sel);
+    lv_style_reset(&styles->roller_sel);
     lv_style_set_bg_opa(&styles->roller_sel, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->roller_sel, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_text_color(&styles->roller_sel, LV_STATE_DEFAULT, LV_COLOR_WHITE);
@@ -816,7 +813,7 @@ static void tileview_init(void)
 static void table_init(void)
 {
 #if LV_USE_TABLE != 0
-    style_init_reset(&styles->table_cell);
+    lv_style_reset(&styles->table_cell);
     lv_style_set_border_color(&styles->table_cell, LV_STATE_DEFAULT, COLOR_BG_BORDER);
     lv_style_set_border_width(&styles->table_cell, LV_STATE_DEFAULT, 1);
     lv_style_set_border_side(&styles->table_cell, LV_STATE_DEFAULT, LV_BORDER_SIDE_TOP | LV_BORDER_SIDE_BOTTOM);
@@ -837,7 +834,7 @@ static void win_init(void)
 static void tabview_win_shared_init(void)
 {
 #if LV_USE_TABVIEW || LV_USE_WIN
-    style_init_reset(&styles->tabview_btns_bg);
+    lv_style_reset(&styles->tabview_btns_bg);
     lv_style_set_bg_opa(&styles->tabview_btns_bg, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->tabview_btns_bg, LV_STATE_DEFAULT, COLOR_BG);
     lv_style_set_text_color(&styles->tabview_btns_bg, LV_STATE_DEFAULT, COLOR_SCR_TEXT);
@@ -846,7 +843,7 @@ static void tabview_win_shared_init(void)
     lv_style_set_pad_left(&styles->tabview_btns_bg, LV_STATE_DEFAULT, LV_DPX(7));
     lv_style_set_pad_right(&styles->tabview_btns_bg, LV_STATE_DEFAULT, LV_DPX(7));
 
-    style_init_reset(&styles->tabview_btns);
+    lv_style_reset(&styles->tabview_btns);
     lv_style_set_bg_opa(&styles->tabview_btns, LV_STATE_PRESSED, LV_OPA_50);
     lv_style_set_bg_color(&styles->tabview_btns, LV_STATE_PRESSED, lv_color_hex3(0x888));
     lv_style_set_text_color(&styles->tabview_btns, LV_STATE_CHECKED, COLOR_SCR_TEXT);
@@ -855,14 +852,14 @@ static void tabview_win_shared_init(void)
     lv_style_set_text_color(&styles->tabview_btns, LV_STATE_FOCUSED, theme.color_primary);
     lv_style_set_text_color(&styles->tabview_btns, LV_STATE_EDITED, theme.color_secondary);
 
-    style_init_reset(&styles->tabview_indic);
+    lv_style_reset(&styles->tabview_indic);
     lv_style_set_bg_opa(&styles->tabview_indic, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->tabview_indic, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_bg_color(&styles->tabview_indic, LV_STATE_EDITED, theme.color_secondary);
     lv_style_set_size(&styles->tabview_indic, LV_STATE_DEFAULT, LV_DPX(5));
     lv_style_set_radius(&styles->tabview_indic, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->tabview_page_scrl);
+    lv_style_reset(&styles->tabview_page_scrl);
     lv_style_set_pad_top(&styles->tabview_page_scrl, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_bottom(&styles->tabview_page_scrl, LV_STATE_DEFAULT, PAD_DEF);
     lv_style_set_pad_left(&styles->tabview_page_scrl, LV_STATE_DEFAULT, PAD_DEF);
@@ -894,9 +891,11 @@ lv_theme_t * lv_theme_material_init(lv_color_t color_primary, lv_color_t color_s
     /* This trick is required only to avoid the garbage collection of
      * styles' data if LVGL is used in a binding (e.g. Micropython)
      * In a general case styles could be simple `static lv_style_t my style` variables*/
-    if(!inited) {
-        LV_GC_ROOT(_lv_theme_material_styles) = lv_mem_alloc(sizeof(theme_styles_t));
-        styles = (theme_styles_t *)LV_GC_ROOT(_lv_theme_material_styles);
+    if(styles == NULL) {
+        styles = lv_mem_alloc(sizeof(theme_styles_t));
+        if (styles == NULL) return NULL;
+        _lv_memset_00(styles, sizeof(theme_styles_t));
+        LV_GC_ROOT(_lv_theme_material_styles) = styles;
     }
 
     theme.color_primary = color_primary;
@@ -943,12 +942,14 @@ lv_theme_t * lv_theme_material_init(lv_color_t color_primary, lv_color_t color_s
     theme.apply_xcb = NULL;
     theme.apply_cb = theme_apply;
 
-    inited = true;
-
     lv_obj_report_style_mod(NULL);
 
     return &theme;
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
 
 static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 {
@@ -1374,16 +1375,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
     }
 
     lv_obj_refresh_style(obj, LV_OBJ_PART_ALL, LV_STYLE_PROP_ALL);
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static void style_init_reset(lv_style_t * style)
-{
-    if(inited) lv_style_reset(style);
-    else lv_style_init(style);
 }
 
 #endif

--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -81,16 +81,12 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name);
-static void style_init_reset(lv_style_t * style);
 
 /**********************
  *  STATIC VARIABLES
  **********************/
 static lv_theme_t theme;
-
 static theme_styles_t * styles;
-
-static bool inited;
 
 /**********************
  *      MACROS
@@ -107,7 +103,7 @@ static bool inited;
 
 static void basic_init(void)
 {
-    style_init_reset(&styles->scr);
+    lv_style_reset(&styles->scr);
     lv_style_set_bg_opa(&styles->scr, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->scr, LV_STATE_DEFAULT, BG_COLOR);
     lv_style_set_text_color(&styles->scr, LV_STATE_DEFAULT, FG_COLOR);
@@ -115,7 +111,7 @@ static void basic_init(void)
     lv_style_set_text_sel_bg_color(&styles->scr, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_value_color(&styles->scr, LV_STATE_DEFAULT, FG_COLOR);
 
-    style_init_reset(&styles->bg);
+    lv_style_reset(&styles->bg);
     lv_style_set_border_post(&styles->bg, LV_STATE_DEFAULT, true);
     lv_style_set_radius(&styles->bg, LV_STATE_DEFAULT, RADIUS);
     lv_style_set_bg_opa(&styles->bg, LV_STATE_DEFAULT, LV_OPA_COVER);
@@ -137,10 +133,10 @@ static void basic_init(void)
     lv_style_set_pad_bottom(&styles->bg, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_inner(&styles->bg, LV_STATE_DEFAULT, LV_DPI / 10);
 
-    style_init_reset(&styles->clip_corner);
+    lv_style_reset(&styles->clip_corner);
     lv_style_set_clip_corner(&styles->clip_corner, LV_STATE_DEFAULT, true);
 
-    style_init_reset(&styles->btn);
+    lv_style_reset(&styles->btn);
     lv_style_set_radius(&styles->btn, LV_STATE_DEFAULT, RADIUS);
     lv_style_set_border_width(&styles->btn, LV_STATE_DEFAULT, BORDER_WIDTH);
     lv_style_set_border_width(&styles->btn, LV_STATE_FOCUSED, BORDER_WIDTH + 1);
@@ -163,60 +159,60 @@ static void basic_init(void)
     lv_style_set_image_recolor(&styles->btn, LV_STATE_CHECKED, BG_COLOR);
     lv_style_set_image_recolor(&styles->btn, LV_STATE_CHECKED | LV_STATE_PRESSED, FG_COLOR);
 
-    style_init_reset(&styles->round);
+    lv_style_reset(&styles->round);
     lv_style_set_radius(&styles->round, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->no_radius);
+    lv_style_reset(&styles->no_radius);
     lv_style_set_radius(&styles->no_radius, LV_STATE_DEFAULT, 0);
 
-    style_init_reset(&styles->border_none);
+    lv_style_reset(&styles->border_none);
     lv_style_set_border_width(&styles->border_none, LV_STATE_DEFAULT, 0);
 
-    style_init_reset(&styles->fg_color);
+    lv_style_reset(&styles->fg_color);
     lv_style_set_bg_color(&styles->fg_color, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_text_color(&styles->fg_color, LV_STATE_DEFAULT, BG_COLOR);
     lv_style_set_image_recolor(&styles->fg_color, LV_STATE_DEFAULT, BG_COLOR);
     lv_style_set_line_color(&styles->fg_color, LV_STATE_DEFAULT, FG_COLOR);
 
-    style_init_reset(&styles->big_line_space);
+    lv_style_reset(&styles->big_line_space);
     lv_style_set_text_line_space(&styles->big_line_space, LV_STATE_DEFAULT, LV_DPI / 10);
 
-    style_init_reset(&styles->pad_none);
+    lv_style_reset(&styles->pad_none);
     lv_style_set_pad_left(&styles->pad_none, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_right(&styles->pad_none, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_top(&styles->pad_none, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_bottom(&styles->pad_none, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_inner(&styles->pad_none, LV_STATE_DEFAULT, 0);
 
-    style_init_reset(&styles->pad_normal);
+    lv_style_reset(&styles->pad_normal);
     lv_style_set_pad_left(&styles->pad_normal, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_right(&styles->pad_normal, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_top(&styles->pad_normal, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_bottom(&styles->pad_normal, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_inner(&styles->pad_normal, LV_STATE_DEFAULT, LV_DPI / 10);
 
-    style_init_reset(&styles->pad_small);
+    lv_style_reset(&styles->pad_small);
     lv_style_set_pad_left(&styles->pad_small, LV_STATE_DEFAULT, LV_DPI / 20);
     lv_style_set_pad_right(&styles->pad_small, LV_STATE_DEFAULT, LV_DPI / 20);
     lv_style_set_pad_top(&styles->pad_small, LV_STATE_DEFAULT, LV_DPI / 20);
     lv_style_set_pad_bottom(&styles->pad_small, LV_STATE_DEFAULT, LV_DPI / 20);
     lv_style_set_pad_inner(&styles->pad_small, LV_STATE_DEFAULT, LV_DPI / 20);
 
-    style_init_reset(&styles->pad_inner);
+    lv_style_reset(&styles->pad_inner);
     lv_style_set_pad_inner(&styles->pad_inner, LV_STATE_DEFAULT, LV_DPI / 15);
 
-    style_init_reset(&styles->txt_underline);
+    lv_style_reset(&styles->txt_underline);
     lv_style_set_text_decor(&styles->txt_underline, LV_STATE_FOCUSED, LV_TEXT_DECOR_UNDERLINE);
 }
 
 static void arc_init(void)
 {
 #if LV_USE_ARC != 0
-    style_init_reset(&styles->arc_bg);
+    lv_style_reset(&styles->arc_bg);
     lv_style_set_line_width(&styles->arc_bg, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 100, 1));
     lv_style_set_line_color(&styles->arc_bg, LV_STATE_DEFAULT, FG_COLOR);
 
-    style_init_reset(&styles->arc_indic);
+    lv_style_reset(&styles->arc_indic);
     lv_style_set_line_width(&styles->arc_indic, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 10, 3));
     lv_style_set_line_color(&styles->arc_indic, LV_STATE_DEFAULT, FG_COLOR);
 #endif
@@ -246,7 +242,7 @@ static void btnmatrix_init(void)
 static void calendar_init(void)
 {
 #if LV_USE_CALENDAR
-    style_init_reset(&styles->calendar_date);
+    lv_style_reset(&styles->calendar_date);
     lv_style_set_value_str(&styles->calendar_date, LV_STATE_CHECKED, LV_SYMBOL_BULLET);
     lv_style_set_value_font(&styles->calendar_date, LV_STATE_CHECKED, LV_THEME_DEFAULT_FONT_TITLE);
     lv_style_set_value_align(&styles->calendar_date, LV_STATE_CHECKED, LV_ALIGN_IN_TOP_RIGHT);
@@ -267,7 +263,7 @@ static void calendar_init(void)
 static void chart_init(void)
 {
 #if LV_USE_CHART
-    style_init_reset(&styles->chart_series);
+    lv_style_reset(&styles->chart_series);
     lv_style_set_size(&styles->chart_series, LV_STATE_DEFAULT, 0);
     lv_style_set_bg_opa(&styles->chart_series, LV_STATE_DEFAULT, LV_OPA_TRANSP);
     lv_style_set_line_width(&styles->chart_series, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 50, 1));
@@ -299,7 +295,7 @@ static void cont_init(void)
 static void gauge_init(void)
 {
 #if LV_USE_GAUGE != 0
-    style_init_reset(&styles->gauge_needle);
+    lv_style_reset(&styles->gauge_needle);
     lv_style_set_line_width(&styles->gauge_needle, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 30, 2));
     lv_style_set_line_color(&styles->gauge_needle, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_size(&styles->gauge_needle, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 10, 4));
@@ -307,7 +303,7 @@ static void gauge_init(void)
     lv_style_set_bg_color(&styles->gauge_needle, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_radius(&styles->gauge_needle, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->gauge_major);
+    lv_style_reset(&styles->gauge_major);
     lv_style_set_line_width(&styles->gauge_major, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 25, 2));
     lv_style_set_line_color(&styles->gauge_major, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_scale_end_color(&styles->gauge_major, LV_STATE_DEFAULT, FG_COLOR);
@@ -334,7 +330,7 @@ static void label_init(void)
 static void linemeter_init(void)
 {
 #if LV_USE_LINEMETER != 0
-    style_init_reset(&styles->linemeter);
+    lv_style_reset(&styles->linemeter);
     lv_style_set_line_width(&styles->linemeter, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 25, 2));
     lv_style_set_scale_end_line_width(&styles->linemeter, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 70, 1));
 #endif
@@ -371,7 +367,7 @@ static void slider_init(void)
 static void switch_init(void)
 {
 #if LV_USE_SWITCH != 0
-    style_init_reset(&styles->sb);
+    lv_style_reset(&styles->sb);
     lv_style_set_bg_opa(&styles->sb, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_bg_color(&styles->sb, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_radius(&styles->sb, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
@@ -412,7 +408,7 @@ static void msgbox_init(void)
 static void textarea_init(void)
 {
 #if LV_USE_TEXTAREA
-    style_init_reset(&styles->ta_cursor);
+    lv_style_reset(&styles->ta_cursor);
     lv_style_set_bg_opa(&styles->ta_cursor, LV_STATE_DEFAULT, LV_OPA_TRANSP);
     lv_style_set_border_width(&styles->ta_cursor, LV_STATE_DEFAULT, LV_MATH_MAX(LV_DPI / 100, 1));
     lv_style_set_border_side(&styles->ta_cursor, LV_STATE_DEFAULT, LV_BORDER_SIDE_LEFT);
@@ -424,7 +420,7 @@ static void textarea_init(void)
 static void list_init(void)
 {
 #if LV_USE_LIST != 0
-    style_init_reset(&styles->list_btn);
+    lv_style_reset(&styles->list_btn);
     lv_style_set_bg_opa(&styles->list_btn, LV_STATE_DEFAULT, LV_OPA_TRANSP);
     lv_style_set_bg_opa(&styles->list_btn, LV_STATE_PRESSED, LV_OPA_COVER);
     lv_style_set_bg_opa(&styles->list_btn, LV_STATE_CHECKED, LV_OPA_COVER);
@@ -450,7 +446,7 @@ static void roller_init(void)
 static void tabview_init(void)
 {
 #if LV_USE_TABVIEW != 0
-    style_init_reset(&styles->tab_bg);
+    lv_style_reset(&styles->tab_bg);
     lv_style_set_border_width(&styles->tab_bg, LV_STATE_DEFAULT, BORDER_WIDTH);
     lv_style_set_border_color(&styles->tab_bg, LV_STATE_DEFAULT, FG_COLOR);
     lv_style_set_border_side(&styles->tab_bg, LV_STATE_DEFAULT, LV_BORDER_SIDE_BOTTOM);
@@ -501,9 +497,11 @@ lv_theme_t * lv_theme_mono_init(lv_color_t color_primary, lv_color_t color_secon
     /* This trick is required only to avoid the garbage collection of
      * styles' data if LVGL is used in a binding (e.g. Micropython)
      * In a general case styles could be simple `static lv_style_t my style` variables*/
-    if(!inited) {
-        LV_GC_ROOT(_lv_theme_mono_styles) = lv_mem_alloc(sizeof(theme_styles_t));
-        styles = (theme_styles_t *)LV_GC_ROOT(_lv_theme_mono_styles);
+    if(styles == NULL) {
+        styles = lv_mem_alloc(sizeof(theme_styles_t));
+        if (styles == NULL) return NULL;
+        _lv_memset_00(styles, sizeof(theme_styles_t));
+        LV_GC_ROOT(_lv_theme_mono_styles) = styles;
     }
 
     theme.color_primary = color_primary;
@@ -551,6 +549,10 @@ lv_theme_t * lv_theme_mono_init(lv_color_t color_primary, lv_color_t color_secon
 
     return &theme;
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
 
 static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 {
@@ -1002,16 +1004,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 
     lv_obj_refresh_style(obj, LV_OBJ_PART_ALL, LV_STYLE_PROP_ALL);
 
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static void style_init_reset(lv_style_t * style)
-{
-    if(inited) lv_style_reset(style);
-    else lv_style_init(style);
 }
 
 #endif

--- a/src/lv_themes/lv_theme_mono.h
+++ b/src/lv_themes/lv_theme_mono.h
@@ -53,4 +53,4 @@ lv_theme_t * lv_theme_mono_init(lv_color_t color_primary, lv_color_t color_secon
 } /* extern "C" */
 #endif
 
-#endif /*LV_THEME_TEMPLATE_H*/
+#endif /*LV_THEME_MONO_H*/

--- a/src/lv_themes/lv_theme_template.c
+++ b/src/lv_themes/lv_theme_template.c
@@ -42,8 +42,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name);
 static lv_theme_t theme;
 static theme_styles_t * styles;
 
-static bool inited;
-
 /**********************
  *      MACROS
  **********************/
@@ -51,11 +49,10 @@ static bool inited;
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-static void style_init_reset(lv_style_t * style);
 
 static void basic_init(void)
 {
-    style_init_reset(&styles->bg);
+    lv_style_reset(&styles->bg);
     lv_style_set_bg_opa(&styles->bg, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_style_set_border_width(&styles->bg, LV_STATE_DEFAULT, 1);
     lv_style_set_border_width(&styles->bg, LV_STATE_FOCUSED, 2);
@@ -71,7 +68,7 @@ static void basic_init(void)
     lv_style_set_pad_bottom(&styles->bg, LV_STATE_DEFAULT, LV_DPI / 10);
     lv_style_set_pad_inner(&styles->bg, LV_STATE_DEFAULT, LV_DPI / 10);
 
-    style_init_reset(&styles->btn);
+    lv_style_reset(&styles->btn);
     lv_style_set_bg_color(&styles->btn, LV_STATE_PRESSED, lv_color_hex3(0xccc));
     lv_style_set_bg_color(&styles->btn, LV_STATE_CHECKED, theme.color_primary);
     lv_style_set_bg_color(&styles->btn, LV_STATE_CHECKED | LV_STATE_PRESSED, lv_color_darken(theme.color_primary,
@@ -80,24 +77,24 @@ static void basic_init(void)
     lv_style_set_text_color(&styles->btn, LV_STATE_DISABLED, LV_COLOR_GRAY);
     lv_style_set_image_recolor(&styles->btn, LV_STATE_DISABLED, LV_COLOR_GRAY);
 
-    style_init_reset(&styles->round);
+    lv_style_reset(&styles->round);
     lv_style_set_radius(&styles->round, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
 
-    style_init_reset(&styles->color);
+    lv_style_reset(&styles->color);
     lv_style_set_bg_color(&styles->color, LV_STATE_DEFAULT, theme.color_primary);
     lv_style_set_line_color(&styles->color, LV_STATE_DEFAULT, theme.color_primary);
 
-    style_init_reset(&styles->gray);
+    lv_style_reset(&styles->gray);
     lv_style_set_bg_color(&styles->gray, LV_STATE_DEFAULT, LV_COLOR_SILVER);
     lv_style_set_line_color(&styles->gray, LV_STATE_DEFAULT, LV_COLOR_SILVER);
     lv_style_set_text_color(&styles->gray, LV_STATE_DEFAULT, LV_COLOR_GRAY);
 
-    style_init_reset(&styles->tick_line);
+    lv_style_reset(&styles->tick_line);
     lv_style_set_line_width(&styles->tick_line, LV_STATE_DEFAULT, 5);
     lv_style_set_scale_end_line_width(&styles->tick_line, LV_STATE_DEFAULT, 5);
     lv_style_set_scale_end_color(&styles->tick_line, LV_STATE_DEFAULT, theme.color_primary);
 
-    style_init_reset(&styles->tight);
+    lv_style_reset(&styles->tight);
     lv_style_set_pad_left(&styles->tight, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_right(&styles->tight, LV_STATE_DEFAULT, 0);
     lv_style_set_pad_top(&styles->tight, LV_STATE_DEFAULT, 0);
@@ -337,9 +334,11 @@ lv_theme_t * lv_theme_template_init(lv_color_t color_primary, lv_color_t color_s
     /* This trick is required only to avoid the garbage collection of
      * styles' data if LVGL is used in a binding (e.g. Micropython)
      * In a general case styles could be simple `static lv_style_t my style` variables or allocated directly into `styles`*/
-    if(!inited) {
-        LV_GC_ROOT(_lv_theme_template_styles) = lv_mem_alloc(sizeof(theme_styles_t));
-        styles = (theme_styles_t *)LV_GC_ROOT(_lv_theme_template_styles);
+    if(styles == NULL) {
+        styles = lv_mem_alloc(sizeof(theme_styles_t));
+        if (styles == NULL) return NULL;
+        _lv_memset_00(styles, sizeof(theme_styles_t));
+        LV_GC_ROOT(_lv_theme_template_styles) = styles;
     }
 
     theme.color_primary = color_primary;
@@ -388,7 +387,11 @@ lv_theme_t * lv_theme_template_init(lv_color_t color_primary, lv_color_t color_s
     return &theme;
 }
 
-void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 {
     LV_UNUSED(th);
 
@@ -830,16 +833,6 @@ void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
     }
 
     lv_obj_refresh_style(obj, LV_OBJ_PART_ALL, LV_STYLE_PROP_ALL);
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static void style_init_reset(lv_style_t * style)
-{
-    if(inited) lv_style_reset(style);
-    else lv_style_init(style);
 }
 
 #endif

--- a/src/lv_themes/lv_themes.mk
+++ b/src/lv_themes/lv_themes.mk
@@ -1,7 +1,8 @@
 CSRCS += lv_theme.c
+
+CSRCS += lv_theme_empty.c
 CSRCS += lv_theme_material.c
 CSRCS += lv_theme_mono.c
-CSRCS += lv_theme_empty.c
 CSRCS += lv_theme_template.c
 
 DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/lv_themes


### PR DESCRIPTION
### Description of the feature or fix

due to inited variable forget to set to 1.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
