### PR TITLE
Espressif IDF component manager

### DIFF
--- a/.github/workflows/esp_upload_component.yml
+++ b/.github/workflows/esp_upload_component.yml
@@ -1,0 +1,19 @@
+name: Push LVGL release to Espressif Component Service
+
+# Upload on successful release
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Upload component to component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          name: "lvgl"
+          namespace: "lvgl"
+          api_token: ${{ secrets.ESP_IDF_COMPONENT_API_TOKEN }}

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,3 @@
+version: "8.0.2"
+description: LVGL - Light and Versatile Graphics Library
+url: https://github.com/lvgl/lvgl


### PR DESCRIPTION
### Description of the feature or fix
This PR adds a workflow for automatic upload to Espressif's component service on successful release of new version.

Idf-component-manager is a new function that allows ESP-IDF users to integrate software package into their project seamlessly.
We'd like the LVGL project to be one of the first external components, hosted on our component service.

More information about idf-component manager can be found in [Espressif API guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html) or [PyPi registry](https://pypi.org/project/idf-component-manager/). The component service itself is hosted [here](https://components.espressif.com/).

In order to upload to Espressif's registry, an API token must be added to Github secrets (see [.github/workflows/esp_upload_component.yml  line 19](https://github.com/lvgl/lvgl/blob/b7733e0d0d338ae8ad9d5f890a7cbd6803dfc7ec/.github/workflows/esp_upload_component.yml#L19)), I can send it to you in private message, if you agree.

### Checkpoints
- [x] Add ESP_IDF token to Github secrets
