### PR TITLE
fix(log): to allow printf and custom_print_cb to work at same time

### DIFF
--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -116,9 +116,8 @@ void lv_log(const char * buf)
 {
 #if LV_LOG_PRINTF
     puts(buf);
-#else
-    if(custom_print_cb) custom_print_cb(buf);
 #endif
+    if(custom_print_cb) custom_print_cb(buf);
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

to allow printf and custom_print_cb to work at same time
related: #2811

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
