### PR TITLE
Added additional checks for consecutive vowels and added simple suppo…

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -481,11 +481,13 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(const lv_point_t * pos_p, const lv_are
         }
 
         // Add a small offset between base character and vowel unless the base character
-        // has a tall edge like the character below (base: 0x0643 | end: 0xFEDA)
-        if(!(next_letter_temp == 0xFEDB || next_letter_temp == 0xFEDC) && !next_next_letter_temp)
-            next_y -= 2;
-
-        pos_x = pos_p->x + (adv_w - g.box_w) / 2;
+        // has a tall edge like the character below (base: 0x0643 | end: 0xFEDA).
+        // Also, tall characters tend to not have centered vowels
+        if(!(next_letter_temp == 0xFEDB || next_letter_temp == 0xFEDC)) {
+            pos_x = pos_p->x + (adv_w - g.box_w) / 2;
+            if(!next_next_letter_temp)
+                next_y -= 2;
+        }
 
         if(!(letter == 0x064D || letter == 0x0650))    // Don't do anything if vowel is a below diacritic mark
             pos_y = next_y - g.box_h;

--- a/src/misc/lv_txt_ap.c
+++ b/src/misc/lv_txt_ap.c
@@ -174,7 +174,12 @@ void _lv_txt_ap_proc(const char * txt, char * txt_out)
             continue;   // Skip this character
         }
         else if(lv_txt_is_arabic_vowel(ch_enc[i + 1])) {    // Next character is a vowel
-            idx_next = lv_ap_get_char_index(ch_enc[i + 2]); // Skip the vowel character to join with the character after it
+            if(lv_txt_is_arabic_vowel(ch_enc[i + 2])) {
+                idx_next = lv_ap_get_char_index(ch_enc[i + 3]); // Skip the vowel character to join with the character after it
+            }
+            else {
+                idx_next = lv_ap_get_char_index(ch_enc[i + 2]); // Need to skip one more character as the next one is also a vowel
+            }
         }
 
         if(index_current == LV_UNDEF_ARABIC_PERSIAN_CHARS) {


### PR DESCRIPTION
### Description of the feature or fix

LVGL currently does not display arabic vowel characters directly top/bottom of the next base character correctly. During development, it was discovered that it's also possible to have 2 consecutive vowels on the same base character. This pull request is to open further discussions on how to perfect vowel character placements.

List of tasks remaining:
- Ensure x and y positions of basic vowels are located correctly
- Fix coding style (lv_draw_label.c and lv_txt_ap.c both need to check for arabic vowels so should put the function a common header and remove temporary static variables (next_letter_temp & next_next_letter_temp) etc)
- Add test to ensure string conjunction is working fine
- %u0651%u064E (w/) and %u064E%u0651 (/w) despite different ordering, should be drawn as (/w) (see below pictures: first and final string)

Expected:
![image](https://user-images.githubusercontent.com/40588409/141453568-eb924ff9-138f-4f16-aeba-fbc67b4e8f61.png)

Current:
![image](https://user-images.githubusercontent.com/40588409/141453604-eb639dc5-a881-4001-b524-63e991f116fc.png)
![image](https://user-images.githubusercontent.com/40588409/141453252-6fb439b0-1ce9-423e-858d-eb9ff2a3f4f9.png)


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
