### PR TITLE
[ESP32-IDF] Remove dependencies for chroma keying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v7.11.1
+
+### New features
+
+### Bugfixes
+- fix(kconfig) remove dependency for LV_COLOR_CHROMA_KEY_HEX
+
 ## v7.11.0 (Planned for 19.02.2021)
 
 ### New features

--- a/Kconfig
+++ b/Kconfig
@@ -62,7 +62,6 @@ menu "LVGL configuration"
 
     config LV_COLOR_TRANSP_HEX
         hex "Images pixels with this color will not be drawn (with chroma keying)."
-        depends on LV_COLOR_SCREEN_TRANSP
         range 0x000000 0xFFFFFF
         default 0x00FF00
         help


### PR DESCRIPTION

### Description of the feature or fix

Remove the depdenency on LV_COLOR_SCREEN_TRANSP which depends on
LV_COLOR_DEPTH_32 so chroma-keying is working with systems that operate
in a 16 bit color space or lower.
This blocks users from using chroma on in LVGL as an ESP-IDF Component on color depths lower than 32bit.

Closes https://github.com/lvgl/lvgl/issues/2233

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update CHANGELOG.md
- [x] Update the documentation
