### PR TITLE
fix(proto) Remove redundant prototype declarations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,7 +47,7 @@
 - fix(core): force the use of 32bit integers in the enumerations so that LVGL can be compiled on 16bit architectures
 - fix(msgbox) add declaration for lv_msgbox_content_class
 - fix(txt) skip basic arabic vowel characters when processing conjunction
-
+- fix(proto) Remove redundant prototype declarations
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/extra/widgets/span/lv_span.c
+++ b/src/extra/widgets/span/lv_span.c
@@ -47,7 +47,6 @@ static void refresh_self_size(lv_obj_t * obj);
 static const lv_font_t * lv_span_get_style_text_font(lv_obj_t * par, lv_span_t * span);
 static lv_coord_t lv_span_get_style_text_letter_space(lv_obj_t * par, lv_span_t * span);
 static lv_color_t lv_span_get_style_text_color(lv_obj_t * par, lv_span_t * span);
-static lv_color_t lv_span_get_style_text_color(lv_obj_t * par, lv_span_t * span);
 static lv_opa_t lv_span_get_style_text_opa(lv_obj_t * par, lv_span_t * span);
 static lv_opa_t lv_span_get_style_text_blend_mode(lv_obj_t * par, lv_span_t * span);
 static int32_t lv_span_get_style_text_decor(lv_obj_t * par, lv_span_t * span);

--- a/src/widgets/lv_btnmatrix.c
+++ b/src/widgets/lv_btnmatrix.c
@@ -47,7 +47,6 @@ static bool button_is_popover(lv_btnmatrix_ctrl_t ctrl_bits);
 static bool button_is_checkable(lv_btnmatrix_ctrl_t ctrl_bits);
 static bool button_is_recolor(lv_btnmatrix_ctrl_t ctrl_bits);
 static bool button_get_checked(lv_btnmatrix_ctrl_t ctrl_bits);
-static bool button_is_recolor(lv_btnmatrix_ctrl_t ctrl_bits);
 static uint16_t get_button_from_point(lv_obj_t * obj, lv_point_t * p);
 static void allocate_btn_areas_and_controls(const lv_obj_t * obj, const char ** map);
 static void invalidate_button_area(const lv_obj_t * obj, uint16_t btn_idx);


### PR DESCRIPTION
### Description of the feature or fix

Build with -Wredundant-decls flagged some duplicate function prototypes

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
