### PR TITLE
fix(qrcodegen): fix coding style/build error

### DIFF
--- a/src/extra/libs/qrcode/qrcodegen.c
+++ b/src/extra/libs/qrcode/qrcodegen.c
@@ -948,9 +948,9 @@ struct qrcodegen_Segment qrcodegen_makeEci(long assignVal, uint8_t buf[]) {
 	result.mode = qrcodegen_Mode_ECI;
 	result.numChars = 0;
 	result.bitLength = 0;
-	if (assignVal < 0)
+	if (assignVal < 0) {
 		assert(false);
-	else if (assignVal < (1 << 7)) {
+	} else if (assignVal < (1 << 7)) {
 		memset(buf, 0, 1 * sizeof(buf[0]));
 		appendBitsToBuffer(assignVal, 8, buf, &result.bitLength);
 	} else if (assignVal < (1 << 14)) {
@@ -962,8 +962,9 @@ struct qrcodegen_Segment qrcodegen_makeEci(long assignVal, uint8_t buf[]) {
 		appendBitsToBuffer(6, 3, buf, &result.bitLength);
 		appendBitsToBuffer(assignVal >> 10, 11, buf, &result.bitLength);
 		appendBitsToBuffer(assignVal & 0x3FF, 10, buf, &result.bitLength);
-	} else
+	} else {
 		assert(false);
+	}
 	result.data = buf;
 	return result;
 }


### PR DESCRIPTION
The way the brackets around this if-else are structured doesn't look
broken but it causes the following build error on some compilers (first
observed on arm-zephyr-eabi-gcc (crosstool-NG 1.24.0.378_e011758) 10.3.0):

./src/extra/libs/qrcode/qrcodegen.c:953:2: error: 'else' without a previous 'if'
  953 |  else if (assignVal < (1 << 7)) {
      |  ^~~~

Fix it by placing brackets consistently.