### PR TITLE
feat(rt-thread): support LVGL projects with GCC/Keil(AC5)/Keil(AC6)/IAR, 4 compiler platforms

### DIFF
--- a/rt-thread/SConscript
+++ b/rt-thread/SConscript
@@ -20,10 +20,12 @@ for root, dirs, files in os.walk(lvgl_src_cwd):
         inc = inc + [os.path.join(root,dir)]
 
 LOCAL_CCFLAGS = ''
-if rtconfig.CROSS_TOOL == 'gcc':
+if rtconfig.PLATFORM == 'gcc': # GCC
     LOCAL_CCFLAGS += ' -std=c99'
-elif rtconfig.CROSS_TOOL == 'keil':
+elif rtconfig.PLATFORM == 'armcc': # Keil AC5
     LOCAL_CCFLAGS += ' --c99 --gnu -g -W'
+elif rtconfig.PLATFORM == 'armclang': # Keil AC6
+    LOCAL_CCFLAGS += ' -std=c99 -g -w'
 
 group = DefineGroup('LVGL', src, depend = ['PKG_USING_LVGL'], CPPPATH = inc, LOCAL_CCFLAGS = LOCAL_CCFLAGS)
 


### PR DESCRIPTION
### Description of the feature or fix

This PR will let LVGL support with GCC/Keil(AC5)/Keil(AC6)/IAR four compiler platforms (toolchain) in RT-Thread project.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
