### PR TITLE
lv_example_snapshot_1.py: add missing import

### DIFF
--- a/examples/others/snapshot/lv_example_snapshot_1.py
+++ b/examples/others/snapshot/lv_example_snapshot_1.py
@@ -1,3 +1,4 @@
+import gc
 import lvgl as lv
 from imagetools import get_png_info, open_png
 


### PR DESCRIPTION
Fixed CI identifies missing import on lv_example_snapshot_1.py

See https://github.com/lvgl/lv_binding_micropython/pull/168/checks?check_run_id=3118737116
