### PR TITLE
fix(disp) set default theme also for non-default displays

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - feat(msgbox): add function to get selected button index
 - fix(btnmatrix): make ORed values work correctly with lv_btnmatrix_has_btn_ctrl
 - fix(snapshot): snapshot is affected by parent's style because of wrong coordinates.
+- fix(disp) set default theme also for non-default displays
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/extra/themes/default/lv_theme_default.c
+++ b/src/extra/themes/default/lv_theme_default.c
@@ -603,6 +603,13 @@ lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, l
     return (lv_theme_t *)&theme;
 }
 
+lv_theme_t * lv_theme_default_get(void)
+{
+    if(!inited) return NULL;
+
+    return (lv_theme_t *)&theme;
+}
+
 bool lv_theme_default_is_inited(void)
 {
     return inited;

--- a/src/extra/themes/default/lv_theme_default.h
+++ b/src/extra/themes/default/lv_theme_default.h
@@ -39,7 +39,16 @@ extern "C" {
 lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, lv_color_t color_secondary, bool dark,
                                    const lv_font_t * font);
 
+/**
+ * Get default theme
+ * @return a pointer to default theme, or NULL if this is not initialized
+ */
+lv_theme_t * lv_theme_default_get(void);
 
+/**
+ * Check if default theme is initialized
+ * @return true if default theme is initialized, false otherwise
+ */
 bool lv_theme_default_is_inited(void);
 
 /**********************

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -153,6 +153,8 @@ lv_disp_t * lv_disp_drv_register(lv_disp_drv_t * driver)
     if(lv_theme_default_is_inited() == false) {
         disp->theme = lv_theme_default_init(disp, lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED),
                                             LV_THEME_DEFAULT_DARK, LV_FONT_DEFAULT);
+    } else {
+        disp->theme = lv_theme_default_get();
     }
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

In case of multiple displays, if LV_USE_THEME_DEFAULT is set, use default theme also for displays other than the default one.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
