### PR TITLE
Update build_micropython.yml

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -37,4 +37,6 @@ jobs:
     - name: Build the unix port
       run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1
     - name: Run tests      
-      run: lib/lv_bindings/tests/run.sh
+      run: |
+        export XDG_RUNTIME_DIR=/tmp
+        lib/lv_bindings/tests/run.sh


### PR DESCRIPTION
Export XDG_RUNTIME_DIR to remove SDL warnings in workflow log
