### PR TITLE
fix(refr): avoid swapping buffers every area in direct mode

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -979,7 +979,7 @@ static void draw_buf_flush(void)
             call_flush_cb(disp->driver, &draw_buf->area, color_p);
         }
     }
-    /*If there 2 buffer swap them. With direct mode swap only on the last area*/
+    /*If there are 2 buffers swap them. With direct mode swap only on the last area*/
     if(draw_buf->buf1 && draw_buf->buf2 && (!disp->driver->direct_mode || draw_buf->flushing_last)) {
         if(draw_buf->buf_act == draw_buf->buf1)
             draw_buf->buf_act = draw_buf->buf2;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -979,6 +979,7 @@ static void draw_buf_flush(void)
             call_flush_cb(disp->driver, &draw_buf->area, color_p);
         }
     }
+    /*If there 2 buffer swap them. With direct mode swap only on the last area*/
     if(draw_buf->buf1 && draw_buf->buf2 && (!disp->driver->direct_mode || draw_buf->flushing_last)) {
         if(draw_buf->buf_act == draw_buf->buf1)
             draw_buf->buf_act = draw_buf->buf2;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -979,7 +979,7 @@ static void draw_buf_flush(void)
             call_flush_cb(disp->driver, &draw_buf->area, color_p);
         }
     }
-    if(draw_buf->buf1 && draw_buf->buf2) {
+    if(draw_buf->buf1 && draw_buf->buf2 && (!disp->driver->direct_mode || draw_buf->flushing_last)) {
         if(draw_buf->buf_act == draw_buf->buf1)
             draw_buf->buf_act = draw_buf->buf2;
         else


### PR DESCRIPTION
### Description of the feature or fix

When using `direct_mode` and 2 buffers, direct mode is not useful because half of the invalidated areas are drawn to buf1 and half are drawn to buf2. This PR ensures that the buffer swap does not occur until a given buffer is fully redrawn.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
