### PR TITLE
feat(ob) add lv_is_initialized

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -84,6 +84,11 @@ const lv_obj_class_t lv_obj_class = {
  *   GLOBAL FUNCTIONS
  **********************/
 
+bool lv_is_initialized(void)
+{
+    return lv_initialized;
+}
+
 void lv_init(void)
 {
     /*Do nothing if already initialized*/

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -205,6 +205,11 @@ void lv_deinit(void);
 #endif
 
 /**
+ * Returns whether the 'lv' library is currently initialized
+ */
+bool lv_is_initialized(void);
+
+/**
  * Create a base object (a rectangle)
  * @param parent    pointer to a parent object. If NULL then a screen will be created.
  * @return          pointer to the new object


### PR DESCRIPTION
Added lv_is_initialized to indicate whether LVGL was initialized

While it's possible to try initialize LVGL after it is already initialized, it warns 'lv_init: already inited' in such case. Therefore it is useful to be able to check on runtime whether LVGL was initialized or not before calling lv_init().

Also useful for making sure LVGL was initialized before trying to register a display driver