### PR TITLE
[fix] dropdown widget can't select item

### DIFF
--- a/src/lv_widgets/lv_dropdown.c
+++ b/src/lv_widgets/lv_dropdown.c
@@ -1259,7 +1259,9 @@ static lv_res_t page_release_handler(lv_obj_t * page)
     /*Search the clicked option (For KEYPAD and ENCODER the new value should be already set)*/
     if(lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER || lv_indev_get_type(indev) == LV_INDEV_TYPE_BUTTON) {
         lv_point_t p;
-        lv_indev_get_point(indev, &p);
+        /* when press released, current point is '-1, -1', we must use last point */
+        p.x = indev->proc.types.pointer.last_point.x;
+        p.y = indev->proc.types.pointer.last_point.y;
         ext->sel_opt_id     = get_id_on_point(ddlist, p.y);
         ext->sel_opt_id_orig = ext->sel_opt_id;
     }


### PR DESCRIPTION
### Description of the feature or fix

I use dropdown widget, but it can't select item, it always select on index 1;

I debug the program, and found a bug in 'dropdown.c':

When press released, current point is '-1, -1', we must use last point to calcu item index,
but page_release_handler use lv_indev_get_point(indev, &p);. it will get current point, i think it's a error;

So i modify it, rebuild, then my program works !

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
