### PR TITLE
Added L suffix for fixing the length of enumeration values to 32bit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - feat(keyboard): add user-defined modes
 - Add support for RT-Thread RTOS
 - feat(disp): add utility functions/macros for dealing with non-fullscreen displays
+- fix(core): force the use of 32bit integers in the enumerations so that LVGL can be compiled on 16bit architectures
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -110,7 +110,6 @@ enum {
 
     LV_OBJ_FLAG_WIDGET_1        = (1L << 25), /**< Custom flag, free to use by widget*/
     LV_OBJ_FLAG_WIDGET_2        = (1L << 26), /**< Custom flag, free to use by widget*/
-L
     LV_OBJ_FLAG_USER_1          = (1L << 27), /**< Custom flag, free to use by user*/
     LV_OBJ_FLAG_USER_2          = (1L << 28), /**< Custom flag, free to use by user*/
     LV_OBJ_FLAG_USER_3          = (1L << 29), /**< Custom flag, free to use by user*/

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -87,34 +87,34 @@ typedef uint32_t lv_part_t;
  * OR-ed values are possible
  */
 enum {
-    LV_OBJ_FLAG_HIDDEN          = (1 << 0),  /**< Make the object hidden. (Like it wasn't there at all)*/
-    LV_OBJ_FLAG_CLICKABLE       = (1 << 1),  /**< Make the object clickable by the input devices*/
-    LV_OBJ_FLAG_CLICK_FOCUSABLE = (1 << 2),  /**< Add focused state to the object when clicked*/
-    LV_OBJ_FLAG_CHECKABLE       = (1 << 3),  /**< Toggle checked state when the object is clicked*/
-    LV_OBJ_FLAG_SCROLLABLE      = (1 << 4),  /**< Make the object scrollable*/
-    LV_OBJ_FLAG_SCROLL_ELASTIC  = (1 << 5),  /**< Allow scrolling inside but with slower speed*/
-    LV_OBJ_FLAG_SCROLL_MOMENTUM = (1 << 6),  /**< Make the object scroll further when "thrown"*/
-    LV_OBJ_FLAG_SCROLL_ONE      = (1 << 7),   /**< Allow scrolling only one snappable children*/
-    LV_OBJ_FLAG_SCROLL_CHAIN    = (1 << 8),  /**< Allow propagating the scroll to a parent*/
-    LV_OBJ_FLAG_SCROLL_ON_FOCUS = (1 << 9),  /**< Automatically scroll object to make it visible when focused*/
-    LV_OBJ_FLAG_SNAPPABLE        = (1 << 10), /**< If scroll snap is enabled on the parent it can snap to this object*/
-    LV_OBJ_FLAG_PRESS_LOCK      = (1 << 11), /**< Keep the object pressed even if the press slid from the object*/
-    LV_OBJ_FLAG_EVENT_BUBBLE    = (1 << 12), /**< Propagate the events to the parent too*/
-    LV_OBJ_FLAG_GESTURE_BUBBLE  = (1 << 13), /**< Propagate the gestures to the parent*/
-    LV_OBJ_FLAG_ADV_HITTEST     = (1 << 14), /**< Allow performing more accurate hit (click) test. E.g. consider rounded corners.*/
-    LV_OBJ_FLAG_IGNORE_LAYOUT   = (1 << 15), /**< Make the object position-able by the layouts*/
-    LV_OBJ_FLAG_FLOATING        = (1 << 16), /**< Do not scroll the object when the parent scrolls and ignore layout*/
+    LV_OBJ_FLAG_HIDDEN          = (1L << 0),  /**< Make the object hidden. (Like it wasn't there at all)*/
+    LV_OBJ_FLAG_CLICKABLE       = (1L << 1),  /**< Make the object clickable by the input devices*/
+    LV_OBJ_FLAG_CLICK_FOCUSABLE = (1L << 2),  /**< Add focused state to the object when clicked*/
+    LV_OBJ_FLAG_CHECKABLE       = (1L << 3),  /**< Toggle checked state when the object is clicked*/
+    LV_OBJ_FLAG_SCROLLABLE      = (1L << 4),  /**< Make the object scrollable*/
+    LV_OBJ_FLAG_SCROLL_ELASTIC  = (1L << 5),  /**< Allow scrolling inside but with slower speed*/
+    LV_OBJ_FLAG_SCROLL_MOMENTUM = (1L << 6),  /**< Make the object scroll further when "thrown"*/
+    LV_OBJ_FLAG_SCROLL_ONE      = (1L << 7),  /**< Allow scrolling only one snappable children*/
+    LV_OBJ_FLAG_SCROLL_CHAIN    = (1L << 8),  /**< Allow propagating the scroll to a parent*/
+    LV_OBJ_FLAG_SCROLL_ON_FOCUS = (1L << 9),  /**< Automatically scroll object to make it visible when focused*/
+    LV_OBJ_FLAG_SNAPPABLE       = (1L << 10), /**< If scroll snap is enabled on the parent it can snap to this object*/
+    LV_OBJ_FLAG_PRESS_LOCK      = (1L << 11), /**< Keep the object pressed even if the press slid from the object*/
+    LV_OBJ_FLAG_EVENT_BUBBLE    = (1L << 12), /**< Propagate the events to the parent too*/
+    LV_OBJ_FLAG_GESTURE_BUBBLE  = (1L << 13), /**< Propagate the gestures to the parent*/
+    LV_OBJ_FLAG_ADV_HITTEST     = (1L << 14), /**< Allow performing more accurate hit (click) test. E.g. consider rounded corners.*/
+    LV_OBJ_FLAG_IGNORE_LAYOUT   = (1L << 15), /**< Make the object position-able by the layouts*/
+    LV_OBJ_FLAG_FLOATING        = (1L << 16), /**< Do not scroll the object when the parent scrolls and ignore layout*/
 
-    LV_OBJ_FLAG_LAYOUT_1        = (1 << 23), /**< Custom flag, free to use by layouts*/
-    LV_OBJ_FLAG_LAYOUT_2        = (1 << 24), /**< Custom flag, free to use by layouts*/
+    LV_OBJ_FLAG_LAYOUT_1        = (1L << 23), /**< Custom flag, free to use by layouts*/
+    LV_OBJ_FLAG_LAYOUT_2        = (1L << 24), /**< Custom flag, free to use by layouts*/
 
-    LV_OBJ_FLAG_WIDGET_1        = (1 << 25), /**< Custom flag, free to use by widget*/
-    LV_OBJ_FLAG_WIDGET_2        = (1 << 26), /**< Custom flag, free to use by widget*/
-
-    LV_OBJ_FLAG_USER_1          = (1 << 27), /**< Custom flag, free to use by user*/
-    LV_OBJ_FLAG_USER_2          = (1 << 28), /**< Custom flag, free to use by user*/
-    LV_OBJ_FLAG_USER_3          = (1 << 29), /**< Custom flag, free to use by user*/
-    LV_OBJ_FLAG_USER_4          = (1 << 30), /**< Custom flag, free to use by user*/
+    LV_OBJ_FLAG_WIDGET_1        = (1L << 25), /**< Custom flag, free to use by widget*/
+    LV_OBJ_FLAG_WIDGET_2        = (1L << 26), /**< Custom flag, free to use by widget*/
+L
+    LV_OBJ_FLAG_USER_1          = (1L << 27), /**< Custom flag, free to use by user*/
+    LV_OBJ_FLAG_USER_2          = (1L << 28), /**< Custom flag, free to use by user*/
+    LV_OBJ_FLAG_USER_3          = (1L << 29), /**< Custom flag, free to use by user*/
+    LV_OBJ_FLAG_USER_4          = (1L << 30), /**< Custom flag, free to use by user*/
 };
 typedef uint32_t lv_obj_flag_t;
 

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -326,12 +326,12 @@ void lv_draw_mask_line_points_init(lv_draw_mask_line_param_t * param, lv_coord_t
         int32_t m;
 
         if(dx) {
-            m = (1 << 20) / dx;  /*m is multiplier to normalize y (upscaled by 1024)*/
+            m = (1L << 20) / dx;  /*m is multiplier to normalize y (upscaled by 1024)*/
             param->yx_steep = (m * dy) >> 10;
         }
 
         if(dy) {
-            m = (1 << 20) / dy;  /*m is multiplier to normalize x (upscaled by 1024)*/
+            m = (1L << 20) / dy;  /*m is multiplier to normalize x (upscaled by 1024)*/
             param->xy_steep = (m * dx) >> 10;
         }
         param->steep = param->yx_steep;
@@ -341,12 +341,12 @@ void lv_draw_mask_line_points_init(lv_draw_mask_line_param_t * param, lv_coord_t
         int32_t m;
 
         if(dy) {
-            m = (1 << 20) / dy;  /*m is multiplier to normalize x (upscaled by 1024)*/
+            m = (1L << 20) / dy;  /*m is multiplier to normalize x (upscaled by 1024)*/
             param->xy_steep = (m * dx) >> 10;
         }
 
         if(dx) {
-            m = (1 << 20) / dx;  /*m is multiplier to normalize x (upscaled by 1024)*/
+            m = (1L << 20) / dx;  /*m is multiplier to normalize x (upscaled by 1024)*/
             param->yx_steep = (m * dy) >> 10;
         }
         param->steep = param->xy_steep;


### PR DESCRIPTION
### Description of the feature or fix

This fix just adds the `L` suffix to the 1s used in the enumerations, so that the compiler uses 32bit values instead of using implementation-based integers.
This was 16-bit architectures can be used too.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
