### PR TITLE
docs(layout) add internal padding paragraph to grid and flex layout p…

### DIFF
--- a/docs/layouts/flex.md
+++ b/docs/layouts/flex.md
@@ -87,13 +87,9 @@ All the Flex-related values are style properties under the hood and you can use 
 
 To modify the minimum space flexbox inserts between objects, the following properties can be set on the flex container style:
 
-- `pad_row`
+- `pad_row` Sets the padding between the rows. 
 
-  Sets the padding between the rows. 
-
-- `pad_column`
-
-  Sets the padding between the columns.
+- `pad_column` Sets the padding between the columns.
 
 These can for example be used if you don't want any padding between your objects: `lv_style_set_pad_column(&row_container_style,0)`
 

--- a/docs/layouts/flex.md
+++ b/docs/layouts/flex.md
@@ -83,6 +83,20 @@ All the Flex-related values are style properties under the hood and you can use 
 - `FLEX_TRACK_PLACE`
 - `FLEX_GROW`
 
+### Internal padding
+
+To modify the minimum space flexbox inserts between objects, the following properties can be set on the flex container style:
+
+- `pad_row`
+
+  Sets the padding between the rows. 
+
+- `pad_column`
+
+  Sets the padding between the columns.
+
+These can for example be used if you don't want any padding between your objects: `lv_style_set_pad_column(&row_container_style,0)`
+
 ## Other features 
 
 ### RTL

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -88,13 +88,8 @@ All the Grid related values are style properties under the hood and you can use 
 
 To modify the minimum space Grid inserts between objects, the following properties can be set on the Grid container style:
 
-- `pad_row`
-
-  Sets the padding between the rows. 
-
-- `pad_column`
-
-  Sets the padding between the columns.
+- `pad_row` Sets the padding between the rows. 
+- `pad_column` Sets the padding between the columns.
 
 ## Other features 
 

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -84,6 +84,18 @@ All the Grid related values are style properties under the hood and you can use 
 - `GRID_CELL_ROW_POS`
 - `GRID_CELL_ROW_SPAN`
 
+### Internal padding
+
+To modify the minimum space Grid inserts between objects, the following properties can be set on the Grid container style:
+
+- `pad_row`
+
+  Sets the padding between the rows. 
+
+- `pad_column`
+
+  Sets the padding between the columns.
+
 ## Other features 
 
 ### RTL


### PR DESCRIPTION
### Description of the feature or fix

Added an internal padding attribute description in the layouts doc page. There was no reference to them and I think it can help when learning to use layouts.