### PR TITLE
fix(refresh) Switch to portable format specifiers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - fix(msgbox) add declaration for lv_msgbox_content_class
 - fix(txt) skip basic arabic vowel characters when processing conjunction
 - fix(proto) Remove redundant prototype declarations
+- fix(refresh) Switch to portable format specifiers
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -307,7 +307,8 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
         uint32_t used_size = mon.total_size - mon.free_size;;
         uint32_t used_kb = used_size / 1024;
         uint32_t used_kb_tenth = (used_size - (used_kb * 1024)) / 102;
-        lv_label_set_text_fmt(mem_label, "%d.%d kB used (%d %%)\n%d%% frag.", used_kb,  used_kb_tenth, mon.used_pct,
+        lv_label_set_text_fmt(mem_label, "%" LV_PRIu32 ".%" LV_PRIu32 " kB used (%d %%)\n" \
+                              "%d%% frag.", used_kb, used_kb_tenth, mon.used_pct,
                               mon.frag_pct);
     }
 #endif

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -39,12 +39,15 @@
 #    include <inttypes.h>
      /* platform-specific printf format for int32_t, usually "d" or "ld" */
 #    define LV_PRId32 PRId32
+#    define LV_PRIu32 PRIu32
 #  else
 #    define LV_PRId32 "d"
+#    define LV_PRIu32 "u"
 #  endif
 #else
    /* hope this is correct for ports without __has_include or without inttypes.h */
 #  define LV_PRId32 "d"
+#  define LV_PRIu32 "u"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description of the feature or fix

Some platforms define `uint32_t` as `unsigned long` rather than `unsigned int`. The %d format specifier is mismatched and the C99 format macros are the only portable way to handle these types.


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
