### PR TITLE
feat(msgbox): omit title label unless needed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fix(examples) don't compile assets unless needed
 - docs(all) Proofread, fix typos and add clarifications in confusing areas
 - fix(zoom) multiplication overflow with zoom calculations on 16-bit platforms
+- feat(msgbox): omit title label unless needed
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/extra/widgets/msgbox/lv_msgbox.c
+++ b/src/extra/widgets/msgbox/lv_msgbox.c
@@ -63,11 +63,16 @@ lv_obj_t * lv_msgbox_create(lv_obj_t * parent, const char * title, const char * 
     lv_obj_set_flex_flow(obj, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(obj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
 
-    mbox->title = lv_label_create(obj);
-    lv_label_set_text(mbox->title, title);
-    lv_label_set_long_mode(mbox->title, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    if(add_close_btn) lv_obj_set_flex_grow(mbox->title, 1);
-    else lv_obj_set_width(mbox->title, LV_PCT(100));
+    bool has_title = title && strlen(title) > 0;
+
+    /*When a close button is required, we need the empty label as spacer to push the button to the right*/
+    if (add_close_btn || has_title) {
+        mbox->title = lv_label_create(obj);
+        lv_label_set_text(mbox->title, has_title ? title : "");
+        lv_label_set_long_mode(mbox->title, LV_LABEL_LONG_SCROLL_CIRCULAR);
+        if(add_close_btn) lv_obj_set_flex_grow(mbox->title, 1);
+        else lv_obj_set_width(mbox->title, LV_PCT(100));
+    }
 
     if(add_close_btn) {
         mbox->close_btn = lv_btn_create(obj);


### PR DESCRIPTION
### Description of the feature or fix

Prior to this commit, when the title string was empty and the close button disabled, an extra empty line showed at the top of the message box. This commit prevents adding the title label unless it has content or is needed as a spacer for the close button.

As a positive side effect, this also prevents the default "text" from displaying when `NULL` is passed as the title.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation (no update needed, I believe)