### PR TITLE
docs(animimg) Add missing animation image page

### DIFF
--- a/docs/widgets/extra/animimg.md
+++ b/docs/widgets/extra/animimg.md
@@ -1,0 +1,55 @@
+```eval_rst
+.. include:: /header.rst 
+:github_url: |github_link_base|/widgets/animimg.md
+```
+# Animation Image (lv_animimg)
+
+## Overview
+
+The animation image is similar to the norlmal 'Image' object. The only difference is that instead of one source image, you set an array of multiple source images.
+
+You can specify a duration and repeat count.
+
+
+
+## Parts and Styles
+- `LV_PART_MAIN` A background rectangle that uses the typical background style properties and the image itself using the image style properties.
+  
+## Usage
+
+### Image sources
+To set the image in a state, use the `lv_animimg_set_src(imgbtn, dsc[], num)`.
+ 
+
+### States
+Instead of the regular `lv_obj_add/clear_state()` functions the `lv_imgbtn_set_state(imgbtn, LV_IMGBTN_STATE_...)` functions should be used to manually set a state.
+
+
+## Events
+No special events are sent by image objects.
+
+See the events of the Base object too.
+
+Learn more about [Events](/overview/event).
+
+## Keys
+No Keys are processed by the object type.
+
+Learn more about [Keys](/overview/indev).
+
+## Example
+
+```eval_rst
+
+.. include:: ../../../examples/widgets/animimg/index.rst
+
+```
+
+## API
+
+```eval_rst
+
+.. doxygenfile:: lv_animimg.h
+  :project: lvgl
+
+```

--- a/docs/widgets/extra/animimg.md
+++ b/docs/widgets/extra/animimg.md
@@ -11,19 +11,15 @@ The animation image is similar to the norlmal 'Image' object. The only differenc
 You can specify a duration and repeat count.
 
 
-
 ## Parts and Styles
 - `LV_PART_MAIN` A background rectangle that uses the typical background style properties and the image itself using the image style properties.
-  
+ 
+
 ## Usage
 
 ### Image sources
 To set the image in a state, use the `lv_animimg_set_src(imgbtn, dsc[], num)`.
  
-
-### States
-Instead of the regular `lv_obj_add/clear_state()` functions the `lv_imgbtn_set_state(imgbtn, LV_IMGBTN_STATE_...)` functions should be used to manually set a state.
-
 
 ## Events
 No special events are sent by image objects.
@@ -32,10 +28,12 @@ See the events of the Base object too.
 
 Learn more about [Events](/overview/event).
 
+
 ## Keys
 No Keys are processed by the object type.
 
 Learn more about [Keys](/overview/indev).
+
 
 ## Example
 

--- a/examples/widgets/animimg/index.rst
+++ b/examples/widgets/animimg/index.rst
@@ -1,0 +1,7 @@
+
+Simple Animation Image 
+""""""""""""""""
+
+.. lv_example:: widgets/animimg/lv_example_animimg_1.c 
+  :language: c
+  :description: A simple example to demonstrate the use of an animation image.


### PR DESCRIPTION
### Description of the feature or fix

Add documentation page for the new `lv_animimg` animation image widget.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
