### PR TITLE
Chart example: add gap between old and new data 

### DIFF
--- a/examples/widgets/chart/lv_example_chart_9.c
+++ b/examples/widgets/chart/lv_example_chart_9.c
@@ -1,0 +1,46 @@
+#include "../../lv_examples.h"
+#if LV_USE_CHART && LV_DRAW_COMPLEX && LV_BUILD_EXAMPLES
+
+
+static void add_data(lv_timer_t * t)
+{
+    lv_obj_t * chart = t->user_data;
+    lv_chart_series_t * ser = lv_chart_get_series_next(chart, NULL);
+
+    lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+
+    uint16_t p = lv_chart_get_point_count(chart);
+    uint16_t s = lv_chart_get_x_start_point(chart, ser);
+    lv_coord_t * a = lv_chart_get_y_array(chart, ser);
+
+    a[(s + 1) % p] = LV_CHART_POINT_NONE;
+    a[(s + 2) % p] = LV_CHART_POINT_NONE;
+    a[(s + 2) % p] = LV_CHART_POINT_NONE;
+
+    lv_chart_refresh(chart);
+}
+
+/**
+ * Circular line chart with gap
+ */
+void lv_example_chart_9(void)
+{
+    /*Create a stacked_area_chart.obj*/
+    lv_obj_t * chart = lv_chart_create(lv_scr_act());
+    lv_chart_set_update_mode(chart, LV_CHART_UPDATE_MODE_CIRCULAR);
+    lv_obj_set_size(chart, 200, 150);
+    lv_obj_center(chart);
+
+    lv_chart_set_point_count(chart, 30);
+    lv_chart_series_t * ser = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_RED), LV_CHART_AXIS_PRIMARY_Y);
+    /*Prefill with data*/
+    uint32_t i;
+    for(i = 0; i < 30; i++) {
+        lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+    }
+
+    lv_timer_create(add_data, 300, chart);
+
+}
+
+#endif

--- a/examples/widgets/lv_example_widgets.h
+++ b/examples/widgets/lv_example_widgets.h
@@ -58,6 +58,7 @@ void lv_example_chart_5(void);
 void lv_example_chart_6(void);
 void lv_example_chart_7(void);
 void lv_example_chart_8(void);
+void lv_example_chart_9(void);
 
 void lv_example_checkbox_1(void);
 

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -976,7 +976,7 @@ static void draw_series_line(lv_obj_t * obj, const lv_area_t * clip_area)
                         lv_draw_line(&p1, &p2, &series_mask, &line_dsc_default);
                     }
 
-                    if(point_w && point_h && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
+                    if(point_w && point_h && ser->y_points[p_prev] != LV_CHART_POINT_NONE) {
                         lv_draw_rect(&point_area, &series_mask, &point_dsc_default);
                     }
 


### PR DESCRIPTION

### Description of the feature or fix

Demonstrate how to add gap between the newest and oldest points of a circular line chart.

@amirgon I was trying to add the MP version too but couldn't figure out how to convert this to get an array:
```c
    lv_coord_t * a = lv_chart_get_y_array(chart, ser);
```

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
