### PR TITLE
feat(rlottie):add apis to pause and resume rlottie

### DIFF
--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -83,9 +83,9 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
 void lv_rlottie_pause(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    if (rlottie->task) {
+
+    if(rlottie->task) {
         lv_timer_pause(rlottie->task);
     }
 }
@@ -93,9 +93,9 @@ void lv_rlottie_pause(lv_obj_t * obj)
 void lv_rlottie_resume(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    if (rlottie->task) {
+
+    if(rlottie->task) {
         lv_timer_resume(rlottie->task);
     }
 }

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -80,6 +80,26 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
     return obj;
 }
 
+void lv_rlottie_pause(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
+    if (rlottie->task) {
+        lv_timer_pause(rlottie->task);
+    }
+}
+
+void lv_rlottie_resume(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
+    if (rlottie->task) {
+        lv_timer_resume(rlottie->task);
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -49,6 +49,9 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, lv_coord_t width, lv_c
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_coord_t height,
                                       const char * rlottie_desc);
 
+void lv_rlottie_pause(lv_obj_t * obj);
+void lv_rlottie_resume(lv_obj_t * obj);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

When using rlottie, we may need to pause and resume animation, so
i add two APIs to pause and resume the timer used by rlottie.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
