### PR TITLE
feat(theme_default) improvements to dark mode

### DIFF
--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -24,10 +24,10 @@
 #define LIGHT_COLOR_CARD       lv_color_white()
 #define LIGHT_COLOR_TEXT       lv_palette_darken(LV_PALETTE_GREY, 4)
 #define LIGHT_COLOR_GREY       lv_palette_lighten(LV_PALETTE_GREY, 2)
-#define DARK_COLOR_SCR         lv_palette_darken(LV_PALETTE_GREY, 4)
-#define DARK_COLOR_CARD        lv_palette_darken(LV_PALETTE_GREY, 3)
+#define DARK_COLOR_SCR         lv_color_hex(0x22252a)
+#define DARK_COLOR_CARD        lv_color_hex(0x282b30)
 #define DARK_COLOR_TEXT        lv_palette_lighten(LV_PALETTE_GREY, 5)
-#define DARK_COLOR_GREY        lv_palette_darken(LV_PALETTE_GREY, 1)
+#define DARK_COLOR_GREY        lv_color_hex(0x2f3237)
 
 #define TRANSITION_TIME         LV_THEME_DEFAULT_TRANSITON_TIME
 #define BORDER_WIDTH            LV_DPX(2)
@@ -404,7 +404,7 @@ static void style_init(void)
     lv_style_set_pad_all(&styles->cb_marker, LV_DPX(3));
     lv_style_set_border_width(&styles->cb_marker, BORDER_WIDTH);
     lv_style_set_border_color(&styles->cb_marker, color_primary);
-    lv_style_set_bg_color(&styles->cb_marker, lv_color_white());
+    lv_style_set_bg_color(&styles->cb_marker, color_card);
     lv_style_set_bg_opa(&styles->cb_marker, LV_OPA_COVER);
     lv_style_set_radius(&styles->cb_marker, RADIUS_DEFAULT / 2);
 
@@ -481,7 +481,7 @@ static void style_init(void)
     lv_style_set_anim_time(&styles->ta_cursor, 400);
 
     style_init_reset(&styles->ta_placeholder);
-    lv_style_set_text_color(&styles->ta_placeholder, lv_palette_main(LV_PALETTE_GREY));
+    lv_style_set_text_color(&styles->ta_placeholder, (theme.flags & MODE_DARK) ? lv_palette_darken(LV_PALETTE_GREY, 2) : lv_palette_lighten(LV_PALETTE_GREY, 1));
 #endif
 
 #if LV_USE_CALENDAR
@@ -493,6 +493,7 @@ static void style_init(void)
     style_init_reset(&styles->calendar_day);
     lv_style_set_border_width(&styles->calendar_day, LV_DPX(1));
     lv_style_set_border_color(&styles->calendar_day, color_grey);
+    lv_style_set_bg_color(&styles->calendar_day, color_card);
     lv_style_set_bg_opa(&styles->calendar_day, LV_OPA_20);
 #endif
 

--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -24,7 +24,7 @@
 #define LIGHT_COLOR_CARD       lv_color_white()
 #define LIGHT_COLOR_TEXT       lv_palette_darken(LV_PALETTE_GREY, 4)
 #define LIGHT_COLOR_GREY       lv_palette_lighten(LV_PALETTE_GREY, 2)
-#define DARK_COLOR_SCR         lv_color_hex(0x22252a)
+#define DARK_COLOR_SCR         lv_color_hex(0x15171A)
 #define DARK_COLOR_CARD        lv_color_hex(0x282b30)
 #define DARK_COLOR_TEXT        lv_palette_lighten(LV_PALETTE_GREY, 5)
 #define DARK_COLOR_GREY        lv_color_hex(0x2f3237)
@@ -230,7 +230,7 @@ static void style_init(void)
     lv_style_set_transition(&styles->transition_normal, &trans_normal); /*Go back to default state with delay*/
 
     style_init_reset(&styles->scrollbar);
-    lv_style_set_bg_color(&styles->scrollbar, (theme.flags & MODE_DARK) ? lv_palette_darken(LV_PALETTE_GREY, 3) : lv_palette_main(LV_PALETTE_GREY));
+    lv_style_set_bg_color(&styles->scrollbar, (theme.flags & MODE_DARK) ? lv_palette_darken(LV_PALETTE_GREY, 2) : lv_palette_main(LV_PALETTE_GREY));
     lv_style_set_radius(&styles->scrollbar, LV_RADIUS_CIRCLE);
     lv_style_set_pad_right(&styles->scrollbar, LV_DPX(7));
     lv_style_set_pad_top(&styles->scrollbar,  LV_DPX(7));

--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -230,8 +230,7 @@ static void style_init(void)
     lv_style_set_transition(&styles->transition_normal, &trans_normal); /*Go back to default state with delay*/
 
     style_init_reset(&styles->scrollbar);
-    lv_style_set_bg_opa(&styles->scrollbar, LV_OPA_COVER);
-    lv_style_set_bg_color(&styles->scrollbar, lv_palette_main(LV_PALETTE_GREY));
+    lv_style_set_bg_color(&styles->scrollbar, (theme.flags & MODE_DARK) ? lv_palette_darken(LV_PALETTE_GREY, 3) : lv_palette_main(LV_PALETTE_GREY));
     lv_style_set_radius(&styles->scrollbar, LV_RADIUS_CIRCLE);
     lv_style_set_pad_right(&styles->scrollbar, LV_DPX(7));
     lv_style_set_pad_top(&styles->scrollbar,  LV_DPX(7));


### PR DESCRIPTION
### Description of the feature or fix

This PR implements a number of adjustments and fixes to the v8 dark theme.

* The brightness of background colors has been further reduced, as I still found it quite bright on STM32.
* The calendar day boxes now have the same background as the calendar (parity with the light theme).
* The checkbox background was corrected to match the card background (parity with the light theme).

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update CHANGELOG.md
- [ ] Update the documentation
