### PR TITLE
Add missing lv_obj_class_t externs

### DIFF
--- a/src/extra/widgets/animimg/lv_animimg.h
+++ b/src/extra/widgets/animimg/lv_animimg.h
@@ -29,6 +29,9 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
+extern const lv_obj_class_t lv_animimg_class;
+
 /*Data of image*/
 typedef struct {
     lv_img_t img;

--- a/src/extra/widgets/calendar/lv_calendar_header_arrow.c
+++ b/src/extra/widgets/calendar/lv_calendar_header_arrow.c
@@ -32,6 +32,10 @@ static void month_event_cb(lv_event_t * e);
  **********************/
 static const char * month_names_def[12] = LV_CALENDAR_DEFAULT_MONTH_NAMES;
 
+const lv_obj_class_t lv_calendar_header_arrow_class = {
+    .base_class = &lv_obj_class
+};
+
 /**********************
  *      MACROS
  **********************/

--- a/src/extra/widgets/calendar/lv_calendar_header_arrow.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_arrow.h
@@ -24,7 +24,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-#define lv_calendar_header_arrow_class lv_obj_class
+extern const lv_obj_class_t lv_calendar_header_arrow_class;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/extra/widgets/calendar/lv_calendar_header_arrow.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_arrow.h
@@ -24,6 +24,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+#define lv_calendar_header_arrow_class lv_obj_class
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/extra/widgets/calendar/lv_calendar_header_dropdown.c
+++ b/src/extra/widgets/calendar/lv_calendar_header_dropdown.c
@@ -30,6 +30,10 @@ static void month_event_cb(lv_event_t * e);
 /**********************
  *  STATIC VARIABLES
  **********************/
+const lv_obj_class_t lv_calendar_header_dropdown_class = {
+    .base_class = &lv_obj_class
+};
+
 static const char * month_list = "01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12";
 static const char * year_list = {
         "2023\n2022\n2021\n"

--- a/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
@@ -24,6 +24,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+#define lv_calendar_header_dropdown_class lv_obj_class
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
@@ -24,7 +24,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-#define lv_calendar_header_dropdown_class lv_obj_class
+extern const lv_obj_class_t lv_calendar_header_dropdown_class;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/extra/widgets/spinner/lv_spinner.c
+++ b/src/extra/widgets/spinner/lv_spinner.c
@@ -26,6 +26,9 @@ static void arc_anim_end_angle(void * obj, int32_t v);
 /**********************
  *  STATIC VARIABLES
  **********************/
+const lv_obj_class_t lv_spinner_class = {
+    .base_class = &lv_obj_class
+};
 
 /**********************
  *      MACROS

--- a/src/extra/widgets/spinner/lv_spinner.h
+++ b/src/extra/widgets/spinner/lv_spinner.h
@@ -30,6 +30,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+#define lv_spinner_class lv_arc_class
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/extra/widgets/spinner/lv_spinner.h
+++ b/src/extra/widgets/spinner/lv_spinner.h
@@ -30,7 +30,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-#define lv_spinner_class lv_arc_class
+extern const lv_obj_class_t lv_spinner_class;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/lv_canvas.h
+++ b/src/widgets/lv_canvas.h
@@ -28,6 +28,9 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
+extern const lv_obj_class_t lv_canvas_class;
+
 /*Data of canvas*/
 typedef struct {
     lv_img_t img;


### PR DESCRIPTION
The Micropython bindings assumes each LVGL object has a 'class' extern in the form of lv_objectname_class

Related: https://github.com/lvgl/lv_binding_micropython/issues/135
