### PR TITLE
fix(msgbox) add declaration for lv_msgbox_content_class

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Add support for RT-Thread RTOS
 - feat(disp): add utility functions/macros for dealing with non-fullscreen displays
 - fix(core): force the use of 32bit integers in the enumerations so that LVGL can be compiled on 16bit architectures
+- fix(msgbox) add declaration for lv_msgbox_content_class
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/extra/widgets/msgbox/lv_msgbox.h
+++ b/src/extra/widgets/msgbox/lv_msgbox.h
@@ -44,7 +44,7 @@ typedef struct {
 } lv_msgbox_t;
 
 extern const lv_obj_class_t lv_msgbox_class;
-
+extern const lv_obj_class_t lv_msgbox_content_class;
 extern const lv_obj_class_t lv_msgbox_backdrop_class;
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

fix(msgbox) add declaration for lv_msgbox_content_class

This allows for styling the content

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
