### PR TITLE
fix(cmake) require 'main' for Micropython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,16 @@ if(ESP_PLATFORM)
 
 file(GLOB_RECURSE SOURCES src/*.c)
 
-idf_component_register(SRCS ${SOURCES}
-                       INCLUDE_DIRS . src ../)
+idf_build_get_property(LV_MICROPYTHON LV_MICROPYTHON)
+
+if (LV_MICROPYTHON)
+    idf_component_register(SRCS ${SOURCES}
+                           INCLUDE_DIRS . src ../
+                           REQUIRES main)
+else()
+    idf_component_register(SRCS ${SOURCES}
+                           INCLUDE_DIRS . src ../)
+endif()
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 


### PR DESCRIPTION
Commit f2c2393b305cd71d2fc01ff8945965dccb8488b4 (#2420) breaks lv_micropython esp32 port. Apparently main dependency is require for LVGL when building Micropython, otherwise GC related code breaks

This commit adds 'main' dependency to LVGL conditionally only if building inside lv_micropython