### PR TITLE
fix(lv_types.h): remove c/c++ compiler version check

### DIFF
--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -13,14 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include <stdint.h>
 
 /*********************
  *      DEFINES
  *********************/
-
-#if defined(__cplusplus) || __STDC_VERSION__ >= 199901L  // If c99 or newer, use stdint.h to determine arch size
-#include <stdint.h>
-#endif
 
 // If __UINTPTR_MAX__ or UINTPTR_MAX are available, use them to determine arch size
 #if defined(__UINTPTR_MAX__) && __UINTPTR_MAX__ > 0xFFFFFFFF


### PR DESCRIPTION
since stdint.h is included in many place unconditionally

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
