### PR TITLE
Add support for animated buttons with rlottie

### DIFF
--- a/docs/libs/rlottie.md
+++ b/docs/libs/rlottie.md
@@ -95,6 +95,9 @@ If you don't enable looping, a `LV_EVENT_READY` is sent when the animation can n
 
 To get the number of frames in an animation or the current frame index, you can cast the `lv_obj_t` instance to a `lv_rlottie_t` instance and inspect the `current_frame` and `total_frames` members. 
 
+If you need to play an animation until a specific frame, you can use `lv_rlottie_stopat_frame` function. 
+It'll resume playing (if paused) until the specified frame is reached and pause from there and also sending a `LV_EVENT_READY` event.
+
 ## Example
 ```eval_rst
 

--- a/docs/widgets/extra/animbtn.md
+++ b/docs/widgets/extra/animbtn.md
@@ -22,8 +22,7 @@ You'll construct this button with `lv_animbtn_create(parent, lottie)`.
 The `lottie` instance is constructed as usual (for example like this: `lv_obj_t * lottie = lv_rlottie_create_from_file(parent, 64, 64, "test.json")`).
 It's orphaned and attached as a child of this button so the given parent is not important. 
 
-Then, to set the button's states from the animation, you'll have to build a `lv_animbtn_state_desc_t` containing the first frame to play when in the state, the last frame not to play (or said differently, if you want to play only one frame, `last_frame` will be `first_frame + 1`).
-You'll also set the `control` mode for this animation state (forward, backward, with or without looping), see `lv_rlottie_ctrl_t`).
+Then, to set the button's states from the animation, you'll have to build a `lv_animbtn_state_desc_t` containing the first frame to play when in the state, the last frame to play and the `control` mode for this animation state (forward, backward, with or without looping), see `lv_rlottie_ctrl_t`).
 
 Then attach your state descriptor to a state with `lv_animbtn_set_state_desc(btn, state, desc)`.
 By default, state descriptors are invalid and not used.

--- a/docs/widgets/extra/animbtn.md
+++ b/docs/widgets/extra/animbtn.md
@@ -1,0 +1,75 @@
+```eval_rst
+.. include:: /header.rst 
+:github_url: |github_link_base|/widgets/animbtn.md
+```
+# Image button (lv_animbtn)
+
+## Overview
+
+The Animation button is very similar to the simple 'Button' object. The only difference is that it displays selected part of an animation in each state instead of drawing a rectangle.
+
+Typically used with a unique [lv_rlottie_t](libs/rlottie.md) animation containing all the states of the button.
+
+
+
+## Parts and Styles
+None. It's a wrapper over a [lv_rlottie_t](libs/rlottie.md) object
+
+## Usage
+
+### Animation source
+You'll construct this button with `lv_animbtn_create(parent, lottie)`.
+The `lottie` instance is constructed as usual (for example like this: `lv_obj_t * lottie = lv_rlottie_create_from_file(parent, 64, 64, "test.json")`).
+It's orphaned and attached as a child of this button so the given parent is not important. 
+
+Then, to set the button's states from the animation, you'll have to build a `lv_animbtn_state_desc_t` containing the first frame to play when in the state, the last frame not to play (or said differently, if you want to play only one frame, `last_frame` will be `first_frame + 1`).
+You'll also set the `control` mode for this animation state (forward, backward, with or without looping), see `lv_rlottie_ctrl_t`).
+
+Then attach your state descriptor to a state with `lv_animbtn_set_state_desc(btn, state, desc)`.
+By default, state descriptors are invalid and not used.
+
+The possible states are:
+- `LV_ANIMBTN_STATE_RELEASED`
+- `LV_ANIMBTN_STATE_PRESSED`
+- `LV_ANIMBTN_STATE_DISABLED`
+- `LV_ANIMBTN_STATE_CHECKED_RELEASED`
+- `LV_ANIMBTN_STATE_CHECKED_PRESSED`
+- `LV_ANIMBTN_STATE_CHECKED_DISABLED`
+
+If you set a descriptor only in `LV_ANIMBTN_STATE_RELEASED`, this descriptor will be used in other states too. 
+If you set e.g. `LV_ANIMBTN_STATE_PRESSED` they will be used in pressed state instead of the released images.
+
+
+### States
+Instead of the regular `lv_obj_add/clear_state()` functions the `lv_animbtn_set_state(imgbtn, LV_ANIMBTN_STATE_...)` functions should be used to manually set a state.
+
+
+## Events
+- `LV_EVENT_VALUE_CHANGED` Sent when the button is toggled.
+
+Learn more about [Events](/overview/event).
+
+## Keys
+- `LV_KEY_RIGHT/UP`  Go to toggled state if `LV_OBJ_FLAG_CHECKABLE` is enabled.
+- `LV_KEY_LEFT/DOWN`  Go to non-toggled state if `LV_OBJ_FLAG_CHECKABLE` is enabled.
+- `LV_KEY_ENTER` Clicks the button
+
+
+Learn more about [Keys](/overview/indev).
+
+## Example
+
+```eval_rst
+
+.. include:: ../../../examples/widgets/animbtn/index.rst
+
+```
+
+## API
+
+```eval_rst
+
+.. doxygenfile:: lv_animbtn.h
+  :project: lvgl
+
+```

--- a/examples/widgets/animbtn/index.rst
+++ b/examples/widgets/animbtn/index.rst
@@ -1,0 +1,7 @@
+
+Simple Animation button 
+"""""""""""""""""""""""
+
+.. lv_example:: widgets/animbtn/lv_example_animbtn_1
+  :language: c
+

--- a/examples/widgets/animbtn/lv_example_animbtn_1.c
+++ b/examples/widgets/animbtn/lv_example_animbtn_1.c
@@ -1,0 +1,25 @@
+#include "../../lv_examples.h"
+#if LV_USE_ANIMBTN && LV_BUILD_EXAMPLES
+
+void lv_example_animbtn_1(void)
+{
+    /*Create a lottie animation to use*/
+    lv_obj_t * lottie = lv_rlottie_create_from_file(lv_scr_act(), 64, 64, "test.json");
+    /*Create a animation button*/
+    lv_obj_t * anim = lv_animbtn_create(lv_scr_act(), lottie);
+
+    /*Prepare descriptors for some states*/
+    lv_animbtn_state_desc_t desc;
+    desc.first_frame = 0;
+    desc.last_frame = 1;
+    desc.control = 0;
+    lv_animbtn_set_state_desc(anim, LV_ANIMBTN_STATE_RELEASED, desc);
+
+    desc.first_frame = 1;
+    desc.last_frame = ((lv_rlottie_t*)lottie)->total_frames;
+    desc.control = LV_RLOTTIE_CTRL_LOOP | LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_FORWARD;
+    lv_animbtn_set_state_desc(anim, LV_ANIMBTN_STATE_CHECKED_RELEASED, desc);
+    lv_obj_center(anim);
+}
+
+#endif

--- a/examples/widgets/animbtn/lv_example_animbtn_1.c
+++ b/examples/widgets/animbtn/lv_example_animbtn_1.c
@@ -17,7 +17,7 @@ void lv_example_animbtn_1(void)
 
     desc.first_frame = 1;
     desc.last_frame = ((lv_rlottie_t*)lottie)->total_frames;
-    desc.control = LV_RLOTTIE_CTRL_LOOP | LV_RLOTTIE_CTRL_PLAY | LV_RLOTTIE_CTRL_FORWARD;
+    desc.control = LV_ANIMBTN_CTRL_LOOP | LV_ANIMBTN_CTRL_FORWARD;
     lv_animbtn_set_state_desc(anim, LV_ANIMBTN_STATE_CHECKED_RELEASED, desc);
     lv_obj_center(anim);
 }

--- a/examples/widgets/animbtn/lv_example_animbtn_1.c
+++ b/examples/widgets/animbtn/lv_example_animbtn_1.c
@@ -1,5 +1,5 @@
 #include "../../lv_examples.h"
-#if LV_USE_ANIMBTN && LV_BUILD_EXAMPLES
+#if LV_USE_ANIMBTN == 1 && LV_USE_RLOTTIE == 1 && LV_BUILD_EXAMPLES
 
 void lv_example_animbtn_1(void)
 {

--- a/examples/widgets/lv_example_widgets.h
+++ b/examples/widgets/lv_example_widgets.h
@@ -75,6 +75,7 @@ void lv_example_img_3(void);
 void lv_example_img_4(void);
 
 void lv_example_imgbtn_1(void);
+void lv_example_animbtn_1(void);
 
 void lv_example_keyboard_1(void);
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -478,6 +478,8 @@
 
 #define LV_USE_IMGBTN     1
 
+#define LV_USE_ANIMBTN    1
+
 #define LV_USE_KEYBOARD   1
 
 #define LV_USE_LED        1

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lvgl.h"
+#include "../../../widgets/lv_img.h"
 #if LV_USE_RLOTTIE
 
 /*********************

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -31,6 +31,7 @@ typedef enum {
     LV_RLOTTIE_CTRL_PAUSE    = 2,
     LV_RLOTTIE_CTRL_PLAY     = 0, /* Yes, play = 0 is the default mode */
     LV_RLOTTIE_CTRL_LOOP     = 8,
+    LV_RLOTTIE_CTRL_STOPAT   = 4,
 } lv_rlottie_ctrl_t;
 
 typedef struct {
@@ -61,6 +62,7 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
 
 void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
+void lv_rlottie_stopat_frame(lv_obj_t * rlottie, const size_t goto_frame, const int forward);
 
 /**********************
  *      MACROS

--- a/src/extra/widgets/animbtn/lv_animbtn.c
+++ b/src/extra/widgets/animbtn/lv_animbtn.c
@@ -169,10 +169,6 @@ static void lv_animbtn_event(const lv_obj_class_t * class_p, lv_event_t * e)
         case LV_EVENT_PRESS_LOST:
             apply_state(obj);
             break;
-        case LV_EVENT_DRAW_MAIN:
-            //draw_main(e);
-            lv_obj_invalidate(animbtn->lottie);
-            break;
         case LV_EVENT_COVER_CHECK: {
                 lv_cover_check_info_t * info = lv_event_get_param(e);
                 if(info->res != LV_COVER_RES_MASKED) info->res = LV_COVER_RES_NOT_COVER;

--- a/src/extra/widgets/animbtn/lv_animbtn.c
+++ b/src/extra/widgets/animbtn/lv_animbtn.c
@@ -1,0 +1,320 @@
+/**
+ * @file lv_animbtn.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_animbtn.h"
+
+#if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
+
+/*********************
+ *      DEFINES
+ *********************/
+#define MY_CLASS &lv_animbtn_class
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void lv_animbtn_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
+static void lv_animbtn_event(const lv_obj_class_t * class_p, lv_event_t * e);
+static void draw_main(lv_event_t * e);
+static void apply_state(lv_obj_t * animbtn);
+static void loop_state(lv_obj_t * animbtn);
+static lv_animbtn_state_t suggest_state(lv_obj_t * animbtn, lv_animbtn_state_t state);
+static lv_animbtn_state_t get_state(const lv_obj_t * animbtn);
+static int is_state_valid(const lv_animbtn_state_desc_t * state);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+const lv_obj_class_t lv_animbtn_class = {
+    .base_class = &lv_obj_class,
+    .instance_size = sizeof(lv_animbtn_t),
+    .constructor_cb = lv_animbtn_constructor,
+    .event_cb = lv_animbtn_event,
+};
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+/**
+ * Create an image button object
+ * @param parent pointer to an object, it will be the parent of the new image button
+ * @return pointer to the created image button
+ */
+lv_obj_t * lv_animbtn_create(lv_obj_t * parent, lv_obj_t * anim)
+{
+    LV_LOG_INFO("begin");
+    lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
+    lv_obj_class_init_obj(obj);
+    /*Capture the animation picture*/
+    ((lv_animbtn_t*)obj)->lottie = anim;
+    lv_obj_set_parent(anim, obj);
+    lv_obj_add_flag(anim, LV_OBJ_FLAG_EVENT_BUBBLE);
+
+    lv_obj_set_size(obj, lv_obj_get_width(anim), lv_obj_get_height(anim));
+    return obj;
+}
+
+/*=====================
+ * Setter functions
+ *====================*/
+
+/**
+ * Set images for a state of the image button
+ * @param obj pointer to an image button object
+ * @param state for which state set the new image
+ * @param src_left pointer to an image source for the left side of the button (a C array or path to
+ * a file)
+ * @param src_mid pointer to an image source for the middle of the button (ideally 1px wide) (a C
+ * array or path to a file)
+ * @param src_right pointer to an image source for the right side of the button (a C array or path
+ * to a file)
+ */
+void lv_animbtn_set_state_desc(lv_obj_t * obj, lv_animbtn_state_t state, const lv_animbtn_state_desc_t desc)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+
+    animbtn->state_desc[state] = desc;
+    animbtn->state_desc[state].control |= 0x80; /*A non existant flag used to mark that the state was used*/
+    apply_state(obj);
+}
+
+void lv_animbtn_set_state(lv_obj_t * obj, lv_animbtn_state_t state)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_state_t obj_state = LV_STATE_DEFAULT;
+    if(state == LV_ANIMBTN_STATE_PRESSED || state == LV_ANIMBTN_STATE_CHECKED_PRESSED) obj_state |= LV_STATE_PRESSED;
+    if(state == LV_ANIMBTN_STATE_DISABLED || state == LV_ANIMBTN_STATE_CHECKED_DISABLED) obj_state |= LV_STATE_DISABLED;
+    if(state == LV_ANIMBTN_STATE_CHECKED_DISABLED || state == LV_ANIMBTN_STATE_CHECKED_PRESSED ||
+       state == LV_ANIMBTN_STATE_CHECKED_RELEASED) {
+        obj_state |= LV_STATE_CHECKED;
+    }
+
+    lv_obj_clear_state(obj, LV_STATE_CHECKED | LV_STATE_PRESSED | LV_STATE_DISABLED);
+    lv_obj_add_state(obj, obj_state);
+
+    apply_state(obj);
+}
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/**
+ * Get the right image in a given state
+ * @param obj pointer to an image button object
+ * @param state the state where to get the image (from `lv_btn_state_t`) `
+ * @return pointer to the left image source (a C array or path to a file)
+ */
+const lv_animbtn_state_desc_t * lv_animbtn_get_state_desc(lv_obj_t * obj, lv_animbtn_state_t state)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+
+    return &animbtn->state_desc[state];
+}
+
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void lv_animbtn_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
+{
+    LV_UNUSED(class_p);
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    /*Initialize the allocated 'ext'*/
+    lv_memset_00(animbtn->state_desc, sizeof(animbtn->state_desc));
+    animbtn->lottie = NULL;
+    animbtn->prev_state = _LV_ANIMBTN_STATE_NUM;
+
+    lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+}
+
+
+static void lv_animbtn_event(const lv_obj_class_t * class_p, lv_event_t * e)
+{
+    LV_UNUSED(class_p);
+
+    lv_res_t res = lv_obj_event_base(&lv_animbtn_class, e);
+    if(res != LV_RES_OK) return;
+
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    int is_same = obj == lv_event_get_target(e);
+    switch(code) {
+        case LV_EVENT_READY:
+            /*Should we loop?*/
+            loop_state(obj);
+            break;
+        case LV_EVENT_PRESSED:
+        case LV_EVENT_RELEASED:
+        case LV_EVENT_PRESS_LOST:
+            apply_state(obj);
+            break;
+        case LV_EVENT_DRAW_MAIN:
+            //draw_main(e);
+            lv_obj_invalidate(animbtn->lottie);
+            break;
+        case LV_EVENT_COVER_CHECK: {
+            lv_cover_check_info_t * info = lv_event_get_param(e);
+            if(info->res != LV_COVER_RES_MASKED) info->res = LV_COVER_RES_NOT_COVER;
+            break;
+        }
+        case LV_EVENT_GET_SELF_SIZE: {
+            lv_point_t * p = lv_event_get_self_size_info(e);
+            lv_img_header_t * header = &((lv_rlottie_t*)animbtn->lottie)->imgdsc.header;
+            p->x = LV_MAX(p->x, header->w);
+            break;
+        }
+        default: break;
+    }
+}
+
+static void draw_main(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target(e);
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    const lv_area_t * clip_area = lv_event_get_param(e);
+
+    lv_coord_t tw = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
+    lv_coord_t th = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
+    lv_area_t coords;
+    lv_area_copy(&coords, &obj->coords);
+    lv_rlottie_t * lottie = (lv_rlottie_t *)animbtn->lottie;
+    coords.x1 -= tw;
+    coords.y1 -= th;
+    coords.x2 = coords.x1 + lottie->imgdsc.header.w - 1;
+    coords.y2 = coords.y1 + lottie->imgdsc.header.h - 1;
+
+    lv_draw_img_dsc_t img_dsc;
+    lv_draw_img_dsc_init(&img_dsc);
+    lv_obj_init_draw_img_dsc(obj, LV_PART_MAIN, &img_dsc);
+
+    lv_draw_img(&coords, clip_area, ((lv_rlottie_t*)animbtn->lottie)->allocated_buf, &img_dsc);
+}
+
+
+static void loop_state(lv_obj_t * obj)
+{
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    lv_animbtn_state_t state  = suggest_state(obj, get_state(obj));
+
+    lv_rlottie_t * lottie = (lv_rlottie_t *)animbtn->lottie;
+    if(animbtn->prev_state != state || lottie == NULL || !is_state_valid(&animbtn->state_desc[state])) return;
+
+    /*Set the logic for the current state*/
+    if ((animbtn->state_desc[state].control & LV_RLOTTIE_CTRL_LOOP) == LV_RLOTTIE_CTRL_LOOP) {
+        lv_rlottie_set_current_frame(lottie, animbtn->state_desc[state].first_frame);
+        lv_rlottie_stopat_frame(lottie, animbtn->state_desc[state].last_frame, (animbtn->state_desc[state].control & LV_RLOTTIE_CTRL_FORWARD) == LV_RLOTTIE_CTRL_FORWARD);
+        lv_obj_invalidate(lottie);
+    }
+}
+
+
+static void apply_state(lv_obj_t * obj)
+{
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    lv_animbtn_state_t state  = suggest_state(obj, get_state(obj));
+
+    lv_rlottie_t * lottie = (lv_rlottie_t *)animbtn->lottie;
+    if(state == animbtn->prev_state || lottie == NULL || !is_state_valid(&animbtn->state_desc[state])) return;
+
+    /*Set the logic for the current state*/
+    lv_rlottie_set_current_frame(lottie, animbtn->state_desc[state].first_frame);
+    lv_rlottie_stopat_frame(lottie, animbtn->state_desc[state].last_frame, (animbtn->state_desc[state].control & LV_RLOTTIE_CTRL_FORWARD) == LV_RLOTTIE_CTRL_FORWARD);
+
+    lv_obj_refresh_self_size(obj);
+    lv_obj_set_height(obj, lottie->imgdsc.header.h); /*Keep the user defined width*/
+
+    lv_obj_invalidate(obj);
+    animbtn->prev_state = state;
+}
+
+/**
+ * Check if a state is valid (initialized).
+ */
+static int is_state_valid(const lv_animbtn_state_desc_t * state) {
+    return (state->control & 0x80) == 0x80;
+}
+
+
+/**
+ * If `src` is not defined for the current state try to get a state which is related to the current but has a valid descriptor.
+ * E.g. if the PRESSED src is not set but the RELEASED does, use the RELEASED.
+ * @param animbtn pointer to an image button
+ * @param state the state to convert
+ * @return the suggested state
+ */
+static lv_animbtn_state_t suggest_state(lv_obj_t * obj, lv_animbtn_state_t state)
+{
+    lv_animbtn_t * animbtn = (lv_animbtn_t *)obj;
+    if(!is_state_valid(&animbtn->state_desc[state])) {
+        switch(state) {
+            case LV_ANIMBTN_STATE_PRESSED:
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_RELEASED])) return LV_ANIMBTN_STATE_RELEASED;
+                break;
+            case LV_ANIMBTN_STATE_CHECKED_RELEASED:
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_RELEASED])) return LV_ANIMBTN_STATE_RELEASED;
+                break;
+            case LV_ANIMBTN_STATE_CHECKED_PRESSED:
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_CHECKED_RELEASED])) return LV_ANIMBTN_STATE_CHECKED_RELEASED;
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_PRESSED])) return LV_ANIMBTN_STATE_PRESSED;
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_RELEASED])) return LV_ANIMBTN_STATE_RELEASED;
+                break;
+            case LV_ANIMBTN_STATE_DISABLED:
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_RELEASED])) return LV_ANIMBTN_STATE_RELEASED;
+                break;
+            case LV_ANIMBTN_STATE_CHECKED_DISABLED:
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_CHECKED_RELEASED])) return LV_ANIMBTN_STATE_CHECKED_RELEASED;
+                if(is_state_valid(&animbtn->state_desc[LV_ANIMBTN_STATE_RELEASED])) return LV_ANIMBTN_STATE_RELEASED;
+                break;
+            default:
+                break;
+        }
+    }
+
+    return state;
+}
+
+lv_animbtn_state_t get_state(const lv_obj_t * animbtn)
+{
+    LV_ASSERT_OBJ(animbtn, MY_CLASS);
+
+    lv_state_t obj_state = lv_obj_get_state(animbtn);
+
+    if(obj_state & LV_STATE_DISABLED) {
+        if(obj_state & LV_STATE_CHECKED) return LV_ANIMBTN_STATE_CHECKED_DISABLED;
+        else return LV_ANIMBTN_STATE_DISABLED;
+    }
+
+    if(obj_state & LV_STATE_CHECKED) {
+        if(obj_state & LV_STATE_PRESSED) return LV_ANIMBTN_STATE_CHECKED_PRESSED;
+        else return LV_ANIMBTN_STATE_CHECKED_RELEASED;
+    }
+    else {
+        if(obj_state & LV_STATE_PRESSED) return LV_ANIMBTN_STATE_PRESSED;
+        else return LV_ANIMBTN_STATE_RELEASED;
+    }
+}
+
+#endif

