### PR TITLE
fix(draw) fix memory access out of bounds when using blend subtractio…

### DIFF
--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -173,8 +173,8 @@ static void fill_set_px(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_
         int32_t area_w = lv_area_get_width(fill_area);
         int32_t area_h = lv_area_get_height(fill_area);
 
-        for(y = 0; y <= area_w; y++) {
-            for(x = 0; x <= area_h; x++) {
+        for(y = 0; y < area_h; y++) {
+            for(x = 0; x < area_w; x++) {
                 if(mask[x]) {
                     disp->driver->set_px_cb(disp->driver, (void *)dest_buf, dest_stride, fill_area->x1 + x, fill_area->y1 + y, color,
                                             (uint32_t)((uint32_t)opa * mask[x]) >> 8);

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -368,8 +368,8 @@ static void fill_blended(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv
     if(mask == NULL) {
         lv_color_t last_dest_color = lv_color_black();
         lv_color_t last_res_color = lv_color_mix(color, last_dest_color, opa);
-        for(y = 0; y < area_w; y++) {
-            for(x = 0; x < area_h; x++) {
+        for(y = 0; y < area_h; y++) {
+            for(x = 0; x < area_w; x++) {
                 if(last_dest_color.full != dest_buf[x].full) {
                     last_dest_color = dest_buf[x];
                     last_res_color = blend_fp(color, dest_buf[x], opa);


### PR DESCRIPTION

### Description of the feature or fix

fix memory access out bound mentioned in https://github.com/lvgl/lvgl/issues/2847

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
