### PR TITLE
fix(color) remove extraneous _LV_COLOR_MAKE_TYPE_HELPER

### DIFF
--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -143,7 +143,7 @@ enum {
 # define LV_COLOR_GET_A8(c) 0xFF
 
 # define _LV_COLOR_ZERO_INITIALIZER8 _LV_COLOR_MAKE_TYPE_HELPER {{0x00, 0x00, 0x00}}
-# define LV_COLOR_MAKE8(r8, g8, b8) _LV_COLOR_MAKE_TYPE_HELPER  {{(uint8_t)((b8 >> 6) & 0x3U), (uint8_t)((g8 >> 5) & 0x7U), (uint8_t)((r8 >> 5) & 0x7U)}}
+# define LV_COLOR_MAKE8(r8, g8, b8) {{(uint8_t)((b8 >> 6) & 0x3U), (uint8_t)((g8 >> 5) & 0x7U), (uint8_t)((r8 >> 5) & 0x7U)}}
 
 # define LV_COLOR_SET_R16(c, v) (c).ch.red = (uint8_t)((v) & 0x1FU)
 #if LV_COLOR_16_SWAP == 0


### PR DESCRIPTION
### Description of the feature or fix

This updates it to match the other `LV_COLOR_MAKEXX` (where XX is the color depth) lines.

Initially reported here: https://forum.lvgl.io/t/lv-color-h36-error-expected-before-lv-color-t-v8-1-0-dev/6180

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
