### PR TITLE
SDL Draw Backend Update

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -143,6 +143,9 @@
 #if LV_USE_DRAW_SDL
     #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
     #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
+
+    #define LV_USE_GPU_SDL LV_USE_DRAW_SDL
+    #define LV_GPU_SDL_INCLUDE_PATH LV_DRAW_SDL_INCLUDE_PATH
 #endif
 
 /*-------------

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -132,23 +132,6 @@
 #define LV_DISP_ROT_MAX_BUF (10*1024)
 
 /*-------------
- * Drawing backend
- *-----------*/
-
-#if defined(LV_USE_GPU_SDL) || defined(LV_GPU_SDL_INCLUDE_PATH)
-    #error "Please use LV_USE_DRAW_SDL and LV_DRAW_SDL_INCLUDE_PATH instead"
-#endif
-
-#define LV_USE_DRAW_SDL 0
-#if LV_USE_DRAW_SDL
-    #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
-    #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
-
-    #define LV_USE_GPU_SDL LV_USE_DRAW_SDL
-    #define LV_GPU_SDL_INCLUDE_PATH LV_DRAW_SDL_INCLUDE_PATH
-#endif
-
-/*-------------
  * GPU
  *-----------*/
 
@@ -173,6 +156,13 @@
 
 /*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
 #define LV_USE_GPU_NXP_VG_LITE 0
+
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+#endif
 
 /*-------------
  * Logging

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -132,6 +132,20 @@
 #define LV_DISP_ROT_MAX_BUF (10*1024)
 
 /*-------------
+ * Drawing backend
+ *-----------*/
+
+#if defined(LV_USE_GPU_SDL) || defined(LV_GPU_SDL_INCLUDE_PATH)
+    #error "Please use LV_USE_DRAW_SDL and LV_DRAW_SDL_INCLUDE_PATH instead"
+#endif
+
+#define LV_USE_DRAW_SDL 0
+#if LV_USE_DRAW_SDL
+    #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
+    #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
+#endif
+
+/*-------------
  * GPU
  *-----------*/
 
@@ -156,15 +170,6 @@
 
 /*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
 #define LV_USE_GPU_NXP_VG_LITE 0
-
-/*Use exnternal renderer*/
-#define LV_USE_EXTERNAL_RENDERER 0
-
-/*Use SDL renderer API. Requires LV_USE_EXTERNAL_RENDERER*/
-#define LV_USE_GPU_SDL 0
-#if LV_USE_GPU_SDL
-    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
-#endif
 
 /*-------------
  * Logging

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -35,10 +35,6 @@
     #include "../gpu/lv_gpu_nxp_pxp_osa.h"
 #endif
 
-#if LV_USE_GPU_SDL
-    #include "../gpu/lv_gpu_sdl.h"
-#endif
-
 /*********************
  *      DEFINES
  *********************/
@@ -127,9 +123,6 @@ void lv_init(void)
     //        for(; ;) ;
     //    }
     //#endif
-    //#if LV_USE_GPU_SDL
-    //    lv_gpu_sdl_init();
-    //#endif
 
     _lv_obj_style_init();
     _lv_ll_init(&LV_GC_ROOT(_lv_disp_ll), sizeof(lv_disp_t));
@@ -186,13 +179,10 @@ void lv_init(void)
     LV_LOG_TRACE("finished");
 }
 
-#if LV_ENABLE_GC || !LV_MEM_CUSTOM || LV_USE_GPU_SDL
+#if LV_ENABLE_GC || !LV_MEM_CUSTOM
 
 void lv_deinit(void)
 {
-#if LV_USE_GPU_SDL
-    lv_gpu_sdl_deinit();
-#endif
     _lv_gc_clear_roots();
 
     lv_disp_set_default(NULL);

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -193,7 +193,7 @@ typedef struct _lv_obj_t {
  */
 void lv_init(void);
 
-#if LV_ENABLE_GC || !LV_MEM_CUSTOM || LV_USE_GPU_SDL
+#if LV_ENABLE_GC || !LV_MEM_CUSTOM
 
 /**
  * Deinit the 'lv' library

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -66,7 +66,7 @@ void lv_draw_sdl_deinit()
     _lv_draw_sdl_utils_deinit();
 }
 
-void lv_draw_sdl_backend_init(lv_draw_backend_t *backend)
+void lv_draw_sdl_backend_init(lv_draw_backend_t * backend)
 {
     lv_draw_backend_init(backend);
     backend->draw_rect = lv_draw_sdl_draw_rect;
@@ -79,7 +79,7 @@ void lv_draw_sdl_backend_init(lv_draw_backend_t *backend)
     backend->blend_map = lv_draw_sdl_draw_blend_map;
 }
 
-void lv_draw_sdl_context_init(lv_draw_sdl_context_t *context)
+void lv_draw_sdl_context_init(lv_draw_sdl_context_t * context)
 {
     lv_memset_00(context, sizeof(lv_draw_sdl_context_t));
     context->internals = lv_mem_alloc(sizeof(lv_draw_sdl_context_t));
@@ -87,7 +87,7 @@ void lv_draw_sdl_context_init(lv_draw_sdl_context_t *context)
     lv_draw_sdl_texture_cache_init(context->internals);
 }
 
-void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t *context)
+void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t * context)
 {
     lv_draw_sdl_texture_cache_deinit(context->internals);
     lv_mem_free(context->internals);

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -64,13 +64,13 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;
     draw_ctx_sdl->internals = lv_mem_alloc(sizeof(lv_draw_sdl_context_internals_t));
     lv_memset_00(draw_ctx_sdl->internals, sizeof(lv_draw_sdl_context_internals_t));
-    lv_draw_sdl_texture_cache_init(draw_ctx_sdl->internals);
+    lv_draw_sdl_texture_cache_init(draw_ctx_sdl);
 }
 
 void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
 {
     lv_draw_sdl_ctx_t *draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
-    lv_draw_sdl_texture_cache_deinit(draw_ctx_sdl->internals);
+    lv_draw_sdl_texture_cache_deinit(draw_ctx_sdl);
     lv_mem_free(draw_ctx_sdl->internals);
     _lv_draw_sdl_utils_deinit();
 }

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_gpu_sdl.c
+ * @file lv_draw_sdl.c
  *
  */
 
@@ -8,15 +8,15 @@
  *********************/
 
 
-#include "../lv_conf_internal.h"
+#include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
-#include "lv_gpu_sdl.h"
-#include "../draw/sdl/lv_draw_sdl_utils.h"
-#include "../draw/sdl/lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl.h"
+#include "lv_draw_sdl_utils.h"
+#include "lv_draw_sdl_texture_cache.h"
 
-#include "../draw/sw/lv_draw_sw.h"
+#include "../sw/lv_draw_sw.h"
 
 /*********************
  *      DEFINES
@@ -56,26 +56,19 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_gpu_sdl_init()
+void lv_draw_sdl_init()
 {
     _lv_draw_sdl_utils_init();
-    _lv_draw_sdl_texture_cache_init();
 }
 
-void lv_gpu_sdl_deinit()
+void lv_draw_sdl_deinit()
 {
-    _lv_draw_sdl_texture_cache_deinit();
     _lv_draw_sdl_utils_deinit();
 }
 
-void lv_gpu_sdl_backend_init(lv_draw_backend_t * backend, SDL_Renderer * renderer, SDL_Texture * texture)
+void lv_draw_sdl_backend_init(lv_draw_backend_t *backend)
 {
     lv_draw_backend_init(backend);
-    lv_draw_sdl_backend_context_t * ctx = lv_mem_alloc(sizeof(lv_draw_sdl_backend_context_t));
-    lv_memset_00(ctx, sizeof(lv_draw_sdl_backend_context_t));
-    ctx->renderer = renderer;
-    ctx->texture = texture;
-    backend->ctx = ctx;
     backend->draw_rect = lv_draw_sdl_draw_rect;
     backend->draw_arc = lv_draw_sw_arc;
     backend->draw_img_core = lv_draw_sdl_img_core;
@@ -86,9 +79,24 @@ void lv_gpu_sdl_backend_init(lv_draw_backend_t * backend, SDL_Renderer * rendere
     backend->blend_map = lv_draw_sdl_draw_blend_map;
 }
 
+void lv_draw_sdl_context_init(lv_draw_sdl_context_t *context)
+{
+    lv_memset_00(context, sizeof(lv_draw_sdl_context_t));
+    context->internals = lv_mem_alloc(sizeof(lv_draw_sdl_context_t));
+    lv_memset_00(context->internals, sizeof(lv_draw_sdl_context_t));
+    lv_draw_sdl_texture_cache_init(context->internals);
+}
+
+void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t *context)
+{
+    lv_draw_sdl_texture_cache_deinit(context->internals);
+    lv_mem_free(context->internals);
+}
+
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -59,7 +59,7 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     draw_ctx->draw_rect = lv_draw_sdl_draw_rect;
     draw_ctx->draw_img_core = lv_draw_sdl_img_core;
     draw_ctx->draw_letter = lv_draw_sdl_draw_letter;
-    lv_draw_sdl_ctx_t *draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
+    lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
     draw_ctx_sdl->renderer = disp_drv->user_data;
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;
     draw_ctx_sdl->internals = lv_mem_alloc(sizeof(lv_draw_sdl_context_internals_t));
@@ -69,7 +69,7 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
 
 void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
 {
-    lv_draw_sdl_ctx_t *draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
+    lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
     lv_draw_sdl_texture_cache_deinit(draw_ctx_sdl);
     lv_mem_free(draw_ctx_sdl->internals);
     _lv_draw_sdl_utils_deinit();

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -10,7 +10,7 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "lv_draw_sdl.h"
 #include "lv_draw_sdl_utils.h"
@@ -84,4 +84,4 @@ static void lv_draw_sdl_noop(void)
 
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -43,7 +43,7 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-
+static void lv_draw_sdl_noop(void);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -97,6 +97,9 @@ void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t *context)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+static void lv_draw_sdl_noop(void)
+{
 
+}
 
 #endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -26,6 +26,12 @@ extern "C" {
  *      DEFINES
  *********************/
 
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+#define LV_DRAW_SDL_TEXTURE_FORMAT SDL_PIXELFORMAT_ARGB8888
+#else
+#define LV_DRAW_SDL_TEXTURE_FORMAT SDL_PIXELFORMAT_RGBA8888
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -16,9 +16,9 @@ extern "C" {
  *********************/
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 #include "../sw/lv_draw_sw.h"
 
@@ -76,7 +76,7 @@ void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx);
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -1,0 +1,85 @@
+/**
+ * @file lv_draw_sdl.h
+ *
+ */
+
+#ifndef LV_DRAW_SDL_H
+#define LV_DRAW_SDL_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_DRAW_SDL
+
+#include LV_DRAW_SDL_INCLUDE_PATH
+
+#include "../lv_draw.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+struct lv_draw_sdl_context_internals_t;
+
+typedef struct lv_draw_sdl_context_t {
+    SDL_Renderer * renderer;
+    SDL_Texture * texture;
+    struct lv_draw_sdl_context_internals_t * internals;
+} lv_draw_sdl_context_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+void lv_draw_sdl_init();
+
+/**
+ * @brief Free caches
+ *
+ */
+void lv_draw_sdl_deinit();
+
+void lv_draw_sdl_backend_init(lv_draw_backend_t *backend);
+
+void lv_draw_sdl_context_init(lv_draw_sdl_context_t *context);
+
+void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t *context);
+
+/*======================
+ * Add/remove functions
+ *=====================*/
+
+/*=====================
+ * Setter functions
+ *====================*/
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/*=====================
+ * Other functions
+ *====================*/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_DRAW_SDL*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_DRAW_SDL_H*/

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #include LV_DRAW_SDL_INCLUDE_PATH
 
-#include "../lv_draw.h"
+#include "../sw/lv_draw_sw.h"
 
 /*********************
  *      DEFINES
@@ -38,29 +38,23 @@ extern "C" {
 
 struct lv_draw_sdl_context_internals_t;
 
-typedef struct lv_draw_sdl_context_t {
+typedef struct {
+    lv_draw_sw_ctx_t base_draw;
     SDL_Renderer * renderer;
-    SDL_Texture * texture;
     struct lv_draw_sdl_context_internals_t * internals;
-} lv_draw_sdl_context_t;
+} lv_draw_sdl_ctx_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_sdl_init();
+void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx);
 
 /**
  * @brief Free caches
  *
  */
-void lv_draw_sdl_deinit();
-
-void lv_draw_sdl_backend_init(lv_draw_backend_t * backend);
-
-void lv_draw_sdl_context_init(lv_draw_sdl_context_t * context);
-
-void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t * context);
+void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx);
 
 /*======================
  * Add/remove functions

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -56,11 +56,11 @@ void lv_draw_sdl_init();
  */
 void lv_draw_sdl_deinit();
 
-void lv_draw_sdl_backend_init(lv_draw_backend_t *backend);
+void lv_draw_sdl_backend_init(lv_draw_backend_t * backend);
 
-void lv_draw_sdl_context_init(lv_draw_sdl_context_t *context);
+void lv_draw_sdl_context_init(lv_draw_sdl_context_t * context);
 
-void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t *context);
+void lv_draw_sdl_context_deinit(lv_draw_sdl_context_t * context);
 
 /*======================
  * Add/remove functions

--- a/src/draw/sdl/lv_draw_sdl.mk
+++ b/src/draw/sdl/lv_draw_sdl.mk
@@ -1,14 +1,13 @@
-CSRCS += lv_draw_sdl_blend.c
-CSRCS += lv_draw_sdl_img.c
-CSRCS += lv_draw_sdl_label.c
-CSRCS += lv_draw_sdl_rect.c
-CSRCS += lv_draw_sdl_lru.c
+CSRCS += lv_draw_sdl_draw_blend.c
+CSRCS += lv_draw_sdl_draw_img.c
+CSRCS += lv_draw_sdl_draw_label.c
+CSRCS += lv_draw_sdl_draw_rect.c
 CSRCS += lv_draw_sdl_mask.c
 CSRCS += lv_draw_sdl_stack_blur.c
 CSRCS += lv_draw_sdl_texture_cache.c
 CSRCS += lv_draw_sdl_utils.c
 
-DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl
-VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl
+DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl
+VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl
 
-CFLAGS += "-I$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl"
+CFLAGS += "-I$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl"

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -46,6 +46,7 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
                                  lv_color_t color, lv_opa_t * mask, lv_opa_t opa, lv_blend_mode_t blend_mode)
 {
     LV_UNUSED(dest_buf);
+    LV_UNUSED(dest_stride);
     /*Do not draw transparent things*/
     if(opa < LV_OPA_MIN) return;
 

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -46,9 +46,10 @@ static void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t
 
 void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
-    if (dsc->src_buf) {
+    if(dsc->src_buf) {
         blend_map((lv_draw_sdl_ctx_t *) draw_ctx, dsc);
-    } else {
+    }
+    else {
         blend_fill((lv_draw_sdl_ctx_t *) draw_ctx, dsc);
     }
 }

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -68,7 +68,6 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
         SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
         SDL_SetTextureAlphaMod(texture, opa);
         SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
-        SDL_RenderSetClipRect(renderer, &draw_area_rect);
         SDL_RenderCopy(renderer, texture, NULL, &draw_area_rect);
         SDL_DestroyTexture(texture);
         SDL_FreeSurface(mask_surface);
@@ -76,7 +75,6 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
     else {
         SDL_SetRenderDrawColor(renderer, color.ch.red, color.ch.green, color.ch.blue, opa);
         SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-        SDL_RenderSetClipRect(renderer, &draw_area_rect);
         SDL_RenderFillRect(renderer, &draw_area_rect);
     }
 }
@@ -112,7 +110,6 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetRenderTarget(renderer, masked);
 
-        SDL_RenderSetClipRect(renderer, NULL);
         SDL_SetTextureAlphaMod(mask_texture, opa);
         SDL_SetTextureBlendMode(mask_texture, SDL_BLENDMODE_NONE);
         SDL_RenderCopy(renderer, mask_texture, NULL, NULL);
@@ -120,7 +117,6 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
         SDL_RenderCopy(renderer, texture, NULL, NULL);
 
         SDL_SetRenderTarget(renderer, ctx->texture);
-        SDL_RenderSetClipRect(renderer, &draw_area_rect);
         SDL_SetTextureBlendMode(masked, SDL_BLENDMODE_BLEND);
         SDL_SetTextureAlphaMod(masked, 0xFF);
         SDL_SetTextureColorMod(masked, 0xFF, 0xFF, 0xFF);
@@ -133,7 +129,6 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetTextureAlphaMod(texture, opa);
         SDL_SetRenderTarget(renderer, ctx->texture);
-        SDL_RenderSetClipRect(renderer, &draw_area_rect);
         SDL_RenderCopy(renderer, texture, NULL, &draw_area_rect);
         SDL_DestroyTexture(texture);
     }

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -57,17 +57,17 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
     lv_area_to_sdl_rect(fill_area, &fill_rect);
 
     if(mask) {
-        SDL_Texture *texture = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK,
-                                                           lv_area_get_height(fill_area),
-                                                           lv_area_get_width(fill_area));
+        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK,
+                                                            lv_area_get_height(fill_area),
+                                                            lv_area_get_width(fill_area));
         SDL_Rect rect = {0, 0, lv_area_get_width(fill_area), lv_area_get_height(fill_area)};
-        uint8_t *pixels = NULL;
+        uint8_t * pixels = NULL;
         int pitch;
         SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch);
         SDL_assert(pixels && pitch);
