### PR TITLE
fix(examples) don't compile assets unless needed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - perf(draw) reimplement circle drawing algorithms (#2374) (Also [change masking](https://docs.lvgl.io/master/overview/drawing.html#masking))
 - fix(draw) false assertion error in lv_draw_mask caused by wrong pointer
 - fix(color) Bad cast in lv_color_mix() caused UB with 16bpp or less
+- fix(examples) don't compile assets unless needed
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/examples/assets/animimg001.c
+++ b/examples/assets/animimg001.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -717,3 +718,4 @@ const lv_img_dsc_t animimg001 = {
   .data = animimg001_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/animimg002.c
+++ b/examples/assets/animimg002.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -717,3 +718,4 @@ const lv_img_dsc_t animimg002 = {
   .data = animimg002_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/animimg003.c
+++ b/examples/assets/animimg003.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -717,3 +718,4 @@ const lv_img_dsc_t animimg003 = {
   .data = animimg003_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_caret_down.c
+++ b/examples/assets/img_caret_down.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -69,3 +70,4 @@ const lv_img_dsc_t img_caret_down = {
   .data = img_caret_down_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_cogwheel_alpha16.c
+++ b/examples/assets/img_cogwheel_alpha16.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -119,3 +121,5 @@ const lv_img_dsc_t img_cogwheel_alpha16 = {
   .header.cf = LV_IMG_CF_ALPHA_4BIT,
   .data = img_cogwheel_alpha16_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_cogwheel_argb.c
+++ b/examples/assets/img_cogwheel_argb.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -430,3 +432,5 @@ const lv_img_dsc_t img_cogwheel_argb = {
   .header.cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
   .data = img_cogwheel_argb_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_cogwheel_chroma_keyed.c
+++ b/examples/assets/img_cogwheel_chroma_keyed.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -431,3 +433,5 @@ const lv_img_dsc_t img_cogwheel_chroma_keyed = {
   .header.cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED,
   .data = img_cogwheel_chroma_keyed_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_cogwheel_indexed16.c
+++ b/examples/assets/img_cogwheel_indexed16.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -136,3 +138,5 @@ const lv_img_dsc_t img_cogwheel_indexed16 = {
   .header.cf = LV_IMG_CF_INDEXED_4BIT,
   .data = img_cogwheel_indexed16_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_cogwheel_rgb.c
+++ b/examples/assets/img_cogwheel_rgb.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -431,3 +433,5 @@ const lv_img_dsc_t img_cogwheel_rgb = {
   .header.cf = LV_IMG_CF_TRUE_COLOR,
   .data = img_cogwheel_rgb_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_hand.c
+++ b/examples/assets/img_hand.c
@@ -1,5 +1,7 @@
 #include "../../lvgl.h"
 
+#if LV_BUILD_EXAMPLES
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -67,3 +69,4 @@ const lv_img_dsc_t img_hand = {
   .data = img_hand_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_skew_strip.c
+++ b/examples/assets/img_skew_strip.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -117,3 +118,4 @@ const lv_img_dsc_t img_skew_strip = {
   .data = img_skew_strip_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/img_star.c
+++ b/examples/assets/img_star.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -153,3 +154,4 @@ const lv_img_dsc_t img_star = {
   .data = img_star_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/imgbtn_left.c
+++ b/examples/assets/imgbtn_left.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -260,3 +261,4 @@ const lv_img_dsc_t imgbtn_left = {
   .data = imgbtn_left_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/imgbtn_mid.c
+++ b/examples/assets/imgbtn_mid.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -232,3 +233,5 @@ const lv_img_dsc_t imgbtn_mid = {
   .header.cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
   .data = imgbtn_mid_map,
 };
+
+#endif /* LV_BUILD_EXAMPLES */

--- a/examples/assets/imgbtn_right.c
+++ b/examples/assets/imgbtn_right.c
@@ -4,6 +4,7 @@
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_BUILD_EXAMPLES
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
@@ -237,3 +238,4 @@ const lv_img_dsc_t imgbtn_right = {
   .data = imgbtn_right_map,
 };
 
+#endif /* LV_BUILD_EXAMPLES */


### PR DESCRIPTION
### Description of the feature or fix

This wraps the code for the assets under examples/assets in `LV_BUILD_EXAMPLES` so that it is not compiled when examples are deactivated in `lv_conf.h`.

This saves a bit of time when compiling a productive application (which should normally not have any of the examples enabled).

### Checkpoints

- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation (no update needed, I believe)
