### PR TITLE
fix(arc): Free memory when drawing full-circle arc

### DIFF
--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -114,10 +114,10 @@ void lv_draw_sw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  
 
         lv_draw_mask_remove_id(mask_out_id);
         if(mask_in_id != LV_MASK_ID_INV) lv_draw_mask_remove_id(mask_in_id);
-        
+
         lv_draw_mask_free_param(&mask_out_param);
         lv_draw_mask_free_param(&mask_in_param);
-        
+
         return;
     }
 

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -114,6 +114,10 @@ void lv_draw_sw_arc(lv_coord_t center_x, lv_coord_t center_y, uint16_t radius,  
 
         lv_draw_mask_remove_id(mask_out_id);
         if(mask_in_id != LV_MASK_ID_INV) lv_draw_mask_remove_id(mask_in_id);
+        
+        lv_draw_mask_free_param(&mask_out_param);
+        lv_draw_mask_free_param(&mask_in_param);
+        
         return;
     }
 


### PR DESCRIPTION
### Description of the feature or fix

Please see #2868 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