-        for (int y = 0; y < rect.h; y++) {
+        for(int y = 0; y < rect.h; y++) {
             SDL_memset(&pixels[y * pitch], 0xFF, 4 * rect.w);
-            for (int x = 0; x < rect.w; x++) {
+            for(int x = 0; x < rect.w; x++) {
                 pixels[y * pitch + x * 4] = mask[y * rect.w + x];
             }
         }

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -107,8 +107,7 @@ void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
     if(opa < LV_OPA_MIN) return;
     lv_coord_t sw = lv_area_get_width(dsc->blend_area), sh = lv_area_get_height(dsc->blend_area);
 
-    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    SDL_Renderer * renderer = draw_ctx->renderer;
 
     SDL_Rect draw_area_rect;
     lv_area_to_sdl_rect(draw_ctx->base_draw.base_draw.clip_area, &draw_area_rect);
@@ -132,7 +131,7 @@ void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
         SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_MOD);
         SDL_RenderCopy(renderer, texture, NULL, NULL);
 
-        SDL_SetRenderTarget(renderer, ctx->base_draw.base_draw.buf);
+        SDL_SetRenderTarget(renderer, draw_ctx->base_draw.base_draw.buf);
         SDL_SetTextureBlendMode(masked, SDL_BLENDMODE_BLEND);
         SDL_SetTextureAlphaMod(masked, 0xFF);
         SDL_SetTextureColorMod(masked, 0xFF, 0xFF, 0xFF);
@@ -144,7 +143,7 @@ void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
     else {
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetTextureAlphaMod(texture, opa);
-        SDL_SetRenderTarget(renderer, ctx->base_draw.base_draw.buf);
+        SDL_SetRenderTarget(renderer, draw_ctx->base_draw.base_draw.buf);
         SDL_RenderCopy(renderer, texture, NULL, &draw_area_rect);
         SDL_DestroyTexture(texture);
     }

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -62,9 +62,9 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
     lv_area_to_sdl_rect(&draw_area, &draw_area_rect);
 
     if(mask) {
-        SDL_Surface * mask_surface = lv_sdl_create_mask_surface(mask, lv_area_get_width(&draw_area),
-                                                                lv_area_get_height(&draw_area),
-                                                                lv_area_get_width(&draw_area));
+        SDL_Surface * mask_surface = lv_sdl_create_opa_surface(mask, lv_area_get_width(&draw_area),
+                                                               lv_area_get_height(&draw_area),
+                                                               lv_area_get_width(&draw_area));
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, mask_surface);
         SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
         SDL_SetTextureAlphaMod(texture, opa);
@@ -105,9 +105,9 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
     if(mask) {
         SDL_Texture * masked = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET,
                                                  lv_area_get_width(src_area), lv_area_get_height(src_area));
-        SDL_Texture * mask_texture = lv_sdl_create_mask_texture(renderer, mask, lv_area_get_width(src_area),
-                                                                lv_area_get_height(src_area),
-                                                                lv_area_get_width(src_area));
+        SDL_Texture * mask_texture = lv_sdl_create_opa_texture(renderer, mask, lv_area_get_width(src_area),
+                                                               lv_area_get_height(src_area),
+                                                               lv_area_get_width(src_area));
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetRenderTarget(renderer, masked);
 

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -9,14 +9,14 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
-#include "../../draw/lv_draw_blend.h"
+#include "../lv_draw_blend.h"
 #include "lv_draw_sdl_texture_cache.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_mask.h"
 
-#include LV_GPU_SDL_INCLUDE_PATH
+#include LV_DRAW_SDL_INCLUDE_PATH
 
 /*********************
  *      DEFINES
@@ -49,7 +49,7 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
     /*Do not draw transparent things*/
     if(opa < LV_OPA_MIN) return;
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     /*Get clipped fill area which is the real draw area.
@@ -87,7 +87,7 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
     /*Do not draw transparent things*/
     if(opa < LV_OPA_MIN) return;
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     SDL_Rect draw_area_rect;
@@ -139,4 +139,4 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -11,7 +11,6 @@
 
 #if LV_USE_DRAW_SDL
 
-#include "../lv_draw_blend.h"
 #include "lv_draw_sdl_texture_cache.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_mask.h"
@@ -30,6 +29,9 @@
  *  STATIC PROTOTYPES
  **********************/
 
+static void blend_fill(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+
+static void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -42,25 +44,38 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_area_t * fill_area,
-                                 lv_color_t color, lv_opa_t * mask, lv_opa_t opa, lv_blend_mode_t blend_mode)
+void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
-    LV_UNUSED(dest_buf);
-    LV_UNUSED(dest_stride);
+    if (dsc->src_buf) {
+        blend_map((lv_draw_sdl_ctx_t *) draw_ctx, dsc);
+    } else {
+        blend_fill((lv_draw_sdl_ctx_t *) draw_ctx, dsc);
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+void blend_fill(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+{
+    const lv_opa_t opa = dsc->opa;
+    const lv_color_t color = dsc->color;
     /*Do not draw transparent things*/
     if(opa < LV_OPA_MIN) return;
 
-    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    SDL_Renderer * renderer = draw_ctx->renderer;
 
+    lv_area_t fill_area;
+    _lv_area_intersect(&fill_area, draw_ctx->base_draw.base_draw.clip_area, dsc->blend_area);
     SDL_Rect fill_rect;
-    lv_area_to_sdl_rect(fill_area, &fill_rect);
+    lv_area_to_sdl_rect(&fill_area, &fill_rect);
 
-    if(mask) {
-        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK,
-                                                            lv_area_get_height(fill_area),
-                                                            lv_area_get_width(fill_area));
-        SDL_Rect rect = {0, 0, lv_area_get_width(fill_area), lv_area_get_height(fill_area)};
+    if(dsc->mask) {
+        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(draw_ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK,
+                                                            lv_area_get_height(&fill_area),
+                                                            lv_area_get_width(&fill_area));
+        SDL_Rect rect = {0, 0, lv_area_get_width(&fill_area), lv_area_get_height(&fill_area)};
         uint8_t * pixels = NULL;
         int pitch;
         SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch);
@@ -68,7 +83,7 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
         for(int y = 0; y < rect.h; y++) {
             SDL_memset(&pixels[y * pitch], 0xFF, 4 * rect.w);
             for(int x = 0; x < rect.w; x++) {
-                pixels[y * pitch + x * 4] = mask[y * rect.w + x];
+                pixels[y * pitch + x * 4] = dsc->mask[y * rect.w + x];
             }
         }
         SDL_UnlockTexture(texture);
@@ -85,35 +100,29 @@ void lv_draw_sdl_draw_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, 
     }
 }
 
-void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_area_t * clip_area,
-                                const lv_color_t * src_buf, const lv_area_t * src_area,
-                                lv_opa_t * mask, lv_opa_t opa, lv_blend_mode_t blend_mode)
+void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
-    LV_UNUSED(dest_buf);
-    LV_UNUSED(dest_stride);
+    const lv_opa_t opa = dsc->opa;
     /*Do not draw transparent things*/
     if(opa < LV_OPA_MIN) return;
+    lv_coord_t sw = lv_area_get_width(dsc->blend_area), sh = lv_area_get_height(dsc->blend_area);
 
-    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     SDL_Rect draw_area_rect;
-    lv_area_to_sdl_rect(clip_area, &draw_area_rect);
+    lv_area_to_sdl_rect(draw_ctx->base_draw.base_draw.clip_area, &draw_area_rect);
 
     Uint32 rmask = 0x00FF0000;
     Uint32 gmask = 0x0000FF00;
     Uint32 bmask = 0x000000FF;
     Uint32 amask = 0x00000000;
-    SDL_Surface * surface = SDL_CreateRGBSurfaceFrom((void *) src_buf, lv_area_get_width(src_area),
-                                                     lv_area_get_height(src_area), LV_COLOR_DEPTH,
-                                                     lv_area_get_width(src_area) * LV_COLOR_DEPTH / 8,
-                                                     rmask, gmask, bmask, amask);
-    if(mask) {
+    SDL_Surface * surface = SDL_CreateRGBSurfaceFrom((void *) dsc->src_buf, sw, sh, LV_COLOR_DEPTH,
+                                                     sw * LV_COLOR_DEPTH / 8, rmask, gmask, bmask, amask);
+    if(dsc->mask) {
         SDL_Texture * masked = SDL_CreateTexture(renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET,
-                                                 lv_area_get_width(src_area), lv_area_get_height(src_area));
-        SDL_Texture * mask_texture = lv_sdl_create_opa_texture(renderer, mask, lv_area_get_width(src_area),
-                                                               lv_area_get_height(src_area),
-                                                               lv_area_get_width(src_area));
+                                                 sw, sh);
+        SDL_Texture * mask_texture = lv_sdl_create_opa_texture(renderer, dsc->mask, sw, sh, sw);
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetRenderTarget(renderer, masked);
 
@@ -123,7 +132,7 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
         SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_MOD);
         SDL_RenderCopy(renderer, texture, NULL, NULL);
 
-        SDL_SetRenderTarget(renderer, ctx->texture);
+        SDL_SetRenderTarget(renderer, ctx->base_draw.base_draw.buf);
         SDL_SetTextureBlendMode(masked, SDL_BLENDMODE_BLEND);
         SDL_SetTextureAlphaMod(masked, 0xFF);
         SDL_SetTextureColorMod(masked, 0xFF, 0xFF, 0xFF);
@@ -135,15 +144,11 @@ void lv_draw_sdl_draw_blend_map(lv_color_t * dest_buf, lv_coord_t dest_stride, c
     else {
         SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
         SDL_SetTextureAlphaMod(texture, opa);
-        SDL_SetRenderTarget(renderer, ctx->texture);
+        SDL_SetRenderTarget(renderer, ctx->base_draw.base_draw.buf);
         SDL_RenderCopy(renderer, texture, NULL, &draw_area_rect);
         SDL_DestroyTexture(texture);
     }
     SDL_FreeSurface(surface);
 }
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
 
 #endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -9,13 +9,13 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "lv_draw_sdl_texture_cache.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_mask.h"
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 /*********************
  *      DEFINES
@@ -150,4 +150,4 @@ void blend_map(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
     SDL_FreeSurface(surface);
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -58,7 +58,7 @@ lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t 
     size_t key_size;
     lv_draw_sdl_cache_key_head_img_t * key = lv_draw_sdl_texture_img_key_create(src, draw_dsc->frame_id, &key_size);
     bool texture_found = false;
-    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(key, key_size, &texture_found);
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(ctx, key, key_size, &texture_found);
     if(!texture_found) {
         _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, draw_dsc->recolor, draw_dsc->frame_id);
         lv_draw_sdl_cache_flag_t tex_flags = 0;
@@ -82,10 +82,10 @@ lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t 
         if(texture && cdsc) {
             lv_img_header_t * header = SDL_malloc(sizeof(lv_img_header_t));
             SDL_memcpy(header, &cdsc->dec_dsc.header, sizeof(lv_img_header_t));
-            lv_draw_sdl_texture_cache_put_advanced(key, key_size, texture, header, SDL_free, tex_flags);
+            lv_draw_sdl_texture_cache_put_advanced(ctx, key, key_size, texture, header, SDL_free, tex_flags);
         }
         else {
-            lv_draw_sdl_texture_cache_put(key, key_size, NULL);
+            lv_draw_sdl_texture_cache_put(ctx, key, key_size, NULL);
         }
     }
     SDL_free(key);

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_draw_img.c
+ * @file lv_gpu_sdl_draw_img.c
  *
  */
 
@@ -11,13 +11,10 @@
 
 #if LV_USE_GPU_SDL
 
-#include "../../draw/lv_draw_img.h"
-#include "../../draw/lv_img_cache.h"
-#include "../../draw/lv_draw_mask.h"
-
-#include "lv_draw_sdl_utils.h"
-#include "lv_draw_sdl_lru.h"
-#include "lv_draw_sdl_texture_cache.h"
+#include "../../core/lv_refr.h"
+#include "lv_gpu_sdl_utils.h"
+#include "lv_gpu_sdl_lru.h"
+#include "lv_gpu_sdl_texture_cache.h"
 
 /*********************
  *      DEFINES
@@ -48,24 +45,30 @@ static SDL_Texture * upload_img_texture_fallback(SDL_Renderer * renderer, lv_img
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, const void * src,
-                              const lv_draw_img_dsc_t * draw_dsc)
+void lv_draw_img(const lv_area_t * coords, const lv_area_t * mask, const void * src,
+                 const lv_draw_img_dsc_t * draw_dsc)
 {
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    if(draw_dsc->opa <= LV_OPA_MIN) return;
+
+    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
+    SDL_Renderer * renderer = (SDL_Renderer *) disp->driver->user_data;
 
     size_t key_size;
-    lv_draw_sdl_cache_key_head_img_t * key = lv_draw_sdl_img_cache_key_create(src, draw_dsc->frame_id, &key_size);
+    lv_gpu_sdl_cache_key_head_img_t * key = lv_gpu_sdl_img_cache_key_create(src, draw_dsc->frame_id, &key_size);
     bool texture_found = false;
     SDL_Texture * texture = lv_gpu_draw_cache_get(key, key_size, &texture_found);
     if(!texture_found) {
         _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, draw_dsc->recolor, draw_dsc->frame_id);
-        lv_draw_sdl_cache_flag_t tex_flags = 0;
+        lv_gpu_sdl_cache_flag_t tex_flags = 0;
         if(cdsc) {
             lv_img_decoder_dsc_t * dsc = &cdsc->dec_dsc;
-            if(dsc->user_data && SDL_memcmp(dsc->user_data, LV_DRAW_SDL_DEC_DSC_TEXTURE_HEAD, 8) == 0) {
-                texture = ((lv_draw_sdl_dec_dsc_userdata_t *) dsc->user_data)->texture;
-                tex_flags |= LV_DRAW_SDL_CACHE_FLAG_MANAGED;
+            if(dsc->user_data && SDL_memcmp(dsc->user_data, LV_GPU_SDL_DEC_DSC_TEXTURE_HEAD, 8) == 0) {
+                lv_gpu_sdl_dec_dsc_userdata_t *ptr = (lv_gpu_sdl_dec_dsc_userdata_t *) dsc->user_data;
+                texture = ptr->texture;
+                if (ptr->texture_managed) {
+                    tex_flags |= LV_GPU_SDL_CACHE_FLAG_MANAGED;
+                }
+                ptr->texture_referenced = true;
             }
             else {
                 texture = upload_img_texture(renderer, dsc);
@@ -77,15 +80,15 @@ lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, 
         if(texture && cdsc) {
             lv_img_header_t * header = SDL_malloc(sizeof(lv_img_header_t));
             SDL_memcpy(header, &cdsc->dec_dsc.header, sizeof(lv_img_header_t));
-            lv_draw_sdl_draw_cache_put_advanced(key, key_size, texture, header, SDL_free, tex_flags);
+            lv_gpu_draw_cache_put_advanced(key, key_size, texture, header, SDL_free, tex_flags);
         }
         else {
-            lv_draw_sdl_draw_cache_put(key, key_size, NULL);
+            lv_gpu_draw_cache_put(key, key_size, NULL);
         }
     }
     SDL_free(key);
     if(!texture) {
-        return LV_RES_INV;
+        return;
     }
 
     SDL_Rect mask_rect, coords_rect;
@@ -117,7 +120,6 @@ lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, 
         SDL_SetTextureAlphaMod(texture, draw_dsc->recolor_opa);
         SDL_RenderCopyEx(renderer, texture, NULL, &coords_rect, draw_dsc->angle, &pivot, SDL_FLIP_NONE);
     }
-    return LV_RES_OK;
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -9,7 +9,7 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "../lv_draw_img.h"
 #include "../lv_img_cache.h"
@@ -176,4 +176,4 @@ static SDL_Texture * upload_img_texture_fallback(SDL_Renderer * renderer, lv_img
 }
 
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -48,10 +48,11 @@ static SDL_Texture * upload_img_texture_fallback(SDL_Renderer * renderer, lv_img
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, const void * src,
-                              const lv_draw_img_dsc_t * draw_dsc)
+lv_res_t lv_draw_sdl_img_core(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                              const lv_area_t * coords, const void * src)
 {
-    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
+    const lv_area_t *clip = draw_ctx->clip_area;
+    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     size_t key_size;
@@ -92,8 +93,8 @@ lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, 
         return LV_RES_INV;
     }
 
-    SDL_Rect mask_rect, coords_rect;
-    lv_area_to_sdl_rect(mask, &mask_rect);
+    SDL_Rect clip_rect, coords_rect;
+    lv_area_to_sdl_rect(clip, &clip_rect);
     lv_area_to_sdl_rect(coords, &coords_rect);
     lv_area_zoom_to_sdl_rect(coords, &coords_rect, draw_dsc->zoom, &draw_dsc->pivot);
 
@@ -101,7 +102,7 @@ lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, 
     SDL_SetTextureAlphaMod(texture, draw_dsc->opa);
     SDL_SetTextureColorMod(texture, 0xFF, 0xFF, 0xFF);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-    SDL_RenderSetClipRect(renderer, &mask_rect);
+    SDL_RenderSetClipRect(renderer, &clip_rect);
 
     SDL_Color recolor;
     lv_color_to_sdl_color(&draw_dsc->recolor, &recolor);

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -48,11 +48,11 @@ static SDL_Texture * upload_img_texture_fallback(SDL_Renderer * renderer, lv_img
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_res_t lv_draw_sdl_img_core(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
                               const lv_area_t * coords, const void * src)
 {
     const lv_area_t *clip = draw_ctx->clip_area;
-    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
     SDL_Renderer * renderer = ctx->renderer;
 
     size_t key_size;

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -51,7 +51,7 @@ static SDL_Texture * upload_img_texture_fallback(SDL_Renderer * renderer, lv_img
 lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
                               const lv_area_t * coords, const void * src)
 {
-    const lv_area_t *clip = draw_ctx->clip_area;
+    const lv_area_t * clip = draw_ctx->clip_area;
     lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
     SDL_Renderer * renderer = ctx->renderer;
 

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -64,9 +64,9 @@ lv_res_t lv_draw_sdl_img_core(const lv_area_t * coords, const lv_area_t * mask, 
         if(cdsc) {
             lv_img_decoder_dsc_t * dsc = &cdsc->dec_dsc;
             if(dsc->user_data && SDL_memcmp(dsc->user_data, LV_DRAW_SDL_DEC_DSC_TEXTURE_HEAD, 8) == 0) {
-                lv_draw_sdl_dec_dsc_userdata_t *ptr = (lv_draw_sdl_dec_dsc_userdata_t *) dsc->user_data;
+                lv_draw_sdl_dec_dsc_userdata_t * ptr = (lv_draw_sdl_dec_dsc_userdata_t *) dsc->user_data;
                 texture = ptr->texture;
-                if (ptr->texture_managed) {
+                if(ptr->texture_managed) {
                     tex_flags |= LV_DRAW_SDL_CACHE_FLAG_MANAGED;
                 }
                 ptr->texture_referenced = true;

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -56,8 +56,8 @@ static lv_font_glyph_key_t font_key_glyph_create(const lv_font_t * font_p, uint3
 void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
                              uint32_t letter)
 {
-    const lv_area_t *clip_area = draw_ctx->clip_area;
-    const lv_font_t *font_p = dsc->font;
+    const lv_area_t * clip_area = draw_ctx->clip_area;
+    const lv_font_t * font_p = dsc->font;
     lv_opa_t opa = dsc->opa;
     lv_color_t color = dsc->color;
     if(opa < LV_OPA_MIN) return;

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -95,7 +95,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
         return;
     }
 
-    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
     SDL_Renderer * renderer = ctx->renderer;
 
     lv_font_glyph_key_t glyph_key = font_key_glyph_create(font_p, letter);

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -9,13 +9,13 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
-#include "../../draw/lv_draw_label.h"
-#include "../../draw/lv_draw_mask.h"
+#include "../lv_draw_label.h"
+#include "../lv_draw_mask.h"
 #include "../../misc/lv_utils.h"
 
-#include LV_GPU_SDL_INCLUDE_PATH
+#include LV_DRAW_SDL_INCLUDE_PATH
 
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
@@ -96,12 +96,12 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
         return;
     }
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     lv_font_glyph_key_t glyph_key = font_key_glyph_create(font_p, letter);
     bool glyph_found = false;
-    SDL_Texture * texture = lv_gpu_draw_cache_get(&glyph_key, sizeof(glyph_key), &glyph_found);
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(&glyph_key, sizeof(glyph_key), &glyph_found);
     if(!glyph_found) {
         if(g.resolved_font) {
             font_p = g.resolved_font;
@@ -113,7 +113,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
         texture = SDL_CreateTextureFromSurface(renderer, mask);
         SDL_FreeSurface(mask);
         lv_mem_free(buf);
-        lv_draw_sdl_draw_cache_put(&glyph_key, sizeof(glyph_key), texture);
+        lv_draw_sdl_texture_cache_put(&glyph_key, sizeof(glyph_key), texture);
     }
     if(!texture) {
         return;
@@ -148,7 +148,7 @@ static void draw_letter_masked(SDL_Renderer * renderer, SDL_Texture * atlas, SDL
     SDL_Texture * screen = SDL_GetRenderTarget(renderer);
 
     lv_area_t mask_area = {.x1 = dst->x, .x2 = dst->x + dst->w - 1, .y1 = dst->y, .y2 = dst->y + dst->h - 1};
-    SDL_Texture * content = lv_gpu_temp_texture_obtain(renderer, dst->w, dst->h);
+    SDL_Texture * content = lv_draw_sdl_texture_temp_obtain(renderer, dst->w, dst->h);
     SDL_SetTextureBlendMode(content, SDL_BLENDMODE_NONE);
     SDL_SetRenderTarget(renderer, content);
 
@@ -194,4 +194,4 @@ static lv_font_glyph_key_t font_key_glyph_create(const lv_font_t * font_p, uint3
     return key;
 }
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -134,7 +134,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
     SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
     SDL_RenderCopy(renderer, texture, &srcrect, &dstrect);
 
-    if (has_mask) {
+    if(has_mask) {
         lv_draw_sdl_mask_end(&apply_area);
     }
 }

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -135,6 +135,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
     SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
     SDL_RenderSetClipRect(renderer, &clip_area_rect);
     SDL_RenderCopy(renderer, texture, NULL, &dstrect);
+    SDL_RenderSetClipRect(renderer, NULL);
 }
 
 /**********************
@@ -150,7 +151,6 @@ static void draw_letter_masked(SDL_Renderer * renderer, SDL_Texture * atlas, SDL
     SDL_Texture * content = lv_gpu_temp_texture_obtain(renderer, dst->w, dst->h);
     SDL_SetTextureBlendMode(content, SDL_BLENDMODE_NONE);
     SDL_SetRenderTarget(renderer, content);
-    SDL_RenderSetClipRect(renderer, NULL);
 
     /* Replace texture with clip mask */
     SDL_Rect mask_rect = {.w = dst->w, .h = dst->h, .x = 0, .y = 0};
@@ -179,6 +179,7 @@ static void draw_letter_masked(SDL_Renderer * renderer, SDL_Texture * atlas, SDL
     SDL_SetRenderTarget(renderer, screen);
     SDL_RenderSetClipRect(renderer, clip);
     SDL_RenderCopy(renderer, content, &mask_rect, dst);
+    SDL_RenderSetClipRect(renderer, NULL);
     SDL_DestroyTexture(mask);
 }
 

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -100,7 +100,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
 
     lv_font_glyph_key_t glyph_key = font_key_glyph_create(font_p, letter);
     bool glyph_found = false;
-    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(&glyph_key, sizeof(glyph_key), &glyph_found);
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(ctx, &glyph_key, sizeof(glyph_key), &glyph_found);
     if(!glyph_found) {
         if(g.resolved_font) {
             font_p = g.resolved_font;
@@ -112,7 +112,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
         texture = SDL_CreateTextureFromSurface(renderer, mask);
         SDL_FreeSurface(mask);
         lv_mem_free(buf);
-        lv_draw_sdl_texture_cache_put(&glyph_key, sizeof(glyph_key), texture);
+        lv_draw_sdl_texture_cache_put(ctx, &glyph_key, sizeof(glyph_key), texture);
     }
     if(!texture) {
         return;

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -9,9 +9,9 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 #include "../lv_draw_label.h"
 #include "../../misc/lv_utils.h"
@@ -157,4 +157,4 @@ static lv_font_glyph_key_t font_key_glyph_create(const lv_font_t * font_p, uint3
     return key;
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -105,7 +105,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
         const uint8_t * bmp = lv_font_get_glyph_bitmap(font_p, letter);
         uint8_t * buf = lv_mem_alloc(g.box_w * g.box_h);
         lv_sdl_to_8bpp(buf, bmp, g.box_w, g.box_h, g.box_w, g.bpp);
-        SDL_Surface * mask = lv_sdl_create_mask_surface(buf, g.box_w, g.box_h, g.box_w);
+        SDL_Surface * mask = lv_sdl_create_opa_surface(buf, g.box_w, g.box_h, g.box_w);
         texture = SDL_CreateTextureFromSurface(renderer, mask);
         SDL_FreeSurface(mask);
         lv_mem_free(buf);

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -116,7 +116,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
     }
 
     const lv_area_t final_area = draw_area;
-    bool has_mask = lv_draw_sdl_mask_begin(&letter_area, &draw_area);
+    bool has_mask = lv_draw_sdl_mask_begin(&letter_area, &draw_area, NULL);
 
     SDL_Rect srcrect, dstrect;
     lv_area_to_sdl_rect(&draw_area, &dstrect);

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -53,10 +53,13 @@ static lv_font_glyph_key_t font_key_glyph_create(const lv_font_t * font_p, uint3
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_area,
-                             const lv_font_t * font_p, uint32_t letter, lv_color_t color, lv_opa_t opa,
-                             lv_blend_mode_t blend_mode)
+void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
+                             uint32_t letter)
 {
+    const lv_area_t *clip_area = draw_ctx->clip_area;
+    const lv_font_t *font_p = dsc->font;
+    lv_opa_t opa = dsc->opa;
+    lv_color_t color = dsc->color;
     if(opa < LV_OPA_MIN) return;
     if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
@@ -92,7 +95,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
         return;
     }
 
-    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
     SDL_Renderer * renderer = ctx->renderer;
 
     lv_font_glyph_key_t glyph_key = font_key_glyph_create(font_p, letter);
@@ -117,7 +120,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
 
     lv_point_t offset = {0, 0};
     lv_area_t t_letter = letter_area, t_clip = *clip_area, apply_area;
-    bool has_mask = lv_draw_sdl_mask_begin(&letter_area, clip_area, NULL, &t_letter, &t_clip, &apply_area);
+    bool has_mask = lv_draw_sdl_mask_begin(ctx, &letter_area, clip_area, NULL, &t_letter, &t_clip, &apply_area);
 
     /*If the letter is completely out of mask don't draw it*/
     if(!_lv_area_intersect(&draw_area, &t_letter, &t_clip)) {
@@ -135,7 +138,7 @@ void lv_draw_sdl_draw_letter(const lv_point_t * pos_p, const lv_area_t * clip_ar
     SDL_RenderCopy(renderer, texture, &srcrect, &dstrect);
 
     if(has_mask) {
-        lv_draw_sdl_mask_end(&apply_area);
+        lv_draw_sdl_mask_end(ctx, &apply_area);
     }
 }
 

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -29,7 +29,7 @@
  **********************/
 
 typedef struct {
-    lv_gpu_cache_key_magic_t magic;
+    lv_sdl_cache_key_magic_t magic;
     const lv_font_t * font_p;
     uint32_t letter;
 } lv_font_glyph_key_t;

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -9,9 +9,9 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
-#include "../../draw/lv_draw_mask.h"
+#include "../lv_draw_mask.h"
 #include "lv_draw_sdl_mask.h"
 #include "lv_draw_sdl_utils.h"
 
@@ -106,4 +106,4 @@ SDL_Texture * lv_sdl_gen_mask_texture(SDL_Renderer * renderer, const lv_area_t *
  **********************/
 
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -57,7 +57,7 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
  *   GLOBAL FUNCTIONS
  **********************/
 
-bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t *ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
+bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
                             const lv_area_t * extension, lv_area_t * coords_out, lv_area_t * clip_out,
                             lv_area_t * apply_area)
 {
@@ -111,7 +111,7 @@ bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t *ctx, const lv_area_t * coords_in,
     return true;
 }
 
-void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t * apply_area)
+void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_area)
 {
 #if HAS_CUSTOM_BLEND_MODE
     lv_draw_sdl_context_internals_t * internals = ctx->internals;

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -170,12 +170,12 @@ SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_ar
     return texture;
 }
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * context, lv_draw_sdl_mask_cache_type_t type,
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_mask_cache_type_t type,
                                           lv_coord_t w, lv_coord_t h)
 {
     lv_point_t * tex_size = NULL;
     lv_mask_key_t mask_key = mask_key_create(type);
-    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(&mask_key, sizeof(lv_mask_key_t), NULL,
+    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(ctx, &mask_key, sizeof(lv_mask_key_t), NULL,
                                                                        (void **) &tex_size);
     if(!result || tex_size->x < w || tex_size->y < h) {
         lv_coord_t size = next_pow_of_2(LV_MAX(w, h));
@@ -183,10 +183,10 @@ SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * context, lv_draw_s
         if(type == LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE) {
             access = SDL_TEXTUREACCESS_TARGET;
         }
-        result = SDL_CreateTexture(context->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, access, size, size);
+        result = SDL_CreateTexture(ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, access, size, size);
         tex_size = lv_mem_alloc(sizeof(lv_point_t));
         tex_size->x = tex_size->y = size;
-        lv_draw_sdl_texture_cache_put_advanced(&mask_key, sizeof(lv_mask_key_t), result, tex_size, lv_mem_free, 0);
+        lv_draw_sdl_texture_cache_put_advanced(ctx, &mask_key, sizeof(lv_mask_key_t), result, tex_size, lv_mem_free, 0);
     }
     return result;
 }

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -39,6 +39,15 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
+bool lv_draw_sdl_mask_begin(const lv_area_t * a)
+{
+    return false;
+}
+
+void lv_draw_sdl_mask_end(const lv_area_t * a)
+{
+
+}
 
 SDL_Surface * lv_sdl_create_mask_surface(lv_opa_t * pixels, lv_coord_t width, lv_coord_t height, lv_coord_t stride)
 {

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -57,22 +57,23 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
  *   GLOBAL FUNCTIONS
  **********************/
 
-bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in, const lv_area_t *extension,
-                       lv_area_t *coords_out, lv_area_t *clip_out, lv_area_t *apply_area) {
+bool lv_draw_sdl_mask_begin(const lv_area_t * coords_in, const lv_area_t * clip_in, const lv_area_t * extension,
+                            lv_area_t * coords_out, lv_area_t * clip_out, lv_area_t * apply_area)
+{
     lv_area_t full_area, full_coords = *coords_in;
-    if (extension) {
+    if(extension) {
         full_coords.x1 -= extension->x1;
         full_coords.x2 += extension->x2;
         full_coords.y1 -= extension->y1;
         full_coords.y2 += extension->y2;
     }
-    if (!_lv_area_intersect(&full_area, &full_coords, clip_in)) return false;
-    if (!lv_draw_mask_is_any(&full_area)) return false;
+    if(!_lv_area_intersect(&full_area, &full_coords, clip_in)) return false;
+    if(!lv_draw_mask_is_any(&full_area)) return false;
 #if HAS_CUSTOM_BLEND_MODE
-    lv_disp_t *disp = _lv_refr_get_disp_refreshing();
+    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
 
-    lv_draw_sdl_context_t *context = disp->driver->user_data;
-    lv_draw_sdl_context_internals_t *internals = context->internals;
+    lv_draw_sdl_context_t * context = disp->driver->user_data;
+    lv_draw_sdl_context_internals_t * internals = context->internals;
     LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
     lv_coord_t w = lv_area_get_width(&full_area), h = lv_area_get_height(&full_area);
 
@@ -83,7 +84,7 @@ bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in
 
     *apply_area = full_area;
     /* Don't need to worry about overflow */
-    lv_coord_t ofs_x = (lv_coord_t) -full_area.x1, ofs_y = (lv_coord_t) -full_area.y1;
+    lv_coord_t ofs_x = (lv_coord_t) - full_area.x1, ofs_y = (lv_coord_t) - full_area.y1;
     /* Offset draw area to start with (0,0) of coords */
     lv_area_move(&full_area, ofs_x, ofs_y);
     lv_area_move(coords_out, ofs_x, ofs_y);
@@ -93,16 +94,16 @@ bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in
     SDL_RenderClear(context->renderer);
 #else
     /* Fallback mask handling. This will at least make bars looks less bad */
-    for (uint8_t i = 0; i < _LV_MASK_MAX_NUM; i++) {
-        _lv_draw_mask_common_dsc_t *comm_param = LV_GC_ROOT(_lv_draw_mask_list[i]).param;
-        if (comm_param == NULL) continue;
-        switch (comm_param->type) {
+    for(uint8_t i = 0; i < _LV_MASK_MAX_NUM; i++) {
+        _lv_draw_mask_common_dsc_t * comm_param = LV_GC_ROOT(_lv_draw_mask_list[i]).param;
+        if(comm_param == NULL) continue;
+        switch(comm_param->type) {
             case LV_DRAW_MASK_TYPE_RADIUS: {
-                const lv_draw_mask_radius_param_t *param = (const lv_draw_mask_radius_param_t *) comm_param;
-                if (param->cfg.outer) break;
-                _lv_area_intersect(clip_out, &full_area, &param->cfg.rect);
-                break;
-            }
+                    const lv_draw_mask_radius_param_t * param = (const lv_draw_mask_radius_param_t *) comm_param;
+                    if(param->cfg.outer) break;
+                    _lv_area_intersect(clip_out, &full_area, &param->cfg.rect);
+                    break;
+                }
             default:
                 break;
         }
@@ -111,11 +112,11 @@ bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in
     return true;
 }
 
-void lv_draw_sdl_mask_end(const lv_area_t *apply_area)
+void lv_draw_sdl_mask_end(const lv_area_t * apply_area)
 {
 #if HAS_CUSTOM_BLEND_MODE
-    lv_draw_sdl_context_t *context = lv_draw_sdl_get_context();
-    lv_draw_sdl_context_internals_t *internals = context->internals;
+    lv_draw_sdl_context_t * context = lv_draw_sdl_get_context();
+    lv_draw_sdl_context_internals_t * internals = context->internals;
     LV_ASSERT(internals->mask != NULL && internals->composition != NULL);
     SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE,
                                                     SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
@@ -164,23 +165,24 @@ SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_ar
 {
     lv_coord_t w = lv_area_get_width(coords), h = lv_area_get_height(coords);
     lv_opa_t * mask_buf = lv_draw_sdl_mask_dump_opa(coords, ids, ids_count);
-    SDL_Surface *surface = lv_sdl_create_opa_surface(mask_buf, w, h, w);
+    SDL_Surface * surface = lv_sdl_create_opa_surface(mask_buf, w, h, w);
     lv_mem_buf_release(mask_buf);
     SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, surface);
     SDL_FreeSurface(surface);
     return texture;
 }
 
-SDL_Texture *lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t *context, lv_draw_sdl_mask_cache_type_t type,
-                                         lv_coord_t w, lv_coord_t h)
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t * context, lv_draw_sdl_mask_cache_type_t type,
+                                          lv_coord_t w, lv_coord_t h)
 {
-    lv_point_t *tex_size = NULL;
+    lv_point_t * tex_size = NULL;
     lv_mask_key_t mask_key = mask_key_create(type);
-    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(&mask_key, sizeof(lv_mask_key_t),NULL, (void **) &tex_size);
-    if (!result || tex_size->x < w || tex_size->y < h) {
+    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(&mask_key, sizeof(lv_mask_key_t), NULL,
+                                                                       (void **) &tex_size);
+    if(!result || tex_size->x < w || tex_size->y < h) {
         lv_coord_t size = next_pow_of_2(LV_MAX(w, h));
         int access = SDL_TEXTUREACCESS_STREAMING;
-        if (type == LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE) {
+        if(type == LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE) {
             access = SDL_TEXTUREACCESS_TARGET;
         }
         result = SDL_CreateTexture(context->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, access, size, size);
@@ -208,7 +210,7 @@ static lv_mask_key_t mask_key_create(lv_draw_sdl_mask_cache_type_t type)
 static lv_coord_t next_pow_of_2(lv_coord_t num)
 {
     lv_coord_t n = 128;
-    while (n < num && n < 16384) {
+    while(n < num && n < 16384) {
         n = n << 1;
     }
     return n;
@@ -221,7 +223,7 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
     SDL_Rect rect = {0, 0, w, h};
     uint8_t * pixels;
     int pitch;
-    if (SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch) != 0) return;
+    if(SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch) != 0) return;
 
     lv_opa_t * line_buf = lv_mem_buf_get(rect.w);
     for(lv_coord_t y = 0; y < rect.h; y++) {
@@ -234,12 +236,14 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
         else {
             res = lv_draw_mask_apply(line_buf, abs_x, abs_y, len);
         }
-        if (res == LV_DRAW_MASK_RES_TRANSP) {
+        if(res == LV_DRAW_MASK_RES_TRANSP) {
             lv_memset_00(&pixels[y * pitch], 4 * rect.w);
-        } else if (res == LV_DRAW_MASK_RES_FULL_COVER) {
+        }
+        else if(res == LV_DRAW_MASK_RES_FULL_COVER) {
             lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
-        } else {
-            for (int x = 0; x < rect.w; x++) {
+        }
+        else {
+            for(int x = 0; x < rect.w; x++) {
                 pixels[y * pitch + x * 4] = line_buf[x];
             }
         }

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -12,7 +12,7 @@
 #include <stdint-gcc.h>
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "../../core/lv_refr.h"
 #include "../lv_draw_mask.h"
@@ -250,4 +250,4 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
     SDL_UnlockTexture(texture);
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -6,16 +6,12 @@
 /*********************
  *      INCLUDES
  *********************/
-
-
-#include <src/misc/lv_gc.h>
-#include <stdint-gcc.h>
 #include "../../lv_conf_internal.h"
 
 #if LV_USE_GPU_SDL
 
+#include "../../misc/lv_gc.h"
 #include "../../core/lv_refr.h"
-#include "../lv_draw_mask.h"
 #include "lv_draw_sdl_mask.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_priv.h"

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 #include "lv_draw_sdl.h"
 #include "../../misc/lv_area.h"

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -33,9 +33,21 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-bool lv_draw_sdl_mask_begin(lv_area_t * draw_area, lv_area_t * coords, lv_area_t * clip);
+/**
+ * Begin drawing with mask. Render target will be switched to a temporary texture,
+ * and drawing coordinates may get clipped or translated
+ * @param coords_in Original coordinates
+ * @param clip_in Original clip area
+ * @param extension Useful for shadows or outlines, can be NULL
+ * @param coords_out Translated coords
+ * @param clip_out Translated clip area
+ * @param apply_area Area of actual composited texture will be drawn
+ * @return true if there are any mask needs to be drawn, false otherwise
+ */
+bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in, const lv_area_t *extension,
+                            lv_area_t *coords_out, lv_area_t *clip_out, lv_area_t *apply_area);
 
-void lv_draw_sdl_mask_end(const lv_area_t * draw_area);
+void lv_draw_sdl_mask_end(const lv_area_t *apply_area);
 
 lv_opa_t * lv_draw_mask_dump(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -33,9 +33,9 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-bool lv_draw_sdl_mask_begin(const lv_area_t * a);
+bool lv_draw_sdl_mask_begin(lv_area_t * draw_area, lv_area_t * coords);
 
-void lv_draw_sdl_mask_end(const lv_area_t * a);
+void lv_draw_sdl_mask_end(const lv_area_t * draw_area);
 
 lv_opa_t * lv_draw_mask_dump(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -48,17 +48,18 @@ typedef enum lv_draw_sdl_mask_cache_type_t {
  * @param apply_area Area of actual composited texture will be drawn
  * @return true if there are any mask needs to be drawn, false otherwise
  */
-bool lv_draw_sdl_mask_begin(const lv_area_t * coords_in, const lv_area_t * clip_in, const lv_area_t * extension,
-                            lv_area_t * coords_out, lv_area_t * clip_out, lv_area_t * apply_area);
+bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t *ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
+                            const lv_area_t * extension, lv_area_t * coords_out, lv_area_t * clip_out,
+                            lv_area_t * apply_area);
 
-void lv_draw_sdl_mask_end(const lv_area_t * apply_area);
+void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t * apply_area);
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t * context, lv_draw_sdl_mask_cache_type_t type,
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * context, lv_draw_sdl_mask_cache_type_t type,
                                           lv_coord_t w, lv_coord_t h);
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -33,6 +33,9 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
+bool lv_draw_sdl_mask_begin(const lv_area_t * a);
+
+void lv_draw_sdl_mask_end(const lv_area_t * a);
 
 lv_opa_t * lv_draw_mask_dump(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -50,11 +50,11 @@ typedef enum lv_draw_sdl_mask_cache_type_t {
  * @param apply_area Area of actual composited texture will be drawn
  * @return true if there are any mask needs to be drawn, false otherwise
  */
-bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t *ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
+bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
                             const lv_area_t * extension, lv_area_t * coords_out, lv_area_t * clip_out,
                             lv_area_t * apply_area);
 
-void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t * apply_area);
+void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_area);
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -48,18 +48,18 @@ typedef enum lv_draw_sdl_mask_cache_type_t {
  * @param apply_area Area of actual composited texture will be drawn
  * @return true if there are any mask needs to be drawn, false otherwise
  */
-bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in, const lv_area_t *extension,
-                            lv_area_t *coords_out, lv_area_t *clip_out, lv_area_t *apply_area);
+bool lv_draw_sdl_mask_begin(const lv_area_t * coords_in, const lv_area_t * clip_in, const lv_area_t * extension,
+                            lv_area_t * coords_out, lv_area_t * clip_out, lv_area_t * apply_area);
 
-void lv_draw_sdl_mask_end(const lv_area_t *apply_area);
+void lv_draw_sdl_mask_end(const lv_area_t * apply_area);
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
-SDL_Texture *lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t *context, lv_draw_sdl_mask_cache_type_t type,
-                                         lv_coord_t w, lv_coord_t h);
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t * context, lv_draw_sdl_mask_cache_type_t type,
+                                          lv_coord_t w, lv_coord_t h);
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -18,13 +18,17 @@ extern "C" {
 
 #include LV_DRAW_SDL_INCLUDE_PATH
 
+#include "lv_draw_sdl.h"
 #include "../../misc/lv_area.h"
 #include "../../misc/lv_color.h"
 
 /*********************
  *      DEFINES
  *********************/
-
+typedef enum lv_draw_sdl_mask_cache_type_t {
+    LV_DRAW_SDL_MASK_KEY_ID_MASK,
+    LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE,
+} lv_draw_sdl_mask_cache_type_t;
 /**********************
  *      TYPEDEFS
  **********************/
@@ -54,6 +58,8 @@ lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * i
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
+SDL_Texture *lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_context_t *context, lv_draw_sdl_mask_cache_type_t type,
+                                         lv_coord_t w, lv_coord_t h);
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -33,7 +33,7 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-bool lv_draw_sdl_mask_begin(lv_area_t * draw_area, lv_area_t * coords);
+bool lv_draw_sdl_mask_begin(lv_area_t * draw_area, lv_area_t * coords, lv_area_t * clip);
 
 void lv_draw_sdl_mask_end(const lv_area_t * draw_area);
 

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -25,13 +25,15 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
 typedef enum lv_draw_sdl_mask_cache_type_t {
     LV_DRAW_SDL_MASK_KEY_ID_MASK,
     LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE,
 } lv_draw_sdl_mask_cache_type_t;
-/**********************
- *      TYPEDEFS
- **********************/
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -59,7 +61,7 @@ lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * i
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * context, lv_draw_sdl_mask_cache_type_t type,
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_mask_cache_type_t type,
                                           lv_coord_t w, lv_coord_t h);
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#include LV_GPU_SDL_INCLUDE_PATH
+#include LV_DRAW_SDL_INCLUDE_PATH
 
 #include "../../misc/lv_area.h"
 #include "../../misc/lv_color.h"

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -49,17 +49,10 @@ bool lv_draw_sdl_mask_begin(const lv_area_t *coords_in, const lv_area_t *clip_in
 
 void lv_draw_sdl_mask_end(const lv_area_t *apply_area);
 
-lv_opa_t * lv_draw_mask_dump(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
+lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 
-SDL_Surface * lv_sdl_create_mask_surface(lv_opa_t * pixels, lv_coord_t width, lv_coord_t height, lv_coord_t stride);
-
-SDL_Texture * lv_sdl_create_mask_texture(SDL_Renderer * renderer, lv_opa_t * pixels, lv_coord_t width,
-                                         lv_coord_t height, lv_coord_t stride);
-
-SDL_Surface * lv_sdl_apply_mask_surface(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
-
-SDL_Texture *
-lv_sdl_gen_mask_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
+SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
+                                            int16_t ids_count);
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_priv.h
+++ b/src/draw/sdl/lv_draw_sdl_priv.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_gpu_sdl.h
+ * @file lv_draw_sdl_priv.h
  *
  */
 
-#ifndef LV_GPU_SDL_H
-#define LV_GPU_SDL_H
+#ifndef LV_DRAW_SDL_PRIV_H
+#define LV_DRAW_SDL_PRIV_H
 
 
 #ifdef __cplusplus
@@ -14,17 +14,14 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_conf_internal.h"
+#include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
-#if LV_USE_EXTERNAL_RENDERER == 0
-#error "SDL GPU requires LV_USE_EXTERNAL_RENDERER 1. Enable it in lv_conf.h"
-#endif
+#include LV_DRAW_SDL_INCLUDE_PATH
 
-#include LV_GPU_SDL_INCLUDE_PATH
-
-#include "../draw/lv_draw.h"
+#include "../lv_draw.h"
+#include "../../misc/lv_lru.h"
 
 /*********************
  *      DEFINES
@@ -34,19 +31,13 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+struct lv_draw_sdl_context_internals_t {
+    lv_lru_t * texture_cache;
+};
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
-void lv_gpu_sdl_init();
-
-/**
- * @brief Free caches
- *
- */
-void lv_gpu_sdl_deinit();
-
-void lv_gpu_sdl_backend_init(lv_draw_backend_t * backend, SDL_Renderer * renderer, SDL_Texture * texture);
 
 /*======================
  * Add/remove functions
@@ -68,10 +59,10 @@ void lv_gpu_sdl_backend_init(lv_draw_backend_t * backend, SDL_Renderer * rendere
  *      MACROS
  **********************/
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif
 
-#endif /*LV_GPU_SDL_H*/
+#endif /*LV_DRAW_SDL_PRIV_H*/

--- a/src/draw/sdl/lv_draw_sdl_priv.h
+++ b/src/draw/sdl/lv_draw_sdl_priv.h
@@ -16,9 +16,9 @@ extern "C" {
  *********************/
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 #include "../lv_draw.h"
 #include "../../misc/lv_lru.h"
@@ -61,7 +61,7 @@ typedef struct lv_draw_sdl_context_internals_t {
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/sdl/lv_draw_sdl_priv.h
+++ b/src/draw/sdl/lv_draw_sdl_priv.h
@@ -31,9 +31,11 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct lv_draw_sdl_context_internals_t {
+typedef struct lv_draw_sdl_context_internals_t {
     lv_lru_t * texture_cache;
-};
+    SDL_Texture * mask;
+    SDL_Texture * composition;
+} lv_draw_sdl_context_internals_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -51,43 +51,43 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 
-static void draw_bg_color(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *draw_area,
-                          const lv_draw_rect_dsc_t *dsc);
+static void draw_bg_color(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                          const lv_draw_rect_dsc_t * dsc);
 
-static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area,
-                        const lv_draw_rect_dsc_t *dsc);
+static void draw_bg_img(const lv_area_t * coords, const lv_area_t * draw_area,
+                        const lv_draw_rect_dsc_t * dsc);
 
-static void draw_border(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *draw_area,
-                        const lv_draw_rect_dsc_t *dsc);
+static void draw_border(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                        const lv_draw_rect_dsc_t * dsc);
 
-static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const lv_area_t *clip,
-                        const lv_draw_rect_dsc_t *dsc);
+static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const lv_area_t * clip,
+                        const lv_draw_rect_dsc_t * dsc);
 
-static void draw_outline(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *clip,
-                         const lv_draw_rect_dsc_t *dsc);
+static void draw_outline(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * clip,
+                         const lv_draw_rect_dsc_t * dsc);
 
-static void draw_border_generic(lv_draw_sdl_context_t *ctx, const lv_area_t *outer_area, const lv_area_t *inner_area,
-                                const lv_area_t *clip, lv_coord_t rout, lv_coord_t rin, lv_color_t color, lv_opa_t opa,
+static void draw_border_generic(lv_draw_sdl_context_t * ctx, const lv_area_t * outer_area, const lv_area_t * inner_area,
+                                const lv_area_t * clip, lv_coord_t rout, lv_coord_t rin, lv_color_t color, lv_opa_t opa,
                                 lv_blend_mode_t blend_mode);
 
-static void draw_border_simple(lv_draw_sdl_context_t *ctx, const lv_area_t *outer_area, const lv_area_t *inner_area,
-                               const lv_area_t *clipped, lv_color_t color, lv_opa_t opa);
+static void draw_border_simple(lv_draw_sdl_context_t * ctx, const lv_area_t * outer_area, const lv_area_t * inner_area,
+                               const lv_area_t * clipped, lv_color_t color, lv_opa_t opa);
 
-static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
-                                const lv_area_t *coords, const lv_area_t *clip, bool full);
+static void frag_render_corners(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                                const lv_area_t * coords, const lv_area_t * clip, bool full);
 
-static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
-                                const lv_area_t *coords, const lv_area_t *clipped, bool full);
+static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                                const lv_area_t * coords, const lv_area_t * clipped, bool full);
 
-static void frag_render_center(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
-                               const lv_area_t *coords, const lv_area_t *clipped, bool full);
+static void frag_render_center(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                               const lv_area_t * coords, const lv_area_t * clipped, bool full);
 
 static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size);
 
 static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_coord_t size, lv_coord_t blur);
 
-static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coord_t rin, const lv_area_t *outer_area,
-                                                        const lv_area_t *inner_area);
+static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coord_t rin, const lv_area_t * outer_area,
+                                                        const lv_area_t * inner_area);
 
 /**********************
  *  STATIC VARIABLES
@@ -105,20 +105,21 @@ static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coor
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_draw_rect(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc) {
-    lv_draw_sdl_context_t *ctx = lv_draw_sdl_get_context();
+void lv_draw_sdl_draw_rect(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
+{
+    lv_draw_sdl_context_t * ctx = lv_draw_sdl_get_context();
 
     lv_area_t extension = {0, 0, 0, 0};
-    if (!SKIP_SHADOW(dsc)) {
-        lv_coord_t ext = (lv_coord_t) (dsc->shadow_spread - dsc->shadow_width / 2 + 1);
+    if(!SKIP_SHADOW(dsc)) {
+        lv_coord_t ext = (lv_coord_t)(dsc->shadow_spread - dsc->shadow_width / 2 + 1);
         lv_area_t core_area;
         extension.x1 = LV_MAX(extension.x1, -dsc->shadow_ofs_x + ext);
         extension.x2 = LV_MAX(extension.x2, dsc->shadow_ofs_x + ext);
         extension.y1 = LV_MAX(extension.y1, -dsc->shadow_ofs_y + ext);
         extension.y2 = LV_MAX(extension.y2, dsc->shadow_ofs_y + ext);
     }
-    if (!SKIP_OUTLINE(dsc)) {
-        lv_coord_t ext = (lv_coord_t) (dsc->outline_pad - 1 + dsc->outline_width);
+    if(!SKIP_OUTLINE(dsc)) {
+        lv_coord_t ext = (lv_coord_t)(dsc->outline_pad - 1 + dsc->outline_width);
         extension.x1 = LV_MAX(extension.x1, ext);
         extension.x2 = LV_MAX(extension.x2, ext);
         extension.y1 = LV_MAX(extension.y1, ext);
@@ -134,14 +135,14 @@ void lv_draw_sdl_draw_rect(const lv_area_t *coords, const lv_area_t *clip, const
     lv_area_to_sdl_rect(&t_clip, &clip_rect);
     draw_shadow(ctx->renderer, &t_coords, &t_clip, dsc);
     /* Shadows and outlines will also draw in extended area */
