### PR TITLE
Cleanup LV_SIGNAL_GET_TYPE implementations

### DIFF
--- a/src/lv_widgets/lv_label.c
+++ b/src/lv_widgets/lv_label.c
@@ -1421,14 +1421,6 @@ static lv_res_t lv_label_signal(lv_obj_t * label, lv_signal_t sign, void * param
         if(ext->static_txt == 0) lv_label_set_text(label, NULL);
 #endif
     }
-    else if(sign == LV_SIGNAL_GET_TYPE) {
-        lv_obj_type_t * buf = param;
-        uint8_t i;
-        for(i = 0; i < LV_MAX_ANCESTOR_NUM - 1; i++) { /*Find the last set data*/
-            if(buf->type[i] == NULL) break;
-        }
-        buf->type[i] = "lv_label";
-    }
 
     return res;
 }

--- a/src/lv_widgets/lv_led.c
+++ b/src/lv_widgets/lv_led.c
@@ -237,14 +237,7 @@ static lv_res_t lv_led_signal(lv_obj_t * led, lv_signal_t sign, void * param)
     res = ancestor_signal(led, sign, param);
     if(res != LV_RES_OK) return res;
 
-    if(sign == LV_SIGNAL_GET_TYPE) {
-        lv_obj_type_t * buf = param;
-        uint8_t i;
-        for(i = 0; i < LV_MAX_ANCESTOR_NUM - 1; i++) { /*Find the last set data*/
-            if(buf->type[i] == NULL) break;
-        }
-        buf->type[i] = "lv_led";
-    }
+    if(sign == LV_SIGNAL_GET_TYPE) return lv_obj_handle_get_type_signal(param, LV_OBJX_NAME);
 
     return res;
 }

--- a/src/lv_widgets/lv_spinbox.c
+++ b/src/lv_widgets/lv_spinbox.c
@@ -399,14 +399,6 @@ static lv_res_t lv_spinbox_signal(lv_obj_t * spinbox, lv_signal_t sign, void * p
     if(sign == LV_SIGNAL_CLEANUP) {
         /*Nothing to cleanup. (No dynamically allocated memory in 'ext')*/
     }
-    else if(sign == LV_SIGNAL_GET_TYPE) {
-        lv_obj_type_t * buf = param;
-        uint8_t i;
-        for(i = 0; i < LV_MAX_ANCESTOR_NUM - 1; i++) { /*Find the last set data*/
-            if(buf->type[i] == NULL) break;
-        }
-        buf->type[i] = "lv_spinbox";
-    }
     else if(sign == LV_SIGNAL_RELEASED) {
         /*If released with an ENCODER then move to the next digit*/
         lv_spinbox_ext_t * ext = lv_obj_get_ext_attr(spinbox);


### PR DESCRIPTION
### Description of the feature or fix

Some widgets still had manual handlers for LV_SIGNAL_GET_TYPE.
In `lv_label` and `lv_spinbox` they were dead code because `lv_obj_handle_get_type_signal()` call already existed.
I cleaned them up so that only `lv_obj_handle_get_type_signal()` is used everywhere.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md -> I think this is minor enough that no point for changelog, no functional changes.
- [ ] Update the documentation -> No documentation changes needed.
