### PR TITLE
fix(examples) remove symlinks

### DIFF
--- a/examples/others/snapshot/lv_example_snapshot_1.py
+++ b/examples/others/snapshot/lv_example_snapshot_1.py
@@ -18,10 +18,10 @@ label.set_text(" memory free:" + str(mem_free/1024) + " kB")
 
 # Create an image from the png file
 try:
-    with open('../../assets/img_star.png','rb') as f:
+    with open('../../assets/star.png','rb') as f:
         png_data = f.read()
 except:
-    print("Could not find img_star.png")
+    print("Could not find star.png")
     sys.exit()
 
 img_star = lv.img_dsc_t({

--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_2.py
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_2.py
@@ -7,10 +7,10 @@ decoder.open_cb = open_png
 
 # Create an image from the png file
 try:
-    with open('../../assets/img_star.png','rb') as f:
+    with open('../../assets/star.png','rb') as f:
         png_data = f.read()
 except:
-    print("Could not find img_star.png")
+    print("Could not find star.png")
     sys.exit()
     
 img_star_argb = lv.img_dsc_t({


### PR DESCRIPTION
Remove symlinks from Python examples because the JS simulator doesn't follow them and sees the target filename instead
