### PR TITLE
Add animation control for rlottie

### DIFF
--- a/docs/libs/rlottie.md
+++ b/docs/libs/rlottie.md
@@ -80,13 +80,13 @@ lv_obj_t * lottie = lv_rlottie_create_from_file(scr, 128, 128, "test.json");
 lv_obj_center(lottie);
 // Pause to a specific frame
 lv_rlottie_set_current_frame(lottie, 50);
-lv_rlottie_set_play_mode(lottie, lv_rlottie_pause);
+lv_rlottie_set_play_mode(lottie, LV_RLOTTIE_CTRL_PAUSE); // The specified frame will be displayed and then the animation will pause
 
 // Play backward and loop
-lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_backward | lv_rlottie_loop);
+lv_rlottie_set_play_mode(lottie, LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_BACKWARD | LV_RLOTTIE_CTRL_LOOP);
 
 // Play forward once (no looping)
-lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_forward);
+lv_rlottie_set_play_mode(lottie, LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_FORWARD);
 ```
 
 The default animation mode is **play forward with loop**.

--- a/docs/libs/rlottie.md
+++ b/docs/libs/rlottie.md
@@ -71,6 +71,30 @@ For example: https://lottiefiles.com/
 
 You can also create your own animations with Adobe After Effects or similar software.
 
+## Controlling animations
+
+LVGL provides two functions to control the animation mode: `lv_rlottie_set_play_mode` and `lv_rlottie_set_current_frame`.
+You'll combine your intentions when calling the first method, like in these examples:
+```c
+lv_obj_t * lottie = lv_rlottie_create_from_file(scr, 128, 128, "test.json");
+lv_obj_center(lottie);
+// Pause to a specific frame
+lv_rlottie_set_current_frame(lottie, 50);
+lv_rlottie_set_play_mode(lottie, lv_rlottie_pause);
+
+// Play backward and loop
+lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_backward | lv_rlottie_loop);
+
+// Play forward once (no looping)
+lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_forward);
+```
+
+The default animation mode is **play forward with loop**.
+
+If you don't enable looping, a `LV_EVENT_READY` is sent when the animation can not make more progress without looping.
+
+To get the number of frames in an animation or the current frame index, you can cast the `lv_obj_t` instance to a `lv_rlottie_t` instance and inspect the `current_frame` and `total_frames` members. 
+
 ## Example
 ```eval_rst
 

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -14,6 +14,7 @@
 *      DEFINES
 *********************/
 #define MY_CLASS &lv_rlottie_class
+#define LV_ARGB32   32
 
 /**********************
 *      TYPEDEFS
@@ -104,9 +105,9 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     rlottie->framerate = (size_t)lottie_animation_get_framerate(rlottie->animation);
     rlottie->current_frame = 0;
 
-    rlottie->scanline_width = create_width * LV_COLOR_DEPTH / 8;
+    rlottie->scanline_width = create_width * LV_ARGB32 / 8;
 
-    size_t allocaled_buf_size = (create_width * create_height * LV_COLOR_DEPTH / 8);
+    size_t allocaled_buf_size = (create_width * create_height * LV_ARGB32 / 8);
     rlottie->allocated_buf = lv_mem_alloc(allocaled_buf_size);
     if(rlottie->allocated_buf != NULL) {
         rlottie->allocated_buffer_size = allocaled_buf_size;
@@ -155,6 +156,43 @@ static void lv_rlottie_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj
 
 }
 
+#if LV_COLOR_DEPTH == 16
+static void convert_to_rgba5658(uint8_t * pix, const size_t width, const size_t height)
+{
+    /* rlottie draws in ARGB32 format, but LVGL only deal with RGB565 format with (optional 8 bit alpha channel)
+       so convert in place here the received buffer to LVGL format. */
+    uint8_t * dest = pix;
+    uint32_t * src = (uint32_t *)pix;
+    for(size_t y = 0; y < height; y++) {
+        /* Convert a 4 bytes per pixel in format ARGB to R5G6B5A8 format
+            naive way:
+                        r = ((c & 0xFF0000) >> 19)
+                        g = ((c & 0xFF00) >> 10)
+                        b = ((c & 0xFF) >> 3)
+                        rgb565 = (r << 11) | (g << 5) | b
+                        a = c >> 24;
+            That's 3 mask, 6 bitshift and 2 or operations
+
+            A bit better:
+                        r = ((c & 0xF80000) >> 8)
+                        g = ((c & 0xFC00) >> 5)
+                        b = ((c & 0xFF) >> 3)
+                        rgb565 = r | g | b
+                        a = c >> 24;
+            That's 3 mask, 3 bitshifts and 2 or operations */
+        for(size_t x = 0; x < width; x++) {
+            uint32_t in = src[x];
+            uint16_t r = (uint16_t)(((in & 0xF80000) >> 8) | ((in & 0xFC00) >> 5) | ((in & 0xFF) >> 3));
+
+            memcpy(dest, &r, sizeof(r));
+            dest[sizeof(r)] = (uint8_t)(in >> 24);
+            dest += LV_IMG_PX_SIZE_ALPHA_BYTE;
+        }
+        src += width;
+    }
+}
+#endif
+
 static void next_frame_task_cb(lv_timer_t * t)
 {
     lv_obj_t * obj = t->user_data;
@@ -172,6 +210,10 @@ static void next_frame_task_cb(lv_timer_t * t)
         rlottie->imgdsc.header.h,
         rlottie->scanline_width
     );
