### PR TITLE
ci(tests): Build Unix port MicroPython submodules in parallel.

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Initialize lv_bindings submodule
       run: git submodule update --init --recursive lib/lv_bindings
     - name: Update Unix port submodules
-      run: make -C ports/unix VARIANT=dev DEBUG=1 submodules
+      run: make -C ports/unix -j $(nproc) VARIANT=dev DEBUG=1 submodules
     - name: Checkout LVGL submodule
       working-directory: ./lib/lv_bindings/lvgl
       run: |


### PR DESCRIPTION
Added missing `-j <numcores>` when building MicroPython submodules.