### PR TITLE
fix(doc): spelling

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -144,7 +144,7 @@ In this case you can just send a Pull Request without worrying about any licensi
 
 If the code you would like to add is based on an article, post or comment on a website (e.g. StackOverflow) the license and/or rules of that site should be followed.
 
-For example in case of StackOwerflow a notice like this can be used:
+For example in case of StackOverflow a notice like this can be used:
 ```
 /* The original version of this code-snippet was published on StackOverflow.
  * Post: http://stackoverflow.com/questions/12345

--- a/docs/build.py
+++ b/docs/build.py
@@ -64,17 +64,17 @@ cmd("cd ../scripts && doxygen Doxyfile")
 # BUILD PDF
 
 if not skip_latex:
-  # Silly workarond to include the more or less correct PDF download link in the PDF
+  # Silly workaround to include the more or less correct PDF download link in the PDF
   #cmd("cp -f " + lang +"/latex/LVGL.pdf LVGL.pdf | true")
   cmd("sphinx-build -b latex . out_latex")
 
   # Generate PDF
   cmd("cd out_latex && latexmk -pdf 'LVGL.tex'")
-  # Copy the result PDF to the main directory to make it avaiable for the HTML build
+  # Copy the result PDF to the main directory to make it available for the HTML build
   cmd("cd out_latex && cp -f LVGL.pdf ../LVGL.pdf")
 else:
   print("skipping latex build as requested")
 
-# BULD HTML
+# BUILD HTML
 cmd("sphinx-build -b html . ../out_html")
 

--- a/docs/libs/gif.md
+++ b/docs/libs/gif.md
@@ -22,7 +22,7 @@ For example:
 lv_gif_set_src(obj, "S:path/to/example.gif");
 ```
 
