### PR TITLE
fix(docs) add static keyword to driver declaration

### DIFF
--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -35,7 +35,7 @@ lv_disp_draw_buf_init(&draw_buf, buf1, NULL, MY_DISP_HOR_RES * MY_DISP_VER_SER /
 ```
 - Implement and register a function which can copy the rendered image to an area of your display:
 ```c
-lv_disp_drv_t disp_drv;               /*Descriptor of a display driver*/
+static lv_disp_drv_t disp_drv;        /*Descriptor of a display driver*/
 lv_disp_drv_init(&disp_drv);          /*Basic initialization*/
 disp_drv.flush_cb = my_disp_flush;    /*Set your driver function*/
 disp_drv.buffer = &draw_buf;          /*Assign the buffer to the display*/
@@ -61,7 +61,7 @@ void my_disp_flush(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * co
 ```
 - Implement and register a function which can read an input device. E.g. for a touch pad:
 ```c
-lv_indev_drv_t indev_drv;                  /*Descriptor of a input device driver*/
+static lv_indev_drv_t indev_drv;           /*Descriptor of a input device driver*/
 lv_indev_drv_init(&indev_drv);             /*Basic initialization*/
 indev_drv.type = LV_INDEV_TYPE_POINTER;    /*Touch pad is a pointer-like device*/
 indev_drv.read_cb = my_touchpad_read;      /*Set your driver function*/


### PR DESCRIPTION
Add [missing static keyword ](https://forum.lvgl.io/t/v8-documentation-problem/6452) to disp_drv and indev_drv declarations in the examples

### Description of the feature or fix

Fix for this forum post:
>  It seems you have forgotten to place the static keyword before the “lv_disp_drv_t disp_drv;” in the get started section of the V8 document (Page 194). It is misleading for beginners.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
