### PR TITLE
fix(snapshot): make coords of screen of fake display same as obj.

### DIFF
--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -123,8 +123,10 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
 
     lv_disp_drv_init(&driver);
     driver.draw_buf = &draw_buf;
-    driver.hor_res = w;
-    driver.ver_res = h;
+
+    /*Make the display big enough to involve the objects on its original places. */
+    driver.hor_res = obj->coords.x1 + w;
+    driver.ver_res = obj->coords.y1 + h;
     lv_disp_drv_use_generic_set_px_cb(&driver, cf);
 
     disp = lv_disp_drv_register(&driver);
@@ -146,10 +148,11 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
 
     disp->inv_p = 0;
 
-    obj->coords.x2 = w - ext_size - 1;
-    obj->coords.x1 = ext_size;
-    obj->coords.y2 = h - ext_size - 1;
-    obj->coords.y1 = ext_size;
+    /*Shift obj by ext_size, so there is room for shadow etc.*/
+    obj->coords.x2 += ext_size;
+    obj->coords.x1 += ext_size;
+    obj->coords.y2 += ext_size;
+    obj->coords.y1 += ext_size;
 
     lv_obj_invalidate(obj);
 


### PR DESCRIPTION

### Snapshot may behave strangly if screen coords is not same as obj for snapshot.

Not sure if it's related to relative layouts, but I have met the problem that snapshot image has wrong layout for children in obj, with this patch it works.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
