### PR TITLE
fix(lv_hal_indev): update lv_indev_drv_update to free the read_timer

### DIFF
--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -112,7 +112,7 @@ void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
     lv_timer_del(indev->driver->read_timer);
 
     LV_ASSERT_NULL(new_drv);
-    if (new_drv->disp == NULL) {
+    if(new_drv->disp == NULL) {
         new_drv->disp = lv_disp_get_default();
     }
     if(new_drv->disp == NULL) {

--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -106,19 +106,18 @@ lv_indev_t * lv_indev_drv_register(lv_indev_drv_t * driver)
  */
 void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
 {
-    LV_ASSERT_NULL( indev );
-    LV_ASSERT_NULL( indev->driver );
-    LV_ASSERT_NULL( indev->driver->read_timer );
-    lv_timer_del( indev->driver->read_timer );
+    LV_ASSERT_NULL(indev);
+    LV_ASSERT_NULL(indev->driver);
+    LV_ASSERT_NULL(indev->driver->read_timer);
+    lv_timer_del(indev->driver->read_timer);
 
-    LV_ASSERT_NULL( new_drv );
-    if ( new_drv->disp == NULL )
-    {
+    LV_ASSERT_NULL(new_drv);
+    if (new_drv->disp == NULL) {
         new_drv->disp = lv_disp_get_default();
     }
     if(new_drv->disp == NULL) {
         LV_LOG_WARN("lv_indev_drv_register: no display registered hence can't attach the indev to "
-                     "a display");
+                    "a display");
         indev->proc.disabled = true;
         return;
     }

--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -106,7 +106,26 @@ lv_indev_t * lv_indev_drv_register(lv_indev_drv_t * driver)
  */
 void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
 {
+    LV_ASSERT_NULL( indev );
+    LV_ASSERT_NULL( indev->driver );
+    LV_ASSERT_NULL( indev->driver->read_timer );
+    lv_timer_del( indev->driver->read_timer );
+
+    LV_ASSERT_NULL( new_drv );
+    if ( new_drv->disp == NULL )
+    {
+        new_drv->disp = lv_disp_get_default();
+    }
+    if(new_drv->disp == NULL) {
+        LV_LOG_WARN("lv_indev_drv_register: no display registered hence can't attach the indev to "
+                     "a display");
+        indev->proc.disabled = true;
+        return;
+    }
+
     indev->driver = new_drv;
+    indev->driver->read_timer = lv_timer_create(lv_indev_read_timer_cb, LV_INDEV_DEF_READ_PERIOD, indev);
+    indev->proc.reset_query   = 1;
 }
 
 /**


### PR DESCRIPTION
The read timer was not freed and recreated. The display was also not checked to be NULL.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
