### PR TITLE
fix(chart) fixed point-following cursor during vertical scroll in charts

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -308,7 +308,7 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
     temp_y = temp_y / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec]);
     p_out->y = h - temp_y;
     p_out->y += lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
-
+    p_out->y -= lv_obj_get_scroll_top(obj);
 }
 
 void lv_chart_refresh(lv_obj_t * obj)


### PR DESCRIPTION
### Description of the feature or fix

Here's the issue(cursor linked to a point not following the cursor during vertical scrolling):
https://sim.lvgl.io/v8.1/micropython/ports/javascript/index.html?script_startup=https://raw.githubusercontent.com/lvgl/lvgl/6d8799fbbfb1477ad2e0887644fb4cd900817199/examples/header.py&script=https://raw.githubusercontent.com/lvgl/lvgl/6d8799fbbfb1477ad2e0887644fb4cd900817199/examples/widgets/chart/lv_example_chart_1.py&script_direct=7e3cdfc917ff6519147fd3877ac9c7dd764be780

After following the cursor drawing code I ended up at the same four lines I just pushed this morning.
`p_out->y -= lv_obj_get_scroll_top(obj);` was missing so the vertical scroll was not accounted for.