-Note that, a file system driver needs to regsitered to open images from files. Read more about it [here](https://docs.lvgl.io/master/overview/file-system.html) or just enable one in `lv_conf.h` with `LV_USE_FS_...` 
+Note that, a file system driver needs to be registered to open images from files. Read more about it [here](https://docs.lvgl.io/master/overview/file-system.html) or just enable one in `lv_conf.h` with `LV_USE_FS_...` 
 
 
 ## Memory requirements

--- a/docs/overview/drawing.md
+++ b/docs/overview/drawing.md
@@ -68,7 +68,7 @@ LVGL has the following built-in mask types which can be calculated and applied r
 - `LV_DRAW_MASK_TYPE_LINE` Removes a side from a line (top, bottom, left or right). `lv_draw_line` uses four instances of it. 
 Essentially, every (skew) line is bounded with four line masks forming a rectangle.
 - `LV_DRAW_MASK_TYPE_RADIUS` Removes the inner or outer corners of a rectangle with a radiused transition. It's also used to create circles by setting the radius to large value (`LV_RADIUS_CIRCLE`) 
-- `LV_DRAW_MASK_TYPE_ANGLE` Removes a circlular sector. It is used by `lv_draw_arc` to remove the "empty" sector. 
+- `LV_DRAW_MASK_TYPE_ANGLE` Removes a circular sector. It is used by `lv_draw_arc` to remove the "empty" sector. 
 - `LV_DRAW_MASK_TYPE_FADE` Create a vertical fade (change opacity) 
 - `LV_DRAW_MASK_TYPE_MAP` The mask is stored in a bitmap array and the necessary parts are applied 
 
@@ -170,7 +170,7 @@ lv_draw_line_dsc_t * line_dsc;      // A draw descriptor that can be modified to
 lv_draw_img_dsc_t *  img_dsc;       // A draw descriptor that can be modified to changed what LVGL will draw. Set only for image-like parts
 lv_draw_arc_dsc_t *  arc_dsc;       // A draw descriptor that can be modified to changed what LVGL will draw. Set only for arc-like parts
 
-// Other paramters 
+// Other parameters 
 lv_area_t * draw_area;              // The area of the part being drawn
 const lv_point_t * p1;              // A point calculated during drawing. E.g. a point of a chart or the center of an arc.
 const lv_point_t * p2;              // A point calculated during drawing. E.g. a point of a chart.

--- a/docs/overview/image.md
+++ b/docs/overview/image.md
@@ -267,7 +267,7 @@ To indicate that the *line read* function should be used, set `dsc->img_data = N
 
 LVGL will use registered image decoders automatically if you try and draw a raw image (i.e. using the `lv_img` object) but you can use them manually too. Create an `lv_img_decoder_dsc_t` variable to describe the decoding session and call `lv_img_decoder_open()`.
 
-The `color` paramter is used only with `LV_IMG_CF_ALPHA_1/2/4/8BIT` images to tell color of the image. 
+The `color` parameter is used only with `LV_IMG_CF_ALPHA_1/2/4/8BIT` images to tell color of the image. 
 `frame_id` can be used if the image to open is an animation. 
 
 

--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -183,7 +183,7 @@ Besides `read_cb` a `feedback_cb` callback can be also specified in `lv_indev_dr
 
 
 ### Associating with a display
-Every input device is associated with a display. By default, a new input device is added to the last  display created or explicitly selected (using `lv_disp_set_default()`).
+Every input device is associated with a display. By default, a new input device is added to the last display created or explicitly selected (using `lv_disp_set_default()`).
 The associated display is stored and can be changed in `disp` field of the driver.
 
 ### Buffered reading

--- a/docs/widgets/core/arc.md
+++ b/docs/widgets/core/arc.md
@@ -30,16 +30,16 @@ The angles should be in the [0;360] range.
 
 ### Rotation
 
-An offset to the 0 degree position can added with `lv_arc_set_rotation(arc, deg)`.
+An offset to the 0 degree position can be added with `lv_arc_set_rotation(arc, deg)`.
 
 ### Mode
 
 The arc can be one of the following modes:
-- `LV_ARC_MODE_NORMAL` The indicator arc is drawn from the minimimum value to the current.
+- `LV_ARC_MODE_NORMAL` The indicator arc is drawn from the minimum value to the current.
 - `LV_ARC_MODE_REVERSE` The indicator arc is drawn counter-clockwise from the maximum value to the current.
 - `LV_ARC_MODE_SYMMETRICAL` The indicator arc is drawn from the middle point to the current value.
 
-The mode can be set by `lv_arc_set_mode(arc, LV_ARC_MODE_...)` and used only if the the angle is set by `lv_arc_set_value()` or the arc is adjusted by finger.
+The mode can be set by `lv_arc_set_mode(arc, LV_ARC_MODE_...)` and used only if the angle is set by `lv_arc_set_value()` or the arc is adjusted by finger.
 
 ### Change rate
 If the arc is pressed the current value will set with a limited speed according to the set *change rate*. 

--- a/docs/widgets/core/btn.md
+++ b/docs/widgets/core/btn.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Buttons have no new features compared to the [Base object](/widgets/obj). They are usuful for semantic purposes and have slightly different default settings.
+Buttons have no new features compared to the [Base object](/widgets/obj). They are useful for semantic purposes and have slightly different default settings.
 
 Buttons, by default, differ from Base object in the following ways:
 - Not scrollable

--- a/docs/widgets/core/dropdown.md
+++ b/docs/widgets/core/dropdown.md
@@ -30,7 +30,7 @@ The button goes to `LV_STATE_CHECKED` when it's opened.
 - `LV_PART_SELECTED` Refers to the currently pressed, checked or pressed+checked option. Also uses the typical background properties. 
 
 As list does not exist when the drop-down list is closed it's not possible to simply add styles to it.
-Insteada add an event handler to the button for `LV_EVENT_READY` (triggered when the list is opened) and add styles to the list in it like this:
+Instead, add an event handler to the button for `LV_EVENT_READY` (triggered when the list is opened) and add styles to the list in it like this:
 ```c
 lv_obj_t * list = lv_dropdown_get_list(dropdown) /*Get the list*/
 lv_obj_add_style(list, &my_style, ...)           /*Add the styles to the list*/}`

--- a/docs/widgets/core/label.md
+++ b/docs/widgets/core/label.md
@@ -31,13 +31,13 @@ Constant strings are safe to use with `lv_label_set_text_static` (except when us
 Newline characters are handled automatically by the label object. You can use `\n` to make a line break. For example: `"line1\nline2\n\nline4"`
 
 ### Long modes
-By default, the width and height of the label is set to `LV_SIZE_CONTENT`. Therefore the size of the label is automatically expanded to the text size. 
-Otherwise, if the width or height are explicitly set (useing  e.g.`lv_obj_set_width` or a layout), the lines wider than the label's width can be manipulated according to several long mode policies. 
-Similary, the policies can be applied if the height of the text is greater than the height of the label.
+By default, the width and height of the label is set to `LV_SIZE_CONTENT`. Therefore, the size of the label is automatically expanded to the text size. 
+Otherwise, if the width or height are explicitly set (using  e.g.`lv_obj_set_width` or a layout), the lines wider than the label's width can be manipulated according to several long mode policies. 
+Similarly, the policies can be applied if the height of the text is greater than the height of the label.
 - `LV_LABEL_LONG_WRAP` Wrap too long lines. If the height is `LV_SIZE_CONTENT` the label's height will be expanded, otherwise the text will be clipped. (Default)
 - `LV_LABEL_LONG_DOT` Replaces the last 3 characters from bottom right corner of the label with dots (`.`) 
 - `LV_LABEL_LONG_SCROLL` If the text is wider than the label scroll it horizontally back and forth. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
-- `LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continously. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
+- `LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continuously. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
 - `LV_LABEL_LONG_CLIP` Simply clip the parts of the text outside the label.
 
 You can specify the long mode with `lv_label_set_long_mode(label, LV_LABEL_LONG_...)`

--- a/docs/widgets/core/textarea.md
+++ b/docs/widgets/core/textarea.md
@@ -94,7 +94,7 @@ This works much like when you select text on your PC with your mouse.
 
 ## Events
 - `LV_EVENT_INSERT` Sent right before a character or text is inserted. 
-The event paramter is the text about to be inserted. `lv_textarea_set_insert_replace(textarea, "New text")` replaces the text to insert. 
+The event parameter is the text about to be inserted. `lv_textarea_set_insert_replace(textarea, "New text")` replaces the text to insert. 
 The new text cannot be in a local variable which is destroyed when the event callback exists. `""` means do not insert anything.
 - `LV_EVENT_VALUE_CHANGED` Sent when the content of the text area has been changed. 
 - `LV_EVENT_READY` Sent when `LV_KEY_ENTER` is pressed (or(sent) to a one line text area.

--- a/docs/widgets/extra/animimg.md
+++ b/docs/widgets/extra/animimg.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The animation image is similar to the norlmal 'Image' object. The only difference is that instead of one source image, you set an array of multiple source images.
+The animation image is similar to the normal 'Image' object. The only difference is that instead of one source image, you set an array of multiple source images.
 
 You can specify a duration and repeat count.
 

--- a/examples/porting/lv_port_indev_template.c
+++ b/examples/porting/lv_port_indev_template.c
@@ -100,7 +100,7 @@ void lv_port_indev_init(void)
      * Mouse
      * -----------------*/
 
-    /*Initialize your touchpad if you have*/
+    /*Initialize your mouse if you have*/
     mouse_init();
 
     /*Register a mouse input device*/

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -145,7 +145,7 @@ void lv_init(void)
 
     uint8_t * txt_u8 = (uint8_t *)txt;
     if(txt_u8[0] != 0xc3 || txt_u8[1] != 0x81 || txt_u8[2] != 0x00) {
-        LV_LOG_WARN("The strings has no UTF-8 encoding. Non-ASCII characters won't be displayed.");
+        LV_LOG_WARN("The strings have no UTF-8 encoding. Non-ASCII characters won't be displayed.");
     }
 
     uint32_t endianess_test = 0x11223344;
@@ -174,7 +174,7 @@ void lv_init(void)
 #endif
 
 #if LV_LOG_LEVEL == LV_LOG_LEVEL_TRACE
-    LV_LOG_WARN("Log level is set the Trace which makes LVGL much slower");
+    LV_LOG_WARN("Log level is set to 'Trace' which makes LVGL much slower");
 #endif
 
     lv_extra_init();

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -55,7 +55,7 @@ lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * pa
         LV_TRACE_OBJ_CREATE("creating a screen");
         lv_disp_t * disp = lv_disp_get_default();
         if(!disp) {
-            LV_LOG_WARN("No display created to so far. No place to assign the new screen");
+            LV_LOG_WARN("No display created yet. No place to assign the new screen");
             return NULL;
         }
 

--- a/src/misc/lv_utils.c
+++ b/src/misc/lv_utils.c
@@ -37,7 +37,7 @@
 /** Searches base[0] to base[n - 1] for an item that matches *key.
  *
  * @note The function cmp must return negative if its first
- *  argument (the search key) is less that its second (a table entry),
+ *  argument (the search key) is less than its second (a table entry),
  *  zero if equal, and positive if greater.
  *
  *  @note Items in the array must be in ascending order.
@@ -46,7 +46,7 @@
  * @param base   Pointer to first element to search
  * @param n      Number of elements
  * @param size   Size of each element
- * @param cmp    Pointer to comparison function (see #lv_font_codeCompare as a comparison function
+ * @param cmp    Pointer to comparison function (see #unicode_list_compare as a comparison function
  * example)
  *
  * @return a pointer to a matching item, or NULL if none exists.

--- a/src/misc/lv_utils.h
+++ b/src/misc/lv_utils.h
@@ -39,7 +39,7 @@ extern "C" {
  * @param base   Pointer to first element to search
  * @param n      Number of elements
  * @param size   Size of each element
- * @param cmp    Pointer to comparison function (see #lv_font_codeCompare as a comparison function
+ * @param cmp    Pointer to comparison function (see #unicode_list_compare as a comparison function
  * example)
  *
  * @return a pointer to a matching item, or NULL if none exists.


### PR DESCRIPTION
Just a bunch of simple spelling fixes

And one comment referenced the lv_font_codeCompare function which was renamed to unicode_list_compare. Now the comment is renamed too.