### PR TITLE
Fix memory leak in lv_disp_remove

### DIFF
--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -220,6 +220,20 @@ void lv_disp_remove(lv_disp_t * disp)
 
     _lv_ll_remove(&LV_GC_ROOT(_lv_disp_ll), disp);
     lv_timer_del(disp->refr_timer);
+
+    /** delete screen and other obj */
+    if (disp->sys_layer) {
+        lv_obj_del(disp->sys_layer);
+        disp->sys_layer = NULL;
+    }
+    if (disp->top_layer) {
+        lv_obj_del(disp->top_layer);
+        disp->top_layer = NULL;
+    }
+    while (disp->screen_cnt != 0) {
+        /*Delete the screenst*/
+        lv_obj_del(disp->screens[0]);
+    }
     lv_mem_free(disp);
 
     if(was_default) lv_disp_set_default(_lv_ll_get_head(&LV_GC_ROOT(_lv_disp_ll)));


### PR DESCRIPTION
### Fix memory leak in lv_disp_remove

When new display registered, top_layer, sys_layer and screens are created together. Need to delete those objects when remove display. 

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
