### PR TITLE
ci(micropython) fix git fetch

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Checkout LVGL submodule
       working-directory: ./lib/lv_bindings/lvgl
       run: |
-        git fetch --force ${{ github.event.repository.git_url }} "+refs/heads/*:refs/remotes/origin/*"
-        git fetch --force ${{ github.event.repository.git_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
+        git fetch --force ${{ github.event.repository.html_url }} "+refs/heads/*:refs/remotes/origin/*"
+        git fetch --force ${{ github.event.repository.html_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
         git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
         git submodule update --init --recursive
     - name: Build mpy-cross


### PR DESCRIPTION
Recent failures in GitHub actions are related to this:  
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Need to switch from "git" protocol to "https" protocol when running git remote operations (git fetch)