### PR TITLE
fix(btnmatrix): make ORed values work correctly with lv_btnmatrix_has_btn_ctrl

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fix(zoom) multiplication overflow with zoom calculations on 16-bit platforms
 - feat(msgbox): omit title label unless needed
 - feat(msgbox): add function to get selected button index
+- fix(btnmatrix): make ORed values work correctly with lv_btnmatrix_has_btn_ctrl
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/widgets/lv_btnmatrix.c
+++ b/src/widgets/lv_btnmatrix.c
@@ -331,7 +331,7 @@ bool lv_btnmatrix_has_btn_ctrl(lv_obj_t * obj, uint16_t btn_id, lv_btnmatrix_ctr
     lv_btnmatrix_t * btnm = (lv_btnmatrix_t *)obj;;
     if(btn_id >= btnm->btn_cnt) return false;
 
-    return (btnm->ctrl_bits[btn_id] & ctrl) ? true : false;
+    return ((btnm->ctrl_bits[btn_id] & ctrl) == ctrl) ? true : false;
 }
 
 bool lv_btnmatrix_get_one_checked(const lv_obj_t * obj)


### PR DESCRIPTION
### Description of the feature or fix

This commit replaces the current `actual & expected` check in `lv_btnmatrix_has_btn_ctrl` with `(actual & expected) == expected`. This is required to make the function work with ORed control flags because otherwise a parity in *any* bit will result in a return value of `true` even if not all expected bits are set.

Here is an example demonstrating the issue:

```
lv_btnmatrix_ctrl_t actual = LV_BTNMATRIX_CTRL_CHECKED;
lv_btnmatrix_ctrl_t expected = LV_BTNMATRIX_CTRL_CHECKED | LV_BTNMATRIX_CTRL_DISABLED;

// will print 1 (true) even though LV_BTNMATRIX_CTRL_DISABLED is not set
printf("%d\n", actual & expected ? true : false);

// will print 0 (false)
printf("%d\n", ((actual & expected) == expected) ? true : false);
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
