### PR TITLE
fix(stm32) Mark unused variable in stm32 DMA2D driver

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - fix(msgbox) add declaration for lv_msgbox_content_class
 - fix(txt) skip basic arabic vowel characters when processing conjunction
 - fix(proto) Remove redundant prototype declarations
+- fix(stm32) Mark unused variable in stm32 DMA2D driver
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard

--- a/src/gpu/lv_gpu_stm32_dma2d.c
+++ b/src/gpu/lv_gpu_stm32_dma2d.c
@@ -76,6 +76,7 @@ void lv_gpu_stm32_dma2d_init(void)
 
     /*Delay after setting peripheral clock*/
     volatile uint32_t temp = RCC->AHB1ENR;
+    LV_UNUSED(temp);
 
     /*set output colour mode*/
     DMA2D->OPFCCR = LV_DMA2D_COLOR_FORMAT;


### PR DESCRIPTION
### Description of the feature or fix

Unused read into temp variable needs to be marked.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
