### PR TITLE
fix(indev): don't call memcpy in lv_indev_drv_update

### DIFF
--- a/src/lv_hal/lv_hal_indev.c
+++ b/src/lv_hal/lv_hal_indev.c
@@ -106,7 +106,7 @@ lv_indev_t * lv_indev_drv_register(lv_indev_drv_t * driver)
  */
 void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
 {
-    memcpy(&indev->driver, new_drv, sizeof(lv_indev_drv_t));
+    indev->driver = new_drv;
 }
 
 /**


### PR DESCRIPTION
### Description of the feature or fix

to avoid the heap overflow

### Checkpoints
- [X ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
