### PR TITLE
rename span interface

### DIFF
--- a/docs/widgets/extra/span.md
+++ b/docs/widgets/extra/span.md
@@ -15,9 +15,9 @@ A spangroup is the object that is used to display rich text. different from the 
 
 ### Set text and style
 
-spangroup object uses span to describe text and text style. so, first we need to create `span` descriptor use function `lv_span_t * span = lv_span_create(spangroup)`.then use `lv_span_set_text(span, "text")` to set text.The style of the modified text is the same as the normal style used,eg:`lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_RED))`.
+spangroup object uses span to describe text and text style. so, first we need to create `span` descriptor use function `lv_span_t * span = lv_spangroup_new_span(spangroup)`.then use `lv_span_set_text(span, "text")` to set text.The style of the modified text is the same as the normal style used,eg:`lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_RED))`.
 
-If spangroup object `mode != LV_SPAN_MODE_FIXED`.You must call `lv_span_refr_mode()` after you have modified `span` style(eg:set text, changed the font size, del span).
+If spangroup object `mode != LV_SPAN_MODE_FIXED`.You must call `lv_spangroup_refr_mode()` after you have modified `span` style(eg:set text, changed the font size, del span).
 
 ### Text align
 like label object, The spangroup can be one the following modes:
@@ -26,7 +26,7 @@ like label object, The spangroup can be one the following modes:
 - `LV_TEXT_ALIGN_RIGHT` Align text to right.
 - `LV_TEXT_ALIGN_AUTO` Align text auto.
 
-use function `lv_span_set_align(spangroup, LV_TEXT_ALIGN_CENTER)` to set text align.
+use function `lv_spangroup_set_align(spangroup, LV_TEXT_ALIGN_CENTER)` to set text align.
 
 ### Modes
 The spangroup can be one the following modes:
@@ -34,17 +34,17 @@ The spangroup can be one the following modes:
 - `LV_SPAN_MODE_EXPAND` Expand the object size to the text size. only one line.
 - `LV_SPAN_MODE_BREAK` Keep width, break the too long lines and auto expand height.
 
-use function `lv_span_set_mode(spangroup, LV_SPAN_MODE_BREAK)` to set obj mode.
+use function `lv_spangroup_set_mode(spangroup, LV_SPAN_MODE_BREAK)` to set obj mode.
 
 ### Overflow
 The spangroup can be one the following modes:
 - `LV_SPAN_OVERFLOW_CLIP` truncate the text at the limit of the area.
 - `LV_SPAN_OVERFLOW_ELLIPSIS` This mode value will display an ellipsis(`...`) when text overflow the area.
 
-use function `lv_span_set_overflow(spangroup, LV_SPAN_OVERFLOW_CLIP)` to set obj Overflow.
+use function `lv_spangroup_set_overflow(spangroup, LV_SPAN_OVERFLOW_CLIP)` to set obj Overflow.
 
 ### first line indent
-use function `lv_span_set_indent(spangroup, 20)` to set text indent of first line.
+use function `lv_spangroup_set_indent(spangroup, 20)` to set text indent of first line.
 
 ## Events
 Only the [Generic events](../overview/event.html#generic-events) are sent by the object type.

--- a/examples/widgets/span/lv_example_span_1.c
+++ b/examples/widgets/span/lv_example_span_1.c
@@ -18,29 +18,29 @@ void lv_example_span_1(void)
     lv_obj_center(spans);
     lv_obj_add_style(spans, &style, 0);
 
-    lv_span_set_align(spans, LV_TEXT_ALIGN_LEFT);
-    lv_span_set_overflow(spans, LV_SPAN_OVERFLOW_CLIP);
-    lv_span_set_indent(spans, 20);
-    lv_span_set_mode(spans, LV_SPAN_MODE_BREAK);
+    lv_spangroup_set_align(spans, LV_TEXT_ALIGN_LEFT);
+    lv_spangroup_set_overflow(spans, LV_SPAN_OVERFLOW_CLIP);
+    lv_spangroup_set_indent(spans, 20);
+    lv_spangroup_set_mode(spans, LV_SPAN_MODE_BREAK);
 
-    lv_span_t * span = lv_span_create(spans);
+    lv_span_t * span = lv_spangroup_new_span(spans);
     lv_span_set_text(span, "china is a beautiful country.");
     lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_RED));
     lv_style_set_text_decor(&span->style, LV_TEXT_DECOR_STRIKETHROUGH | LV_TEXT_DECOR_UNDERLINE);
     lv_style_set_text_opa(&span->style, LV_OPA_30);
 
