### PR TITLE
fix(border_post):ignore bg_img_opa draw when draw border_post

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -575,6 +575,7 @@ static void lv_obj_draw(lv_event_t * e)
             draw_dsc.bg_opa = LV_OPA_TRANSP;
             draw_dsc.outline_opa = LV_OPA_TRANSP;
             draw_dsc.shadow_opa = LV_OPA_TRANSP;
+            draw_dsc.bg_img_opa = LV_OPA_TRANSP;
             lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &draw_dsc);
 
             lv_coord_t w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);


### PR DESCRIPTION
### Description of the feature or fix

ignore bg_img_opa draw when draw border_post.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
