### PR TITLE
fix(qrcode):replace memcpy() with lv_memcpy() and delete useless macros

### DIFF
--- a/src/extra/libs/qrcode/lv_qrcode.c
+++ b/src/extra/libs/qrcode/lv_qrcode.c
@@ -15,7 +15,6 @@
  *      DEFINES
  *********************/
 #define MY_CLASS &lv_qrcode_class
-#define QR_SIZE     140
 
 /**********************
  *      TYPEDEFS
@@ -201,8 +200,6 @@ static void lv_qrcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     lv_canvas_set_buffer(obj, buf, size_param, size_param, LV_IMG_CF_INDEXED_1BIT);
     lv_canvas_set_palette(obj, 0, dark_color_param);
     lv_canvas_set_palette(obj, 1, light_color_param);
-
-
 }
 
 static void lv_qrcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)

--- a/src/extra/libs/qrcode/lv_qrcode.c
+++ b/src/extra/libs/qrcode/lv_qrcode.c
@@ -106,7 +106,7 @@ lv_res_t lv_qrcode_update(lv_obj_t * qrcode, const void * data, uint32_t data_le
     LV_ASSERT_MALLOC(qr0);
     uint8_t * data_tmp = lv_mem_alloc(qrcodegen_BUFFER_LEN_FOR_VERSION(qr_version));
     LV_ASSERT_MALLOC(data_tmp);
-    memcpy(data_tmp, data, data_len);
+    lv_memcpy(data_tmp, data, data_len);
 
     bool ok = qrcodegen_encodeBinary(data_tmp, data_len,
                                      qr0, qrcodegen_Ecc_MEDIUM,
@@ -170,7 +170,7 @@ lv_res_t lv_qrcode_update(lv_obj_t * qrcode, const void * data, uint32_t data_le
         int s;
         const uint8_t * row_ori = buf_u8 + row_byte_cnt * y;
         for(s = 1; s < scale; s++) {
-            memcpy((uint8_t *)buf_u8 + row_byte_cnt * (y + s), row_ori, row_byte_cnt);
+            lv_memcpy((uint8_t *)buf_u8 + row_byte_cnt * (y + s), row_ori, row_byte_cnt);
         }
     }
 


### PR DESCRIPTION
### Description of the feature or fix

1. replace memcpy() with lv_memcpy() 
2. delete useless macros

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
