### PR TITLE
Add initial test for checkbox

### DIFF
--- a/tests/src/test_cases/test_arc.c
+++ b/tests/src/test_cases/test_arc.c
@@ -3,9 +3,10 @@
 
 #include "unity/unity.h"
 
-void test_bugfix_for_2522(void);
+void test_arc_angles_when_reversed(void);
 
-void test_bugfix_for_2522(void)
+/* See #2522 for more information */
+void test_arc_angles_when_reversed(void)
 {
     uint16_t expected_start_angle = 36;
     uint16_t expected_end_angle = 90;
@@ -18,7 +19,6 @@ void test_bugfix_for_2522(void)
 
     lv_arc_set_bg_angles(arcBlack, 0, 90);
     
-    /* lv_arc_set_value calls value_update, where the fix is done */
     lv_arc_set_value(arcBlack, expected_value);
 
     TEST_ASSERT_EQUAL_UINT16(expected_start_angle, lv_arc_get_angle_start(arcBlack));

--- a/tests/src/test_cases/test_bugfix.c
+++ b/tests/src/test_cases/test_bugfix.c
@@ -1,0 +1,29 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+void test_bugfix_for_2522(void);
+
+void test_bugfix_for_2522(void)
+{
+    uint16_t expected_start_angle = 36;
+    uint16_t expected_end_angle = 90;
+    int16_t expected_value = 40;
+
+    lv_obj_t *arcBlack;
+    arcBlack = lv_arc_create(lv_scr_act());
+
+    lv_arc_set_mode(arcBlack, LV_ARC_MODE_REVERSE);
+
+    lv_arc_set_bg_angles(arcBlack, 0, 90);
+    
+    /* lv_arc_set_value calls value_update, where the fix is done */
+    lv_arc_set_value(arcBlack, expected_value);
+
+    TEST_ASSERT_EQUAL_UINT16(expected_start_angle, lv_arc_get_angle_start(arcBlack));
+    TEST_ASSERT_EQUAL_UINT16(expected_end_angle, lv_arc_get_angle_end(arcBlack));
+    TEST_ASSERT_EQUAL_INT16(expected_value, lv_arc_get_value(arcBlack));
+}
+
+#endif

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -8,6 +8,7 @@
 void test_checkbox_creation_successfull(void);
 void test_checkbox_should_call_event_handler_on_click_when_enabled(void);
 void test_checkbox_should_have_default_text_when_created(void);
+void test_checkbox_should_return_dinamically_allocated_text(void);
 
 static lv_obj_t *active_screen = NULL;
 static lv_obj_t *checkbox = NULL;
@@ -54,6 +55,19 @@ void test_checkbox_should_have_default_text_when_created(void)
     checkbox = lv_checkbox_create(active_screen);
 
     TEST_ASSERT_EQUAL_STRING(default_text, lv_checkbox_get_text(checkbox));
+    TEST_ASSERT_NOT_NULL(lv_checkbox_get_text(checkbox));
+}
+
+void test_checkbox_should_return_dinamically_allocated_text(void)
+{
+    const char *message = "Hello World!";
+
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+
+    lv_checkbox_set_text(checkbox, message);
+
+    TEST_ASSERT_EQUAL_STRING(message, lv_checkbox_get_text(checkbox));
     TEST_ASSERT_NOT_NULL(lv_checkbox_get_text(checkbox));
 }
 

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -1,0 +1,48 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+#include "lv_test_indev.h"
+
+void test_checkbox_creation_successfull(void);
+void test_checkbox_should_call_event_handler_on_click_when_enabled(void);
+
+static lv_obj_t *active_screen = NULL;
+static lv_obj_t *checkbox = NULL;
+
+static volatile bool event_called = false;
+
+static void event_handler(lv_event_t *e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+
+    if (LV_EVENT_VALUE_CHANGED == code) {
+        event_called = true;
+    }
+}
+
+void test_checkbox_creation_successfull(void)
+{
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+
+    TEST_ASSERT_NOT_NULL(checkbox);
+}
+
+void test_checkbox_should_call_event_handler_on_click_when_enabled(void)
+{
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+    
+    lv_obj_add_state(checkbox, LV_STATE_CHECKED);
+    lv_obj_add_event_cb(checkbox, event_handler, LV_EVENT_ALL, NULL);
+
+    lv_test_mouse_click_at(checkbox->coords.x1, checkbox->coords.y1);
+
+    TEST_ASSERT_TRUE(event_called);
+    
+    event_called = false;
+}
+
+#endif

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -88,27 +88,30 @@ void test_checkbox_should_allocate_memory_for_static_text(void)
 
     lv_checkbox_set_text_static(checkbox, static_text);
 
