### PR TITLE
optimize: add non-null judgment to lv_examplse_obj_2

### DIFF
--- a/examples/widgets/obj/lv_example_obj_2.c
+++ b/examples/widgets/obj/lv_example_obj_2.c
@@ -6,6 +6,8 @@ static void drag_event_handler(lv_event_t * e)
     lv_obj_t * obj = lv_event_get_target(e);
 
     lv_indev_t * indev = lv_indev_get_act();
+    if(indev == NULL)  return;
+
     lv_point_t vect;
     lv_indev_get_vect(indev, &vect);
 


### PR DESCRIPTION
### Description of the feature or fix

hi，although indev is definitely not NULL in LV_EVENT_PRESSING event . but example is a template, and other events may be modified to mimic this function.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
