### PR TITLE
Make lv_meter_indicator_type_t of type uint8_t

### DIFF
--- a/src/extra/widgets/meter/lv_meter.h
+++ b/src/extra/widgets/meter/lv_meter.h
@@ -51,12 +51,13 @@ typedef struct {
     int16_t rotation;
 } lv_meter_scale_t;
 
-typedef enum {
+enum {
     LV_METER_INDICATOR_TYPE_NEEDLE_IMG,
     LV_METER_INDICATOR_TYPE_NEEDLE_LINE,
     LV_METER_INDICATOR_TYPE_SCALE_LINES,
     LV_METER_INDICATOR_TYPE_ARC,
-} lv_meter_indicator_type_t;
+};
+typedef uint8_t lv_meter_indicator_type_t;
 
 typedef struct {
     lv_meter_scale_t * scale;


### PR DESCRIPTION
### Description of the feature or fix

Make `lv_meter_indicator_type_t` as `uint8_t` instead of `int` to save 4 bytes in `lv_meter_indicator_t`

As discussed in #2614 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
