### PR TITLE
Fix(examples) Remove semicolons from Python code

### DIFF
--- a/docs/overview/style.md
+++ b/docs/overview/style.md
@@ -93,7 +93,7 @@ So if a button is pressed, and the text color comes from here, the pressed text 
 Objects can be composed of *parts* which may each have their own styles. 
 
 The following predefined parts exist in LVGL:
-- `LV_PART_MAIN` A background like rectangle*/
+- `LV_PART_MAIN` A background like rectangle
 - `LV_PART_SCROLLBAR`  The scrollbar(s)
 - `LV_PART_INDICATOR` Indicator, e.g. for slider, bar, switch, or the tick box of the checkbox
 - `LV_PART_KNOB` Like a handle to grab to adjust a value

--- a/examples/anim/lv_example_anim_3.py
+++ b/examples/anim/lv_example_anim_3.py
@@ -48,7 +48,7 @@ class LvExampleAnim_3():
         
         self.p1_label = lv.label(par)
         self.p2_label = lv.label(par)
-        self.p1_label.set_text("p1:0");
+        self.p1_label.set_text("p1:0")
         self.p2_label.set_text("p2:0")
         self.p1_label.set_grid_cell(lv.GRID_ALIGN.START, 0, 1,lv.GRID_ALIGN.START, 1, 1)
         self.p2_label.set_grid_cell(lv.GRID_ALIGN.START, 0, 1,lv.GRID_ALIGN.START, 2, 1)
@@ -78,7 +78,7 @@ class LvExampleAnim_3():
         self.ser1 = self.chart.add_series(lv.palette_main(lv.PALETTE.RED), lv.chart.AXIS.PRIMARY_Y)
         self.chart.set_range(lv.chart.AXIS.PRIMARY_Y, 0, 1024)
         self.chart.set_range(lv.chart.AXIS.PRIMARY_X, 0, 1024)
-        self.chart.set_point_count(CHART_POINTS_NUM);
+        self.chart.set_point_count(CHART_POINTS_NUM)
         self.chart.set_grid_cell(lv.GRID_ALIGN.STRETCH, 0, 3,lv.GRID_ALIGN.STRETCH, 3, 1)
         
     def refer_chart_cubic_bezier(self):
@@ -92,7 +92,7 @@ class LvExampleAnim_3():
         slider = e.get_target()
         
         if slider == self.p1_slider:
-            label = self.p1_label;
+            label = self.p1_label
             self.p1 = slider.get_value()
             label.set_text("p1: {:d}".format(self.p1))
         else:

--- a/examples/anim/lv_example_anim_timeline_1.py
+++ b/examples/anim/lv_example_anim_timeline_1.py
@@ -137,7 +137,7 @@ class LV_ExampleAnimTimeline_1(object):
     def btn_del_event_handler(self,e):
         if self.anim_timeline:
             lv.anim_timeline_del(self.anim_timeline)
-        self.anim_timeline = None;
+        self.anim_timeline = None
 
 
 lv_example_anim_timeline_1 = LV_ExampleAnimTimeline_1()

--- a/examples/event/lv_example_event_1.py
+++ b/examples/event/lv_example_event_1.py
@@ -11,11 +11,11 @@ class Event_1():
         btn.add_event_cb(self.event_cb, lv.EVENT.CLICKED, None)
         
         label = lv.label(btn)
-        label.set_text("Click me!");
+        label.set_text("Click me!")
         label.center()
 
     def event_cb(self,e):
-        print("Clicked");
+        print("Clicked")
             
         btn = e.get_target()
         label = btn.get_child(0)

--- a/examples/event/lv_example_event_2.py
+++ b/examples/event/lv_example_event_2.py
@@ -17,6 +17,6 @@ btn_label.set_text("Click me!")
 btn_label.center()
 
 info_label = lv.label(lv.scr_act())
-info_label.set_text("The last button event:\nNone");
+info_label.set_text("The last button event:\nNone")
 
 btn.add_event_cb(lambda e: event_cb(e,info_label), lv.EVENT.ALL, None)

--- a/examples/get_started/lv_example_get_started_2.py
+++ b/examples/get_started/lv_example_get_started_2.py
@@ -54,9 +54,9 @@ btn2.set_size(120, 50)                      # Set its size
 btn2.add_style(style_btn, 0)
 btn2.add_style(style_btn_red, 0)
 btn2.add_style(style_btn_pressed, lv.STATE.PRESSED)
