### PR TITLE
lv_theme_mono: fix runtime error with spinner widget using mono theme

### DIFF
--- a/src/lv_themes/lv_theme_mono.c
+++ b/src/lv_themes/lv_theme_mono.c
@@ -687,13 +687,10 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj, lv_theme_style_t name)
 #if LV_USE_SPINNER
         case LV_THEME_SPINNER:
             list = lv_obj_get_style_list(obj, LV_SPINNER_PART_BG);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->tick_line);
+            _lv_style_list_add_style(list, &styles->arc_bg);
 
             list = lv_obj_get_style_list(obj, LV_SPINNER_PART_INDIC);
-            _lv_style_list_add_style(list, &styles->bg);
-            _lv_style_list_add_style(list, &styles->fg_color);
-            _lv_style_list_add_style(list, &styles->tick_line);
+            _lv_style_list_add_style(list, &styles->arc_indic);
             break;
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

When using the spinner widget with the mono theme, a runtime error
occurs when the widget is styled:

Warn: Invalid style (local variable or not initialized?)
(lv_style.c #952 lv_debug_check_style())
Error: _lv_style_list_add_style         (lv_style.c #189
_lv_style_list_add_style())
Error: Invalid style (0x000055CF3A53A190)       (lv_debug.c #127
lv_debug_log_error())

This is apparently due to styles->tick_line not being initialized.

The spinner uses the arc's styles in the material theme, so the same
approach is applied here.  

### Checkpoints
- [x ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
