### PR TITLE
feat(lottie) move rlottie_capi.h to lv_rlottie.c

### DIFF
--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -9,6 +9,8 @@
 #include "lv_rlottie.h"
 #if LV_USE_RLOTTIE
 
+#include <rlottie_capi.h>
+
 /*********************
 *      DEFINES
 *********************/
@@ -170,6 +172,7 @@ static void lv_rlottie_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj
         rlottie->dest_frame = 0;
     }
 
+    lv_img_cache_invalidate_src(&rlottie->imgdsc);
     if(rlottie->allocated_buf) {
         lv_mem_free(rlottie->allocated_buf);
         rlottie->allocated_buf = NULL;

--- a/src/extra/libs/rlottie/lv_rlottie.h
+++ b/src/extra/libs/rlottie/lv_rlottie.h
@@ -16,8 +16,6 @@ extern "C" {
 #include "../../../lvgl.h"
 #if LV_USE_RLOTTIE
 
-#include <rlottie_capi.h>
-
 /*********************
  *      DEFINES
  *********************/
@@ -33,9 +31,11 @@ typedef enum {
     LV_RLOTTIE_CTRL_LOOP     = 8,
 } lv_rlottie_ctrl_t;
 
+/** definition in lottieanimation_capi.c */
+struct Lottie_Animation_S;
 typedef struct {
     lv_img_t img_ext;
-    Lottie_Animation * animation;
+    struct Lottie_Animation_S * animation;
     lv_timer_t * task;
     lv_img_dsc_t imgdsc;
     size_t total_frames;


### PR DESCRIPTION
### Description of the feature or fix

There is no need to include rlottie_capi.h in lv_rlottie.h. so i move it to lv_rlottie.c. 
After deleting lv_rlottie obj, the memory of the image source will be released,  but it is not invalidated, causing a crash.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
