### PR TITLE
fix(zoom) multiplication overflow with zoom on 16-bit platforms

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fix(color) Bad cast in lv_color_mix() caused UB with 16bpp or less
 - fix(examples) don't compile assets unless needed
 - docs(all) Proofread, fix typos and add clarifications in confusing areas
+- fix(zoom) multiplication overflow with zoom calculations on 16-bit platforms
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/draw/lv_img_buf.c
+++ b/src/draw/lv_img_buf.c
@@ -483,10 +483,10 @@ void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t 
         return;
     }
 
-    res->x1 = (((-pivot->x) * zoom) >> 8) - 1;
-    res->y1 = (((-pivot->y) * zoom) >> 8) - 1;
-    res->x2 = (((w - pivot->x) * zoom) >> 8) + 2;
-    res->y2 = (((h - pivot->y) * zoom) >> 8) + 2;
+    res->x1 = (((int32_t)(-pivot->x) * zoom) >> 8) - 1;
+    res->y1 = (((int32_t)(-pivot->y) * zoom) >> 8) - 1;
+    res->x2 = (((int32_t)(w - pivot->x) * zoom) >> 8) + 2;
+    res->y2 = (((int32_t)(h - pivot->y) * zoom) >> 8) + 2;
 
     if(angle == 0) {
         res->x1 += pivot->x;

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -276,8 +276,8 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
         return;
     }
 
