### PR TITLE
Add cmake target to build static liblvgl.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,9 @@ zephyr_library_sources(${SOURCES})
 
 endif() # CONFIG_LVGL
 
-elseif(LIBLVGL_STATIC)
+else()
 
 file(GLOB_RECURSE SOURCES src/*.c)
 add_library(lvgl STATIC ${SOURCES})
 
-else()
-message(FATAL_ERROR "Unknown platform.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ zephyr_library_sources(${SOURCES})
 
 endif() # CONFIG_LVGL
 
+elseif(LIBLVGL_STATIC)
+
+file(GLOB_RECURSE SOURCES src/*.c)
+add_library(lvgl STATIC ${SOURCES})
+
 else()
 message(FATAL_ERROR "Unknown platform.")
 endif()


### PR DESCRIPTION
### Description of the feature or fix

It may be an arguable change, because from what I understand LVGL is assumed to be built from sources writing CMakeLists.txt (or Makefile) for each individual project. But on the other hand, it may be handy to have `liblvgl.a` and then link your application(s) with it without incorporating its sources directly into your project (since LVLG is a standalone library and does not depend on lv_examples, lv_drivers and so on).

```
cmake -DLIBLVGL_STATIC=TRUE -DCMAKE_C_FLAGS="-DLV_CONF_PATH=<path_to>/lv_conf.h" ..
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
