### PR TITLE
fix(area): Use unsigned integer literal for bit shifing.

### DIFF
--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -234,9 +234,9 @@ void lv_area_align(const lv_area_t * base, lv_area_t * to_align, lv_align_t alig
  **********************/
 
 #if LV_USE_LARGE_COORD
-#define _LV_COORD_TYPE_SHIFT    (29)
+#define _LV_COORD_TYPE_SHIFT    (29U)
 #else
-#define _LV_COORD_TYPE_SHIFT    (13)
+#define _LV_COORD_TYPE_SHIFT    (13U)
 #endif
 
 #define _LV_COORD_TYPE_MASK     (3 << _LV_COORD_TYPE_SHIFT)


### PR DESCRIPTION
Fixes hicpp-signed-bitwise error.

### Description of the feature or fix

Use unsigned integer literals for `_LV_COORD_TYPE_SHIFT` to silence clang-tidy error about using signed integer to perform bitshift operations (hicpp-signed-bitwise).

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
