### PR TITLE
fix(lv_textarea.c) Fix crash while delete non-ascii character in pwd …

### DIFF
--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -259,8 +259,7 @@ void lv_textarea_del_char(lv_obj_t * obj)
     }
 
     if(ta->pwd_mode != 0) {
-        uint32_t byte_pos = _lv_txt_encoded_get_byte_id(ta->pwd_tmp, ta->cursor.pos - 1);
-        _lv_txt_cut(ta->pwd_tmp, ta->cursor.pos - 1, _lv_txt_encoded_size(&ta->pwd_tmp[byte_pos]));
+        _lv_txt_cut(ta->pwd_tmp, ta->cursor.pos - 1, 1);
 
         ta->pwd_tmp = lv_mem_realloc(ta->pwd_tmp, strlen(ta->pwd_tmp) + 1);
         LV_ASSERT_MALLOC(ta->pwd_tmp);


### PR DESCRIPTION
### Description of the feature or fix

Steps to reproduce：
* textarea set to password mode.
* input a non-ascii(>= 2 bytes) character.
* delete it.

Reason:
Call _lv_txt_cut with byte length not character length.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
