### PR TITLE
fix(cmake) added languages to cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(lvgl
+project(lvgl LANGUAGES C
   HOMEPAGE_URL https://github.com/lvgl/lvgl/)
 
 if(ESP_PLATFORM)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v8.1.0 (In progress)
+- fix(cmake) added languages to cmake project #2635
 - Fixed lv_deinit declaration when LV_USE_GPU_SDL is enabled
 - added sample lv_example_list_2.py
 - lv_obj_move_up(obj) and lv_obj_move_down(obj) added. (#2461)


### PR DESCRIPTION
Fixes `CMake Error: Could not find cmake module file: CMakeDetermineHOMEPAGE_URLCompiler.cmake` on CMake 3.6

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
