### PR TITLE
fix(gc): remove the inclusion of LV_GC_INCLUDE

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -10,10 +10,6 @@
 #include "lv_disp.h"
 #include "../misc/lv_gc.h"
 
-#if defined(LV_GC_INCLUDE)
-    #include LV_GC_INCLUDE
-#endif /*LV_ENABLE_GC*/
-
 /*********************
  *      DEFINES
  *********************/

--- a/src/extra/themes/basic/lv_theme_basic.c
+++ b/src/extra/themes/basic/lv_theme_basic.c
@@ -13,10 +13,6 @@
 #include "lv_theme_basic.h"
 #include "../../../misc/lv_gc.h"
 
-#if defined(LV_GC_INCLUDE)
-#include LV_GC_INCLUDE
-#endif /*LV_ENABLE_GC*/
-
 /*********************
  *      DEFINES
  *********************/

--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -13,10 +13,6 @@
 #include "lv_theme_default.h"
 #include "../../../misc/lv_gc.h"
 
-#if defined(LV_GC_INCLUDE)
-#include LV_GC_INCLUDE
-#endif /*LV_ENABLE_GC*/
-
 /*********************
  *      DEFINES
  *********************/


### PR DESCRIPTION
### Description of the feature or fix

Don't need anymore with patch:
```
commit d6ca15a74923f2e86ce1e4ee6ee83bb2bbc887b8
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Tue Jan 12 09:13:41 2021 -0600

    Move LV_GC_INCLUDE to the common place(gc.h)  (#2010)
    
    * Move LV_GC_INCLUDE to the common place(gc.h)
    
    to avoid the duplication in many source files
    
    * fix(theme template): Always initialize _lv_theme_material_styles
    
    just like what other theme do
```

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
