### PR TITLE
fix(draw_mask):will crash if get_width/height < 0

### DIFF
--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -471,9 +471,9 @@ void lv_draw_mask_radius_init(lv_draw_mask_radius_param_t * param, const lv_area
 {
     lv_coord_t w = lv_area_get_width(rect);
     lv_coord_t h = lv_area_get_height(rect);
-    if(radius < 0) radius = 0;
     int32_t short_side = LV_MIN(w, h);
     if(radius > short_side >> 1) radius = short_side >> 1;
+    if(radius < 0) radius = 0;
 
     lv_area_copy(&param->cfg.rect, rect);
     param->cfg.radius = radius;


### PR DESCRIPTION
### Description of the feature or fix

 Radius will still be < 0 if  get_width/height < 0 .when the circ_calc_aa4() function is called  after. `lv_mem_alloc(radius * 6 + 6)` will fail due to the large amount of memory that needs to be allocated.


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
