### PR TITLE
fix(snapshot) snapshot is affected by parent's style because of wrong coords

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - feat(msgbox): omit title label unless needed
 - feat(msgbox): add function to get selected button index
 - fix(btnmatrix): make ORed values work correctly with lv_btnmatrix_has_btn_ctrl
+- fix(snapshot): snapshot is affected by parent's style because of wrong coordinates.
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -138,6 +138,12 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
     obj->parent = screen;
 
     disp->inv_p = 0;
+
+    obj->coords.x2 = lv_area_get_width(&obj->coords) - 1;
+    obj->coords.x1 = 0;
+    obj->coords.y2 = lv_area_get_height(&obj->coords) - 1;
+    obj->coords.y1 = 0;
+
     lv_obj_invalidate(obj);
 
     /*Don't call lv_refr_now to avoid animation disruption */
@@ -150,9 +156,12 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
 
     lv_disp_remove(disp);
 
+    lv_obj_mark_layout_as_dirty(obj);
+    lv_obj_invalidate(obj);
+
     dsc->data = buf;
-    dsc->header.w = w;
-    dsc->header.h = h;
+    dsc->header.w = lv_area_get_width(&draw_buf.area);
+    dsc->header.h = lv_area_get_height(&draw_buf.area);
     dsc->header.cf = cf;
     return LV_RES_OK;
 }


### PR DESCRIPTION
### Coords of object for snapshot should be reset to position (0,0).

Assume an _objectB_ has parent _objectA_, when _objectA_ has a style of pad_all set to non-zero value like 10, _objectA_'s coords should be manually set to 0,0 before taking snapshot. Otherwise, _objectA_'s style will affect snapshot of _objectB_.

To solve the problem, manually set the coordinates to (0,0), keep size unchanged, and mark object layout as dirty when finishing snapshot.

The generated image size is also updated to real size drawn to buffer.

Below code on project lv_sim_eclipse_sdl can be used to reproduce the problem.
```c
void snapshort_demo(void)
{
  lv_obj_t* root = lv_obj_create(lv_scr_act());
  lv_obj_remove_style_all(root);
  lv_obj_set_size(root, 800, 100);
  lv_obj_set_style_pad_all(root, 40, 0);

  lv_obj_t* container = lv_obj_create(root);
  lv_obj_set_size(container, 800, 100);
  lv_obj_set_style_bg_color(container, lv_color_black(), 0);
  lv_obj_set_style_bg_opa(container, LV_OPA_50, 0);

  lv_img_dsc_t *dsc = lv_snapshot_take(container, LV_IMG_CF_TRUE_COLOR_ALPHA);
  lv_obj_t* img = lv_img_create(lv_scr_act());
  lv_img_set_src(img, dsc);
  lv_obj_align(img, LV_ALIGN_BOTTOM_MID, 0, 0);
}
```
### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
