### PR TITLE
CMake: Allow building LVGL without kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ if(ESP_PLATFORM)
 file(GLOB_RECURSE SOURCES src/*.c)
 
 idf_component_register(SRCS ${SOURCES}
-                       INCLUDE_DIRS . src
+                       INCLUDE_DIRS . src ../
                        REQUIRES main)
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")

--- a/scripts/lv_conf_checker.py
+++ b/scripts/lv_conf_checker.py
@@ -28,10 +28,11 @@ fout.write(
 #include <stdint.h>
 
 /* Handle special Kconfig options */
-#include "lv_conf_kconfig.h"
-
-#ifdef CONFIG_LV_CONF_SKIP
-#define LV_CONF_SKIP
+#ifndef LV_KCONFIG_IGNORE
+#   include "lv_conf_kconfig.h"
+#   ifdef CONFIG_LV_CONF_SKIP
+#       define LV_CONF_SKIP
+#   endif
 #endif
 
 /* If "lv_conf.h" is available from here try to use it later.*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -11,10 +11,11 @@
 #include <stdint.h>
 
 /* Handle special Kconfig options */
-#include "lv_conf_kconfig.h"
-
-#ifdef CONFIG_LV_CONF_SKIP
-#define LV_CONF_SKIP
+#ifndef LV_KCONFIG_IGNORE
+#   include "lv_conf_kconfig.h"
+#   ifdef CONFIG_LV_CONF_SKIP
+#       define LV_CONF_SKIP
+#   endif
 #endif
 
 /* If "lv_conf.h" is available from here try to use it later.*/


### PR DESCRIPTION
Also add ../ to the search path, such that lv_conf.h could be found on parent directory

Related discussion: https://github.com/lvgl/lvgl/pull/1875#issuecomment-803179499

