### PR TITLE
Dennis c bugfix adding arabic vowel support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,7 @@
 - feat(keyboard): add user-defined modes
 - Add support for RT-Thread RTOS
 - feat(disp): add utility functions/macros for dealing with non-fullscreen displays
-- fix(draw) skip basic arabic vowel characters when processing conjunction
+- fix(txt) skip basic arabic vowel characters when processing conjunction
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - feat(keyboard): add user-defined modes
 - Add support for RT-Thread RTOS
 - feat(disp): add utility functions/macros for dealing with non-fullscreen displays
+- fix(draw) skip basic arabic vowel characters when processing conjunction
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/misc/lv_txt_ap.c
+++ b/src/misc/lv_txt_ap.c
@@ -38,6 +38,7 @@ typedef struct {
 #if LV_USE_ARABIC_PERSIAN_CHARS == 1
 static uint32_t lv_ap_get_char_index(uint16_t c);
 static uint32_t lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next);
+static bool lv_txt_is_arabic_vowel(uint16_t c);
 
 /**********************
  *  STATIC VARIABLES
@@ -166,6 +167,16 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
         index_current = lv_ap_get_char_index(ch_enc[i]);
         idx_next = lv_ap_get_char_index(ch_enc[i + 1]);
 
+        if(lv_txt_is_arabic_vowel(ch_enc[i])) {  // Current character is a vowel
+            ch_fin[j] = ch_enc[i];
+            i++;
+            j++;
+            continue;   // Skip this character
+        }
+        else if(lv_txt_is_arabic_vowel(ch_enc[i + 1])) {    // Next character is a vowel
+            idx_next = lv_ap_get_char_index(ch_enc[i + 2]); // Skip the vowel character to join with the character after it
+        }
+
         if(index_current == LV_UNDEF_ARABIC_PERSIAN_CHARS) {
             ch_fin[j] = ch_enc[i];
             j++;
@@ -280,6 +291,11 @@ static uint32_t lv_txt_lam_alef(uint32_t ch_curr, uint32_t ch_next)
         return 0xFEFB;    // (lam-alef) alef
     }
     return 0;
+}
+
+static bool lv_txt_is_arabic_vowel(uint16_t c)
+{
+    return (c >= 0x064B) && (c <= 0x0652);
 }
 
 #endif


### PR DESCRIPTION
### Description of the feature or fix

LVGL currently does not consider vowel characters when processing arabic conjunction which disjoins strings when a vowel appears. This temporary fix skips basic vowel characters and allows the string to join up properly but will need more work in the future, such as consider all the vowels and position the vowel character correctly (height of a vowel character needs to consider the height of the base character etc).

