### PR TITLE
fix lv_chart_set_point_count() bug

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -109,7 +109,9 @@ void lv_chart_set_point_count(lv_obj_t * obj, uint16_t cnt)
     if(cnt < 1) cnt = 1;
 
     _LV_LL_READ_BACK(&chart->series_ll, ser) {
-        if(!ser->x_ext_buf_assigned) new_points_alloc(obj, ser, cnt, &ser->x_points);
+        if(chart->type == LV_CHART_TYPE_SCATTER) {
+            if(!ser->x_ext_buf_assigned) new_points_alloc(obj, ser, cnt, &ser->x_points);
+        }
         if(!ser->y_ext_buf_assigned) new_points_alloc(obj, ser, cnt, &ser->y_points);
         ser->start_point = 0;
     }


### PR DESCRIPTION
### Description of the feature or fix

Call `lv_chart_set_point_count()` after `lv_chart_add_series()`, program will crash. 

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