-btn2.set_style_radius(lv.RADIUS.CIRCLE, 0); # Add a local style
+btn2.set_style_radius(lv.RADIUS.CIRCLE, 0)  # Add a local style
 
 label = lv.label(btn2)                      # Add a label to the button
-label.set_text("Button 2");                 # Set the labels text
+label.set_text("Button 2")                  # Set the labels text
 label.center()
 

--- a/examples/get_started/lv_example_get_started_3.py
+++ b/examples/get_started/lv_example_get_started_3.py
@@ -15,7 +15,7 @@ slider.center()                                                    # Align to th
 slider.add_event_cb(slider_event_cb, lv.EVENT.VALUE_CHANGED, None) # Assign an event function
 
 # Create a label below the slider
-label = lv.label(lv.scr_act());
+label = lv.label(lv.scr_act())
 label.set_text("0")
 label.align_to(slider, lv.ALIGN.OUT_TOP_MID, 0, -15)               # Align below the slider
 

--- a/examples/layouts/grid/lv_example_grid_2.py
+++ b/examples/layouts/grid/lv_example_grid_2.py
@@ -16,7 +16,7 @@ obj = lv.obj(cont)
 obj.set_size(lv.SIZE.CONTENT, lv.SIZE.CONTENT)
 obj.set_grid_cell(lv.GRID_ALIGN.START, 0, 1,
                   lv.GRID_ALIGN.START, 0, 1)
-label = lv.label(obj);
+label = lv.label(obj)
 label.set_text("c0, r0")
 
 # Cell to 1;0 and align to to the start (left) horizontally and center vertically too
@@ -33,7 +33,7 @@ obj.set_size(lv.SIZE.CONTENT, lv.SIZE.CONTENT)
 obj.set_grid_cell(lv.GRID_ALIGN.START, 2, 1,
                   lv.GRID_ALIGN.END, 0, 1)
 label = lv.label(obj)
-label.set_text("c2, r0");
+label.set_text("c2, r0")
 
 # Cell to 1;1 but 2 column wide (span = 2).Set width and height to stretched.
 obj = lv.obj(cont)

--- a/examples/layouts/grid/lv_example_grid_6.py
+++ b/examples/layouts/grid/lv_example_grid_6.py
@@ -19,7 +19,7 @@ for i in range(9):
     # Stretch the cell horizontally and vertically too
     # Set span to 1 to make the cell 1 column/row sized
     obj.set_grid_cell(lv.GRID_ALIGN.STRETCH, col, 1,
-                      lv.GRID_ALIGN.STRETCH, row, 1);
+                      lv.GRID_ALIGN.STRETCH, row, 1)
     
     label = lv.label(obj)
     label.set_text("{:d},{:d}".format(col, row))

--- a/examples/scroll/lv_example_scroll_2.py
+++ b/examples/scroll/lv_example_scroll_2.py
@@ -37,7 +37,7 @@ panel.update_snap(lv.ANIM.ON)
 
 
 # Switch between "One scroll" and "Normal scroll" mode
-sw = lv.switch(lv.scr_act());
+sw = lv.switch(lv.scr_act())
 sw.align(lv.ALIGN.TOP_RIGHT, -20, 10)
 sw.add_event_cb(lambda evt:  sw_event_cb(evt,panel), lv.EVENT.ALL, None)
 label = lv.label(lv.scr_act())

--- a/examples/scroll/lv_example_scroll_6.py
+++ b/examples/scroll/lv_example_scroll_6.py
@@ -16,7 +16,7 @@ def scroll_event_cb(e):
 
         child_y_center = child_a.y1 + child_a.get_height() // 2
 
-        diff_y = child_y_center - cont_y_center;
+        diff_y = child_y_center - cont_y_center
         diff_y = abs(diff_y)
 
         # Get the x of diff_y on a circle.
@@ -26,7 +26,7 @@ def scroll_event_cb(e):
             x = r
         else:
             # Use Pythagoras theorem to get x from radius and y
-            x_sqr = r * r - diff_y * diff_y;
+            x_sqr = r * r - diff_y * diff_y
             res = lv.sqrt_res_t()
             lv.sqrt(x_sqr, res, 0x8000)   # Use lvgl's built in sqrt root function
             x = r - res.i

--- a/examples/styles/lv_example_style_1.py
+++ b/examples/styles/lv_example_style_1.py
@@ -20,5 +20,5 @@ obj = lv.obj(lv.scr_act())
 obj.add_style(style, 0)
 
 label = lv.label(obj)
-label.set_text("Hello");
+label.set_text("Hello")
 

