### PR TITLE
added lv_obj_move_to_index(obj, index), renamed lv_obj_get_child_id(obj) to lv_obj_get_index(obj)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## v8.1.0 (In progress)
 - renamed lv_obj_get_child_id(obj) to lv_obj_get_index(obj).
-- added lv_obj_move_to_index(obj, index).
-- lv_obj_move_up(obj) and lv_obj_move_down(obj) added. (#2461)
+- added lv_obj_move_to_index(obj, index). (#2461)
 - lv_obj_swap(obj1, obj2) added. (#2461)
 - feat(anim) add interface for handling lv_anim user data. (#2415)
 - feat(obj) add lv_is_initialized (#2402)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v8.1.0 (In progress)
 - renamed lv_obj_get_child_id(obj) to lv_obj_get_index(obj).
 - added lv_obj_move_to_index(obj, index). (#2461)
+- redefined lv_obj_move_foreground(obj) and lv_obj_move_background(obj) as inline functions now calling lv_obj_move_to_index(obj, index).
 - lv_obj_swap(obj1, obj2) added. (#2461)
 - feat(anim) add interface for handling lv_anim user data. (#2415)
 - feat(obj) add lv_is_initialized (#2402)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v8.1.0 (In progress)
+- renamed lv_obj_get_child_id(obj) to lv_obj_get_index(obj).
+- added lv_obj_move_to_index(obj, index).
 - lv_obj_move_up(obj) and lv_obj_move_down(obj) added. (#2461)
 - lv_obj_swap(obj1, obj2) added. (#2461)
 - feat(anim) add interface for handling lv_anim user data. (#2415)

--- a/docs/overview/layer.md
+++ b/docs/overview/layer.md
@@ -40,9 +40,10 @@ lv_obj_del(label2);
 
 ## Bring to the foreground
 
-There are 4 explicit way to bring an object to the foreground:
+There are 5 explicit way to bring an object to the foreground:
 - Use `lv_obj_move_foreground(obj)` to explicitly tell the library to bring an object to the foreground. Similarly, use `lv_obj_move_background(obj)` to move to the background.
-- Use `lv_obj_move_up(obj)` moves the object one position up in the hierarchy, Similarly, use `lv_obj_move_down(obj)` moves the object one position down in the hierarchy. 
+- Use `lv_obj_move_to_index(obj, index)` to set the index of the object in its parent. 
+- Use `lv_obj_move_up(obj)` to move the object one position up in the hierarchy, Similarly, use `lv_obj_move_down(obj)` moves the object one position down in the hierarchy. 
 - Use `lv_obj_swap(obj1, obj2)` to swap the relative position of two objects.
 - When `lv_obj_set_parent(obj, new_parent)` is used, `obj` will be on the foreground on the `new_parent`.
 

--- a/docs/overview/layer.md
+++ b/docs/overview/layer.md
@@ -40,10 +40,9 @@ lv_obj_del(label2);
 
 ## Bring to the foreground
 
-There are 5 explicit way to bring an object to the foreground:
+There are 4 explicit way to bring an object to the foreground:
 - Use `lv_obj_move_foreground(obj)` to explicitly tell the library to bring an object to the foreground. Similarly, use `lv_obj_move_background(obj)` to move to the background.
 - Use `lv_obj_move_to_index(obj, index)` to set the index of the object in its parent. 
-- Use `lv_obj_move_up(obj)` to move the object one position up in the hierarchy, Similarly, use `lv_obj_move_down(obj)` moves the object one position down in the hierarchy. 
 - Use `lv_obj_swap(obj1, obj2)` to swap the relative position of two objects.
 - When `lv_obj_set_parent(obj, new_parent)` is used, `obj` will be on the foreground on the `new_parent`.
 

--- a/docs/widgets/obj.md
+++ b/docs/widgets/obj.md
@@ -71,8 +71,6 @@ You can bring an object to the foreground or send it to the background with `lv_
 
 You can change the index of an object in its parent using  `lv_obj_move_to_index(obj, index)`. 
 
-You can move an object one position up or down in the hierargy with `lv_obj_move_up(obj)` and `lv_obj_move_down(obj)`. 
-
 You can swap the position of two objects with `lv_obj_swap(obj1, obj2)`.
 
 ### Screens

--- a/docs/widgets/obj.md
+++ b/docs/widgets/obj.md
@@ -65,9 +65,11 @@ for(i = 0; i < lv_obj_get_child_cnt(parent); i++) {
 }
 ```
 
-`lv_obj_get_child_id(obj)` returns the index of the object. That is how many younger children its parent has.
+`lv_obj_get_index(obj)` returns the index of the object. That is how many younger children its parent has.
 
 You can bring an object to the foreground or send it to the background with `lv_obj_move_foreground(obj)` and `lv_obj_move_background(obj)`.
+
+You can change the index of an object in its parent using  `lv_obj_move_to_index(obj, index)`. 
 
 You can move an object one position up or down in the hierargy with `lv_obj_move_up(obj)` and `lv_obj_move_down(obj)`. 
 

--- a/examples/widgets/list/lv_example_list_2.c
+++ b/examples/widgets/list/lv_example_list_2.c
@@ -4,8 +4,6 @@
 #include "../../lv_examples.h"
 #if LV_USE_LIST && LV_BUILD_EXAMPLES
 
-#define USE_MOVE_TO_INDEX
-
 static lv_obj_t* list1;
 static lv_obj_t* list2;
 
@@ -61,13 +59,9 @@ static void event_handler_up(lv_event_t* e)
     if ((code == LV_EVENT_CLICKED) || (code == LV_EVENT_LONG_PRESSED_REPEAT))
     {
         if (currentButton == NULL) return;
-#ifndef USE_MOVE_TO_INDEX
-        lv_obj_move_up(currentButton);
-#else
         uint32_t index = lv_obj_get_index(currentButton);
         if (index <= 0) return;
         lv_obj_move_to_index(currentButton, index - 1);
-#endif
         lv_obj_scroll_to_view(currentButton, LV_ANIM_ON);
     }
 }
@@ -94,13 +88,9 @@ static void event_handler_dn(lv_event_t* e)
     if ((code == LV_EVENT_CLICKED) || (code == LV_EVENT_LONG_PRESSED_REPEAT))
     {
         if (currentButton == NULL) return;
-#ifndef USE_MOVE_TO_INDEX
-        lv_obj_move_down(currentButton);
-#else
         const uint32_t index = lv_obj_get_index(currentButton);
 
         lv_obj_move_to_index(currentButton, index + 1);
-#endif
         lv_obj_scroll_to_view(currentButton, LV_ANIM_ON);
     }
 }

--- a/examples/widgets/list/lv_example_list_2.c
+++ b/examples/widgets/list/lv_example_list_2.c
@@ -78,7 +78,6 @@ static void event_handler_center(lv_event_t* e)
     if ((code == LV_EVENT_CLICKED) || (code == LV_EVENT_LONG_PRESSED_REPEAT))
     {
         if (currentButton == NULL) return;
-        uint32_t index = lv_obj_get_index(currentButton);
 
         lv_obj_t* parent = lv_obj_get_parent(currentButton);
         const uint32_t pos = lv_obj_get_child_cnt(parent) / 2;

--- a/examples/widgets/win/lv_example_win_1.c
+++ b/examples/widgets/win/lv_example_win_1.c
@@ -5,7 +5,7 @@
 static void event_handler(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target(e);
-    LV_LOG_USER("Button %d clicked", lv_obj_get_child_id(obj));
+    LV_LOG_USER("Button %d clicked", lv_obj_get_index(obj));
 }
 
 void lv_example_win_1(void)

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -197,42 +197,6 @@ void lv_obj_set_parent(lv_obj_t * obj, lv_obj_t * parent)
     lv_obj_invalidate(obj);
 }
 
-void lv_obj_move_foreground(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_obj_t * parent = lv_obj_get_parent(obj);
-
-    uint32_t i;
-    for(i = lv_obj_get_index(obj); i < lv_obj_get_child_cnt(parent) - 1; i++) {
-        parent->spec_attr->children[i] = parent->spec_attr->children[i + 1];
-    }
-    parent->spec_attr->children[lv_obj_get_child_cnt(parent) - 1] = obj;
-
-    /*Notify the new parent about the child*/
-    lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
-
-    lv_obj_invalidate(parent);
-}
-
-void lv_obj_move_background(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_obj_t * parent = lv_obj_get_parent(obj);
-
-    int32_t i;
-    for(i = lv_obj_get_index(obj); i > 0; i--) {
-        parent->spec_attr->children[i] = parent->spec_attr->children[i-1];
-    }
-    parent->spec_attr->children[0] = obj;
-
-    /*Notify the new parent about the child*/
-    lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
-
-    lv_obj_invalidate(parent);
-}
-
 void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -295,51 +295,6 @@ void lv_obj_swap(lv_obj_t * obj1, lv_obj_t * obj2)
     lv_group_swap_obj(obj1, obj2);
 }
 
-void lv_obj_move_up(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_obj_t * parent = lv_obj_get_parent(obj);
-
-    uint_fast32_t index = lv_obj_get_index(obj);
-    if (index > 0)
-    {
-        lv_obj_t * obj2 = parent->spec_attr->children[index - 1];
-        parent->spec_attr->children[index - 1] = obj;
-        parent->spec_attr->children[index] = obj2;
-
-        lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
-        lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj2);
-
-        lv_obj_invalidate(parent);
-
-        lv_group_swap_obj(obj, obj2);
-    }
-}
-
-
-void lv_obj_move_down(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_obj_t * parent = lv_obj_get_parent(obj);
-
-    uint_fast32_t index = lv_obj_get_index(obj);
-    if (index < lv_obj_get_child_cnt(parent) - 1)
-    {
-        lv_obj_t * obj2 = parent->spec_attr->children[index + 1];
-        parent->spec_attr->children[index + 1] = obj;
-        parent->spec_attr->children[index] = obj2;
-
-        lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
-        lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj2);
-
-        lv_obj_invalidate(parent);
-
-        lv_group_swap_obj(obj, obj2);
-    }
-}
-
 lv_obj_t * lv_obj_get_screen(const lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -425,13 +425,6 @@ uint32_t lv_obj_get_index(const lv_obj_t * obj)
     return 0xFFFFFFFF; /*Shouldn't happen*/
 }
 
-uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
-{
-    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
-    return lv_obj_get_index(obj);
-}
-
-
 void lv_obj_tree_walk(lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void* user_data)
 {
     walk_core(start_obj, cb, user_data);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -241,12 +241,12 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
 
     lv_obj_t * parent = lv_obj_get_parent(obj);
 
-    index = max(0, min(index, (int32_t ) lv_obj_get_child_cnt(parent) - 1));
-
-    if (index == old_index) return;
+    if(index < 0) return;
+    if(index >= lv_obj_get_child_cnt(parent)) return;
+    if(index == old_index) return;
 
     int32_t i = old_index;
-    if (index < old_index)
+    if(index < old_index)
     {
         while (i > index)
         {

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -425,6 +425,12 @@ uint32_t lv_obj_get_index(const lv_obj_t * obj)
     return 0xFFFFFFFF; /*Shouldn't happen*/
 }
 
+uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+{
+    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
+    return lv_obj_get_index(obj);
+}
+
 
 void lv_obj_tree_walk(lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void* user_data)
 {

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -242,7 +242,7 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
     lv_obj_t * parent = lv_obj_get_parent(obj);
 
     if(index < 0) return;
-    if(index >= lv_obj_get_child_cnt(parent)) return;
+    if(index >= (int32_t) lv_obj_get_child_cnt(parent)) return;
     if(index == old_index) return;
 
     int32_t i = old_index;

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -187,7 +187,11 @@ uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
  * @return          the child index of the object.
  *                  E.g. 0: the oldest (firstly created child)
  */
-uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj);
+static uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+{
+    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
+    return lv_obj_get_index(obj);
+}
 
 /**
  * Iterate through all children of any object.

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -110,24 +110,12 @@ void lv_obj_move_background(struct _lv_obj_t * obj);
 void lv_obj_swap(struct _lv_obj_t* obj1, struct _lv_obj_t* obj2);
 
 /**
- * moves the object one position up in the hierarchy.
- * When used in listboxes, it can be used to sort the listbox items.
- * @param obj  pointer to the object to be moved upwards.
- */
-void lv_obj_move_up(struct _lv_obj_t* obj);
-
-/**
- * moves the object one position down in the hierarchy.
- * When used in listboxes, it can be used to sort the listbox items.
- * @param obj  pointer to the object to be moved downwards.
- */
-void lv_obj_move_down(struct _lv_obj_t* obj);
-
-/**
  * moves the object to the given index in its parent.
  * When used in listboxes, it can be used to sort the listbox items.
  * @param obj  pointer to the object to be moved.
  * @param index  new index in parent.
+ * @note to move to the foreground: lv_obj_move_to_index(obj, 0)
+ * @note to move forward (up): lv_obj_move_to_index(obj, lv_obj_get_index(obj) - 1) 
  */
 void lv_obj_move_to_index(struct _lv_obj_t* obj, int32_t index);
 

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -181,6 +181,15 @@ uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
 uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
 
 /**
+ * DEPRECATED FUNCTION, please use uint32_t lv_obj_get_index(obj);
+ * Get the index of a child.
+ * @param obj       pointer to an object
+ * @return          the child index of the object.
+ *                  E.g. 0: the oldest (firstly created child)
+ */
+uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj);
+
+/**
  * Iterate through all children of any object.
  * @param start_obj     start integrating from this object
  * @param cb            call this callback on the objects

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -187,11 +187,7 @@ uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
  * @return          the child index of the object.
  *                  E.g. 0: the oldest (firstly created child)
  */
-inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
-{
-    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
-    return lv_obj_get_index(obj);
-}
+uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj);
 
 /**
  * Iterate through all children of any object.

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -181,19 +181,6 @@ uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
 uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
 
 /**
- * DEPRECATED FUNCTION, please use uint32_t lv_obj_get_index(obj);
- * Get the index of a child.
- * @param obj       pointer to an object
- * @return          the child index of the object.
- *                  E.g. 0: the oldest (firstly created child)
- */
-static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
-{
-    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
-    return lv_obj_get_index(obj);
-}
-
-/**
  * Iterate through all children of any object.
  * @param start_obj     start integrating from this object
  * @param cb            call this callback on the objects

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -86,22 +86,6 @@ void lv_obj_del_async(struct _lv_obj_t * obj);
 void lv_obj_set_parent(struct _lv_obj_t * obj, struct _lv_obj_t * parent);
 
 /**
- * Move the object to the foreground.
- * It will look like if it was created as the last child of its parent.
- * It also means it can cover any of the siblings.
- * @param obj       pointer to an object
- */
-void lv_obj_move_foreground(struct _lv_obj_t * obj);
-
-/**
- * Move the object to the background.
- * It will look like if it was created as the first child of its parent.
- * It also means any of the siblings can cover the object.
- * @param obj       pointer to an object
- */
-void lv_obj_move_background(struct _lv_obj_t * obj);
-
-/**
  * Swap the positions of two objects.
  * When used in listboxes, it can be used to sort the listbox items.
  * @param obj1  pointer to the first object

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -187,7 +187,11 @@ uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
  * @return          the child index of the object.
  *                  E.g. 0: the oldest (firstly created child)
  */
-uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj);
+inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+{
+    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
+    return lv_obj_get_index(obj);
+}
 
 /**
  * Iterate through all children of any object.

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -187,7 +187,7 @@ uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
  * @return          the child index of the object.
  *                  E.g. 0: the oldest (firstly created child)
  */
-static uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
 {
     LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
     return lv_obj_get_index(obj);

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -124,6 +124,14 @@ void lv_obj_move_up(struct _lv_obj_t* obj);
 void lv_obj_move_down(struct _lv_obj_t* obj);
 
 /**
+ * moves the object to the given index in its parent.
+ * When used in listboxes, it can be used to sort the listbox items.
+ * @param obj  pointer to the object to be moved.
+ * @param index  new index in parent.
+ */
+void lv_obj_move_to_index(struct _lv_obj_t* obj, int32_t index);
+
+/**
  * Get the screen of an object
  * @param obj       pointer to an object
  * @return          pointer to the object's screen
@@ -166,11 +174,11 @@ uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
 
 /**
  * Get the index of a child.
- * @param obj       pointer to an obejct
+ * @param obj       pointer to an object
  * @return          the child index of the object.
  *                  E.g. 0: the oldest (firstly created child)
  */
-uint32_t lv_obj_get_child_id(const struct _lv_obj_t * obj);
+uint32_t lv_obj_get_index(const struct _lv_obj_t* obj);
 
 /**
  * Iterate through all children of any object.

--- a/src/extra/themes/basic/lv_theme_basic.c
+++ b/src/extra/themes/basic/lv_theme_basic.c
@@ -201,12 +201,12 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 
 #if LV_USE_WIN
         /*Header*/
-        if(lv_obj_get_child_id(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        if(lv_obj_get_index(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->light, 0);
             return;
         }
         /*Content*/
-        else if(lv_obj_get_child_id(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        else if(lv_obj_get_index(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->light, 0);
             lv_obj_add_style(obj, &styles->scrollbar, LV_PART_SCROLLBAR);
             return;

--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -630,13 +630,13 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 
 #if LV_USE_WIN
         /*Header*/
-        if(lv_obj_get_child_id(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        if(lv_obj_get_index(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->bg_color_grey, 0);
             lv_obj_add_style(obj, &styles->pad_tiny, 0);
             return;
         }
         /*Content*/
-        else if(lv_obj_get_child_id(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        else if(lv_obj_get_index(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->scr, 0);
             lv_obj_add_style(obj, &styles->pad_normal, 0);
             lv_obj_add_style(obj, &styles->scrollbar, LV_PART_SCROLLBAR);

--- a/src/extra/themes/mono/lv_theme_mono.c
+++ b/src/extra/themes/mono/lv_theme_mono.c
@@ -219,13 +219,13 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 
 #if LV_USE_WIN
         /*Header*/
-        if(lv_obj_get_child_id(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        if(lv_obj_get_index(obj) == 0 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->card, 0);
             lv_obj_add_style(obj, &styles->no_radius, 0);
             return;
         }
         /*Content*/
-        else if(lv_obj_get_child_id(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
+        else if(lv_obj_get_index(obj) == 1 && lv_obj_check_type(lv_obj_get_parent(obj), &lv_win_class)) {
             lv_obj_add_style(obj, &styles->card, 0);
             lv_obj_add_style(obj, &styles->no_radius, 0);
             lv_obj_add_style(obj, &styles->scrollbar, LV_PART_SCROLLBAR);

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -47,7 +47,7 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
 
 static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
 {
-    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
+    LV_LOG_WARN("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
     return lv_obj_get_index(obj);
 }
 

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -41,6 +41,17 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
  *      MACROS
  **********************/
 
+ /**********************
+  * DEPRECATED FUNCTIONS
+  **********************/
+
+inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+{
+    LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
+    return lv_obj_get_index(obj);
+}
+
+
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -41,9 +41,39 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
  *      MACROS
  **********************/
 
- /**********************
-  * DEPRECATED FUNCTIONS
-  **********************/
+
+/**********************
+ * INLINE FUNCTIONS
+ **********************/
+
+/**
+ * Move the object to the foreground.
+ * It will look like if it was created as the last child of its parent.
+ * It also means it can cover any of the siblings.
+ * @param obj       pointer to an object
+ */
+static inline void lv_obj_move_foreground(lv_obj_t* obj)
+{
+    lv_obj_t* parent = lv_obj_get_parent(obj);
+    lv_obj_move_to_index(obj, lv_obj_get_child_cnt(parent) - 1);
+}
+
+/**
+ * Move the object to the background.
+ * It will look like if it was created as the first child of its parent.
+ * It also means any of the siblings can cover the object.
+ * @param obj       pointer to an object
+ */
+static inline void lv_obj_move_background(lv_obj_t* obj)
+{
+    lv_obj_move_to_index(obj, 0);
+}
+
+
+
+/**********************
+ * DEPRECATED FUNCTIONS
+ **********************/
 
 static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
 {

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -45,13 +45,11 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
   * DEPRECATED FUNCTIONS
   **********************/
 
-/* function is inline in lv_obj_tree.h, otherwise Micropython will not build
-inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
+static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
 {
     LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
     return lv_obj_get_index(obj);
 }
-*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -45,12 +45,13 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
   * DEPRECATED FUNCTIONS
   **********************/
 
+/* function is inline in lv_obj_tree.h, otherwise Micropython will not build
 inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t* obj)
 {
     LV_LOG_USER("lv_obj_get_child_id(obj) is deprecated, please use lv_obj_get_index(obj).");
     return lv_obj_get_index(obj);
 }
-
+*/
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
- added lv_obj_move_to_index(obj, index).
- renamed lv_obj_get_child_id(obj) to lv_obj_get_index(obj).

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
