### PR TITLE
fix(color) Bad cast in lv_color_mix() caused UB with 16bpp or less

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - perf(draw) reimplement rectangle drawing algorithms 
 - perf(draw) reimplement circle drawing algorithms (#2374) (Also [change masking](https://docs.lvgl.io/master/overview/drawing.html#masking))
 - fix(draw) false assertion error in lv_draw_mask caused by wrong pointer
+- fix(color) Bad cast in lv_color_mix() caused UB with 16bpp or less
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -464,7 +464,7 @@ LV_ATTRIBUTE_FAST_MEM static inline lv_color_t lv_color_mix(lv_color_t c1, lv_co
     /*Source: https://stackoverflow.com/a/50012418/1999969*/
     mix = ( mix + 4 ) >> 3;
     uint32_t bg = (uint32_t)((uint32_t)c2.full | ((uint32_t)c2.full << 16)) & 0x7E0F81F; /*0b00000111111000001111100000011111*/
-    uint32_t fg = (uint32_t)((uint32_t)c1.full | (uint32_t)(c1.full << 16)) & 0x7E0F81F;
+    uint32_t fg = (uint32_t)((uint32_t)c1.full | ((uint32_t)c1.full << 16)) & 0x7E0F81F;
     uint32_t result = ((((fg - bg) * mix) >> 5) + bg) & 0x7E0F81F;
     ret.full = (uint16_t)((result >> 16) | result);
 #elif LV_COLOR_DEPTH != 1


### PR DESCRIPTION
Left shift overflows when lv_color_t is 16 bits or less because of cast outside parens.

Note that this showed up in a UBSan warning. Other devs should consider enabling it on platforms that support it.
