### PR TITLE
Fix two examples in the docs with new v8 api

### DIFF
--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -38,7 +38,7 @@ lv_disp_draw_buf_init(&draw_buf, buf1, NULL, MY_DISP_HOR_RES * MY_DISP_VER_SER /
 static lv_disp_drv_t disp_drv;        /*Descriptor of a display driver*/
 lv_disp_drv_init(&disp_drv);          /*Basic initialization*/
 disp_drv.flush_cb = my_disp_flush;    /*Set your driver function*/
-disp_drv.buffer = &draw_buf;          /*Assign the buffer to the display*/
+disp_drv.draw_buf = &draw_buf;          /*Assign the buffer to the display*/
 disp_drv.hor_res = MY_DISP_HOR_RES;   /*Set the horizontal resolution of the display*/
 disp_drv.ver_res = MY_DISP_VER_RES;   /*Set the vertical resolution of the display*/
 lv_disp_drv_register(&disp_drv);      /*Finally register the driver*/

--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -38,7 +38,7 @@ lv_disp_draw_buf_init(&draw_buf, buf1, NULL, MY_DISP_HOR_RES * MY_DISP_VER_SER /
 static lv_disp_drv_t disp_drv;        /*Descriptor of a display driver*/
 lv_disp_drv_init(&disp_drv);          /*Basic initialization*/
 disp_drv.flush_cb = my_disp_flush;    /*Set your driver function*/
-disp_drv.draw_buf = &draw_buf;          /*Assign the buffer to the display*/
+disp_drv.draw_buf = &draw_buf;        /*Assign the buffer to the display*/
 disp_drv.hor_res = MY_DISP_HOR_RES;   /*Set the horizontal resolution of the display*/
 disp_drv.ver_res = MY_DISP_VER_RES;   /*Set the vertical resolution of the display*/
 lv_disp_drv_register(&disp_drv);      /*Finally register the driver*/

--- a/docs/overview/indev.md
+++ b/docs/overview/indev.md
@@ -23,7 +23,7 @@ Pointer input devices (like a mouse) can have a cursor.
 lv_indev_t * mouse_indev = lv_indev_drv_register(&indev_drv);
 
 LV_IMG_DECLARE(mouse_cursor_icon);                          /*Declare the image file.*/
-lv_obj_t * cursor_obj =  lv_img_create(lv_scr_act(), NULL); /*Create an image object for the cursor */
+lv_obj_t * cursor_obj =  lv_img_create(lv_scr_act());       /*Create an image object for the cursor */
 lv_img_set_src(cursor_obj, &mouse_cursor_icon);             /*Set the image source*/
 lv_indev_set_cursor(mouse_indev, cursor_obj);               /*Connect the image  object to the driver*/
 


### PR DESCRIPTION
### Description of the feature or fix

Update 2 examples in the docs:
- The fieldname `buffer` has changed to `draw_buf` in v8 api
- Removed the 2nd parameter from lv_img_create in the cursor indev example

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
