### PR TITLE
docs(events) LV_EVENT_APPLY was removed

### DIFF
--- a/docs/widgets/core/dropdown.md
+++ b/docs/widgets/core/dropdown.md
@@ -77,7 +77,6 @@ To manually open or close the drop-down list the `lv_dropdown_open/close(dropdow
 ## Events
 Apart from the [Generic events](../overview/event.html#generic-events), the following [Special events](../overview/event.html#special-events) are sent by the drop-down list:
 - `LV_EVENT_VALUE_CHANGED` Sent when the new option is selected or the list is opened/closed.
-- `LV_EVENT_APPLY` Sent when the list is opened
 - `LV_EVENT_CANCEL`  Sent when the list is closed
 
 See the events of the [Base object](/widgets/obj) too.

--- a/docs/widgets/core/textarea.md
+++ b/docs/widgets/core/textarea.md
@@ -97,7 +97,6 @@ This works much like when you select text on your PC with your mouse.
 The event paramter is the text about to be inserted. `lv_textarea_set_insert_replace(textarea, "New text")` replaces the text to insert. 
 The new text cannot be in a local variable which is destroyed when the event callback exists. `""` means do not insert anything.
 - `LV_EVENT_VALUE_CHANGED` Sent when the content of the text area has been changed. 
-- `LV_EVENT_APPLY` Sent when `LV_KEY_ENTER` is pressed (or(sent) to a one line text area.
 
 See the events of the [Base object](/widgets/obj) too.
 


### PR DESCRIPTION
### Description of the feature or fix
LV_EVENT_APPLY is no longer part of the source code. Apparently it was removed some time ago, yet it was still documented in textarea.md and dropdown.md

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [X] Update the documentation
