### PR TITLE
add lv_chart_refresh() to the functions which modify the data

### DIFF
--- a/docs/widgets/extra/chart.md
+++ b/docs/widgets/extra/chart.md
@@ -61,7 +61,7 @@ For `LV_CHART_TYPE_SCATTER` type  `lv_chart_set_ext_x_array(chart, ser, value_ar
 ### Modify the data
 You have several options to set the data of series:
 1. Set the values manually in the array like `ser1->points[3] = 7` and refresh the chart with `lv_chart_refresh(chart)`.
-2. Use `lv_chart_set_value_by_id(chart, ser, value, id)` where `id` is the index of the point you wish to update.
+2. Use `lv_chart_set_value_by_id(chart, ser, id, value)` where `id` is the index of the point you wish to update.
 3. Use the `lv_chart_set_next_value(chart, ser, value)`.
 4. Initialize all points to a given value with: `lv_chart_set_all_value(chart, ser, value)`.
 

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -539,6 +539,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, lv_coord_t
     invalidate_point(obj, ser->start_point);
     ser->start_point = (ser->start_point + 1) % chart->point_cnt;
     invalidate_point(obj, ser->start_point);
+    lv_chart_refresh(obj);
 }
 
 void lv_chart_set_next_value2(lv_obj_t * obj, lv_chart_series_t * ser, lv_coord_t x_value, lv_coord_t y_value)
@@ -570,6 +571,7 @@ void lv_chart_set_value_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint16_t 
 
     if(id >= chart->point_cnt) return;
     ser->y_points[id] = value;
+    lv_chart_refresh(obj);
 }
 
 void lv_chart_set_value_by_id2(lv_obj_t * obj, lv_chart_series_t * ser, uint16_t id, lv_coord_t x_value,
@@ -587,6 +589,7 @@ void lv_chart_set_value_by_id2(lv_obj_t * obj, lv_chart_series_t * ser, uint16_t
     if(id >= chart->point_cnt) return;
     ser->x_points[id] = x_value;
     ser->y_points[id] = y_value;
+    lv_chart_refresh(obj);
 }
 
 void lv_chart_set_ext_y_array(lv_obj_t * obj, lv_chart_series_t * ser, lv_coord_t array[])


### PR DESCRIPTION
### Description of the feature or fix

Like mentioned here: https://github.com/lvgl/lvgl/issues/2817
I would suggest to add the lv_chart_refresh() to some more functions.
It was already in place for the lv_chart_set_next_value2(), maybe it was forgotten for the others?

It will then be in line with the wiki, because it does not mention to call the lv_chart_refresh() once the other functions are called.

### Checkpoints
- [x ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ x] Update the documentation