+
+#if LV_COLOR_DEPTH == 16
+    convert_to_rgba5658(rlottie->allocated_buf, rlottie->imgdsc.header.w, rlottie->imgdsc.header.h);
+#endif
 
     lv_obj_invalidate(obj);
 

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -95,7 +95,7 @@ void lv_rlottie_set_play_mode(lv_obj_t * obj, const lv_rlottie_ctrl_t ctrl)
 void lv_rlottie_set_current_frame(lv_obj_t * obj, const size_t goto_frame)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    rlottie->dest_frame = goto_frame < rlottie->total_frames ? goto_frame : rlottie->total_frames - 1;
+    rlottie->current_frame = goto_frame < rlottie->total_frames ? goto_frame : rlottie->total_frames - 1;
 }
 
 /**********************
@@ -231,7 +231,7 @@ static void next_frame_task_cb(lv_timer_t * t)
             lv_timer_pause(t);
             return;
         }
-        rlottie->current_frame = rlottie->dest_frame;
+        rlottie->dest_frame = rlottie->current_frame;
     }
     else {
         if((rlottie->play_ctrl & LV_RLOTTIE_CTRL_BACKWARD) == LV_RLOTTIE_CTRL_BACKWARD) {

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -204,8 +204,12 @@ static void convert_to_rgba5658(uint32_t * pix, const size_t width, const size_t
             That's 3 mask, 3 bitshifts and 2 or operations */
         for(size_t x = 0; x < width; x++) {
             uint32_t in = src[x];
-
+#if LV_COLOR_16_SWAP == 0
             uint16_t r = (uint16_t)(((in & 0xF80000) >> 8) | ((in & 0xFC00) >> 5) | ((in & 0xFF) >> 3));
+#else
+            /* We want: rrrr rrrr GGGg gggg bbbb bbbb => gggb bbbb rrrr rGGG */
+            uint16_t r = (uint16_t)(((c & 0xF80000) >> 16) | ((c & 0xFC00) >> 13) | ((c & 0x1C00) << 3) | ((c & 0xF8) << 5));
+#endif
 
             lv_memcpy(dest, &r, sizeof(r));
             dest[sizeof(r)] = (uint8_t)(in >> 24);

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -141,7 +141,7 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     lv_img_set_src(obj, &rlottie->imgdsc);
 
     rlottie->play_ctrl = LV_RLOTTIE_CTRL_FORWARD | LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_LOOP;
-    rlottie->dest_frame = 0;
+    rlottie->dest_frame = (size_t) -1; /* invalid destination frame so it's possible to pause on frame 0 */
 
     rlottie->task = lv_timer_create(next_frame_task_cb, 1000 / rlottie->framerate, obj);
 
@@ -276,7 +276,6 @@ static void next_frame_task_cb(lv_timer_t * t)
 #endif
 
     lv_obj_invalidate(obj);
-
 }
 
 #endif /*LV_USE_RLOTTIE*/

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -141,7 +141,7 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     lv_img_set_src(obj, &rlottie->imgdsc);
 
     rlottie->play_ctrl = LV_RLOTTIE_CTRL_FORWARD | LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_LOOP;
-    rlottie->dest_frame = (size_t) -1; /* invalid destination frame so it's possible to pause on frame 0 */
+    rlottie->dest_frame = rlottie->total_frames; /* invalid destination frame so it's possible to pause on frame 0 */
 
     rlottie->task = lv_timer_create(next_frame_task_cb, 1000 / rlottie->framerate, obj);
 

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -236,9 +236,8 @@ static void next_frame_task_cb(lv_timer_t * t)
                 if((rlottie->play_ctrl & lv_rlottie_loop) == lv_rlottie_loop)
                     rlottie->current_frame = rlottie->total_frames - 1;
                 else {
-                    if(rlottie->dest_frame != rlottie->current_frame)
-                        lv_event_send(obj, LV_EVENT_READY, NULL);
-                    rlottie->dest_frame = rlottie->current_frame; /* Remember we've sent the event */
+                    lv_event_send(obj, LV_EVENT_READY, NULL);
+                    lv_timer_pause(t);
                     return;
                 }
             }
@@ -250,9 +249,8 @@ static void next_frame_task_cb(lv_timer_t * t)
                 if((rlottie->play_ctrl & lv_rlottie_loop) == lv_rlottie_loop)
                     rlottie->current_frame = 0;
                 else {
-                    if(rlottie->dest_frame != rlottie->current_frame)
-                        lv_event_send(obj, LV_EVENT_READY, NULL);
-                    rlottie->dest_frame = rlottie->current_frame; /* Remember we've sent the event */
+                    lv_event_send(obj, LV_EVENT_READY, NULL);
+                    lv_timer_pause(t);
                     return;
                 }
             }

