### PR TITLE
build_micropython.yml workflow fix

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Clone lv_micropython
       run: |
         git clone https://github.com/lvgl/lv_micropython.git .
-        git checkout dev-8.0
+        git checkout master
     - name: Update submodules
       run: git submodule update --init --recursive
     - name: Checkout LVGL submodule


### PR DESCRIPTION
Micropython dev-8.0 was merged to main. Change workflow to checkout main branch instead of dev-8.0
