### PR TITLE
Minor fix for color module

### DIFF
--- a/src/misc/lv_assert.h
+++ b/src/misc/lv_assert.h
@@ -14,7 +14,8 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
-#include <stdbool.h>
+#include "lv_log.h"
+#include "lv_mem.h"
 #include LV_ASSERT_HANDLER_INCLUDE
 
 /*********************

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -203,8 +203,6 @@ enum {
 #define _LV_COLOR_ZERO_INITIALIZER LV_CONCAT(_LV_COLOR_ZERO_INITIALIZER, LV_COLOR_DEPTH)
 #define LV_COLOR_MAKE(r8, g8, b8) LV_CONCAT(LV_COLOR_MAKE, LV_COLOR_DEPTH)(r8, g8, b8)
 
-#define LV_UDIV255(x) ((uint32_t)((uint32_t) (x) * 0x8081) >> 0x17)
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "lv_assert.h"
 #include "lv_math.h"
 #include "lv_types.h"
 
@@ -579,10 +580,7 @@ LV_ATTRIBUTE_FAST_MEM static inline void lv_color_mix_with_alpha(lv_color_t bg_c
             /*Info:
              * https://en.wikipedia.org/wiki/Alpha_compositing#Analytical_derivation_of_the_over_operator*/
             res_opa_saved = 255 - ((uint16_t)((uint16_t)(255 - fg_opa) * (255 - bg_opa)) >> 8);
-            if(res_opa_saved == 0) {
-                while(1)
-                    ;
-            }
+            LV_ASSERT(res_opa_saved != 0);
             lv_opa_t ratio = (uint16_t)((uint16_t)fg_opa * 255) / res_opa_saved;
             res_color_saved = lv_color_mix(fg_color, bg_color, ratio);
 

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -129,6 +129,7 @@ uint32_t lv_rand(uint32_t min, uint32_t max);
 #define LV_CLAMP(min, val, max) (LV_MAX(min, (LV_MIN(val, max))))
 
 #define LV_ABS(x) ((x) > 0 ? (x) : (-(x)))
+#define LV_UDIV255(x) (((x) * 0x8081U) >> 0x17)
 
 #define LV_IS_SIGNED(t) (((t)(-1)) < ((t) 0))
 #define LV_UMAX_OF(t) (((0x1ULL << ((sizeof(t) * 8ULL) - 1ULL)) - 1ULL) | (0xFULL << ((sizeof(t) * 8ULL) - 4ULL)))


### PR DESCRIPTION
### Description of the feature or fix

- fix(color): move LV_UDIV255 to lv_math.h
- fix(color): replace the inifite loop with LV_ASSERT

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
