### PR TITLE
fix(obj): use the current target instead of target

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -698,7 +698,7 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
     LV_UNUSED(class_p);
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     if(code == LV_EVENT_PRESSED) {
         lv_obj_add_state(obj, LV_STATE_PRESSED);
     }


### PR DESCRIPTION
When the event is bubbling, use lv_event_get_current_target
to get the obj that needs to be processed

Signed-off-by: wangxuedong <wangxuedong@xiaomi.com>

### Description of the feature or fix

Before this modification, if lv_switch has set event bubbling, its state cannot be changed
by the mouse or touch. The sample code is as follows:
```C
  lv_obj_t* sw = lv_switch_create(lv_scr_act());
  lv_obj_set_size(sw, 200, 100);
  lv_obj_center(sw);
  lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
```


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