-    lv_coord_t w = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-    lv_coord_t h = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t w = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t h = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
 
     if(chart->type == LV_CHART_TYPE_LINE) {
         p_out->x = (w * id) / (chart->point_cnt - 1);
@@ -287,8 +287,8 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
     }
     else if(chart->type == LV_CHART_TYPE_BAR) {
         uint32_t ser_cnt = _lv_ll_get_len(&chart->series_ll);
-        int32_t ser_gap = (lv_obj_get_style_pad_column(obj, LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the column on the ~same X*/
-        int32_t block_gap = (lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
+        int32_t ser_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the column on the ~same X*/
+        int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
         lv_coord_t block_w = (w - ((chart->point_cnt - 1) * block_gap)) / chart->point_cnt;
         lv_coord_t col_w = block_w / ser_cnt;
 
@@ -716,8 +716,8 @@ static void lv_chart_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_event_set_ext_draw_size(e, LV_MAX4(chart->tick[0].draw_size, chart->tick[1].draw_size, chart->tick[2].draw_size, chart->tick[3].draw_size));
     } else if(code == LV_EVENT_GET_SELF_SIZE) {
         lv_point_t * p = lv_event_get_param(e);
-        p->x = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-        p->y = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+        p->x = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+        p->y = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
     } else if(code == LV_EVENT_DRAW_MAIN) {
         const lv_area_t * clip_area = lv_event_get_param(e);
         draw_div_lines(obj, clip_area);
@@ -749,8 +749,8 @@ static void draw_div_lines(lv_obj_t * obj, const lv_area_t * clip_area)
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;
     lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
-    lv_coord_t w     = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-    lv_coord_t h     = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t h     = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
 
     lv_draw_line_dsc_t line_dsc;
     lv_draw_line_dsc_init(&line_dsc);
@@ -851,8 +851,8 @@ static void draw_series_line(lv_obj_t * obj, const lv_area_t * clip_area)
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;
     lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
-    lv_coord_t w     = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-    lv_coord_t h     = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t h     = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
     lv_coord_t x_ofs = obj->coords.x1 + pad_left - lv_obj_get_scroll_left(obj);
     lv_coord_t y_ofs = obj->coords.y1 + pad_top - lv_obj_get_scroll_top(obj);
     lv_chart_series_t * ser;
@@ -1013,8 +1013,8 @@ static void draw_series_scatter(lv_obj_t * obj, const lv_area_t * clip_area)
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
     lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-    lv_coord_t w     = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-    lv_coord_t h     = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t h     = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
     lv_coord_t x_ofs = obj->coords.x1 + pad_left + border_width - lv_obj_get_scroll_left(obj);
     lv_coord_t y_ofs = obj->coords.y1 + pad_top + border_width - lv_obj_get_scroll_top(obj);
     lv_chart_series_t * ser;
@@ -1151,15 +1151,15 @@ static void draw_series_bar(lv_obj_t * obj, const lv_area_t * clip_area)
     lv_area_t col_a;
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
     lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-    lv_coord_t w     = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
-    lv_coord_t h     = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t h     = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
     int32_t y_tmp;
     lv_chart_series_t * ser;
     uint32_t ser_cnt = _lv_ll_get_len(&chart->series_ll);
-    int32_t block_gap = (lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
+    int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
     lv_coord_t block_w = (w - ((chart->point_cnt - 1) * block_gap)) / chart->point_cnt;
     lv_coord_t col_w = block_w / ser_cnt;
-    int32_t ser_gap = (lv_obj_get_style_pad_column(obj, LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the column on the ~same X*/
+    int32_t ser_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the column on the ~same X*/
     lv_coord_t x_ofs = pad_left - lv_obj_get_scroll_left(obj);
     lv_coord_t y_ofs = pad_top - lv_obj_get_scroll_top(obj);
 
@@ -1340,7 +1340,7 @@ static void draw_y_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
 
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-    lv_coord_t h     = (lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
+    lv_coord_t h     = ((int32_t)lv_obj_get_content_height(obj) * chart->zoom_y) >> 8;
     lv_coord_t y_ofs = obj->coords.y1 + pad_top + border_width - lv_obj_get_scroll_top(obj);
 
     lv_coord_t label_gap;
@@ -1463,7 +1463,7 @@ static void draw_x_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
     lv_point_t p2;
 
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + lv_obj_get_style_border_width(obj, LV_PART_MAIN);
-    lv_coord_t w     = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
 
 
     lv_draw_label_dsc_t label_dsc;
@@ -1505,7 +1505,7 @@ static void draw_x_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
 
     /*The columns ticks should be aligned to the center of blocks*/
     if(chart->type == LV_CHART_TYPE_BAR) {
-        int32_t block_gap = (lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the columns on ~adjacent X*/
+        int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the columns on ~adjacent X*/
         lv_coord_t block_w = (w + block_gap) / (chart->point_cnt);
         x_ofs += (block_w - block_gap) / 2;
         w -= block_w - block_gap;
@@ -1599,7 +1599,7 @@ static void draw_axes(lv_obj_t * obj, const lv_area_t * mask)
 static uint32_t get_index_from_x(lv_obj_t * obj, lv_coord_t x)
 {
     lv_chart_t * chart  = (lv_chart_t *)obj;
-    lv_coord_t w = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t w = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
     x-= pad_left;
 
@@ -1616,7 +1616,7 @@ static void invalidate_point(lv_obj_t * obj, uint16_t i)
     lv_chart_t * chart  = (lv_chart_t *)obj;
     if(i >= chart->point_cnt) return;
 
-    lv_coord_t w  = (lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
+    lv_coord_t w  = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
     lv_coord_t scroll_left = lv_obj_get_scroll_left(obj);
 
     /*In shift mode the whole chart changes so the whole object*/
@@ -1651,7 +1651,7 @@ static void invalidate_point(lv_obj_t * obj, uint16_t i)
     }
     else if(chart->type == LV_CHART_TYPE_BAR) {
         lv_area_t col_a;
-        int32_t block_gap = (lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
+        int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj, LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
         lv_coord_t block_w = (w + block_gap) / chart->point_cnt;
 
         lv_coord_t x_act;

--- a/src/widgets/lv_img.c
+++ b/src/widgets/lv_img.c
@@ -191,7 +191,7 @@ void lv_img_set_angle(lv_obj_t * obj, int16_t angle)
     if(angle == img->angle) return;
 
     lv_coord_t transf_zoom = lv_obj_get_style_transform_zoom(obj, LV_PART_MAIN);
-    transf_zoom = (transf_zoom * img->zoom) >> 8;
+    transf_zoom = ((int32_t)transf_zoom * img->zoom) >> 8;
 
     lv_coord_t transf_angle = lv_obj_get_style_transform_angle(obj, LV_PART_MAIN);
 
@@ -222,7 +222,7 @@ void lv_img_set_pivot(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
     if(img->pivot.x == x && img->pivot.y == y) return;
 
     lv_coord_t transf_zoom = lv_obj_get_style_transform_zoom(obj, LV_PART_MAIN);
-    transf_zoom = (transf_zoom * img->zoom) >> 8;
+    transf_zoom = ((int32_t)transf_zoom * img->zoom) >> 8;
 
     lv_coord_t transf_angle = lv_obj_get_style_transform_angle(obj, LV_PART_MAIN);
     transf_angle += img->angle;
@@ -264,7 +264,7 @@ void lv_img_set_zoom(lv_obj_t * obj, uint16_t zoom)
     lv_coord_t w = lv_obj_get_width(obj);
     lv_coord_t h = lv_obj_get_height(obj);
     lv_area_t a;
-    _lv_img_buf_get_transformed_area(&a, w, h, transf_angle, (transf_zoom * img->zoom) >> 8, &img->pivot);
+    _lv_img_buf_get_transformed_area(&a, w, h, transf_angle, ((int32_t)transf_zoom * img->zoom) >> 8, &img->pivot);
     a.x1 += obj->coords.x1 - 1;
     a.y1 += obj->coords.y1 - 1;
     a.x2 += obj->coords.x1 + 1;
@@ -274,7 +274,7 @@ void lv_img_set_zoom(lv_obj_t * obj, uint16_t zoom)
     img->zoom = zoom;
     lv_obj_refresh_ext_draw_size(obj);
 
-    _lv_img_buf_get_transformed_area(&a, w, h, transf_angle, (transf_zoom * img->zoom) >> 8, &img->pivot);
+    _lv_img_buf_get_transformed_area(&a, w, h, transf_angle, ((int32_t)transf_zoom * img->zoom) >> 8, &img->pivot);
     a.x1 += obj->coords.x1 - 1;
     a.y1 += obj->coords.y1 - 1;
     a.x2 += obj->coords.x1 + 1;
@@ -462,7 +462,7 @@ static void lv_img_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         lv_coord_t * s = lv_event_get_param(e);
         lv_coord_t transf_zoom = lv_obj_get_style_transform_zoom(obj, LV_PART_MAIN);
-        transf_zoom = (transf_zoom * img->zoom) >> 8;
+        transf_zoom = ((int32_t)transf_zoom * img->zoom) >> 8;
 
         lv_coord_t transf_angle = lv_obj_get_style_transform_angle(obj, LV_PART_MAIN);
         transf_angle += img->angle;


### PR DESCRIPTION
### Description of the feature or fix

lv_coord_t is typically an int16_t. On 32-bit and larger platforms this will be promoted to int (32-bits wide)
before any operations are performed and then there is enough precision to prevent any numeric range
issues. However, on a 16-bit platform int16_t is (generally) the same rank as int and no promotion will
happen. This creates an overflow risk with multiplications. Zoom factors are encoded as a fixed point
number so the risk is even greater.

Consider the case where both a style transform zoom property is set and an image zoom is set. If both
are 2.0 they will be multiplied for a 4.0 overall zoom factor. In Q8.8 fixed point this is:
   (512 * 512) >> 8 =  (262144) >> 8 = 1024 == 4.0
On a 16-bit platform the intermediate multiply overflows before the final shift adjustment. Even if one
property is left at the default LV_IMG_ZOOM_NONE (256 == 1.0) an overflow will still happen. 

This affects both images and the lv_chart widget. I cleaned up all the muls I could find related to zoom
by casting to int32_t. For lv_chart the expressions are dropping the fractional part and a round up by
adding 0.5 would be more correct but probably won't make any visual improvement so I left it as is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
