### PR TITLE
Added printf-like function attribute to _lv_txt_set_text_vfmt and lv_label_set_text_fmt

### DIFF
--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -483,7 +483,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len)
  * @param fmt `printf`-like format
  * @return pointer to the allocated text string.
  */
-__attribute__ ((format(printf, 1, 0))) char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
+LV_FORMAT_ATTRIBUTE(1, 0) char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
 {
     /*Allocate space for the new text by using trick from C99 standard section 7.19.6.12*/
     va_list ap_copy;

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -483,7 +483,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len)
  * @param fmt `printf`-like format
  * @return pointer to the allocated text string.
  */
-char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
+__attribute__ ((format(printf, 1, 0))) char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
 {
     /*Allocate space for the new text by using trick from C99 standard section 7.19.6.12*/
     va_list ap_copy;

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "lv_area.h"
 #include "../font/lv_font.h"
 #include "lv_printf.h"
+#include "lv_types.h"
 
 /*********************
  *      DEFINES
@@ -30,15 +31,6 @@ extern "C" {
 
 #define LV_TXT_ENC_UTF8 1
 #define LV_TXT_ENC_ASCII 2
-
-/**********************
-*      MACROS
-**********************/
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
-#else
-#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
-#endif
 
 /**********************
  *      TYPEDEFS

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -32,6 +32,15 @@ extern "C" {
 #define LV_TXT_ENC_ASCII 2
 
 /**********************
+*      MACROS
+**********************/
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
+#else
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
+#endif
+
+/**********************
  *      TYPEDEFS
  **********************/
 
@@ -141,7 +150,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len);
  * @param fmt `printf`-like format
  * @return pointer to the allocated text string.
  */
-char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap) __attribute__ ((format(printf, 1, 0)));
+char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap) LV_FORMAT_ATTRIBUTE(1, 0);
 
 /**
  * Decode two encoded character from a string.

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -141,7 +141,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len);
  * @param fmt `printf`-like format
  * @return pointer to the allocated text string.
  */
-char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap);
+char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap) __attribute__ ((format(printf, 1, 0)));
 
 /**
  * Decode two encoded character from a string.

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -80,6 +80,12 @@ typedef uint32_t lv_uintptr_t;
 #define _LV_CONCAT3(x, y, z) x ## y ## z
 #define LV_CONCAT3(x, y, z) _LV_CONCAT3(x, y, z)
 
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
+#else
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
+#endif
+
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -144,7 +144,7 @@ void lv_label_set_text(lv_obj_t * obj, const char * text)
     lv_label_refr_text(obj);
 }
 
-void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
+__attribute__ ((format (printf, 2, 3))) void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file lv_label.c
  *
  */
@@ -144,7 +144,7 @@ void lv_label_set_text(lv_obj_t * obj, const char * text)
     lv_label_refr_text(obj);
 }
 
-__attribute__ ((format (printf, 2, 3))) void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
+LV_FORMAT_ATTRIBUTE(2, 3) void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -37,6 +37,15 @@ LV_EXPORT_CONST_INT(LV_LABEL_POS_LAST);
 LV_EXPORT_CONST_INT(LV_LABEL_TEXT_SELECTION_OFF);
 
 /**********************
+*      MACROS
+**********************/
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
+#else
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
+#endif
+
+/**********************
  *      TYPEDEFS
  **********************/
 
@@ -105,7 +114,7 @@ void lv_label_set_text(lv_obj_t * obj, const char * text);
  * @param fmt           `printf`-like format
  * @example lv_label_set_text_fmt(label1, "%d user", user_num);
  */
-void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTRIBUTE(2, 3);
 
 /**
  * Set a static text. It will not be saved by the label so the 'text' variable

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -37,15 +37,6 @@ LV_EXPORT_CONST_INT(LV_LABEL_POS_LAST);
 LV_EXPORT_CONST_INT(LV_LABEL_TEXT_SELECTION_OFF);
 
 /**********************
-*      MACROS
-**********************/
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
-#else
-#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
-#endif
-
-/**********************
  *      TYPEDEFS
  **********************/
 

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -105,7 +105,7 @@ void lv_label_set_text(lv_obj_t * obj, const char * text);
  * @param fmt           `printf`-like format
  * @example lv_label_set_text_fmt(label1, "%d user", user_num);
  */
-void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...);
+void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 /**
  * Set a static text. It will not be saved by the label so the 'text' variable


### PR DESCRIPTION
### Description of the feature or fix

Added printf-like function attribute to _lv_txt_set_text_vfmt and lv_label_set_text_fmt. This improves static analysis and compiler warnings of incorrect format usage.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md) - No functional difference 
- [ ] Update the documentation - No functional difference