-    if (has_content) {
+    if(has_content) {
         draw_bg_color(ctx, &t_coords, &t_area, dsc);
         draw_bg_img(&t_coords, &t_area, dsc);
         draw_border(ctx, &t_coords, &t_area, dsc);
     }
     draw_outline(ctx, &t_coords, &t_clip, dsc);
 
-    if (has_mask) {
+    if(has_mask) {
         lv_draw_sdl_mask_end(&apply_area);
     }
 }
@@ -150,13 +151,14 @@ void lv_draw_sdl_draw_rect(const lv_area_t *coords, const lv_area_t *clip, const
  *   STATIC FUNCTIONS
  **********************/
 
-static void draw_bg_color(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *draw_area,
-                          const lv_draw_rect_dsc_t *dsc) {
-    if (dsc->bg_opa <= LV_OPA_TRANSP) return;
+static void draw_bg_color(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                          const lv_draw_rect_dsc_t * dsc)
+{
+    if(dsc->bg_opa <= LV_OPA_TRANSP) return;
     SDL_Color bg_color;
     lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
     lv_coord_t radius = dsc->radius;
-    if (radius <= 0) {
+    if(radius <= 0) {
         SDL_Rect rect;
         lv_area_to_sdl_rect(draw_area, &rect);
         SDL_SetRenderDrawColor(ctx->renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);
@@ -175,8 +177,8 @@ static void draw_bg_color(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, c
     lv_area_copy(&coords_frag, coords);
     lv_area_set_width(&coords_frag, frag_size);
     lv_area_set_height(&coords_frag, frag_size);
-    SDL_Texture *texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
-    if (texture == NULL) {
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
+    if(texture == NULL) {
         lv_draw_mask_radius_param_t mask_rout_param;
         lv_draw_mask_radius_init(&mask_rout_param, coords, radius, false);
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
@@ -194,11 +196,12 @@ static void draw_bg_color(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, c
     frag_render_center(ctx->renderer, texture, frag_size, coords, draw_area, false);
 }
 
-static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area, const lv_draw_rect_dsc_t *dsc) {
-    if (SKIP_IMAGE(dsc)) return;
+static void draw_bg_img(const lv_area_t * coords, const lv_area_t * draw_area, const lv_draw_rect_dsc_t * dsc)
+{
+    if(SKIP_IMAGE(dsc)) return;
 
     lv_img_src_t src_type = lv_img_src_get_type(dsc->bg_img_src);
-    if (src_type == LV_IMG_SRC_SYMBOL) {
+    if(src_type == LV_IMG_SRC_SYMBOL) {
         lv_point_t size;
         lv_txt_get_size(&size, dsc->bg_img_src, dsc->bg_img_symbol_font, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
         lv_area_t a;
@@ -213,18 +216,20 @@ static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area, con
         label_draw_dsc.color = dsc->bg_img_recolor;
         label_draw_dsc.opa = dsc->bg_img_opa;
         lv_draw_label(&a, draw_area, &label_draw_dsc, dsc->bg_img_src, NULL);
-    } else {
+    }
+    else {
         lv_img_header_t header;
         size_t key_size;
-        lv_draw_sdl_cache_key_head_img_t *key = lv_draw_sdl_texture_img_key_create(dsc->bg_img_src, 0, &key_size);
+        lv_draw_sdl_cache_key_head_img_t * key = lv_draw_sdl_texture_img_key_create(dsc->bg_img_src, 0, &key_size);
         bool key_found;
-        lv_img_header_t *cache_header = NULL;
-        SDL_Texture *texture = lv_draw_sdl_texture_cache_get_with_userdata(key, key_size, &key_found,
-                                                                           (void **) &cache_header);
+        lv_img_header_t * cache_header = NULL;
+        SDL_Texture * texture = lv_draw_sdl_texture_cache_get_with_userdata(key, key_size, &key_found,
+                                                                            (void **) &cache_header);
         SDL_free(key);
-        if (texture) {
+        if(texture) {
             header = *cache_header;
-        } else if (key_found || lv_img_decoder_get_info(dsc->bg_img_src, &header) != LV_RES_OK) {
+        }
+        else if(key_found || lv_img_decoder_get_info(dsc->bg_img_src, &header) != LV_RES_OK) {
             /* When cache hit but with negative result, use default decoder. If still fail, return.*/
             LV_LOG_WARN("Couldn't read the background image");
             return;
@@ -238,7 +243,7 @@ static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area, con
         img_dsc.opa = dsc->bg_img_opa;
 
         /*Center align*/
-        if (dsc->bg_img_tiled == false) {
+        if(dsc->bg_img_tiled == false) {
             lv_area_t area;
             area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - header.w / 2;
             area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - header.h / 2;
@@ -246,16 +251,17 @@ static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area, con
             area.y2 = area.y1 + header.h - 1;
 
             lv_draw_img(&area, draw_area, dsc->bg_img_src, &img_dsc);
-        } else {
+        }
+        else {
             lv_area_t area;
             area.y1 = coords->y1;
             area.y2 = area.y1 + header.h - 1;
 
-            for (; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
+            for(; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
 
                 area.x1 = coords->x1;
                 area.x2 = area.x1 + header.w - 1;
-                for (; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
+                for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
                     lv_draw_img(&area, draw_area, dsc->bg_img_src, &img_dsc);
                 }
             }
@@ -263,10 +269,11 @@ static void draw_bg_img(const lv_area_t *coords, const lv_area_t *draw_area, con
     }
 }
 
-static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const lv_area_t *clip,
-                        const lv_draw_rect_dsc_t *dsc) {
+static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const lv_area_t * clip,
+                        const lv_draw_rect_dsc_t * dsc)
+{
     /*Check whether the shadow is visible*/
-    if (SKIP_SHADOW(dsc)) return;
+    if(SKIP_SHADOW(dsc)) return;
 
     lv_coord_t sw = dsc->shadow_width;
 
@@ -284,12 +291,12 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
 
     lv_opa_t opa = dsc->shadow_opa;
 
-    if (opa > LV_OPA_MAX) opa = LV_OPA_COVER;
+    if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
     /*Get clipped draw area which is the real draw area.
      *It is always the same or inside `shadow_area`*/
     lv_area_t draw_area;
-    if (!_lv_area_intersect(&draw_area, &shadow_area, clip)) return;
+    if(!_lv_area_intersect(&draw_area, &shadow_area, clip)) return;
 
     SDL_Rect core_area_rect;
     lv_area_to_sdl_rect(&shadow_area, &core_area_rect);
@@ -300,14 +307,14 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
                                    LV_MAX(sw / 2, radius));
 
     /* This is how big the corner is after blurring */
-    lv_coord_t blur_growth = (lv_coord_t) (sw / 2 + 1);
+    lv_coord_t blur_growth = (lv_coord_t)(sw / 2 + 1);
 
-    lv_coord_t blur_frag_size = (lv_coord_t) (frag_size + blur_growth);
+    lv_coord_t blur_frag_size = (lv_coord_t)(frag_size + blur_growth);
 
     lv_draw_rect_shadow_key_t key = rect_shadow_key_create(radius, frag_size, sw);
 
-    SDL_Texture *texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
-    if (texture == NULL) {
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
+    if(texture == NULL) {
         lv_area_t mask_area = {blur_growth, blur_growth}, mask_area_blurred = {0, 0};
         lv_area_set_width(&mask_area, frag_size * 2);
         lv_area_set_height(&mask_area, frag_size * 2);
@@ -317,7 +324,7 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
         lv_draw_mask_radius_param_t mask_rout_param;
         lv_draw_mask_radius_init(&mask_rout_param, &mask_area, radius, false);
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
-        lv_opa_t *mask_buf = lv_draw_sdl_mask_dump_opa(&mask_area_blurred, &mask_id, 1);
+        lv_opa_t * mask_buf = lv_draw_sdl_mask_dump_opa(&mask_area_blurred, &mask_id, 1);
         lv_stack_blur_grayscale(mask_buf, lv_area_get_width(&mask_area_blurred), lv_area_get_height(&mask_area_blurred),
                                 sw / 2 + sw % 2);
         texture = lv_sdl_create_opa_texture(renderer, mask_buf, blur_frag_size, blur_frag_size,
@@ -340,9 +347,10 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
 }
 
 
-static void draw_border(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *draw_area,
-                        const lv_draw_rect_dsc_t *dsc) {
-    if (SKIP_BORDER(dsc)) return;
+static void draw_border(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                        const lv_draw_rect_dsc_t * dsc)
+{
+    if(SKIP_BORDER(dsc)) return;
 
     SDL_Color border_color;
     lv_color_to_sdl_color(&dsc->border_color, &border_color);
@@ -361,13 +369,14 @@ static void draw_border(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, con
                         dsc->blend_mode);
 }
 
-static void draw_outline(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, const lv_area_t *clip,
-                         const lv_draw_rect_dsc_t *dsc) {
-    if (SKIP_OUTLINE(dsc)) return;
+static void draw_outline(lv_draw_sdl_context_t * ctx, const lv_area_t * coords, const lv_area_t * clip,
+                         const lv_draw_rect_dsc_t * dsc)
+{
+    if(SKIP_OUTLINE(dsc)) return;
 
     lv_opa_t opa = dsc->outline_opa;
 
-    if (opa > LV_OPA_MAX) opa = LV_OPA_COVER;
+    if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
     /*Get the inner radius*/
     lv_area_t area_inner;
@@ -389,13 +398,13 @@ static void draw_outline(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, co
     area_outer.y2 += dsc->outline_width;
 
     lv_area_t draw_area;
-    if (!_lv_area_intersect(&draw_area, &area_outer, clip)) return;
+    if(!_lv_area_intersect(&draw_area, &area_outer, clip)) return;
 
     int32_t inner_w = lv_area_get_width(&area_inner);
     int32_t inner_h = lv_area_get_height(&area_inner);
     lv_coord_t rin = dsc->radius;
     int32_t short_side = LV_MIN(inner_w, inner_h);
-    if (rin > short_side >> 1) rin = short_side >> 1;
+    if(rin > short_side >> 1) rin = short_side >> 1;
 
     lv_coord_t rout = rin + dsc->outline_width;
 
@@ -403,34 +412,36 @@ static void draw_outline(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, co
                         dsc->blend_mode);
 }
 
-static void draw_border_generic(lv_draw_sdl_context_t *ctx, const lv_area_t *outer_area, const lv_area_t *inner_area,
-                                const lv_area_t *clip, lv_coord_t rout, lv_coord_t rin, lv_color_t color, lv_opa_t opa,
-                                lv_blend_mode_t blend_mode) {
+static void draw_border_generic(lv_draw_sdl_context_t * ctx, const lv_area_t * outer_area, const lv_area_t * inner_area,
+                                const lv_area_t * clip, lv_coord_t rout, lv_coord_t rin, lv_color_t color, lv_opa_t opa,
+                                lv_blend_mode_t blend_mode)
+{
     opa = opa >= LV_OPA_COVER ? LV_OPA_COVER : opa;
 
-    SDL_Renderer *renderer = ctx->renderer;
+    SDL_Renderer * renderer = ctx->renderer;
 
     lv_draw_rect_border_key_t key = rect_border_key_create(rout, rin, outer_area, inner_area);
     lv_coord_t radius = LV_MIN3(rout, lv_area_get_width(outer_area) / 2, lv_area_get_height(outer_area) / 2);
     lv_coord_t max_side = LV_MAX4(key.offsets.x1, key.offsets.y1, -key.offsets.x2, -key.offsets.y2);
     lv_coord_t frag_size = LV_MAX(radius, max_side);
-    SDL_Texture *texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
-    if (texture == NULL) {
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(&key, sizeof(key), NULL);
+    if(texture == NULL) {
         /* Create a mask texture with size of (frag_size * 2 + 1) */
         const lv_area_t frag_area = {0, 0, frag_size * 2, frag_size * 2};
 
         /*Create mask for the outer area*/
         int16_t mask_ids[2] = {LV_MASK_ID_INV, LV_MASK_ID_INV};
         lv_draw_mask_radius_param_t mask_rout_param;
-        if (rout > 0) {
+        if(rout > 0) {
             lv_draw_mask_radius_init(&mask_rout_param, &frag_area, rout, false);
             mask_ids[0] = lv_draw_mask_add(&mask_rout_param, NULL);
         }
 
         /*Create mask for the inner mask*/
-        if (rin < 0) rin = 0;
+        if(rin < 0) rin = 0;
         const lv_area_t frag_inner_area = {frag_area.x1 + key.offsets.x1, frag_area.y1 + key.offsets.y1,
-                                           frag_area.x2 + key.offsets.x2, frag_area.y2 + key.offsets.y2};
+                                           frag_area.x2 + key.offsets.x2, frag_area.y2 + key.offsets.y2
+                                          };
         lv_draw_mask_radius_param_t mask_rin_param;
         lv_draw_mask_radius_init(&mask_rin_param, &frag_inner_area, rin, true);
         mask_ids[1] = lv_draw_mask_add(&mask_rin_param, NULL);
@@ -456,37 +467,39 @@ static void draw_border_generic(lv_draw_sdl_context_t *ctx, const lv_area_t *out
     frag_render_borders(renderer, texture, frag_size, outer_area, clip, true);
 }
 
-static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
-                                const lv_area_t *coords, const lv_area_t *clipped, bool full) {
+static void frag_render_corners(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                                const lv_area_t * coords, const lv_area_t * clipped, bool full)
+{
     lv_area_t corner_area, dst_area;
     /* Upper left */
     corner_area.x1 = coords->x1;
     corner_area.y1 = coords->y1;
     corner_area.x2 = coords->x1 + frag_size - 1;
     corner_area.y2 = coords->y1 + frag_size - 1;
-    if (_lv_area_intersect(&dst_area, &corner_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &corner_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area), dh = lv_area_get_height(&dst_area);
-        lv_coord_t sx = (lv_coord_t) (dst_area.x1 - corner_area.x1), sy = (lv_coord_t) (dst_area.y1 - corner_area.y1);
+        lv_coord_t sx = (lv_coord_t)(dst_area.x1 - corner_area.x1), sy = (lv_coord_t)(dst_area.y1 - corner_area.y1);
         SDL_Rect src_rect = {sx, sy, dw, dh};
         SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
     }
     /* Upper right, clip right edge if too big */
     corner_area.x1 = LV_MAX(coords->x2 - frag_size + 1, coords->x1 + frag_size);
     corner_area.x2 = coords->x2;
-    if (_lv_area_intersect(&dst_area, &corner_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &corner_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area), dh = lv_area_get_height(&dst_area);
-        if (full) {
-            lv_coord_t sx = (lv_coord_t) (dst_area.x1 - corner_area.x1),
-                    sy = (lv_coord_t) (dst_area.y1 - corner_area.y1);
+        if(full) {
+            lv_coord_t sx = (lv_coord_t)(dst_area.x1 - corner_area.x1),
+                       sy = (lv_coord_t)(dst_area.y1 - corner_area.y1);
             SDL_Rect src_rect = {frag_size + 1 + sx, sy, dw, dh};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
+        }
+        else {
             SDL_Rect src_rect = {corner_area.x2 - dst_area.x2, dst_area.y1 - corner_area.y1, dw, dh};
             SDL_RenderCopyEx(renderer, frag, &src_rect, &dst_rect, 0, NULL, SDL_FLIP_HORIZONTAL);
         }
@@ -494,17 +507,18 @@ static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_co
     /* Lower right, clip bottom edge if too big */
     corner_area.y1 = LV_MAX(coords->y2 - frag_size + 1, coords->y1 + frag_size);
     corner_area.y2 = coords->y2;
-    if (_lv_area_intersect(&dst_area, &corner_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &corner_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area), dh = lv_area_get_height(&dst_area);
-        if (full) {
-            lv_coord_t sx = (lv_coord_t) (dst_area.x1 - corner_area.x1),
-                    sy = (lv_coord_t) (dst_area.y1 - corner_area.y1);
+        if(full) {
+            lv_coord_t sx = (lv_coord_t)(dst_area.x1 - corner_area.x1),
+                       sy = (lv_coord_t)(dst_area.y1 - corner_area.y1);
             SDL_Rect src_rect = {frag_size + 1 + sx, frag_size + 1 + sy, dw, dh};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
+        }
+        else {
             SDL_Rect src_rect = {corner_area.x2 - dst_area.x2, corner_area.y2 - dst_area.y2, dw, dh};
             SDL_RenderCopyEx(renderer, frag, &src_rect, &dst_rect, 0, NULL, SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL);
         }
@@ -512,40 +526,43 @@ static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_co
     /* Lower left, right edge should not be clipped */
     corner_area.x1 = coords->x1;
     corner_area.x2 = coords->x1 + frag_size - 1;
-    if (_lv_area_intersect(&dst_area, &corner_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &corner_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area), dh = lv_area_get_height(&dst_area);
-        if (full) {
-            lv_coord_t sx = (lv_coord_t) (dst_area.x1 - corner_area.x1),
-                    sy = (lv_coord_t) (dst_area.y1 - corner_area.y1);
+        if(full) {
+            lv_coord_t sx = (lv_coord_t)(dst_area.x1 - corner_area.x1),
+                       sy = (lv_coord_t)(dst_area.y1 - corner_area.y1);
             SDL_Rect src_rect = {sx, frag_size + 1 + sy, dw, dh};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
+        }
+        else {
             SDL_Rect src_rect = {dst_area.x1 - corner_area.x1, corner_area.y2 - dst_area.y2, dw, dh};
             SDL_RenderCopyEx(renderer, frag, &src_rect, &dst_rect, 0, NULL, SDL_FLIP_VERTICAL);
         }
     }
 }
 
-static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
-                                const lv_area_t *coords, const lv_area_t *clipped, bool full) {
+static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                                const lv_area_t * coords, const lv_area_t * clipped, bool full)
+{
     lv_area_t border_area, dst_area;
     /* Top border */
     border_area.x1 = coords->x1 + frag_size;
     border_area.y1 = coords->y1;
     border_area.x2 = coords->x2 - frag_size;
     border_area.y2 = coords->y1 + frag_size - 1;
-    if (_lv_area_intersect(&dst_area, &border_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &border_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
-        lv_coord_t sy = (lv_coord_t) (dst_area.y1 - border_area.y1);
-        if (full) {
+        lv_coord_t sy = (lv_coord_t)(dst_area.y1 - border_area.y1);
+        if(full) {
             SDL_Rect src_rect = {frag_size, sy, 1, lv_area_get_height(&dst_area)};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
+        }
+        else {
             SDL_Rect src_rect = {frag_size - 1, sy, 1, lv_area_get_height(&dst_area)};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
         }
@@ -553,17 +570,18 @@ static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_co
     /* Bottom border */
     border_area.y1 = LV_MAX(coords->y2 - frag_size + 1, coords->y1 + frag_size);
     border_area.y2 = coords->y2;
-    if (_lv_area_intersect(&dst_area, &border_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &border_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dh = lv_area_get_height(&dst_area);
-        if (full) {
-            lv_coord_t sy = (lv_coord_t) (dst_area.y1 - border_area.y1);
+        if(full) {
+            lv_coord_t sy = (lv_coord_t)(dst_area.y1 - border_area.y1);
             SDL_Rect src_rect = {frag_size, frag_size + 1 + sy, 1, dh};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
-            lv_coord_t sy = (lv_coord_t) (border_area.y2 - dst_area.y2);
+        }
+        else {
+            lv_coord_t sy = (lv_coord_t)(border_area.y2 - dst_area.y2);
             SDL_Rect src_rect = {frag_size - 1, sy, 1, dh};
             SDL_RenderCopyEx(renderer, frag, &src_rect, &dst_rect, 0, NULL, SDL_FLIP_VERTICAL);
         }
@@ -573,16 +591,17 @@ static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_co
     border_area.y1 = coords->y1 + frag_size;
     border_area.x2 = coords->x1 + frag_size - 1;
     border_area.y2 = coords->y2 - frag_size;
-    if (_lv_area_intersect(&dst_area, &border_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &border_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area);
-        lv_coord_t sx = (lv_coord_t) (dst_area.x1 - border_area.x1);
-        if (full) {
+        lv_coord_t sx = (lv_coord_t)(dst_area.x1 - border_area.x1);
+        if(full) {
             SDL_Rect src_rect = {sx, frag_size, dw, 1};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
+        }
+        else {
             SDL_Rect src_rect = {sx, frag_size - 1, dw, 1};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
         }
@@ -590,50 +609,55 @@ static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_co
     /* Right border */
     border_area.x1 = LV_MAX(coords->x2 - frag_size + 1, coords->x1 + frag_size);
     border_area.x2 = coords->x2;
-    if (_lv_area_intersect(&dst_area, &border_area, clipped)) {
+    if(_lv_area_intersect(&dst_area, &border_area, clipped)) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(&dst_area, &dst_rect);
 
         lv_coord_t dw = lv_area_get_width(&dst_area);
-        if (full) {
-            lv_coord_t sx = (lv_coord_t) (dst_area.x1 - border_area.x1);
+        if(full) {
+            lv_coord_t sx = (lv_coord_t)(dst_area.x1 - border_area.x1);
             SDL_Rect src_rect = {frag_size + 1 + sx, frag_size, dw, 1};
             SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-        } else {
-            lv_coord_t sx = (lv_coord_t) (border_area.x2 - dst_area.x2);
+        }
+        else {
+            lv_coord_t sx = (lv_coord_t)(border_area.x2 - dst_area.x2);
             SDL_Rect src_rect = {sx, frag_size - 1, dw, 1};
             SDL_RenderCopyEx(renderer, frag, &src_rect, &dst_rect, 0, NULL, SDL_FLIP_HORIZONTAL);
         }
     }
 }
 
-static void frag_render_center(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size, const lv_area_t *coords,
-                               const lv_area_t *clipped, bool full) {
+static void frag_render_center(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
+                               const lv_area_t * coords,
+                               const lv_area_t * clipped, bool full)
+{
     SDL_SetRenderDrawColor(renderer, 0, 0, 255, 80);
     lv_area_t center_area = {
-            coords->x1 + frag_size,
-            coords->y1 + frag_size,
-            coords->x2 - frag_size,
-            coords->y2 - frag_size,
+        coords->x1 + frag_size,
+        coords->y1 + frag_size,
+        coords->x2 - frag_size,
+        coords->y2 - frag_size,
     };
-    if (center_area.x2 < center_area.x1 || center_area.y2 < center_area.y1) return;
+    if(center_area.x2 < center_area.x1 || center_area.y2 < center_area.y1) return;
     lv_area_t draw_area;
-    if (!_lv_area_intersect(&draw_area, &center_area, clipped)) {
+    if(!_lv_area_intersect(&draw_area, &center_area, clipped)) {
         return;
     }
     SDL_Rect dst_rect;
     lv_area_to_sdl_rect(&draw_area, &dst_rect);
-    if (full) {
+    if(full) {
         SDL_Rect src_rect = {frag_size, frag_size, 1, 1};
         SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
-    } else {
+    }
+    else {
         SDL_Rect src_rect = {frag_size - 1, frag_size - 1, 1, 1};
         SDL_RenderCopy(renderer, frag, &src_rect, &dst_rect);
     }
-//    SDL_RenderDrawRect(renderer, &dst_rect);
+    //    SDL_RenderDrawRect(renderer, &dst_rect);
 }
 
-static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size) {
+static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size)
+{
     lv_draw_rect_bg_key_t key;
     SDL_memset(&key, 0, sizeof(key));
     key.magic = LV_GPU_CACHE_KEY_MAGIC_RECT_BG;
@@ -642,7 +666,8 @@ static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t si
     return key;
 }
 
-static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_coord_t size, lv_coord_t blur) {
+static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_coord_t size, lv_coord_t blur)
+{
     lv_draw_rect_shadow_key_t key;
     SDL_memset(&key, 0, sizeof(key));
     key.magic = LV_GPU_CACHE_KEY_MAGIC_RECT_SHADOW;
@@ -652,8 +677,9 @@ static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_co
     return key;
 }
 
-static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coord_t rin, const lv_area_t *outer_area,
-                                                        const lv_area_t *inner_area) {
+static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coord_t rin, const lv_area_t * outer_area,
+                                                        const lv_area_t * inner_area)
+{
     lv_draw_rect_border_key_t key;
     /* VERY IMPORTANT! Padding between members is uninitialized, so we have to wipe them manually */
     SDL_memset(&key, 0, sizeof(key));

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -217,7 +217,7 @@ static void draw_bg_img(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const
         label_draw_dsc.font = dsc->bg_img_symbol_font;
         label_draw_dsc.color = dsc->bg_img_recolor;
         label_draw_dsc.opa = dsc->bg_img_opa;
-        lv_draw_label(&a, draw_area, &label_draw_dsc, dsc->bg_img_src, NULL);
+        lv_draw_label((lv_draw_ctx_t *) ctx, &label_draw_dsc, &a, dsc->bg_img_src, NULL);
     }
     else {
         lv_img_header_t header;
@@ -252,7 +252,7 @@ static void draw_bg_img(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const
             area.x2 = area.x1 + header.w - 1;
             area.y2 = area.y1 + header.h - 1;
 
-            lv_draw_img(&ctx->base_draw.base_draw, &img_dsc, &area, dsc->bg_img_src);
+            lv_draw_img((lv_draw_ctx_t *) ctx, &img_dsc, &area, dsc->bg_img_src);
         }
         else {
             lv_area_t area;
@@ -264,7 +264,7 @@ static void draw_bg_img(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const
                 area.x1 = coords->x1;
                 area.x2 = area.x1 + header.w - 1;
                 for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
-                    lv_draw_img(&ctx->base_draw.base_draw, &img_dsc, &area, dsc->bg_img_src);
+                    lv_draw_img((lv_draw_ctx_t *) ctx, &img_dsc, &area, dsc->bg_img_src);
                 }
             }
         }

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -181,7 +181,7 @@ static void draw_bg_color(lv_draw_sdl_context_t *ctx, const lv_area_t *coords, c
         lv_draw_mask_radius_param_t mask_rout_param;
         lv_draw_mask_radius_init(&mask_rout_param, coords, radius, false);
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
-        texture = lv_sdl_gen_mask_texture(ctx->renderer, &coords_frag, &mask_id, 1);
+        texture = lv_draw_sdl_mask_dump_texture(ctx->renderer, &coords_frag, &mask_id, 1);
         lv_draw_mask_remove_id(mask_id);
         SDL_assert(texture);
         lv_draw_sdl_texture_cache_put(&key, sizeof(key), texture);
@@ -317,10 +317,10 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
         lv_draw_mask_radius_param_t mask_rout_param;
         lv_draw_mask_radius_init(&mask_rout_param, &core_area, radius, false);
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
-        lv_opa_t *mask_buf = lv_draw_mask_dump(&blur_frag, &mask_id, 1);
+        lv_opa_t *mask_buf = lv_draw_sdl_mask_dump_opa(&blur_frag, &mask_id, 1);
         lv_stack_blur_grayscale(mask_buf, lv_area_get_width(&blur_frag), lv_area_get_height(&blur_frag), sw / 2 + 1);
-        texture = lv_sdl_create_mask_texture(renderer, mask_buf, blur_frag_size, blur_frag_size,
-                                             lv_area_get_width(&blur_frag));
+        texture = lv_sdl_create_opa_texture(renderer, mask_buf, lv_area_get_width(&blur_frag),
+                                            lv_area_get_height(&blur_frag), lv_area_get_width(&blur_frag));
         lv_mem_buf_release(mask_buf);
         lv_draw_mask_remove_id(mask_id);
         SDL_assert(texture);
@@ -468,7 +468,7 @@ static void draw_border_generic(lv_draw_sdl_context_t *ctx, const lv_area_t *out
         lv_area_set_width(&frag_area, frag_size);
         lv_area_set_height(&frag_area, frag_size);
 
-        texture = lv_sdl_gen_mask_texture(renderer, &frag_area, mask_ids, 2);
+        texture = lv_draw_sdl_mask_dump_texture(renderer, &frag_area, mask_ids, 2);
 
         lv_draw_mask_remove_id(mask_ids[1]);
         lv_draw_mask_remove_id(mask_ids[0]);

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -104,7 +104,7 @@ static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coor
 
 void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords)
 {
-    const lv_area_t *clip = draw_ctx->clip_area;
+    const lv_area_t * clip = draw_ctx->clip_area;
     lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
 
     lv_area_t extension = {0, 0, 0, 0};

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -112,26 +112,23 @@ void lv_draw_sdl_draw_rect(const lv_area_t *coords, const lv_area_t *clip, const
 
     lv_draw_sdl_context_t *ctx = lv_draw_sdl_get_context();
 
-    bool has_mask = lv_draw_sdl_mask_begin(&draw_area);
+    /* Coords will be translated so coords will start at (0,0) */
+    lv_area_t t_coords = *coords, t_area = draw_area;
+    bool has_mask = has_draw_content && lv_draw_sdl_mask_begin(&t_area, &t_coords);
 
     SDL_Rect clip_rect;
     lv_area_to_sdl_rect(clip, &clip_rect);
-    draw_shadow(ctx->renderer, coords, clip, dsc);
+    draw_shadow(ctx->renderer, &t_coords, &t_area, dsc);
     /* Shadows and outlines will also draw in extended area */
     if (has_draw_content) {
-        draw_bg_color(ctx, coords, &draw_area, dsc);
-        draw_bg_img(coords, clip, dsc);
-        draw_border(ctx, coords, &draw_area, dsc);
+        draw_bg_color(ctx, &t_coords, &t_area, dsc);
+        draw_bg_img(&t_coords, &t_area, dsc);
+        draw_border(ctx, &t_coords, &t_area, dsc);
     }
-    draw_outline(coords, clip, dsc);
+    draw_outline(&t_coords, &t_area, dsc);
 
     if (has_mask) {
         lv_draw_sdl_mask_end(&draw_area);
-    }
-
-    if (has_draw_content) {
-        SDL_Rect rect;
-        lv_area_to_sdl_rect(coords, &rect);
     }
 }
 

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -9,7 +9,7 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "../lv_draw_rect.h"
 #include "../lv_draw_img.h"
@@ -695,4 +695,4 @@ static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coor
     return key;
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -108,7 +108,7 @@ static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coor
 void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords)
 {
     const lv_area_t *clip = draw_ctx->clip_area;
-    lv_draw_sdl_ctx_t * ctx = lv_draw_sdl_get_context();
+    lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
 
     lv_area_t extension = {0, 0, 0, 0};
     if(!SKIP_SHADOW(dsc)) {

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -296,10 +296,12 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
 
     lv_coord_t radius = dsc->radius;
     /* No matter how big the shadow is, what we need is just a corner */
-    lv_coord_t frag_size = LV_MIN3(radius, lv_area_get_width(&core_area) / 2, lv_area_get_height(&core_area) / 2);
+    lv_coord_t frag_size = LV_MIN3(lv_area_get_width(&core_area) / 2, lv_area_get_height(&core_area) / 2,
+                                   LV_MAX(sw / 2, radius));
 
     /* This is how big the corner is after blurring */
     lv_coord_t blur_growth = (lv_coord_t) (sw / 2 + 1);
+
     lv_coord_t blur_frag_size = (lv_coord_t) (frag_size + blur_growth);
 
     lv_draw_rect_shadow_key_t key = rect_shadow_key_create(radius, frag_size, sw);

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -53,36 +53,36 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 
-static void draw_bg_color(SDL_Renderer * renderer, const lv_area_t * coords, const lv_draw_rect_dsc_t * dsc);
+static void draw_bg_color(SDL_Renderer *renderer, const lv_area_t *coords, const lv_draw_rect_dsc_t *dsc);
 
-static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip,
-                        const lv_draw_rect_dsc_t * dsc);
+static void draw_bg_img(const lv_area_t *coords, const lv_area_t *clip,
+                        const lv_draw_rect_dsc_t *dsc);
 
-static void draw_border(SDL_Renderer * renderer, const lv_area_t * coords, const lv_draw_rect_dsc_t * dsc);
+static void draw_border(SDL_Renderer *renderer, const lv_area_t *coords, const lv_draw_rect_dsc_t *dsc);
 
-static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const lv_area_t * clip,
-                        const lv_draw_rect_dsc_t * dsc);
+static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const lv_area_t *clip,
+                        const lv_draw_rect_dsc_t *dsc);
 
-static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc);
+static void draw_outline(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc);
 
-static void draw_border_generic(const lv_area_t * outer_area, const lv_area_t * inner_area, lv_coord_t rout,
+static void draw_border_generic(const lv_area_t *outer_area, const lv_area_t *inner_area, lv_coord_t rout,
                                 lv_coord_t rin, lv_color_t color, lv_opa_t opa, lv_blend_mode_t blend_mode);
 
-static void draw_border_simple(const lv_area_t * outer_area, const lv_area_t * inner_area, lv_color_t color,
+static void draw_border_simple(const lv_area_t *outer_area, const lv_area_t *inner_area, lv_color_t color,
                                lv_opa_t opa);
 
-static void draw_rect_masked(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc);
+static void draw_rect_masked(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc);
 
-static void draw_rect_masked_simple(const lv_area_t * coords, const lv_area_t * mask, const lv_draw_rect_dsc_t * dsc);
+static void draw_rect_masked_simple(const lv_area_t *coords, const lv_area_t *mask, const lv_draw_rect_dsc_t *dsc);
 
-static void frag_render_corners(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
-                                const lv_area_t * coords);
+static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
+                                const lv_area_t *coords);
 
-static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
-                                const lv_area_t * coords);
+static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
+                                const lv_area_t *coords);
 
-static void frag_render_center(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
-                               const lv_area_t * coords);
+static void frag_render_center(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
+                               const lv_area_t *coords);
 
 static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size);
 
@@ -107,18 +107,17 @@ static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coor
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_draw_rect(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
-{
+void lv_draw_sdl_draw_rect(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc) {
     lv_area_t draw_area;
     bool has_draw_content = _lv_area_intersect(&draw_area, coords, clip);
 
-    if(lv_draw_mask_is_any(&draw_area)) {
+    if (lv_draw_mask_is_any(&draw_area)) {
         draw_rect_masked(coords, clip, dsc);
         return;
     }
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    lv_draw_sdl_backend_context_t *ctx = lv_draw_sdl_get_context();
+    SDL_Renderer *renderer = ctx->renderer;
 
 
     SDL_Rect clip_rect;
@@ -126,24 +125,24 @@ void lv_draw_sdl_draw_rect(const lv_area_t * coords, const lv_area_t * clip, con
     SDL_RenderSetClipRect(renderer, &clip_rect);
     draw_shadow(renderer, coords, clip, dsc);
     /* Shadows and outlines will also draw in extended area */
-    if(has_draw_content) {
+    if (has_draw_content) {
         draw_bg_color(renderer, coords, dsc);
         draw_bg_img(coords, clip, dsc);
         draw_border(renderer, coords, dsc);
     }
     draw_outline(coords, clip, dsc);
+    SDL_RenderSetClipRect(renderer, NULL);
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static void draw_bg_color(SDL_Renderer * renderer, const lv_area_t * coords, const lv_draw_rect_dsc_t * dsc)
-{
+static void draw_bg_color(SDL_Renderer *renderer, const lv_area_t *coords, const lv_draw_rect_dsc_t *dsc) {
     SDL_Color bg_color;
     lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
     lv_coord_t radius = dsc->radius;
-    if(radius > 0) {
+    if (radius > 0) {
         /*A small texture with a quarter of the rect is enough*/
         lv_coord_t bg_w = lv_area_get_width(coords), bg_h = lv_area_get_height(coords), bg_min = LV_MIN(bg_w, bg_h);
         /* If size isn't times of 2, increase 1 px */
@@ -154,8 +153,8 @@ static void draw_bg_color(SDL_Renderer * renderer, const lv_area_t * coords, con
         lv_area_copy(&coords_frag, coords);
         lv_area_set_width(&coords_frag, frag_size);
         lv_area_set_height(&coords_frag, frag_size);
-        SDL_Texture * texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
-        if(texture == NULL) {
+        SDL_Texture *texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
+        if (texture == NULL) {
             lv_draw_mask_radius_param_t mask_rout_param;
             lv_draw_mask_radius_init(&mask_rout_param, coords, radius, false);
             int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
@@ -171,8 +170,7 @@ static void draw_bg_color(SDL_Renderer * renderer, const lv_area_t * coords, con
         frag_render_corners(renderer, texture, frag_size, coords);
         frag_render_borders(renderer, texture, frag_size, coords);
         frag_render_center(renderer, texture, frag_size, coords);
-    }
-    else {
+    } else {
         SDL_Rect coords_rect;
         lv_area_to_sdl_rect(coords, &coords_rect);
         SDL_SetRenderDrawColor(renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);
@@ -181,12 +179,11 @@ static void draw_bg_color(SDL_Renderer * renderer, const lv_area_t * coords, con
     }
 }
 
-static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
-{
-    if(SKIP_IMAGE(dsc)) return;
+static void draw_bg_img(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc) {
+    if (SKIP_IMAGE(dsc)) return;
 
     lv_img_src_t src_type = lv_img_src_get_type(dsc->bg_img_src);
-    if(src_type == LV_IMG_SRC_SYMBOL) {
+    if (src_type == LV_IMG_SRC_SYMBOL) {
         lv_point_t size;
         lv_txt_get_size(&size, dsc->bg_img_src, dsc->bg_img_symbol_font, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
         lv_area_t a;
@@ -201,19 +198,17 @@ static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip, const 
         label_draw_dsc.color = dsc->bg_img_recolor;
         label_draw_dsc.opa = dsc->bg_img_opa;
         lv_draw_label(&a, clip, &label_draw_dsc, dsc->bg_img_src, NULL);
-    }
-    else {
+    } else {
         lv_img_header_t header;
         size_t key_size;
-        lv_draw_sdl_cache_key_head_img_t * key = lv_draw_sdl_img_cache_key_create(dsc->bg_img_src, 0, &key_size);
+        lv_draw_sdl_cache_key_head_img_t *key = lv_draw_sdl_img_cache_key_create(dsc->bg_img_src, 0, &key_size);
         bool key_found;
-        lv_img_header_t * cache_header = NULL;
-        SDL_Texture * texture = lv_gpu_draw_cache_get_with_userdata(key, key_size, &key_found, (void **) &cache_header);
+        lv_img_header_t *cache_header = NULL;
+        SDL_Texture *texture = lv_gpu_draw_cache_get_with_userdata(key, key_size, &key_found, (void **) &cache_header);
         SDL_free(key);
-        if(texture) {
+        if (texture) {
             header = *cache_header;
-        }
-        else if(key_found || lv_img_decoder_get_info(dsc->bg_img_src, &header) != LV_RES_OK) {
+        } else if (key_found || lv_img_decoder_get_info(dsc->bg_img_src, &header) != LV_RES_OK) {
             /* When cache hit but with negative result, use default decoder. If still fail, return.*/
             LV_LOG_WARN("Couldn't read the background image");
             return;
@@ -227,7 +222,7 @@ static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip, const 
         img_dsc.opa = dsc->bg_img_opa;
 
         /*Center align*/
-        if(dsc->bg_img_tiled == false) {
+        if (dsc->bg_img_tiled == false) {
             lv_area_t area;
             area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - header.w / 2;
             area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - header.h / 2;
@@ -235,17 +230,16 @@ static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip, const 
             area.y2 = area.y1 + header.h - 1;
 
             lv_draw_img(&area, clip, dsc->bg_img_src, &img_dsc);
-        }
-        else {
+        } else {
             lv_area_t area;
             area.y1 = coords->y1;
             area.y2 = area.y1 + header.h - 1;
 
-            for(; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
+            for (; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
 
                 area.x1 = coords->x1;
                 area.x2 = area.x1 + header.w - 1;
-                for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
+                for (; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
                     lv_draw_img(&area, clip, dsc->bg_img_src, &img_dsc);
                 }
             }
@@ -253,11 +247,10 @@ static void draw_bg_img(const lv_area_t * coords, const lv_area_t * clip, const 
     }
 }
 
-static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const lv_area_t * clip,
-                        const lv_draw_rect_dsc_t * dsc)
-{
+static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const lv_area_t *clip,
+                        const lv_draw_rect_dsc_t *dsc) {
     /*Check whether the shadow is visible*/
-    if(SKIP_SHADOW(dsc)) return;
+    if (SKIP_SHADOW(dsc)) return;
 
     lv_coord_t sw = dsc->shadow_width;
 
@@ -275,12 +268,12 @@ static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const
 
     lv_opa_t opa = dsc->shadow_opa;
 
-    if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
+    if (opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
     /*Get clipped draw area which is the real draw area.
      *It is always the same or inside `shadow_area`*/
     lv_area_t draw_area;
-    if(!_lv_area_intersect(&draw_area, &shadow_area, clip)) return;
+    if (!_lv_area_intersect(&draw_area, &shadow_area, clip)) return;
 
     SDL_Rect core_area_rect;
     lv_area_to_sdl_rect(&shadow_area, &core_area_rect);
@@ -302,12 +295,12 @@ static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const
     lv_area_copy(&blur_frag, &shadow_area);
     lv_area_set_width(&blur_frag, blur_frag_size * 2);
     lv_area_set_height(&blur_frag, blur_frag_size * 2);
-    SDL_Texture * texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
-    if(texture == NULL) {
+    SDL_Texture *texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
+    if (texture == NULL) {
         lv_draw_mask_radius_param_t mask_rout_param;
         lv_draw_mask_radius_init(&mask_rout_param, &core_area, radius, false);
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
-        lv_opa_t * mask_buf = lv_draw_mask_dump(&blur_frag, &mask_id, 1);
+        lv_opa_t *mask_buf = lv_draw_mask_dump(&blur_frag, &mask_id, 1);
         lv_stack_blur_grayscale(mask_buf, lv_area_get_width(&blur_frag), lv_area_get_height(&blur_frag), sw / 2 + 1);
         texture = lv_sdl_create_mask_texture(renderer, mask_buf, blur_frag_size, blur_frag_size,
                                              lv_area_get_width(&blur_frag));
@@ -329,38 +322,36 @@ static void draw_shadow(SDL_Renderer * renderer, const lv_area_t * coords, const
 }
 
 
-static void draw_border(SDL_Renderer * renderer, const lv_area_t * coords, const lv_draw_rect_dsc_t * dsc)
-{
-    if(SKIP_BORDER(dsc)) return;
+static void draw_border(SDL_Renderer *renderer, const lv_area_t *coords, const lv_draw_rect_dsc_t *dsc) {
+    if (SKIP_BORDER(dsc)) return;
 
     SDL_Color border_color;
     lv_color_to_sdl_color(&dsc->border_color, &border_color);
 
 
-    if(dsc->border_side != LV_BORDER_SIDE_FULL) {
+    if (dsc->border_side != LV_BORDER_SIDE_FULL) {
         SDL_SetRenderDrawColor(renderer, border_color.r, border_color.g, border_color.b, dsc->border_opa);
         SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-        for(int w = 0; w <= dsc->border_width; w++) {
-            if(dsc->border_side & LV_BORDER_SIDE_TOP) {
+        for (int w = 0; w <= dsc->border_width; w++) {
+            if (dsc->border_side & LV_BORDER_SIDE_TOP) {
                 SDL_RenderDrawLine(renderer, coords->x1, coords->y1 + w, coords->x2, coords->y1 + w);
             }
-            if(dsc->border_side & LV_BORDER_SIDE_BOTTOM) {
+            if (dsc->border_side & LV_BORDER_SIDE_BOTTOM) {
                 SDL_RenderDrawLine(renderer, coords->x1, coords->y2 - w, coords->x2, coords->y2 - w);
             }
-            if(dsc->border_side & LV_BORDER_SIDE_LEFT) {
+            if (dsc->border_side & LV_BORDER_SIDE_LEFT) {
                 SDL_RenderDrawLine(renderer, coords->x1 + w, coords->y1, coords->x1 + w, coords->y2);
             }
-            if(dsc->border_side & LV_BORDER_SIDE_RIGHT) {
+            if (dsc->border_side & LV_BORDER_SIDE_RIGHT) {
                 SDL_RenderDrawLine(renderer, coords->x2 - w, coords->y1, coords->x2 - w, coords->y2);
             }
         }
-    }
-    else {
+    } else {
         int32_t coords_w = lv_area_get_width(coords);
         int32_t coords_h = lv_area_get_height(coords);
         int32_t rout = dsc->radius;
         int32_t short_side = LV_MIN(coords_w, coords_h);
-        if(rout > short_side >> 1) rout = short_side >> 1;
+        if (rout > short_side >> 1) rout = short_side >> 1;
 
         /*Get the inner area*/
         lv_area_t area_inner;
@@ -371,19 +362,18 @@ static void draw_border(SDL_Renderer * renderer, const lv_area_t * coords, const
         area_inner.y2 -= ((dsc->border_side & LV_BORDER_SIDE_BOTTOM) ? dsc->border_width : -(dsc->border_width + rout));
 
         lv_coord_t rin = rout - dsc->border_width;
-        if(rin < 0) rin = 0;
+        if (rin < 0) rin = 0;
         draw_border_generic(coords, &area_inner, rout, rin, dsc->border_color, dsc->border_opa,
                             dsc->blend_mode);
     }
 }
 
-static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
-{
-    if(SKIP_OUTLINE(dsc)) return;
+static void draw_outline(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc) {
+    if (SKIP_OUTLINE(dsc)) return;
 
     lv_opa_t opa = dsc->outline_opa;
 
-    if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
+    if (opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
     /*Get the inner radius*/
     lv_area_t area_inner;
@@ -405,13 +395,13 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const
     area_outer.y2 += dsc->outline_width;
 
     lv_area_t draw_area;
-    if(!_lv_area_intersect(&draw_area, &area_outer, clip)) return;
+    if (!_lv_area_intersect(&draw_area, &area_outer, clip)) return;
 
     int32_t inner_w = lv_area_get_width(&area_inner);
     int32_t inner_h = lv_area_get_height(&area_inner);
     int32_t rin = dsc->radius;
     int32_t short_side = LV_MIN(inner_w, inner_h);
-    if(rin > short_side >> 1) rin = short_side >> 1;
+    if (rin > short_side >> 1) rin = short_side >> 1;
 
     lv_coord_t rout = rin + dsc->outline_width;
 
@@ -419,18 +409,17 @@ static void draw_outline(const lv_area_t * coords, const lv_area_t * clip, const
                         dsc->blend_mode);
 }
 
-static void draw_border_generic(const lv_area_t * outer_area, const lv_area_t * inner_area, lv_coord_t rout,
-                                lv_coord_t rin, lv_color_t color, lv_opa_t opa, lv_blend_mode_t blend_mode)
-{
+static void draw_border_generic(const lv_area_t *outer_area, const lv_area_t *inner_area, lv_coord_t rout,
+                                lv_coord_t rin, lv_color_t color, lv_opa_t opa, lv_blend_mode_t blend_mode) {
     opa = opa >= LV_OPA_COVER ? LV_OPA_COVER : opa;
 
-    if(rout == 0 || rin == 0) {
+    if (rout == 0 || rin == 0) {
         draw_border_simple(outer_area, inner_area, color, opa);
         return;
     }
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    lv_draw_sdl_backend_context_t *ctx = lv_draw_sdl_get_context();
+    SDL_Renderer *renderer = ctx->renderer;
 
     lv_coord_t border_width = lv_area_get_width(outer_area);
     lv_coord_t border_height = lv_area_get_height(outer_area);
@@ -439,18 +428,18 @@ static void draw_border_generic(const lv_area_t * outer_area, const lv_area_t * 
     lv_coord_t frag_size = rout == LV_RADIUS_CIRCLE ? min_half : LV_MIN(rout + 1, min_half);
     lv_draw_rect_border_key_t key = rect_border_key_create(rout, rin, inner_area->x1 - outer_area->x1 + 1,
                                                            frag_size, LV_BORDER_SIDE_FULL);
-    SDL_Texture * texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
-    if(texture == NULL) {
+    SDL_Texture *texture = lv_gpu_draw_cache_get(&key, sizeof(key), NULL);
+    if (texture == NULL) {
         /*Create mask for the outer area*/
         int16_t mask_ids[2] = {LV_MASK_ID_INV, LV_MASK_ID_INV};
         lv_draw_mask_radius_param_t mask_rout_param;
-        if(rout > 0) {
+        if (rout > 0) {
             lv_draw_mask_radius_init(&mask_rout_param, outer_area, rout, false);
             mask_ids[0] = lv_draw_mask_add(&mask_rout_param, NULL);
         }
 
         /*Create mask for the inner mask*/
-        if(rin < 0) rin = 0;
+        if (rin < 0) rin = 0;
         lv_draw_mask_radius_param_t mask_rin_param;
         lv_draw_mask_radius_init(&mask_rin_param, inner_area, rin, true);
         mask_ids[1] = lv_draw_mask_add(&mask_rin_param, NULL);
@@ -481,12 +470,11 @@ static void draw_border_generic(const lv_area_t * outer_area, const lv_area_t * 
     frag_render_borders(renderer, texture, frag_size, outer_area);
 }
 
-static void draw_border_simple(const lv_area_t * outer_area, const lv_area_t * inner_area, lv_color_t color,
-                               lv_opa_t opa)
-{
+static void draw_border_simple(const lv_area_t *outer_area, const lv_area_t *inner_area, lv_color_t color,
+                               lv_opa_t opa) {
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    lv_draw_sdl_backend_context_t *ctx = lv_draw_sdl_get_context();
+    SDL_Renderer *renderer = ctx->renderer;
 
     SDL_Color color_sdl;
     lv_color_to_sdl_color(&color, &color_sdl);
@@ -518,9 +506,8 @@ static void draw_border_simple(const lv_area_t * outer_area, const lv_area_t * i
 
 }
 
-static void frag_render_corners(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
-                                const lv_area_t * coords)
-{
+static void frag_render_corners(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
+                                const lv_area_t *coords) {
     lv_coord_t bg_w = lv_area_get_width(coords);
     lv_coord_t bg_h = lv_area_get_height(coords);
     SDL_Rect srcrect = {0, 0, frag_size, frag_size};
@@ -541,9 +528,8 @@ static void frag_render_corners(SDL_Renderer * renderer, SDL_Texture * frag, lv_
     SDL_RenderCopyEx(renderer, frag, &srcrect, &dstrect, 0, NULL, SDL_FLIP_VERTICAL);
 }
 
-static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size,
-                                const lv_area_t * coords)
-{
+static void frag_render_borders(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size,
+                                const lv_area_t *coords) {
     lv_coord_t bg_w = lv_area_get_width(coords);
     lv_coord_t bg_h = lv_area_get_height(coords);
     SDL_Rect srcrect;
@@ -552,7 +538,7 @@ static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_
     srcrect.h = dstrect.h = frag_size;
     dstrect.w = bg_w - frag_size * 2;
     /* Has space to fill */
-    if(dstrect.w > 0 && dstrect.h > 0) {
+    if (dstrect.w > 0 && dstrect.h > 0) {
         srcrect.w = 1;
         srcrect.y = 0;
         srcrect.x = frag_size - 1;
@@ -562,19 +548,19 @@ static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_
         SDL_RenderCopy(renderer, frag, &srcrect, &dstrect);
         /* Bottom edge */
         dstrect.y = coords->y2 - frag_size + 1;
-        if(bg_h < frag_size * 2) {
+        if (bg_h < frag_size * 2) {
             /* Bottom edge will overlap with top, so decrease it by 1 px */
             srcrect.h = dstrect.h = frag_size - 1;
             dstrect.y += 1;
         }
-        if(srcrect.h > 0) {
+        if (srcrect.h > 0) {
             SDL_RenderCopyEx(renderer, frag, &srcrect, &dstrect, 0, NULL, SDL_FLIP_VERTICAL);
         }
     }
     /* For left/right edges, stretch pixels on the bottom */
     srcrect.w = dstrect.w = frag_size;
     dstrect.h = bg_h - frag_size * 2;
-    if(dstrect.w > 0 && dstrect.h > 0) {
+    if (dstrect.w > 0 && dstrect.h > 0) {
         srcrect.h = 1;
         srcrect.x = 0;
         srcrect.y = frag_size - 1;
@@ -584,39 +570,38 @@ static void frag_render_borders(SDL_Renderer * renderer, SDL_Texture * frag, lv_
         SDL_RenderCopy(renderer, frag, &srcrect, &dstrect);
         /* Right edge */
         dstrect.x = coords->x2 - frag_size + 1;
-        if(bg_w < frag_size * 2) {
+        if (bg_w < frag_size * 2) {
             /* Right edge will overlap with left, so decrease it by 1 px */
             srcrect.w = dstrect.w = frag_size - 1;
             dstrect.x += 1;
         }
-        if(srcrect.w > 0) {
+        if (srcrect.w > 0) {
             SDL_RenderCopyEx(renderer, frag, &srcrect, &dstrect, 0, NULL, SDL_FLIP_HORIZONTAL);
         }
     }
 }
 
 static void
-frag_render_center(SDL_Renderer * renderer, SDL_Texture * frag, lv_coord_t frag_size, const lv_area_t * coords)
-{
+frag_render_center(SDL_Renderer *renderer, SDL_Texture *frag, lv_coord_t frag_size, const lv_area_t *coords) {
     lv_coord_t bg_w = lv_area_get_width(coords);
     lv_coord_t bg_h = lv_area_get_height(coords);
     SDL_Rect dstrect = {coords->x1 + frag_size, coords->y1 + frag_size, bg_w - frag_size * 2, bg_h - frag_size * 2};
-    if(dstrect.w > 0 && dstrect.h > 0) {
+    if (dstrect.w > 0 && dstrect.h > 0) {
         SDL_Rect srcrect = {frag_size - 1, frag_size - 1, 1, 1};
         SDL_RenderCopy(renderer, frag, &srcrect, &dstrect);
     }
 }
 
-static void draw_rect_masked(const lv_area_t * coords, const lv_area_t * clip, const lv_draw_rect_dsc_t * dsc)
-{
-    if(dsc->radius <= 0 && SKIP_BORDER(dsc) && SKIP_SHADOW(dsc) && SKIP_IMAGE(dsc) && SKIP_OUTLINE(dsc)) {
+static void draw_rect_masked(const lv_area_t *coords, const lv_area_t *clip, const lv_draw_rect_dsc_t *dsc) {
+    if (dsc->radius <= 0 && SKIP_BORDER(dsc) && SKIP_SHADOW(dsc) && SKIP_IMAGE(dsc) && SKIP_OUTLINE(dsc)) {
         draw_rect_masked_simple(coords, clip, dsc);
         return;
     }
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
-
-    SDL_Texture * screen = SDL_GetRenderTarget(renderer);
+    lv_area_t clip_intersect;
+    if (!_lv_area_intersect(&clip_intersect, clip, coords)) {
+        return;
+    }
+    lv_point_t clip_offset = {clip_intersect.x1 - coords->x1, clip_intersect.y1 - coords->y1};
 
     lv_coord_t sw = dsc->shadow_width;
 
@@ -624,10 +609,20 @@ static void draw_rect_masked(const lv_area_t * coords, const lv_area_t * clip, c
     lv_area_increase(&sh_area, dsc->shadow_spread + sw / 2 + 1, dsc->shadow_spread + sw / 2 + 1);
     lv_area_move(&sh_area, dsc->shadow_ofs_x, dsc->shadow_ofs_y);
 
-    lv_coord_t draw_w = lv_area_get_width(&sh_area);
-    lv_coord_t draw_h = lv_area_get_height(&sh_area);
+    SDL_Rect clip_rect;
+    SDL_Rect draw_rect;
+    lv_area_to_sdl_rect(&sh_area, &draw_rect);
+    lv_area_to_sdl_rect(clip, &clip_rect);
+
+    SDL_Rect dst_rect;
+    if (!SDL_IntersectRect(&draw_rect, &clip_rect, &dst_rect)) return;
+
+    lv_draw_sdl_backend_context_t *ctx = lv_draw_sdl_get_context();
+    SDL_Renderer *renderer = ctx->renderer;
+
+    SDL_Texture *screen = SDL_GetRenderTarget(renderer);
     /* Render drawing area to an offscreen texture */
-    SDL_Texture * content = lv_gpu_temp_texture_obtain(renderer, draw_w, draw_h);
+    SDL_Texture *content = lv_gpu_temp_texture_obtain(renderer, dst_rect.w, dst_rect.h);
     SDL_assert(content);
     SDL_SetTextureColorMod(content, 0xFF, 0xFF, 0xFF);
     SDL_SetTextureAlphaMod(content, 0xFF);
@@ -636,66 +631,75 @@ static void draw_rect_masked(const lv_area_t * coords, const lv_area_t * clip, c
     SDL_SetRenderTarget(renderer, content);
     SDL_SetRenderDrawColor(renderer, 0xFF, 0xFF, 0xFF, 0x00);
     SDL_RenderClear(renderer);
-    SDL_RenderSetClipRect(renderer, NULL);
-    lv_area_t content_coords;
+    lv_area_t content_coords, content_clip;
     lv_area_copy(&content_coords, coords);
-    lv_area_move(&content_coords, -sh_area.x1, -sh_area.y1);
+    lv_area_copy(&content_clip, clip);
+    /* Move content coords to offset */
+    lv_area_move(&content_coords, -content_coords.x1 - clip_offset.x, -content_coords.y1 - clip_offset.y);
+    /* Move content clip coords to offset */
+    lv_area_move(&content_clip, -content_clip.x1 - clip_offset.x, -content_clip.y1 - clip_offset.y);
 
-    draw_shadow(renderer, &content_coords, clip, dsc);
+    draw_shadow(renderer, &content_coords, &content_clip, dsc);
     draw_bg_color(renderer, &content_coords, dsc);
-    draw_bg_img(&content_coords, clip, dsc);
+    draw_bg_img(&content_coords, &content_clip, dsc);
     draw_border(renderer, &content_coords, dsc);
-    draw_outline(&content_coords, clip, dsc);
+    draw_outline(&content_coords, &content_clip, dsc);
 
-    SDL_Texture * clip_mask = lv_sdl_gen_mask_texture(renderer, &sh_area, NULL, 0);
-    SDL_Rect src_rect = {.w = draw_w, .h = draw_h, .x = 0, .y = 0};
+    lv_area_t dst_area = {
+            .x1 = dst_rect.x, .y1 = dst_rect.y,
+            .x2 = dst_rect.x + dst_rect.w - 1,
+            .y2 = dst_rect.y + dst_rect.h - 1
+    };
+    SDL_Texture *clip_mask = lv_sdl_gen_mask_texture(renderer, &dst_area, NULL, 0);
+
+    SDL_Rect content_rect = {0, 0, dst_rect.w, dst_rect.h};
 #if SDL_VERSION_ATLEAST(2, 0, 6)
     SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE,
                                                     SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
                                                     SDL_BLENDFACTOR_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
     SDL_SetTextureBlendMode(clip_mask, mode);
-    SDL_RenderCopy(renderer, clip_mask, NULL, &src_rect);
+    SDL_RenderCopy(renderer, clip_mask, NULL, &content_rect);
 #endif
 
-    SDL_Rect mask_rect;
-    SDL_Rect draw_rect;
-    lv_area_to_sdl_rect(&sh_area, &draw_rect);
-    lv_area_to_sdl_rect(clip, &mask_rect);
-
     SDL_SetRenderTarget(renderer, screen);
-    SDL_RenderSetClipRect(renderer, &mask_rect);
-    SDL_RenderCopy(renderer, content, &src_rect, &draw_rect);
+
+    SDL_RenderCopy(renderer, content, &content_rect, &dst_rect);
     SDL_DestroyTexture(clip_mask);
 }
 
-static void draw_rect_masked_simple(const lv_area_t * coords, const lv_area_t * mask, const lv_draw_rect_dsc_t * dsc)
-{
+static void draw_rect_masked_simple(const lv_area_t *coords, const lv_area_t *mask, const lv_draw_rect_dsc_t *dsc) {
+    SDL_Rect coords_rect, mask_rect;
+    lv_area_to_sdl_rect(coords, &coords_rect);
+    lv_area_to_sdl_rect(mask, &mask_rect);
+
+    SDL_Rect draw_rect;
+    if (!SDL_IntersectRect(&coords_rect, &mask_rect, &draw_rect)) return;
+
     SDL_Color bg_color;
     lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
 
-    lv_draw_sdl_backend_context_t * ctx = lv_draw_sdl_get_context();
-    SDL_Renderer * renderer = ctx->renderer;
+    lv_draw_sdl_backend_context_t *ctx = lv_draw_sdl_get_context();
+    SDL_Renderer *renderer = ctx->renderer;
 
-    SDL_Surface * indexed = lv_sdl_apply_mask_surface(coords, NULL, 0);
-    SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, indexed);
+    SDL_Surface *indexed = lv_sdl_apply_mask_surface(coords, NULL, 0);
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, indexed);
 
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     SDL_SetTextureAlphaMod(texture, dsc->bg_opa);
     SDL_SetTextureColorMod(texture, bg_color.r, bg_color.g, bg_color.b);
 
-    SDL_Rect coords_rect, mask_rect;
-    lv_area_to_sdl_rect(coords, &coords_rect);
-    lv_area_to_sdl_rect(mask, &mask_rect);
-
-    SDL_RenderSetClipRect(renderer, &mask_rect);
-    SDL_RenderCopy(renderer, texture, NULL, &coords_rect);
+    SDL_Rect src_rect = {
+            .x = draw_rect.x - coords_rect.x,
+            .y = draw_rect.y - coords_rect.y,
+            .w = draw_rect.w, .h = draw_rect.h,
+    };
+    SDL_RenderCopy(renderer, texture, &src_rect, &draw_rect);
 
     SDL_DestroyTexture(texture);
     SDL_FreeSurface(indexed);
 }
 
-static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size)
-{
+static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t size) {
     lv_draw_rect_bg_key_t key;
     SDL_memset(&key, 0, sizeof(key));
     key.magic = LV_GPU_CACHE_KEY_MAGIC_RECT_BG;
@@ -704,8 +708,7 @@ static lv_draw_rect_bg_key_t rect_bg_key_create(lv_coord_t radius, lv_coord_t si
     return key;
 }
 
-static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_coord_t size, lv_coord_t blur)
-{
+static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_coord_t size, lv_coord_t blur) {
     lv_draw_rect_shadow_key_t key;
     SDL_memset(&key, 0, sizeof(key));
     key.magic = LV_GPU_CACHE_KEY_MAGIC_RECT_SHADOW;
@@ -716,8 +719,7 @@ static lv_draw_rect_shadow_key_t rect_shadow_key_create(lv_coord_t radius, lv_co
 }
 
 static lv_draw_rect_border_key_t rect_border_key_create(lv_coord_t rout, lv_coord_t rin, lv_coord_t thickness,
-                                                        lv_coord_t size, lv_border_side_t side)
-{
+                                                        lv_coord_t size, lv_border_side_t side) {
     lv_draw_rect_border_key_t key;
     /* VERY IMPORTANT! Padding between members is uninitialized, so we have to wipe them manually */
     SDL_memset(&key, 0, sizeof(key));

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -29,20 +29,20 @@
  **********************/
 
 typedef struct {
-    lv_gpu_cache_key_magic_t magic;
+    lv_sdl_cache_key_magic_t magic;
     lv_coord_t radius;
     lv_coord_t size;
 } lv_draw_rect_bg_key_t;
 
 typedef struct {
-    lv_gpu_cache_key_magic_t magic;
+    lv_sdl_cache_key_magic_t magic;
     lv_coord_t radius;
     lv_coord_t size;
     lv_coord_t blur;
 } lv_draw_rect_shadow_key_t;
 
 typedef struct {
-    lv_gpu_cache_key_magic_t magic;
+    lv_sdl_cache_key_magic_t magic;
     lv_coord_t rout, rin;
     lv_coord_t thickness;
     lv_coord_t size;

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -317,7 +317,7 @@ static void draw_shadow(SDL_Renderer *renderer, const lv_area_t *coords, const l
         int16_t mask_id = lv_draw_mask_add(&mask_rout_param, NULL);
         lv_opa_t *mask_buf = lv_draw_sdl_mask_dump_opa(&mask_area_blurred, &mask_id, 1);
         lv_stack_blur_grayscale(mask_buf, lv_area_get_width(&mask_area_blurred), lv_area_get_height(&mask_area_blurred),
-                                sw / 2 + 1);
+                                sw / 2 + sw % 2);
         texture = lv_sdl_create_opa_texture(renderer, mask_buf, blur_frag_size, blur_frag_size,
                                             lv_area_get_width(&mask_area_blurred));
         lv_mem_buf_release(mask_buf);

--- a/src/draw/sdl/lv_draw_sdl_stack_blur.c
+++ b/src/draw/sdl/lv_draw_sdl_stack_blur.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_draw_sdl_stack_blur.h"
 
+#if LV_USE_DRAW_SDL
 /*********************
  *      DEFINES
  *********************/
@@ -245,3 +246,4 @@ static void stack_blur_job(lv_opa_t * src, unsigned int w, unsigned int h, unsig
     }
 }
 
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_stack_blur.c
+++ b/src/draw/sdl/lv_draw_sdl_stack_blur.c
@@ -8,7 +8,7 @@
  *********************/
 #include "lv_draw_sdl_stack_blur.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 /*********************
  *      DEFINES
  *********************/
@@ -246,4 +246,4 @@ static void stack_blur_job(lv_opa_t * src, unsigned int w, unsigned int h, unsig
     }
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_stack_blur.h
+++ b/src/draw/sdl/lv_draw_sdl_stack_blur.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "../../misc/lv_color.h"
 
@@ -37,7 +37,7 @@ void lv_stack_blur_grayscale(lv_opa_t * buf, uint16_t w, uint16_t h, uint16_t r)
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/sdl/lv_draw_sdl_stack_blur.h
+++ b/src/draw/sdl/lv_draw_sdl_stack_blur.h
@@ -15,6 +15,8 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
+#if LV_USE_DRAW_SDL
+
 #include "../../misc/lv_color.h"
 
 /*********************
@@ -34,6 +36,8 @@ void lv_stack_blur_grayscale(lv_opa_t * buf, uint16_t w, uint16_t h, uint16_t r)
 /**********************
  *      MACROS
  **********************/
+
+#endif /*LV_USE_DRAW_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -9,7 +9,7 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "lv_draw_sdl_texture_cache.h"
 
@@ -56,7 +56,7 @@ static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t *ctx, const v
 
 void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t *ctx)
 {
-    ctx->internals->texture_cache = lv_lru_new(LV_DRAW_SDL_LRU_SIZE, 65536,
+    ctx->internals->texture_cache = lv_lru_new(LV_GPU_SDL_LRU_SIZE, 65536,
                                           (lv_lru_free_t *) draw_cache_free_value, NULL);
 }
 
@@ -174,5 +174,5 @@ static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t *ctx, const v
     return value;
 }
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -9,13 +9,11 @@
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
 #include "lv_draw_sdl_texture_cache.h"
 
-#include "../../misc/lv_log.h"
-#include "../../draw/lv_draw_label.h"
-#include "../../draw/lv_draw_img.h"
+#include "lv_draw_sdl_utils.h"
 
 /*********************
  *      DEFINES
@@ -43,14 +41,13 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static lv_lru_t * get_lru();
 
 static void draw_cache_free_value(draw_cache_value_t *);
 
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-static lv_lru_t * lv_sdl_texture_cache;
 
 /**********************
  *      MACROS
@@ -60,26 +57,27 @@ static lv_lru_t * lv_sdl_texture_cache;
  *   GLOBAL FUNCTIONS
  **********************/
 
-void _lv_draw_sdl_texture_cache_init()
+void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t *internals)
 {
-    lv_sdl_texture_cache = lv_lru_new(1024 * 1024 * 8, 65536, (lv_lru_free_t *) draw_cache_free_value,
-                                      NULL);
+    internals->texture_cache = lv_lru_new(LV_DRAW_SDL_LRU_SIZE, 65536,
+                                                   (lv_lru_free_t *) draw_cache_free_value, NULL);
 }
 
-void _lv_draw_sdl_texture_cache_deinit()
+void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t *internals)
 {
-    lv_lru_free(lv_sdl_texture_cache);
+    lv_lru_free(internals->texture_cache);
 }
 
-SDL_Texture * lv_gpu_draw_cache_get(const void * key, size_t key_length, bool * found)
+SDL_Texture * lv_draw_sdl_texture_cache_get(const void * key, size_t key_length, bool * found)
 {
-    return lv_gpu_draw_cache_get_with_userdata(key, key_length, found, NULL);
+    return lv_draw_sdl_texture_cache_get_with_userdata(key, key_length, found, NULL);
 }
 
-SDL_Texture * lv_gpu_draw_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata)
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata)
 {
+    lv_lru_t *lru = get_lru();
     draw_cache_value_t * value = NULL;
-    lv_lru_get(lv_sdl_texture_cache, key, key_length, (void **) &value);
+    lv_lru_get(lru, key, key_length, (void **) &value);
     if(!value) {
         if(found) {
             *found = false;
@@ -97,27 +95,28 @@ SDL_Texture * lv_gpu_draw_cache_get_with_userdata(const void * key, size_t key_l
     return value->texture;
 }
 
-void lv_draw_sdl_draw_cache_put(const void * key, size_t key_length, SDL_Texture * texture)
+void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Texture * texture)
 {
-    lv_draw_sdl_draw_cache_put_advanced(key, key_length, texture, NULL, NULL, 0);
+    lv_draw_sdl_texture_cache_put_advanced(key, key_length, texture, NULL, NULL, 0);
 }
 
-void lv_draw_sdl_draw_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                         lv_lru_free_t userdata_free, lv_draw_sdl_cache_flag_t flags)
+void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
+                                            void userdata_free(void * ), lv_draw_sdl_cache_flag_t flags)
 {
+    lv_lru_t *lru = get_lru();
     draw_cache_value_t * value = SDL_malloc(sizeof(draw_cache_value_t));
     value->texture = texture;
     value->userdata = userdata;
     value->userdata_free = userdata_free;
     value->flags = flags;
     if(!texture) {
-        lv_lru_set(lv_sdl_texture_cache, key, key_length, value, 1);
+        lv_lru_set(lru, key, key_length, value, 1);
         return;
     }
     if(flags & LV_DRAW_SDL_CACHE_FLAG_MANAGED) {
         /* Managed texture doesn't count into cache size */
         LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));
-        lv_lru_set(lv_sdl_texture_cache, key, key_length, value, 1);
+        lv_lru_set(lru, key, key_length, value, 1);
         return;
     }
     Uint32 format;
@@ -126,16 +125,16 @@ void lv_draw_sdl_draw_cache_put_advanced(const void * key, size_t key_length, SD
         return;
     }
     LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));
-    lv_lru_set(lv_sdl_texture_cache, key, key_length, value, width * height * SDL_BITSPERPIXEL(format) / 8);
+    lv_lru_set(lru, key, key_length, value, width * height * SDL_BITSPERPIXEL(format) / 8);
 }
 
-SDL_Texture * lv_gpu_temp_texture_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height)
+SDL_Texture * lv_draw_sdl_texture_temp_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height)
 {
     temp_texture_key_t key;
     SDL_memset(&key, 0, sizeof(key));
     key.magic = LV_GPU_CACHE_KEY_TEMP;
     temp_texture_userdata_t * userdata = NULL;
-    SDL_Texture * texture = lv_gpu_draw_cache_get_with_userdata(&key, sizeof(key), NULL, (void **) &userdata);
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get_with_userdata(&key, sizeof(key), NULL, (void **) &userdata);
     if(texture && userdata->width >= width && userdata->height >= height) {
         return texture;
     }
@@ -143,11 +142,11 @@ SDL_Texture * lv_gpu_temp_texture_obtain(SDL_Renderer * renderer, lv_coord_t wid
     userdata = SDL_malloc(sizeof(temp_texture_userdata_t));
     userdata->width = width;
     userdata->height = height;
-    lv_draw_sdl_draw_cache_put_advanced(&key, sizeof(key), texture, userdata, SDL_free, 0);
+    lv_draw_sdl_texture_cache_put_advanced(&key, sizeof(key), texture, userdata, SDL_free, 0);
     return texture;
 }
 
-lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_img_cache_key_create(const void * src, int32_t frame_id, size_t * size)
+lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id, size_t * size)
 {
     lv_draw_sdl_cache_key_head_img_t header;
     /* VERY IMPORTANT! Padding between members is uninitialized, so we have to wipe them manually */
@@ -180,6 +179,11 @@ lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_img_cache_key_create(const void *
  *   STATIC FUNCTIONS
  **********************/
 
+static lv_lru_t * get_lru()
+{
+    return lv_draw_sdl_get_context()->internals->texture_cache;
+}
+
 static void draw_cache_free_value(draw_cache_value_t * value)
 {
     if(value->texture && !(value->flags & LV_DRAW_SDL_CACHE_FLAG_MANAGED)) {
@@ -193,5 +197,5 @@ static void draw_cache_free_value(draw_cache_value_t * value)
 }
 
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/
 

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -128,24 +128,6 @@ void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length,
     lv_lru_set(lru, key, key_length, value, width * height * SDL_BITSPERPIXEL(format) / 8);
 }
 
-SDL_Texture * lv_draw_sdl_texture_temp_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height)
-{
-    temp_texture_key_t key;
-    SDL_memset(&key, 0, sizeof(key));
-    key.magic = LV_GPU_CACHE_KEY_TEMP;
-    temp_texture_userdata_t * userdata = NULL;
-    SDL_Texture * texture = lv_draw_sdl_texture_cache_get_with_userdata(&key, sizeof(key), NULL, (void **) &userdata);
-    if(texture && userdata->width >= width && userdata->height >= height) {
-        return texture;
-    }
-    texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height);
-    userdata = SDL_malloc(sizeof(temp_texture_userdata_t));
-    userdata->width = width;
-    userdata->height = height;
-    lv_draw_sdl_texture_cache_put_advanced(&key, sizeof(key), texture, userdata, SDL_free, 0);
-    return texture;
-}
-
 lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id, size_t * size)
 {
     lv_draw_sdl_cache_key_head_img_t header;

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -40,7 +40,7 @@ typedef struct {
 
 static void draw_cache_free_value(draw_cache_value_t *);
 
-static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                                  bool * found);
 /**********************
  *  STATIC VARIABLES
@@ -54,23 +54,23 @@ static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t *ctx, const v
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t *ctx)
+void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t * ctx)
 {
     ctx->internals->texture_cache = lv_lru_new(LV_GPU_SDL_LRU_SIZE, 65536,
-                                          (lv_lru_free_t *) draw_cache_free_value, NULL);
+                                               (lv_lru_free_t *) draw_cache_free_value, NULL);
 }
 
-void lv_draw_sdl_texture_cache_deinit(lv_draw_sdl_ctx_t *ctx)
+void lv_draw_sdl_texture_cache_deinit(lv_draw_sdl_ctx_t * ctx)
 {
     lv_lru_free(ctx->internals->texture_cache);
 }
 
-SDL_Texture * lv_draw_sdl_texture_cache_get(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, bool * found)
+SDL_Texture * lv_draw_sdl_texture_cache_get(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length, bool * found)
 {
     return lv_draw_sdl_texture_cache_get_with_userdata(ctx, key, key_length, found, NULL);
 }
 
-SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                                           bool * found, void ** userdata)
 {
     draw_cache_value_t * value = draw_cache_get_entry(ctx, key, key_length, found);
@@ -81,12 +81,12 @@ SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t *ctx
     return value->texture;
 }
 
-void lv_draw_sdl_texture_cache_put(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, SDL_Texture * texture)
+void lv_draw_sdl_texture_cache_put(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length, SDL_Texture * texture)
 {
     lv_draw_sdl_texture_cache_put_advanced(ctx, key, key_length, texture, NULL, NULL, 0);
 }
 
-void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                             SDL_Texture * texture, void * userdata, void userdata_free(void *),
                                             lv_draw_sdl_cache_flag_t flags)
 {
@@ -156,7 +156,7 @@ static void draw_cache_free_value(draw_cache_value_t * value)
     SDL_free(value);
 }
 
-static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+static draw_cache_value_t * draw_cache_get_entry(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                                  bool * found)
 {
     lv_lru_t * lru = ctx->internals->texture_cache;

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -45,7 +45,7 @@ static lv_lru_t * get_lru();
 
 static void draw_cache_free_value(draw_cache_value_t *);
 
-static draw_cache_value_t *draw_cache_get_entry(const void * key, size_t key_length, bool * found);
+static draw_cache_value_t * draw_cache_get_entry(const void * key, size_t key_length, bool * found);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -58,13 +58,13 @@ static draw_cache_value_t *draw_cache_get_entry(const void * key, size_t key_len
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t *internals)
+void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t * internals)
 {
     internals->texture_cache = lv_lru_new(LV_DRAW_SDL_LRU_SIZE, 65536,
-                                                   (lv_lru_free_t *) draw_cache_free_value, NULL);
+                                          (lv_lru_free_t *) draw_cache_free_value, NULL);
 }
 
-void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t *internals)
+void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t * internals)
 {
     lv_lru_free(internals->texture_cache);
 }
@@ -74,10 +74,11 @@ SDL_Texture * lv_draw_sdl_texture_cache_get(const void * key, size_t key_length,
     return lv_draw_sdl_texture_cache_get_with_userdata(key, key_length, found, NULL);
 }
 
-SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata)
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found,
+                                                          void ** userdata)
 {
     draw_cache_value_t * value = draw_cache_get_entry(key, key_length, found);
-    if (!value) return NULL;
+    if(!value) return NULL;
     if(userdata) {
         *userdata = value->userdata;
     }
@@ -90,9 +91,9 @@ void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Text
 }
 
 void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                            void userdata_free(void * ), lv_draw_sdl_cache_flag_t flags)
+                                            void userdata_free(void *), lv_draw_sdl_cache_flag_t flags)
 {
-    lv_lru_t *lru = get_lru();
+    lv_lru_t * lru = get_lru();
     draw_cache_value_t * value = SDL_malloc(sizeof(draw_cache_value_t));
     value->texture = texture;
     value->userdata = userdata;
@@ -167,9 +168,9 @@ static void draw_cache_free_value(draw_cache_value_t * value)
     SDL_free(value);
 }
 
-static draw_cache_value_t *draw_cache_get_entry(const void * key, size_t key_length, bool * found)
+static draw_cache_value_t * draw_cache_get_entry(const void * key, size_t key_length, bool * found)
 {
-    lv_lru_t *lru = get_lru();
+    lv_lru_t * lru = get_lru();
     draw_cache_value_t * value = NULL;
     lv_lru_get(lru, key, key_length, (void **) &value);
     if(!value) {

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -49,8 +49,8 @@ typedef enum {
     LV_GPU_CACHE_KEY_MAGIC_RECT_SHADOW = 0x32,
     LV_GPU_CACHE_KEY_MAGIC_RECT_BORDER = 0x33,
     LV_GPU_CACHE_KEY_MAGIC_FONT_GLYPH = 0x41,
-    LV_GPU_CACHE_KEY_TEMP = 0xFF,
-} lv_gpu_cache_key_magic_t;
+    LV_GPU_CACHE_KEY_MAGIC_MASK = 0x51,
+} lv_sdl_cache_key_magic_t;
 
 typedef enum {
     LV_DRAW_SDL_CACHE_FLAG_NONE = 0,
@@ -58,7 +58,7 @@ typedef enum {
 } lv_draw_sdl_cache_flag_t;
 
 typedef struct {
-    lv_gpu_cache_key_magic_t magic;
+    lv_sdl_cache_key_magic_t magic;
     lv_img_src_t type;
     int32_t frame_id;
 } lv_draw_sdl_cache_key_head_img_t;
@@ -71,9 +71,21 @@ void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t *inte
 
 void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t *internals);
 
+/**
+ * Find cached texture by key. The texture can be destroyed during usage.
+ */
 SDL_Texture * lv_draw_sdl_texture_cache_get(const void * key, size_t key_length, bool * found);
 
-SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata);
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found,
+                                                          void ** userdata);
+
+/**
+ * Find cached texture by key. The texture will be marked so it won't be destroyed.
+ */
+SDL_Texture * lv_draw_sdl_texture_cache_take(const void * key, size_t key_length, bool * found);
+
+SDL_Texture * lv_draw_sdl_texture_cache_take_with_userdata(const void * key, size_t key_length, bool * found,
+                                                          void ** userdata);
 
 void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
 

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -67,30 +67,23 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t * internals);
+void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t *ctx);
 
-void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t * internals);
+void lv_draw_sdl_texture_cache_deinit(lv_draw_sdl_ctx_t *ctx);
 
 /**
  * Find cached texture by key. The texture can be destroyed during usage.
  */
-SDL_Texture * lv_draw_sdl_texture_cache_get(const void * key, size_t key_length, bool * found);
+SDL_Texture * lv_draw_sdl_texture_cache_get(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, bool * found);
 
-SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found,
-                                                          void ** userdata);
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+                                                          bool * found, void ** userdata);
 
-/**
- * Find cached texture by key. The texture will be marked so it won't be destroyed.
- */
-SDL_Texture * lv_draw_sdl_texture_cache_take(const void * key, size_t key_length, bool * found);
+void lv_draw_sdl_texture_cache_put(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, SDL_Texture * texture);
 
-SDL_Texture * lv_draw_sdl_texture_cache_take_with_userdata(const void * key, size_t key_length, bool * found,
-                                                           void ** userdata);
-
-void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
-
-void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                            void userdata_free(void *), lv_draw_sdl_cache_flag_t flags);
+void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+                                            SDL_Texture * texture, void * userdata, void userdata_free(void *),
+                                            lv_draw_sdl_cache_flag_t flags);
 
 lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id,
                                                                       size_t * size);

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_draw_sdl_texture_cache.h
+ * @file lv_gpu_sdl_texture_cache.h
  *
  */
 
-#ifndef LV_DRAW_SDL_TEXTURE_CACHE_H
-#define LV_DRAW_SDL_TEXTURE_CACHE_H
+#ifndef LV_GPU_SDL_TEXTURE_CACHE_H
+#define LV_GPU_SDL_TEXTURE_CACHE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,13 +19,13 @@ extern "C" {
 #include LV_GPU_SDL_INCLUDE_PATH
 #include "../../draw/lv_img_decoder.h"
 #include "../../misc/lv_area.h"
-#include "lv_draw_sdl_lru.h"
+#include "lv_gpu_sdl_lru.h"
 
 /*********************
  *      DEFINES
  *********************/
 
-#define LV_DRAW_SDL_DEC_DSC_TEXTURE_HEAD "@LVSDLTex"
+#define LV_GPU_SDL_DEC_DSC_TEXTURE_HEAD "@LVSDLTex"
 
 /**********************
  *      TYPEDEFS
@@ -34,7 +34,9 @@ extern "C" {
 typedef struct {
     char head[8];
     SDL_Texture * texture;
-} lv_draw_sdl_dec_dsc_userdata_t;
+    bool texture_managed;
+    bool texture_referenced;
+} lv_gpu_sdl_dec_dsc_userdata_t;
 
 typedef enum {
     LV_GPU_CACHE_KEY_MAGIC_ARC = 0x01,
@@ -48,36 +50,36 @@ typedef enum {
 } lv_gpu_cache_key_magic_t;
 
 typedef enum {
-    LV_DRAW_SDL_CACHE_FLAG_NONE = 0,
-    LV_DRAW_SDL_CACHE_FLAG_MANAGED = 1,
-} lv_draw_sdl_cache_flag_t;
+    LV_GPU_SDL_CACHE_FLAG_NONE = 0,
+    LV_GPU_SDL_CACHE_FLAG_MANAGED = 1,
+} lv_gpu_sdl_cache_flag_t;
 
 typedef struct {
     lv_gpu_cache_key_magic_t magic;
     lv_img_src_t type;
     int32_t frame_id;
-} lv_draw_sdl_cache_key_head_img_t;
+} lv_gpu_sdl_cache_key_head_img_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-void _lv_draw_sdl_texture_cache_init();
+void _lv_gpu_sdl_texture_cache_init();
 
-void _lv_draw_sdl_texture_cache_deinit();
+void _lv_gpu_sdl_texture_cache_deinit();
 
 SDL_Texture * lv_gpu_draw_cache_get(const void * key, size_t key_length, bool * found);
 
 SDL_Texture * lv_gpu_draw_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata);
 
-void lv_draw_sdl_draw_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
+void lv_gpu_draw_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
 
-void lv_draw_sdl_draw_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                         lv_lru_free_t userdata_free, lv_draw_sdl_cache_flag_t flags);
+void lv_gpu_draw_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
+                                    lv_lru_free_t userdata_free, lv_gpu_sdl_cache_flag_t flags);
 
 SDL_Texture * lv_gpu_temp_texture_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height);
 
-lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_img_cache_key_create(const void * src, int32_t frame_id, size_t * size);
+lv_gpu_sdl_cache_key_head_img_t * lv_gpu_sdl_img_cache_key_create(const void * src, int32_t frame_id, size_t * size);
 
 /**********************
  *      MACROS
@@ -87,4 +89,4 @@ lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_img_cache_key_create(const void *
 } /*extern "C"*/
 #endif
 
-#endif /*LV_DRAW_SDL_TEXTURE_CACHE_H*/
+#endif /*LV_GPU_SDL_TEXTURE_CACHE_H*/

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -67,21 +67,21 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t *ctx);
+void lv_draw_sdl_texture_cache_init(lv_draw_sdl_ctx_t * ctx);
 
-void lv_draw_sdl_texture_cache_deinit(lv_draw_sdl_ctx_t *ctx);
+void lv_draw_sdl_texture_cache_deinit(lv_draw_sdl_ctx_t * ctx);
 
 /**
  * Find cached texture by key. The texture can be destroyed during usage.
  */
-SDL_Texture * lv_draw_sdl_texture_cache_get(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, bool * found);
+SDL_Texture * lv_draw_sdl_texture_cache_get(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length, bool * found);
 
-SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                                           bool * found, void ** userdata);
 
-void lv_draw_sdl_texture_cache_put(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length, SDL_Texture * texture);
+void lv_draw_sdl_texture_cache_put(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length, SDL_Texture * texture);
 
-void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t *ctx, const void * key, size_t key_length,
+void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t * ctx, const void * key, size_t key_length,
                                             SDL_Texture * texture, void * userdata, void userdata_free(void *),
                                             lv_draw_sdl_cache_flag_t flags);
 

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -67,9 +67,9 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t *internals);
+void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t * internals);
 
-void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t *internals);
+void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t * internals);
 
 /**
  * Find cached texture by key. The texture can be destroyed during usage.
@@ -85,14 +85,15 @@ SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size
 SDL_Texture * lv_draw_sdl_texture_cache_take(const void * key, size_t key_length, bool * found);
 
 SDL_Texture * lv_draw_sdl_texture_cache_take_with_userdata(const void * key, size_t key_length, bool * found,
-                                                          void ** userdata);
+                                                           void ** userdata);
 
 void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
 
 void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                            void userdata_free(void*), lv_draw_sdl_cache_flag_t flags);
+                                            void userdata_free(void *), lv_draw_sdl_cache_flag_t flags);
 
-lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id, size_t * size);
+lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id,
+                                                                      size_t * size);
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -16,9 +16,9 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 #include "lv_draw_sdl.h"
 #include "lv_draw_sdl_priv.h"
 #include "../../draw/lv_img_decoder.h"
@@ -91,7 +91,7 @@ lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void
 /**********************
  *      MACROS
  **********************/
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_gpu_sdl_texture_cache.h
+ * @file lv_draw_sdl_texture_cache.h
  *
  */
 
-#ifndef LV_GPU_SDL_TEXTURE_CACHE_H
-#define LV_GPU_SDL_TEXTURE_CACHE_H
+#ifndef LV_DRAW_SDL_TEXTURE_CACHE_H
+#define LV_DRAW_SDL_TEXTURE_CACHE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,16 +16,19 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#include LV_GPU_SDL_INCLUDE_PATH
+#if LV_USE_DRAW_SDL
+
+#include LV_DRAW_SDL_INCLUDE_PATH
+#include "lv_draw_sdl.h"
+#include "lv_draw_sdl_priv.h"
 #include "../../draw/lv_img_decoder.h"
 #include "../../misc/lv_area.h"
-#include "lv_gpu_sdl_lru.h"
 
 /*********************
  *      DEFINES
  *********************/
 
-#define LV_GPU_SDL_DEC_DSC_TEXTURE_HEAD "@LVSDLTex"
+#define LV_DRAW_SDL_DEC_DSC_TEXTURE_HEAD "@LVSDLTex"
 
 /**********************
  *      TYPEDEFS
@@ -36,7 +39,7 @@ typedef struct {
     SDL_Texture * texture;
     bool texture_managed;
     bool texture_referenced;
-} lv_gpu_sdl_dec_dsc_userdata_t;
+} lv_draw_sdl_dec_dsc_userdata_t;
 
 typedef enum {
     LV_GPU_CACHE_KEY_MAGIC_ARC = 0x01,
@@ -50,43 +53,44 @@ typedef enum {
 } lv_gpu_cache_key_magic_t;
 
 typedef enum {
-    LV_GPU_SDL_CACHE_FLAG_NONE = 0,
-    LV_GPU_SDL_CACHE_FLAG_MANAGED = 1,
-} lv_gpu_sdl_cache_flag_t;
+    LV_DRAW_SDL_CACHE_FLAG_NONE = 0,
+    LV_DRAW_SDL_CACHE_FLAG_MANAGED = 1,
+} lv_draw_sdl_cache_flag_t;
 
 typedef struct {
     lv_gpu_cache_key_magic_t magic;
     lv_img_src_t type;
     int32_t frame_id;
-} lv_gpu_sdl_cache_key_head_img_t;
+} lv_draw_sdl_cache_key_head_img_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-void _lv_gpu_sdl_texture_cache_init();
+void lv_draw_sdl_texture_cache_init(struct lv_draw_sdl_context_internals_t *internals);
 
-void _lv_gpu_sdl_texture_cache_deinit();
+void lv_draw_sdl_texture_cache_deinit(struct lv_draw_sdl_context_internals_t *internals);
 
-SDL_Texture * lv_gpu_draw_cache_get(const void * key, size_t key_length, bool * found);
+SDL_Texture * lv_draw_sdl_texture_cache_get(const void * key, size_t key_length, bool * found);
 
-SDL_Texture * lv_gpu_draw_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata);
+SDL_Texture * lv_draw_sdl_texture_cache_get_with_userdata(const void * key, size_t key_length, bool * found, void ** userdata);
 
-void lv_gpu_draw_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
+void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Texture * texture);
 
-void lv_gpu_draw_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
-                                    lv_lru_free_t userdata_free, lv_gpu_sdl_cache_flag_t flags);
+void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
+                                            void userdata_free(void*), lv_draw_sdl_cache_flag_t flags);
 
-SDL_Texture * lv_gpu_temp_texture_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height);
+SDL_Texture * lv_draw_sdl_texture_temp_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height);
 
-lv_gpu_sdl_cache_key_head_img_t * lv_gpu_sdl_img_cache_key_create(const void * src, int32_t frame_id, size_t * size);
+lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id, size_t * size);
 
 /**********************
  *      MACROS
  **********************/
+#endif /*LV_USE_DRAW_SDL*/
 
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif
 
-#endif /*LV_GPU_SDL_TEXTURE_CACHE_H*/
+#endif /*LV_DRAW_SDL_TEXTURE_CACHE_H*/

--- a/src/draw/sdl/lv_draw_sdl_texture_cache.h
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.h
@@ -80,8 +80,6 @@ void lv_draw_sdl_texture_cache_put(const void * key, size_t key_length, SDL_Text
 void lv_draw_sdl_texture_cache_put_advanced(const void * key, size_t key_length, SDL_Texture * texture, void * userdata,
                                             void userdata_free(void*), lv_draw_sdl_cache_flag_t flags);
 
-SDL_Texture * lv_draw_sdl_texture_temp_obtain(SDL_Renderer * renderer, lv_coord_t width, lv_coord_t height);
-
 lv_draw_sdl_cache_key_head_img_t * lv_draw_sdl_texture_img_key_create(const void * src, int32_t frame_id, size_t * size);
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -143,6 +143,24 @@ SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp)
     return palette;
 }
 
+SDL_Surface * lv_sdl_create_opa_surface(lv_opa_t * opa, lv_coord_t width, lv_coord_t height, lv_coord_t stride)
+{
+    SDL_Surface * indexed = SDL_CreateRGBSurfaceFrom(opa, width, height, 8, stride, 0, 0, 0, 0);
+    SDL_SetSurfacePalette(indexed, lv_sdl_get_grayscale_palette(8));
+    SDL_Surface * converted = SDL_ConvertSurfaceFormat(indexed, SDL_PIXELFORMAT_ARGB8888, 0);
+    SDL_FreeSurface(indexed);
+    return converted;
+}
+
+SDL_Texture * lv_sdl_create_opa_texture(SDL_Renderer * renderer, lv_opa_t * pixels, lv_coord_t width,
+                                        lv_coord_t height, lv_coord_t stride)
+{
+    SDL_Surface * indexed = lv_sdl_create_opa_surface(pixels, width, height, stride);
+    SDL_Texture * texture = SDL_CreateTextureFromSurface(renderer, indexed);
+    SDL_FreeSurface(indexed);
+    return texture;
+}
+
 void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, int stride, uint8_t bpp)
 {
     int src_len = width * height;

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -203,7 +203,7 @@ void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, 
 
 lv_draw_sdl_context_t * lv_draw_sdl_get_context()
 {
-    lv_disp_t *disp = _lv_refr_get_disp_refreshing();
+    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
     return disp->driver->user_data;
 }
 

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -27,7 +27,6 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -36,6 +35,7 @@ extern const uint8_t _lv_bpp2_opa_table[4];
 extern const uint8_t _lv_bpp4_opa_table[16];
 extern const uint8_t _lv_bpp8_opa_table[256];
 
+static int utils_init_count = 0;
 static SDL_Palette * lv_sdl_palette_grayscale8 = NULL;
 
 /**********************
@@ -48,14 +48,23 @@ static SDL_Palette * lv_sdl_palette_grayscale8 = NULL;
 
 void _lv_draw_sdl_utils_init()
 {
-    if (lv_sdl_palette_grayscale8) return;
+    utils_init_count++;
+    if (utils_init_count > 1) {
+        return;
+    }
     lv_sdl_palette_grayscale8 = lv_sdl_alloc_palette_for_bpp(_lv_bpp8_opa_table, 8);
 }
 
 void _lv_draw_sdl_utils_deinit()
 {
-    SDL_FreePalette(lv_sdl_palette_grayscale8);
-    lv_sdl_palette_grayscale8 = NULL;
+    if (utils_init_count == 0) {
+        return;
+    }
+    utils_init_count--;
+    if (utils_init_count == 0) {
+        SDL_FreePalette(lv_sdl_palette_grayscale8);
+        lv_sdl_palette_grayscale8 = NULL;
+    }
 }
 
 void lv_area_to_sdl_rect(const lv_area_t * in, SDL_Rect * out)

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -33,14 +33,9 @@
  **********************/
 extern const uint8_t _lv_bpp1_opa_table[2];
 extern const uint8_t _lv_bpp2_opa_table[4];
-extern const uint8_t _lv_bpp3_opa_table[8];
 extern const uint8_t _lv_bpp4_opa_table[16];
 extern const uint8_t _lv_bpp8_opa_table[256];
 
-static SDL_Palette * lv_sdl_palette_grayscale1 = NULL;
-static SDL_Palette * lv_sdl_palette_grayscale2 = NULL;
-static SDL_Palette * lv_sdl_palette_grayscale3 = NULL;
-static SDL_Palette * lv_sdl_palette_grayscale4 = NULL;
 static SDL_Palette * lv_sdl_palette_grayscale8 = NULL;
 
 /**********************
@@ -53,20 +48,14 @@ static SDL_Palette * lv_sdl_palette_grayscale8 = NULL;
 
 void _lv_draw_sdl_utils_init()
 {
-    lv_sdl_palette_grayscale1 = lv_sdl_alloc_palette_for_bpp(_lv_bpp1_opa_table, 1);
-    lv_sdl_palette_grayscale2 = lv_sdl_alloc_palette_for_bpp(_lv_bpp2_opa_table, 2);
-    lv_sdl_palette_grayscale3 = lv_sdl_alloc_palette_for_bpp(_lv_bpp3_opa_table, 3);
-    lv_sdl_palette_grayscale4 = lv_sdl_alloc_palette_for_bpp(_lv_bpp4_opa_table, 4);
+    if (lv_sdl_palette_grayscale8) return;
     lv_sdl_palette_grayscale8 = lv_sdl_alloc_palette_for_bpp(_lv_bpp8_opa_table, 8);
 }
 
 void _lv_draw_sdl_utils_deinit()
 {
-    SDL_FreePalette(lv_sdl_palette_grayscale1);
-    SDL_FreePalette(lv_sdl_palette_grayscale2);
-    SDL_FreePalette(lv_sdl_palette_grayscale3);
-    SDL_FreePalette(lv_sdl_palette_grayscale4);
     SDL_FreePalette(lv_sdl_palette_grayscale8);
+    lv_sdl_palette_grayscale8 = NULL;
 }
 
 void lv_area_to_sdl_rect(const lv_area_t * in, SDL_Rect * out)
@@ -117,36 +106,10 @@ SDL_Palette * lv_sdl_alloc_palette_for_bpp(const uint8_t * mapping, uint8_t bpp)
     return result;
 }
 
-SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp)
-{
-    SDL_Palette * palette;
-    switch(bpp) {
-        case 1:
-            palette = lv_sdl_palette_grayscale1;
-            break;
-        case 2:
-            palette = lv_sdl_palette_grayscale2;
-            break;
-        case 3:
-            palette = lv_sdl_palette_grayscale3;
-            break;
-        case 4:
-            palette = lv_sdl_palette_grayscale4;
-            break;
-        case 8:
-            palette = lv_sdl_palette_grayscale8;
-            break;
-        default:
-            return NULL;
-    }
-    LV_ASSERT_MSG(lv_sdl_palette_grayscale8, "lv_draw_sdl was not initialized properly");
-    return palette;
-}
-
 SDL_Surface * lv_sdl_create_opa_surface(lv_opa_t * opa, lv_coord_t width, lv_coord_t height, lv_coord_t stride)
 {
     SDL_Surface * indexed = SDL_CreateRGBSurfaceFrom(opa, width, height, 8, stride, 0, 0, 0, 0);
-    SDL_SetSurfacePalette(indexed, lv_sdl_get_grayscale_palette(8));
+    SDL_SetSurfacePalette(indexed, lv_sdl_palette_grayscale8);
     SDL_Surface * converted = SDL_ConvertSurfaceFormat(indexed, LV_DRAW_SDL_TEXTURE_FORMAT, 0);
     SDL_FreeSurface(indexed);
     return converted;

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -8,12 +8,13 @@
  *********************/
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_GPU_SDL
+#if LV_USE_DRAW_SDL
 
 #include "lv_draw_sdl_utils.h"
 
-#include "../../draw/lv_draw.h"
-#include "../../draw/lv_draw_label.h"
+#include "../lv_draw.h"
+#include "../lv_draw_label.h"
+#include "../../core/lv_refr.h"
 
 /*********************
  *      DEFINES
@@ -182,13 +183,14 @@ void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, 
     }
 }
 
-lv_draw_sdl_backend_context_t * lv_draw_sdl_get_context()
+lv_draw_sdl_context_t * lv_draw_sdl_get_context()
 {
-    return lv_draw_backend_get()->ctx;
+    lv_disp_t *disp = _lv_refr_get_disp_refreshing();
+    return disp->driver->user_data;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_GPU_SDL*/
+#endif /*LV_USE_DRAW_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -147,7 +147,7 @@ SDL_Surface * lv_sdl_create_opa_surface(lv_opa_t * opa, lv_coord_t width, lv_coo
 {
     SDL_Surface * indexed = SDL_CreateRGBSurfaceFrom(opa, width, height, 8, stride, 0, 0, 0, 0);
     SDL_SetSurfacePalette(indexed, lv_sdl_get_grayscale_palette(8));
-    SDL_Surface * converted = SDL_ConvertSurfaceFormat(indexed, SDL_PIXELFORMAT_ARGB8888, 0);
+    SDL_Surface * converted = SDL_ConvertSurfaceFormat(indexed, LV_DRAW_SDL_TEXTURE_FORMAT, 0);
     SDL_FreeSurface(indexed);
     return converted;
 }

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -8,7 +8,7 @@
  *********************/
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "lv_draw_sdl_utils.h"
 
@@ -174,4 +174,4 @@ lv_draw_sdl_ctx_t * lv_draw_sdl_get_context()
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -201,10 +201,10 @@ void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, 
     }
 }
 
-lv_draw_sdl_context_t * lv_draw_sdl_get_context()
+lv_draw_sdl_ctx_t * lv_draw_sdl_get_context()
 {
     lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-    return disp->driver->user_data;
+    return (lv_draw_sdl_ctx_t *) disp->driver->draw_ctx;
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -49,7 +49,7 @@ static SDL_Palette * lv_sdl_palette_grayscale8 = NULL;
 void _lv_draw_sdl_utils_init()
 {
     utils_init_count++;
-    if (utils_init_count > 1) {
+    if(utils_init_count > 1) {
         return;
     }
     lv_sdl_palette_grayscale8 = lv_sdl_alloc_palette_for_bpp(_lv_bpp8_opa_table, 8);
@@ -57,11 +57,11 @@ void _lv_draw_sdl_utils_init()
 
 void _lv_draw_sdl_utils_deinit()
 {
-    if (utils_init_count == 0) {
+    if(utils_init_count == 0) {
         return;
     }
     utils_init_count--;
-    if (utils_init_count == 0) {
+    if(utils_init_count == 0) {
         SDL_FreePalette(lv_sdl_palette_grayscale8);
         lv_sdl_palette_grayscale8 = NULL;
     }

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -102,11 +102,6 @@ void lv_area_zoom_to_sdl_rect(const lv_area_t * in, SDL_Rect * out, uint16_t zoo
     out->h = sh;
 }
 
-double lv_sdl_round(double d)
-{
-    return (d - (long) d) < 0.5 ? SDL_floor(d) : SDL_ceil(d);
-}
-
 SDL_Palette * lv_sdl_alloc_palette_for_bpp(const uint8_t * mapping, uint8_t bpp)
 {
     SDL_assert(bpp >= 1 && bpp <= 8);

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -48,6 +48,11 @@ SDL_Palette * lv_sdl_alloc_palette_for_bpp(const uint8_t * mapping, uint8_t bpp)
 
 SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp);
 
+SDL_Surface * lv_sdl_create_opa_surface(lv_opa_t * opa, lv_coord_t width, lv_coord_t height, lv_coord_t stride);
+
+SDL_Texture * lv_sdl_create_opa_texture(SDL_Renderer * renderer, lv_opa_t * pixels, lv_coord_t width,
+                                        lv_coord_t height, lv_coord_t stride);
+
 void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, int stride, uint8_t bpp);
 
 lv_draw_sdl_context_t * lv_draw_sdl_get_context();

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -46,8 +46,6 @@ void lv_area_zoom_to_sdl_rect(const lv_area_t * in, SDL_Rect * out, uint16_t zoo
 
 SDL_Palette * lv_sdl_alloc_palette_for_bpp(const uint8_t * mapping, uint8_t bpp);
 
-SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp);
-
 SDL_Surface * lv_sdl_create_opa_surface(lv_opa_t * opa, lv_coord_t width, lv_coord_t height, lv_coord_t stride);
 
 SDL_Texture * lv_sdl_create_opa_texture(SDL_Renderer * renderer, lv_opa_t * pixels, lv_coord_t width,

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -45,8 +45,6 @@ void lv_color_to_sdl_color(const lv_color_t * in, SDL_Color * out);
 
 void lv_area_zoom_to_sdl_rect(const lv_area_t * in, SDL_Rect * out, uint16_t zoom, const lv_point_t * pivot);
 
-double lv_sdl_round(double d);
-
 SDL_Palette * lv_sdl_alloc_palette_for_bpp(const uint8_t * mapping, uint8_t bpp);
 
 SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp);

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -14,13 +14,13 @@ extern "C" {
  *********************/
 
 #include "../../lv_conf_internal.h"
-#if LV_USE_DRAW_SDL
+#if LV_USE_GPU_SDL
 
 #include "lv_draw_sdl.h"
 #include "../../misc/lv_color.h"
 #include "../../misc/lv_area.h"
 
-#include LV_DRAW_SDL_INCLUDE_PATH
+#include LV_GPU_SDL_INCLUDE_PATH
 
 /*********************
  *      DEFINES
@@ -59,7 +59,7 @@ lv_draw_sdl_ctx_t * lv_draw_sdl_get_context();
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_SDL*/
+#endif /*LV_USE_GPU_SDL*/
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -55,7 +55,7 @@ SDL_Texture * lv_sdl_create_opa_texture(SDL_Renderer * renderer, lv_opa_t * pixe
 
 void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, int stride, uint8_t bpp);
 
-lv_draw_sdl_context_t * lv_draw_sdl_get_context();
+lv_draw_sdl_ctx_t * lv_draw_sdl_get_context();
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -14,11 +14,13 @@ extern "C" {
  *********************/
 
 #include "../../lv_conf_internal.h"
+#if LV_USE_DRAW_SDL
 
+#include "lv_draw_sdl.h"
 #include "../../misc/lv_color.h"
 #include "../../misc/lv_area.h"
 
-#include LV_GPU_SDL_INCLUDE_PATH
+#include LV_DRAW_SDL_INCLUDE_PATH
 
 /*********************
  *      DEFINES
@@ -27,10 +29,7 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct lv_draw_sdl_backend_context_t {
-    SDL_Renderer * renderer;
-    SDL_Texture * texture;
-} lv_draw_sdl_backend_context_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -51,12 +50,13 @@ SDL_Palette * lv_sdl_get_grayscale_palette(uint8_t bpp);
 
 void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, int stride, uint8_t bpp);
 
-lv_draw_sdl_backend_context_t * lv_draw_sdl_get_context();
+lv_draw_sdl_context_t * lv_draw_sdl_get_context();
 
 /**********************
  *      MACROS
  **********************/
 
+#endif /*LV_USE_DRAW_SDL*/
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -116,7 +116,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, cons
         dest_buf += dest_stride * (blend_area.y1 - draw_ctx->buf_area->y1) + (blend_area.x1 - draw_ctx->buf_area->x1);
     }
 
-    lv_color_t * src_buf = dsc->src_buf;
+    const lv_color_t * src_buf = dsc->src_buf;
     lv_coord_t src_stride;
     if(src_buf) {
         src_stride = lv_area_get_width(dsc->blend_area);
@@ -273,10 +273,10 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_ar
                             *(d + 1) = c32;
                         }
 #else
-                        buf[0] = color;
-                        buf[1] = color;
-                        buf[2] = color;
-                        buf[3] = color;
+                        dest_buf[0] = color;
+                        dest_buf[1] = color;
+                        dest_buf[2] = color;
+                        dest_buf[3] = color;
 #endif
                         dest_buf += 4;
                         mask += 4;

--- a/src/gpu/lv_gpu.mk
+++ b/src/gpu/lv_gpu.mk
@@ -2,7 +2,6 @@ CSRCS += lv_gpu_nxp_pxp.c
 CSRCS += lv_gpu_nxp_pxp_osa.c
 CSRCS += lv_gpu_nxp_vglite.c
 CSRCS += lv_gpu_stm32_dma2d.c
-CSRCS += lv_gpu_sdl.c
 
 DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu
 VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -17,6 +17,7 @@
 #include "../core/lv_obj.h"
 #include "../core/lv_refr.h"
 #include "../core/lv_theme.h"
+#include "../draw/sdl/lv_draw_sdl.h"
 #if LV_USE_THEME_DEFAULT
     #include "../extra/themes/default/lv_theme_default.h"
 #endif
@@ -100,9 +101,9 @@ void lv_disp_drv_init(lv_disp_drv_t * driver)
     driver->draw_ctx_deinit = lv_draw_nxp_vglite_init;
     driver->draw_ctx_size = sizeof(lv_draw_nxp_vglite_t);
 #elif LV_USE_GPU_SDL
-    driver->draw_ctx_init = lv_draw_sdl_init;
-    driver->draw_ctx_deinit = lv_draw_sdl_init;
-    driver->draw_ctx_size = sizeof(lv_draw_sdl_t);
+    driver->draw_ctx_init = lv_draw_sdl_init_ctx;
+    driver->draw_ctx_deinit = lv_draw_sdl_deinit_ctx;
+    driver->draw_ctx_size = sizeof(lv_draw_sdl_ctx_t);
 #else
     driver->draw_ctx_init = lv_draw_sw_init_ctx;
     driver->draw_ctx_deinit = lv_draw_sw_init_ctx;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -319,6 +319,38 @@
 #endif
 
 /*-------------
+ * Drawing backend
+ *-----------*/
+
+#if defined(LV_USE_GPU_SDL) || defined(LV_GPU_SDL_INCLUDE_PATH)
+    #error "Please use LV_USE_DRAW_SDL and LV_DRAW_SDL_INCLUDE_PATH instead"
+#endif
+
+#ifndef LV_USE_DRAW_SDL
+    #ifdef CONFIG_LV_USE_DRAW_SDL
+        #define LV_USE_DRAW_SDL CONFIG_LV_USE_DRAW_SDL
+    #else
+        #define LV_USE_DRAW_SDL 0
+    #endif
+#endif
+#if LV_USE_DRAW_SDL
+    #ifndef LV_DRAW_SDL_INCLUDE_PATH
+        #ifdef CONFIG_LV_DRAW_SDL_INCLUDE_PATH
+            #define LV_DRAW_SDL_INCLUDE_PATH CONFIG_LV_DRAW_SDL_INCLUDE_PATH
+        #else
+            #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
+        #endif
+    #endif
+    #ifndef LV_DRAW_SDL_LRU_SIZE
+        #ifdef CONFIG_LV_DRAW_SDL_LRU_SIZE
+            #define LV_DRAW_SDL_LRU_SIZE CONFIG_LV_DRAW_SDL_LRU_SIZE
+        #else
+            #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
+        #endif
+    #endif
+#endif
+
+/*-------------
  * GPU
  *-----------*/
 
@@ -371,33 +403,6 @@
         #define LV_USE_GPU_NXP_VG_LITE CONFIG_LV_USE_GPU_NXP_VG_LITE
     #else
         #define LV_USE_GPU_NXP_VG_LITE 0
-    #endif
-#endif
-
-/*Use exnternal renderer*/
-#ifndef LV_USE_EXTERNAL_RENDERER
-    #ifdef CONFIG_LV_USE_EXTERNAL_RENDERER
-        #define LV_USE_EXTERNAL_RENDERER CONFIG_LV_USE_EXTERNAL_RENDERER
-    #else
-        #define LV_USE_EXTERNAL_RENDERER 0
-    #endif
-#endif
-
-/*Use SDL renderer API. Requires LV_USE_EXTERNAL_RENDERER*/
-#ifndef LV_USE_GPU_SDL
-    #ifdef CONFIG_LV_USE_GPU_SDL
-        #define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
-    #else
-        #define LV_USE_GPU_SDL 0
-    #endif
-#endif
-#if LV_USE_GPU_SDL
-    #ifndef LV_GPU_SDL_INCLUDE_PATH
-        #ifdef CONFIG_LV_GPU_SDL_INCLUDE_PATH
-            #define LV_GPU_SDL_INCLUDE_PATH CONFIG_LV_GPU_SDL_INCLUDE_PATH
-        #else
-            #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
-        #endif
     #endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -319,53 +319,6 @@
 #endif
 
 /*-------------
- * Drawing backend
- *-----------*/
-
-#if defined(LV_USE_GPU_SDL) || defined(LV_GPU_SDL_INCLUDE_PATH)
-    #error "Please use LV_USE_DRAW_SDL and LV_DRAW_SDL_INCLUDE_PATH instead"
-#endif
-
-#ifndef LV_USE_DRAW_SDL
-    #ifdef CONFIG_LV_USE_DRAW_SDL
-        #define LV_USE_DRAW_SDL CONFIG_LV_USE_DRAW_SDL
-    #else
-        #define LV_USE_DRAW_SDL 0
-    #endif
-#endif
-#if LV_USE_DRAW_SDL
-    #ifndef LV_DRAW_SDL_INCLUDE_PATH
-        #ifdef CONFIG_LV_DRAW_SDL_INCLUDE_PATH
-            #define LV_DRAW_SDL_INCLUDE_PATH CONFIG_LV_DRAW_SDL_INCLUDE_PATH
-        #else
-            #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
-        #endif
-    #endif
-    #ifndef LV_DRAW_SDL_LRU_SIZE
-        #ifdef CONFIG_LV_DRAW_SDL_LRU_SIZE
-            #define LV_DRAW_SDL_LRU_SIZE CONFIG_LV_DRAW_SDL_LRU_SIZE
-        #else
-            #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
-        #endif
-    #endif
-
-    #ifndef LV_USE_GPU_SDL
-        #ifdef CONFIG_LV_USE_GPU_SDL
-            #define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
-        #else
-            #define LV_USE_GPU_SDL LV_USE_DRAW_SDL
-        #endif
-    #endif
-    #ifndef LV_GPU_SDL_INCLUDE_PATH
-        #ifdef CONFIG_LV_GPU_SDL_INCLUDE_PATH
-            #define LV_GPU_SDL_INCLUDE_PATH CONFIG_LV_GPU_SDL_INCLUDE_PATH
-        #else
-            #define LV_GPU_SDL_INCLUDE_PATH LV_DRAW_SDL_INCLUDE_PATH
-        #endif
-    #endif
-#endif
-
-/*-------------
  * GPU
  *-----------*/
 
@@ -418,6 +371,31 @@
         #define LV_USE_GPU_NXP_VG_LITE CONFIG_LV_USE_GPU_NXP_VG_LITE
     #else
         #define LV_USE_GPU_NXP_VG_LITE 0
+    #endif
+#endif
+
+/*Use SDL renderer API*/
+#ifndef LV_USE_GPU_SDL
+    #ifdef CONFIG_LV_USE_GPU_SDL
+        #define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
+    #else
+        #define LV_USE_GPU_SDL 0
+    #endif
+#endif
+#if LV_USE_GPU_SDL
+    #ifndef LV_GPU_SDL_INCLUDE_PATH
+        #ifdef CONFIG_LV_GPU_SDL_INCLUDE_PATH
+            #define LV_GPU_SDL_INCLUDE_PATH CONFIG_LV_GPU_SDL_INCLUDE_PATH
+        #else
+            #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+        #endif
+    #endif
+    #ifndef LV_GPU_SDL_LRU_SIZE
+        #ifdef CONFIG_LV_GPU_SDL_LRU_SIZE
+            #define LV_GPU_SDL_LRU_SIZE CONFIG_LV_GPU_SDL_LRU_SIZE
+        #else
+            #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+        #endif
     #endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -348,6 +348,21 @@
             #define LV_DRAW_SDL_LRU_SIZE 1024 * 1024 * 8
         #endif
     #endif
+
+    #ifndef LV_USE_GPU_SDL
+        #ifdef CONFIG_LV_USE_GPU_SDL
+            #define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
+        #else
+            #define LV_USE_GPU_SDL LV_USE_DRAW_SDL
+        #endif
+    #endif
+    #ifndef LV_GPU_SDL_INCLUDE_PATH
+        #ifdef CONFIG_LV_GPU_SDL_INCLUDE_PATH
+            #define LV_GPU_SDL_INCLUDE_PATH CONFIG_LV_GPU_SDL_INCLUDE_PATH
+        #else
+            #define LV_GPU_SDL_INCLUDE_PATH LV_DRAW_SDL_INCLUDE_PATH
+        #endif
+    #endif
 #endif
 
 /*-------------

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -254,13 +254,13 @@ static uint32_t lv_lru_hash(lv_lru_t * cache, const void * key, uint32_t key_len
         key_length -= 4;
     }
 
-    if (key_length >= 3) {
+    if(key_length >= 3) {
         h ^= data[2] << 16;
     }
-    if (key_length >= 2) {
+    if(key_length >= 2) {
         h ^= data[1] << 8;
     }
-    if (key_length >= 1) {
+    if(key_length >= 1) {
         h ^= data[0];
         h *= m;
     }

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -309,7 +309,7 @@ static void lv_lru_remove_lru_item(lv_lru_t * cache)
         prev = NULL;
 
         while(item) {
-            if(item->access_count < min_access_count || min_access_count == -1) {
+            if(item->access_count < min_access_count || (int64_t) min_access_count == -1) {
                 min_access_count = item->access_count;
                 min_item = item;
                 min_prev = prev;

--- a/src/misc/lv_lru.h
+++ b/src/misc/lv_lru.h
@@ -51,10 +51,10 @@ typedef struct lruc_item {
 typedef struct {
     lruc_item ** items;
     uint64_t access_count;
-    uint64_t free_memory;
-    uint64_t total_memory;
-    uint64_t average_item_length;
-    uint32_t hash_table_size;
+    size_t free_memory;
+    size_t total_memory;
+    size_t average_item_length;
+    size_t hash_table_size;
     time_t seed;
     lv_lru_free_t * value_free;
     lv_lru_free_t * key_free;
@@ -66,7 +66,7 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_lru_t * lv_lru_new(uint64_t cache_size, uint32_t average_length, lv_lru_free_t * value_free,
+lv_lru_t * lv_lru_new(size_t cache_size, size_t average_length, lv_lru_free_t * value_free,
                       lv_lru_free_t * key_free);
 
 lruc_error lv_lru_free(lv_lru_t * cache);

--- a/src/misc/lv_lru.h
+++ b/src/misc/lv_lru.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_lru.h
+ * @file lv_lru.h
  *
  */
 
@@ -14,9 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_conf_internal.h"
-
-#include LV_GPU_SDL_INCLUDE_PATH
+#include "../lv_conf_internal.h"
 
 #include <stdint.h>
 #include <time.h>
@@ -61,7 +59,6 @@ typedef struct {
     lv_lru_free_t * value_free;
     lv_lru_free_t * key_free;
     lruc_item * free_items;
-    SDL_mutex * mutex;
 } lv_lru_t;
 
 

--- a/src/misc/lv_misc.mk
+++ b/src/misc/lv_misc.mk
@@ -8,6 +8,7 @@ CSRCS += lv_fs.c
 CSRCS += lv_gc.c
 CSRCS += lv_ll.c
 CSRCS += lv_log.c
+CSRCS += lv_lru.c
 CSRCS += lv_math.c
 CSRCS += lv_mem.c
 CSRCS += lv_printf.c


### PR DESCRIPTION
### Description of the feature or fix

This update significantly improved drawing performance for SDL backend. Although it can't be reflected with benchmark, as it's already over 500fps, but it has over 50% higher framerate on webOS.

Before: 30fps
![Before: 30fps](https://user-images.githubusercontent.com/830358/145689995-0e889c75-6cd7-478c-bb91-701488b1e5c8.png)

After: > 50fps
![After: > 50fps](https://user-images.githubusercontent.com/830358/145689979-d65bd7c7-1517-4aab-9e70-83f8a401d15b.png)

Also, this PR improves rendering fidelity. For example, when drawing border with SIDE_RIGHT and SIDE_BOTTOM, previous implementation didn't draw anything.

Before:
![image](https://user-images.githubusercontent.com/830358/145690074-ed924b96-1ab8-46fd-9757-1f14af08c83f.png)

After:
![image](https://user-images.githubusercontent.com/830358/145690099-d7290fa5-e1f0-4e0e-a920-dfd34e3fe049.png)


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
