### PR TITLE
fix(draw_border):draw error if radius == 0 and parent clip_corner == true

### DIFF
--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -1080,7 +1080,9 @@ void draw_border_generic(const lv_area_t * clip_area, const lv_area_t * outer_ar
 {
     opa = opa >= LV_OPA_COVER ? LV_OPA_COVER : opa;
 
-    if(rout == 0 && rin == 0) {
+    bool mask_any = lv_draw_mask_is_any(outer_area);
+
+    if(!mask_any && rout == 0 && rin == 0) {
         draw_border_simple(clip_area, outer_area, inner_area, color, opa);
         return;
     }
@@ -1091,8 +1093,6 @@ void draw_border_generic(const lv_area_t * clip_area, const lv_area_t * outer_ar
     lv_area_t draw_area;
     if(!_lv_area_intersect(&draw_area, outer_area, clip_area)) return;
     int32_t draw_area_w = lv_area_get_width(&draw_area);
-
-    bool mask_any = lv_draw_mask_is_any(outer_area);
 
     /*Create a mask if there is a radius*/
     lv_opa_t * mask_buf = lv_mem_buf_get(draw_area_w);


### PR DESCRIPTION

### Description of the feature or fix

draw error if radius == 0 and parent clip_corner == true

test code:
```c
    lv_obj_t *par = lv_obj_create(lv_scr_act());
    lv_obj_set_size(par, 200, 200);
    lv_obj_set_style_radius(par, 200, 0);
    lv_obj_set_style_pad_all(par, 0, 0);
    lv_obj_set_style_clip_corner(par, true, 0);
    lv_obj_set_style_border_width(par, 4, 0);
    lv_obj_set_style_border_color(par, lv_palette_main(LV_PALETTE_ORANGE), 0);
    lv_obj_set_scrollbar_mode(par, LV_SCROLLBAR_MODE_OFF);

    lv_obj_t *child = lv_obj_create(par);
    lv_obj_set_size(child, 100, 100);
    lv_obj_set_style_radius(child, 0, 0);
    lv_obj_set_style_border_width(child, 1, 0);
    lv_obj_set_style_border_color(child, lv_palette_main(LV_PALETTE_RED), 0);
```

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
