### PR TITLE
fix(lv_fs_win32): missing <stdio.h>

### DIFF
--- a/src/extra/libs/fsdrv/lv_fs_win32.c
+++ b/src/extra/libs/fsdrv/lv_fs_win32.c
@@ -11,6 +11,7 @@
 #if LV_USE_FS_WIN32 != '\0'
 
 #include <windows.h>
+#include <stdio.h>
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
### Description of the feature or fix

fs_dir_open() in lv_fs_win32.c uses sprintf() function; however, this c file doesn't include <stdio.h> so that vs2019 will give an error. 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
