### PR TITLE
fix(config) Add default trace macros when LV_USE_LOG is disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - fix(msgbox) add declaration for lv_msgbox_content_class
 - fix(txt) skip basic arabic vowel characters when processing conjunction
 - fix(proto) Remove redundant prototype declarations
+- fix(config) Add default trace macros when LV_USE_LOG is disabled
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -197,6 +197,19 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  define LV_LOG_TRACE_LAYOUT     1
 #  define LV_LOG_TRACE_ANIM       1
 
+#else /*LV_USE_LOG*/
+#  pragma LVGL no_expand push
+#  define LV_LOG_LEVEL            LV_LOG_LEVEL_NONE
+#  define LV_LOG_PRINTF           0
+#  define LV_LOG_TRACE_MEM        0
+#  define LV_LOG_TRACE_TIMER      0
+#  define LV_LOG_TRACE_INDEV      0
+#  define LV_LOG_TRACE_DISP_REFR  0
+#  define LV_LOG_TRACE_EVENT      0
+#  define LV_LOG_TRACE_OBJ_CREATE 0
+#  define LV_LOG_TRACE_LAYOUT     0
+#  define LV_LOG_TRACE_ANIM       0
+#  pragma LVGL no_expand pop
 #endif  /*LV_USE_LOG*/
 
 /*-------------

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -530,6 +530,17 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  endif
 #endif
 
+#else /*LV_USE_LOG*/
+#  define LV_LOG_LEVEL            LV_LOG_LEVEL_NONE
+#  define LV_LOG_PRINTF           0
+#  define LV_LOG_TRACE_MEM        0
+#  define LV_LOG_TRACE_TIMER      0
+#  define LV_LOG_TRACE_INDEV      0
+#  define LV_LOG_TRACE_DISP_REFR  0
+#  define LV_LOG_TRACE_EVENT      0
+#  define LV_LOG_TRACE_OBJ_CREATE 0
+#  define LV_LOG_TRACE_LAYOUT     0
+#  define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
 /*-------------

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -530,6 +530,17 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  endif
 #endif
 
+#else
+#  define LV_LOG_LEVEL            LV_LOG_LEVEL_NONE
+#  define LV_LOG_PRINTF           0
+#  define LV_LOG_TRACE_MEM        0
+#  define LV_LOG_TRACE_TIMER      0
+#  define LV_LOG_TRACE_INDEV      0
+#  define LV_LOG_TRACE_DISP_REFR  0
+#  define LV_LOG_TRACE_EVENT      0
+#  define LV_LOG_TRACE_OBJ_CREATE 0
+#  define LV_LOG_TRACE_LAYOUT     0
+#  define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
 /*-------------


### PR DESCRIPTION
### Description of the feature or fix

The LV_LOG_TRACE macros are not defined when LV_USE_LOG is 0. Most of the code referencing these macros use `#if LV_LOG_TRACE...` without checking if the macro is defined first. The reference to missing definitions is flagged by -Wundef.

This adds inactive defaults for all macros flagged by the warning.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
