### PR TITLE
fix(draw_img):radius Mask doesn't work in Specific condition

### DIFF
--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -358,8 +358,7 @@ LV_ATTRIBUTE_FAST_MEM static void lv_draw_map(const lv_area_t * map_area, const 
     draw_area.x2 -= disp_area->x1;
     draw_area.y2 -= disp_area->y1;
 
-    bool mask_any = lv_draw_mask_is_any(map_area);
-
+    bool mask_any = lv_draw_mask_is_any(&draw_area);
     /*The simplest case just copy the pixels into the draw_buf*/
     if(!mask_any && draw_dsc->angle == 0 && draw_dsc->zoom == LV_IMG_ZOOM_NONE &&
        chroma_key == false && alpha_byte == false && draw_dsc->recolor_opa == LV_OPA_TRANSP) {


### PR DESCRIPTION
### Description of the feature or fix

img radius Mask doesn't work in Specific condition.
test code:
```c
lv_obj_t *par = lv_obj_create(lv_scr_act());
    lv_obj_remove_style_all(par);
    lv_obj_center(par);
    lv_obj_set_size(par, 152, 152);
    lv_obj_set_style_radius(par, 24, 0);
    lv_obj_set_style_clip_corner(par, true, 0);
    lv_obj_set_style_border_width(par, 1, 0);
    lv_obj_set_style_border_color(par, lv_palette_main(LV_PALETTE_ORANGE), 0);

    lv_obj_t *child = lv_img_create(par);
    lv_img_set_src(child, "test.jpg");
    lv_img_set_zoom(child, 320);
    lv_obj_center(child);
```
test img:
![test](https://user-images.githubusercontent.com/35251456/140699810-28e477df-0f60-4d82-83dc-e8e297fdca1c.jpg)

run result:
![image](https://user-images.githubusercontent.com/35251456/140699719-d5af5d12-408d-4265-894a-2d9ff6dd6abb.png)


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