--- a/examples/styles/lv_example_style_10.py
+++ b/examples/styles/lv_example_style_10.py
@@ -33,4 +33,3 @@ obj.add_style(style_def, 0)
 obj.add_style(style_pr, lv.STATE.PRESSED)
 
 obj.center()
-

--- a/examples/styles/lv_example_style_11.py
+++ b/examples/styles/lv_example_style_11.py
@@ -3,7 +3,7 @@
 #
 # A base style
 
-style_base =  lv.style_t()
+style_base = lv.style_t()
 style_base.init()
 style_base.set_bg_color(lv.palette_main(lv.PALETTE.LIGHT_BLUE))
 style_base.set_border_color(lv.palette_darken(lv.PALETTE.LIGHT_BLUE, 3))
@@ -41,4 +41,3 @@ obj_warning.align(lv.ALIGN.RIGHT_MID, -20, 0)
 label = lv.label(obj_warning)
 label.set_text("Warning")
 label.center()
-

--- a/examples/styles/lv_example_style_12.py
+++ b/examples/styles/lv_example_style_12.py
@@ -15,4 +15,3 @@ obj.add_style(style, 0)
 obj.set_style_bg_color(lv.palette_main(lv.PALETTE.ORANGE), lv.PART.MAIN)
 
 obj.center()
-

--- a/examples/styles/lv_example_style_13.py
+++ b/examples/styles/lv_example_style_13.py
@@ -20,4 +20,3 @@ obj.add_style(style_indic, lv.PART.INDICATOR)
 obj.add_style(style_indic_pr, lv.PART.INDICATOR | lv.STATE.PRESSED)
 obj.set_value(70, lv.ANIM.OFF)
 obj.center()
-

--- a/examples/styles/lv_example_style_14.c
+++ b/examples/styles/lv_example_style_14.c
@@ -28,7 +28,7 @@ static void new_theme_init_and_set(void)
     static lv_theme_t th_new;
     th_new = *th_act;
 
-    /*Set the parent theme ans the style applay callback for the new theme*/
+    /*Set the parent theme and the style apply callback for the new theme*/
     lv_theme_set_parent(&th_new, th_act);
     lv_theme_set_apply_cb(&th_new, new_theme_apply_cb);
 
@@ -59,8 +59,6 @@ void lv_example_style_14(void)
 
     label = lv_label_create(btn);
     lv_label_set_text(label, "New theme");
-
-
 }
 
 #endif

--- a/examples/styles/lv_example_style_14.py
+++ b/examples/styles/lv_example_style_14.py
@@ -16,8 +16,9 @@ class NewTheme(lv.theme_t):
         th_act = lv.theme_get_from_obj(lv.scr_act())
         # This theme will be applied only after base theme is applied
         self.set_parent(th_act)        
-        
-class ExampleStyle_14():
+
+
+class ExampleStyle_14:
     
     def __init__(self):
         # 
@@ -38,7 +39,7 @@ class ExampleStyle_14():
         label = lv.label(btn)
         label.set_text("New theme")
         
-    def new_theme_apply_cb(self,th, obj):
+    def new_theme_apply_cb(self, th, obj):
         print(th,obj)
         if obj.get_class() == lv.btn_class:
             obj.add_style(self.th_new.style_btn, 0)
@@ -49,5 +50,6 @@ class ExampleStyle_14():
         self.th_new = NewTheme()
         self.th_new.set_apply_cb(self.new_theme_apply_cb)
         lv.disp_get_default().set_theme(self.th_new)
-        
+
+
 exampleStyle_14 = ExampleStyle_14()

--- a/examples/styles/lv_example_style_2.py
+++ b/examples/styles/lv_example_style_2.py
@@ -19,4 +19,3 @@ style.set_bg_grad_stop(192)
 obj = lv.obj(lv.scr_act())
 obj.add_style(style, 0)
 obj.center()
-

--- a/examples/styles/lv_example_style_3.py
+++ b/examples/styles/lv_example_style_3.py
@@ -19,4 +19,3 @@ style.set_border_side(lv.BORDER_SIDE.BOTTOM | lv.BORDER_SIDE.RIGHT)
 obj = lv.obj(lv.scr_act())
 obj.add_style(style, 0)
 obj.center()
-

--- a/examples/styles/lv_example_style_4.py
+++ b/examples/styles/lv_example_style_4.py
@@ -19,5 +19,3 @@ style.set_outline_pad(8)
 obj = lv.obj(lv.scr_act())
 obj.add_style(style, 0)
 obj.center()
