### PR TITLE
fix(table) avoid set cell value fmt corrupting table row height

### DIFF
--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -179,25 +179,7 @@ void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint16_t row, uint16_t col, con
     va_end(ap2);
 
     table->cell_data[cell][0] = ctrl;
-
-    /*Refresh the row height*/
-    lv_coord_t cell_left = lv_obj_get_style_pad_left(obj, LV_PART_ITEMS);
-    lv_coord_t cell_right = lv_obj_get_style_pad_right(obj, LV_PART_ITEMS);
-    lv_coord_t cell_top = lv_obj_get_style_pad_top(obj, LV_PART_ITEMS);
-    lv_coord_t cell_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_ITEMS);
-
-    lv_coord_t letter_space = lv_obj_get_style_text_letter_space(obj, LV_PART_ITEMS);
-    lv_coord_t line_space = lv_obj_get_style_text_line_space(obj, LV_PART_ITEMS);
-    const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_ITEMS);
-
-    lv_coord_t h = get_row_height(obj, row, font, letter_space, line_space,
-                                       cell_left, cell_right, cell_top, cell_bottom);
-
-
-    lv_coord_t minh = lv_obj_get_style_min_height(obj, LV_PART_ITEMS);
-    lv_coord_t maxh = lv_obj_get_style_max_height(obj, LV_PART_ITEMS);
-
-    table->row_h[row] = LV_CLAMP(minh, h, maxh);
+    refr_size(obj, row);
 
     lv_obj_invalidate(obj);
 }

--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -36,7 +36,7 @@ static void draw_main(lv_event_t * e);
 static lv_coord_t get_row_height(lv_obj_t * obj, uint16_t row_id, const lv_font_t * font,
                                  lv_coord_t letter_space, lv_coord_t line_space,
                                  lv_coord_t cell_left, lv_coord_t cell_right, lv_coord_t cell_top, lv_coord_t cell_bottom);
-static void refr_size(lv_obj_t * obj, uint32_t strat_row);
+static void refr_size(lv_obj_t * obj, uint32_t start_row);
 static lv_res_t get_pressed_cell(lv_obj_t * obj, uint16_t * row, uint16_t * col);
 
 /**********************
@@ -745,7 +745,7 @@ static void draw_main(lv_event_t * e)
     }
 }
 
-static void refr_size(lv_obj_t * obj, uint32_t strat_row)
+static void refr_size(lv_obj_t * obj, uint32_t start_row)
 {
     lv_table_t * table = (lv_table_t *)obj;
 
@@ -763,7 +763,7 @@ static void refr_size(lv_obj_t * obj, uint32_t strat_row)
     lv_coord_t minh = lv_obj_get_style_min_height(obj, LV_PART_ITEMS);
     lv_coord_t maxh = lv_obj_get_style_max_height(obj, LV_PART_ITEMS);
 
-    for(i = strat_row; i < table->row_cnt; i++) {
+    for(i = start_row; i < table->row_cnt; i++) {
         table->row_h[i] = get_row_height(obj, i, font, letter_space, line_space,
                                        cell_left, cell_right, cell_top, cell_bottom);
         table->row_h[i] = LV_CLAMP(minh, table->row_h[i], maxh);


### PR DESCRIPTION
### Description of the feature or fix

I was porting my v7 UI to v8.
There was a table that was designed to occupy almost the entire height of the screen (minus a few pixels). In v8 the not only is the table height wrong, it also broke the scrolling behavior of its parent (likely some internal state went inconsistent).

I realized that this can be repro'd in my code only when a certain (merged) cell is set using `lv_table_set_cell_value_fmt` first. If I call `lv_table_set_cell_value` first and let it finish redrawing, then the table will not become corrupted, even if I call `lv_table_set_cell_value` subsequently. 

This prompted me to look at the code. It is apparent that `lv_table_set_cell_value_fmt` had been rolling its own row height calculation, while in `lv_table_set_cell_value` this part has been refactored out to `refr_size(obj, row);`. It is likely that the inlined impl in `lv_table_set_cell_value_fmt` went out of sync in subtle ways. This patch reunifies the two codepaths.

------

--- rants below ---

While this gives the correct behavior, here we actually have an instance of [accidentally quadratic](https://accidentallyquadratic.tumblr.com/) problem: Suppose the table is R rows and C cols, then setting cell value (not necessarily formatting!) is `O(R^2*C)` instead of `O(R*C)`. It is true that you are not supposed to have a table that big (and constantly updated) in LVGL but still we could do better.

My suggestion is we can defer the update until refresh. It's certainly possible to push this burden to the user using a scope pair e.g. `lv_table_update_begin()` and `lv_table_update_end()`. Alternatively it might be possible to transparently do this internally.

I still find the v8 `lv_table` very limiting compared to v7. It used to be declarative with "cell classes"; now it's imperative and tightly coupled to the implementation details. I don't think a normal user should be touching low-level drawing data structures.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation --- N/A
