### PR TITLE
feat(lv_hal_indev): Add missing lv_indev_delete()

### DIFF
--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -110,6 +110,23 @@ void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
 }
 
 /**
+* Remove the provided input device. Make sure not to use the provided input device afterwards anymore.
+* @param indev pointer to delete
+*/
+void lv_indev_delete(lv_indev_t* indev)
+{
+    LV_ASSERT_NULL(indev);
+    LV_ASSERT_NULL(indev->driver);
+    LV_ASSERT_NULL(indev->driver->read_timer);
+    /*Clean up the read timer first*/
+    lv_timer_del(indev->driver->read_timer);
+    /*Remove the input device from the list*/
+    _lv_ll_remove(&LV_GC_ROOT(_lv_indev_ll), indev);
+    /*Free the memory of the input device*/
+    lv_mem_free(indev);
+}
+
+/**
  * Get the next input device.
  * @param indev pointer to the current input device. NULL to initialize.
  * @return the next input devise or NULL if no more. Give the first input device when the parameter

--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -113,7 +113,7 @@ void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
 * Remove the provided input device. Make sure not to use the provided input device afterwards anymore.
 * @param indev pointer to delete
 */
-void lv_indev_delete(lv_indev_t* indev)
+void lv_indev_delete(lv_indev_t * indev)
 {
     LV_ASSERT_NULL(indev);
     LV_ASSERT_NULL(indev->driver);

--- a/src/hal/lv_hal_indev.h
+++ b/src/hal/lv_hal_indev.h
@@ -208,6 +208,12 @@ lv_indev_t * lv_indev_drv_register(struct _lv_indev_drv_t * driver);
 void lv_indev_drv_update(lv_indev_t * indev, struct _lv_indev_drv_t * new_drv);
 
 /**
+* Remove the provided input device. Make sure not to use the provided input device afterwards anymore.
+* @param indev pointer to delete
+*/
+void lv_indev_delete(lv_indev_t* indev);
+
+/**
  * Get the next input device.
  * @param indev pointer to the current input device. NULL to initialize.
  * @return the next input device or NULL if there are no more. Provide the first input device when

--- a/src/hal/lv_hal_indev.h
+++ b/src/hal/lv_hal_indev.h
@@ -211,7 +211,7 @@ void lv_indev_drv_update(lv_indev_t * indev, struct _lv_indev_drv_t * new_drv);
 * Remove the provided input device. Make sure not to use the provided input device afterwards anymore.
 * @param indev pointer to delete
 */
-void lv_indev_delete(lv_indev_t* indev);
+void lv_indev_delete(lv_indev_t * indev);
 
 /**
  * Get the next input device.


### PR DESCRIPTION
### Description of the feature or fix

For the display there exists a lv_disp_delete() function. But this is missing for the input device.
The included change adds this functionality to the API.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
