### PR TITLE
Revert "build: Make install rules optionnal"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,40 +85,40 @@ else()
         target_compile_options(lvgl_interface INTERFACE -Wno-unused-function)
     else(MICROPY_DIR)
         # without micropython, build lvgl and examples libs normally
+        # default linux build uses this scope
         add_library(lvgl STATIC ${SOURCES})
         add_library(lvgl_examples STATIC ${EXAMPLE_SOURCES})
+
+        include_directories(${CMAKE_SOURCE_DIR})
+
+        # Lbrary and headers can be installed to system using make install
+        file(GLOB LVGL_PUBLIC_HEADERS
+          "${CMAKE_SOURCE_DIR}/lv_conf.h"
+          "${CMAKE_SOURCE_DIR}/lvgl.h")
+
+        if("${LIB_INSTALL_DIR}" STREQUAL "")
+            set(LIB_INSTALL_DIR "lib")
+        endif()
+        if("${INC_INSTALL_DIR}" STREQUAL "")
+            set(INC_INSTALL_DIR "include/lvgl")
+        endif()
+
+        install(DIRECTORY "${CMAKE_SOURCE_DIR}/src"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/${INC_INSTALL_DIR}/"
+            FILES_MATCHING
+            PATTERN "*.h")
+
+        set_target_properties(lvgl PROPERTIES
+            OUTPUT_NAME lvgl
+            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            PUBLIC_HEADER "${LVGL_PUBLIC_HEADERS}")
+
+        install(TARGETS lvgl
+            ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+            PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}")
+
     endif(MICROPY_DIR)
 
 endif()
 
-option(install "Enable install to system" OFF)
-if(install)
-include_directories(${CMAKE_SOURCE_DIR})
 
-file(GLOB LVGL_PUBLIC_HEADERS
-  "${CMAKE_SOURCE_DIR}/lv_conf.h"
-  "${CMAKE_SOURCE_DIR}/lvgl.h")
-
-
-if("${LIB_INSTALL_DIR}" STREQUAL "")
-    set(LIB_INSTALL_DIR "lib")
-endif()
-
-if("${INC_INSTALL_DIR}" STREQUAL "")
-    set(INC_INSTALL_DIR "include/lvgl")
-endif()
-
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/src"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/${INC_INSTALL_DIR}/"
-    FILES_MATCHING
-    PATTERN "*.h")
-
-set_target_properties(lvgl PROPERTIES
-    OUTPUT_NAME lvgl
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    PUBLIC_HEADER "${LVGL_PUBLIC_HEADERS}")
-
-install(TARGETS lvgl
-    ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
-    PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}")
-endif(install)


### PR DESCRIPTION
This will simplify packaging recipes, it's not mandatory
but there is no reason to keep this,
if is does not imply any regressions.

This reverts commit 272148dbdc40aac9c9446a3a9bcc6511f5eb8bbf.
Relate-to: https://github.com/lvgl/lvgl/issues/2534

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