-
-

--- a/examples/styles/lv_example_style_5.py
+++ b/examples/styles/lv_example_style_5.py
@@ -20,4 +20,3 @@ style.set_shadow_ofs_y(20)
 obj = lv.obj(lv.scr_act())
 obj.add_style(style, 0)
 obj.center()
-

--- a/examples/styles/lv_example_style_6.py
+++ b/examples/styles/lv_example_style_6.py
@@ -6,7 +6,7 @@ decoder.open_cb = open_png
 
 # Create an image from the png file
 try:
-    with open('../assets/img_cogwheel_argb.png','rb') as f:
+    with open('../assets/img_cogwheel_argb.png', 'rb') as f:
         png_data = f.read()
 except:
     print("Could not find img_cogwheel_argb.png")
@@ -41,4 +41,3 @@ obj.add_style(style, 0)
 obj.set_src(img_cogwheel_argb)
 
 obj.center()
-

--- a/examples/styles/lv_example_style_7.py
+++ b/examples/styles/lv_example_style_7.py
@@ -11,5 +11,3 @@ style.set_arc_width(4)
 obj = lv.arc(lv.scr_act())
 obj.add_style(style, 0)
 obj.center()
-
-

--- a/examples/styles/lv_example_style_8.py
+++ b/examples/styles/lv_example_style_8.py
@@ -21,7 +21,7 @@ style.set_text_decor(lv.TEXT_DECOR.UNDERLINE)
 obj = lv.label(lv.scr_act())
 obj.add_style(style, 0)
 obj.set_text("Text of\n"
-             "a label");
+             "a label")
 
 obj.center()
 

