### PR TITLE
fix(mem): ALIGN_MASK should equal 0x3 on 32bit platform

### DIFF
--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -34,7 +34,7 @@
     #define ALIGN_MASK       0x7
 #else
     #define MEM_UNIT         uint32_t
-    #define ALIGN_MASK       0x7
+    #define ALIGN_MASK       0x3
 #endif
 
 #define ZERO_MEM_SENTINEL  0xa1b2c3d4


### PR DESCRIPTION
### Description of the feature or fix

minor fix

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
