### PR TITLE
fix(chart) fixed cursor positioning with large Y rescaling without LV_USE_LARGE_COORD

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -303,9 +303,10 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
     p_out->x += lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;
     p_out->x -= lv_obj_get_scroll_left(obj);
 
-    p_out->y = (int32_t)((int32_t)ser->y_points[id] - chart->ymin[ser->y_axis_sec]) * h;
-    p_out->y = p_out->y / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec]);
-    p_out->y = h - p_out->y;
+    int32_t temp_y = 0;
+    temp_y = (int32_t)((int32_t)ser->y_points[id] - chart->ymin[ser->y_axis_sec]) * h;
+    temp_y = temp_y / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec]);
+    p_out->y = h - temp_y;
     p_out->y += lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
 
 }


### PR DESCRIPTION
### Description of the feature or fix
Example of the issue (notice the `chart.set_range(lv.chart.AXIS.PRIMARY_Y, -1000, 1000)`, and that when clicking the chart the cursor gets wrongly positioned):
https://sim.lvgl.io/v8.1/micropython/ports/javascript/index.html?script_startup=https://raw.githubusercontent.com/lvgl/lvgl/bfab70802e361ccd396c9779a000e7342793f9f3/examples/header.py&script=https://raw.githubusercontent.com/lvgl/lvgl/bfab70802e361ccd396c9779a000e7342793f9f3/examples/widgets/chart/lv_example_chart_6.py&script_direct=f5c92e36d5f5c45f8ecbe82983e2c216a5bb72d0

This is due to the overflow of
`p_out->y = (int32_t)((int32_t)ser->y_points[id] - chart->ymin[ser->y_axis_sec]) * h;`
when `p_out->y` is an int16_t (when LV_USE_LARGE_COORD is not set).
This is just a temporary calculation, so there is no need to use LV_USE_LARGE_COORD just for this. In most cases, after the division:
`p_out->y = p_out->y / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec])`
`p_out->y` will again be in the [-32k,+32k] range.
Using a temporary int32_t solves this.

