### PR TITLE
Fix a compilation error and build warning

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -256,7 +256,7 @@ void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
     lv_timer_pause(disp->refr_timer, false);
 }
 
-void lv_obj_update_layout(lv_obj_t * obj)
+void lv_obj_update_layout(const lv_obj_t * obj)
 {
     static bool mutex = false;
     if(mutex) {

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -128,7 +128,7 @@ void lv_obj_mark_layout_as_dirty(struct _lv_obj_t * obj);
  * Update the layout of an object.
  * @param obj      pointer to an object whose children needs to be updated
  */
-void lv_obj_update_layout(struct _lv_obj_t * obj);
+void lv_obj_update_layout(const struct _lv_obj_t * obj);
 
 /**
  * Regsiter a new layout

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -882,7 +882,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #endif
 
 /*Pixel perfect monospace fonts
- *http://pelulamu.net/unscii/*/
+ *http://pelulamu.net/unscii/ */
 #ifndef LV_FONT_UNSCII_8
 #  ifdef CONFIG_LV_FONT_UNSCII_8
 #    define LV_FONT_UNSCII_8 CONFIG_LV_FONT_UNSCII_8


### PR DESCRIPTION
lv_obj_update_layout() gets called with a const*

the /* in the url in lv_conf_internal could be interpreted as a nested comment