### PR TITLE
Examples: remove cast in MP scripts

### DIFF
--- a/examples/event/lv_example_event_1.py
+++ b/examples/event/lv_example_event_1.py
@@ -17,7 +17,7 @@ class Event_1():
     def event_cb(self,e):
         print("Clicked");
             
-        btn = lv.btn.__cast__(e.get_target())
+        btn = e.get_target()
         label = btn.get_child(0)
         label.set_text(str(self.cnt))
         self.cnt += 1

--- a/examples/get_started/lv_example_get_started_1.py
+++ b/examples/get_started/lv_example_get_started_1.py
@@ -21,7 +21,7 @@ class CounterBtn():
             self.cnt += 1
 
         # Get the first child of the button which is the label and change its text
-        label = lv.label.__cast__(btn.get_child(0))
+        label = btn.get_child(0)
         label.set_text("Button: " + str(self.cnt))
 
 

--- a/examples/widgets/bar/lv_example_bar_6.py
+++ b/examples/widgets/bar/lv_example_bar_6.py
@@ -6,7 +6,7 @@ def event_cb(e):
     if dsc.part != lv.PART.INDICATOR:
         return
 
-    obj= lv.bar.__cast__(e.get_target())
+    obj= e.get_target()
 
     label_dsc = lv.draw_label_dsc_t()
     label_dsc.init()

--- a/examples/widgets/bar/test.py
+++ b/examples/widgets/bar/test.py
@@ -9,7 +9,7 @@ def event_cb(e):
     if dsc.part != lv.PART.INDICATOR:
         return
 
-    obj= lv.bar.__cast__(e.get_target())
+    obj= e.get_target()
 
     label_dsc = lv.draw_label_dsc_t()
     label_dsc.init()

--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_3.py
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_3.py
@@ -1,5 +1,5 @@
 def event_cb(e):
-    obj = lv.btnmatrix.__cast__(e.get_target())
+    obj = e.get_target()
     id = obj.get_selected_btn()
     if id == 0:
         prev = True

--- a/examples/widgets/calendar/lv_example_calendar_1.py
+++ b/examples/widgets/calendar/lv_example_calendar_1.py
@@ -2,7 +2,7 @@ def event_handler(evt):
     code = evt.get_code()
 
     if code == lv.EVENT.VALUE_CHANGED:
-        source = lv.calendar.__cast__(evt.get_target())
+        source = evt.get_target()
         date = lv.calendar_date_t()
         lv.calendar.get_pressed_date(source,date)
         if date:

--- a/examples/widgets/chart/lv_example_chart_2.py
+++ b/examples/widgets/chart/lv_example_chart_2.py
@@ -1,6 +1,6 @@
 def draw_event_cb(e):
 
-    obj = lv.obj.__cast__(e.get_target())
+    obj = e.get_target()
 
     # Add the faded area before the lines are drawn
     dsc = lv.obj_draw_part_dsc_t.__cast__(e.get_param())

