### PR TITLE
Add grid navigation feature

### DIFF
--- a/docs/others/gridnav.md
+++ b/docs/others/gridnav.md
@@ -1,0 +1,61 @@
+```eval_rst
+.. include:: /header.rst 
+:github_url: |github_link_base|/others/gridnav.md
+```
+# Grid navigation
+
+Grid navigation (gridnav for short) is feature that allow focusing the children of an object using arrows. 
+
+If the children are arranged into a grid-like layout up, down, left and right arrows focuses nearest sibling
+in the respective direction.
+
+
+It doesn't matter how the children are positioned as only the current x and y coordinates are considered.
+So gridnav works manually positioned children, or [Flex](/layouts/flex.html) or [Grid](/layouts/grid.html) layouts too.
+
+Gridnav works if the children are arranged into a single row or column too. 
+Therefore, it can be useful for example to simply the navigation on a [List widget](/widgets/extra/list.html).
+
+Gridnav assumes that the object to which gridnav is added is part of a [group](/overview/indev.html#groups). 
+This way, if the object with gridnav is focused, the arrow key presses are automatically forwarded to the object
+so that gridnav can process arrows.
+
+To move the focus to next widget of the group use `LV_KEY_NEXT/PREV` or `lv_group_focus_next/prev()` or the `TAB` key on keyboards as usual. 
+ 
+If the container is scrollable and the focused child is out of the view, gridnav will automatically scroll to the that object. 
+ 
+## Usage
+
+To add gridnav feature to an object use `lv_gridnav_add(cont, flags)`.
+
+`flags` control the behavior of gridnav:
+- `LV_GRIDNAV_CTRL_NONE` Default settings 
+- `LV_GRIDNAV_CTRL_ROLLOVER`  If there is no next/previous object in a direction, 
+the focus goes to the object in the next/previous row (on left/right keys) or first/last row (on up/down keys 
+- `LV_GRIDNAV_CTRL_SCROLL_FIRST` If an arrow is pressed and the focused object can be scrolled in that direction
+then it will be scrolled instead of going to the next/previous object.  If there is no more room for scrolling the next/previous object will be focused normally 
+
+`lv_gridnav_remove(cont)` removes gridnav from an object.
+
+## Focusable objects
+
+An object needs to be clickable or click focusable (`LV_OBJ_FLAG_CLICKABLE` or `LV_OBJ_FLAG_CLICK_FOCUSABLE`) and not hidden (`LV_OBJ_FLAG_HIDDEN`) to be focusable 
+by gridnav.
+
+
+## Example
+
+```eval_rst
+
+.. include:: ../../examples/others/gridnav/index.rst
+
+```
+## API
+
+
+```eval_rst
+
+.. doxygenfile:: lv_gridnav.h
+  :project: lvgl
+
+```

--- a/docs/others/gridnav.md
+++ b/docs/others/gridnav.md
@@ -4,29 +4,28 @@
 ```
 # Grid navigation
 
-Grid navigation (gridnav for short) is feature that allow focusing the children of an object using arrows. 
+Grid navigation (gridnav for short) is a feature that changes the currently focused child object as arrow keys are pressed.
 
-If the children are arranged into a grid-like layout up, down, left and right arrows focuses nearest sibling
+If the children are arranged into a grid-like layout then the up, down, left and right arrows move focus to the nearest sibling
 in the respective direction.
 
+It doesn't matter how the children are positioned, as only the current x and y coordinates are considered.
+This means that gridnav works with manually positioned children, as well as [Flex](/layouts/flex.html) and [Grid](/layouts/grid.html) layouts.
 
-It doesn't matter how the children are positioned as only the current x and y coordinates are considered.
-So gridnav works manually positioned children, or [Flex](/layouts/flex.html) or [Grid](/layouts/grid.html) layouts too.
-
-Gridnav works if the children are arranged into a single row or column too. 
-Therefore, it can be useful for example to simply the navigation on a [List widget](/widgets/extra/list.html).
+Gridnav also works if the children are arranged into a single row or column.
+That makes it useful, for example, to simplify navigation on a [List widget](/widgets/extra/list.html).
 
 Gridnav assumes that the object to which gridnav is added is part of a [group](/overview/indev.html#groups). 
 This way, if the object with gridnav is focused, the arrow key presses are automatically forwarded to the object
-so that gridnav can process arrows.
+so that gridnav can process the arrow keys.
 
-To move the focus to next widget of the group use `LV_KEY_NEXT/PREV` or `lv_group_focus_next/prev()` or the `TAB` key on keyboards as usual. 
+To move the focus to the next widget of the group use `LV_KEY_NEXT/PREV` or `lv_group_focus_next/prev()` or the `TAB` key on keyboard as usual. 
  
-If the container is scrollable and the focused child is out of the view, gridnav will automatically scroll to the that object. 
+If the container is scrollable and the focused child is out of the view, gridnav will automatically scroll the child into view.
  
 ## Usage
 
-To add gridnav feature to an object use `lv_gridnav_add(cont, flags)`.
+To add the gridnav feature to an object use `lv_gridnav_add(cont, flags)`.
 
 `flags` control the behavior of gridnav:
 - `LV_GRIDNAV_CTRL_NONE` Default settings 
@@ -35,12 +34,12 @@ the focus goes to the object in the next/previous row (on left/right keys) or fi
 - `LV_GRIDNAV_CTRL_SCROLL_FIRST` If an arrow is pressed and the focused object can be scrolled in that direction
 then it will be scrolled instead of going to the next/previous object.  If there is no more room for scrolling the next/previous object will be focused normally 
 
-`lv_gridnav_remove(cont)` removes gridnav from an object.
+`lv_gridnav_remove(cont)` Removes gridnav from an object.
 
 ## Focusable objects
 
-An object needs to be clickable or click focusable (`LV_OBJ_FLAG_CLICKABLE` or `LV_OBJ_FLAG_CLICK_FOCUSABLE`) and not hidden (`LV_OBJ_FLAG_HIDDEN`) to be focusable 
-by gridnav.
+An object needs to be clickable or click focusable (`LV_OBJ_FLAG_CLICKABLE` or `LV_OBJ_FLAG_CLICK_FOCUSABLE`) 
+and not hidden (`LV_OBJ_FLAG_HIDDEN`) to be focusable by gridnav.
 
 
 ## Example

--- a/docs/others/index.md
+++ b/docs/others/index.md
@@ -12,5 +12,6 @@
    
    snapshot
    monkey
+   gridnav
 ```
 

--- a/examples/layouts/flex/lv_example_flex_2.c
+++ b/examples/layouts/flex/lv_example_flex_2.c
@@ -21,6 +21,7 @@ void lv_example_flex_2(void)
     for(i = 0; i < 8; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
+        lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
 
         lv_obj_t * label = lv_label_create(obj);
         lv_label_set_text_fmt(label, "%"LV_PRIu32, i);

--- a/examples/others/gridnav/index.rst
+++ b/examples/others/gridnav/index.rst
@@ -1,0 +1,18 @@
+
+Basic grid navigation
+"""""""""""""""""""""
+
+.. lv_example:: others/monkey/lv_example_gridnav_1
+  :language: c
+
+Grid navigation on a list
+""""""""""""""""""""""""
+
+.. lv_example:: others/monkey/lv_example_gridnav_2
+  :language: c
+
+Nested grid navigations
+"""""""""""""""""""""""
+
+.. lv_example:: others/monkey/lv_example_gridanav_3
+  :language: c

--- a/examples/others/gridnav/lv_example_gridnav.h
+++ b/examples/others/gridnav/lv_example_gridnav.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_example_monkey.h
+ * @file lv_example_gridnav.h
  *
  */
 
-#ifndef LV_EXAMPLE_MONKEY_H
-#define LV_EXAMPLE_MONKEY_H
+#ifndef LV_EXAMPLE_GRIDNAV_H
+#define LV_EXAMPLE_GRIDNAV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,9 +25,9 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-void lv_example_monkey_1(void);
-void lv_example_monkey_2(void);
-void lv_example_monkey_3(void);
+void lv_example_gridnav_1(void);
+void lv_example_gridnav_2(void);
+void lv_example_gridnav_3(void);
 
 /**********************
  *      MACROS
@@ -37,4 +37,4 @@ void lv_example_monkey_3(void);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_EXAMPLE_MONKEY_H*/
+#endif /*LV_EXAMPLE_GRIDNAV_H*/

--- a/examples/others/gridnav/lv_example_gridnav.h
+++ b/examples/others/gridnav/lv_example_gridnav.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_example_others.h
+ * @file lv_example_monkey.h
  *
  */
 
-#ifndef LV_EXAMPLE_OTHERS_H
-#define LV_EXAMPLE_OTHERS_H
+#ifndef LV_EXAMPLE_MONKEY_H
+#define LV_EXAMPLE_MONKEY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,9 +13,6 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "snapshot/lv_example_snapshot.h"
-#include "monkey/lv_example_monkey.h"
-#include "gridnav/lv_example_gridnav.h"
 
 /*********************
  *      DEFINES
@@ -28,6 +25,9 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+void lv_example_monkey_1(void);
+void lv_example_monkey_2(void);
+void lv_example_monkey_3(void);
 
 /**********************
  *      MACROS
@@ -37,4 +37,4 @@ extern "C" {
 } /*extern "C"*/
 #endif
 
-#endif /*LV_EX_OTHERS_H*/
+#endif /*LV_EXAMPLE_MONKEY_H*/

--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -65,7 +65,7 @@ void lv_example_gridnav_1(void)
     lv_group_remove_obj(sw1);   /*Not needed, we use the gridnav instead*/
 
     lv_obj_t * sw2 = lv_switch_create(cont2);
-    lv_obj_set_pos(sw2, lv_pct(50), 220);
+    lv_obj_set_pos(sw2, lv_pct(50), 200);
     lv_group_remove_obj(sw2);   /*Not needed, we use the gridnav instead*/
 }
 

--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -20,7 +20,6 @@ void lv_example_gridnav_1(void)
     /*Only the container needs to be in a group*/
     lv_group_add_obj(lv_group_get_default(), cont1);
 
-
     lv_obj_t * label = lv_label_create(cont1);
     lv_label_set_text_fmt(label, "No rollover");
 

--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -1,0 +1,73 @@
+#include "../../lv_examples.h"
+#if LV_USE_GRIDNAV && LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/**
+ * Demonstrate a a basic grid navigation
+ */
+void lv_example_gridnav_1(void)
+{
+    /*It's assumed that the default group is set and
+     *there is a keyboard indev*/
+
+    lv_obj_t * cont1 = lv_obj_create(lv_scr_act());
+    lv_gridnav_add(cont1, LV_GRIDNAV_CTRL_NONE);
+
+    /*Use flex here, but works with grid or manually placed objects as well*/
+    lv_obj_set_flex_flow(cont1, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_bg_color(cont1, lv_palette_lighten(LV_PALETTE_BLUE, 5), LV_STATE_FOCUSED);
+    lv_obj_set_size(cont1, lv_pct(50), lv_pct(100));
+
+    /*Only the container needs to be in a group*/
+    lv_group_add_obj(lv_group_get_default(), cont1);
+
+
+    lv_obj_t * label = lv_label_create(cont1);
+    lv_label_set_text_fmt(label, "No rollover");
+
+    uint32_t i;
+    for(i = 0; i < 10; i++) {
+        lv_obj_t * obj = lv_btn_create(cont1);
+        lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
+        lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+        lv_group_remove_obj(obj);   /*Not needed, we use the gridnav instead*/
+
+        lv_obj_t * label = lv_label_create(obj);
+        lv_label_set_text_fmt(label, "%d", i);
+        lv_obj_center(label);
+    }
+
+    /* Create a second container with rollover grid nav mode.*/
+
+    lv_obj_t * cont2 = lv_obj_create(lv_scr_act());
+    lv_gridnav_add(cont2, LV_GRIDNAV_CTRL_ROLLOVER);
+    lv_obj_set_style_bg_color(cont2, lv_palette_lighten(LV_PALETTE_BLUE, 5), LV_STATE_FOCUSED);
+    lv_obj_set_size(cont2, lv_pct(50), lv_pct(100));
+    lv_obj_align(cont2, LV_ALIGN_RIGHT_MID, 0, 0);
+
+    label = lv_label_create(cont2);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_label_set_text_fmt(label, "Rollover\nUse tab to focus the other container");
+
+    /*Only the container needs to be in a group*/
+    lv_group_add_obj(lv_group_get_default(), cont2);
+
+    /*Add and place some children manually*/
+    lv_obj_t * ta = lv_textarea_create(cont2);
+    lv_obj_set_size(ta, lv_pct(100), 80);
+    lv_obj_set_pos(ta, 0, 80);
+    lv_group_remove_obj(ta);   /*Not needed, we use the gridnav instead*/
+
+    lv_obj_t * cb = lv_checkbox_create(cont2);
+    lv_obj_set_pos(cb, 0, 170);
+    lv_group_remove_obj(cb);   /*Not needed, we use the gridnav instead*/
+
+    lv_obj_t * sw1 = lv_switch_create(cont2);
+    lv_obj_set_pos(sw1, 0, 200);
+    lv_group_remove_obj(sw1);   /*Not needed, we use the gridnav instead*/
+
+    lv_obj_t * sw2 = lv_switch_create(cont2);
+    lv_obj_set_pos(sw2, lv_pct(50), 220);
+    lv_group_remove_obj(sw2);   /*Not needed, we use the gridnav instead*/
+}
+
+#endif

--- a/examples/others/gridnav/lv_example_gridnav_2.c
+++ b/examples/others/gridnav/lv_example_gridnav_2.c
@@ -1,0 +1,44 @@
+#include "../../lv_examples.h"
+#if LV_USE_GRIDNAV && LV_USE_LIST && LV_BUILD_EXAMPLES
+
+/**
+ * Grid navigation on a list
+ */
+void lv_example_gridnav_2(void)
+{
+    /*It's assumed that the default group is set and
+     *there is a keyboard indev*/
+
+    lv_obj_t * list1 = lv_list_create(lv_scr_act());
+    lv_gridnav_add(list1, LV_GRIDNAV_CTRL_NONE);
+    lv_obj_set_size(list1, lv_pct(45), lv_pct(80));
+    lv_obj_align(list1, LV_ALIGN_LEFT_MID, 5, 0);
+    lv_obj_set_style_bg_color(list1, lv_palette_lighten(LV_PALETTE_BLUE, 5), LV_STATE_FOCUSED);
+    lv_group_add_obj(lv_group_get_default(), list1);
+
+
+    char buf[32];
+    uint32_t i;
+    for(i = 0; i < 15; i++) {
+        lv_snprintf(buf, sizeof(buf), "File %d", i + 1);
+        lv_obj_t * item = lv_list_add_btn(list1, LV_SYMBOL_FILE, buf);
+        lv_obj_set_style_bg_opa(item, 0, 0);
+        lv_group_remove_obj(item);   /*Not needed, we use the gridnav instead*/
+    }
+
+    lv_obj_t * list2 = lv_list_create(lv_scr_act());
+    lv_gridnav_add(list2, LV_GRIDNAV_CTRL_ROLLOVER);
+    lv_obj_set_size(list2, lv_pct(45), lv_pct(80));
+    lv_obj_align(list2, LV_ALIGN_RIGHT_MID, -5, 0);
+    lv_obj_set_style_bg_color(list2, lv_palette_lighten(LV_PALETTE_BLUE, 5), LV_STATE_FOCUSED);
+    lv_group_add_obj(lv_group_get_default(), list2);
+
+    for(i = 0; i < 15; i++) {
+        lv_snprintf(buf, sizeof(buf), "Folder %d", i + 1);
+        lv_obj_t * item = lv_list_add_btn(list2, LV_SYMBOL_DIRECTORY, buf);
+        lv_obj_set_style_bg_opa(item, 0, 0);
+        lv_group_remove_obj(item);
+    }
+}
+
+#endif

--- a/examples/others/gridnav/lv_example_gridnav_3.c
+++ b/examples/others/gridnav/lv_example_gridnav_3.c
@@ -1,0 +1,76 @@
+#include "../../lv_examples.h"
+#if LV_USE_GRIDNAV && LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+static void cont_sub_event_cb(lv_event_t * e)
+{
+    uint32_t k = lv_event_get_key(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
+    if(k == LV_KEY_ENTER) {
+        lv_group_focus_obj(obj);
+    }
+    else if(k == LV_KEY_ESC) {
+        lv_group_focus_next(lv_obj_get_group(obj));
+    }
+
+}
+
+/**
+ * Nested grid navigations
+ */
+void lv_example_gridnav_3(void)
+{
+    /*It's assumed that the default group is set and
+     *there is a keyboard indev*/
+
+    lv_obj_t * cont_main = lv_obj_create(lv_scr_act());
+    lv_gridnav_add(cont_main, LV_GRIDNAV_CTRL_ROLLOVER);
+
+    /*Only the container needs to be in a group*/
+    lv_group_add_obj(lv_group_get_default(), cont_main);
+
+    /*Use flex here, but works with grid or manually placed objects as well*/
+    lv_obj_set_flex_flow(cont_main, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_bg_color(cont_main, lv_palette_lighten(LV_PALETTE_BLUE, 5), LV_STATE_FOCUSED);
+    lv_obj_set_size(cont_main, lv_pct(80), LV_SIZE_CONTENT);
+
+    lv_obj_t * btn;
+    lv_obj_t * label;
+
+    btn = lv_btn_create(cont_main);
+    lv_group_remove_obj(btn);
+    label = lv_label_create(btn);
+    lv_label_set_text(label, "Button 1");
+
+    btn = lv_btn_create(cont_main);
+    lv_group_remove_obj(btn);
+    label = lv_label_create(btn);
+    lv_label_set_text(label, "Button 2");
+
+    lv_obj_t * cont_sub = lv_obj_create(cont_main);
+    lv_gridnav_add(cont_sub, LV_GRIDNAV_CTRL_ROLLOVER);
+    /*Only the container needs to be in a group*/
+    lv_group_add_obj(lv_group_get_default(), cont_sub);
+
+    lv_obj_add_event_cb(cont_sub, cont_sub_event_cb, LV_EVENT_KEY, NULL);
+
+    /*Use flex here, but works with grid or manually placed objects as well*/
+    lv_obj_set_flex_flow(cont_sub, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_bg_color(cont_sub, lv_palette_lighten(LV_PALETTE_RED, 5), LV_STATE_FOCUSED);
+    lv_obj_set_size(cont_sub, lv_pct(100), LV_SIZE_CONTENT);
+
+    label = lv_label_create(cont_sub);
+    lv_label_set_text(label, "Use ENTER/ESC to focus/defocus this container");
+    lv_obj_set_width(label, lv_pct(100));
+
+    btn = lv_btn_create(cont_sub);
+    lv_group_remove_obj(btn);
+    label = lv_label_create(btn);
+    lv_label_set_text(label, "Button 3");
+
+    btn = lv_btn_create(cont_sub);
+    lv_group_remove_obj(btn);
+    label = lv_label_create(btn);
+    lv_label_set_text(label, "Button 4");
+}
+
+#endif

--- a/examples/others/gridnav/lv_example_gridnav_3.c
+++ b/examples/others/gridnav/lv_example_gridnav_3.c
@@ -23,7 +23,7 @@ void lv_example_gridnav_3(void)
      *there is a keyboard indev*/
 
     lv_obj_t * cont_main = lv_obj_create(lv_scr_act());
-    lv_gridnav_add(cont_main, LV_GRIDNAV_CTRL_ROLLOVER);
+    lv_gridnav_add(cont_main, LV_GRIDNAV_CTRL_ROLLOVER | LV_GRIDNAV_CTRL_SCROLL_FIRST);
 
     /*Only the container needs to be in a group*/
     lv_group_add_obj(lv_group_get_default(), cont_main);
@@ -46,31 +46,56 @@ void lv_example_gridnav_3(void)
     label = lv_label_create(btn);
     lv_label_set_text(label, "Button 2");
 
-    lv_obj_t * cont_sub = lv_obj_create(cont_main);
-    lv_gridnav_add(cont_sub, LV_GRIDNAV_CTRL_ROLLOVER);
-    /*Only the container needs to be in a group*/
-    lv_group_add_obj(lv_group_get_default(), cont_sub);
 
-    lv_obj_add_event_cb(cont_sub, cont_sub_event_cb, LV_EVENT_KEY, NULL);
+    /*Create an other container with long text to show how LV_GRIDNAV_CTRL_SCROLL_FIRST works*/
+    lv_obj_t * cont_sub1 = lv_obj_create(cont_main);
+    lv_obj_set_size(cont_sub1, lv_pct(100), 100);
+
+    label = lv_label_create(cont_sub1);
+    lv_obj_set_style_bg_color(cont_sub1, lv_palette_lighten(LV_PALETTE_RED, 5), LV_STATE_FOCUSED);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_label_set_text(label,
+            "I'm a very long text which is makes my container scrollable. "
+            "As LV_GRIDNAV_FLAG_SCROLL_FIRST is enabled arrow will scroll me first "
+            "and a new objects will be focused only when an edge is reached with the scrolling.\n\n"
+            "This is only some placeholder text to be sure the parent will be scrollable. \n\n"
+            "Hello world!\n"
+            "Hello world!\n"
+            "Hello world!\n"
+            "Hello world!\n"
+            "Hello world!\n"
+            "Hello world!");
+
+    /*Create a third container that can be focused with ENTER and contains an other grid nav*/
+    lv_obj_t * cont_sub2 = lv_obj_create(cont_main);
+    lv_gridnav_add(cont_sub2, LV_GRIDNAV_CTRL_ROLLOVER);
+    /*Only the container needs to be in a group*/
+    lv_group_add_obj(lv_group_get_default(), cont_sub2);
+
+    lv_obj_add_event_cb(cont_sub2, cont_sub_event_cb, LV_EVENT_KEY, NULL);
 
     /*Use flex here, but works with grid or manually placed objects as well*/
-    lv_obj_set_flex_flow(cont_sub, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_style_bg_color(cont_sub, lv_palette_lighten(LV_PALETTE_RED, 5), LV_STATE_FOCUSED);
-    lv_obj_set_size(cont_sub, lv_pct(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(cont_sub2, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_bg_color(cont_sub2, lv_palette_lighten(LV_PALETTE_RED, 5), LV_STATE_FOCUSED);
+    lv_obj_set_size(cont_sub2, lv_pct(100), LV_SIZE_CONTENT);
 
-    label = lv_label_create(cont_sub);
+    label = lv_label_create(cont_sub2);
     lv_label_set_text(label, "Use ENTER/ESC to focus/defocus this container");
     lv_obj_set_width(label, lv_pct(100));
 
-    btn = lv_btn_create(cont_sub);
+    btn = lv_btn_create(cont_sub2);
     lv_group_remove_obj(btn);
     label = lv_label_create(btn);
     lv_label_set_text(label, "Button 3");
 
-    btn = lv_btn_create(cont_sub);
+    btn = lv_btn_create(cont_sub2);
     lv_group_remove_obj(btn);
     label = lv_label_create(btn);
     lv_label_set_text(label, "Button 4");
+
+
+
+
 }
 
 #endif

--- a/examples/others/gridnav/lv_example_gridnav_4.c
+++ b/examples/others/gridnav/lv_example_gridnav_4.c
@@ -1,0 +1,47 @@
+#include "../../lv_examples.h"
+#if LV_USE_GRIDNAV && LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+
+static void event_handler(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * list = lv_obj_get_parent(obj);
+    LV_LOG_USER("Clicked: %s", lv_list_get_btn_text(list, obj));
+}
+
+/**
+ * Simple navigation on a list widget
+ */
+void lv_example_gridnav_4(void)
+{
+    /*It's assumed that the default group is set and
+     *there is a keyboard indev*/
+
+    lv_obj_t * list = lv_list_create(lv_scr_act());
+    lv_gridnav_add(list, LV_GRIDNAV_CTRL_ROLLOVER);
+    lv_obj_align(list, LV_ALIGN_LEFT_MID, 0, 10);
+    lv_group_add_obj(lv_group_get_default(), list);
+
+    uint32_t i;
+    for(i = 0; i < 20; i++) {
+        char buf[32];
+
+        /*Add some separators too, they are not focusable by gridnav*/
+        if((i % 5) == 0) {
+            lv_snprintf(buf, sizeof(buf), "Section %d", i / 5 + 1);
+            lv_list_add_text(list, buf);
+        }
+
+        lv_snprintf(buf, sizeof(buf), "File %d", i + 1);
+        lv_obj_t * item = lv_list_add_btn(list, LV_SYMBOL_FILE, buf);
+        lv_obj_add_event_cb(item, event_handler, LV_EVENT_CLICKED, NULL);
+        lv_group_remove_obj(item);  /*The default group adds it automatically*/
+    }
+
+    lv_obj_t * btn = lv_btn_create(lv_scr_act());
+    lv_obj_align(btn, LV_ALIGN_RIGHT_MID, 0, -10);
+    lv_obj_t * label = lv_label_create(btn);
+    lv_label_set_text(label, "Button");
+}
+
+#endif

--- a/examples/widgets/list/lv_example_list_1.c
+++ b/examples/widgets/list/lv_example_list_1.c
@@ -10,6 +10,7 @@ static void event_handler(lv_event_t * e)
         LV_LOG_USER("Clicked: %s", lv_list_get_btn_text(list1, obj));
     }
 }
+
 void lv_example_list_1(void)
 {
     /*Create a list*/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -604,10 +604,13 @@
  *----------*/
 
 /*1: Enable API to take snapshot for object*/
-#define LV_USE_SNAPSHOT 1
+#define LV_USE_SNAPSHOT 0
 
 /*1: Enable Monkey test*/
-#define LV_USE_MONKEY 0
+#define LV_USE_MONKEY   0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV  0
 
 /*==================
 * EXAMPLES

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -183,16 +183,26 @@ void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end);
  *====================*/
 
 /**
- *
  * Scroll by a given amount of pixels
  * @param obj       pointer to an object to scroll
- * @param x         pixels to scroll horizontally
- * @param y         pixels to scroll vertically
+ * @param dx         pixels to scroll horizontally
+ * @param dy         pixels to scroll vertically
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  * @note            > 0 value means scroll right/bottom (show the more content on the right/bottom)
- * @note
+ * @note            e.g. dy = -20 means scroll down 20 px
  */
 void lv_obj_scroll_by(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en);
+
+/**
+ * Scroll by a given amount of pixels.
+ * `dx` and `dy` will be limited internally to allow scrolling only on the content area.
+ * @param obj       pointer to an object to scroll
+ * @param dx        pixels to scroll horizontally
+ * @param dy        pixels to scroll vertically
+ * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
+ * @note            e.g. dy = -20 means scroll down 20 px
+ */
+void lv_obj_scroll_by_bounded(struct _lv_obj_t * obj, lv_coord_t dx, lv_coord_t dy, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given coordinate on an object.

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -102,11 +102,13 @@ static void gridnav_event_cb(lv_event_t * e)
         lv_obj_t * guess = NULL;
 
         if(key == LV_KEY_RIGHT) {
-            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_right(dsc->focused_obj) > 0) {
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) &&
+               lv_obj_get_scroll_right(dsc->focused_obj) > 0) {
                 lv_coord_t d = lv_obj_get_width(dsc->focused_obj) / 4;
                 if(d <= 0) d = 1;
                 lv_obj_scroll_by_bounded(dsc->focused_obj, -d, 0, LV_ANIM_ON);
-            } else {
+            }
+            else {
                 guess = find_chid(obj, dsc->focused_obj, FIND_RIGHT);
                 if(guess == NULL) {
                     if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
@@ -120,11 +122,13 @@ static void gridnav_event_cb(lv_event_t * e)
             }
         }
         else if(key == LV_KEY_LEFT) {
-            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_left(dsc->focused_obj) > 0) {
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) &&
+               lv_obj_get_scroll_left(dsc->focused_obj) > 0) {
                 lv_coord_t d = lv_obj_get_width(dsc->focused_obj) / 4;
                 if(d <= 0) d = 1;
                 lv_obj_scroll_by_bounded(dsc->focused_obj, d, 0, LV_ANIM_ON);
-            } else {
+            }
+            else {
                 guess = find_chid(obj, dsc->focused_obj, FIND_LEFT);
                 if(guess == NULL) {
                     if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
@@ -138,11 +142,13 @@ static void gridnav_event_cb(lv_event_t * e)
             }
         }
         else if(key == LV_KEY_DOWN) {
-            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_bottom(dsc->focused_obj) > 0) {
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) &&
+               lv_obj_get_scroll_bottom(dsc->focused_obj) > 0) {
                 lv_coord_t d = lv_obj_get_height(dsc->focused_obj) / 4;
                 if(d <= 0) d = 1;
                 lv_obj_scroll_by_bounded(dsc->focused_obj, 0, -d, LV_ANIM_ON);
-            } else {
+            }
+            else {
                 guess = find_chid(obj, dsc->focused_obj, FIND_BOTTOM);
                 if(guess == NULL) {
                     if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
@@ -155,11 +161,13 @@ static void gridnav_event_cb(lv_event_t * e)
             }
         }
         else if(key == LV_KEY_UP) {
-            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_top(dsc->focused_obj) > 0) {
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) &&
+               lv_obj_get_scroll_top(dsc->focused_obj) > 0) {
                 lv_coord_t d = lv_obj_get_height(dsc->focused_obj) / 4;
                 if(d <= 0) d = 1;
                 lv_obj_scroll_by_bounded(dsc->focused_obj, 0, d, LV_ANIM_ON);
-            } else {
+            }
+            else {
                 guess = find_chid(obj, dsc->focused_obj, FIND_TOP);
                 if(guess == NULL) {
                     if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -100,49 +100,74 @@ static void gridnav_event_cb(lv_event_t * e)
 
         uint32_t key = lv_indev_get_key(lv_indev_get_act());
         lv_obj_t * guess = NULL;
+
         if(key == LV_KEY_RIGHT) {
-            guess = find_chid(obj, dsc->focused_obj, FIND_RIGHT);
-            if(guess == NULL) {
-                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
-                    guess = find_chid(obj, dsc->focused_obj, FIND_NEXT_ROW_FIRST_ITEM);
-                    if(guess == NULL) guess = find_first_focusable(obj);
-                }
-                else {
-                    lv_group_focus_next(lv_obj_get_group(obj));
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_right(dsc->focused_obj) > 0) {
+                lv_coord_t d = lv_obj_get_width(dsc->focused_obj) / 4;
+                if(d <= 0) d = 1;
+                lv_obj_scroll_by_bounded(dsc->focused_obj, -d, 0, LV_ANIM_ON);
+            } else {
+                guess = find_chid(obj, dsc->focused_obj, FIND_RIGHT);
+                if(guess == NULL) {
+                    if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                        guess = find_chid(obj, dsc->focused_obj, FIND_NEXT_ROW_FIRST_ITEM);
+                        if(guess == NULL) guess = find_first_focusable(obj);
+                    }
+                    else {
+                        lv_group_focus_next(lv_obj_get_group(obj));
+                    }
                 }
             }
         }
         else if(key == LV_KEY_LEFT) {
-            guess = find_chid(obj, dsc->focused_obj, FIND_LEFT);
-            if(guess == NULL) {
-                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
-                    guess = find_chid(obj, dsc->focused_obj, FIND_PREV_ROW_LAST_ITEM);
-                    if(guess == NULL) guess = find_last_focusable(obj);
-                }
-                else {
-                    lv_group_focus_prev(lv_obj_get_group(obj));
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_left(dsc->focused_obj) > 0) {
+                lv_coord_t d = lv_obj_get_width(dsc->focused_obj) / 4;
+                if(d <= 0) d = 1;
+                lv_obj_scroll_by_bounded(dsc->focused_obj, d, 0, LV_ANIM_ON);
+            } else {
+                guess = find_chid(obj, dsc->focused_obj, FIND_LEFT);
+                if(guess == NULL) {
+                    if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                        guess = find_chid(obj, dsc->focused_obj, FIND_PREV_ROW_LAST_ITEM);
+                        if(guess == NULL) guess = find_last_focusable(obj);
+                    }
+                    else {
+                        lv_group_focus_prev(lv_obj_get_group(obj));
+                    }
                 }
             }
         }
         else if(key == LV_KEY_DOWN) {
-            guess = find_chid(obj, dsc->focused_obj, FIND_BOTTOM);
-            if(guess == NULL) {
-                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
-                    guess = find_chid(obj, dsc->focused_obj, FIND_FIRST_ROW);
-                }
-                else {
-                    lv_group_focus_next(lv_obj_get_group(obj));
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_bottom(dsc->focused_obj) > 0) {
+                lv_coord_t d = lv_obj_get_height(dsc->focused_obj) / 4;
+                if(d <= 0) d = 1;
+                lv_obj_scroll_by_bounded(dsc->focused_obj, 0, -d, LV_ANIM_ON);
+            } else {
+                guess = find_chid(obj, dsc->focused_obj, FIND_BOTTOM);
+                if(guess == NULL) {
+                    if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                        guess = find_chid(obj, dsc->focused_obj, FIND_FIRST_ROW);
+                    }
+                    else {
+                        lv_group_focus_next(lv_obj_get_group(obj));
+                    }
                 }
             }
         }
         else if(key == LV_KEY_UP) {
-            guess = find_chid(obj, dsc->focused_obj, FIND_TOP);
-            if(guess == NULL) {
-                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
-                    guess = find_chid(obj, dsc->focused_obj, FIND_LAST_ROW);
-                }
-                else {
-                    lv_group_focus_prev(lv_obj_get_group(obj));
+            if((dsc->ctrl & LV_GRIDNAV_CTRL_SCROLL_FIRST) && lv_obj_has_flag(dsc->focused_obj, LV_OBJ_FLAG_SCROLLABLE) && lv_obj_get_scroll_top(dsc->focused_obj) > 0) {
+                lv_coord_t d = lv_obj_get_height(dsc->focused_obj) / 4;
+                if(d <= 0) d = 1;
+                lv_obj_scroll_by_bounded(dsc->focused_obj, 0, d, LV_ANIM_ON);
+            } else {
+                guess = find_chid(obj, dsc->focused_obj, FIND_TOP);
+                if(guess == NULL) {
+                    if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                        guess = find_chid(obj, dsc->focused_obj, FIND_LAST_ROW);
+                    }
+                    else {
+                        lv_group_focus_prev(lv_obj_get_group(obj));
+                    }
                 }
             }
         }

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -147,7 +147,9 @@ static void gridnav_event_cb(lv_event_t * e)
             }
         }
         else {
-            lv_event_send(dsc->focused_obj, LV_EVENT_KEY, &key);
+            if(lv_group_get_focused(lv_obj_get_group(obj)) == obj) {
+                lv_event_send(dsc->focused_obj, LV_EVENT_KEY, &key);
+            }
         }
 
         if(guess && guess != dsc->focused_obj) {
@@ -196,10 +198,12 @@ static void gridnav_event_cb(lv_event_t * e)
     else if(code == LV_EVENT_PRESSED || code == LV_EVENT_PRESSING || code == LV_EVENT_PRESS_LOST ||
             code == LV_EVENT_LONG_PRESSED || code == LV_EVENT_LONG_PRESSED_REPEAT ||
             code == LV_EVENT_CLICKED || code == LV_EVENT_RELEASED) {
-        /*Forward press/release related event too*/
-        lv_indev_type_t t = lv_indev_get_type(lv_indev_get_act());
-        if(t == LV_INDEV_TYPE_ENCODER || t == LV_INDEV_TYPE_KEYPAD) {
-            lv_event_send(dsc->focused_obj, code, lv_indev_get_act());
+        if(lv_group_get_focused(lv_obj_get_group(obj)) == obj) {
+            /*Forward press/release related event too*/
+            lv_indev_type_t t = lv_indev_get_type(lv_indev_get_act());
+            if(t == LV_INDEV_TYPE_ENCODER || t == LV_INDEV_TYPE_KEYPAD) {
+                lv_event_send(dsc->focused_obj, code, lv_indev_get_act());
+            }
         }
     }
 }

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -58,6 +58,8 @@ static lv_coord_t get_y_center(lv_obj_t * obj);
 
 void lv_gridnav_add(lv_obj_t * obj, lv_gridnav_ctrl_t ctrl)
 {
+    lv_gridnav_remove(obj); /*Be sure to not add gridnav twice*/
+
     lv_gridnav_dsc_t * dsc = lv_mem_alloc(sizeof(lv_gridnav_dsc_t));
     LV_ASSERT_MALLOC(dsc);
     dsc->ctrl = ctrl;
@@ -70,9 +72,8 @@ void lv_gridnav_add(lv_obj_t * obj, lv_gridnav_ctrl_t ctrl)
 void lv_gridnav_remove(lv_obj_t * obj)
 {
     lv_gridnav_dsc_t * dsc = lv_obj_get_event_user_data(obj, gridnav_event_cb);
-    if(dsc == NULL) {
-        return; /* no gridnav on this object */
-    }
+    if(dsc == NULL) return; /* no gridnav on this object */
+
     lv_mem_free(dsc);
     lv_obj_remove_event_cb(obj, gridnav_event_cb);
 }

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -70,6 +70,9 @@ void lv_gridnav_add(lv_obj_t * obj, lv_gridnav_ctrl_t ctrl)
 void lv_gridnav_remove(lv_obj_t * obj)
 {
     lv_gridnav_dsc_t * dsc = lv_obj_get_event_user_data(obj, gridnav_event_cb);
+    if(dsc == NULL) {
+        return; /* no gridnav on this object */
+    }
     lv_mem_free(dsc);
     lv_obj_remove_event_cb(obj, gridnav_event_cb);
 }

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -1,0 +1,275 @@
+
+
+/**
+ * @file lv_gridnav.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_gridnav.h"
+#include "../../../misc/lv_assert.h"
+#include "../../../misc/lv_math.h"
+#include "../../../core/lv_indev.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef struct {
+    lv_gridnav_ctrl_t ctrl;
+    lv_obj_t * focused_obj;
+} lv_gridnav_dsc_t;
+
+typedef enum {
+    FIND_LEFT,
+    FIND_RIGHT,
+    FIND_TOP,
+    FIND_BOTTOM,
+    FIND_NEXT_ROW_FIRST_ITEM,
+    FIND_PREV_ROW_LAST_ITEM,
+    FIND_FIRST_ROW,
+    FIND_LAST_ROW,
+} find_mode_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void gridnav_event_cb(lv_event_t * e);
+static lv_obj_t * find_chid(lv_obj_t * obj, lv_obj_t * start_child, find_mode_t mode);
+static lv_coord_t get_x_center(lv_obj_t * obj);
+static lv_coord_t get_y_center(lv_obj_t * obj);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_gridnav_add(lv_obj_t * obj, lv_gridnav_ctrl_t ctrl)
+{
+    lv_gridnav_dsc_t * dsc = lv_mem_alloc(sizeof(lv_gridnav_dsc_t));
+    LV_ASSERT_MALLOC(dsc);
+    dsc->ctrl = ctrl;
+    dsc->focused_obj = NULL;
+    lv_obj_add_event_cb(obj, gridnav_event_cb, LV_EVENT_ALL, dsc);
+
+    lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLL_WITH_ARROW);
+}
+
+void lv_gridnav_remove(lv_obj_t * obj)
+{
+    lv_gridnav_dsc_t * dsc = lv_obj_get_event_user_data(obj, gridnav_event_cb);
+    lv_mem_free(dsc);
+    lv_obj_remove_event_cb(obj, gridnav_event_cb);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void gridnav_event_cb(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_current_target(e);
+    lv_gridnav_dsc_t * dsc = lv_event_get_user_data(e);
+    lv_event_code_t code = lv_event_get_code(e);
+
+    if(code == LV_EVENT_KEY) {
+        uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+        if(child_cnt == 0) return;
+
+        uint32_t key = lv_indev_get_key(lv_indev_get_act());
+        lv_obj_t * guess = NULL;
+        if(key == LV_KEY_RIGHT) {
+            guess = find_chid(obj, dsc->focused_obj, FIND_RIGHT);
+            if(guess == NULL) {
+                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                    guess = find_chid(obj, dsc->focused_obj, FIND_NEXT_ROW_FIRST_ITEM);
+                    if(guess == NULL) guess = lv_obj_get_child(obj, 0);
+                }
+                else {
+                    lv_group_focus_next(lv_obj_get_group(obj));
+                }
+            }
+        }
+        else if(key == LV_KEY_LEFT) {
+            guess = find_chid(obj, dsc->focused_obj, FIND_LEFT);
+            if(guess == NULL) {
+                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                    guess = find_chid(obj, dsc->focused_obj, FIND_PREV_ROW_LAST_ITEM);
+                    /*Last item*/
+                    if(guess == NULL) guess = lv_obj_get_child(obj, -1);
+                }
+                else {
+                    lv_group_focus_prev(lv_obj_get_group(obj));
+                }
+            }
+        }
+        else if(key == LV_KEY_DOWN) {
+            guess = find_chid(obj, dsc->focused_obj, FIND_BOTTOM);
+            if(guess == NULL) {
+                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                    guess = find_chid(obj, dsc->focused_obj, FIND_FIRST_ROW);
+                }
+                else {
+                    lv_group_focus_next(lv_obj_get_group(obj));
+                }
+            }
+        }
+        else if(key == LV_KEY_UP) {
+            guess = find_chid(obj, dsc->focused_obj, FIND_TOP);
+            if(guess == NULL) {
+                if(dsc->ctrl & LV_GRIDNAV_CTRL_ROLLOVER) {
+                    guess = find_chid(obj, dsc->focused_obj, FIND_LAST_ROW);
+                }
+                else {
+                    lv_group_focus_prev(lv_obj_get_group(obj));
+                }
+            }
+        }
+        else {
+            lv_event_send(dsc->focused_obj, LV_EVENT_KEY, &key);
+        }
+
+        if(guess && guess != dsc->focused_obj) {
+            lv_obj_clear_state(dsc->focused_obj, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
+            lv_obj_add_state(guess, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
+            lv_obj_scroll_to_view(guess, LV_ANIM_ON);
+            dsc->focused_obj = guess;
+        }
+    }
+    else if(code == LV_EVENT_FOCUSED) {
+        if(dsc->focused_obj) {
+            lv_obj_add_state(dsc->focused_obj, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
+            lv_obj_scroll_to_view(dsc->focused_obj, LV_ANIM_OFF);
+        }
+    }
+    else if(code == LV_EVENT_DEFOCUSED) {
+        if(dsc->focused_obj) {
+            lv_obj_clear_state(dsc->focused_obj, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
+        }
+    }
+    else if(code == LV_EVENT_CHILD_CREATED) {
+        if(lv_obj_has_state(obj, LV_STATE_FOCUSED)) {
+            lv_obj_t * child = lv_event_get_target(e);
+            if(lv_obj_get_parent(child) == obj) {
+                if(dsc->focused_obj == NULL) {
+                    dsc->focused_obj = child;
+                    lv_obj_add_state(child, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
+                    lv_obj_scroll_to_view(child, LV_ANIM_OFF);
+                }
+            }
+        }
+    }
+    else if(code == LV_EVENT_CHILD_DELETED) {
+        /*This event bubble, so be sure this object's child was deleted.
+         *As we don't know which object was deleted we can't make the next focused.
+         *So make the first object focused*/
+        lv_obj_t * target = lv_event_get_target(e);
+        if(target == obj) {
+            dsc->focused_obj = lv_obj_get_child(obj, 0);
+        }
+    }
+    else if(code == LV_EVENT_DELETE) {
+        lv_gridnav_remove(obj);
+    }
+    else if(code == LV_EVENT_PRESSED || code == LV_EVENT_PRESSING || code == LV_EVENT_PRESS_LOST ||
+            code == LV_EVENT_LONG_PRESSED || code == LV_EVENT_LONG_PRESSED_REPEAT ||
+            code == LV_EVENT_CLICKED || LV_EVENT_RELEASED) {
+        /*Forward press/release related event too*/
+        lv_indev_type_t t = lv_indev_get_type(lv_indev_get_act());
+        if(t == LV_INDEV_TYPE_ENCODER || t == LV_INDEV_TYPE_KEYPAD) {
+            lv_event_send(dsc->focused_obj, code, lv_indev_get_act());
+        }
+    }
+}
+
+static lv_obj_t * find_chid(lv_obj_t * obj, lv_obj_t * start_child, find_mode_t mode)
+{
+    lv_coord_t x_start = get_x_center(start_child);
+    lv_coord_t y_start = get_y_center(start_child);
+    uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+    lv_obj_t * guess = NULL;
+    lv_coord_t x_err_guess = LV_COORD_MAX;
+    lv_coord_t y_err_guess = LV_COORD_MAX;
+    lv_coord_t h_half = lv_obj_get_height(start_child) / 2;
+    lv_coord_t h_max = lv_obj_get_height(obj) + lv_obj_get_scroll_top(obj) + lv_obj_get_scroll_bottom(obj);
+    uint32_t i;
+    for(i = 0; i < child_cnt; i++) {
+        lv_obj_t * child = lv_obj_get_child(obj, i);
+        if(child == start_child) continue;
+        if(lv_obj_has_flag(child, LV_OBJ_FLAG_CLICK_FOCUSABLE) == false) continue;
+
+        lv_coord_t x_err;
+        lv_coord_t y_err;
+        switch(mode) {
+            case FIND_LEFT:
+                x_err = get_x_center(child) - x_start;
+                y_err = get_y_center(child) - y_start;
+                if(x_err >= 0) continue;    /*It's on the right*/
+                if(LV_ABS(y_err) > h_half) continue;    /*Too far*/
+                break;
+            case FIND_RIGHT:
+                x_err = get_x_center(child) - x_start;
+                y_err = get_y_center(child) - y_start;
+                if(x_err <= 0) continue;    /*It's on the left*/
+                if(LV_ABS(y_err) > h_half) continue;    /*Too far*/
+                break;
+            case FIND_TOP:
+                x_err = get_x_center(child) - x_start;
+                y_err = get_y_center(child) - y_start;
+                if(y_err >= 0) continue;    /*It's on the bottom*/
+                break;
+            case FIND_BOTTOM:
+                x_err = get_x_center(child) - x_start;
+                y_err = get_y_center(child) - y_start;
+                if(y_err <= 0) continue;    /*It's on the top*/
+                break;
+            case FIND_NEXT_ROW_FIRST_ITEM:
+                y_err = get_y_center(child) - y_start;
+                if(y_err <= 0) continue;    /*It's on the top*/
+                x_err = lv_obj_get_x(child);
+                break;
+            case FIND_PREV_ROW_LAST_ITEM:
+                y_err = get_y_center(child) - y_start;
+                if(y_err >= 0) continue;    /*It's on the bottom*/
+                x_err = obj->coords.x2 - child->coords.x2;
+                break;
+            case FIND_FIRST_ROW:
+                x_err = get_x_center(child) - x_start;
+                y_err = lv_obj_get_y(child);
+                break;
+            case FIND_LAST_ROW:
+                x_err = get_x_center(child) - x_start;
+                y_err = h_max - lv_obj_get_y(child);
+        }
+
+        if(guess == NULL ||
+           (y_err * y_err + x_err * x_err < y_err_guess * y_err_guess + x_err_guess * x_err_guess)) {
+            guess = child;
+            x_err_guess  = x_err;
+            y_err_guess  = y_err;
+        }
+    }
+    return guess;
+}
+
+static lv_coord_t get_x_center(lv_obj_t * obj)
+{
+    return obj->coords.x1 + lv_area_get_width(&obj->coords) / 2;
+}
+
+static lv_coord_t get_y_center(lv_obj_t * obj)
+{
+    return obj->coords.y1 + lv_area_get_height(&obj->coords) / 2;
+}

--- a/src/extra/others/gridnav/lv_gridnav.h
+++ b/src/extra/others/gridnav/lv_gridnav.h
@@ -1,0 +1,104 @@
+/**
+ * @file lv_templ.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/*This typedef exists purely to keep -Wpedantic happy when the file is empty.*/
+/*It can be removed.*/
+typedef int _keep_pedantic_happy;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+/**
+ * @file lv_gridnav.h
+ *
+ */
+
+#ifndef LV_GRIDFOCUS_H
+#define LV_GRIDFOCUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../../core/lv_obj.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef enum {
+    LV_GRIDNAV_CTRL_NONE = 0x0,
+
+    /** If there is no next/previous object in a direction,
+     *  the focus goes to the object in the next/previous row (on left/right keys)
+     *  or first/last row (on up/down keys)
+     */
+    LV_GRIDNAV_CTRL_ROLLOVER = 0x1,
+} lv_gridnav_ctrl_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Add grid navigation feature to an object. It expects the children to be arranged
+ * into a grid-like layout. Although it's not required to have pixel perfect alignment.
+ * This feature makes possible to use keys to navigate among the children and focus them.
+ * The keys other than arrows and press/release related events
+ * are forwarded to the focused child.
+ * @param obj       pointer to an object on which navigation should be applied.
+ * @param ctrl      control flags from `lv_gridnav_ctrl_t`.
+ */
+void lv_gridnav_add(lv_obj_t * obj, lv_gridnav_ctrl_t ctrl);
+
+/**
+ * Remove the grid navigation support from an object
+ * @param obj       pointer to an object
+ */
+void lv_gridnav_remove(lv_obj_t * obj);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_GRIDFOCUS_H*/

--- a/src/extra/others/gridnav/lv_gridnav.h
+++ b/src/extra/others/gridnav/lv_gridnav.h
@@ -67,11 +67,19 @@ extern "C" {
 typedef enum {
     LV_GRIDNAV_CTRL_NONE = 0x0,
 
-    /** If there is no next/previous object in a direction,
-     *  the focus goes to the object in the next/previous row (on left/right keys)
-     *  or first/last row (on up/down keys)
+    /**
+     * If there is no next/previous object in a direction,
+     * the focus goes to the object in the next/previous row (on left/right keys)
+     * or first/last row (on up/down keys)
      */
     LV_GRIDNAV_CTRL_ROLLOVER = 0x1,
+
+    /**
+     * If an arrow is pressed and the focused object can be scrolled in that direction
+     * then it will be scrolled instead of going to the next/previous object.
+     * If there is no more room for scrolling the next/previous object will be focused normally */
+    LV_GRIDNAV_CTRL_SCROLL_FIRST = 0x2,
+
 } lv_gridnav_ctrl_t;
 
 /**********************

--- a/src/extra/others/gridnav/lv_gridnav.h
+++ b/src/extra/others/gridnav/lv_gridnav.h
@@ -55,6 +55,8 @@ extern "C" {
  *********************/
 #include "../../../core/lv_obj.h"
 
+#if LV_USE_GRIDNAV
+
 /*********************
  *      DEFINES
  *********************/
@@ -96,6 +98,7 @@ void lv_gridnav_remove(lv_obj_t * obj);
 /**********************
  *      MACROS
  **********************/
+#endif /*LV_USE_GRIDNAV*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/extra/others/lv_others.h
+++ b/src/extra/others/lv_others.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "snapshot/lv_snapshot.h"
 #include "monkey/lv_monkey.h"
+#include "gridnav/lv_gridnav.h"
 
 /*********************
  *      DEFINES

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1942,14 +1942,10 @@
 
 /*1: Enable API to take snapshot for object*/
 #ifndef LV_USE_SNAPSHOT
-    #ifdef _LV_KCONFIG_PRESENT
-        #ifdef CONFIG_LV_USE_SNAPSHOT
-            #define LV_USE_SNAPSHOT CONFIG_LV_USE_SNAPSHOT
-        #else
-            #define LV_USE_SNAPSHOT 0
-        #endif
+    #ifdef CONFIG_LV_USE_SNAPSHOT
+        #define LV_USE_SNAPSHOT CONFIG_LV_USE_SNAPSHOT
     #else
-        #define LV_USE_SNAPSHOT 1
+        #define LV_USE_SNAPSHOT 0
     #endif
 #endif
 
@@ -1958,7 +1954,16 @@
     #ifdef CONFIG_LV_USE_MONKEY
         #define LV_USE_MONKEY CONFIG_LV_USE_MONKEY
     #else
-        #define LV_USE_MONKEY 0
+        #define LV_USE_MONKEY   0
+    #endif
+#endif
+
+/*1: Enable grid navigation*/
+#ifndef LV_USE_GRIDNAV
+    #ifdef CONFIG_LV_USE_GRIDNAV
+        #define LV_USE_GRIDNAV CONFIG_LV_USE_GRIDNAV
+    #else
+        #define LV_USE_GRIDNAV  0
     #endif
 #endif
 
@@ -1992,13 +1997,13 @@
     #endif
 #endif
 #if LV_USE_DEMO_WIDGETS
-    #ifndef LV_DEMO_WIDGETS_SLIDESHOW
-        #ifdef CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
-            #define LV_DEMO_WIDGETS_SLIDESHOW CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
-        #else
-            #define LV_DEMO_WIDGETS_SLIDESHOW  0
-        #endif
+#ifndef LV_DEMO_WIDGETS_SLIDESHOW
+    #ifdef CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+        #define LV_DEMO_WIDGETS_SLIDESHOW CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+    #else
+        #define LV_DEMO_WIDGETS_SLIDESHOW  0
     #endif
+#endif
 #endif
 
 /*Demonstrate the usage of encoder and keyboard*/
@@ -2037,41 +2042,41 @@
     #endif
 #endif
 #if LV_USE_DEMO_MUSIC
-    #ifndef LV_DEMO_MUSIC_SQUARE
-        #ifdef CONFIG_LV_DEMO_MUSIC_SQUARE
-            #define LV_DEMO_MUSIC_SQUARE CONFIG_LV_DEMO_MUSIC_SQUARE
-        #else
-            #define LV_DEMO_MUSIC_SQUARE       0
-        #endif
+#ifndef LV_DEMO_MUSIC_SQUARE
+    #ifdef CONFIG_LV_DEMO_MUSIC_SQUARE
+        #define LV_DEMO_MUSIC_SQUARE CONFIG_LV_DEMO_MUSIC_SQUARE
+    #else
+        #define LV_DEMO_MUSIC_SQUARE       0
     #endif
-    #ifndef LV_DEMO_MUSIC_LANDSCAPE
-        #ifdef CONFIG_LV_DEMO_MUSIC_LANDSCAPE
-            #define LV_DEMO_MUSIC_LANDSCAPE CONFIG_LV_DEMO_MUSIC_LANDSCAPE
-        #else
-            #define LV_DEMO_MUSIC_LANDSCAPE    0
-        #endif
+#endif
+#ifndef LV_DEMO_MUSIC_LANDSCAPE
+    #ifdef CONFIG_LV_DEMO_MUSIC_LANDSCAPE
+        #define LV_DEMO_MUSIC_LANDSCAPE CONFIG_LV_DEMO_MUSIC_LANDSCAPE
+    #else
+        #define LV_DEMO_MUSIC_LANDSCAPE    0
     #endif
-    #ifndef LV_DEMO_MUSIC_ROUND
-        #ifdef CONFIG_LV_DEMO_MUSIC_ROUND
-            #define LV_DEMO_MUSIC_ROUND CONFIG_LV_DEMO_MUSIC_ROUND
-        #else
-            #define LV_DEMO_MUSIC_ROUND        0
-        #endif
+#endif
+#ifndef LV_DEMO_MUSIC_ROUND
+    #ifdef CONFIG_LV_DEMO_MUSIC_ROUND
+        #define LV_DEMO_MUSIC_ROUND CONFIG_LV_DEMO_MUSIC_ROUND
+    #else
+        #define LV_DEMO_MUSIC_ROUND        0
     #endif
-    #ifndef LV_DEMO_MUSIC_LARGE
-        #ifdef CONFIG_LV_DEMO_MUSIC_LARGE
-            #define LV_DEMO_MUSIC_LARGE CONFIG_LV_DEMO_MUSIC_LARGE
-        #else
-            #define LV_DEMO_MUSIC_LARGE        0
-        #endif
+#endif
+#ifndef LV_DEMO_MUSIC_LARGE
+    #ifdef CONFIG_LV_DEMO_MUSIC_LARGE
+        #define LV_DEMO_MUSIC_LARGE CONFIG_LV_DEMO_MUSIC_LARGE
+    #else
+        #define LV_DEMO_MUSIC_LARGE        0
     #endif
-    #ifndef LV_DEMO_MUSIC_AUTO_PLAY
-        #ifdef CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
-            #define LV_DEMO_MUSIC_AUTO_PLAY CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
-        #else
-            #define LV_DEMO_MUSIC_AUTO_PLAY    0
-        #endif
+#endif
+#ifndef LV_DEMO_MUSIC_AUTO_PLAY
+    #ifdef CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
+        #define LV_DEMO_MUSIC_AUTO_PLAY CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
+    #else
+        #define LV_DEMO_MUSIC_AUTO_PLAY    0
     #endif
+#endif
 #endif
 
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1997,13 +1997,13 @@
     #endif
 #endif
 #if LV_USE_DEMO_WIDGETS
-#ifndef LV_DEMO_WIDGETS_SLIDESHOW
-    #ifdef CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
-        #define LV_DEMO_WIDGETS_SLIDESHOW CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
-    #else
-        #define LV_DEMO_WIDGETS_SLIDESHOW  0
+    #ifndef LV_DEMO_WIDGETS_SLIDESHOW
+        #ifdef CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+            #define LV_DEMO_WIDGETS_SLIDESHOW CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+        #else
+            #define LV_DEMO_WIDGETS_SLIDESHOW  0
+        #endif
     #endif
-#endif
 #endif
 
 /*Demonstrate the usage of encoder and keyboard*/
@@ -2042,41 +2042,41 @@
     #endif
 #endif
 #if LV_USE_DEMO_MUSIC
-#ifndef LV_DEMO_MUSIC_SQUARE
-    #ifdef CONFIG_LV_DEMO_MUSIC_SQUARE
-        #define LV_DEMO_MUSIC_SQUARE CONFIG_LV_DEMO_MUSIC_SQUARE
-    #else
-        #define LV_DEMO_MUSIC_SQUARE       0
+    #ifndef LV_DEMO_MUSIC_SQUARE
+        #ifdef CONFIG_LV_DEMO_MUSIC_SQUARE
+            #define LV_DEMO_MUSIC_SQUARE CONFIG_LV_DEMO_MUSIC_SQUARE
+        #else
+            #define LV_DEMO_MUSIC_SQUARE       0
+        #endif
     #endif
-#endif
-#ifndef LV_DEMO_MUSIC_LANDSCAPE
-    #ifdef CONFIG_LV_DEMO_MUSIC_LANDSCAPE
-        #define LV_DEMO_MUSIC_LANDSCAPE CONFIG_LV_DEMO_MUSIC_LANDSCAPE
-    #else
-        #define LV_DEMO_MUSIC_LANDSCAPE    0
+    #ifndef LV_DEMO_MUSIC_LANDSCAPE
+        #ifdef CONFIG_LV_DEMO_MUSIC_LANDSCAPE
+            #define LV_DEMO_MUSIC_LANDSCAPE CONFIG_LV_DEMO_MUSIC_LANDSCAPE
+        #else
+            #define LV_DEMO_MUSIC_LANDSCAPE    0
+        #endif
     #endif
-#endif
-#ifndef LV_DEMO_MUSIC_ROUND
-    #ifdef CONFIG_LV_DEMO_MUSIC_ROUND
-        #define LV_DEMO_MUSIC_ROUND CONFIG_LV_DEMO_MUSIC_ROUND
-    #else
-        #define LV_DEMO_MUSIC_ROUND        0
+    #ifndef LV_DEMO_MUSIC_ROUND
+        #ifdef CONFIG_LV_DEMO_MUSIC_ROUND
+            #define LV_DEMO_MUSIC_ROUND CONFIG_LV_DEMO_MUSIC_ROUND
+        #else
+            #define LV_DEMO_MUSIC_ROUND        0
+        #endif
     #endif
-#endif
-#ifndef LV_DEMO_MUSIC_LARGE
-    #ifdef CONFIG_LV_DEMO_MUSIC_LARGE
-        #define LV_DEMO_MUSIC_LARGE CONFIG_LV_DEMO_MUSIC_LARGE
-    #else
-        #define LV_DEMO_MUSIC_LARGE        0
+    #ifndef LV_DEMO_MUSIC_LARGE
+        #ifdef CONFIG_LV_DEMO_MUSIC_LARGE
+            #define LV_DEMO_MUSIC_LARGE CONFIG_LV_DEMO_MUSIC_LARGE
+        #else
+            #define LV_DEMO_MUSIC_LARGE        0
+        #endif
     #endif
-#endif
-#ifndef LV_DEMO_MUSIC_AUTO_PLAY
-    #ifdef CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
-        #define LV_DEMO_MUSIC_AUTO_PLAY CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
-    #else
-        #define LV_DEMO_MUSIC_AUTO_PLAY    0
+    #ifndef LV_DEMO_MUSIC_AUTO_PLAY
+        #ifdef CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
+            #define LV_DEMO_MUSIC_AUTO_PLAY CONFIG_LV_DEMO_MUSIC_AUTO_PLAY
+        #else
+            #define LV_DEMO_MUSIC_AUTO_PLAY    0
+        #endif
     #endif
-#endif
 #endif
 
 


### PR DESCRIPTION
### Description of the feature or fix

This feature allows to navigate among the elements (i.e. make one of them focused) of a parent container. A typical example is a file browser where the icons are arranged in a grid-like layout and you can use arrows to select a file.

The non-arrow keys and press/release related event are passed to the focused child


Here is an example code:
```c
void gridnav_test(void)
{
    static lv_style_t style;
    lv_style_init(&style);
    lv_style_set_flex_flow(&style, LV_FLEX_FLOW_ROW_WRAP);
    lv_style_set_flex_main_place(&style, LV_FLEX_ALIGN_SPACE_EVENLY);
    lv_style_set_layout(&style, LV_LAYOUT_FLEX);

    lv_obj_t * cont = lv_obj_create(lv_scr_act());
    lv_obj_set_size(cont, 300, 220);
    lv_obj_center(cont);
    lv_obj_add_style(cont, &style, 0);

    lv_group_add_obj(lv_group_get_default(), cont);
    lv_obj_set_style_bg_color(cont, lv_color_hex(0xffaabb), LV_STATE_FOCUSED);

    lv_gridnav_add(cont, LV_GRIDNAV_CTRL_ROLLOVER);

    unsigned int i;
    for(i = 0; i < 13; i++) {
        lv_obj_t * obj = lv_btn_create(cont);
        lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
        lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);

        lv_obj_t * label = lv_label_create(obj);
        lv_label_set_text_fmt(label, "%u", i);
        lv_obj_center(label);
    }
    lv_obj_t * obj = lv_textarea_create(cont);
}
```

![gridnav](https://user-images.githubusercontent.com/7599318/146557342-7e3f3934-44e6-4126-bc68-f7f0b55cd639.gif)

I still need to add examples and docs.

This feature was added as the specification received from @foundationken. So, Ken, please a take a look! :slightly_smiling_face: 

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
