### PR TITLE
docs(animimg) Add animim to extra widgets index

### DIFF
--- a/docs/widgets/extra/index.md
+++ b/docs/widgets/extra/index.md
@@ -9,6 +9,7 @@
 .. toctree::
    :maxdepth: 1
    
+   animimg
    calendar
    chart
    colorwheel

--- a/examples/widgets/animimg/index.rst
+++ b/examples/widgets/animimg/index.rst
@@ -2,6 +2,6 @@
 Simple Animation Image 
 """"""""""""""""
 
-.. lv_example:: widgets/animimg/lv_example_animimg_1.c 
+.. lv_example:: widgets/animimg/lv_example_animimg_1
   :language: c
   :description: A simple example to demonstrate the use of an animation image.


### PR DESCRIPTION
### Description of the feature or fix

- `lv_example_animimg_1` should not contain the `.c` extension
- Add animation image to the index page for extra widgets

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