-    span = lv_span_create(spans);
+    span = lv_spangroup_new_span(spans);
     lv_span_set_text_static(span, "good good study, day day up.");
 #if LV_FONT_MONTSERRAT_24
     lv_style_set_text_font(&span->style,  &lv_font_montserrat_24);
 #endif
     lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_GREEN));
 
-    span = lv_span_create(spans);
+    span = lv_spangroup_new_span(spans);
     lv_span_set_text_static(span, "LVGL is an open-source graphics library.");
     lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_BLUE));
 
-    span = lv_span_create(spans);
+    span = lv_spangroup_new_span(spans);
     lv_span_set_text_static(span, "the boy no name.");
     lv_style_set_text_color(&span->style, lv_palette_main(LV_PALETTE_GREEN));
 #if LV_FONT_MONTSERRAT_20
@@ -48,13 +48,10 @@ void lv_example_span_1(void)
 #endif
     lv_style_set_text_decor(&span->style, LV_TEXT_DECOR_UNDERLINE);
 
-    span = lv_span_create(spans);
+    span = lv_spangroup_new_span(spans);
     lv_span_set_text(span, "I have a dream that hope to come true.");
 
-    lv_span_refr_mode(spans);
-
-    //lv_span_del(spans, span);
-    //lv_obj_del(spans);
+    lv_spangroup_refr_mode(spans);
 }
 
 #endif

--- a/src/extra/widgets/span/lv_span.c
+++ b/src/extra/widgets/span/lv_span.c
@@ -65,7 +65,8 @@ static lv_snippet_t * lv_get_snippet(uint16_t index);
 /**********************
  *  STATIC VARIABLES
  **********************/
