### PR TITLE
fix(rt-thread): improve the structure

### DIFF
--- a/rt-thread/lv_rt_thread_conf.h
+++ b/rt-thread/lv_rt_thread_conf.h
@@ -46,7 +46,6 @@
 
 #ifdef PKG_LVGL_ENABLE_LOG
 #  define LV_USE_LOG 1
-#  define LV_LOG_PRINTF 0
 #else
 #  define LV_USE_LOG 0
 #endif

--- a/rt-thread/lv_rt_thread_port.c
+++ b/rt-thread/lv_rt_thread_port.c
@@ -11,17 +11,13 @@
 #ifdef __RTTHREAD__
 
 #include <rtthread.h>
-#include <lvgl.h>
 #define DBG_TAG    "LVGL"
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>
 
-#ifndef PKG_USING_LVGL_DISP_DEVICE
-#  include <lv_port_disp.h>
-#endif
-#ifndef PKG_USING_LVGL_INDEV_DEVICE
-#  include <lv_port_indev.h>
-#endif
+#include <lvgl.h>
+#include <lv_port_disp.h>
+#include <lv_port_indev.h>
 
 #if LV_USE_LOG
 static void lv_rt_log(const char *buf)
@@ -38,12 +34,8 @@ static int lv_port_init(void)
 
     lv_init();
 
-#ifndef PKG_USING_LVGL_DISP_DEVICE
     lv_port_disp_init();
-#endif
-#ifndef PKG_USING_LVGL_INDEV_DEVICE
     lv_port_indev_init();
-#endif
 
     return 0;
 }


### PR DESCRIPTION
### Description of the feature or fix

Remove meaningless macros. These were prepared for porting to RT-Thread LCD device framework, but it will slow down the FPS. Thus, these macros need to remove.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
