### PR TITLE
fix(doc) Fix spelling, parameter descriptions, comments, etc

### DIFF
--- a/examples/libs/ffmpeg/lv_example_ffmpeg_1.c
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_1.c
@@ -2,7 +2,7 @@
 #if LV_USE_FFMPEG && LV_BUILD_EXAMPLES
 
 /**
- * Open a image from a file
+ * Open an image from a file
  */
 void lv_example_ffmpeg_1(void)
 {

--- a/examples/libs/rlottie/lv_example_rlottie_1.py
+++ b/examples/libs/rlottie/lv_example_rlottie_1.py
@@ -2,7 +2,7 @@
 import lvgl as lv
 import display_driver
 #
-# Load an lottie animation from flash
+# Load a lottie animation from flash
 #
 from lv_example_rlottie_approve import lv_example_rlottie_approve
 

--- a/examples/widgets/keyboard/lv_example_keyboard_1.py
+++ b/examples/widgets/keyboard/lv_example_keyboard_1.py
@@ -9,7 +9,7 @@ def ta_event_cb(e,kb):
         kb.set_textarea(None)
         kb.add_flag(lv.obj.FLAG.HIDDEN)
         
-# Create a keyboard to use it with an of the text areas
+# Create a keyboard to use it with one of the text areas
 kb = lv.keyboard(lv.scr_act())
 
 # Create a text area. The keyboard will write here

--- a/examples/widgets/roller/lv_example_roller_3.c
+++ b/examples/widgets/roller/lv_example_roller_3.c
@@ -51,7 +51,7 @@ static void mask_event_cb(lv_event_t * e)
 }
 
 /**
- * Add an fade mask to roller.
+ * Add a fade mask to roller.
  */
 void lv_example_roller_3(void)
 {

--- a/examples/widgets/roller/lv_example_roller_3.py
+++ b/examples/widgets/roller/lv_example_roller_3.py
@@ -8,7 +8,7 @@ class Lv_Roller_3():
         self.mask_bottom_id = -1
         
         # 
-        # Add an fade mask to roller.
+        # Add a fade mask to roller.
         #
         style =  lv.style_t()
         style.init()
@@ -94,6 +94,6 @@ class Lv_Roller_3():
             lv.draw_mask_remove_id(self.mask_top_id)
             lv.draw_mask_remove_id(self.mask_bottom_id)
             self.mask_top_id = -1;
-            self.mask_bottom_id = -1;        
+            self.mask_bottom_id = -1;
             
 roller3 = Lv_Roller_3()

--- a/src/core/lv_event.h
+++ b/src/core/lv_event.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_templ.h
+ * @file lv_event.h
  *
  */
 

--- a/src/core/lv_indev.h
+++ b/src/core/lv_indev.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /**
  * Called periodically to read the input devices
- * @param param pointer to and input device to read
+ * @param timer pointer to a timer to read
  */
 void lv_indev_read_timer_cb(lv_timer_t * timer);
 

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -468,12 +468,11 @@ lv_text_align_t lv_obj_calculate_style_text_align(const struct _lv_obj_t * obj, 
 /**
  * Get the local style of an object for a given part and for a given state.
  * If the local style for the part-state pair doesn't exist allocate and return it.
- * @param obj   pointer to an object
- * @param part  the part in whose local style to get
- * @param state the state in whose local style to get
+ * @param obj pointer to an object
+ * @param selector OR-ed value of parts and state for which the style should be get
  * @return pointer to the local style
  */
-static lv_style_t * get_local_style(lv_obj_t * obj,  lv_style_selector_t selector)
+static lv_style_t * get_local_style(lv_obj_t * obj, lv_style_selector_t selector)
 {
     uint32_t i;
     for(i = 0; i < obj->style_cnt; i++) {
@@ -506,8 +505,7 @@ static lv_style_t * get_local_style(lv_obj_t * obj,  lv_style_selector_t selecto
  * Get the transition style of an object for a given part and for a given state.
  * If the transition style for the part-state pair doesn't exist allocate and return it.
  * @param obj   pointer to an object
- * @param part  the part in whose local style to get
- * @param state the state in whose local style to get
+ * @param selector OR-ed value of parts and state for which the style should be get
  * @return pointer to the transition style
  */
 static _lv_obj_style_t * get_trans_style(lv_obj_t * obj,  lv_style_selector_t selector)

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -133,10 +133,9 @@ lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t p
 /**
  * Set local style property on an object's part and state.
  * @param obj       pointer to an object
- * @param part      a part to which the property should be added
- * @param state     a state to which the property should be added
  * @param prop      the property
  * @param value     value of the property. The correct element should be set according to the type of the property
+ * @param selector  OR-ed value of parts and state for which the style should be set
  */
 void lv_obj_set_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t value,
                                  lv_style_selector_t selector);
@@ -147,9 +146,8 @@ lv_res_t lv_obj_get_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t pro
 /**
  * Remove a local style property from a part of an object with a given state.
  * @param obj       pointer to an object
- * @param part      the part of the object which style property should be removed.
- * @param state     the state from which the property should be removed.
  * @param prop      a style property to remove.
+ * @param selector  OR-ed value of parts and state for which the style should be removed
  * @return true     the property was found and removed; false: the property was not found
  */
 bool lv_obj_remove_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_selector_t selector);
@@ -239,4 +237,4 @@ lv_text_align_t lv_obj_calculate_style_text_align(const struct _lv_obj_t * obj, 
 } /*extern "C"*/
 #endif
 
-#endif /*LV_TEMPL_H*/
+#endif /*LV_OBJ_STYLE_H*/

--- a/src/core/lv_theme.h
+++ b/src/core/lv_theme.h
@@ -47,7 +47,7 @@ typedef struct _lv_theme_t {
 
 /**
  * Get the theme assigned to the display of the object
- * @param obj       pointer to object
+ * @param obj       pointer to a theme object
  * @return          the theme of the object's display (can be NULL)
  */
 lv_theme_t  * lv_theme_get_from_obj(lv_obj_t * obj);
@@ -77,29 +77,34 @@ void lv_theme_set_apply_cb(lv_theme_t * theme, lv_theme_apply_cb_t apply_cb);
 
 /**
  * Get the small font of the theme
+ * @param obj pointer to an object
  * @return pointer to the font
  */
 const lv_font_t * lv_theme_get_font_small(lv_obj_t * obj);
 /**
  * Get the normal font of the theme
+ * @param obj pointer to an object
  * @return pointer to the font
  */
 const lv_font_t * lv_theme_get_font_normal(lv_obj_t * obj);
 
 /**
  * Get the subtitle font of the theme
+ * @param obj pointer to an object
  * @return pointer to the font
  */
 const lv_font_t * lv_theme_get_font_large(lv_obj_t * obj);
 
 /**
  * Get the primary color of the theme
+ * @param obj pointer to an object
  * @return the color
  */
 lv_color_t lv_theme_get_color_primary(lv_obj_t * obj);
 
 /**
  * Get the secondary color of the theme
+ * @param obj pointer to an object
  * @return the color
  */
 lv_color_t lv_theme_get_color_secondary(lv_obj_t * obj);

--- a/src/draw/lv_draw_arc.h
+++ b/src/draw/lv_draw_arc.h
@@ -76,4 +76,4 @@ void lv_draw_arc_get_area(lv_coord_t x, lv_coord_t y, uint16_t radius,  uint16_t
 } /*extern "C"*/
 #endif
 
-#endif /*LV_DRAW_ARC*/
+#endif /*LV_DRAW_ARC_H*/

--- a/src/draw/lv_draw_mask.h
+++ b/src/draw/lv_draw_mask.h
@@ -340,7 +340,7 @@ void lv_draw_mask_angle_init(lv_draw_mask_angle_param_t * param, lv_coord_t vert
 
 /**
  * Initialize a fade mask.
- * @param param param pointer to a `lv_draw_mask_param_t` to initialize
+ * @param param pointer to an `lv_draw_mask_radius_param_t` to initialize
  * @param rect coordinates of the rectangle to affect (absolute coordinates)
  * @param radius radius of the rectangle
  * @param inv true: keep the pixels inside the rectangle; keep the pixels outside of the rectangle

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_label.c
+ * @file lv_draw_sw_letter.c
  *
  */
 

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -462,7 +462,7 @@ void lv_draw_mask_angle_init(lv_draw_mask_angle_param_t * param, lv_coord_t vert
 
 /**
  * Initialize a fade mask.
- * @param param param pointer to a `lv_draw_mask_param_t` to initialize
+ * @param param pointer to an `lv_draw_mask_radius_param_t` to initialize
  * @param rect coordinates of the rectangle to affect (absolute coordinates)
  * @param radius radius of the rectangle
  * @param inv true: keep the pixels inside the rectangle; keep the pixels outside of the rectangle

--- a/src/extra/libs/bmp/lv_bmp.h
+++ b/src/extra/libs/bmp/lv_bmp.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_templ.h
+ * @file lv_bmp.h
  *
  */
 

--- a/src/extra/libs/lv_libs.h
+++ b/src/extra/libs/lv_libs.h
@@ -43,4 +43,4 @@ extern "C" {
 } /*extern "C"*/
 #endif
 
-#endif /*LV_LAYOUTS_H*/
+#endif /*LV_LIBS_H*/

--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -177,7 +177,7 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
  * @param obj    The object to generate snapshot.
  * @param cf     color format for generated image.
  *
- * @return a pointer to a image descriptor, or NULL if failed.
+ * @return a pointer to an image descriptor, or NULL if failed.
  */
 lv_img_dsc_t * lv_snapshot_take(lv_obj_t * obj, lv_img_cf_t cf)
 {

--- a/src/extra/others/snapshot/lv_snapshot.h
+++ b/src/extra/others/snapshot/lv_snapshot.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param obj    The object to generate snapshot.
  * @param cf     color format for generated image.
  *
- * @return a pointer to a image descriptor, or NULL if failed.
+ * @return a pointer to an image descriptor, or NULL if failed.
  */
 lv_img_dsc_t * lv_snapshot_take(lv_obj_t * obj, lv_img_cf_t cf);
 

--- a/src/extra/themes/mono/lv_theme_mono.h
+++ b/src/extra/themes/mono/lv_theme_mono.h
@@ -48,4 +48,4 @@ lv_theme_t * lv_theme_mono_init(lv_disp_t * disp, bool dark_bg, const lv_font_t 
 } /*extern "C"*/
 #endif
 
-#endif /*LV_THEME_DEFAULT_H*/
+#endif /*LV_USE_THEME_MONO_H*/

--- a/src/extra/widgets/animimg/lv_animimg.h
+++ b/src/extra/widgets/animimg/lv_animimg.h
@@ -54,8 +54,7 @@ typedef uint8_t lv_animimg_part_t;
 
 /**
  * Create an animation image objects
- * @param par pointer to an object, it will be the parent of the new button
- * @param copy pointer to a image object, if not NULL then the new object will be copied from it
+ * @param parent pointer to an object, it will be the parent of the new button
  * @return pointer to the created animation image object
  */
 lv_obj_t * lv_animimg_create(lv_obj_t * parent);
@@ -65,7 +64,7 @@ lv_obj_t * lv_animimg_create(lv_obj_t * parent);
  *====================*/
 
 /**
- * Set the  image animation images source.
+ * Set the image animation images source.
  * @param img pointer to an animation image object
  * @param dsc pointer to a series images
  * @param num images' number
@@ -73,13 +72,13 @@ lv_obj_t * lv_animimg_create(lv_obj_t * parent);
 void lv_animimg_set_src(lv_obj_t * img,  lv_img_dsc_t * dsc[], uint8_t num);
 
 /**
- * Startup the  image animation.
- * @param img pointer to an animation image object
+ * Startup the image animation.
+ * @param obj pointer to an animation image object
  */
 void lv_animimg_start(lv_obj_t * obj);
 
 /**
- * Set the  image animation duration time. unit:ms
+ * Set the image animation duration time. unit:ms
  * @param img pointer to an animation image object
  */
 void lv_animimg_set_duration(lv_obj_t * img, uint32_t duration);
@@ -87,6 +86,7 @@ void lv_animimg_set_duration(lv_obj_t * img, uint32_t duration);
 /**
  * Set the image animation reapeatly play times.
  * @param img pointer to an animation image object
+ * @param count the number of times to repeat the animation
  */
 void lv_animimg_set_repeat_count(lv_obj_t * img, uint16_t count);
 

--- a/src/extra/widgets/calendar/lv_calendar_header_arrow.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_arrow.h
@@ -46,4 +46,4 @@ lv_obj_t * lv_calendar_header_arrow_create(lv_obj_t * parent);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_CALENDAR_H*/
+#endif /*LV_CALENDAR_HEADER_ARROW_H*/

--- a/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
+++ b/src/extra/widgets/calendar/lv_calendar_header_dropdown.h
@@ -46,4 +46,4 @@ lv_obj_t * lv_calendar_header_dropdown_create(lv_obj_t * parent);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_CALENDAR_H*/
+#endif /*LV_CALENDAR_HEADER_DROPDOWN_H*/

--- a/src/extra/widgets/chart/lv_chart.h
+++ b/src/extra/widgets/chart/lv_chart.h
@@ -135,7 +135,7 @@ typedef enum {
  **********************/
 
 /**
- * Create a chart objects
+ * Create a chart object
  * @param parent    pointer to an object, it will be the parent of the new chart
  * @return          pointer to the created chart
  */

--- a/src/extra/widgets/colorwheel/lv_colorwheel.c
+++ b/src/extra/widgets/colorwheel/lv_colorwheel.c
@@ -71,7 +71,7 @@ static bool create_knob_recolor;
 
 /**
  * Create a color_picker object
- * @param par pointer to an object, it will be the parent of the new color_picker
+ * @param parent pointer to an object, it will be the parent of the new color_picker
  * @return pointer to the created color_picker
  */
 lv_obj_t * lv_colorwheel_create(lv_obj_t * parent, bool knob_recolor)

--- a/src/extra/widgets/colorwheel/lv_colorwheel.h
+++ b/src/extra/widgets/colorwheel/lv_colorwheel.h
@@ -55,7 +55,7 @@ extern const lv_obj_class_t lv_colorwheel_class;
  **********************/
 
 /**
- * Create a color picker objects with disc shape
+ * Create a color picker object with disc shape
  * @param parent pointer to an object, it will be the parent of the new color picker
  * @param knob_recolor true: set the knob's color to the current color
  * @return pointer to the created color picker

--- a/src/extra/widgets/imgbtn/lv_imgbtn.c
+++ b/src/extra/widgets/imgbtn/lv_imgbtn.c
@@ -49,8 +49,8 @@ const lv_obj_class_t lv_imgbtn_class = {
  **********************/
 
 /**
- * Create a image button object
- * @param par pointer to an object, it will be the parent of the new image button
+ * Create an image button object
+ * @param parent pointer to an object, it will be the parent of the new image button
  * @return pointer to the created image button
  */
 lv_obj_t * lv_imgbtn_create(lv_obj_t * parent)
@@ -67,7 +67,7 @@ lv_obj_t * lv_imgbtn_create(lv_obj_t * parent)
 
 /**
  * Set images for a state of the image button
- * @param imgbtn pointer to an image button object
+ * @param obj pointer to an image button object
  * @param state for which state set the new image
  * @param src_left pointer to an image source for the left side of the button (a C array or path to
  * a file)
@@ -115,7 +115,7 @@ void lv_imgbtn_set_state(lv_obj_t * obj, lv_imgbtn_state_t state)
 
 /**
  * Get the left image in a given state
- * @param imgbtn pointer to an image button object
+ * @param obj pointer to an image button object
  * @param state the state where to get the image (from `lv_btn_state_t`) `
  * @return pointer to the left image source (a C array or path to a file)
  */
@@ -130,7 +130,7 @@ const void * lv_imgbtn_get_src_left(lv_obj_t * obj, lv_imgbtn_state_t state)
 
 /**
  * Get the middle image in a given state
- * @param imgbtn pointer to an image button object
+ * @param obj pointer to an image button object
  * @param state the state where to get the image (from `lv_btn_state_t`) `
  * @return pointer to the middle image source (a C array or path to a file)
  */
@@ -144,7 +144,7 @@ const void * lv_imgbtn_get_src_middle(lv_obj_t * obj, lv_imgbtn_state_t state)
 
 /**
  * Get the right image in a given state
- * @param imgbtn pointer to an image button object
+ * @param obj pointer to an image button object
  * @param state the state where to get the image (from `lv_btn_state_t`) `
  * @return pointer to the left image source (a C array or path to a file)
  */

--- a/src/extra/widgets/imgbtn/lv_imgbtn.h
+++ b/src/extra/widgets/imgbtn/lv_imgbtn.h
@@ -49,8 +49,8 @@ extern const lv_obj_class_t lv_imgbtn_class;
  **********************/
 
 /**
- * Create a image button objects
- * @param par pointer to an object, it will be the parent of the new image button
+ * Create an image button object
+ * @param parent pointer to an object, it will be the parent of the new image button
  * @return pointer to the created image button
  */
 lv_obj_t * lv_imgbtn_create(lv_obj_t * parent);

--- a/src/extra/widgets/keyboard/lv_keyboard.c
+++ b/src/extra/widgets/keyboard/lv_keyboard.c
@@ -130,8 +130,8 @@ static const lv_btnmatrix_ctrl_t * kb_ctrl[9] = {
  **********************/
 
 /**
- * Create a keyboard objects
- * @param par pointer to an object, it will be the parent of the new keyboard
+ * Create a Keyboard object
+ * @param parent pointer to an object, it will be the parent of the new keyboard
  * @return pointer to the created keyboard
  */
 lv_obj_t * lv_keyboard_create(lv_obj_t * parent)

--- a/src/extra/widgets/keyboard/lv_keyboard.h
+++ b/src/extra/widgets/keyboard/lv_keyboard.h
@@ -63,8 +63,8 @@ extern const lv_obj_class_t lv_keyboard_class;
  **********************/
 
 /**
- * Create a keyboard objects
- * @param par pointer to an object, it will be the parent of the new keyboard
+ * Create a Keyboard object
+ * @param parent pointer to an object, it will be the parent of the new keyboard
  * @return pointer to the created keyboard
  */
 lv_obj_t * lv_keyboard_create(lv_obj_t * parent);

--- a/src/extra/widgets/led/lv_led.c
+++ b/src/extra/widgets/led/lv_led.c
@@ -47,8 +47,8 @@ const lv_obj_class_t lv_led_class  = {
  **********************/
 
 /**
- * Create a led objects
- * @param par pointer to an object, it will be the parent of the new led
+ * Create a led object
+ * @param parent pointer to an object, it will be the parent of the new led
  * @return pointer to the created led
  */
 lv_obj_t * lv_led_create(lv_obj_t * parent)

--- a/src/extra/widgets/led/lv_led.h
+++ b/src/extra/widgets/led/lv_led.h
@@ -57,8 +57,8 @@ typedef enum {
  **********************/
 
 /**
- * Create a led objects
- * @param par pointer to an object, it will be the parent of the new led
+ * Create a led object
+ * @param parent pointer to an object, it will be the parent of the new led
  * @return pointer to the created led
  */
 lv_obj_t * lv_led_create(lv_obj_t * parent);

--- a/src/extra/widgets/meter/lv_meter.h
+++ b/src/extra/widgets/meter/lv_meter.h
@@ -115,7 +115,7 @@ typedef enum {
  **********************/
 
 /**
- * Create a meter objects
+ * Create a Meter object
  * @param parent pointer to an object, it will be the parent of the new bar.
  * @return pointer to the created meter
  */

--- a/src/extra/widgets/span/lv_span.c
+++ b/src/extra/widgets/span/lv_span.c
@@ -87,7 +87,7 @@ const lv_obj_class_t lv_spangroup_class  = {
  **********************/
 
 /**
- * Create a spangroup objects
+ * Create a spangroup object
  * @param par pointer to an object, it will be the parent of the new spangroup
  * @return pointer to the created spangroup
  */

--- a/src/extra/widgets/span/lv_span.h
+++ b/src/extra/widgets/span/lv_span.h
@@ -66,7 +66,7 @@ extern const lv_obj_class_t lv_spangroup_class;
  **********************/
 
 /**
- * Create a spangroup objects
+ * Create a spangroup object
  * @param par pointer to an object, it will be the parent of the new spangroup
  * @return pointer to the created spangroup
  */

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -60,7 +60,7 @@ lv_obj_t * lv_spinbox_create(lv_obj_t * parent)
 
 /**
  * Set spinbox value
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param i value to be set
  */
 void lv_spinbox_set_value(lv_obj_t * obj, int32_t i)
@@ -189,7 +189,7 @@ void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction)
 
 /**
  * Get the spinbox numeral value (user has to convert to float according to its digit format)
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @return value integer value of the spinbox
  */
 int32_t lv_spinbox_get_value(lv_obj_t * obj)
@@ -201,7 +201,7 @@ int32_t lv_spinbox_get_value(lv_obj_t * obj)
 }
 /**
  * Get the spinbox step value (user has to convert to float according to its digit format)
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @return value integer step value of the spinbox
  */
 int32_t lv_spinbox_get_step(lv_obj_t * obj)
@@ -218,7 +218,7 @@ int32_t lv_spinbox_get_step(lv_obj_t * obj)
 
 /**
  * Select next lower digit for edition
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_step_next(lv_obj_t * obj)
 {
@@ -236,7 +236,7 @@ void lv_spinbox_step_next(lv_obj_t * obj)
 
 /**
  * Select next higher digit for edition
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_step_prev(lv_obj_t * obj)
 {
@@ -252,7 +252,7 @@ void lv_spinbox_step_prev(lv_obj_t * obj)
 
 /**
  * Get spinbox rollover function status
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 bool lv_spinbox_get_rollover(lv_obj_t * obj)
 {
@@ -264,7 +264,7 @@ bool lv_spinbox_get_rollover(lv_obj_t * obj)
 
 /**
  * Increment spinbox value by one step
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_increment(lv_obj_t * obj)
 {
@@ -290,7 +290,7 @@ void lv_spinbox_increment(lv_obj_t * obj)
 
 /**
  * Decrement spinbox value by one step
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_decrement(lv_obj_t * obj)
 {

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -52,8 +52,8 @@ extern const lv_obj_class_t lv_spinbox_class;
  **********************/
 
 /**
- * Create a spinbox objects
- * @param par pointer to an object, it will be the parent of the new spinbox
+ * Create a Spinbox object
+ * @param parent pointer to an object, it will be the parent of the new spinbox
  * @return pointer to the created spinbox
  */
 lv_obj_t * lv_spinbox_create(lv_obj_t * parent);
@@ -64,21 +64,21 @@ lv_obj_t * lv_spinbox_create(lv_obj_t * parent);
 
 /**
  * Set spinbox value
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param i value to be set
  */
 void lv_spinbox_set_value(lv_obj_t * obj, int32_t i);
 
 /**
  * Set spinbox rollover function
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param b true or false to enable or disable (default)
  */
 void lv_spinbox_set_rollover(lv_obj_t * obj, bool b);
 
 /**
  * Set spinbox digit format (digit count and decimal format)
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param digit_count number of digit excluding the decimal separator and the sign
  * @param separator_position number of digit before the decimal point. If 0, decimal point is not
  * shown
@@ -87,14 +87,14 @@ void lv_spinbox_set_digit_format(lv_obj_t * obj, uint8_t digit_count, uint8_t se
 
 /**
  * Set spinbox step
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param step steps on increment/decrement. Can be 1, 10, 100, 1000, etc the digit that will change.
  */
 void lv_spinbox_set_step(lv_obj_t * obj, uint32_t step);
 
 /**
  * Set spinbox value range
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param range_min maximum value, inclusive
  * @param range_max minimum value, inclusive
  */
@@ -102,14 +102,14 @@ void lv_spinbox_set_range(lv_obj_t * obj, int32_t range_min, int32_t range_max);
 
 /**
  * Set cursor position to a specific digit for edition
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param pos selected position in spinbox
  */
 void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos);
 
 /**
  * Set direction of digit step when clicking an encoder button while in editing mode
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @param direction the direction (LV_DIR_RIGHT or LV_DIR_LEFT)
  */
 void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
@@ -120,20 +120,20 @@ void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
 
 /**
  * Get spinbox rollover function status
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 bool lv_spinbox_get_rollover(lv_obj_t * obj);
 
 /**
  * Get the spinbox numeral value (user has to convert to float according to its digit format)
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @return value integer value of the spinbox
  */
 int32_t lv_spinbox_get_value(lv_obj_t * obj);
 
 /**
  * Get the spinbox step value (user has to convert to float according to its digit format)
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  * @return value integer step value of the spinbox
  */
 int32_t lv_spinbox_get_step(lv_obj_t * obj);
@@ -144,25 +144,25 @@ int32_t lv_spinbox_get_step(lv_obj_t * obj);
 
 /**
  * Select next lower digit for edition by dividing the step by 10
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_step_next(lv_obj_t * obj);
 
 /**
  * Select next higher digit for edition by multiplying the step by 10
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_step_prev(lv_obj_t * obj);
 
 /**
  * Increment spinbox value by one step
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_increment(lv_obj_t * obj);
 
 /**
  * Decrement spinbox value by one step
- * @param spinbox pointer to spinbox
+ * @param obj pointer to spinbox
  */
 void lv_spinbox_decrement(lv_obj_t * obj);
 
@@ -175,4 +175,4 @@ void lv_spinbox_decrement(lv_obj_t * obj);
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif
-#endif /*LV_USE_SPINBOX*/
+#endif /*LV_SPINBOX_H*/

--- a/src/extra/widgets/spinner/lv_spinner.c
+++ b/src/extra/widgets/spinner/lv_spinner.c
@@ -45,7 +45,7 @@ static uint32_t arc_length_param;
 
 /**
  * Create a spinner object
- * @param par pointer to an object, it will be the parent of the new spinner
+ * @param parent pointer to an object, it will be the parent of the new spinner
  * @return pointer to the created spinner
  */
 lv_obj_t * lv_spinner_create(lv_obj_t * parent, uint32_t time, uint32_t arc_length)

--- a/src/extra/widgets/tileview/lv_tileview.h
+++ b/src/extra/widgets/tileview/lv_tileview.h
@@ -42,8 +42,8 @@ extern const lv_obj_class_t lv_tileview_tile_class;
  **********************/
 
 /**
- * Create a tileview objects
- * @param par pointer to an object, it will be the parent of the new tileview
+ * Create a Tileview object
+ * @param parent pointer to an object, it will be the parent of the new tileview
  * @return pointer to the created tileview
  */
 lv_obj_t * lv_tileview_create(lv_obj_t * parent);

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_text.c
+ * @file lv_txt.c
  *
  */
 

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_text.h
+ * @file lv_txt.h
  *
  */
 
@@ -259,4 +259,4 @@ extern uint32_t (*_lv_txt_get_encoded_length)(const char *);
 } /*extern "C"*/
 #endif
 
-#endif /*USE_TXT*/
+#endif /*LV_TXT_H*/

--- a/src/widgets/lv_arc.h
+++ b/src/widgets/lv_arc.h
@@ -70,7 +70,7 @@ typedef enum {
 
 /**
  * Create an arc object
- * @param par pointer to an object, it will be the parent of the new arc
+ * @param parent pointer to an object, it will be the parent of the new arc
  * @return pointer to the created arc
  */
 lv_obj_t * lv_arc_create(lv_obj_t * parent);

--- a/src/widgets/lv_bar.h
+++ b/src/widgets/lv_bar.h
@@ -71,7 +71,7 @@ typedef enum {
  **********************/
 
 /**
- * Create a bar objects
+ * Create a bar object
  * @param parent    pointer to an object, it will be the parent of the new bar
  * @return          pointer to the created bar
  */

--- a/src/widgets/lv_btnmatrix.h
+++ b/src/widgets/lv_btnmatrix.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_btnm.h
+ * @file lv_btnmatrix.h
  *
  */
 
@@ -78,7 +78,7 @@ typedef enum {
  **********************/
 
 /**
- * Create a button matrix objects
+ * Create a button matrix object
  * @param parent    pointer to an object, it will be the parent of the new button matrix
  * @return          pointer to the created button matrix
  */

--- a/src/widgets/lv_dropdown.h
+++ b/src/widgets/lv_dropdown.h
@@ -63,7 +63,7 @@ extern const  lv_obj_class_t lv_dropdownlist_class;
  **********************/
 
 /**
- * Create a drop-down list objects
+ * Create a drop-down list object
  * @param parent pointer to an object, it will be the parent of the new drop-down list
  * @return pointer to the created drop-down list
  */

--- a/src/widgets/lv_img.h
+++ b/src/widgets/lv_img.h
@@ -71,7 +71,7 @@ typedef uint8_t lv_img_size_mode_t;
  **********************/
 
 /**
- * Create a image objects
+ * Create an image object
  * @param parent pointer to an object, it will be the parent of the new image
  * @return pointer to the created image
  */

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -819,8 +819,8 @@ static void draw_main(lv_event_t * e)
         label_draw_dsc.sel_bg_color = lv_obj_get_style_bg_color(obj, LV_PART_SELECTED);
     }
 
-    /* In SROLL and SROLL_CIRC mode the CENTER and RIGHT are pointless so remove them.
-     * (In addition they will result misalignment is this case)*/
+    /* In SCROLL and SCROLL_CIRCULAR mode the CENTER and RIGHT are pointless, so remove them.
+     * (In addition, they will create misalignment in this situation)*/
     if((label->long_mode == LV_LABEL_LONG_SCROLL || label->long_mode == LV_LABEL_LONG_SCROLL_CIRCULAR) &&
        (label_draw_dsc.align == LV_TEXT_ALIGN_CENTER || label_draw_dsc.align == LV_TEXT_ALIGN_RIGHT)) {
         lv_point_t size;
@@ -911,7 +911,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
 
     lv_obj_refresh_self_size(obj);
 
-    /*In scroll mode start an offset animations*/
+    /*In scroll mode start an offset animation*/
     if(label->long_mode == LV_LABEL_LONG_SCROLL) {
         uint16_t anim_speed = lv_obj_get_style_anim_speed(obj, LV_PART_MAIN);
         if(anim_speed == 0) anim_speed = LV_LABEL_DEF_SCROLL_SPEED;

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -69,11 +69,11 @@ typedef struct {
 #endif
 
     lv_point_t offset; /*Text draw position offset*/
-    lv_label_long_mode_t long_mode : 3; /*Determinate what to do with the long texts*/
+    lv_label_long_mode_t long_mode : 3; /*Determine what to do with the long texts*/
     uint8_t static_txt : 1;             /*Flag to indicate the text is static*/
     uint8_t recolor : 1;                /*Enable in-line letter re-coloring*/
-    uint8_t expand : 1;                 /*Ignore real width (used by the library with LV_LABEL_LONG_SROLL)*/
-    uint8_t dot_tmp_alloc : 1; /*1: dot_tmp has been allocated;.0: dot_tmp directly holds up to 4 bytes of characters*/
+    uint8_t expand : 1;                 /*Ignore real width (used by the library with LV_LABEL_LONG_SCROLL)*/
+    uint8_t dot_tmp_alloc : 1;          /*1: dot_tmp has been allocated;.0: dot_tmp directly holds up to 4 bytes of characters*/
 } lv_label_t;
 
 extern const lv_obj_class_t lv_label_class;
@@ -83,7 +83,7 @@ extern const lv_obj_class_t lv_label_class;
  **********************/
 
 /**
- * Create a label objects
+ * Create a label object
  * @param parent    pointer to an object, it will be the parent of the new label.
  * @return          pointer to the created button
  */
@@ -95,14 +95,14 @@ lv_obj_t * lv_label_create(lv_obj_t * parent);
 
 /**
  * Set a new text for a label. Memory will be allocated to store the text by the label.
- * @param label         pointer to a label object
+ * @param obj           pointer to a label object
  * @param text          '\0' terminated character string. NULL to refresh with the current text.
  */
 void lv_label_set_text(lv_obj_t * obj, const char * text);
 
 /**
  * Set a new formatted text for a label. Memory will be allocated to store the text by the label.
- * @param label         pointer to a label object
+ * @param obj           pointer to a label object
  * @param fmt           `printf`-like format
  * @example lv_label_set_text_fmt(label1, "%d user", user_num);
  */
@@ -111,14 +111,14 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTR
 /**
  * Set a static text. It will not be saved by the label so the 'text' variable
  * has to be 'alive' while the label exists.
- * @param label         pointer to a label object
+ * @param obj           pointer to a label object
  * @param text          pointer to a text. NULL to refresh with the current text.
  */
 void lv_label_set_text_static(lv_obj_t * obj, const char * text);
 
 /**
  * Set the behavior of the label with longer text then the object size
- * @param label         pointer to a label object
+ * @param obj           pointer to a label object
  * @param long_mode     the new mode from 'lv_label_long_mode' enum.
  *                      In LV_LONG_WRAP/DOT/SCROLL/SCROLL_CIRC the size of the label should be set AFTER this function
  */
@@ -126,7 +126,7 @@ void lv_label_set_long_mode(lv_obj_t * obj, lv_label_long_mode_t long_mode);
 
 /**
  * Enable the recoloring by in-line commands
- * @param label         pointer to a label object
+ * @param obj           pointer to a label object
  * @param en            true: enable recoloring, false: disable
  * @example "This is a #ff0000 red# word"
  */
@@ -152,7 +152,7 @@ void lv_label_set_text_sel_end(lv_obj_t * obj, uint32_t index);
 
 /**
  * Get the text of a label
- * @param obj     pointer to a label object
+ * @param obj       pointer to a label object
  * @return          the text of the label
  */
 char * lv_label_get_text(const lv_obj_t * obj);
@@ -191,9 +191,9 @@ uint32_t lv_label_get_letter_on(const lv_obj_t * obj, lv_point_t * pos_in);
 
 /**
  * Check if a character is drawn under a point.
- * @param label Label object
- * @param pos Point to check for character under
- * @return whether a character is drawn under the point
+ * @param obj       pointer to a label object
+ * @param pos       Point to check for character under
+ * @return          whether a character is drawn under the point
  */
 bool lv_label_is_char_under_pos(const lv_obj_t * obj, lv_point_t * pos);
 
@@ -226,7 +226,7 @@ void lv_label_ins_text(lv_obj_t * obj, uint32_t pos, const char * txt);
 
 /**
  * Delete characters from a label. The label text can not be static.
- * @param label     pointer to a label object
+ * @param obj       pointer to a label object
  * @param pos       character index from where to cut. Expressed in character index and not byte index.
  *                  0: start in from of the first character
  * @param cnt       number of characters to cut

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -73,7 +73,7 @@ typedef struct {
     uint8_t static_txt : 1;             /*Flag to indicate the text is static*/
     uint8_t recolor : 1;                /*Enable in-line letter re-coloring*/
     uint8_t expand : 1;                 /*Ignore real width (used by the library with LV_LABEL_LONG_SCROLL)*/
-    uint8_t dot_tmp_alloc : 1;          /*1: dot_tmp has been allocated;.0: dot_tmp directly holds up to 4 bytes of characters*/
+    uint8_t dot_tmp_alloc : 1;         /*1: dot is allocated, 0: dot directly holds up to 4 chars*/
 } lv_label_t;
 
 extern const lv_obj_class_t lv_label_class;

--- a/src/widgets/lv_line.h
+++ b/src/widgets/lv_line.h
@@ -42,8 +42,8 @@ extern const lv_obj_class_t lv_line_class;
  **********************/
 
 /**
- * Create a line objects
- * @param par pointer to an object, it will be the parent of the new line
+ * Create a line object
+ * @param parent pointer to an object, it will be the parent of the new line
  * @return pointer to the created line
  */
 lv_obj_t * lv_line_create(lv_obj_t * parent);

--- a/src/widgets/lv_objx_templ.h
+++ b/src/widgets/lv_objx_templ.h
@@ -46,7 +46,7 @@ extern const lv_obj_class_t lv_templ_class;
  **********************/
 
 /**
- * Create a templ objects
+ * Create a templ object
  * @param parent    pointer to an object, it will be the parent of the new templ
  * @return          pointer to the created bar
  */

--- a/src/widgets/lv_roller.c
+++ b/src/widgets/lv_roller.c
@@ -72,7 +72,7 @@ const lv_obj_class_t lv_roller_label_class  = {
 
 /**
  * Create a roller object
- * @param par pointer to an object, it will be the parent of the new roller
+ * @param parent pointer to an object, it will be the parent of the new roller
  * @return pointer to the created roller
  */
 lv_obj_t * lv_roller_create(lv_obj_t * parent)

--- a/src/widgets/lv_roller.h
+++ b/src/widgets/lv_roller.h
@@ -53,7 +53,7 @@ extern const lv_obj_class_t lv_roller_class;
  **********************/
 
 /**
- * Create a roller objects
+ * Create a roller object
  * @param parent    pointer to an object, it will be the parent of the new roller.
  * @return          pointer to the created roller
  */

--- a/src/widgets/lv_slider.h
+++ b/src/widgets/lv_slider.h
@@ -65,7 +65,7 @@ typedef enum {
  **********************/
 
 /**
- * Create a slider objects
+ * Create a slider object
  * @param parent    pointer to an object, it will be the parent of the new slider.
  * @return          pointer to the created slider
  */

--- a/src/widgets/lv_switch.h
+++ b/src/widgets/lv_switch.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_sw.h
+ * @file lv_switch.h
  *
  */
 
@@ -39,7 +39,7 @@ extern const lv_obj_class_t lv_switch_class;
  **********************/
 
 /**
- * Create a switch objects
+ * Create a switch object
  * @param parent pointer to an object, it will be the parent of the new switch
  * @return pointer to the created switch
  */

--- a/src/widgets/lv_textarea.h
+++ b/src/widgets/lv_textarea.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_ta.h
+ * @file lv_textarea.h
  *
  */
 
@@ -76,7 +76,7 @@ enum {
  **********************/
 
 /**
- * Create a text area objects
+ * Create a text area object
  * @param parent    pointer to an object, it will be the parent of the new text area
  * @return          pointer to the created text area
  */


### PR DESCRIPTION
No code changes, but lots of trivial changes to fix spelling, wrong named parameters, missing parameters, wrong comment, etc.