### PR TITLE
fix(event): event_send_core crash in special case.

### DIFF
--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -410,9 +410,10 @@ static lv_res_t event_send_core(lv_event_t * e)
         if(indev_act->driver->feedback_cb) indev_act->driver->feedback_cb(indev_act->driver, e->code);
     }
 
-    lv_event_dsc_t * event_dsc = lv_obj_get_event_dsc(e->current_target, 0);
     lv_res_t res = LV_RES_OK;
     res = lv_obj_event_base(NULL, e);
+
+    lv_event_dsc_t * event_dsc = lv_obj_get_event_dsc(e->current_target, 0);
 
     uint32_t i = 0;
     while(event_dsc && res == LV_RES_OK) {


### PR DESCRIPTION
### Description of the feature or fix
Add or delete event callback in lv_obj_event_base, the
address of event_dsc will change, causing crash.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