--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -229,7 +229,9 @@ static void next_frame_task_cb(lv_timer_t * t)
                 if((rlottie->play_ctrl & lv_rlottie_loop) == lv_rlottie_loop)
                     rlottie->current_frame = rlottie->total_frames - 1;
                 else {
-                    lv_event_send(obj, LV_EVENT_READY, NULL);
+                    if(rlottie->dest_frame != rlottie->current_frame)
+                        lv_event_send(obj, LV_EVENT_READY, NULL);
+                    rlottie->dest_frame = rlottie->current_frame; /* Remember we've sent the event */
                     return;
                 }
             }
@@ -241,7 +243,9 @@ static void next_frame_task_cb(lv_timer_t * t)
                 if((rlottie->play_ctrl & lv_rlottie_loop) == lv_rlottie_loop)
                     rlottie->current_frame = 0;
                 else {
-                    lv_event_send(obj, LV_EVENT_READY, NULL);
+                    if(rlottie->dest_frame != rlottie->current_frame)
+                        lv_event_send(obj, LV_EVENT_READY, NULL);
+                    rlottie->dest_frame = rlottie->current_frame; /* Remember we've sent the event */
                     return;
                 }
             }

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -25,6 +25,14 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef enum
+{
+    lv_rlottie_forward = 0,
+    lv_rlottie_pause,
+    lv_rlottie_goto,
+    lv_rlottie_backward,
+} lv_rlottie_play_control_t;
+
 typedef struct {
     lv_img_t img_ext;
     Lottie_Animation * animation;
@@ -36,6 +44,8 @@ typedef struct {
     uint32_t * allocated_buf;
     size_t allocated_buffer_size;
     size_t scanline_width;
+    lv_rlottie_play_control_t play_ctrl;
+    size_t dest_frame;
 } lv_rlottie_t;
 
 extern const lv_obj_class_t lv_rlottie_class;
@@ -48,6 +58,8 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, lv_coord_t width, lv_c
 
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_coord_t height,
                                       const char * rlottie_desc);
+
+void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_play_control_t ctrl, size_t param);
 
 /**********************
  *      MACROS

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -26,12 +26,12 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 typedef enum {
-    lv_rlottie_forward  = 0,
-    lv_rlottie_backward = 1,
-    lv_rlottie_pause    = 2,
-    lv_rlottie_play     = 0, /* Yes, play = 0 is the default mode */
-    lv_rlottie_loop     = 8,
-} lv_rlottie_play_control_t;
+    LV_RLOTTIE_CTRL_FORWARD  = 0,
+    LV_RLOTTIE_CTRL_BACKWARD = 1,
+    LV_RLOTTIE_CTRL_PAUSE    = 2,
+    LV_RLOTTIE_CTRL_PLAY     = 0, /* Yes, play = 0 is the default mode */
+    LV_RLOTTIE_CTRL_LOOP     = 8,
+} lv_rlottie_ctrl_t;
 
 typedef struct {
     lv_img_t img_ext;
@@ -44,7 +44,7 @@ typedef struct {
     uint32_t * allocated_buf;
     size_t allocated_buffer_size;
     size_t scanline_width;
-    lv_rlottie_play_control_t play_ctrl;
+    lv_rlottie_ctrl_t play_ctrl;
     size_t dest_frame;
 } lv_rlottie_t;
 
@@ -59,7 +59,7 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, lv_coord_t width, lv_c
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_coord_t height,
                                       const char * rlottie_desc);
 
-void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_play_control_t ctrl);
+void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
 
 /**********************

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -25,12 +25,12 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-typedef enum
-{
-    lv_rlottie_forward = 0,
-    lv_rlottie_pause,
-    lv_rlottie_goto,
-    lv_rlottie_backward,
+typedef enum {
+    lv_rlottie_forward  = 0,
+    lv_rlottie_backward = 1,
+    lv_rlottie_pause    = 2,
+    lv_rlottie_play     = 0, /* Yes, play = 0 is the default mode */
+    lv_rlottie_loop     = 8,
 } lv_rlottie_play_control_t;
 
 typedef struct {
@@ -59,7 +59,8 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, lv_coord_t width, lv_c
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_coord_t height,
                                       const char * rlottie_desc);
 
-void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_play_control_t ctrl, size_t param);
+void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_play_control_t ctrl);
+void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix


Fix #4 in lv_lib_rlottie.
This adds 2 functions to control rlottie animation:
```cpp
void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_play_control_t ctrl);
void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
```
to be used like this:
```cpp
  lv_obj_t * lottie = lv_rlottie_create_from_file(scr, 128, 128, "test.json");
  lv_obj_center(lottie);
  // Pause to a specific frame
  lv_rlottie_set_current_frame(lottie, 50);
  lv_rlottie_set_play_mode(lottie, lv_rlottie_pause);
  // Play backward and loop
  lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_backward | lv_rlottie_loop);
  // Play forward once (no looping)
  lv_rlottie_set_play_mode(lottie, lv_rlottie_play | lv_rlottie_forward);
```
Also triggers an EVENT_READY at end of animation (only if not looping, obviously).