--- a/src/extra/widgets/animbtn/lv_animbtn.h
+++ b/src/extra/widgets/animbtn/lv_animbtn.h
@@ -14,7 +14,6 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../../../lvgl.h"
-#include "../../libs/rlottie/lv_rlottie.h"
 
 #if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
 
@@ -32,10 +31,10 @@ typedef enum {
 } lv_animbtn_state_t;
 
 typedef enum {
-    LV_ANIMBTN_CTRL_FORWARD  = LV_RLOTTIE_CTRL_FORWARD,
-    LV_ANIMBTN_CTRL_BACKWARD = LV_RLOTTIE_CTRL_BACKWARD,
-    LV_ANIMBTN_CTRL_LOOP     = LV_RLOTTIE_CTRL_LOOP,
-} lv_animbtn_ctrl_t;
+    LV_ANIMBTN_CTRL_FORWARD  = 0,
+    LV_ANIMBTN_CTRL_BACKWARD = 1,
+    LV_ANIMBTN_CTRL_LOOP     = 8,
+} lv_animbtn_ctrl_t; /* Should match lv_rlottie_ctrl_t */
 
 /*State status for anim button*/
 typedef struct {

--- a/src/extra/widgets/animbtn/lv_animbtn.h
+++ b/src/extra/widgets/animbtn/lv_animbtn.h
@@ -1,0 +1,118 @@
+/**
+ * @file lv_animbtn.h
+ *
+ */
+
+#ifndef LV_ANIMBTN_H
+#define LV_ANIMBTN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../../lvgl.h"
+
+#if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
+
+/*********************
+ *      DEFINES
+ *********************/
+typedef enum {
+    LV_ANIMBTN_STATE_RELEASED,
+    LV_ANIMBTN_STATE_PRESSED,
+    LV_ANIMBTN_STATE_DISABLED,
+    LV_ANIMBTN_STATE_CHECKED_RELEASED,
+    LV_ANIMBTN_STATE_CHECKED_PRESSED,
+    LV_ANIMBTN_STATE_CHECKED_DISABLED,
+    _LV_ANIMBTN_STATE_NUM,
+} lv_animbtn_state_t;
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+/*State status for anim button*/
+typedef struct {
+    size_t first_frame;
+    size_t last_frame;
+    size_t control; /* A lv_rlottie_ctrl_t instance and only checking Forward/Backward and Loop here */
+} lv_animbtn_state_desc_t;
+
+/*Data of anim button*/
+typedef struct {
+    lv_obj_t obj;
+    lv_animbtn_state_desc_t state_desc[_LV_ANIMBTN_STATE_NUM];
+    lv_obj_t * lottie;
+    lv_animbtn_state_t prev_state;
+} lv_animbtn_t;
+
+extern const lv_obj_class_t lv_animbtn_class;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Create an animated button object
+ * @param parent pointer to an object, it will be the parent of the new animation button
+ * @param anim  pointer to a lv_rlottie object used as backend of this button
+ * @return pointer to the created anim button
+ */
+lv_obj_t * lv_animbtn_create(lv_obj_t * parent, lv_obj_t * anim);
+
+/*======================
+ * Add/remove functions
+ *=====================*/
+
+/*=====================
+ * Setter functions
+ *====================*/
+
+/**
+ * Set animation for a state of the animation button
+ * @param animbtn pointer to an animation button object
+ * @param state for which state set the new animation
+ * @param desc description of what to do when the button is in this state
+ *
+ * In a specific state, the button can either play a short sequence once or loop, forward or backward or go to a specific frame and pause from there.
+ */
+void lv_animbtn_set_state_desc(lv_obj_t * animbtn, lv_animbtn_state_t state, lv_animbtn_state_desc_t desc);
+
+
+/**
+ * Use this function instead of `lv_obj_add/clear_state` to set a state manually
+ * @param animbtn pointer to an animation button object
+ * @param state  the new state
+ */
+void lv_animbtn_set_state(lv_obj_t * animbtn, lv_animbtn_state_t state);
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/**
+ * Get animation for a state of the animation button
+ * @param animbtn pointer to an animation button object
+ * @param state the state where to get the animation (from `lv_btn_state_t`) `
+ * @return pointer to the description for this state
+ */
+const lv_animbtn_state_desc_t * lv_animbtn_get_state_desc(lv_obj_t * animbtn, lv_animbtn_state_t state);
+
+
+/*=====================
+ * Other functions
+ *====================*/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_ANIMBTN*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_ANIMBTN_H*/

--- a/src/extra/widgets/animbtn/lv_animbtn.h
+++ b/src/extra/widgets/animbtn/lv_animbtn.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lvgl.h"
+#include "../../libs/rlottie/lv_rlottie.h"
 
 #if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
 
@@ -31,9 +31,9 @@ typedef enum {
 } lv_animbtn_state_t;
 
 typedef enum {
-    LV_ANIMBTN_CTRL_FORWARD  = 0,
-    LV_ANIMBTN_CTRL_BACKWARD = 1,
-    LV_ANIMBTN_CTRL_LOOP     = 8,
+    LV_ANIMBTN_CTRL_FORWARD  = LV_RLOTTIE_CTRL_FORWARD,
+    LV_ANIMBTN_CTRL_BACKWARD = LV_RLOTTIE_CTRL_BACKWARD,
+    LV_ANIMBTN_CTRL_LOOP     = LV_RLOTTIE_CTRL_LOOP,
 } lv_animbtn_ctrl_t; /* Should match lv_rlottie_ctrl_t */
 
 /*State status for anim button*/

--- a/src/extra/widgets/animbtn/lv_animbtn.h
+++ b/src/extra/widgets/animbtn/lv_animbtn.h
@@ -17,9 +17,9 @@ extern "C" {
 
 #if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
 
-/*********************
- *      DEFINES
- *********************/
+/**********************
+ *      TYPEDEFS
+ **********************/
 typedef enum {
     LV_ANIMBTN_STATE_RELEASED,
     LV_ANIMBTN_STATE_PRESSED,
@@ -30,14 +30,17 @@ typedef enum {
     _LV_ANIMBTN_STATE_NUM,
 } lv_animbtn_state_t;
 
-/**********************
- *      TYPEDEFS
- **********************/
+typedef enum {
+    LV_ANIMBTN_CTRL_FORWARD  = 0,
+    LV_ANIMBTN_CTRL_BACKWARD = 1,
+    LV_ANIMBTN_CTRL_LOOP     = 8,
+} lv_animbtn_ctrl_t; /* Should match lv_rlottie_ctrl_t */
+
 /*State status for anim button*/
 typedef struct {
     size_t first_frame;
     size_t last_frame;
-    size_t control; /* A lv_rlottie_ctrl_t instance and only checking Forward/Backward and Loop here */
+    lv_animbtn_ctrl_t control;
 } lv_animbtn_state_desc_t;
 
 /*Data of anim button*/
@@ -61,10 +64,6 @@ extern const lv_obj_class_t lv_animbtn_class;
  * @return pointer to the created anim button
  */
 lv_obj_t * lv_animbtn_create(lv_obj_t * parent, lv_obj_t * anim);
-
-/*======================
- * Add/remove functions
- *=====================*/
 
 /*=====================
  * Setter functions
@@ -99,15 +98,6 @@ void lv_animbtn_set_state(lv_obj_t * animbtn, lv_animbtn_state_t state);
  * @return pointer to the description for this state
  */
 const lv_animbtn_state_desc_t * lv_animbtn_get_state_desc(lv_obj_t * animbtn, lv_animbtn_state_t state);
-
-
-/*=====================
- * Other functions
- *====================*/
-
-/**********************
- *      MACROS
- **********************/
 
 #endif /*LV_USE_ANIMBTN*/
 

--- a/src/extra/widgets/animbtn/lv_animbtn.h
+++ b/src/extra/widgets/animbtn/lv_animbtn.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../../../lvgl.h"
+#include "../../libs/rlottie/lv_rlottie.h"
 
 #if LV_USE_RLOTTIE != 0 && LV_USE_ANIMBTN != 0
 
@@ -31,10 +32,10 @@ typedef enum {
 } lv_animbtn_state_t;
 
 typedef enum {
-    LV_ANIMBTN_CTRL_FORWARD  = 0,
-    LV_ANIMBTN_CTRL_BACKWARD = 1,
-    LV_ANIMBTN_CTRL_LOOP     = 8,
-} lv_animbtn_ctrl_t; /* Should match lv_rlottie_ctrl_t */
+    LV_ANIMBTN_CTRL_FORWARD  = LV_RLOTTIE_CTRL_FORWARD,
+    LV_ANIMBTN_CTRL_BACKWARD = LV_RLOTTIE_CTRL_BACKWARD,
+    LV_ANIMBTN_CTRL_LOOP     = LV_RLOTTIE_CTRL_LOOP,
+} lv_animbtn_ctrl_t;
 
 /*State status for anim button*/
 typedef struct {

--- a/src/extra/widgets/lv_widgets.h
+++ b/src/extra/widgets/lv_widgets.h
@@ -31,6 +31,7 @@ extern "C" {
 #include "colorwheel/lv_colorwheel.h"
 #include "led/lv_led.h"
 #include "imgbtn/lv_imgbtn.h"
+#include "animbtn/lv_animbtn.h"
 #include "span/lv_span.h"
 
 /*********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1515,6 +1515,18 @@
     #endif
 #endif
 
+#ifndef LV_USE_ANIMBTN
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_ANIMBTN
+            #define LV_USE_ANIMBTN CONFIG_LV_USE_ANIMBTN
+        #else
+            #define LV_USE_ANIMBTN 0
+        #endif
+    #else
+        #define LV_USE_ANIMBTN    1
+    #endif
+#endif
+
 #ifndef LV_USE_KEYBOARD
     #ifdef _LV_KCONFIG_PRESENT
         #ifdef CONFIG_LV_USE_KEYBOARD


### PR DESCRIPTION
### Description of the feature or fix

This PR adds a new widget: **Animation button**.
An *animation button* is a button whose state are described as part of a rlottie animation. 

Unlike an `lv_imgbtn`, it's not static (it can be) and instead, it plays part of the animation when in a specific state.
For example, the RELEASED state will play animation from frame 0 to frame 1, and the CHECKED state will play animation from frame 12 to frame 60 in loop, etc...

So, why it's useful ?

1. Even if used as static picture, you only need one "small" file to describe a complex button (instead of multiple files with an image button)
2. You get dynamic interface for free with almost no scripting. Your interface is alive, everything is animated when appropriate.
3. You can draw your buttons in After Effects, Glaxnimate, Synfig, or whatever other vector editing software with animation support and you don't need to render to pictures in your build process. Save as lottie and you're done.
4. Vector rendering meaning it's independent of the button size (ahem, except when you don't have enough RAM, but that's another discussion). Design your button once, no need to support multiple export to different png sizes.
 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
