### PR TITLE
docs fix typo: arae -> area

### DIFF
--- a/docs/widgets/core/arc.md
+++ b/docs/widgets/core/arc.md
@@ -73,7 +73,7 @@ lv_obj_clear_flag(arc, LV_OBJ_FLAG_CLICKABLE);
         - `arc_dsc`
     - LV_ARC_DRAW_PART_KNOB The knob
         - `part`: `LV_PART_KNOB`
-        - `draw_area`: the arae of the knob
+        - `draw_area`: the area of the knob
         - `rect_dsc`:
     
 See the events of the [Base object](/widgets/obj) too.

--- a/docs/widgets/core/textarea.md
+++ b/docs/widgets/core/textarea.md
@@ -80,7 +80,7 @@ To align the text in the Text area ` lv_textarea_set_align(textarea, LV_TEXT_ALI
 
 
 ### Accepted characters
-You can set a list of accepted characters with `lv_textarae_set_accepted_chars(textarea, "0123456789.+-")`. 
+You can set a list of accepted characters with `lv_textarea_set_accepted_chars(textarea, "0123456789.+-")`. 
 Other characters will be ignored. 
 
 ### Max text length


### PR DESCRIPTION
### Description of the feature or fix
This PR fixes an easily overlooked typo of the word "area" in two places.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
