### PR TITLE
examples: import umods

### DIFF
--- a/examples/header.py
+++ b/examples/header.py
@@ -1,10 +1,7 @@
 #!/opt/bin/lv_micropython -i
 
 import lvgl as lv
-try:
-    import sys
-except ImportError:
-    import usys as sys
+import usys as sys
 
 # JS requires a special import
 if sys.platform == 'javascript':

--- a/examples/widgets/chart/lv_example_chart_7.py
+++ b/examples/widgets/chart/lv_example_chart_7.py
@@ -1,5 +1,5 @@
 #!/opt/bin/lv_micropython -i
-import time
+import utime as time
 import lvgl as lv
 import display_driver
 

--- a/examples/widgets/img/lv_example_img_1.py
+++ b/examples/widgets/img/lv_example_img_1.py
@@ -1,5 +1,5 @@
 #!/opt/bin/lv_micropython -i
-import sys
+import usys as sys
 import lvgl as lv
 import display_driver
 from imagetools import get_png_info, open_png

--- a/examples/widgets/img/lv_example_img_2.py
+++ b/examples/widgets/img/lv_example_img_2.py
@@ -1,5 +1,5 @@
 #!/opt/bin/lv_micropython -i
-import sys
+import usys as sys
 import lvgl as lv
 import display_driver
 from imagetools import get_png_info, open_png

--- a/examples/widgets/img/lv_example_img_3.py
+++ b/examples/widgets/img/lv_example_img_3.py
@@ -1,5 +1,5 @@
 #!/opt/bin/lv_micropython -i
-import sys
+import usys as sys
 import lvgl as lv
 import display_driver
 from imagetools import get_png_info, open_png

--- a/examples/widgets/meter/lv_example_meter_1.py
+++ b/examples/widgets/meter/lv_example_meter_1.py
@@ -1,5 +1,5 @@
 #!//opt/bin/lv_micropython -i
-import time
+import utime as time
 import lvgl as lv
 import display_driver
 

--- a/examples/widgets/meter/lv_example_meter_2.py
+++ b/examples/widgets/meter/lv_example_meter_2.py
@@ -1,5 +1,5 @@
 #!//opt/bin/lv_micropython -i
-import time
+import utime as time
 import lvgl as lv
 import display_driver
 

--- a/examples/widgets/meter/lv_example_meter_3.py
+++ b/examples/widgets/meter/lv_example_meter_3.py
@@ -1,5 +1,5 @@
 #!//opt/bin/lv_micropython -i
-import time
+import utime as time
 import lvgl as lv
 import display_driver
 from imagetools import get_png_info, open_png

--- a/examples/widgets/roller/lv_example_roller_3.py
+++ b/examples/widgets/roller/lv_example_roller_3.py
@@ -1,8 +1,8 @@
 #!/opt/bin/lv_micropython -i
-import time
+import utime as time
 import lvgl as lv
 import display_driver
-import sys
+import usys as sys
 
 class Lv_Roller_3():
 


### PR DESCRIPTION
import usys and utime instead of sys and time, as these are not available on all platforms