-struct _snippet_stack snippet_stack;
+static struct _snippet_stack snippet_stack;
+
 const lv_obj_class_t lv_spangroup_class  = {
     .base_class = &lv_obj_class,
     .constructor_cb = lv_spangroup_constructor,
@@ -99,7 +100,7 @@ lv_obj_t * lv_spangroup_create(lv_obj_t * par)
  * @param obj pointer to a spangroup object.
  * @return pointer to the created span.
  */
-lv_span_t * lv_span_create(lv_obj_t * obj)
+lv_span_t * lv_spangroup_new_span(lv_obj_t * obj)
 {
     if(obj == NULL) {
         return NULL;
@@ -122,7 +123,7 @@ lv_span_t * lv_span_create(lv_obj_t * obj)
  * @param obj pointer to a spangroup object.
  * @param span pointer to a span.
  */
-void lv_span_del(lv_obj_t * obj, lv_span_t * span)
+void lv_spangroup_del_span(lv_obj_t * obj, lv_span_t * span)
 {
     if(obj == NULL) {
         return;
@@ -141,7 +142,7 @@ void lv_span_del(lv_obj_t * obj, lv_span_t * span)
         }
     }
 
-    lv_span_refr_mode(obj);
+    lv_spangroup_refr_mode(obj);
 }
 
 /*=====================
@@ -193,7 +194,7 @@ void lv_span_set_text_static(lv_span_t * span, const char * text)
  * @param obj pointer to a spangroup object.
  * @param align see lv_text_align_t for details.
  */
-void lv_span_set_align(lv_obj_t * obj, lv_text_align_t align)
+void lv_spangroup_set_align(lv_obj_t * obj, lv_text_align_t align)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     if(spans->align == align) return;
@@ -207,7 +208,7 @@ void lv_span_set_align(lv_obj_t * obj, lv_text_align_t align)
  * @param obj pointer to a spangroup object.
  * @param overflow see lv_span_overflow_t for details.
  */
-void lv_span_set_overflow(lv_obj_t * obj, lv_span_overflow_t overflow)
+void lv_spangroup_set_overflow(lv_obj_t * obj, lv_span_overflow_t overflow)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     if(spans->overflow == overflow) return;
@@ -221,7 +222,7 @@ void lv_span_set_overflow(lv_obj_t * obj, lv_span_overflow_t overflow)
  * @param obj pointer to a spangroup object.
  * @param indent The first line indentation
  */
-void lv_span_set_indent(lv_obj_t * obj, lv_coord_t indent)
+void lv_spangroup_set_indent(lv_obj_t * obj, lv_coord_t indent)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     if(spans->indent == indent) return;
@@ -235,13 +236,13 @@ void lv_span_set_indent(lv_obj_t * obj, lv_coord_t indent)
  * @param obj pointer to a spangroup object.
  * @param mode see lv_span_mode_t for details.
  */
-void lv_span_set_mode(lv_obj_t * obj, lv_span_mode_t mode)
+void lv_spangroup_set_mode(lv_obj_t * obj, lv_span_mode_t mode)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     if(spans->mode == mode) return;
 
     spans->mode = mode;
-    lv_span_refr_mode(obj);
+    lv_spangroup_refr_mode(obj);
 }
 
 /*=====================
@@ -253,7 +254,7 @@ void lv_span_set_mode(lv_obj_t * obj, lv_span_mode_t mode)
  * @param obj pointer to a spangroup object.
  * @return the align value.
  */
-lv_text_align_t lv_span_get_align(lv_obj_t * obj)
+lv_text_align_t lv_spangroup_get_align(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     return spans->align;
@@ -264,7 +265,7 @@ lv_text_align_t lv_span_get_align(lv_obj_t * obj)
  * @param obj pointer to a spangroup object.
  * @return the overflow value.
  */
-lv_span_overflow_t lv_span_get_overflow(lv_obj_t * obj)
+lv_span_overflow_t lv_spangroup_get_overflow(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     return spans->overflow;
@@ -275,7 +276,7 @@ lv_span_overflow_t lv_span_get_overflow(lv_obj_t * obj)
  * @param obj pointer to a spangroup object.
  * @return the indent value.
  */
-lv_coord_t lv_span_get_indent(lv_obj_t * obj)
+lv_coord_t lv_spangroup_get_indent(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     return spans->indent;
@@ -286,7 +287,7 @@ lv_coord_t lv_span_get_indent(lv_obj_t * obj)
  * @param obj pointer to a spangroup object.
  * @return the mode value.
  */
-lv_span_mode_t lv_span_get_mode(lv_obj_t * obj)
+lv_span_mode_t lv_spangroup_get_mode(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     return spans->mode;
@@ -296,7 +297,7 @@ lv_span_mode_t lv_span_get_mode(lv_obj_t * obj)
  * update the mode of the spangroup.
  * @param obj pointer to a spangroup object.
  */
-void lv_span_refr_mode(lv_obj_t * obj)
+void lv_spangroup_refr_mode(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
 
@@ -305,15 +306,15 @@ void lv_span_refr_mode(lv_obj_t * obj)
     }
 
     if(spans->mode == LV_SPAN_MODE_EXPAND) {
-        lv_coord_t width = lv_span_get_expand_width(obj);
-        lv_coord_t height = lv_span_get_max_line_h(obj);
+        lv_coord_t width = lv_spangroup_get_expand_width(obj);
+        lv_coord_t height = lv_spangroup_get_max_line_h(obj);
         lv_coord_t top_pad = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
         lv_coord_t bottom_pad = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
         lv_obj_set_width(obj, width + spans->indent);
         lv_obj_set_height(obj, height + top_pad + bottom_pad);
     }
     else if(spans->mode == LV_SPAN_MODE_BREAK) {
-        lv_coord_t height = lv_span_get_expand_height(obj, lv_obj_get_width(obj));
+        lv_coord_t height = lv_spangroup_get_expand_height(obj, lv_obj_get_width(obj));
         lv_obj_set_height(obj, height);
     }
 
@@ -324,7 +325,7 @@ void lv_span_refr_mode(lv_obj_t * obj)
  * get max line height of all span in the spangroup.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_max_line_h(lv_obj_t * obj)
+lv_coord_t lv_spangroup_get_max_line_h(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
 
@@ -345,7 +346,7 @@ lv_coord_t lv_span_get_max_line_h(lv_obj_t * obj)
  * get the width when all span of spangroup on a line. include spangroup pad.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_expand_width(lv_obj_t * obj)
+lv_coord_t lv_spangroup_get_expand_width(lv_obj_t * obj)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
 
@@ -380,7 +381,7 @@ lv_coord_t lv_span_get_expand_width(lv_obj_t * obj)
  * get the height with width fixed. the height include spangroup pad.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_expand_height(lv_obj_t * obj, lv_coord_t width)
+lv_coord_t lv_spangroup_get_expand_height(lv_obj_t * obj, lv_coord_t width)
 {
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
     if(_lv_ll_get_head(&spans->child_ll) == NULL) {
@@ -519,10 +520,10 @@ static void lv_spangroup_event(const lv_obj_class_t * class_p, lv_event_t * e)
         draw_main(e);
     }
     else if(code == LV_EVENT_STYLE_CHANGED) {
-        lv_span_refr_mode(obj);
+        lv_spangroup_refr_mode(obj);
     }
     else if(code == LV_EVENT_SIZE_CHANGED) {
-        lv_span_refr_mode(obj);
+        lv_spangroup_refr_mode(obj);
     }
 }
 

--- a/src/extra/widgets/span/lv_span.h
+++ b/src/extra/widgets/span/lv_span.h
@@ -74,14 +74,14 @@ lv_obj_t * lv_spangroup_create(lv_obj_t * par);
  * @param obj pointer to a spangroup object.
  * @return pointer to the created span.
  */
-lv_span_t * lv_span_create(lv_obj_t * obj);
+lv_span_t * lv_spangroup_new_span(lv_obj_t * obj);
 
 /**
  * Remove the span from the spangroup and free memory.
  * @param obj pointer to a spangroup object.
  * @param span pointer to a span.
  */
-void lv_span_del(lv_obj_t * obj, lv_span_t * span);
+void lv_spangroup_del_span(lv_obj_t * obj, lv_span_t * span);
 
 /*=====================
  * Setter functions
@@ -107,28 +107,28 @@ void lv_span_set_text_static(lv_span_t * span, const char * text);
  * @param obj pointer to a spangroup object.
  * @param align see lv_text_align_t for details.
  */
-void lv_span_set_align(lv_obj_t * obj, lv_text_align_t align);
+void lv_spangroup_set_align(lv_obj_t * obj, lv_text_align_t align);
 
 /**
  * Set the overflow of the spangroup.
  * @param obj pointer to a spangroup object.
  * @param overflow see lv_span_overflow_t for details.
  */
-void lv_span_set_overflow(lv_obj_t * obj, lv_span_overflow_t overflow);
+void lv_spangroup_set_overflow(lv_obj_t * obj, lv_span_overflow_t overflow);
 
 /**
  * Set the indent of the spangroup.
  * @param obj pointer to a spangroup object.
  * @param indent The first line indentation
  */
-void lv_span_set_indent(lv_obj_t * obj, lv_coord_t indent);
+void lv_spangroup_set_indent(lv_obj_t * obj, lv_coord_t indent);
 
 /**
  * Set the mode of the spangroup.
  * @param obj pointer to a spangroup object.
  * @param mode see lv_span_mode_t for details.
  */
-void lv_span_set_mode(lv_obj_t * obj, lv_span_mode_t mode);
+void lv_spangroup_set_mode(lv_obj_t * obj, lv_span_mode_t mode);
 
 /*=====================
  * Getter functions
@@ -139,45 +139,45 @@ void lv_span_set_mode(lv_obj_t * obj, lv_span_mode_t mode);
  * @param obj pointer to a spangroup object.
  * @return the align value.
  */
-lv_text_align_t lv_span_get_align(lv_obj_t * obj);
+lv_text_align_t lv_spangroup_get_align(lv_obj_t * obj);
 
 /**
  * get the overflow of the spangroup.
  * @param obj pointer to a spangroup object.
  * @return the overflow value.
  */
-lv_span_overflow_t lv_span_get_overflow(lv_obj_t * obj);
+lv_span_overflow_t lv_spangroup_get_overflow(lv_obj_t * obj);
 
 /**
  * get the indent of the spangroup.
  * @param obj pointer to a spangroup object.
  * @return the indent value.
  */
-lv_coord_t lv_span_get_indent(lv_obj_t * obj);
+lv_coord_t lv_spangroup_get_indent(lv_obj_t * obj);
 
 /**
  * get the mode of the spangroup.
  * @param obj pointer to a spangroup object.
  */
-lv_span_mode_t lv_span_get_mode(lv_obj_t * obj);
+lv_span_mode_t lv_spangroup_get_mode(lv_obj_t * obj);
 
 /**
  * get max line height of all span in the spangroup.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_max_line_h(lv_obj_t * obj);
+lv_coord_t lv_spangroup_get_max_line_h(lv_obj_t * obj);
 
 /**
  * get the width when all span of spangroup on a line. include spangroup pad.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_expand_width(lv_obj_t * obj);
+lv_coord_t lv_spangroup_get_expand_width(lv_obj_t * obj);
 
 /**
  * get the height with width fixed. the height include spangroup pad.
  * @param obj pointer to a spangroup object.
  */
-lv_coord_t lv_span_get_expand_height(lv_obj_t * obj, lv_coord_t width);
+lv_coord_t lv_spangroup_get_expand_height(lv_obj_t * obj, lv_coord_t width);
 
 
 /*=====================
@@ -188,7 +188,7 @@ lv_coord_t lv_span_get_expand_height(lv_obj_t * obj, lv_coord_t width);
  * update the mode of the spangroup.
  * @param obj pointer to a spangroup object.
  */
-void lv_span_refr_mode(lv_obj_t * obj);
+void lv_spangroup_refr_mode(lv_obj_t * obj);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

for the reasion:#1763, rename span interface.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
