### PR TITLE
feat(switch) add smooth animation when changing state

### DIFF
--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -74,6 +74,7 @@ typedef struct {
     lv_style_t transition_delayed;
     lv_style_t transition_normal;
     lv_style_t anim;
+    lv_style_t anim_fast;
 
     /*Parts*/
     lv_style_t knob;
@@ -379,6 +380,9 @@ static void style_init(void)
 
     style_init_reset(&styles->anim);
     lv_style_set_anim_time(&styles->anim, 200);
+
+    style_init_reset(&styles->anim_fast);
+    lv_style_set_anim_time(&styles->anim_fast, 120);
 
 #if LV_USE_ARC
     style_init_reset(&styles->arc_indic);
@@ -772,6 +776,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
     else if(lv_obj_check_type(obj, &lv_switch_class)) {
         lv_obj_add_style(obj, &styles->bg_color_grey, 0);
         lv_obj_add_style(obj, &styles->circle, 0);
+        lv_obj_add_style(obj, &styles->anim_fast, 0);
         lv_obj_add_style(obj, &styles->disabled, LV_STATE_DISABLED);
         lv_obj_add_style(obj, &styles->outline_primary, LV_STATE_FOCUS_KEY);
         lv_obj_add_style(obj, &styles->bg_color_primary, LV_PART_INDICATOR | LV_STATE_CHECKED);
@@ -781,6 +786,9 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         lv_obj_add_style(obj, &styles->bg_color_white, LV_PART_KNOB);
         lv_obj_add_style(obj, &styles->switch_knob, LV_PART_KNOB);
         lv_obj_add_style(obj, &styles->disabled, LV_PART_KNOB | LV_STATE_DISABLED);
+
+        lv_obj_add_style(obj, &styles->transition_normal, LV_PART_INDICATOR | LV_STATE_CHECKED);
+        lv_obj_add_style(obj, &styles->transition_normal, LV_PART_INDICATOR);
     }
 #endif
 

--- a/src/widgets/lv_switch.h
+++ b/src/widgets/lv_switch.h
@@ -17,11 +17,6 @@ extern "C" {
 
 #if LV_USE_SWITCH != 0
 
-/*Testing of dependencies*/
-#if LV_USE_SLIDER == 0
-#error "lv_switch: lv_slider is required. Enable it in lv_conf.h (LV_USE_SLIDER  1)"
-#endif
-
 #include "../core/lv_obj.h"
 
 /*********************
@@ -33,7 +28,14 @@ extern "C" {
  **********************/
 
 typedef struct {
+    lv_obj_t * sw;
+    int32_t anim_state;
+} _lv_switch_anim_t;
+
+
+typedef struct {
     lv_obj_t obj;
+    _lv_switch_anim_t value_anim;
 }lv_switch_t;
 
 extern const lv_obj_class_t lv_switch_class;

--- a/src/widgets/lv_switch.h
+++ b/src/widgets/lv_switch.h
@@ -28,14 +28,8 @@ extern "C" {
  **********************/
 
 typedef struct {
-    lv_obj_t * sw;
-    int32_t anim_state;
-} _lv_switch_anim_t;
-
-
-typedef struct {
     lv_obj_t obj;
-    _lv_switch_anim_t value_anim;
+    int32_t anim_state;
 }lv_switch_t;
 
 extern const lv_obj_class_t lv_switch_class;


### PR DESCRIPTION
### Description of the feature or fix

The switch now animates smoothly when changing state as it did in 7.11 and earlier.

Based on @HX2003's work. I made a few minor changes to fix build errors and improve readability, but the implementation is 100% identical.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
