### PR TITLE
docs(group) Fix reference to lv_cont that was removed in v8

### DIFF
--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -53,7 +53,7 @@ typedef void (*lv_group_focus_cb_t)(struct _lv_group_t *);
 
 /**
  * Groups can be used to logically hold objects so that they can be individually focused.
- * They are NOT for laying out objects on a screen (try `lv_cont` for that).
+ * They are NOT for laying out objects on a screen (try `lv_obj` for that).
  */
 typedef struct _lv_group_t {
     lv_ll_t obj_ll;        /**< Linked list to store the objects in the group*/

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -53,7 +53,7 @@ typedef void (*lv_group_focus_cb_t)(struct _lv_group_t *);
 
 /**
  * Groups can be used to logically hold objects so that they can be individually focused.
- * They are NOT for laying out objects on a screen (try `lv_obj` for that).
+ * They are NOT for laying out objects on a screen (try layouts for that).
  */
 typedef struct _lv_group_t {
     lv_ll_t obj_ll;        /**< Linked list to store the objects in the group*/


### PR DESCRIPTION
As reported on [this forum post](https://forum.lvgl.io/t/documantation-mislead/6876): 

### Description of the feature or fix

> It seems you have forgotten to redress this part on lv_group.
> 
> > Groups can be used to logically hold objects so that they can be individually focused. They are NOT for laying out objects on a screen (try lv_cont for that)
> 
> There is no lv_cont left in V8

Fixes a reference to `lv_cont` that was removed in v8 with `lv_obj` in `lv_group.h` 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
