### PR TITLE
docs(porting) fix indev example to remove v7 bool return

### DIFF
--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -123,7 +123,7 @@ indev_drv.read_cb = encoder_with_keys_read;
 
 ...
 
-bool encoder_with_keys_read(lv_indev_drv_t * drv, lv_indev_data_t*data){
+void encoder_with_keys_read(lv_indev_drv_t * drv, lv_indev_data_t*data){
   data->key = last_key();            /*Get the last pressed or released key*/
                                      /* use LV_KEY_ENTER for encoder press */
   if(key_pressed()) data->state = LV_INDEV_STATE_PRESSED;

--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -132,8 +132,6 @@ bool encoder_with_keys_read(lv_indev_drv_t * drv, lv_indev_data_t*data){
       /* Optionally you can also use enc_diff, if you have encoder*/
       data->enc_diff = enc_get_new_moves();
   }
-
-  return false; /*No buffering now so no more data read*/
 }
 ```
 


### PR DESCRIPTION
### Description of the feature or fix

It seems that v8 indev `read_cb` no longer accepts a bool return.
Other examples in the porting guide have been updated, but this one has not.
This patch removes it.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
