### PR TITLE
fix(draw_label):radius Mask doesn't work in Specific condition

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -549,7 +549,10 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_coord_t pos_x, lv_coord_
     fill_area.y1 = row_start + pos_y;
     fill_area.y2 = fill_area.y1;
 #if LV_DRAW_COMPLEX
-    bool mask_any = lv_draw_mask_is_any(&fill_area);
+    lv_area_t mask_area;
+    lv_area_copy(&mask_area, &fill_area);
+    mask_area.y2 = mask_area.y1 + row_end;
+    bool mask_any = lv_draw_mask_is_any(&mask_area);
 #endif
 
     uint32_t col_bit_max = 8 - bpp;
@@ -705,6 +708,9 @@ static void draw_letter_subpx(lv_coord_t pos_x, lv_coord_t pos_y, lv_font_glyph_
     /*If the letter is partially out of mask the move there on draw_buf*/
     disp_buf_buf_tmp += (row_start * disp_buf_width) + col_start / 3;
 
+    lv_area_t mask_area;
+    lv_area_copy(&mask_area, &map_area);
+    mask_area.y2 = mask_area.y1 + row_end;
     bool mask_any = lv_draw_mask_is_any(&map_area);
     uint8_t font_rgb[3];
 


### PR DESCRIPTION
### Description of the feature or fix

test code
```c
    lv_obj_t *par = lv_obj_create(lv_scr_act());
    lv_obj_remove_style_all(par);
    lv_obj_center(par);
    lv_obj_set_size(par, 100, 100);
    lv_obj_set_style_radius(par, 50, 0);
    lv_obj_set_style_clip_corner(par, true, 0);
    lv_obj_set_style_border_width(par, 1, 0);
    lv_obj_set_style_border_color(par, lv_palette_main(LV_PALETTE_ORANGE), 0);

    lv_obj_t *child = lv_label_create(par);
    lv_obj_set_size(child, 100, 100);
    lv_label_set_text_static(child, "LVGL is an open-source graphics.LVGL is an open-source graphics.");
    lv_label_set_long_mode(child, LV_LABEL_LONG_WRAP);
    lv_obj_center(child);
```

result:
![image](https://user-images.githubusercontent.com/35251456/140920388-b6077317-6a96-4d7c-9508-4b6e1924b049.png)


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
