### PR TITLE
feat(obj) Backport keypad and encoder scrolling from v7 `lv_page` to v8 `lv_obj`

### DIFF
--- a/docs/widgets/obj.md
+++ b/docs/widgets/obj.md
@@ -166,7 +166,9 @@ By default, the objects can be clicked only on their coordinates, however, this 
 Learn more about [Events](/overview/event).
 
 ## Keys
-If `LV_OBJ_FLAG_CHECKABLE` is enabled `LV_KEY_RIGHT` and `LV_KEY_UP` make the object checked, and `LV_KEY_LEFT` and `LV_KEY_DOWN` make it unchecked.
+If `LV_OBJ_FLAG_CHECKABLE` is enabled, `LV_KEY_RIGHT` and `LV_KEY_UP` make the object checked, and `LV_KEY_LEFT` and `LV_KEY_DOWN` make it unchecked.
+
+If `LV_OBJ_FLAG_SCROLLABLE` is enabled, but the object is not editable (as declared by the widget class), the arrow keys (`LV_KEY_UP`, `LV_KEY_DOWN`, `LV_KEY_LEFT`, `LV_KEY_RIGHT`) scroll the object. If the object can only scroll vertically, `LV_KEY_LEFT` and `LV_KEY_RIGHT` will scroll up/down instead, making it compatible with an encoder input device. See [Input devices overview](/overview/indev) for more on encoder behaviors and the edit mode.
 
 
 Learn more about [Keys](/overview/indev).

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -251,13 +251,7 @@ lv_res_t lv_group_send_data(lv_group_t * group, uint32_t c)
 {
     lv_obj_t * act = lv_group_get_focused(group);
     if(act == NULL) return LV_RES_OK;
-
-    lv_res_t res;
-
-    res = lv_event_send(act, LV_EVENT_KEY, &c);
-    if(res != LV_RES_OK) return res;
-
-    return res;
+    return lv_event_send(act, LV_EVENT_KEY, &c);
 }
 
 void lv_group_set_focus_cb(lv_group_t * group, lv_group_focus_cb_t focus_cb)

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -702,6 +702,34 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
                 if(res != LV_RES_OK) return;
             }
         }
+        else if(lv_obj_has_flag(obj, LV_OBJ_FLAG_SCROLLABLE) && !lv_obj_is_editable(obj)) {
+            /*scroll by keypad or encoder*/
+            lv_anim_enable_t anim_enable = LV_ANIM_OFF;
+            lv_coord_t sl = lv_obj_get_scroll_left(obj);
+            lv_coord_t sr = lv_obj_get_scroll_right(obj);
+            char c = *((char *)lv_event_get_param(e));
+            if(c == LV_KEY_DOWN) {
+                /*use scroll_to_x/y functions to enforce scroll limits*/
+                lv_obj_scroll_to_y(obj, lv_obj_get_scroll_y(obj) + lv_obj_get_height(obj) / 4, anim_enable);
+            }
+            else if(c == LV_KEY_UP) {
+                lv_obj_scroll_to_y(obj, lv_obj_get_scroll_y(obj) - lv_obj_get_height(obj) / 4, anim_enable);
+            }
+            else if(c == LV_KEY_RIGHT) {
+                /*If the object can't be scrolled horizontally then scroll it vertically*/
+                if(!((lv_obj_get_scroll_dir(obj) & LV_DIR_HOR) && (sl > 0 || sr > 0)))
+                    lv_obj_scroll_to_y(obj, lv_obj_get_scroll_y(obj) + lv_obj_get_height(obj) / 4, anim_enable);
+                else
+                    lv_obj_scroll_to_x(obj, lv_obj_get_scroll_x(obj) + lv_obj_get_width(obj) / 4, anim_enable);
+            }
+            else if(c == LV_KEY_LEFT) {
+                /*If the object can't be scrolled horizontally then scroll it vertically*/
+                if(!((lv_obj_get_scroll_dir(obj) & LV_DIR_HOR) && (sl > 0 || sr > 0)))
+                    lv_obj_scroll_to_y(obj, lv_obj_get_scroll_y(obj) - lv_obj_get_height(obj) / 4, anim_enable);
+                else
+                    lv_obj_scroll_to_x(obj, lv_obj_get_scroll_x(obj) - lv_obj_get_width(obj) / 4, anim_enable);
+            }
+        }
     }
     else if(code == LV_EVENT_FOCUSED) {
         if(lv_obj_has_flag(obj, LV_OBJ_FLAG_SCROLL_ON_FOCUS)) {


### PR DESCRIPTION
Note to maintainers: This is my first time contributing code here. My design might not be totally in line with what you folks have in mind, but it does scratch my own itch in a reasonable way. Hope we could work something out together.

## Description of the feature or fix

### Background

I am developing on a board with a non-touch screen, a clickable encoder, and two additional buttons.
Currently I am trying to migrate my UI to LVGL v8.

### Issue

In v8, `lv_page` is collapsed into `lv_obj`. However scrolling by keypad and encoder does not work on a v8 `lv_obj`:
- `lv_obj` does not accept arrow keys anyway
- the encoder will not go into edit mode (so it will not send arrow keys) because `lv_obj` is non-editable

### Solution

Both issues are addressed here:

- `lv_obj` will accept arrow keys if it is scrollable but not editable; this will trigger manual scrolling in the same way as v7 `lv_page`.
- When considering "editable" status in the context of encoder indev processing, scrollable is also considered "editable".

New behavior:

- Using a keypad, this simply backports the `lv_page` behavior (arrow keys => scroll).
- Using a encoder, this will make a scrollable but non-editable object appear to be editable to encoder indev handling. If the object is added to a group, the encoder will be able to enter the editing mode on it for scrolling.

Basically I want this behavior to be opt-in, which is consistent with the v7 pattern of using an explicit `lv_page` to enable scrolling of arbitrary content. This is made possible in this design:

- The scrollable flag can be easily modified on a per-object basis.
- No editable status has been touched for any widget --- this is important because the editable status is per-class.
- Scrollable containers will not be auto-added to the default group. To opt-in, the UI designer must manually add a tab stop.

Regarding the scrollable flag: It might even be desirable to disable this flag by default, and maybe even automatically re-enable when the scrollbars show up. Alternatively we can use `lv_obj_get_scroll_top` and friends to discover the actual scrollability. I'd be happy to change this behavior to whatever the maintainers feel appropriate. My gut feeling is that (akin to HTML/CSS) "declared scrollable" vs. "actually scrollable" need to be more explicit even in LVGL's internal handling.

### Example

https://user-images.githubusercontent.com/1770521/126459529-6512e550-e901-41f1-9790-bf26b55ec3c0.mp4

## Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [X] Update the documentation
