### PR TITLE
Fix set px cb crash

### DIFF
--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -420,8 +420,6 @@ static void map_set_px(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_a
 
     int32_t src_stride = lv_area_get_width(src_area);
 
-    dest_buf += dest_stride * clip_area->y1 + clip_area->x1;
-
     src_buf += src_stride * (clip_area->y1 - src_area->y1);
     src_buf += (clip_area->x1 - src_area->x1);
 
@@ -430,7 +428,7 @@ static void map_set_px(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_a
 
     if(mask == NULL) {
         for(y = 0; y < clip_h; y++) {
-            for(x = 0; x <= clip_w; x++) {
+            for(x = 0; x < clip_w; x++) {
                 disp->driver->set_px_cb(disp->driver, (void *)dest_buf, dest_stride, clip_area->x1 + x, clip_area->y1 + y, src_buf[x],
                                         opa);
             }
@@ -439,7 +437,7 @@ static void map_set_px(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_a
     }
     else {
         for(y = 0; y < clip_h; y++) {
-            for(x = 0; x <= clip_w; x++) {
+            for(x = 0; x < clip_w; x++) {
                 if(mask[x]) {
                     disp->driver->set_px_cb(disp->driver, (void *)dest_buf, dest_stride, clip_area->x1 + x, clip_area->y1 + y, src_buf[x],
                                             (uint32_t)((uint32_t)opa * mask[x]) >> 8);


### PR DESCRIPTION
### disp->driver->set_px_cb write buffer overflow

The coords in below code means the dest_buf includes clip_area data, thus should not modify dest_buf in line423.
```c
disp->driver->set_px_cb(disp->driver, (void *)dest_buf, dest_stride, clip_area->x1 + x, clip_area->y1 + y, src_buf[x],
                                        opa);
```

And buffer width should not overflow `clip_w`.

Include lv_gpu_sdl.mk optionally, to avoid compiling error.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
