### PR TITLE
Add dependency on GNU parallel.

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install SDL
+    - name: Install Dependencies
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
         sudo apt-get update -y -qq
-        sudo apt-get install libsdl2-dev
+        sudo apt-get install libsdl2-dev parallel
     - name: Clone lv_micropython
       run: |
         git clone https://github.com/lvgl/lv_micropython.git .


### PR DESCRIPTION
lv_binding_micropython added a dependency on GNU parallel[1] to allow
the tests to be run in parallel.

[1] https://www.gnu.org/software/parallel/