### PR TITLE
fix(indev) provide raw old points to read_cb, not rotated points

### DIFF
--- a/src/lv_core/lv_indev.c
+++ b/src/lv_core/lv_indev.c
@@ -414,6 +414,10 @@ lv_task_t * lv_indev_get_read_task(lv_disp_t * indev)
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
     lv_disp_t * disp = i->driver.disp;
+    /*Save the raw points so they can be used again in _lv_indev_read*/
+    i->proc.types.pointer.last_raw_point.x = data->point.x;
+    i->proc.types.pointer.last_raw_point.y = data->point.y;
+    /*Rotate the points if necessary*/
     if(disp->driver.rotated == LV_DISP_ROT_180 || disp->driver.rotated == LV_DISP_ROT_270) {
         data->point.x = disp->driver.hor_res - data->point.x - 1;
         data->point.y = disp->driver.ver_res - data->point.y - 1;

--- a/src/lv_hal/lv_hal_indev.c
+++ b/src/lv_hal/lv_hal_indev.c
@@ -132,8 +132,8 @@ bool _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
     /* For touchpad sometimes users don't the last pressed coordinate on release.
      * So be sure a coordinates are initialized to the last point */
     if(indev->driver.type == LV_INDEV_TYPE_POINTER) {
-        data->point.x = indev->proc.types.pointer.act_point.x;
-        data->point.y = indev->proc.types.pointer.act_point.y;
+        data->point.x = indev->proc.types.pointer.last_raw_point.x;
+        data->point.y = indev->proc.types.pointer.last_raw_point.y;
     }
     /*Similarly set at least the last key in case of the user doesn't set it on release*/
     else if(indev->driver.type == LV_INDEV_TYPE_KEYPAD) {

--- a/src/lv_hal/lv_hal_indev.h
+++ b/src/lv_hal/lv_hal_indev.h
@@ -131,6 +131,7 @@ typedef struct _lv_indev_proc_t {
             /*Pointer and button data*/
             lv_point_t act_point; /**< Current point of input device. */
             lv_point_t last_point; /**< Last point of input device. */
+            lv_point_t last_raw_point; /**< Last point read from read_cb. */
             lv_point_t vect; /**< Difference between `act_point` and `last_point`. */
             lv_point_t drag_sum; /*Count the dragged pixels to check LV_INDEV_DEF_DRAG_LIMIT*/
             lv_point_t drag_throw_vect;


### PR DESCRIPTION
### Description of the feature or fix

As @fvanroie noted in #2046, my implementation of touch rotation was providing rotated points to the `read_cb` callback. For drivers which only set the points while the screen is pressed, this results in a cursor dancing effect.

This PR fixes that by storing the raw points which were provided and using those on the next call.

This will need to be cherrypicked to v8, but I have done the initial fix for v7 as that is the more stable version at the moment.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
