### PR TITLE
attempt at a better LV_PRId32

### DIFF
--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -34,13 +34,13 @@
 #ifndef _LV_PRINTF_H_
 #define _LV_PRINTF_H_
 
-/* ports without C99's inttypes.h */
-#ifdef __XC16__
-   #define LV_PRId32 "d"
-#else
-   /* if you get an error here, handle your port above */
+#if __has_include(<inttypes.h>)
    #include<inttypes.h>
+   /* platform-specific printf format for int32_t, usually "d" or "ld" */
    #define LV_PRId32 PRId32
+#else
+   /* hope this is correct for ports without inttypes.h */
+   #define LV_PRId32 "d"
 #endif
 
 #ifdef __cplusplus

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -34,13 +34,13 @@
 #ifndef _LV_PRINTF_H_
 #define _LV_PRINTF_H_
 
-/* not all compilers provide inttypes.h which would define these */
-#include<limits.h>
-
-#if LONG_MAX==2147483647
-   #define LV_PRId32 "ld"
-#else
+/* ports without C99's inttypes.h */
+#ifdef __XC16__
    #define LV_PRId32 "d"
+#else
+   /* if you get an error here, handle your port above */
+   #include<inttypes.h>
+   #define LV_PRId32 PRId32
 #endif
 
 #ifdef __cplusplus

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -34,12 +34,12 @@
 #ifndef _LV_PRINTF_H_
 #define _LV_PRINTF_H_
 
-#if __has_include(<inttypes.h>)
+#if defined(__has_include) && __has_include(<inttypes.h>)
    #include<inttypes.h>
    /* platform-specific printf format for int32_t, usually "d" or "ld" */
    #define LV_PRId32 PRId32
 #else
-   /* hope this is correct for ports without inttypes.h */
+   /* hope this is correct for ports without __has_include or without inttypes.h */
    #define LV_PRId32 "d"
 #endif
 


### PR DESCRIPTION
This should fix ESP32 regression with #2512 (`LV_PRId32`) the proper way. Ports without `inttypes.h` (hopefully only a few, added `__XC16__` as an example) must be manually handled, for the rest, use platform's `inttypes.h`.