+    lv_mem_monitor(&m1);
+
     TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size);
 }
 
 void test_checkbox_should_free_memory_when_static_text_is_refreshed(void)
 {
-    uint32_t available_memory = 0;
-    const char *static_text = "Keep me while you exist, ";
+    uint32_t initial_available_memory = 0;
+    const char *static_text = "Keep me while you exist";
 
     lv_mem_monitor_t m1;
     lv_mem_monitor(&m1);
 
     active_screen = lv_scr_act();
     checkbox = lv_checkbox_create(active_screen);
+    
+    initial_available_memory = m1.free_size;
 
     lv_checkbox_set_text_static(checkbox, static_text);
-
-    available_memory = m1.free_size;
- 
     lv_checkbox_set_text_static(checkbox, NULL);
 
-    TEST_ASSERT_GREATER_THAN(available_memory, m1.free_size);
+    lv_mem_monitor(&m1);
+
+    TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size);
 }
 
 #endif

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -9,6 +9,8 @@ void test_checkbox_creation_successfull(void);
 void test_checkbox_should_call_event_handler_on_click_when_enabled(void);
 void test_checkbox_should_have_default_text_when_created(void);
 void test_checkbox_should_return_dinamically_allocated_text(void);
+void test_checkbox_should_allocate_memory_for_static_text(void);
+void test_checkbox_should_free_memory_when_static_text_is_refreshed(void);
 
 static lv_obj_t *active_screen = NULL;
 static lv_obj_t *checkbox = NULL;
@@ -69,6 +71,44 @@ void test_checkbox_should_return_dinamically_allocated_text(void)
 
     TEST_ASSERT_EQUAL_STRING(message, lv_checkbox_get_text(checkbox));
     TEST_ASSERT_NOT_NULL(lv_checkbox_get_text(checkbox));
+}
+
+void test_checkbox_should_allocate_memory_for_static_text(void)
+{
+    uint32_t initial_available_memory = 0;
+    const char *static_text = "Keep me while you exist";
+
+    lv_mem_monitor_t m1;
+    lv_mem_monitor(&m1);
+
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+
+    initial_available_memory = m1.free_size;
+
+    lv_checkbox_set_text_static(checkbox, static_text);
+
+    TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size);
+}
+
+void test_checkbox_should_free_memory_when_static_text_is_refreshed(void)
+{
+    uint32_t available_memory = 0;
+    const char *static_text = "Keep me while you exist, ";
+
+    lv_mem_monitor_t m1;
+    lv_mem_monitor(&m1);
+
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+
+    lv_checkbox_set_text_static(checkbox, static_text);
+
+    available_memory = m1.free_size;
+ 
+    lv_checkbox_set_text_static(checkbox, NULL);
+
+    TEST_ASSERT_GREATER_THAN(available_memory, m1.free_size);
 }
 
 #endif

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -7,6 +7,7 @@
 
 void test_checkbox_creation_successfull(void);
 void test_checkbox_should_call_event_handler_on_click_when_enabled(void);
+void test_checkbox_should_have_default_text_when_created(void);
 
 static lv_obj_t *active_screen = NULL;
 static lv_obj_t *checkbox = NULL;
@@ -43,6 +44,17 @@ void test_checkbox_should_call_event_handler_on_click_when_enabled(void)
     TEST_ASSERT_TRUE(event_called);
     
     event_called = false;
+}
+
+void test_checkbox_should_have_default_text_when_created(void)
+{
+    const char *default_text = "Check box";
+
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+
+    TEST_ASSERT_EQUAL_STRING(default_text, lv_checkbox_get_text(checkbox));
+    TEST_ASSERT_NOT_NULL(lv_checkbox_get_text(checkbox));
 }
 
 #endif

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -10,7 +10,6 @@ void test_checkbox_should_call_event_handler_on_click_when_enabled(void);
 void test_checkbox_should_have_default_text_when_created(void);
 void test_checkbox_should_return_dinamically_allocated_text(void);
 void test_checkbox_should_allocate_memory_for_static_text(void);
-void test_checkbox_should_free_memory_when_static_text_is_refreshed(void);
 
 static lv_obj_t *active_screen = NULL;
 static lv_obj_t *checkbox = NULL;
@@ -87,27 +86,6 @@ void test_checkbox_should_allocate_memory_for_static_text(void)
     initial_available_memory = m1.free_size;
 
     lv_checkbox_set_text_static(checkbox, static_text);
-
-    lv_mem_monitor(&m1);
-
-    TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size);
-}
-
-void test_checkbox_should_free_memory_when_static_text_is_refreshed(void)
-{
-    uint32_t initial_available_memory = 0;
-    const char *static_text = "Keep me while you exist";
-
-    lv_mem_monitor_t m1;
-    lv_mem_monitor(&m1);
-
-    active_screen = lv_scr_act();
-    checkbox = lv_checkbox_create(active_screen);
-    
-    initial_available_memory = m1.free_size;
-
-    lv_checkbox_set_text_static(checkbox, static_text);
-    lv_checkbox_set_text_static(checkbox, NULL);
 
     lv_mem_monitor(&m1);
 


### PR DESCRIPTION
### Description of the feature or fix

Add initial set of tests for checkbox widget, I choose this widget because it's one of the simplest (?)

@kisvegabor What else should we test? If the checkbox state is `LV_STATE_DISABLED` and we click on it, should it call the `event_handler`?

Also, I wasn't able to use the Unity `setup` and `tearDown` functions, and is it possible to debug the `test_checkbox` object file? I was trying to debug using gdb but couldn't find the generated executables.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
