### PR TITLE
optimize(qrcode):eliminate blank

### DIFF
--- a/src/extra/libs/qrcode/qrcodegen.c
+++ b/src/extra/libs/qrcode/qrcodegen.c
@@ -1007,3 +1007,28 @@ static int numCharCountBits(enum qrcodegen_Mode mode, int version) {
 		default:  assert(false);  return -1;  // Dummy value
 	}
 }
+
+int qrcodegen_getMinFitVersion(enum qrcodegen_Ecc ecl, size_t dataLen)
+{
+	struct qrcodegen_Segment seg;
+	seg.mode = qrcodegen_Mode_BYTE;
+	seg.bitLength = calcSegmentBitLength(seg.mode, dataLen);
+	seg.numChars = (int)dataLen;
+
+	for (int version = qrcodegen_VERSION_MIN; version <= qrcodegen_VERSION_MAX; version++) {
+		int dataCapacityBits = getNumDataCodewords(version, ecl) * 8;  // Number of data bits available
+		int dataUsedBits = getTotalBits(&seg, 1, version);
+		if (dataUsedBits != -1 && dataUsedBits <= dataCapacityBits)
+			return version;
+	}
+	return -1;
+}
+
+int qrcodegen_version2size(int version)
+{
+	if (version < qrcodegen_VERSION_MIN || version > qrcodegen_VERSION_MAX) {
+		return -1;
+	}
+
+	return ((version - 1)*4 + 21);
+}

--- a/src/extra/libs/qrcode/qrcodegen.h
+++ b/src/extra/libs/qrcode/qrcodegen.h
@@ -305,6 +305,14 @@ int qrcodegen_getSize(const uint8_t qrcode[]);
  */
 bool qrcodegen_getModule(const uint8_t qrcode[], int x, int y);
 
+/* 
+ * Returns the qrcode size of the specified version. Returns -1 on failure
+ */
+int qrcodegen_version2size(int version);
+/* 
+ * Returns the min version of the data that can be stored. Returns -1 on failure
+ */
+int qrcodegen_getMinFitVersion(enum qrcodegen_Ecc ecl, size_t dataLen);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description of the feature or fix

Extra blank occurs when obj_w % qr_size != 0(see [link](https://github.com/lvgl/lvgl/blob/master/src/extra/libs/qrcode/lv_qrcode.c#L111) ). according to the definition of the QR code, the max value of qr_size  can be 40. In other words, blank ranges from 0 to 39px.this can be challenging to show friendliness. In order to ensure the size of the generated QR code is fixed, so I inserted this blank into the image data. according to the test, the change had almost no effect on the scans.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
