### PR TITLE
LV_FORMAT_ATTRIBUTE fix for gnu > 4.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fix(snapshot): snapshot is affected by parent's style because of wrong coordinates.
 - fix(disp) set default theme also for non-default displays
 - feat(btnmatrix/keyboard): add option to show popovers on button press
+- fix(types) LV_FORMAT_ATTRIBUTE now works with gnu version greater than 4.4
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -77,14 +77,18 @@ typedef uint32_t lv_uintptr_t;
 #define _LV_CONCAT3(x, y, z) x ## y ## z
 #define LV_CONCAT3(x, y, z) _LV_CONCAT3(x, y, z)
 
-#if (defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)) && !defined(PYCPARSER)
-#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__ ((format(printf, fmtstr, vararg)))
+#if defined(PYCPARSER)
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
+#elif defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4)
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__((format(gnu_printf, fmtstr, vararg)))
+#elif (defined(__clang__) || defined(__GNUC__) || defined(__GNUG__))
+#define LV_FORMAT_ATTRIBUTE(fmtstr, vararg) __attribute__((format(printf, fmtstr, vararg)))
 #else
 #define LV_FORMAT_ATTRIBUTE(fmtstr, vararg)
 #endif
 
 #ifdef __cplusplus
-} /*extern "C"*/
+} /*extern "C"*/ 
 #endif
 
 #endif /*LV_TYPES_H*/


### PR DESCRIPTION
### Description 

When building with a gcc new that 4.4 a warning will come that looks like this:
```code
In file included from c:\projects\lib\egon0.0.1.0\source\lvgl\src\misc\lv_style.h:21,
                 from C:\projects\lib\EGON0.0.1.0\source\lvgl/src/core/lv_obj.h:20,
                 from C:\projects\lib\EGON0.0.1.0\source\lvgl/lvgl.h:33,
                 from C:\projects\lib\EGON0.0.1.0\source\core/EGON_core.h:24,
                 from C:\projects\lib\EGON0.0.1.0\source\core\styles\EGON_builder_style_text.h:16,
                 from C:\projects\lib\EGON0.0.1.0\source\core\styles\EGON_builder_style_text.c:13:
c:\projects\lib\egon0.0.1.0\source\lvgl\src\misc\lv_txt.h:145:1: warning: '_printf' is an unrecognized format function type [-Wformat=]  145 | char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap) LV_FORMAT_ATTRIBUTE(1, 0);
      | ^~~~
In file included from C:\projects\lib\EGON0.0.1.0\source\lvgl/lvgl.h:49,
                 from C:\projects\lib\EGON0.0.1.0\source\core/EGON_core.h:24,
                 from C:\projects\lib\EGON0.0.1.0\source\core\styles\EGON_builder_style_text.h:16,
                 from C:\projects\lib\EGON0.0.1.0\source\core\styles\EGON_builder_style_text.c:13:
C:\projects\lib\EGON0.0.1.0\source\lvgl/src/widgets/lv_label.h:109:1: warning: '_printf' is an unrecognized format function type [-Wformat=]
  109 | void
```

This is because in printf changed to gnu_printf in version 4.4

The code has been tested with arm-none-eabi-gcc
````code
arm-none-eabi-gcc --version
arm-none-eabi-gcc.exe (GNU Arm Embedded Toolchain 9-2020-q2-update) 9.3.1 20200408 (release)
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
````
and MINGW32
````
gcc --version
gcc.exe (i686-posix-dwarf-rev0, Built by MinGW-W64 project) 8.1.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
````

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