--- a/examples/widgets/chart/lv_example_chart_5.py
+++ b/examples/widgets/chart/lv_example_chart_5.py
@@ -44,13 +44,13 @@ ecg_sample = [
 
 def slider_x_event_cb(e):
 
-    slider = lv.slider.__cast__(e.get_target())
+    slider = e.get_target()
     v = slider.get_value()
     chart.set_zoom_x(v)
 
 def slider_y_event_cb(e):
 
-    slider = lv.slider.__cast__(e.get_target())
+    slider = e.get_target()
     v = slider.get_value()
     chart.set_zoom_y(v)
 

--- a/examples/widgets/chart/lv_example_chart_6.py
+++ b/examples/widgets/chart/lv_example_chart_6.py
@@ -37,7 +37,7 @@ class ExampleChart_6():
     def event_cb(self,e):
 
         code = e.get_code()
-        chart = lv.chart.__cast__(e.get_target())
+        chart = e.get_target()
 
         if code == lv.EVENT.VALUE_CHANGED:
             # print("last_id: ",self.last_id)

--- a/examples/widgets/checkbox/lv_example_checkbox_1.py
+++ b/examples/widgets/checkbox/lv_example_checkbox_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.checkbox.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.VALUE_CHANGED:
         txt = obj.get_text()
         if obj.get_state() & lv.STATE.CHECKED:

--- a/examples/widgets/dropdown/lv_example_dropdown_1.py
+++ b/examples/widgets/dropdown/lv_example_dropdown_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.dropdown.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.VALUE_CHANGED: 
         option = " "*10 # should be large enough to store the option
         obj.get_selected_str(option, len(option))

--- a/examples/widgets/dropdown/lv_example_dropdown_3.py
+++ b/examples/widgets/dropdown/lv_example_dropdown_3.py
@@ -19,7 +19,7 @@ img_caret_down_argb = lv.img_dsc_t({
 })
 
 def event_cb(e):
-    dropdown = lv.dropdown.__cast__(e.get_target())
+    dropdown = e.get_target()
     option = " "*64 # should be large enough to store the option
     dropdown.get_selected_str(option, len(option))
     print(option.strip() +" is selected")

--- a/examples/widgets/list/lv_example_list_1.py
+++ b/examples/widgets/list/lv_example_list_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.btn.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.CLICKED:
             print("Clicked: list1." + list1.get_btn_text(obj))
 

--- a/examples/widgets/list/test.py
+++ b/examples/widgets/list/test.py
@@ -3,7 +3,7 @@ import lvgl as lv
 import display_driver
 def event_handler(e):
     code = e.get_code()
-    obj = lv.btn.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.CLICKED:
             print("Clicked: list1." + list1.get_btn_text(obj))
 

--- a/examples/widgets/msgbox/lv_example_msgbox_1.py
+++ b/examples/widgets/msgbox/lv_example_msgbox_1.py
@@ -1,6 +1,6 @@
 def event_cb(e):
-    mbox = lv.msgbox.__cast__(e.get_current_target())
-    print("Button " + mbox.get_active_btn_text() + " clicked")
+    mbox = e.get_current_target()
+    print("Button %s clicked" % mbox.get_active_btn_text())
 
 btns = ["Apply", "Close", ""]
 

--- a/examples/widgets/roller/lv_example_roller_1.py
+++ b/examples/widgets/roller/lv_example_roller_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.roller.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.VALUE_CHANGED:
         option = " "*10
         obj.get_selected_str(option, len(option))

--- a/examples/widgets/roller/lv_example_roller_2.py
+++ b/examples/widgets/roller/lv_example_roller_2.py
@@ -2,7 +2,7 @@ import fs_driver
 
 def event_handler(e):
     code = e.get_code()
-    obj = lv.roller.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.VALUE_CHANGED: 
         option = " "*10
         obj.get_selected_str(option, len(option))

--- a/examples/widgets/slider/lv_example_slider_1.py
+++ b/examples/widgets/slider/lv_example_slider_1.py
@@ -3,7 +3,7 @@
 #
 def slider_event_cb(e):
 
-    slider = lv.slider.__cast__(e.get_target())
+    slider = e.get_target()
     slider_label.set_text("{:d}%".format(slider.get_value()))
     slider_label.align_to(slider, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
 

--- a/examples/widgets/slider/lv_example_slider_3.py
+++ b/examples/widgets/slider/lv_example_slider_3.py
@@ -1,6 +1,6 @@
 def slider_event_cb(e):
     code = e.get_code()
-    obj = lv.slider.__cast__(e.get_target())
+    obj = e.get_target()
 
     # Provide some extra space for the value
     if code == lv.EVENT.REFR_EXT_DRAW_SIZE:

--- a/examples/widgets/switch/lv_example_switch_1.py
+++ b/examples/widgets/switch/lv_example_switch_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.switch.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.VALUE_CHANGED:
         if obj.has_state(lv.STATE.CHECKED):
             print("State: on")

--- a/examples/widgets/table/lv_example_table_1.py
+++ b/examples/widgets/table/lv_example_table_1.py
@@ -1,5 +1,5 @@
 def draw_part_event_cb(e):
-    obj = lv.table.__cast__(e.get_target())
+    obj = e.get_target()
     dsc = lv.obj_draw_part_dsc_t.__cast__(e.get_param())
     # If the cells are drawn../
     if dsc.part == lv.PART.ITEMS:

--- a/examples/widgets/table/lv_example_table_2.py
+++ b/examples/widgets/table/lv_example_table_2.py
@@ -4,7 +4,7 @@ import gc
 ITEM_CNT = 200
 
 def draw_event_cb(e):
-    obj = lv.table.__cast__(e.get_target())
+    obj = e.get_target()
     dsc = lv.obj_draw_part_dsc_t.__cast__(e.get_param())
     # If the cells are drawn...
     if dsc.part == lv.PART.ITEMS:
@@ -40,7 +40,7 @@ def draw_event_cb(e):
         lv.draw_rect(sw_area, dsc.clip_area, rect_dsc)
 
 def change_event_cb(e):
-    obj = lv.table.__cast__(e.get_target())
+    obj = e.get_target()
     row = lv.C_Pointer()
     col = lv.C_Pointer()
     table.get_selected_cell(row, col)

--- a/examples/widgets/textarea/lv_example_textarea_1.py
+++ b/examples/widgets/textarea/lv_example_textarea_1.py
@@ -3,13 +3,13 @@ def textarea_event_handler(e,ta):
     
 def btnm_event_handler(e,ta):
 
-    obj = lv.btnmatrix.__cast__(e.get_target())
+    obj = e.get_target()
     txt = obj.get_btn_text(obj.get_selected_btn())
     if txt == lv.SYMBOL.BACKSPACE:
         ta.del_char()
     elif txt == lv.SYMBOL.NEW_LINE:
         lv.event_send(ta,lv.EVENT.READY,None)
-    else:
+    elif txt:
         ta.add_text(txt)
 
 ta = lv.textarea(lv.scr_act())

--- a/examples/widgets/textarea/lv_example_textarea_2.py
+++ b/examples/widgets/textarea/lv_example_textarea_2.py
@@ -1,6 +1,6 @@
 def ta_event_cb(e):
     code = e.get_code()
-    ta = lv.textarea.__cast__(e.get_target())
+    ta = e.get_target()
     if code == lv.EVENT.CLICKED or code == lv.EVENT.FOCUSED:
         # Focus on the clicked text area
         if kb != None:

--- a/examples/widgets/textarea/lv_example_textarea_3.py
+++ b/examples/widgets/textarea/lv_example_textarea_3.py
@@ -1,5 +1,5 @@
 def ta_event_cb(e):
-    ta = lv.textarea.__cast__(e.get_target())
+    ta = e.get_target()
     txt = ta.get_text()
     # print(txt)
     pos = ta.get_cursor_pos()

--- a/examples/widgets/win/lv_example_win_1.py
+++ b/examples/widgets/win/lv_example_win_1.py
@@ -1,6 +1,6 @@
 def event_handler(e):
     code = e.get_code()
-    obj = lv.obj.__cast__(e.get_target())
+    obj = e.get_target()
     if code == lv.EVENT.CLICKED:
         print("Button {:d} clicked".format(obj.get_child_id()))
 


### PR DESCRIPTION
After https://github.com/lvgl/lv_binding_micropython/pull/161 merged, it is no longer needed to cast the result of 'e.get_target()'

Also, additional small fixes to allow CI improvements
