### PR TITLE
Minor change lv_conf_internal_gen.py

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -91,7 +91,7 @@ for i in fin.read().splitlines():
   if r:
     line = re.sub('\(.*?\)', '', r[1], 1)    #remove parentheses from macros
     dr = re.sub('.*# *define', '', i, 1)
-    d = "#    define " + dr
+    d = "#    define" + dr
 		
     fout.write(
       f'#ifndef {line}\n'

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 '''
-Generates a checker file for lv_conf.h from lv_conf_template.h define all the not defined values
+Generates lv_conf_internal.h from lv_conf_template.h to provide default values
 '''
 
 import sys

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -58,7 +58,7 @@
 #  ifdef CONFIG_LV_COLOR_DEPTH
 #    define LV_COLOR_DEPTH CONFIG_LV_COLOR_DEPTH
 #  else
-#    define  LV_COLOR_DEPTH     16
+#    define LV_COLOR_DEPTH     16
 #  endif
 #endif
 
@@ -67,7 +67,7 @@
 #  ifdef CONFIG_LV_COLOR_16_SWAP
 #    define LV_COLOR_16_SWAP CONFIG_LV_COLOR_16_SWAP
 #  else
-#    define  LV_COLOR_16_SWAP   0
+#    define LV_COLOR_16_SWAP   0
 #  endif
 #endif
 
@@ -78,7 +78,7 @@
 #  ifdef CONFIG_LV_COLOR_SCREEN_TRANSP
 #    define LV_COLOR_SCREEN_TRANSP CONFIG_LV_COLOR_SCREEN_TRANSP
 #  else
-#    define  LV_COLOR_SCREEN_TRANSP    0
+#    define LV_COLOR_SCREEN_TRANSP    0
 #  endif
 #endif
 
@@ -87,7 +87,7 @@
 #  ifdef CONFIG_LV_COLOR_CHROMA_KEY
 #    define LV_COLOR_CHROMA_KEY CONFIG_LV_COLOR_CHROMA_KEY
 #  else
-#    define  LV_COLOR_CHROMA_KEY    lv_color_hex(0x00ff00)         /*pure green*/
+#    define LV_COLOR_CHROMA_KEY    lv_color_hex(0x00ff00)         /*pure green*/
 #  endif
 #endif
 
@@ -100,7 +100,7 @@
 #  ifdef CONFIG_LV_MEM_CUSTOM
 #    define LV_MEM_CUSTOM CONFIG_LV_MEM_CUSTOM
 #  else
-#    define  LV_MEM_CUSTOM      0
+#    define LV_MEM_CUSTOM      0
 #  endif
 #endif
 #if LV_MEM_CUSTOM == 0
@@ -109,7 +109,7 @@
 #  ifdef CONFIG_LV_MEM_SIZE
 #    define LV_MEM_SIZE CONFIG_LV_MEM_SIZE
 #  else
-#    define  LV_MEM_SIZE    (32U * 1024U)          /*[bytes]*/
+#    define LV_MEM_SIZE    (32U * 1024U)          /*[bytes]*/
 #  endif
 #endif
 
@@ -118,7 +118,7 @@
 #  ifdef CONFIG_LV_MEM_ADR
 #    define LV_MEM_ADR CONFIG_LV_MEM_ADR
 #  else
-#    define  LV_MEM_ADR          0     /*0: unused*/
+#    define LV_MEM_ADR          0     /*0: unused*/
 #  endif
 #endif
 /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
@@ -132,28 +132,28 @@
 #  ifdef CONFIG_LV_MEM_CUSTOM_INCLUDE
 #    define LV_MEM_CUSTOM_INCLUDE CONFIG_LV_MEM_CUSTOM_INCLUDE
 #  else
-#    define  LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+#    define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
 #  endif
 #endif
 #ifndef LV_MEM_CUSTOM_ALLOC
 #  ifdef CONFIG_LV_MEM_CUSTOM_ALLOC
 #    define LV_MEM_CUSTOM_ALLOC CONFIG_LV_MEM_CUSTOM_ALLOC
 #  else
-#    define  LV_MEM_CUSTOM_ALLOC     malloc
+#    define LV_MEM_CUSTOM_ALLOC     malloc
 #  endif
 #endif
 #ifndef LV_MEM_CUSTOM_FREE
 #  ifdef CONFIG_LV_MEM_CUSTOM_FREE
 #    define LV_MEM_CUSTOM_FREE CONFIG_LV_MEM_CUSTOM_FREE
 #  else
-#    define  LV_MEM_CUSTOM_FREE      free
+#    define LV_MEM_CUSTOM_FREE      free
 #  endif
 #endif
 #ifndef LV_MEM_CUSTOM_REALLOC
 #  ifdef CONFIG_LV_MEM_CUSTOM_REALLOC
 #    define LV_MEM_CUSTOM_REALLOC CONFIG_LV_MEM_CUSTOM_REALLOC
 #  else
-#    define  LV_MEM_CUSTOM_REALLOC   realloc
+#    define LV_MEM_CUSTOM_REALLOC   realloc
 #  endif
 #endif
 #endif     /*LV_MEM_CUSTOM*/
@@ -163,7 +163,7 @@
 #  ifdef CONFIG_LV_MEMCPY_MEMSET_STD
 #    define LV_MEMCPY_MEMSET_STD CONFIG_LV_MEMCPY_MEMSET_STD
 #  else
-#    define  LV_MEMCPY_MEMSET_STD    0
+#    define LV_MEMCPY_MEMSET_STD    0
 #  endif
 #endif
 
@@ -176,7 +176,7 @@
 #  ifdef CONFIG_LV_DISP_DEF_REFR_PERIOD
 #    define LV_DISP_DEF_REFR_PERIOD CONFIG_LV_DISP_DEF_REFR_PERIOD
 #  else
-#    define  LV_DISP_DEF_REFR_PERIOD     30      /*[ms]*/
+#    define LV_DISP_DEF_REFR_PERIOD     30      /*[ms]*/
 #  endif
 #endif
 
@@ -185,7 +185,7 @@
 #  ifdef CONFIG_LV_INDEV_DEF_READ_PERIOD
 #    define LV_INDEV_DEF_READ_PERIOD CONFIG_LV_INDEV_DEF_READ_PERIOD
 #  else
-#    define  LV_INDEV_DEF_READ_PERIOD    30      /*[ms]*/
+#    define LV_INDEV_DEF_READ_PERIOD    30      /*[ms]*/
 #  endif
 #endif
 
@@ -195,7 +195,7 @@
 #  ifdef CONFIG_LV_TICK_CUSTOM
 #    define LV_TICK_CUSTOM CONFIG_LV_TICK_CUSTOM
 #  else
-#    define  LV_TICK_CUSTOM     0
+#    define LV_TICK_CUSTOM     0
 #  endif
 #endif
 #if LV_TICK_CUSTOM
@@ -203,14 +203,14 @@
 #  ifdef CONFIG_LV_TICK_CUSTOM_INCLUDE
 #    define LV_TICK_CUSTOM_INCLUDE CONFIG_LV_TICK_CUSTOM_INCLUDE
 #  else
-#    define  LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the system time function*/
+#    define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the system time function*/
 #  endif
 #endif
 #ifndef LV_TICK_CUSTOM_SYS_TIME_EXPR
 #  ifdef CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
 #    define LV_TICK_CUSTOM_SYS_TIME_EXPR CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
 #  else
-#    define  LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current system time in ms*/
+#    define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current system time in ms*/
 #  endif
 #endif
 #endif   /*LV_TICK_CUSTOM*/
@@ -221,7 +221,7 @@
 #  ifdef CONFIG_LV_DPI_DEF
 #    define LV_DPI_DEF CONFIG_LV_DPI_DEF
 #  else
-#    define  LV_DPI_DEF                  130     /*[px/inch]*/
+#    define LV_DPI_DEF                  130     /*[px/inch]*/
 #  endif
 #endif
 
@@ -239,7 +239,7 @@
 #  ifdef CONFIG_LV_DRAW_COMPLEX
 #    define LV_DRAW_COMPLEX CONFIG_LV_DRAW_COMPLEX
 #  else
-#    define  LV_DRAW_COMPLEX 1
+#    define LV_DRAW_COMPLEX 1
 #  endif
 #endif
 #if LV_DRAW_COMPLEX != 0
@@ -251,7 +251,7 @@
 #  ifdef CONFIG_LV_SHADOW_CACHE_SIZE
 #    define LV_SHADOW_CACHE_SIZE CONFIG_LV_SHADOW_CACHE_SIZE
 #  else
-#    define  LV_SHADOW_CACHE_SIZE    0
+#    define LV_SHADOW_CACHE_SIZE    0
 #  endif
 #endif
 
@@ -263,7 +263,7 @@
 #  ifdef CONFIG_LV_CIRCLE_CACHE_SIZE
 #    define LV_CIRCLE_CACHE_SIZE CONFIG_LV_CIRCLE_CACHE_SIZE
 #  else
-#    define  LV_CIRCLE_CACHE_SIZE    4
+#    define LV_CIRCLE_CACHE_SIZE    4
 #  endif
 #endif
 
@@ -278,7 +278,7 @@
 #  ifdef CONFIG_LV_IMG_CACHE_DEF_SIZE
 #    define LV_IMG_CACHE_DEF_SIZE CONFIG_LV_IMG_CACHE_DEF_SIZE
 #  else
-#    define  LV_IMG_CACHE_DEF_SIZE       0
+#    define LV_IMG_CACHE_DEF_SIZE       0
 #  endif
 #endif
 
@@ -287,7 +287,7 @@
 #  ifdef CONFIG_LV_DISP_ROT_MAX_BUF
 #    define LV_DISP_ROT_MAX_BUF CONFIG_LV_DISP_ROT_MAX_BUF
 #  else
-#    define  LV_DISP_ROT_MAX_BUF         (10*1024)
+#    define LV_DISP_ROT_MAX_BUF         (10*1024)
 #  endif
 #endif
 
@@ -300,7 +300,7 @@
 #  ifdef CONFIG_LV_USE_GPU_STM32_DMA2D
 #    define LV_USE_GPU_STM32_DMA2D CONFIG_LV_USE_GPU_STM32_DMA2D
 #  else
-#    define  LV_USE_GPU_STM32_DMA2D  0
+#    define LV_USE_GPU_STM32_DMA2D  0
 #  endif
 #endif
 #if LV_USE_GPU_STM32_DMA2D
@@ -310,7 +310,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_GPU_DMA2D_CMSIS_INCLUDE
 #    define LV_GPU_DMA2D_CMSIS_INCLUDE CONFIG_LV_GPU_DMA2D_CMSIS_INCLUDE
 #  else
-#    define  LV_GPU_DMA2D_CMSIS_INCLUDE
+#    define LV_GPU_DMA2D_CMSIS_INCLUDE
 #  endif
 #endif
 #endif
@@ -320,7 +320,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_NXP_PXP
 #    define LV_USE_GPU_NXP_PXP CONFIG_LV_USE_GPU_NXP_PXP
 #  else
-#    define  LV_USE_GPU_NXP_PXP      0
+#    define LV_USE_GPU_NXP_PXP      0
 #  endif
 #endif
 #if LV_USE_GPU_NXP_PXP
@@ -333,7 +333,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_NXP_PXP_AUTO_INIT
 #    define LV_USE_GPU_NXP_PXP_AUTO_INIT CONFIG_LV_USE_GPU_NXP_PXP_AUTO_INIT
 #  else
-#    define  LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#    define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
 #  endif
 #endif
 #endif
@@ -343,7 +343,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_NXP_VG_LITE
 #    define LV_USE_GPU_NXP_VG_LITE CONFIG_LV_USE_GPU_NXP_VG_LITE
 #  else
-#    define  LV_USE_GPU_NXP_VG_LITE   0
+#    define LV_USE_GPU_NXP_VG_LITE   0
 #  endif
 #endif
 
@@ -354,7 +354,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_SDL
 #    define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
 #  else
-#    define  LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
+#    define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
 #  endif
 #endif
 #  else
@@ -366,7 +366,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_EXTERNAL_RENDERER
 #    define LV_USE_EXTERNAL_RENDERER CONFIG_LV_USE_EXTERNAL_RENDERER
 #  else
-#    define  LV_USE_EXTERNAL_RENDERER 1
+#    define LV_USE_EXTERNAL_RENDERER 1
 #  endif
 #endif
 #  ifndef LV_GPU_SDL_INCLUDE
@@ -374,7 +374,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_GPU_SDL_INCLUDE_PATH
 #    define LV_GPU_SDL_INCLUDE_PATH CONFIG_LV_GPU_SDL_INCLUDE_PATH
 #  else
-#    define  LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+#    define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
 #  endif
 #endif
 #  endif
@@ -385,7 +385,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_EXTERNAL_RENDERER
 #    define LV_USE_EXTERNAL_RENDERER CONFIG_LV_USE_EXTERNAL_RENDERER
 #  else
-#    define  LV_USE_EXTERNAL_RENDERER 0
+#    define LV_USE_EXTERNAL_RENDERER 0
 #  endif
 #endif
 #endif
@@ -399,7 +399,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LOG
 #    define LV_USE_LOG CONFIG_LV_USE_LOG
 #  else
-#    define  LV_USE_LOG      0
+#    define LV_USE_LOG      0
 #  endif
 #endif
 #if LV_USE_LOG
@@ -415,7 +415,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_LEVEL
 #    define LV_LOG_LEVEL CONFIG_LV_LOG_LEVEL
 #  else
-#    define  LV_LOG_LEVEL    LV_LOG_LEVEL_WARN
+#    define LV_LOG_LEVEL    LV_LOG_LEVEL_WARN
 #  endif
 #endif
 
@@ -425,7 +425,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_PRINTF
 #    define LV_LOG_PRINTF CONFIG_LV_LOG_PRINTF
 #  else
-#    define  LV_LOG_PRINTF   0
+#    define LV_LOG_PRINTF   0
 #  endif
 #endif
 
@@ -434,56 +434,56 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_TRACE_MEM
 #    define LV_LOG_TRACE_MEM CONFIG_LV_LOG_TRACE_MEM
 #  else
-#    define  LV_LOG_TRACE_MEM            1
+#    define LV_LOG_TRACE_MEM            1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_TIMER
 #  ifdef CONFIG_LV_LOG_TRACE_TIMER
 #    define LV_LOG_TRACE_TIMER CONFIG_LV_LOG_TRACE_TIMER
 #  else
-#    define  LV_LOG_TRACE_TIMER          1
+#    define LV_LOG_TRACE_TIMER          1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_INDEV
 #  ifdef CONFIG_LV_LOG_TRACE_INDEV
 #    define LV_LOG_TRACE_INDEV CONFIG_LV_LOG_TRACE_INDEV
 #  else
-#    define  LV_LOG_TRACE_INDEV          1
+#    define LV_LOG_TRACE_INDEV          1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_DISP_REFR
 #  ifdef CONFIG_LV_LOG_TRACE_DISP_REFR
 #    define LV_LOG_TRACE_DISP_REFR CONFIG_LV_LOG_TRACE_DISP_REFR
 #  else
-#    define  LV_LOG_TRACE_DISP_REFR      1
+#    define LV_LOG_TRACE_DISP_REFR      1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_EVENT
 #  ifdef CONFIG_LV_LOG_TRACE_EVENT
 #    define LV_LOG_TRACE_EVENT CONFIG_LV_LOG_TRACE_EVENT
 #  else
-#    define  LV_LOG_TRACE_EVENT          1
+#    define LV_LOG_TRACE_EVENT          1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_OBJ_CREATE
 #  ifdef CONFIG_LV_LOG_TRACE_OBJ_CREATE
 #    define LV_LOG_TRACE_OBJ_CREATE CONFIG_LV_LOG_TRACE_OBJ_CREATE
 #  else
-#    define  LV_LOG_TRACE_OBJ_CREATE     1
+#    define LV_LOG_TRACE_OBJ_CREATE     1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_LAYOUT
 #  ifdef CONFIG_LV_LOG_TRACE_LAYOUT
 #    define LV_LOG_TRACE_LAYOUT CONFIG_LV_LOG_TRACE_LAYOUT
 #  else
-#    define  LV_LOG_TRACE_LAYOUT         1
+#    define LV_LOG_TRACE_LAYOUT         1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_ANIM
 #  ifdef CONFIG_LV_LOG_TRACE_ANIM
 #    define LV_LOG_TRACE_ANIM CONFIG_LV_LOG_TRACE_ANIM
 #  else
-#    define  LV_LOG_TRACE_ANIM           1
+#    define LV_LOG_TRACE_ANIM           1
 #  endif
 #endif
 
@@ -499,35 +499,35 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ASSERT_NULL
 #    define LV_USE_ASSERT_NULL CONFIG_LV_USE_ASSERT_NULL
 #  else
-#    define  LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#    define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
 #  endif
 #endif
 #ifndef LV_USE_ASSERT_MALLOC
 #  ifdef CONFIG_LV_USE_ASSERT_MALLOC
 #    define LV_USE_ASSERT_MALLOC CONFIG_LV_USE_ASSERT_MALLOC
 #  else
-#    define  LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#    define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
 #  endif
 #endif
 #ifndef LV_USE_ASSERT_STYLE
 #  ifdef CONFIG_LV_USE_ASSERT_STYLE
 #    define LV_USE_ASSERT_STYLE CONFIG_LV_USE_ASSERT_STYLE
 #  else
-#    define  LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#    define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
 #  endif
 #endif
 #ifndef LV_USE_ASSERT_MEM_INTEGRITY
 #  ifdef CONFIG_LV_USE_ASSERT_MEM_INTEGRITY
 #    define LV_USE_ASSERT_MEM_INTEGRITY CONFIG_LV_USE_ASSERT_MEM_INTEGRITY
 #  else
-#    define  LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#    define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
 #  endif
 #endif
 #ifndef LV_USE_ASSERT_OBJ
 #  ifdef CONFIG_LV_USE_ASSERT_OBJ
 #    define LV_USE_ASSERT_OBJ CONFIG_LV_USE_ASSERT_OBJ
 #  else
-#    define  LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+#    define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
 #  endif
 #endif
 
@@ -536,14 +536,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ASSERT_HANDLER_INCLUDE
 #    define LV_ASSERT_HANDLER_INCLUDE CONFIG_LV_ASSERT_HANDLER_INCLUDE
 #  else
-#    define  LV_ASSERT_HANDLER_INCLUDE   <stdint.h>
+#    define LV_ASSERT_HANDLER_INCLUDE   <stdint.h>
 #  endif
 #endif
 #ifndef LV_ASSERT_HANDLER
 #  ifdef CONFIG_LV_ASSERT_HANDLER
 #    define LV_ASSERT_HANDLER CONFIG_LV_ASSERT_HANDLER
 #  else
-#    define  LV_ASSERT_HANDLER   while(1);   /*Halt by default*/
+#    define LV_ASSERT_HANDLER   while(1);   /*Halt by default*/
 #  endif
 #endif
 
@@ -556,7 +556,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_PERF_MONITOR
 #    define LV_USE_PERF_MONITOR CONFIG_LV_USE_PERF_MONITOR
 #  else
-#    define  LV_USE_PERF_MONITOR     0
+#    define LV_USE_PERF_MONITOR     0
 #  endif
 #endif
 
@@ -566,7 +566,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_MEM_MONITOR
 #    define LV_USE_MEM_MONITOR CONFIG_LV_USE_MEM_MONITOR
 #  else
-#    define  LV_USE_MEM_MONITOR      0
+#    define LV_USE_MEM_MONITOR      0
 #  endif
 #endif
 
@@ -575,7 +575,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_REFR_DEBUG
 #    define LV_USE_REFR_DEBUG CONFIG_LV_USE_REFR_DEBUG
 #  else
-#    define  LV_USE_REFR_DEBUG       0
+#    define LV_USE_REFR_DEBUG       0
 #  endif
 #endif
 
@@ -584,7 +584,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPRINTF_CUSTOM
 #    define LV_SPRINTF_CUSTOM CONFIG_LV_SPRINTF_CUSTOM
 #  else
-#    define  LV_SPRINTF_CUSTOM   0
+#    define LV_SPRINTF_CUSTOM   0
 #  endif
 #endif
 #if LV_SPRINTF_CUSTOM
@@ -592,21 +592,21 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPRINTF_INCLUDE
 #    define LV_SPRINTF_INCLUDE CONFIG_LV_SPRINTF_INCLUDE
 #  else
-#    define  LV_SPRINTF_INCLUDE <stdio.h>
+#    define LV_SPRINTF_INCLUDE <stdio.h>
 #  endif
 #endif
 #ifndef lv_snprintf
 #  ifdef CONFIG_LV_SNPRINTF
 #    define lv_snprintf CONFIG_LV_SNPRINTF
 #  else
-#    define  lv_snprintf     snprintf
+#    define lv_snprintf     snprintf
 #  endif
 #endif
 #ifndef lv_vsnprintf
 #  ifdef CONFIG_LV_VSNPRINTF
 #    define lv_vsnprintf CONFIG_LV_VSNPRINTF
 #  else
-#    define  lv_vsnprintf    vsnprintf
+#    define lv_vsnprintf    vsnprintf
 #  endif
 #endif
 #else   /*LV_SPRINTF_CUSTOM*/
@@ -614,7 +614,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPRINTF_USE_FLOAT
 #    define LV_SPRINTF_USE_FLOAT CONFIG_LV_SPRINTF_USE_FLOAT
 #  else
-#    define  LV_SPRINTF_USE_FLOAT 0
+#    define LV_SPRINTF_USE_FLOAT 0
 #  endif
 #endif
 #endif  /*LV_SPRINTF_CUSTOM*/
@@ -623,7 +623,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_USER_DATA
 #    define LV_USE_USER_DATA CONFIG_LV_USE_USER_DATA
 #  else
-#    define  LV_USE_USER_DATA      1
+#    define LV_USE_USER_DATA      1
 #  endif
 #endif
 
@@ -633,7 +633,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ENABLE_GC
 #    define LV_ENABLE_GC CONFIG_LV_ENABLE_GC
 #  else
-#    define  LV_ENABLE_GC 0
+#    define LV_ENABLE_GC 0
 #  endif
 #endif
 #if LV_ENABLE_GC != 0
@@ -641,7 +641,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_GC_INCLUDE
 #    define LV_GC_INCLUDE CONFIG_LV_GC_INCLUDE
 #  else
-#    define  LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
+#    define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
 #  endif
 #endif
 #endif /*LV_ENABLE_GC*/
@@ -651,7 +651,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SNAPSHOT
 #    define LV_USE_SNAPSHOT CONFIG_LV_USE_SNAPSHOT
 #  else
-#    define  LV_USE_SNAPSHOT         1
+#    define LV_USE_SNAPSHOT         1
 #  endif
 #endif
 
@@ -664,7 +664,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BIG_ENDIAN_SYSTEM
 #    define LV_BIG_ENDIAN_SYSTEM CONFIG_LV_BIG_ENDIAN_SYSTEM
 #  else
-#    define  LV_BIG_ENDIAN_SYSTEM    0
+#    define LV_BIG_ENDIAN_SYSTEM    0
 #  endif
 #endif
 
@@ -673,7 +673,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_TICK_INC
 #    define LV_ATTRIBUTE_TICK_INC CONFIG_LV_ATTRIBUTE_TICK_INC
 #  else
-#    define  LV_ATTRIBUTE_TICK_INC
+#    define LV_ATTRIBUTE_TICK_INC
 #  endif
 #endif
 
@@ -682,7 +682,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_TIMER_HANDLER
 #    define LV_ATTRIBUTE_TIMER_HANDLER CONFIG_LV_ATTRIBUTE_TIMER_HANDLER
 #  else
-#    define  LV_ATTRIBUTE_TIMER_HANDLER
+#    define LV_ATTRIBUTE_TIMER_HANDLER
 #  endif
 #endif
 
@@ -691,7 +691,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_FLUSH_READY
 #    define LV_ATTRIBUTE_FLUSH_READY CONFIG_LV_ATTRIBUTE_FLUSH_READY
 #  else
-#    define  LV_ATTRIBUTE_FLUSH_READY
+#    define LV_ATTRIBUTE_FLUSH_READY
 #  endif
 #endif
 
@@ -700,7 +700,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_MEM_ALIGN_SIZE
 #    define LV_ATTRIBUTE_MEM_ALIGN_SIZE CONFIG_LV_ATTRIBUTE_MEM_ALIGN_SIZE
 #  else
-#    define  LV_ATTRIBUTE_MEM_ALIGN_SIZE
+#    define LV_ATTRIBUTE_MEM_ALIGN_SIZE
 #  endif
 #endif
 
@@ -710,7 +710,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_MEM_ALIGN
 #    define LV_ATTRIBUTE_MEM_ALIGN CONFIG_LV_ATTRIBUTE_MEM_ALIGN
 #  else
-#    define  LV_ATTRIBUTE_MEM_ALIGN
+#    define LV_ATTRIBUTE_MEM_ALIGN
 #  endif
 #endif
 
@@ -719,7 +719,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_LARGE_CONST
 #    define LV_ATTRIBUTE_LARGE_CONST CONFIG_LV_ATTRIBUTE_LARGE_CONST
 #  else
-#    define  LV_ATTRIBUTE_LARGE_CONST
+#    define LV_ATTRIBUTE_LARGE_CONST
 #  endif
 #endif
 
@@ -728,7 +728,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_LARGE_RAM_ARRAY
 #    define LV_ATTRIBUTE_LARGE_RAM_ARRAY CONFIG_LV_ATTRIBUTE_LARGE_RAM_ARRAY
 #  else
-#    define  LV_ATTRIBUTE_LARGE_RAM_ARRAY
+#    define LV_ATTRIBUTE_LARGE_RAM_ARRAY
 #  endif
 #endif
 
@@ -737,7 +737,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_FAST_MEM
 #    define LV_ATTRIBUTE_FAST_MEM CONFIG_LV_ATTRIBUTE_FAST_MEM
 #  else
-#    define  LV_ATTRIBUTE_FAST_MEM
+#    define LV_ATTRIBUTE_FAST_MEM
 #  endif
 #endif
 
@@ -746,7 +746,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ATTRIBUTE_DMA
 #    define LV_ATTRIBUTE_DMA CONFIG_LV_ATTRIBUTE_DMA
 #  else
-#    define  LV_ATTRIBUTE_DMA
+#    define LV_ATTRIBUTE_DMA
 #  endif
 #endif
 
@@ -756,7 +756,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_EXPORT_CONST_INT
 #    define LV_EXPORT_CONST_INT CONFIG_LV_EXPORT_CONST_INT
 #  else
-#    define  LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+#    define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
 #  endif
 #endif
 
@@ -765,7 +765,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LARGE_COORD
 #    define LV_USE_LARGE_COORD CONFIG_LV_USE_LARGE_COORD
 #  else
-#    define  LV_USE_LARGE_COORD  0
+#    define LV_USE_LARGE_COORD  0
 #  endif
 #endif
 
@@ -779,147 +779,147 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_8
 #    define LV_FONT_MONTSERRAT_8 CONFIG_LV_FONT_MONTSERRAT_8
 #  else
-#    define  LV_FONT_MONTSERRAT_8     0
+#    define LV_FONT_MONTSERRAT_8     0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_10
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_10
 #    define LV_FONT_MONTSERRAT_10 CONFIG_LV_FONT_MONTSERRAT_10
 #  else
-#    define  LV_FONT_MONTSERRAT_10    0
+#    define LV_FONT_MONTSERRAT_10    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_12
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_12
 #    define LV_FONT_MONTSERRAT_12 CONFIG_LV_FONT_MONTSERRAT_12
 #  else
-#    define  LV_FONT_MONTSERRAT_12    0
+#    define LV_FONT_MONTSERRAT_12    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_14
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_14
 #    define LV_FONT_MONTSERRAT_14 CONFIG_LV_FONT_MONTSERRAT_14
 #  else
-#    define  LV_FONT_MONTSERRAT_14    1
+#    define LV_FONT_MONTSERRAT_14    1
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_16
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_16
 #    define LV_FONT_MONTSERRAT_16 CONFIG_LV_FONT_MONTSERRAT_16
 #  else
-#    define  LV_FONT_MONTSERRAT_16    0
+#    define LV_FONT_MONTSERRAT_16    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_18
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_18
 #    define LV_FONT_MONTSERRAT_18 CONFIG_LV_FONT_MONTSERRAT_18
 #  else
-#    define  LV_FONT_MONTSERRAT_18    0
+#    define LV_FONT_MONTSERRAT_18    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_20
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_20
 #    define LV_FONT_MONTSERRAT_20 CONFIG_LV_FONT_MONTSERRAT_20
 #  else
-#    define  LV_FONT_MONTSERRAT_20    0
+#    define LV_FONT_MONTSERRAT_20    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_22
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_22
 #    define LV_FONT_MONTSERRAT_22 CONFIG_LV_FONT_MONTSERRAT_22
 #  else
-#    define  LV_FONT_MONTSERRAT_22    0
+#    define LV_FONT_MONTSERRAT_22    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_24
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_24
 #    define LV_FONT_MONTSERRAT_24 CONFIG_LV_FONT_MONTSERRAT_24
 #  else
-#    define  LV_FONT_MONTSERRAT_24    0
+#    define LV_FONT_MONTSERRAT_24    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_26
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_26
 #    define LV_FONT_MONTSERRAT_26 CONFIG_LV_FONT_MONTSERRAT_26
 #  else
-#    define  LV_FONT_MONTSERRAT_26    0
+#    define LV_FONT_MONTSERRAT_26    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_28
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_28
 #    define LV_FONT_MONTSERRAT_28 CONFIG_LV_FONT_MONTSERRAT_28
 #  else
-#    define  LV_FONT_MONTSERRAT_28    0
+#    define LV_FONT_MONTSERRAT_28    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_30
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_30
 #    define LV_FONT_MONTSERRAT_30 CONFIG_LV_FONT_MONTSERRAT_30
 #  else
-#    define  LV_FONT_MONTSERRAT_30    0
+#    define LV_FONT_MONTSERRAT_30    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_32
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_32
 #    define LV_FONT_MONTSERRAT_32 CONFIG_LV_FONT_MONTSERRAT_32
 #  else
-#    define  LV_FONT_MONTSERRAT_32    0
+#    define LV_FONT_MONTSERRAT_32    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_34
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_34
 #    define LV_FONT_MONTSERRAT_34 CONFIG_LV_FONT_MONTSERRAT_34
 #  else
-#    define  LV_FONT_MONTSERRAT_34    0
+#    define LV_FONT_MONTSERRAT_34    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_36
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_36
 #    define LV_FONT_MONTSERRAT_36 CONFIG_LV_FONT_MONTSERRAT_36
 #  else
-#    define  LV_FONT_MONTSERRAT_36    0
+#    define LV_FONT_MONTSERRAT_36    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_38
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_38
 #    define LV_FONT_MONTSERRAT_38 CONFIG_LV_FONT_MONTSERRAT_38
 #  else
-#    define  LV_FONT_MONTSERRAT_38    0
+#    define LV_FONT_MONTSERRAT_38    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_40
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_40
 #    define LV_FONT_MONTSERRAT_40 CONFIG_LV_FONT_MONTSERRAT_40
 #  else
-#    define  LV_FONT_MONTSERRAT_40    0
+#    define LV_FONT_MONTSERRAT_40    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_42
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_42
 #    define LV_FONT_MONTSERRAT_42 CONFIG_LV_FONT_MONTSERRAT_42
 #  else
-#    define  LV_FONT_MONTSERRAT_42    0
+#    define LV_FONT_MONTSERRAT_42    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_44
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_44
 #    define LV_FONT_MONTSERRAT_44 CONFIG_LV_FONT_MONTSERRAT_44
 #  else
-#    define  LV_FONT_MONTSERRAT_44    0
+#    define LV_FONT_MONTSERRAT_44    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_46
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_46
 #    define LV_FONT_MONTSERRAT_46 CONFIG_LV_FONT_MONTSERRAT_46
 #  else
-#    define  LV_FONT_MONTSERRAT_46    0
+#    define LV_FONT_MONTSERRAT_46    0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_48
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_48
 #    define LV_FONT_MONTSERRAT_48 CONFIG_LV_FONT_MONTSERRAT_48
 #  else
-#    define  LV_FONT_MONTSERRAT_48    0
+#    define LV_FONT_MONTSERRAT_48    0
 #  endif
 #endif
 
@@ -928,28 +928,28 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_12_SUBPX
 #    define LV_FONT_MONTSERRAT_12_SUBPX CONFIG_LV_FONT_MONTSERRAT_12_SUBPX
 #  else
-#    define  LV_FONT_MONTSERRAT_12_SUBPX      0
+#    define LV_FONT_MONTSERRAT_12_SUBPX      0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_28_COMPRESSED
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_28_COMPRESSED
 #    define LV_FONT_MONTSERRAT_28_COMPRESSED CONFIG_LV_FONT_MONTSERRAT_28_COMPRESSED
 #  else
-#    define  LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#    define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
 #  endif
 #endif
 #ifndef LV_FONT_DEJAVU_16_PERSIAN_HEBREW
 #  ifdef CONFIG_LV_FONT_DEJAVU_16_PERSIAN_HEBREW
 #    define LV_FONT_DEJAVU_16_PERSIAN_HEBREW CONFIG_LV_FONT_DEJAVU_16_PERSIAN_HEBREW
 #  else
-#    define  LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Perisan letters and all their forms*/
+#    define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Perisan letters and all their forms*/
 #  endif
 #endif
 #ifndef LV_FONT_SIMSUN_16_CJK
 #  ifdef CONFIG_LV_FONT_SIMSUN_16_CJK
 #    define LV_FONT_SIMSUN_16_CJK CONFIG_LV_FONT_SIMSUN_16_CJK
 #  else
-#    define  LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+#    define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
 #  endif
 #endif
 
@@ -958,14 +958,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_UNSCII_8
 #    define LV_FONT_UNSCII_8 CONFIG_LV_FONT_UNSCII_8
 #  else
-#    define  LV_FONT_UNSCII_8        0
+#    define LV_FONT_UNSCII_8        0
 #  endif
 #endif
 #ifndef LV_FONT_UNSCII_16
 #  ifdef CONFIG_LV_FONT_UNSCII_16
 #    define LV_FONT_UNSCII_16 CONFIG_LV_FONT_UNSCII_16
 #  else
-#    define  LV_FONT_UNSCII_16       0
+#    define LV_FONT_UNSCII_16       0
 #  endif
 #endif
 
@@ -976,7 +976,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_CUSTOM_DECLARE
 #    define LV_FONT_CUSTOM_DECLARE CONFIG_LV_FONT_CUSTOM_DECLARE
 #  else
-#    define  LV_FONT_CUSTOM_DECLARE
+#    define LV_FONT_CUSTOM_DECLARE
 #  endif
 #endif
 
@@ -985,7 +985,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_DEFAULT
 #    define LV_FONT_DEFAULT CONFIG_LV_FONT_DEFAULT
 #  else
-#    define  LV_FONT_DEFAULT &lv_font_montserrat_14
+#    define LV_FONT_DEFAULT &lv_font_montserrat_14
 #  endif
 #endif
 
@@ -996,7 +996,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_FMT_TXT_LARGE
 #    define LV_FONT_FMT_TXT_LARGE CONFIG_LV_FONT_FMT_TXT_LARGE
 #  else
-#    define  LV_FONT_FMT_TXT_LARGE   0
+#    define LV_FONT_FMT_TXT_LARGE   0
 #  endif
 #endif
 
@@ -1005,7 +1005,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FONT_COMPRESSED
 #    define LV_USE_FONT_COMPRESSED CONFIG_LV_USE_FONT_COMPRESSED
 #  else
-#    define  LV_USE_FONT_COMPRESSED  0
+#    define LV_USE_FONT_COMPRESSED  0
 #  endif
 #endif
 
@@ -1014,7 +1014,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FONT_SUBPX
 #    define LV_USE_FONT_SUBPX CONFIG_LV_USE_FONT_SUBPX
 #  else
-#    define  LV_USE_FONT_SUBPX       0
+#    define LV_USE_FONT_SUBPX       0
 #  endif
 #endif
 #if LV_USE_FONT_SUBPX
@@ -1023,7 +1023,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_SUBPX_BGR
 #    define LV_FONT_SUBPX_BGR CONFIG_LV_FONT_SUBPX_BGR
 #  else
-#    define  LV_FONT_SUBPX_BGR       0  /*0: RGB; 1:BGR order*/
+#    define LV_FONT_SUBPX_BGR       0  /*0: RGB; 1:BGR order*/
 #  endif
 #endif
 #endif
@@ -1042,7 +1042,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_ENC
 #    define LV_TXT_ENC CONFIG_LV_TXT_ENC
 #  else
-#    define  LV_TXT_ENC LV_TXT_ENC_UTF8
+#    define LV_TXT_ENC LV_TXT_ENC_UTF8
 #  endif
 #endif
 
@@ -1051,7 +1051,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_BREAK_CHARS
 #    define LV_TXT_BREAK_CHARS CONFIG_LV_TXT_BREAK_CHARS
 #  else
-#    define  LV_TXT_BREAK_CHARS                  " ,.;:-_"
+#    define LV_TXT_BREAK_CHARS                  " ,.;:-_"
 #  endif
 #endif
 
@@ -1061,7 +1061,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_LINE_BREAK_LONG_LEN
 #    define LV_TXT_LINE_BREAK_LONG_LEN CONFIG_LV_TXT_LINE_BREAK_LONG_LEN
 #  else
-#    define  LV_TXT_LINE_BREAK_LONG_LEN          0
+#    define LV_TXT_LINE_BREAK_LONG_LEN          0
 #  endif
 #endif
 
@@ -1071,7 +1071,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
 #    define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN CONFIG_LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
 #  else
-#    define  LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
+#    define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
 #  endif
 #endif
 
@@ -1081,7 +1081,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN
 #    define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN CONFIG_LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN
 #  else
-#    define  LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+#    define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
 #  endif
 #endif
 
@@ -1090,7 +1090,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_COLOR_CMD
 #    define LV_TXT_COLOR_CMD CONFIG_LV_TXT_COLOR_CMD
 #  else
-#    define  LV_TXT_COLOR_CMD "#"
+#    define LV_TXT_COLOR_CMD "#"
 #  endif
 #endif
 
@@ -1101,7 +1101,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BIDI
 #    define LV_USE_BIDI CONFIG_LV_USE_BIDI
 #  else
-#    define  LV_USE_BIDI         0
+#    define LV_USE_BIDI         0
 #  endif
 #endif
 #if LV_USE_BIDI
@@ -1113,7 +1113,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BIDI_BASE_DIR_DEF
 #    define LV_BIDI_BASE_DIR_DEF CONFIG_LV_BIDI_BASE_DIR_DEF
 #  else
-#    define  LV_BIDI_BASE_DIR_DEF  LV_BASE_DIR_AUTO
+#    define LV_BIDI_BASE_DIR_DEF  LV_BASE_DIR_AUTO
 #  endif
 #endif
 #endif
@@ -1124,7 +1124,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ARABIC_PERSIAN_CHARS
 #    define LV_USE_ARABIC_PERSIAN_CHARS CONFIG_LV_USE_ARABIC_PERSIAN_CHARS
 #  else
-#    define  LV_USE_ARABIC_PERSIAN_CHARS 0
+#    define LV_USE_ARABIC_PERSIAN_CHARS 0
 #  endif
 #endif
 
@@ -1138,7 +1138,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ARC
 #    define LV_USE_ARC CONFIG_LV_USE_ARC
 #  else
-#    define  LV_USE_ARC          1
+#    define LV_USE_ARC          1
 #  endif
 #endif
 
@@ -1146,7 +1146,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ANIMIMG
 #    define LV_USE_ANIMIMG CONFIG_LV_USE_ANIMIMG
 #  else
-#    define  LV_USE_ANIMIMG	    1
+#    define LV_USE_ANIMIMG	    1
 #  endif
 #endif
 
@@ -1154,7 +1154,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BAR
 #    define LV_USE_BAR CONFIG_LV_USE_BAR
 #  else
-#    define  LV_USE_BAR          1
+#    define LV_USE_BAR          1
 #  endif
 #endif
 
@@ -1162,7 +1162,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BTN
 #    define LV_USE_BTN CONFIG_LV_USE_BTN
 #  else
-#    define  LV_USE_BTN          1
+#    define LV_USE_BTN          1
 #  endif
 #endif
 
@@ -1170,7 +1170,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BTNMATRIX
 #    define LV_USE_BTNMATRIX CONFIG_LV_USE_BTNMATRIX
 #  else
-#    define  LV_USE_BTNMATRIX    1
+#    define LV_USE_BTNMATRIX    1
 #  endif
 #endif
 
@@ -1178,7 +1178,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CANVAS
 #    define LV_USE_CANVAS CONFIG_LV_USE_CANVAS
 #  else
-#    define  LV_USE_CANVAS       1
+#    define LV_USE_CANVAS       1
 #  endif
 #endif
 
@@ -1186,7 +1186,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CHECKBOX
 #    define LV_USE_CHECKBOX CONFIG_LV_USE_CHECKBOX
 #  else
-#    define  LV_USE_CHECKBOX     1
+#    define LV_USE_CHECKBOX     1
 #  endif
 #endif
 
@@ -1194,7 +1194,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_DROPDOWN
 #    define LV_USE_DROPDOWN CONFIG_LV_USE_DROPDOWN
 #  else
-#    define  LV_USE_DROPDOWN     1   /*Requires: lv_label*/
+#    define LV_USE_DROPDOWN     1   /*Requires: lv_label*/
 #  endif
 #endif
 
@@ -1202,7 +1202,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_IMG
 #    define LV_USE_IMG CONFIG_LV_USE_IMG
 #  else
-#    define  LV_USE_IMG          1   /*Requires: lv_label*/
+#    define LV_USE_IMG          1   /*Requires: lv_label*/
 #  endif
 #endif
 
@@ -1210,7 +1210,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LABEL
 #    define LV_USE_LABEL CONFIG_LV_USE_LABEL
 #  else
-#    define  LV_USE_LABEL        1
+#    define LV_USE_LABEL        1
 #  endif
 #endif
 #if LV_USE_LABEL
@@ -1218,14 +1218,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LABEL_TEXT_SELECTION
 #    define LV_LABEL_TEXT_SELECTION CONFIG_LV_LABEL_TEXT_SELECTION
 #  else
-#    define  LV_LABEL_TEXT_SELECTION         1   /*Enable selecting text of the label*/
+#    define LV_LABEL_TEXT_SELECTION         1   /*Enable selecting text of the label*/
 #  endif
 #endif
 #ifndef LV_LABEL_LONG_TXT_HINT
 #  ifdef CONFIG_LV_LABEL_LONG_TXT_HINT
 #    define LV_LABEL_LONG_TXT_HINT CONFIG_LV_LABEL_LONG_TXT_HINT
 #  else
-#    define  LV_LABEL_LONG_TXT_HINT    1   /*Store some extra info in labels to speed up drawing of very long texts*/
+#    define LV_LABEL_LONG_TXT_HINT    1   /*Store some extra info in labels to speed up drawing of very long texts*/
 #  endif
 #endif
 #endif
@@ -1234,7 +1234,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LINE
 #    define LV_USE_LINE CONFIG_LV_USE_LINE
 #  else
-#    define  LV_USE_LINE         1
+#    define LV_USE_LINE         1
 #  endif
 #endif
 
@@ -1242,7 +1242,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ROLLER
 #    define LV_USE_ROLLER CONFIG_LV_USE_ROLLER
 #  else
-#    define  LV_USE_ROLLER       1   /*Requires: lv_label*/
+#    define LV_USE_ROLLER       1   /*Requires: lv_label*/
 #  endif
 #endif
 #if LV_USE_ROLLER
@@ -1250,7 +1250,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ROLLER_INF_PAGES
 #    define LV_ROLLER_INF_PAGES CONFIG_LV_ROLLER_INF_PAGES
 #  else
-#    define  LV_ROLLER_INF_PAGES       7   /*Number of extra "pages" when the roller is infinite*/
+#    define LV_ROLLER_INF_PAGES       7   /*Number of extra "pages" when the roller is infinite*/
 #  endif
 #endif
 #endif
@@ -1259,7 +1259,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SLIDER
 #    define LV_USE_SLIDER CONFIG_LV_USE_SLIDER
 #  else
-#    define  LV_USE_SLIDER       1   /*Requires: lv_bar*/
+#    define LV_USE_SLIDER       1   /*Requires: lv_bar*/
 #  endif
 #endif
 
@@ -1267,7 +1267,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SWITCH
 #    define LV_USE_SWITCH CONFIG_LV_USE_SWITCH
 #  else
-#    define  LV_USE_SWITCH    1
+#    define LV_USE_SWITCH    1
 #  endif
 #endif
 
@@ -1275,7 +1275,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TEXTAREA
 #    define LV_USE_TEXTAREA CONFIG_LV_USE_TEXTAREA
 #  else
-#    define  LV_USE_TEXTAREA   1     /*Requires: lv_label*/
+#    define LV_USE_TEXTAREA   1     /*Requires: lv_label*/
 #  endif
 #endif
 #if LV_USE_TEXTAREA != 0
@@ -1283,7 +1283,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TEXTAREA_DEF_PWD_SHOW_TIME
 #    define LV_TEXTAREA_DEF_PWD_SHOW_TIME CONFIG_LV_TEXTAREA_DEF_PWD_SHOW_TIME
 #  else
-#    define  LV_TEXTAREA_DEF_PWD_SHOW_TIME     1500    /*ms*/
+#    define LV_TEXTAREA_DEF_PWD_SHOW_TIME     1500    /*ms*/
 #  endif
 #endif
 #endif
@@ -1292,7 +1292,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TABLE
 #    define LV_USE_TABLE CONFIG_LV_USE_TABLE
 #  else
-#    define  LV_USE_TABLE  1
+#    define LV_USE_TABLE  1
 #  endif
 #endif
 
@@ -1307,7 +1307,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CALENDAR
 #    define LV_USE_CALENDAR CONFIG_LV_USE_CALENDAR
 #  else
-#    define  LV_USE_CALENDAR     1
+#    define LV_USE_CALENDAR     1
 #  endif
 #endif
 #if LV_USE_CALENDAR
@@ -1315,7 +1315,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_CALENDAR_WEEK_STARTS_MONDAY
 #    define LV_CALENDAR_WEEK_STARTS_MONDAY CONFIG_LV_CALENDAR_WEEK_STARTS_MONDAY
 #  else
-#    define  LV_CALENDAR_WEEK_STARTS_MONDAY 0
+#    define LV_CALENDAR_WEEK_STARTS_MONDAY 0
 #  endif
 #endif
 # if LV_CALENDAR_WEEK_STARTS_MONDAY
@@ -1323,7 +1323,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_CALENDAR_DEFAULT_DAY_NAMES
 #    define LV_CALENDAR_DEFAULT_DAY_NAMES CONFIG_LV_CALENDAR_DEFAULT_DAY_NAMES
 #  else
-#    define  LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+#    define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
 #  endif
 #endif
 # else
@@ -1331,7 +1331,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_CALENDAR_DEFAULT_DAY_NAMES
 #    define LV_CALENDAR_DEFAULT_DAY_NAMES CONFIG_LV_CALENDAR_DEFAULT_DAY_NAMES
 #  else
-#    define  LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+#    define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
 #  endif
 #endif
 # endif
@@ -1340,21 +1340,21 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_CALENDAR_DEFAULT_MONTH_NAMES
 #    define LV_CALENDAR_DEFAULT_MONTH_NAMES CONFIG_LV_CALENDAR_DEFAULT_MONTH_NAMES
 #  else
-#    define  LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+#    define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
 #  endif
 #endif
 #ifndef LV_USE_CALENDAR_HEADER_ARROW
 #  ifdef CONFIG_LV_USE_CALENDAR_HEADER_ARROW
 #    define LV_USE_CALENDAR_HEADER_ARROW CONFIG_LV_USE_CALENDAR_HEADER_ARROW
 #  else
-#    define  LV_USE_CALENDAR_HEADER_ARROW       1
+#    define LV_USE_CALENDAR_HEADER_ARROW       1
 #  endif
 #endif
 #ifndef LV_USE_CALENDAR_HEADER_DROPDOWN
 #  ifdef CONFIG_LV_USE_CALENDAR_HEADER_DROPDOWN
 #    define LV_USE_CALENDAR_HEADER_DROPDOWN CONFIG_LV_USE_CALENDAR_HEADER_DROPDOWN
 #  else
-#    define  LV_USE_CALENDAR_HEADER_DROPDOWN    1
+#    define LV_USE_CALENDAR_HEADER_DROPDOWN    1
 #  endif
 #endif
 #endif  /*LV_USE_CALENDAR*/
@@ -1363,7 +1363,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CHART
 #    define LV_USE_CHART CONFIG_LV_USE_CHART
 #  else
-#    define  LV_USE_CHART        1
+#    define LV_USE_CHART        1
 #  endif
 #endif
 
@@ -1371,7 +1371,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_COLORWHEEL
 #    define LV_USE_COLORWHEEL CONFIG_LV_USE_COLORWHEEL
 #  else
-#    define  LV_USE_COLORWHEEL   1
+#    define LV_USE_COLORWHEEL   1
 #  endif
 #endif
 
@@ -1379,7 +1379,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_IMGBTN
 #    define LV_USE_IMGBTN CONFIG_LV_USE_IMGBTN
 #  else
-#    define  LV_USE_IMGBTN       1
+#    define LV_USE_IMGBTN       1
 #  endif
 #endif
 
@@ -1387,7 +1387,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_KEYBOARD
 #    define LV_USE_KEYBOARD CONFIG_LV_USE_KEYBOARD
 #  else
-#    define  LV_USE_KEYBOARD     1
+#    define LV_USE_KEYBOARD     1
 #  endif
 #endif
 
@@ -1395,7 +1395,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LED
 #    define LV_USE_LED CONFIG_LV_USE_LED
 #  else
-#    define  LV_USE_LED          1
+#    define LV_USE_LED          1
 #  endif
 #endif
 
@@ -1403,7 +1403,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LIST
 #    define LV_USE_LIST CONFIG_LV_USE_LIST
 #  else
-#    define  LV_USE_LIST         1
+#    define LV_USE_LIST         1
 #  endif
 #endif
 
@@ -1411,7 +1411,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_METER
 #    define LV_USE_METER CONFIG_LV_USE_METER
 #  else
-#    define  LV_USE_METER        1
+#    define LV_USE_METER        1
 #  endif
 #endif
 
@@ -1419,7 +1419,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_MSGBOX
 #    define LV_USE_MSGBOX CONFIG_LV_USE_MSGBOX
 #  else
-#    define  LV_USE_MSGBOX       1
+#    define LV_USE_MSGBOX       1
 #  endif
 #endif
 
@@ -1427,7 +1427,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPINBOX
 #    define LV_USE_SPINBOX CONFIG_LV_USE_SPINBOX
 #  else
-#    define  LV_USE_SPINBOX      1
+#    define LV_USE_SPINBOX      1
 #  endif
 #endif
 
@@ -1435,7 +1435,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPINNER
 #    define LV_USE_SPINNER CONFIG_LV_USE_SPINNER
 #  else
-#    define  LV_USE_SPINNER      1
+#    define LV_USE_SPINNER      1
 #  endif
 #endif
 
@@ -1443,7 +1443,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TABVIEW
 #    define LV_USE_TABVIEW CONFIG_LV_USE_TABVIEW
 #  else
-#    define  LV_USE_TABVIEW      1
+#    define LV_USE_TABVIEW      1
 #  endif
 #endif
 
@@ -1451,7 +1451,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TILEVIEW
 #    define LV_USE_TILEVIEW CONFIG_LV_USE_TILEVIEW
 #  else
-#    define  LV_USE_TILEVIEW     1
+#    define LV_USE_TILEVIEW     1
 #  endif
 #endif
 
@@ -1459,7 +1459,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_WIN
 #    define LV_USE_WIN CONFIG_LV_USE_WIN
 #  else
-#    define  LV_USE_WIN          1
+#    define LV_USE_WIN          1
 #  endif
 #endif
 
@@ -1467,7 +1467,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPAN
 #    define LV_USE_SPAN CONFIG_LV_USE_SPAN
 #  else
-#    define  LV_USE_SPAN         1
+#    define LV_USE_SPAN         1
 #  endif
 #endif
 #if LV_USE_SPAN
@@ -1476,7 +1476,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPAN_SNIPPET_STACK_SIZE
 #    define LV_SPAN_SNIPPET_STACK_SIZE CONFIG_LV_SPAN_SNIPPET_STACK_SIZE
 #  else
-#    define  LV_SPAN_SNIPPET_STACK_SIZE   64
+#    define LV_SPAN_SNIPPET_STACK_SIZE   64
 #  endif
 #endif
 #endif
@@ -1490,7 +1490,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_DEFAULT
 #    define LV_USE_THEME_DEFAULT CONFIG_LV_USE_THEME_DEFAULT
 #  else
-#    define  LV_USE_THEME_DEFAULT    1
+#    define LV_USE_THEME_DEFAULT    1
 #  endif
 #endif
 #if LV_USE_THEME_DEFAULT
@@ -1500,7 +1500,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_DARK
 #    define LV_THEME_DEFAULT_DARK CONFIG_LV_THEME_DEFAULT_DARK
 #  else
-#    define  LV_THEME_DEFAULT_DARK     0
+#    define LV_THEME_DEFAULT_DARK     0
 #  endif
 #endif
 
@@ -1509,7 +1509,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_GROW
 #    define LV_THEME_DEFAULT_GROW CONFIG_LV_THEME_DEFAULT_GROW
 #  else
-#    define  LV_THEME_DEFAULT_GROW              1
+#    define LV_THEME_DEFAULT_GROW              1
 #  endif
 #endif
 
@@ -1518,7 +1518,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_TRANSITON_TIME
 #    define LV_THEME_DEFAULT_TRANSITON_TIME CONFIG_LV_THEME_DEFAULT_TRANSITON_TIME
 #  else
-#    define  LV_THEME_DEFAULT_TRANSITON_TIME    80
+#    define LV_THEME_DEFAULT_TRANSITON_TIME    80
 #  endif
 #endif
 #endif /*LV_USE_THEME_DEFAULT*/
@@ -1528,7 +1528,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_BASIC
 #    define LV_USE_THEME_BASIC CONFIG_LV_USE_THEME_BASIC
 #  else
-#    define  LV_USE_THEME_BASIC    1
+#    define LV_USE_THEME_BASIC    1
 #  endif
 #endif
 
@@ -1537,7 +1537,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_MONO
 #    define LV_USE_THEME_MONO CONFIG_LV_USE_THEME_MONO
 #  else
-#    define  LV_USE_THEME_MONO       1
+#    define LV_USE_THEME_MONO       1
 #  endif
 #endif
 
@@ -1550,7 +1550,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FLEX
 #    define LV_USE_FLEX CONFIG_LV_USE_FLEX
 #  else
-#    define  LV_USE_FLEX     1
+#    define LV_USE_FLEX     1
 #  endif
 #endif
 
@@ -1559,7 +1559,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GRID
 #    define LV_USE_GRID CONFIG_LV_USE_GRID
 #  else
-#    define  LV_USE_GRID     1
+#    define LV_USE_GRID     1
 #  endif
 #endif
 
@@ -1572,7 +1572,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BUILD_EXAMPLES
 #    define LV_BUILD_EXAMPLES CONFIG_LV_BUILD_EXAMPLES
 #  else
-#    define  LV_BUILD_EXAMPLES   1
+#    define LV_BUILD_EXAMPLES   1
 #  endif
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

- fix(lv_conf_internal_gen.py): change lv_conf.h to lv_conf_internal.h
- fix(lv_conf_internal_gen.py): remove the extra space before macro
- fix: regenerate lv_conf_internal.h 

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
