### PR TITLE
Separate section comment from declaration comment.

### DIFF
--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -34,6 +34,7 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
 /**
  * Options for text rendering.
  */


### PR DESCRIPTION
### Description of the feature or fix
To maintain uniformity of comment formatting, but primarily to
work around a deficiency in the rust library bindgen (0.58 and earlier),
comments should be separated by a newline.
A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
