### PR TITLE
kconfig: minor fix for default dark theme option

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -498,7 +498,7 @@ menu "LVGL configuration"
         config LV_USE_THEME_DEFAULT
             bool "A simple, impressive and very complete theme"
             default y
-        config LV_THEME_DEFAULT_PALETTE_LIGHT
+        config LV_THEME_DEFAULT_DARK
             bool "Yes to set light mode, No to set dark mode"
             default y
             depends on LV_USE_THEME_DEFAULT


### PR DESCRIPTION
### Description of the feature or fix

Changes the name of the CONFIG variable from LV_THEME_DEFAULT_PALETTE_LIGHT to LV_THEME_DEFAULT_DARK.
Most likely it should have been included in 4f46336a544d6cde0ed14f37775dfd8ecb772af3

### Checkpoints
- [NA] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [NA] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [NA] Update the documentation
