### PR TITLE
fix(disp) Fix assert failure in lv_disp_remove

### DIFF
--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -218,9 +218,6 @@ void lv_disp_remove(lv_disp_t * disp)
         indev = lv_indev_get_next(indev);
     }
 
-    _lv_ll_remove(&LV_GC_ROOT(_lv_disp_ll), disp);
-    lv_timer_del(disp->refr_timer);
-
     /** delete screen and other obj */
     if (disp->sys_layer) {
         lv_obj_del(disp->sys_layer);
@@ -234,6 +231,9 @@ void lv_disp_remove(lv_disp_t * disp)
         /*Delete the screenst*/
         lv_obj_del(disp->screens[0]);
     }
+
+    _lv_ll_remove(&LV_GC_ROOT(_lv_disp_ll), disp);
+    lv_timer_del(disp->refr_timer);
     lv_mem_free(disp);
 
     if(was_default) lv_disp_set_default(_lv_ll_get_head(&LV_GC_ROOT(_lv_disp_ll)));


### PR DESCRIPTION
### lv_disp_remove will assert fail

In lv_disp_remove, delete disp's  screens will assert failed because disp is already removed from _lv_disp_ll, thus makes object invalid.
Should firstly delete disp's objects before remove it from list.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