--- a/examples/styles/lv_example_style_9.py
+++ b/examples/styles/lv_example_style_9.py
@@ -19,4 +19,3 @@ p =  [ {"x":10, "y":30},
 obj.set_points(p, 3)
 
 obj.center()
-

--- a/examples/widgets/bar/lv_example_bar_4.py
+++ b/examples/widgets/bar/lv_example_bar_4.py
@@ -29,7 +29,7 @@ style_indic =  lv.style_t()
 
 style_indic.init()
 style_indic.set_bg_img_src(img_skew_strip_dsc)
-style_indic.set_bg_img_tiled(True);
+style_indic.set_bg_img_tiled(True)
 style_indic.set_bg_img_opa(lv.OPA._30)
 
 bar = lv.bar(lv.scr_act())

--- a/examples/widgets/btn/lv_example_btn_3.py
+++ b/examples/widgets/btn/lv_example_btn_3.py
@@ -34,5 +34,5 @@ btn1.add_style(style_pr, lv.STATE.PRESSED)
 btn1.add_style(style_def, 0)
 
 label = lv.label(btn1)
-label.set_text("Gum");
+label.set_text("Gum")
 

--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_2.py
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_2.py
@@ -25,7 +25,7 @@ def event_cb(e):
         dsc = lv.obj_draw_part_dsc_t.__cast__(e.get_param())
         # Change the draw descriptor the 2nd button
         if dsc.id == 1:
-            dsc.rect_dsc.radius = 0;
+            dsc.rect_dsc.radius = 0
             if obj.get_selected_btn() == dsc.id:
                 dsc.rect_dsc.bg_color = lv.palette_darken(lv.PALETTE.GREY, 3)
             else:
@@ -54,7 +54,7 @@ def event_cb(e):
 
         # Add custom content to the 4th button when the button itself was drawn
         if dsc.id == 3:
-            # LV_IMG_DECLARE(img_star);
+            # LV_IMG_DECLARE(img_star)
             header = lv.img_header_t()
             res = lv.img.decoder_get_info(img_star_argb, header)
             if res != lv.RES.OK:
@@ -63,9 +63,9 @@ def event_cb(e):
             else:
                 a = lv.area_t()
                 a.x1 = dsc.draw_area.x1 + (dsc.draw_area.get_width() - header.w) // 2
-                a.x2 = a.x1 + header.w - 1;
+                a.x2 = a.x1 + header.w - 1
                 a.y1 = dsc.draw_area.y1 + (dsc.draw_area.get_height() - header.h) // 2
-                a.y2 = a.y1 + header.h - 1;
+                a.y2 = a.y1 + header.h - 1
                 img_draw_dsc = lv.draw_img_dsc_t()
                 img_draw_dsc.init()
                 img_draw_dsc.recolor = lv.color_black()

--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_3.py
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_3.py
@@ -47,7 +47,7 @@ map = [lv.SYMBOL.LEFT,"1","2", "3", "4", "5",lv.SYMBOL.RIGHT, ""]
 
 btnm = lv.btnmatrix(lv.scr_act())
 btnm.set_map(map)
-btnm.add_style(style_bg, 0);
+btnm.add_style(style_bg, 0)
 btnm.add_style(style_btn, lv.PART.ITEMS)
 btnm.add_event_cb(event_cb, lv.EVENT.VALUE_CHANGED, None)
 btnm.set_size(225, 35)
@@ -57,7 +57,7 @@ btnm.set_btn_ctrl_all(lv.btnmatrix.CTRL.CHECKABLE)
 btnm.clear_btn_ctrl(0, lv.btnmatrix.CTRL.CHECKABLE)
 btnm.clear_btn_ctrl(6, lv.btnmatrix.CTRL.CHECKABLE)
 
-btnm.set_one_checked(True);
+btnm.set_one_checked(True)
 btnm.set_btn_ctrl(1, lv.btnmatrix.CTRL.CHECKED)
 
 btnm.center()

--- a/examples/widgets/canvas/lv_example_canvas_1.py
+++ b/examples/widgets/canvas/lv_example_canvas_1.py
@@ -30,7 +30,7 @@ canvas.fill_bg(lv.palette_lighten(lv.PALETTE.GREY, 3), lv.OPA.COVER)
 canvas.draw_rect(70, 60, 100, 70, rect_dsc)
 canvas.draw_text(40, 20, 100, label_dsc, "Some text on text canvas")
 
-# Test the rotation. It requires an other buffer where the orignal image is stored.
+# Test the rotation. It requires an other buffer where the original image is stored.
 # So copy the current image to buffer and rotate it to the canvas
 
 img = lv.img_dsc_t()
@@ -40,4 +40,4 @@ img.header.w = _CANVAS_WIDTH
 img.header.h = _CANVAS_HEIGHT
 
 canvas.fill_bg(lv.palette_lighten(lv.PALETTE.GREY, 3), lv.OPA.COVER)
-canvas.transform(img, 30, LV_IMG_ZOOM_NONE, 0, 0, _CANVAS_WIDTH // 2, _CANVAS_HEIGHT // 2, True);
+canvas.transform(img, 30, LV_IMG_ZOOM_NONE, 0, 0, _CANVAS_WIDTH // 2, _CANVAS_HEIGHT // 2, True)

--- a/examples/widgets/chart/lv_example_chart_1.py
+++ b/examples/widgets/chart/lv_example_chart_1.py
@@ -5,7 +5,7 @@ chart.center()
 chart.set_type(lv.chart.TYPE.LINE)   # Show lines and points too
 
 # Add two data series
-ser1 = chart.add_series(lv.palette_main(lv.PALETTE.RED), lv.chart.AXIS.PRIMARY_Y);
+ser1 = chart.add_series(lv.palette_main(lv.PALETTE.RED), lv.chart.AXIS.PRIMARY_Y)
 ser2 = chart.add_series(lv.palette_main(lv.PALETTE.GREEN), lv.chart.AXIS.SECONDARY_Y)
 print(ser2)
 # Set next points on ser1

--- a/examples/widgets/chart/lv_example_chart_2.py
+++ b/examples/widgets/chart/lv_example_chart_2.py
@@ -44,7 +44,7 @@ def draw_event_cb(e):
 
 def add_data(timer):
     # LV_UNUSED(timer);
-    cnt = 0;
+    cnt = 0
     chart1.set_next_value(ser1, lv.rand(20, 90))
 
     if cnt % 4 == 0:

--- a/examples/widgets/chart/lv_example_chart_3.py
+++ b/examples/widgets/chart/lv_example_chart_3.py
@@ -28,8 +28,8 @@ chart.set_axis_tick(lv.chart.AXIS.SECONDARY_Y, 10, 5, 3, 4,True, 50)
 chart.set_zoom_x(800)
 
 # Add two data series
-ser1 = lv.chart.add_series(chart, lv.palette_lighten(lv.PALETTE.GREEN, 2), lv.chart.AXIS.PRIMARY_Y);
-ser2 = lv.chart.add_series(chart, lv.palette_darken(lv.PALETTE.GREEN, 2), lv.chart.AXIS.SECONDARY_Y);
+ser1 = lv.chart.add_series(chart, lv.palette_lighten(lv.PALETTE.GREEN, 2), lv.chart.AXIS.PRIMARY_Y)
+ser2 = lv.chart.add_series(chart, lv.palette_darken(lv.PALETTE.GREEN, 2), lv.chart.AXIS.SECONDARY_Y)
 
 # Set the next points on 'ser1'
 chart.set_next_value(ser1, 31)

--- a/examples/widgets/chart/lv_example_chart_4.py
+++ b/examples/widgets/chart/lv_example_chart_4.py
@@ -24,7 +24,7 @@ def event_cb(e):
             draw_rect_dsc.bg_color = lv.color_black()
             draw_rect_dsc.bg_opa = lv.OPA._50
             draw_rect_dsc.radius = 3
-            draw_rect_dsc.bg_img_src = buf;
+            draw_rect_dsc.bg_img_src = buf
             draw_rect_dsc.bg_img_recolor = lv.color_white()
             
             a = lv.area_t()

--- a/examples/widgets/chart/lv_example_chart_6.py
+++ b/examples/widgets/chart/lv_example_chart_6.py
@@ -56,7 +56,7 @@ class ExampleChart_6():
                 # print("last_id: ",self.last_id)
             if dsc.part == lv.PART.CURSOR and dsc.p1 and dsc.p2 and dsc.p1.y == dsc.p2.y and self.last_id >= 0:
 
-                v = self.ser_p[self.last_id];
+                v = self.ser_p[self.last_id]
      
                 # print("value: ",v)
                 value_txt = str(v)
@@ -66,13 +66,13 @@ class ExampleChart_6():
                 a = lv.area_t()
                 a.y2 = dsc.p1.y - 5
                 a.y1 = a.y2 - size.y - 10
-                a.x1 = dsc.p1.x + 10;
-                a.x2 = a.x1 + size.x + 10;
+                a.x1 = dsc.p1.x + 10
+                a.x2 = a.x1 + size.x + 10
                 
                 draw_rect_dsc = lv.draw_rect_dsc_t()
                 draw_rect_dsc.init()
                 draw_rect_dsc.bg_color = lv.palette_main(lv.PALETTE.BLUE)
-                draw_rect_dsc.radius = 3;
+                draw_rect_dsc.radius = 3
                 
                 lv.draw_rect(a, dsc.clip_area, draw_rect_dsc)
                 

--- a/examples/widgets/checkbox/lv_example_checkbox_1.py
+++ b/examples/widgets/checkbox/lv_example_checkbox_1.py
@@ -4,9 +4,9 @@ def event_handler(e):
     if code == lv.EVENT.VALUE_CHANGED:
         txt = obj.get_text()
         if obj.get_state() & lv.STATE.CHECKED:
-            state =  "Checked"
+            state = "Checked"
         else:
-            state = "Unchecked";
+            state = "Unchecked"
         print(txt + ":" + state)
 
 

--- a/examples/widgets/img/lv_example_img_2.py
+++ b/examples/widgets/img/lv_example_img_2.py
@@ -25,8 +25,8 @@ img_cogwheel_argb = lv.img_dsc_t({
 def create_slider(color):
     slider = lv.slider(lv.scr_act())
     slider.set_range(0, 255)
-    slider.set_size(10, 200);
-    slider.set_style_bg_color(color, lv.PART.KNOB);
+    slider.set_size(10, 200)
+    slider.set_style_bg_color(color, lv.PART.KNOB)
     slider.set_style_bg_color(color.color_darken(lv.OPA._40), lv.PART.INDICATOR)
     slider.add_event_cb(slider_event_cb, lv.EVENT.VALUE_CHANGED, None)
     return slider

--- a/examples/widgets/imgbtn/lv_example_imgbtn_1.py
+++ b/examples/widgets/imgbtn/lv_example_imgbtn_1.py
@@ -69,6 +69,6 @@ imgbtn1.align(lv.ALIGN.CENTER, 0, 0)
 
 # Create a label on the image button
 label = lv.label(imgbtn1)
-label.set_text("Button");
+label.set_text("Button")
 label.align(lv.ALIGN.CENTER, 0, -4)
 

--- a/examples/widgets/label/lv_example_label_1.py
+++ b/examples/widgets/label/lv_example_label_1.py
@@ -2,7 +2,7 @@
 # Show line wrap, re-color, line align and text scrolling.
 #
 label1 = lv.label(lv.scr_act())
-label1.set_long_mode(lv.label.LONG.WRAP);     # Break the long lines*/
+label1.set_long_mode(lv.label.LONG.WRAP)      # Break the long lines*/
 label1.set_recolor(True)                      # Enable re-coloring by commands in the text
 label1.set_text("#0000ff Re-color# #ff00ff words# #ff0000 of a# label, align the lines to the center"
                               "and  wrap long text automatically.")

--- a/examples/widgets/label/lv_example_label_3.py
+++ b/examples/widgets/label/lv_example_label_3.py
@@ -4,7 +4,7 @@ import fs_driver
 #
 
 ltr_label = lv.label(lv.scr_act())
-ltr_label.set_text("In modern terminology, a microcontroller is similar to a system on a chip (SoC).");
+ltr_label.set_text("In modern terminology, a microcontroller is similar to a system on a chip (SoC).")
 # ltr_label.set_style_text_font(ltr_label, &lv_font_montserrat_16, 0);
 
 fs_drv = lv.fs_drv_t()

--- a/examples/widgets/menu/lv_example_menu_4.py
+++ b/examples/widgets/menu/lv_example_menu_4.py
@@ -13,7 +13,7 @@ def float_btn_event_cb(e):
     cont = lv.menu_cont(main_page)
     label = lv.label(cont)
     label.set_text("Item {:d}".format(btn_cnt))
-    menu.set_load_page_event(cont, sub_page);
+    menu.set_load_page_event(cont, sub_page)
 
 # Create a menu object
 menu = lv.menu(lv.scr_act())

--- a/examples/widgets/roller/lv_example_roller_2.py
+++ b/examples/widgets/roller/lv_example_roller_2.py
@@ -39,7 +39,7 @@ roller.add_event_cb(event_handler, lv.EVENT.ALL, None)
 roller.set_selected(2, lv.ANIM.OFF)
 
 # A roller on the middle with center aligned text, and auto (default) width
-roller = lv.roller(lv.scr_act());
+roller = lv.roller(lv.scr_act())
 roller.set_options(opts, lv.roller.MODE.NORMAL)
 roller.set_visible_row_count(3)
 roller.add_style(style_sel, lv.PART.SELECTED)
@@ -48,7 +48,7 @@ roller.add_event_cb(event_handler, lv.EVENT.ALL, None)
 roller.set_selected(5, lv.ANIM.OFF)
 
 # A roller on the right with right aligned text, and custom width
-roller = lv.roller(lv.scr_act());
+roller = lv.roller(lv.scr_act())
 roller.set_options(opts, lv.roller.MODE.NORMAL)
 roller.set_visible_row_count(4)
 roller.set_width(80)

--- a/examples/widgets/roller/lv_example_roller_3.py
+++ b/examples/widgets/roller/lv_example_roller_3.py
@@ -93,7 +93,7 @@ class Lv_Roller_3():
             # Remove the masks
             lv.draw_mask_remove_id(self.mask_top_id)
             lv.draw_mask_remove_id(self.mask_bottom_id)
-            self.mask_top_id = -1;
-            self.mask_bottom_id = -1;
+            self.mask_top_id = -1
+            self.mask_bottom_id = -1
             
 roller3 = Lv_Roller_3()

--- a/examples/widgets/span/lv_example_span_1.py
+++ b/examples/widgets/span/lv_example_span_1.py
@@ -25,7 +25,7 @@ span.style.set_text_decor(lv.TEXT_DECOR.STRIKETHROUGH | lv.TEXT_DECOR.UNDERLINE)
 span.style.set_text_opa(lv.OPA._30)
 
 span = spans.new_span()
-span.set_text_static("good good study, day day up.");
+span.set_text_static("good good study, day day up.")
 #if LV_FONT_MONTSERRAT_24
 #    lv_style_set_text_font(&span->style,  &lv_font_montserrat_24);
 #endif

--- a/examples/widgets/table/lv_example_table_1.py
+++ b/examples/widgets/table/lv_example_table_1.py
@@ -25,24 +25,24 @@ def draw_part_event_cb(e):
 table = lv.table(lv.scr_act())
 
 # Fill the first column
-table.set_cell_value(0, 0, "Name");
-table.set_cell_value(1, 0, "Apple");
-table.set_cell_value(2, 0, "Banana");
-table.set_cell_value(3, 0, "Lemon");
-table.set_cell_value(4, 0, "Grape");
-table.set_cell_value(5, 0, "Melon");
-table.set_cell_value(6, 0, "Peach");
-table.set_cell_value(7, 0, "Nuts");
+table.set_cell_value(0, 0, "Name")
+table.set_cell_value(1, 0, "Apple")
+table.set_cell_value(2, 0, "Banana")
+table.set_cell_value(3, 0, "Lemon")
+table.set_cell_value(4, 0, "Grape")
+table.set_cell_value(5, 0, "Melon")
+table.set_cell_value(6, 0, "Peach")
+table.set_cell_value(7, 0, "Nuts")
 
 # Fill the second column
-table.set_cell_value(0, 1, "Price");
-table.set_cell_value(1, 1, "$7");
-table.set_cell_value(2, 1, "$4");
-table.set_cell_value(3, 1, "$6");
-table.set_cell_value(4, 1, "$2");
-table.set_cell_value(5, 1, "$5");
-table.set_cell_value(6, 1, "$1");
-table.set_cell_value(7, 1, "$9");
+table.set_cell_value(0, 1, "Price")
+table.set_cell_value(1, 1, "$7")
+table.set_cell_value(2, 1, "$4")
+table.set_cell_value(3, 1, "$6")
+table.set_cell_value(4, 1, "$2")
+table.set_cell_value(5, 1, "$5")
+table.set_cell_value(6, 1, "$1")
+table.set_cell_value(7, 1, "$9")
 
 # Set a smaller height to the table. It'll make it scrollable
 table.set_height(200)

--- a/examples/widgets/table/lv_example_table_2.py
+++ b/examples/widgets/table/lv_example_table_2.py
@@ -16,15 +16,15 @@ def draw_event_cb(e):
         if chk:
             rect_dsc.bg_color = lv.theme_get_color_primary(obj)
         else:
-            rect_dsc.bg_color = lv.palette_lighten(lv.PALETTE.GREY,2)
+            rect_dsc.bg_color = lv.palette_lighten(lv.PALETTE.GREY, 2)
             
         rect_dsc.radius = lv.RADIUS.CIRCLE
 
         sw_area = lv.area_t()
-        sw_area.x1 = dsc.draw_area.x2 - 50;
-        sw_area.x2 = sw_area.x1 + 40;
-        sw_area.y1 =  dsc.draw_area.y1 + dsc.draw_area.get_height() // 2 - 10
-        sw_area.y2 = sw_area.y1 + 20;
+        sw_area.x1 = dsc.draw_area.x2 - 50
+        sw_area.x2 = sw_area.x1 + 40
+        sw_area.y1 = dsc.draw_area.y1 + dsc.draw_area.get_height() // 2 - 10
+        sw_area.y2 = sw_area.y1 + 20
         lv.draw_rect(sw_area, dsc.clip_area, rect_dsc)
          
         rect_dsc.bg_color = lv.color_white()
@@ -35,8 +35,8 @@ def draw_event_cb(e):
         else:
             sw_area.x1 += 2
             sw_area.x2 = sw_area.x1 + 16
-        sw_area.y1 += 2;
-        sw_area.y2 -= 2;
+        sw_area.y1 += 2
+        sw_area.y2 -= 2
         lv.draw_rect(sw_area, dsc.clip_area, rect_dsc)
 
 def change_event_cb(e):
@@ -60,7 +60,7 @@ def change_event_cb(e):
 gc.enable()
 gc.collect()
 mem_free = gc.mem_free()
-print("mem_free: ",mem_free)
+print("mem_free: ", mem_free)
 t = ticks_ms()
 print("ticks: ", t)
 table = lv.table(lv.scr_act())
@@ -78,7 +78,7 @@ table.remove_style(None, lv.PART.ITEMS | lv.STATE.PRESSED)
 for i in range(ITEM_CNT):
     table.set_cell_value(i, 0, "Item " + str(i+1))
 
-table.align(lv.ALIGN.CENTER, 0, -20);
+table.align(lv.ALIGN.CENTER, 0, -20)
 
 # Add an event callback to to apply some custom drawing
 table.add_event_cb(draw_event_cb, lv.EVENT.DRAW_PART_END, None)
@@ -93,4 +93,3 @@ label.set_text(str(ITEM_CNT) + " items were created in " + str(elaps) + " ms\n u
 #label.set_text(str(ITEM_CNT) + " items were created in " + str(elaps) + " ms")
 
 label.align(lv.ALIGN.BOTTOM_MID, 0, -10)
-


### PR DESCRIPTION
A semi-colon in Python denotes separation, rather than termination.
This commit removes all semicolons at line endings in the Python examples.

Also a few other trivial Python style changes like removing extra empty lines at file endings, missing spaces after an operator, double spaces after an operator.