### PR TITLE
Corrected a function name in obj.md

### DIFF
--- a/docs/widgets/obj.md
+++ b/docs/widgets/obj.md
@@ -42,7 +42,7 @@ lv_obj_align(obj, LV_ALIGN_CENTER, 10, 20);
 
 To align one object to another use `lv_obj_align_to(obj_to_align, obj_referece, LV_ALIGN_..., x, y)`
 
-For example, to align a text below an image: `lv_obj_align(text, image, LV_ALIGN_OUT_BOTTOM_MID, 0, 10)`.
+For example, to align a text below an image: `lv_obj_align_to(text, image, LV_ALIGN_OUT_BOTTOM_MID, 0, 10)`.
 
 The following align types exist:
 ![](/misc/align.png "Alignment types in LVGL")


### PR DESCRIPTION
### Description of the feature or fix

In the example of `lv_obj_align_to(obj_to_align, obj_referece, LV_ALIGN_..., x, y)`, the function name was written as `lv_obj_align()` instead of `lv_obj_align_to()` .