### PR TITLE
feat(msgbox): add function to get selected button index

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fix(examples) don't compile assets unless needed
 - docs(all) Proofread, fix typos and add clarifications in confusing areas
 - fix(zoom) multiplication overflow with zoom calculations on 16-bit platforms
+- feat(msgbox): add function to get selected button index
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/docs/widgets/extra/msgbox.md
+++ b/docs/widgets/extra/msgbox.md
@@ -43,7 +43,7 @@ lv_obj_t * lv_msgbox_get_btns(lv_obj_t * mbox);
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` is sent by the buttons if one of them is clicked. `LV_OBJ_FLAG_EVENT_BUBBLE` is enabled on the buttons so you can add events to the message box itself. 
-In the event handler, `lv_event_get_target(e)` will return the button matrix and `lv_event_get_current_target(e)` will givreturn the message box. `lv_msgbox_get_active_btn_text(msgbox)` can be used to get the text of the clicked button. 
+In the event handler, `lv_event_get_target(e)` will return the button matrix and `lv_event_get_current_target(e)` will return the message box. `lv_msgbox_get_active_btn(msgbox)` and `lv_msgbox_get_active_btn_text(msgbox)` can be used to get the index and text of the clicked button.
 
 Learn more about [Events](/overview/event).
 

--- a/src/extra/widgets/msgbox/lv_msgbox.c
+++ b/src/extra/widgets/msgbox/lv_msgbox.c
@@ -130,6 +130,12 @@ lv_obj_t * lv_msgbox_get_btns(lv_obj_t * obj)
     return mbox->btns;
 }
 
+uint16_t lv_msgbox_get_active_btn(lv_obj_t * mbox)
+{
+    lv_obj_t * btnm = lv_msgbox_get_btns(mbox);
+    return lv_btnmatrix_get_selected_btn(btnm);
+}
+
 const char * lv_msgbox_get_active_btn_text(lv_obj_t * mbox)
 {
     lv_obj_t * btnm = lv_msgbox_get_btns(mbox);

--- a/src/extra/widgets/msgbox/lv_msgbox.h
+++ b/src/extra/widgets/msgbox/lv_msgbox.h
@@ -67,6 +67,13 @@ lv_obj_t * lv_msgbox_get_text(lv_obj_t * obj);
 
 lv_obj_t * lv_msgbox_get_btns(lv_obj_t * obj);
 
+/**
+ * Get the index of the selected button
+ * @param mbox message box object
+ * @return     index of the button (LV_BTNMATRIX_BTN_NONE: if unset)
+ */
+uint16_t lv_msgbox_get_active_btn(lv_obj_t * mbox);
+
 const char * lv_msgbox_get_active_btn_text(lv_obj_t * mbox);
 
 void lv_msgbox_close(lv_obj_t * mbox);


### PR DESCRIPTION
### Description of the feature or fix

This adds a new function `lv_msgbox_get_active_btn` that works analogously to `lv_msgbox_get_active_btn_text` but returns the button index instead of its text.

The index is more convenient for comparison in localized applications as it doesn't depend on the current language.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
