### PR TITLE
SDL backend improvements

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -570,6 +570,7 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
                 lv_draw_img_dsc_t dsc;
                 lv_draw_img_dsc_init(&dsc);
                 dsc.opa = disp_refr->bg_opa;
+                dsc.blend_mode = LV_BLEND_MODE_REPLACE;
                 lv_draw_img(draw_ctx, &dsc, &a, disp_refr->bg_img);
             }
             else {
@@ -581,6 +582,7 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
             lv_draw_rect_dsc_init(&dsc);
             dsc.bg_color = disp_refr->bg_color;
             dsc.bg_opa = disp_refr->bg_opa;
+            dsc.blend_mode = LV_BLEND_MODE_REPLACE;
             lv_draw_rect(draw_ctx, &dsc, draw_ctx->buf_area);
         }
     }

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -570,7 +570,7 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
                 lv_draw_img_dsc_t dsc;
                 lv_draw_img_dsc_init(&dsc);
                 dsc.opa = disp_refr->bg_opa;
-                if (dsc.opa < LV_OPA_COVER) {
+                if(dsc.opa < LV_OPA_COVER) {
                     dsc.blend_mode = LV_BLEND_MODE_REPLACE;
                 }
                 lv_draw_img(draw_ctx, &dsc, &a, disp_refr->bg_img);
@@ -584,7 +584,7 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
             lv_draw_rect_dsc_init(&dsc);
             dsc.bg_color = disp_refr->bg_color;
             dsc.bg_opa = disp_refr->bg_opa;
-            if (dsc.bg_opa < LV_OPA_COVER) {
+            if(dsc.bg_opa < LV_OPA_COVER) {
                 dsc.blend_mode = LV_BLEND_MODE_REPLACE;
             }
             lv_draw_rect(draw_ctx, &dsc, draw_ctx->buf_area);

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -570,7 +570,9 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
                 lv_draw_img_dsc_t dsc;
                 lv_draw_img_dsc_init(&dsc);
                 dsc.opa = disp_refr->bg_opa;
-                dsc.blend_mode = LV_BLEND_MODE_REPLACE;
+                if (dsc.opa < LV_OPA_COVER) {
+                    dsc.blend_mode = LV_BLEND_MODE_REPLACE;
+                }
                 lv_draw_img(draw_ctx, &dsc, &a, disp_refr->bg_img);
             }
             else {
@@ -582,7 +584,9 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
             lv_draw_rect_dsc_init(&dsc);
             dsc.bg_color = disp_refr->bg_color;
             dsc.bg_opa = disp_refr->bg_opa;
-            dsc.blend_mode = LV_BLEND_MODE_REPLACE;
+            if (dsc.bg_opa < LV_OPA_COVER) {
+                dsc.blend_mode = LV_BLEND_MODE_REPLACE;
+            }
             lv_draw_rect(draw_ctx, &dsc, draw_ctx->buf_area);
         }
     }

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -77,8 +77,8 @@ typedef struct _lv_draw_ctx_t  {
                       const lv_point_t * point2);
 
 
-    void (*draw_polygon)(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_point_t points[],
-                         uint16_t point_cnt);
+    void (*draw_polygon)(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc,
+                         const lv_point_t * points, uint16_t point_cnt);
 
     /**
      * Wait until all background operation are finished. (E.g. GPU opertions)

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -203,7 +203,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw
     uint32_t i;
     uint32_t par_start = 0;
     lv_color_t recolor;
-    lv_color_t color;
+    lv_color_t color = lv_color_hex(0);
     int32_t letter_w;
 
     lv_draw_rect_dsc_t draw_dsc_sel;

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -27,6 +27,9 @@ lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t 
 void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
                              uint32_t letter);
 
+void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
+                     const lv_point_t * point2);
+
 void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
@@ -57,6 +60,7 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     draw_ctx->draw_rect = lv_draw_sdl_draw_rect;
     draw_ctx->draw_img = lv_draw_sdl_img_core;
     draw_ctx->draw_letter = lv_draw_sdl_draw_letter;
+    draw_ctx->draw_line = lv_draw_sdl_draw_line;
     lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
     draw_ctx_sdl->renderer = ((lv_draw_sdl_drv_param_t *) disp_drv->user_data)->renderer;
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -16,8 +16,6 @@
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
 
-#include "../sw/lv_draw_sw.h"
-
 /*********************
  *      DEFINES
  *********************/

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -30,6 +30,9 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
 void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
                      const lv_point_t * point2);
 
+void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
+                          uint16_t radius, uint16_t start_angle, uint16_t end_angle);
+
 void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
@@ -61,6 +64,7 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     draw_ctx->draw_img = lv_draw_sdl_img_core;
     draw_ctx->draw_letter = lv_draw_sdl_draw_letter;
     draw_ctx->draw_line = lv_draw_sdl_draw_line;
+    draw_ctx->draw_arc = lv_draw_sdl_draw_arc;
     lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
     draw_ctx_sdl->renderer = ((lv_draw_sdl_drv_param_t *) disp_drv->user_data)->renderer;
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -38,7 +38,7 @@ void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void lv_draw_sdl_noop(void);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -57,10 +57,10 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     lv_memset_00(draw_ctx, sizeof(lv_draw_sdl_ctx_t));
     lv_draw_sw_init_ctx(disp_drv, draw_ctx);
     draw_ctx->draw_rect = lv_draw_sdl_draw_rect;
-    draw_ctx->draw_img_core = lv_draw_sdl_img_core;
+    draw_ctx->draw_img = lv_draw_sdl_img_core;
     draw_ctx->draw_letter = lv_draw_sdl_draw_letter;
     lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
-    draw_ctx_sdl->renderer = disp_drv->user_data;
+    draw_ctx_sdl->renderer = ((lv_draw_sdl_drv_param_t *) disp_drv->user_data)->renderer;
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;
     draw_ctx_sdl->internals = lv_mem_alloc(sizeof(lv_draw_sdl_context_internals_t));
     lv_memset_00(draw_ctx_sdl->internals, sizeof(lv_draw_sdl_context_internals_t));
@@ -75,13 +75,15 @@ void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     _lv_draw_sdl_utils_deinit();
 }
 
+SDL_Texture * lv_draw_sdl_create_screen_texture(SDL_Renderer * renderer, lv_coord_t hor, lv_coord_t ver)
+{
+    SDL_Texture *texture = SDL_CreateTexture(renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET, hor, ver);
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    return texture;
+}
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-static void lv_draw_sdl_noop(void)
-{
-
-}
 
 #endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -28,7 +28,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
                              uint32_t letter);
 
 void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
-                     const lv_point_t * point2);
+                           const lv_point_t * point2);
 
 void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
                           uint16_t radius, uint16_t start_angle, uint16_t end_angle);
@@ -83,7 +83,7 @@ void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
 
 SDL_Texture * lv_draw_sdl_create_screen_texture(SDL_Renderer * renderer, lv_coord_t hor, lv_coord_t ver)
 {
-    SDL_Texture *texture = SDL_CreateTexture(renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET, hor, ver);
+    SDL_Texture * texture = SDL_CreateTexture(renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET, hor, ver);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     return texture;
 }

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -39,6 +39,13 @@ extern "C" {
 struct lv_draw_sdl_context_internals_t;
 
 typedef struct {
+    /**
+     * Render for display driver
+     */
+    SDL_Renderer * renderer;
+} lv_draw_sdl_drv_param_t;
+
+typedef struct {
     lv_draw_sw_ctx_t base_draw;
     SDL_Renderer * renderer;
     struct lv_draw_sdl_context_internals_t * internals;
@@ -55,6 +62,8 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx);
  *
  */
 void lv_draw_sdl_deinit_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx);
+
+SDL_Texture * lv_draw_sdl_create_screen_texture(SDL_Renderer * renderer, lv_coord_t hor, lv_coord_t ver);
 
 /*======================
  * Add/remove functions

--- a/src/draw/sdl/lv_draw_sdl.mk
+++ b/src/draw/sdl/lv_draw_sdl.mk
@@ -1,13 +1,16 @@
-CSRCS += lv_draw_sdl_draw_blend.c
-CSRCS += lv_draw_sdl_draw_img.c
-CSRCS += lv_draw_sdl_draw_label.c
-CSRCS += lv_draw_sdl_draw_rect.c
+CSRCS += lv_draw_sdl.c
+CSRCS += lv_draw_sdl_blend.c
+CSRCS += lv_draw_sdl_composite.c
+CSRCS += lv_draw_sdl_img.c
+CSRCS += lv_draw_sdl_label.c
+CSRCS += lv_draw_sdl_line.c
 CSRCS += lv_draw_sdl_mask.c
+CSRCS += lv_draw_sdl_rect.c
 CSRCS += lv_draw_sdl_stack_blur.c
 CSRCS += lv_draw_sdl_texture_cache.c
 CSRCS += lv_draw_sdl_utils.c
 
-DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl
-VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl
+DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl
+VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl
 
-CFLAGS += "-I$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/gpu/sdl"
+CFLAGS += "-I$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl"

--- a/src/draw/sdl/lv_draw_sdl_arc.c
+++ b/src/draw/sdl/lv_draw_sdl_arc.c
@@ -1,0 +1,137 @@
+/**
+ * @file lv_templ.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_GPU_SDL
+
+#include "lv_draw_sdl.h"
+#include "lv_draw_sdl_utils.h"
+#include "lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl_composite.h"
+#include "lv_draw_sdl_mask.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    lv_sdl_cache_key_magic_t magic;
+    uint16_t radius;
+    uint16_t angle;
+    lv_coord_t width;
+    uint8_t rounded;
+} lv_draw_arc_key_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t radius, uint16_t start_angle,
+                                 uint16_t end_angle);
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
+                          uint16_t radius, uint16_t start_angle, uint16_t end_angle)
+{
+    lv_draw_sdl_ctx_t *ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
+    SDL_Renderer * renderer = ctx->renderer;
+
+    lv_area_t area_out;
+    area_out.x1 = center->x - radius;
+    area_out.y1 = center->y - radius;
+    area_out.x2 = center->x + radius - 1;  /*-1 because the center already belongs to the left/bottom part*/
+    area_out.y2 = center->y + radius - 1;
+
+    lv_area_t draw_area;
+    if (!_lv_area_intersect(&draw_area, &area_out, draw_ctx->clip_area)) {
+        return;
+    }
+
+    lv_area_t area_in;
+    lv_area_copy(&area_in, &area_out);
+    area_in.x1 += dsc->width;
+    area_in.y1 += dsc->width;
+    area_in.x2 -= dsc->width;
+    area_in.y2 -= dsc->width;
+
+
+    while(start_angle >= 360) start_angle -= 360;
+    while(end_angle >= 360) end_angle -= 360;
+
+    int16_t mask_ids[3] = {LV_MASK_ID_INV, LV_MASK_ID_INV, LV_MASK_ID_INV};
+
+    lv_draw_mask_radius_param_t mask_in_param;
+    if(lv_area_get_width(&area_in) > 0 && lv_area_get_height(&area_in) > 0) {
+        lv_draw_mask_radius_init(&mask_in_param, &area_in, LV_RADIUS_CIRCLE, true);
+        mask_ids[2] = lv_draw_mask_add(&mask_in_param, NULL);
+    }
+
+    lv_draw_mask_radius_param_t mask_out_param;
+    lv_draw_mask_radius_init(&mask_out_param, &area_out, LV_RADIUS_CIRCLE, false);
+    mask_ids[1] = lv_draw_mask_add(&mask_out_param, NULL);
+
+    lv_draw_mask_angle_param_t mask_angle_param;
+    lv_draw_mask_angle_init(&mask_angle_param, center->x, center->y, start_angle, end_angle);
+    mask_ids[0] = lv_draw_mask_add(&mask_angle_param, NULL);
+
+    lv_coord_t w = lv_area_get_width(&draw_area), h = lv_area_get_height(&draw_area);
+    SDL_Texture *texture = lv_draw_sdl_composite_tmp_obtain(ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK, w, h);
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    lv_draw_sdl_mask_dump_to_texture(texture, &draw_area, mask_ids, mask_ids[2] != LV_MASK_ID_INV ? 3 : 2);
+
+    lv_draw_mask_remove_id(mask_ids[0]);
+    lv_draw_mask_remove_id(mask_ids[1]);
+    lv_draw_mask_free_param(&mask_angle_param);
+    lv_draw_mask_free_param(&mask_out_param);
+
+    if(mask_ids[2] != LV_MASK_ID_INV) {
+        lv_draw_mask_remove_id(mask_ids[2]);
+        lv_draw_mask_free_param(&mask_in_param);
+    }
+
+    SDL_Rect srcrect = {0, 0, w, h}, dstrect;
+    lv_area_to_sdl_rect(&draw_area, &dstrect);
+    SDL_Color color;
+    lv_color_to_sdl_color(&dsc->color, &color);
+    SDL_SetTextureColorMod(texture, color.r, color.g, color.b);
+    SDL_SetTextureAlphaMod(texture, dsc->opa);
+    SDL_RenderCopy(ctx->renderer, texture, &srcrect, &dstrect);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t radius, uint16_t start_angle,
+                                        uint16_t end_angle)
+{
+    lv_draw_arc_key_t key;
+    lv_memset_00(&key, sizeof(lv_draw_arc_key_t));
+    key.magic = LV_GPU_CACHE_KEY_MAGIC_ARC;
+    key.radius = radius;
+    key.angle = ((end_angle - start_angle) % 360 + 360) % 360;
+    key.width = dsc->width;
+    key.rounded = dsc->rounded;
+    return key;
+}
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_arc.c
+++ b/src/draw/sdl/lv_draw_sdl_arc.c
@@ -44,13 +44,14 @@ typedef struct {
  *      MACROS
  **********************/
 
-static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t radius, uint16_t start_angle,
-                                 uint16_t end_angle);
+static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t * dsc, uint16_t radius, uint16_t start_angle,
+                                        uint16_t end_angle);
 
 static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count,
                        const int16_t * caps);
 
-static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t *center, lv_area_t *out);
+static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t * center,
+                         lv_area_t * out);
 
 /**********************
  *   GLOBAL FUNCTIONS
@@ -58,7 +59,7 @@ static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, c
 void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
                           uint16_t radius, uint16_t start_angle, uint16_t end_angle)
 {
-    lv_draw_sdl_ctx_t *ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
+    lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
     SDL_Renderer * renderer = ctx->renderer;
 
     lv_area_t area_out;
@@ -68,7 +69,7 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
     area_out.y2 = center->y + radius - 1;
 
     lv_area_t draw_area;
-    if (!_lv_area_intersect(&draw_area, &area_out, draw_ctx->clip_area)) {
+    if(!_lv_area_intersect(&draw_area, &area_out, draw_ctx->clip_area)) {
         return;
     }
 
@@ -105,7 +106,7 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
     }
 
     lv_draw_mask_radius_param_t cap_start_param, cap_end_param;
-    if (mask_ids_count == 3 && dsc->rounded) {
+    if(mask_ids_count == 3 && dsc->rounded) {
         lv_area_t start_area, end_area;
         get_cap_area((int16_t) start_angle, dsc->width, radius, center, &start_area);
         get_cap_area((int16_t) end_angle, dsc->width, radius, center, &end_area);
@@ -116,14 +117,14 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
     }
 
     lv_coord_t w = lv_area_get_width(&draw_area), h = lv_area_get_height(&draw_area);
-    SDL_Texture *texture = lv_draw_sdl_composite_texture_obtain(ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM1, w, h);
+    SDL_Texture * texture = lv_draw_sdl_composite_texture_obtain(ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM1, w, h);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     dump_masks(texture, &draw_area, mask_ids, mask_ids_count, cap_ids[0] != LV_MASK_ID_INV ? cap_ids : NULL);
 
     lv_draw_mask_remove_id(mask_ids[0]);
     lv_draw_mask_free_param(&mask_out_param);
 
-    if (mask_ids_count > 1) {
+    if(mask_ids_count > 1) {
         lv_draw_mask_remove_id(mask_ids[1]);
         lv_draw_mask_free_param(&mask_in_param);
     }
@@ -133,7 +134,7 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
         lv_draw_mask_free_param(&mask_angle_param);
     }
 
-    if (cap_ids[0] != LV_MASK_ID_INV) {
+    if(cap_ids[0] != LV_MASK_ID_INV) {
         lv_draw_mask_remove_id(cap_ids[0]);
         lv_draw_mask_remove_id(cap_ids[1]);
         lv_draw_mask_free_param(&cap_start_param);
@@ -153,7 +154,7 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t radius, uint16_t start_angle,
+static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t * dsc, uint16_t radius, uint16_t start_angle,
                                         uint16_t end_angle)
 {
     lv_draw_arc_key_t key;
@@ -190,22 +191,24 @@ static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const in
         }
         else {
             for(int x = 0; x < rect.w; x++) {
-                uint8_t *pixel = &pixels[y * pitch + x * 4];
+                uint8_t * pixel = &pixels[y * pitch + x * 4];
                 *pixel = line_buf[x];
                 pixel[1] = pixel[2] = pixel[3] = 0xFF;
             }
         }
         if(caps) {
-            for (int i = 0; i < 2; i++) {
+            for(int i = 0; i < 2; i++) {
                 lv_memset_ff(line_buf, rect.w);
                 res = lv_draw_mask_apply_ids(line_buf, abs_x, abs_y, len, &caps[i], 1);
-                if (res == LV_DRAW_MASK_RES_TRANSP) {
+                if(res == LV_DRAW_MASK_RES_TRANSP) {
                     /* Ignore */
-                } else if (res == LV_DRAW_MASK_RES_FULL_COVER) {
+                }
+                else if(res == LV_DRAW_MASK_RES_FULL_COVER) {
                     lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
-                } else {
-                    for (int x = 0; x < rect.w; x++) {
-                        uint8_t *pixel = &pixels[y * pitch + x * 4];
+                }
+                else {
+                    for(int x = 0; x < rect.w; x++) {
+                        uint8_t * pixel = &pixels[y * pitch + x * 4];
                         uint16_t old_opa = line_buf[x] + *pixel;
                         *pixel = LV_MIN(old_opa, 0xFF);
                         pixel[1] = pixel[2] = pixel[3] = 0xFF;
@@ -218,7 +221,8 @@ static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const in
     SDL_UnlockTexture(texture);
 }
 
-static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t *center, lv_area_t *out)
+static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t * center,
+                         lv_area_t * out)
 {
     const uint8_t ps = 8;
     const uint8_t pa = 127;

--- a/src/draw/sdl/lv_draw_sdl_arc.c
+++ b/src/draw/sdl/lv_draw_sdl_arc.c
@@ -116,7 +116,7 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
     }
 
     lv_coord_t w = lv_area_get_width(&draw_area), h = lv_area_get_height(&draw_area);
-    SDL_Texture *texture = lv_draw_sdl_composite_tmp_obtain(ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK, w, h);
+    SDL_Texture *texture = lv_draw_sdl_composite_texture_obtain(ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM1, w, h);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     dump_masks(texture, &draw_area, mask_ids, mask_ids_count, cap_ids[0] != LV_MASK_ID_INV ? cap_ids : NULL);
 

--- a/src/draw/sdl/lv_draw_sdl_arc.c
+++ b/src/draw/sdl/lv_draw_sdl_arc.c
@@ -190,9 +190,9 @@ static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const in
         }
         else {
             for(int x = 0; x < rect.w; x++) {
-                const lv_coord_t idx = y * pitch + x * 4;
-                pixels[idx] = line_buf[x];
-                pixels[idx + 1] = pixels[idx + 2] = pixels[idx + 3] = 0xFF;
+                uint8_t *pixel = &pixels[y * pitch + x * 4];
+                *pixel = line_buf[x];
+                pixel[1] = pixel[2] = pixel[3] = 0xFF;
             }
         }
         if(caps) {
@@ -205,9 +205,10 @@ static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const in
                     lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
                 } else {
                     for (int x = 0; x < rect.w; x++) {
-                        const lv_coord_t idx = y * pitch + x * 4;
-                        pixels[idx] = LV_MIN(line_buf[x] + pixels[idx], 0xFF);
-                        pixels[idx + 1] = pixels[idx + 2] = pixels[idx + 3] = 0xFF;
+                        uint8_t *pixel = &pixels[y * pitch + x * 4];
+                        uint16_t old_opa = line_buf[x] + *pixel;
+                        *pixel = LV_MIN(old_opa, 0xFF);
+                        pixel[1] = pixel[2] = pixel[3] = 0xFF;
                     }
                 }
             }

--- a/src/draw/sdl/lv_draw_sdl_arc.c
+++ b/src/draw/sdl/lv_draw_sdl_arc.c
@@ -47,6 +47,11 @@ typedef struct {
 static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t radius, uint16_t start_angle,
                                  uint16_t end_angle);
 
+static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count,
+                       const int16_t * caps);
+
+static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t *center, lv_area_t *out);
+
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
@@ -78,35 +83,61 @@ void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * ds
     while(start_angle >= 360) start_angle -= 360;
     while(end_angle >= 360) end_angle -= 360;
 
-    int16_t mask_ids[3] = {LV_MASK_ID_INV, LV_MASK_ID_INV, LV_MASK_ID_INV};
+    int16_t mask_ids[3] = {LV_MASK_ID_INV, LV_MASK_ID_INV, LV_MASK_ID_INV}, mask_ids_count = 1;
+    int16_t cap_ids[2] = {LV_MASK_ID_INV, LV_MASK_ID_INV};
+
+    lv_draw_mask_radius_param_t mask_out_param;
+    lv_draw_mask_radius_init(&mask_out_param, &area_out, LV_RADIUS_CIRCLE, false);
+    mask_ids[0] = lv_draw_mask_add(&mask_out_param, NULL);
 
     lv_draw_mask_radius_param_t mask_in_param;
     if(lv_area_get_width(&area_in) > 0 && lv_area_get_height(&area_in) > 0) {
         lv_draw_mask_radius_init(&mask_in_param, &area_in, LV_RADIUS_CIRCLE, true);
-        mask_ids[2] = lv_draw_mask_add(&mask_in_param, NULL);
+        mask_ids[1] = lv_draw_mask_add(&mask_in_param, NULL);
+        mask_ids_count++;
     }
 
-    lv_draw_mask_radius_param_t mask_out_param;
-    lv_draw_mask_radius_init(&mask_out_param, &area_out, LV_RADIUS_CIRCLE, false);
-    mask_ids[1] = lv_draw_mask_add(&mask_out_param, NULL);
-
     lv_draw_mask_angle_param_t mask_angle_param;
-    lv_draw_mask_angle_init(&mask_angle_param, center->x, center->y, start_angle, end_angle);
-    mask_ids[0] = lv_draw_mask_add(&mask_angle_param, NULL);
+    if((start_angle - end_angle) % 360) {
+        lv_draw_mask_angle_init(&mask_angle_param, center->x, center->y, start_angle, end_angle);
+        mask_ids[2] = lv_draw_mask_add(&mask_angle_param, NULL);
+        mask_ids_count++;
+    }
+
+    lv_draw_mask_radius_param_t cap_start_param, cap_end_param;
+    if (mask_ids_count == 3 && dsc->rounded) {
+        lv_area_t start_area, end_area;
+        get_cap_area((int16_t) start_angle, dsc->width, radius, center, &start_area);
+        get_cap_area((int16_t) end_angle, dsc->width, radius, center, &end_area);
+        lv_draw_mask_radius_init(&cap_start_param, &start_area, dsc->width / 2, false);
+        cap_ids[0] = lv_draw_mask_add(&cap_start_param, NULL);
+        lv_draw_mask_radius_init(&cap_end_param, &end_area, dsc->width / 2, false);
+        cap_ids[1] = lv_draw_mask_add(&cap_end_param, NULL);
+    }
 
     lv_coord_t w = lv_area_get_width(&draw_area), h = lv_area_get_height(&draw_area);
     SDL_Texture *texture = lv_draw_sdl_composite_tmp_obtain(ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK, w, h);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-    lv_draw_sdl_mask_dump_to_texture(texture, &draw_area, mask_ids, mask_ids[2] != LV_MASK_ID_INV ? 3 : 2);
+    dump_masks(texture, &draw_area, mask_ids, mask_ids_count, cap_ids[0] != LV_MASK_ID_INV ? cap_ids : NULL);
 
     lv_draw_mask_remove_id(mask_ids[0]);
-    lv_draw_mask_remove_id(mask_ids[1]);
-    lv_draw_mask_free_param(&mask_angle_param);
     lv_draw_mask_free_param(&mask_out_param);
 
-    if(mask_ids[2] != LV_MASK_ID_INV) {
-        lv_draw_mask_remove_id(mask_ids[2]);
+    if (mask_ids_count > 1) {
+        lv_draw_mask_remove_id(mask_ids[1]);
         lv_draw_mask_free_param(&mask_in_param);
+    }
+
+    if(mask_ids_count > 2) {
+        lv_draw_mask_remove_id(mask_ids[2]);
+        lv_draw_mask_free_param(&mask_angle_param);
+    }
+
+    if (cap_ids[0] != LV_MASK_ID_INV) {
+        lv_draw_mask_remove_id(cap_ids[0]);
+        lv_draw_mask_remove_id(cap_ids[1]);
+        lv_draw_mask_free_param(&cap_start_param);
+        lv_draw_mask_free_param(&cap_end_param);
     }
 
     SDL_Rect srcrect = {0, 0, w, h}, dstrect;
@@ -134,4 +165,95 @@ static lv_draw_arc_key_t arc_key_create(const lv_draw_arc_dsc_t *dsc, uint16_t r
     key.rounded = dsc->rounded;
     return key;
 }
+
+static void dump_masks(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count,
+                       const int16_t * caps)
+{
+    lv_coord_t w = lv_area_get_width(coords), h = lv_area_get_height(coords);
+    SDL_assert(w > 0 && h > 0);
+    SDL_Rect rect = {0, 0, w, h};
+    uint8_t * pixels;
+    int pitch;
+    if(SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch) != 0) return;
+
+    lv_opa_t * line_buf = lv_mem_buf_get(rect.w);
+    for(lv_coord_t y = 0; y < rect.h; y++) {
+        lv_memset_ff(line_buf, rect.w);
+        lv_coord_t abs_x = (lv_coord_t) coords->x1, abs_y = (lv_coord_t)(y + coords->y1), len = (lv_coord_t) rect.w;
+        lv_draw_mask_res_t res;
+        res = lv_draw_mask_apply_ids(line_buf, abs_x, abs_y, len, ids, ids_count);
+        if(res == LV_DRAW_MASK_RES_TRANSP) {
+            lv_memset_00(&pixels[y * pitch], 4 * rect.w);
+        }
+        else if(res == LV_DRAW_MASK_RES_FULL_COVER) {
+            lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
+        }
+        else {
+            for(int x = 0; x < rect.w; x++) {
+                const lv_coord_t idx = y * pitch + x * 4;
+                pixels[idx] = line_buf[x];
+                pixels[idx + 1] = pixels[idx + 2] = pixels[idx + 3] = 0xFF;
+            }
+        }
+        if(caps) {
+            for (int i = 0; i < 2; i++) {
+                lv_memset_ff(line_buf, rect.w);
+                res = lv_draw_mask_apply_ids(line_buf, abs_x, abs_y, len, &caps[i], 1);
+                if (res == LV_DRAW_MASK_RES_TRANSP) {
+                    /* Ignore */
+                } else if (res == LV_DRAW_MASK_RES_FULL_COVER) {
+                    lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
+                } else {
+                    for (int x = 0; x < rect.w; x++) {
+                        const lv_coord_t idx = y * pitch + x * 4;
+                        pixels[idx] = LV_MIN(line_buf[x] + pixels[idx], 0xFF);
+                        pixels[idx + 1] = pixels[idx + 2] = pixels[idx + 3] = 0xFF;
+                    }
+                }
+            }
+        }
+    }
+    lv_mem_buf_release(line_buf);
+    SDL_UnlockTexture(texture);
+}
+
+static void get_cap_area(int16_t angle, lv_coord_t thickness, uint16_t radius, const lv_point_t *center, lv_area_t *out)
+{
+    const uint8_t ps = 8;
+    const uint8_t pa = 127;
+
+    int32_t thick_half = thickness / 2;
+    uint8_t thick_corr = (thickness & 0x01) ? 0 : 1;
+
+    int32_t cir_x;
+    int32_t cir_y;
+
+    cir_x = ((radius - thick_half) * lv_trigo_sin(90 - angle)) >> (LV_TRIGO_SHIFT - ps);
+    cir_y = ((radius - thick_half) * lv_trigo_sin(angle)) >> (LV_TRIGO_SHIFT - ps);
+
+    /*Actually the center of the pixel need to be calculated so apply 1/2 px offset*/
+    if(cir_x > 0) {
+        cir_x = (cir_x - pa) >> ps;
+        out->x1 = cir_x - thick_half + thick_corr;
+        out->x2 = cir_x + thick_half;
+    }
+    else {
+        cir_x = (cir_x + pa) >> ps;
+        out->x1 = cir_x - thick_half;
+        out->x2 = cir_x + thick_half - thick_corr;
+    }
+
+    if(cir_y > 0) {
+        cir_y = (cir_y - pa) >> ps;
+        out->y1 = cir_y - thick_half + thick_corr;
+        out->y2 = cir_y + thick_half;
+    }
+    else {
+        cir_y = (cir_y + pa) >> ps;
+        out->y1 = cir_y - thick_half;
+        out->y2 = cir_y + thick_half - thick_corr;
+    }
+    lv_area_move(out, center->x, center->y);
+}
+
 #endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -73,9 +73,9 @@ void blend_fill(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc
     lv_area_to_sdl_rect(&fill_area, &fill_rect);
 
     if(dsc->mask) {
-        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(draw_ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
-                                                            lv_area_get_height(&fill_area),
-                                                            lv_area_get_width(&fill_area));
+        SDL_Texture * texture = lv_draw_sdl_composite_tmp_obtain(draw_ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
+                                                                 lv_area_get_height(&fill_area),
+                                                                 lv_area_get_width(&fill_area));
         SDL_Rect rect = {0, 0, lv_area_get_width(&fill_area), lv_area_get_height(&fill_area)};
         uint8_t * pixels = NULL;
         int pitch;

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -73,9 +73,9 @@ void blend_fill(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc
     lv_area_to_sdl_rect(&fill_area, &fill_rect);
 
     if(dsc->mask) {
-        SDL_Texture * texture = lv_draw_sdl_composite_tmp_obtain(draw_ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
-                                                                 lv_area_get_height(&fill_area),
-                                                                 lv_area_get_width(&fill_area));
+        SDL_Texture * texture = lv_draw_sdl_composite_texture_obtain(draw_ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM0,
+                                                                     lv_area_get_height(&fill_area),
+                                                                     lv_area_get_width(&fill_area));
         SDL_Rect rect = {0, 0, lv_area_get_width(&fill_area), lv_area_get_height(&fill_area)};
         uint8_t * pixels = NULL;
         int pitch;

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -13,7 +13,7 @@
 
 #include "lv_draw_sdl_texture_cache.h"
 #include "lv_draw_sdl_utils.h"
-#include "lv_draw_sdl_mask.h"
+#include "lv_draw_sdl_composite.h"
 
 #include LV_GPU_SDL_INCLUDE_PATH
 
@@ -73,7 +73,7 @@ void blend_fill(lv_draw_sdl_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc
     lv_area_to_sdl_rect(&fill_area, &fill_rect);
 
     if(dsc->mask) {
-        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(draw_ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK,
+        SDL_Texture * texture = lv_draw_sdl_mask_tmp_obtain(draw_ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
                                                             lv_area_get_height(&fill_area),
                                                             lv_area_get_width(&fill_area));
         SDL_Rect rect = {0, 0, lv_area_get_width(&fill_area), lv_area_get_height(&fill_area)};

--- a/src/draw/sdl/lv_draw_sdl_composite.c
+++ b/src/draw/sdl/lv_draw_sdl_composite.c
@@ -149,12 +149,22 @@ void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_ar
             case LV_BLEND_MODE_ADDITIVE:
                 SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_ADD);
                 break;
-//#if HAS_CUSTOM_BLEND_MODE
-//        case LV_BLEND_MODE_SUBTRACTIVE:
-//            break;
-//        case LV_BLEND_MODE_MULTIPLY:
-//            break;
-//#endif
+#if HAS_CUSTOM_BLEND_MODE
+            case LV_BLEND_MODE_SUBTRACTIVE: {
+                SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ONE, SDL_BLENDFACTOR_ONE,
+                                                                SDL_BLENDOPERATION_SUBTRACT, SDL_BLENDFACTOR_ONE,
+                                                                SDL_BLENDFACTOR_ONE, SDL_BLENDOPERATION_SUBTRACT);
+                SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
+                break;
+            }
+            case LV_BLEND_MODE_MULTIPLY: {
+                SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_SRC_COLOR,
+                                                                SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
+                                                                SDL_BLENDFACTOR_DST_ALPHA, SDL_BLENDOPERATION_ADD);
+                SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
+                break;
+            }
+#endif
             default:
                 LV_LOG_WARN("Doesn't support blend mode %d", blend_mode);
                 SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);

--- a/src/draw/sdl/lv_draw_sdl_composite.c
+++ b/src/draw/sdl/lv_draw_sdl_composite.c
@@ -40,7 +40,7 @@ static composite_key_t mask_key_create(lv_draw_sdl_composite_texture_id_t type);
 
 static lv_coord_t next_pow_of_2(lv_coord_t num);
 
-static void dump_masks(SDL_Texture *texture, const lv_area_t *coords);
+static void dump_masks(SDL_Texture * texture, const lv_area_t * coords);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -83,7 +83,7 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
 
     const bool draw_mask = has_mask && HAS_CUSTOM_BLEND_MODE;
     const bool draw_blend = blend_mode != LV_BLEND_MODE_NORMAL && blend_mode != LV_BLEND_MODE_REPLACE;
-    if (draw_mask || draw_blend) {
+    if(draw_mask || draw_blend) {
         lv_draw_sdl_context_internals_t * internals = ctx->internals;
         LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
 
@@ -101,18 +101,19 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
         internals->mask = lv_draw_sdl_composite_texture_obtain(ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM0, w, h);
         dump_masks(internals->mask, apply_area);
 #endif
-    } else if (has_mask) {
+    }
+    else if(has_mask) {
         /* Fallback mask handling. This will at least make bars looks less bad */
         for(uint8_t i = 0; i < _LV_MASK_MAX_NUM; i++) {
             _lv_draw_mask_common_dsc_t * comm_param = LV_GC_ROOT(_lv_draw_mask_list[i]).param;
             if(comm_param == NULL) continue;
             switch(comm_param->type) {
                 case LV_DRAW_MASK_TYPE_RADIUS: {
-                    const lv_draw_mask_radius_param_t * param = (const lv_draw_mask_radius_param_t *) comm_param;
-                    if(param->cfg.outer) break;
-                    _lv_area_intersect(clip_out, apply_area, &param->cfg.rect);
-                    break;
-                }
+                        const lv_draw_mask_radius_param_t * param = (const lv_draw_mask_radius_param_t *) comm_param;
+                        if(param->cfg.outer) break;
+                        _lv_area_intersect(clip_out, apply_area, &param->cfg.rect);
+                        break;
+                    }
                 default:
                     break;
             }
@@ -121,12 +122,12 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
     return has_mask;
 }
 
-void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_area, lv_blend_mode_t blend_mode)
+void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_area, lv_blend_mode_t blend_mode)
 {
     lv_draw_sdl_context_internals_t * internals = ctx->internals;
     SDL_Rect src_rect = {0, 0, lv_area_get_width(apply_area), lv_area_get_height(apply_area)};
 #if HAS_CUSTOM_BLEND_MODE
-    if (internals->mask) {
+    if(internals->mask) {
         SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE,
                                                         SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
                                                         SDL_BLENDFACTOR_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
@@ -136,12 +137,12 @@ void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_ar
 #endif
 
     /* Shapes are drawn on composite layer when mask or blend mode is present */
-    if (internals->composition) {
+    if(internals->composition) {
         SDL_Rect dst_rect;
         lv_area_to_sdl_rect(apply_area, &dst_rect);
 
         SDL_SetRenderTarget(ctx->renderer, ctx->base_draw.base_draw.buf);
-        switch (blend_mode) {
+        switch(blend_mode) {
             case LV_BLEND_MODE_NORMAL:
             case LV_BLEND_MODE_REPLACE:
                 SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
@@ -151,19 +152,19 @@ void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_ar
                 break;
 #if HAS_CUSTOM_BLEND_MODE
             case LV_BLEND_MODE_SUBTRACTIVE: {
-                SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ONE, SDL_BLENDFACTOR_ONE,
-                                                                SDL_BLENDOPERATION_SUBTRACT, SDL_BLENDFACTOR_ONE,
-                                                                SDL_BLENDFACTOR_ONE, SDL_BLENDOPERATION_SUBTRACT);
-                SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
-                break;
-            }
+                    SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ONE, SDL_BLENDFACTOR_ONE,
+                                                                    SDL_BLENDOPERATION_SUBTRACT, SDL_BLENDFACTOR_ONE,
+                                                                    SDL_BLENDFACTOR_ONE, SDL_BLENDOPERATION_SUBTRACT);
+                    SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
+                    break;
+                }
             case LV_BLEND_MODE_MULTIPLY: {
-                SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_SRC_COLOR,
-                                                                SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
-                                                                SDL_BLENDFACTOR_DST_ALPHA, SDL_BLENDOPERATION_ADD);
-                SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
-                break;
-            }
+                    SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_SRC_COLOR,
+                                                                    SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
+                                                                    SDL_BLENDFACTOR_DST_ALPHA, SDL_BLENDOPERATION_ADD);
+                    SDL_SetRenderDrawBlendMode(ctx->renderer, mode);
+                    break;
+                }
 #endif
             default:
                 LV_LOG_WARN("Doesn't support blend mode %d", blend_mode);
@@ -221,7 +222,7 @@ static lv_coord_t next_pow_of_2(lv_coord_t num)
     return n;
 }
 
-static void dump_masks(SDL_Texture *texture, const lv_area_t *coords)
+static void dump_masks(SDL_Texture * texture, const lv_area_t * coords)
 {
     lv_coord_t w = lv_area_get_width(coords), h = lv_area_get_height(coords);
     SDL_assert(w > 0 && h > 0);

--- a/src/draw/sdl/lv_draw_sdl_composite.c
+++ b/src/draw/sdl/lv_draw_sdl_composite.c
@@ -1,0 +1,248 @@
+/**
+ * @file lv_draw_sdl_composite.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_GPU_SDL
+
+#include "../../misc/lv_gc.h"
+#include "../../core/lv_refr.h"
+#include "lv_draw_sdl_composite.h"
+#include "lv_draw_sdl_utils.h"
+#include "lv_draw_sdl_priv.h"
+#include "lv_draw_sdl_texture_cache.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+#define HAS_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    lv_sdl_cache_key_magic_t magic;
+    lv_draw_sdl_composite_cache_type_t type;
+} composite_key_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static composite_key_t mask_key_create(lv_draw_sdl_composite_cache_type_t type);
+
+static lv_coord_t next_pow_of_2(lv_coord_t num);
+
+static void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
+                                 const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
+                                 lv_area_t * clip_out, lv_area_t * apply_area)
+{
+    lv_area_t full_coords = *coords_in;
+
+    /* Normalize full_coords */
+    if(full_coords.x1 > full_coords.x2) {
+        lv_coord_t x2 = full_coords.x2;
+        full_coords.x2 = full_coords.x1;
+        full_coords.x1 = x2;
+    }
+    if(full_coords.y1 > full_coords.y2) {
+        lv_coord_t y2 = full_coords.y2;
+        full_coords.y2 = full_coords.y1;
+        full_coords.y1 = y2;
+    }
+
+    if(extension) {
+        full_coords.x1 -= extension->x1;
+        full_coords.x2 += extension->x2;
+        full_coords.y1 -= extension->y1;
+        full_coords.y2 += extension->y2;
+    }
+
+    if(!_lv_area_intersect(apply_area, &full_coords, clip_in)) return false;
+    bool has_mask = lv_draw_mask_is_any(apply_area);
+
+    if (has_mask || (blend_mode != LV_BLEND_MODE_NORMAL && blend_mode != LV_BLEND_MODE_REPLACE)) {
+        lv_draw_sdl_context_internals_t * internals = ctx->internals;
+        LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
+        lv_coord_t w = lv_area_get_width(apply_area), h = lv_area_get_height(apply_area);
+        internals->composition = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_TEMP, w, h);
+        /* Don't need to worry about overflow */
+        lv_coord_t ofs_x = (lv_coord_t) - apply_area->x1, ofs_y = (lv_coord_t) - apply_area->y1;
+        /* Offset draw area to start with (0,0) of coords */
+        lv_area_move(coords_out, ofs_x, ofs_y);
+        lv_area_move(clip_out, ofs_x, ofs_y);
+        SDL_SetRenderTarget(ctx->renderer, internals->composition);
+        SDL_SetRenderDrawColor(ctx->renderer, 255, 255, 255, 0);
+        SDL_RenderClear(ctx->renderer);
+#if HAS_CUSTOM_BLEND_MODE
+        internals->mask = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK, w, h);
+        texture_apply_mask(internals->mask, apply_area, NULL, 0);
+#else
+        /* Fallback mask handling. This will at least make bars looks less bad */
+        for(uint8_t i = 0; i < _LV_MASK_MAX_NUM; i++) {
+            _lv_draw_mask_common_dsc_t * comm_param = LV_GC_ROOT(_lv_draw_mask_list[i]).param;
+            if(comm_param == NULL) continue;
+            switch(comm_param->type) {
+                case LV_DRAW_MASK_TYPE_RADIUS: {
+                        const lv_draw_mask_radius_param_t * param = (const lv_draw_mask_radius_param_t *) comm_param;
+                        if(param->cfg.outer) break;
+                        _lv_area_intersect(clip_out, apply_area, &param->cfg.rect);
+                        break;
+                    }
+                default:
+                    break;
+            }
+        }
+#endif
+    }
+    return has_mask;
+}
+
+void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
+                               lv_blend_mode_t blend_mode)
+{
+    lv_draw_sdl_context_internals_t * internals = ctx->internals;
+    SDL_Rect src_rect = {0, 0, lv_area_get_width(apply_area), lv_area_get_height(apply_area)};
+#if HAS_CUSTOM_BLEND_MODE
+    if (internals->mask) {
+        SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE,
+                                                        SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
+                                                        SDL_BLENDFACTOR_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
+        SDL_SetTextureBlendMode(internals->mask, mode);
+        SDL_RenderCopy(ctx->renderer, internals->mask, &src_rect, &src_rect);
+    }
+#endif
+
+    /* Shapes are drawn on composite layer when mask or blend mode is present */
+    if (internals->composition) {
+        SDL_Rect dst_rect;
+        lv_area_to_sdl_rect(apply_area, &dst_rect);
+
+        SDL_SetRenderTarget(ctx->renderer, ctx->base_draw.base_draw.buf);
+        switch (blend_mode) {
+            case LV_BLEND_MODE_NORMAL:
+            case LV_BLEND_MODE_REPLACE:
+                SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
+                break;
+            case LV_BLEND_MODE_ADDITIVE:
+                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_ADD);
+                break;
+//#if HAS_CUSTOM_BLEND_MODE
+//        case LV_BLEND_MODE_SUBTRACTIVE:
+//            break;
+//        case LV_BLEND_MODE_MULTIPLY:
+//            break;
+//#endif
+            default:
+                LV_LOG_WARN("Doesn't support blend mode %d", blend_mode);
+                SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
+                /* Unsupported yet */
+                break;
+        }
+        SDL_RenderCopy(ctx->renderer, internals->composition, &src_rect, &dst_rect);
+    }
+
+    internals->mask = internals->composition = NULL;
+}
+
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
+                                          lv_coord_t w, lv_coord_t h)
+{
+    lv_point_t * tex_size = NULL;
+    composite_key_t mask_key = mask_key_create(type);
+    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(ctx, &mask_key, sizeof(composite_key_t), NULL,
+                                                                       (void **) &tex_size);
+    if(!result || tex_size->x < w || tex_size->y < h) {
+        lv_coord_t size = next_pow_of_2(LV_MAX(w, h));
+        int access = SDL_TEXTUREACCESS_STREAMING;
+        if(type == LV_DRAW_SDL_COMPOSITE_KEY_ID_TEMP) {
+            access = SDL_TEXTUREACCESS_TARGET;
+        }
+        result = SDL_CreateTexture(ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, access, size, size);
+        tex_size = lv_mem_alloc(sizeof(lv_point_t));
+        tex_size->x = tex_size->y = size;
+        lv_draw_sdl_texture_cache_put_advanced(ctx, &mask_key, sizeof(composite_key_t), result, tex_size, lv_mem_free, 0);
+    }
+    return result;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static composite_key_t mask_key_create(lv_draw_sdl_composite_cache_type_t type)
+{
+    composite_key_t key;
+    /* VERY IMPORTANT! Padding between members is uninitialized, so we have to wipe them manually */
+    SDL_memset(&key, 0, sizeof(key));
+    key.magic = LV_GPU_CACHE_KEY_MAGIC_MASK;
+    key.type = type;
+    return key;
+}
+
+static lv_coord_t next_pow_of_2(lv_coord_t num)
+{
+    lv_coord_t n = 128;
+    while(n < num && n < 16384) {
+        n = n << 1;
+    }
+    return n;
+}
+
+static void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count)
+{
+    lv_coord_t w = lv_area_get_width(coords), h = lv_area_get_height(coords);
+    SDL_assert(w > 0 && h > 0);
+    SDL_Rect rect = {0, 0, w, h};
+    uint8_t * pixels;
+    int pitch;
+    if(SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch) != 0) return;
+
+    lv_opa_t * line_buf = lv_mem_buf_get(rect.w);
+    for(lv_coord_t y = 0; y < rect.h; y++) {
+        lv_memset_ff(line_buf, rect.w);
+        lv_coord_t abs_x = (lv_coord_t) coords->x1, abs_y = (lv_coord_t)(y + coords->y1), len = (lv_coord_t) rect.w;
+        lv_draw_mask_res_t res;
+        if(ids) {
+            res = lv_draw_mask_apply_ids(line_buf, abs_x, abs_y, len, ids, ids_count);
+        }
+        else {
+            res = lv_draw_mask_apply(line_buf, abs_x, abs_y, len);
+        }
+        if(res == LV_DRAW_MASK_RES_TRANSP) {
+            lv_memset_00(&pixels[y * pitch], 4 * rect.w);
+        }
+        else if(res == LV_DRAW_MASK_RES_FULL_COVER) {
+            lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
+        }
+        else {
+            for(int x = 0; x < rect.w; x++) {
+                pixels[y * pitch + x * 4] = line_buf[x];
+            }
+        }
+    }
+    lv_mem_buf_release(line_buf);
+    SDL_UnlockTexture(texture);
+}
+
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_composite.h
+++ b/src/draw/sdl/lv_draw_sdl_composite.h
@@ -55,7 +55,7 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
                                  const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
                                  lv_area_t * clip_out, lv_area_t * apply_area);
 
-void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_area, lv_blend_mode_t blend_mode);
+void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_area, lv_blend_mode_t blend_mode);
 
 SDL_Texture * lv_draw_sdl_composite_texture_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_texture_id_t id,
                                                    lv_coord_t w, lv_coord_t h);

--- a/src/draw/sdl/lv_draw_sdl_composite.h
+++ b/src/draw/sdl/lv_draw_sdl_composite.h
@@ -30,10 +30,11 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef enum lv_draw_sdl_mask_cache_type_t {
-    LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
-    LV_DRAW_SDL_COMPOSITE_KEY_ID_TEMP,
-} lv_draw_sdl_composite_cache_type_t;
+typedef enum lv_draw_sdl_composite_texture_id_t {
+    LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM0,
+    LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM1,
+    LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_TARGET0,
+} lv_draw_sdl_composite_texture_id_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -56,8 +57,8 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
 
 void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_area, lv_blend_mode_t blend_mode);
 
-SDL_Texture * lv_draw_sdl_composite_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
-                                               lv_coord_t w, lv_coord_t h);
+SDL_Texture * lv_draw_sdl_composite_texture_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_texture_id_t id,
+                                                   lv_coord_t w, lv_coord_t h);
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_composite.h
+++ b/src/draw/sdl/lv_draw_sdl_composite.h
@@ -1,0 +1,71 @@
+/**
+ * @file lv_draw_sdl_composite.h
+ *
+ */
+
+#ifndef LV_DRAW_SDL_COMPOSITE_H
+#define LV_DRAW_SDL_COMPOSITE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../lv_conf_internal.h"
+
+#include LV_GPU_SDL_INCLUDE_PATH
+
+#include "lv_draw_sdl.h"
+#include "../../misc/lv_area.h"
+#include "../../misc/lv_color.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef enum lv_draw_sdl_mask_cache_type_t {
+    LV_DRAW_SDL_COMPOSITE_KEY_ID_MASK,
+    LV_DRAW_SDL_COMPOSITE_KEY_ID_TEMP,
+} lv_draw_sdl_composite_cache_type_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Begin drawing with mask. Render target will be switched to a temporary texture,
+ * and drawing coordinates may get clipped or translated
+ * @param coords_in Original coordinates
+ * @param clip_in Original clip area
+ * @param extension Useful for shadows or outlines, can be NULL
+ * @param coords_out Translated coords
+ * @param clip_out Translated clip area
+ * @param apply_area Area of actual composited texture will be drawn
+ * @return true if there are any mask needs to be drawn, false otherwise
+ */
+bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
+                                 const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
+                                 lv_area_t * clip_out, lv_area_t * apply_area);
+
+void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
+                               lv_blend_mode_t blend_mode);
+
+SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
+                                          lv_coord_t w, lv_coord_t h);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_DRAW_SDL_COMPOSITE_H*/

--- a/src/draw/sdl/lv_draw_sdl_composite.h
+++ b/src/draw/sdl/lv_draw_sdl_composite.h
@@ -57,8 +57,8 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
 void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
                                lv_blend_mode_t blend_mode);
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
-                                          lv_coord_t w, lv_coord_t h);
+SDL_Texture * lv_draw_sdl_composite_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
+                                               lv_coord_t w, lv_coord_t h);
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_composite.h
+++ b/src/draw/sdl/lv_draw_sdl_composite.h
@@ -54,8 +54,7 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
                                  const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
                                  lv_area_t * clip_out, lv_area_t * apply_area);
 
-void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
-                               lv_blend_mode_t blend_mode);
+void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t *ctx, const lv_area_t *apply_area, lv_blend_mode_t blend_mode);
 
 SDL_Texture * lv_draw_sdl_composite_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_composite_cache_type_t type,
                                                lv_coord_t w, lv_coord_t h);

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -109,7 +109,8 @@ lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t 
         SDL_SetTextureColorMod(texture, draw_dsc->recolor.ch.red, recolor.g, recolor.b);
         SDL_SetTextureAlphaMod(texture, draw_dsc->opa);
         SDL_RenderCopyEx(renderer, texture, NULL, &coords_rect, draw_dsc->angle, &pivot, SDL_FLIP_NONE);
-    } else if(draw_dsc->recolor_opa > LV_OPA_TRANSP) {
+    }
+    else if(draw_dsc->recolor_opa > LV_OPA_TRANSP) {
         /* Draw blended. src: origA, dst: origA * recolorA */
         SDL_SetTextureColorMod(texture, 0xFF, 0xFF, 0xFF);
         SDL_SetTextureAlphaMod(texture, draw_dsc->opa);
@@ -117,7 +118,8 @@ lv_res_t lv_draw_sdl_img_core(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t 
         SDL_SetTextureColorMod(texture, recolor.r, recolor.g, recolor.b);
         SDL_SetTextureAlphaMod(texture, draw_dsc->opa * draw_dsc->recolor_opa / 255);
         SDL_RenderCopyEx(renderer, texture, NULL, &coords_rect, draw_dsc->angle, &pivot, SDL_FLIP_NONE);
-    } else {
+    }
+    else {
         /* Draw with no recolor */
         SDL_SetTextureColorMod(texture, 0xFF, 0xFF, 0xFF);
         SDL_SetTextureAlphaMod(texture, draw_dsc->opa);

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -18,7 +18,7 @@
 
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
-#include "lv_draw_sdl_mask.h"
+#include "lv_draw_sdl_composite.h"
 
 /*********************
  *      DEFINES
@@ -118,9 +118,8 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
         return;
     }
 
-    lv_point_t offset = {0, 0};
     lv_area_t t_letter = letter_area, t_clip = *clip_area, apply_area;
-    bool has_mask = lv_draw_sdl_mask_begin(ctx, &letter_area, clip_area, NULL, dsc->blend_mode, &t_letter, &t_clip,
+    bool has_mask = lv_draw_sdl_composite_begin(ctx, &letter_area, clip_area, NULL, dsc->blend_mode, &t_letter, &t_clip,
                                            &apply_area);
 
     /*If the letter is completely out of mask don't draw it*/
@@ -138,7 +137,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
     SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
     SDL_RenderCopy(renderer, texture, &srcrect, &dstrect);
 
-    lv_draw_sdl_mask_end(ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(ctx, has_mask, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -120,7 +120,8 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
 
     lv_point_t offset = {0, 0};
     lv_area_t t_letter = letter_area, t_clip = *clip_area, apply_area;
-    bool has_mask = lv_draw_sdl_mask_begin(ctx, &letter_area, clip_area, NULL, &t_letter, &t_clip, &apply_area);
+    bool has_mask = lv_draw_sdl_mask_begin(ctx, &letter_area, clip_area, NULL, dsc->blend_mode, &t_letter, &t_clip,
+                                           &apply_area);
 
     /*If the letter is completely out of mask don't draw it*/
     if(!_lv_area_intersect(&draw_area, &t_letter, &t_clip)) {
@@ -137,9 +138,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
     SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
     SDL_RenderCopy(renderer, texture, &srcrect, &dstrect);
 
-    if(has_mask) {
-        lv_draw_sdl_mask_end(ctx, &apply_area);
-    }
+    lv_draw_sdl_mask_end(ctx, has_mask, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -120,7 +120,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
 
     lv_area_t t_letter = letter_area, t_clip = *clip_area, apply_area;
     bool has_mask = lv_draw_sdl_composite_begin(ctx, &letter_area, clip_area, NULL, dsc->blend_mode, &t_letter, &t_clip,
-                                           &apply_area);
+                                                &apply_area);
 
     /*If the letter is completely out of mask don't draw it*/
     if(!_lv_area_intersect(&draw_area, &t_letter, &t_clip)) {

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -137,7 +137,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
     SDL_SetTextureColorMod(texture, color.ch.red, color.ch.green, color.ch.blue);
     SDL_RenderCopy(renderer, texture, &srcrect, &dstrect);
 
-    lv_draw_sdl_composite_end(ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(ctx, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -96,7 +96,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
     SDL_RenderCopyEx(renderer, texture, &srcrect, &dstrect, angle, &center, 0);
     SDL_RenderSetClipRect(renderer, NULL);
 
-    lv_draw_sdl_composite_end(sdl_ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(sdl_ctx, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -121,9 +121,6 @@ static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_dr
     SDL_Texture *target = SDL_GetRenderTarget(sdl_ctx->renderer);
     SDL_SetRenderTarget(sdl_ctx->renderer, texture);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-#if SDL_VERSION_ATLEAST(2, 0, 12)
-    SDL_SetTextureScaleMode(texture, SDL_ScaleModeBest);
-#endif
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0x0);
     SDL_RenderClear(sdl_ctx->renderer);
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0xFF);

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -78,7 +78,8 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
 
     lv_area_t t_coords = coords, t_clip = *clip, apply_area;
     lv_area_t extension = {dsc->width / 2, dsc->width / 2, dsc->width / 2, dsc->width / 2};
-    bool has_mask = lv_draw_sdl_mask_begin(sdl_ctx, &coords, clip, &extension, &t_coords, &t_clip, &apply_area);
+    bool has_mask = lv_draw_sdl_mask_begin(sdl_ctx, &coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
+                                           &apply_area);
 
     SDL_Color color;
     lv_color_to_sdl_color(&dsc->color, &color);
@@ -94,9 +95,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
     SDL_RenderCopyEx(renderer, texture, &srcrect, &dstrect, angle, &center, 0);
     SDL_RenderSetClipRect(renderer, NULL);
 
-    if(has_mask) {
-        lv_draw_sdl_mask_end(sdl_ctx, &apply_area);
-    }
+    lv_draw_sdl_mask_end(sdl_ctx, has_mask, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -121,7 +121,9 @@ static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_dr
     SDL_Texture *target = SDL_GetRenderTarget(sdl_ctx->renderer);
     SDL_SetRenderTarget(sdl_ctx->renderer, texture);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+#if SDL_VERSION_ATLEAST(2, 0, 12)
     SDL_SetTextureScaleMode(texture, SDL_ScaleModeBest);
+#endif
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0x0);
     SDL_RenderClear(sdl_ctx->renderer);
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0xFF);

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -44,9 +44,10 @@ typedef struct {
  *      MACROS
  **********************/
 
-static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t *dsc, lv_coord_t length);
+static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t * dsc, lv_coord_t length);
 
-static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_draw_line_dsc_t *dsc, lv_coord_t length);
+static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t * sdl_ctx, const lv_draw_line_dsc_t * dsc,
+                                         lv_coord_t length);
 
 /**********************
  *   GLOBAL FUNCTIONS
@@ -54,18 +55,18 @@ static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_dr
 void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
                            const lv_point_t * point2)
 {
-    lv_draw_sdl_ctx_t *sdl_ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
+    lv_draw_sdl_ctx_t * sdl_ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
     SDL_Renderer * renderer = sdl_ctx->renderer;
     lv_coord_t x1 = point1->x, x2 = point2->x, y1 = point1->y, y2 = point2->y;
     double length = SDL_sqrt(SDL_pow(x2 - x1, 2) + SDL_pow(y2 - y1, 2));
-    if (length - (long) length > 0.5) {
+    if(length - (long) length > 0.5) {
         length = (long) length + 1;
     }
 
     double angle = SDL_atan2(y2 - y1, x2 - x1) * 180 / M_PI;
     lv_draw_line_key_t key = line_key_create(dsc, length);
-    SDL_Texture *texture = lv_draw_sdl_texture_cache_get(sdl_ctx, &key, sizeof(key), NULL);
-    if (!texture) {
+    SDL_Texture * texture = lv_draw_sdl_texture_cache_get(sdl_ctx, &key, sizeof(key), NULL);
+    if(!texture) {
         texture = line_texture_create(sdl_ctx, dsc, length);
         lv_draw_sdl_texture_cache_put(sdl_ctx, &key, sizeof(key), texture);
     }
@@ -80,7 +81,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
     lv_area_t t_coords = coords, t_clip = *clip, apply_area;
     lv_area_t extension = {dsc->width / 2, dsc->width / 2, dsc->width / 2, dsc->width / 2};
     bool has_mask = lv_draw_sdl_composite_begin(sdl_ctx, &coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
-                                           &apply_area);
+                                                &apply_area);
 
     SDL_Color color;
     lv_color_to_sdl_color(&dsc->color, &color);
@@ -91,7 +92,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
     SDL_SetTextureColorMod(texture, color.r, color.g, color.b);
     SDL_SetTextureAlphaMod(texture, dsc->opa);
     SDL_Rect srcrect = {0, 0, length + dsc->width + 2, dsc->width + 2},
-            dstrect = {t_coords.x1 - 1 - dsc->width / 2, t_coords.y1 - 1, srcrect.w, srcrect.h};
+             dstrect = {t_coords.x1 - 1 - dsc->width / 2, t_coords.y1 - 1, srcrect.w, srcrect.h};
     SDL_Point center = {1 + dsc->width / 2, 1 + dsc->width / 2};
     SDL_RenderCopyEx(renderer, texture, &srcrect, &dstrect, angle, &center, 0);
     SDL_RenderSetClipRect(renderer, NULL);
@@ -103,7 +104,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t *dsc, lv_coord_t length)
+static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t * dsc, lv_coord_t length)
 {
     lv_draw_line_key_t key;
     lv_memset_00(&key, sizeof(lv_draw_line_key_t));
@@ -114,11 +115,11 @@ static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t *dsc, lv_coor
     return key;
 }
 
-static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_draw_line_dsc_t *dsc, lv_coord_t length)
+static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t * sdl_ctx, const lv_draw_line_dsc_t * dsc, lv_coord_t length)
 {
-    SDL_Texture *texture = SDL_CreateTexture(sdl_ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET,
-                                             length + dsc->width + 2, dsc->width + 2);
-    SDL_Texture *target = SDL_GetRenderTarget(sdl_ctx->renderer);
+    SDL_Texture * texture = SDL_CreateTexture(sdl_ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET,
+                                              length + dsc->width + 2, dsc->width + 2);
+    SDL_Texture * target = SDL_GetRenderTarget(sdl_ctx->renderer);
     SDL_SetRenderTarget(sdl_ctx->renderer, texture);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0x0);
@@ -126,13 +127,13 @@ static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_dr
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0xFF);
     SDL_Rect line_rect = {1 + dsc->width / 2, 1, length, dsc->width};
     SDL_RenderFillRect(sdl_ctx->renderer, &line_rect);
-    if (dsc->round_start || dsc->round_end) {
+    if(dsc->round_start || dsc->round_end) {
         lv_draw_mask_radius_param_t param;
         lv_area_t round_area = {0, 0, dsc->width - 1, dsc->width - 1};
         lv_draw_mask_radius_init(&param, &round_area, LV_RADIUS_CIRCLE, false);
 
         int16_t mask_id = lv_draw_mask_add(&param, NULL);
-        SDL_Texture *round_texture = lv_draw_sdl_mask_dump_texture(sdl_ctx->renderer, &round_area, &mask_id, 1);
+        SDL_Texture * round_texture = lv_draw_sdl_mask_dump_texture(sdl_ctx->renderer, &round_area, &mask_id, 1);
         lv_draw_mask_remove_id(mask_id);
 
         SDL_Rect round_src = {0, 0, dsc->width, dsc->width};

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -1,0 +1,151 @@
+/**
+ * @file lv_templ.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_GPU_SDL
+
+#include "lv_draw_sdl.h"
+#include "lv_draw_sdl_utils.h"
+#include "lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl_mask.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+#define ROUND_START 0x01
+#define ROUND_END 0x02
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    lv_sdl_cache_key_magic_t magic;
+    lv_coord_t length;
+    lv_coord_t width;
+    uint8_t round;
+} lv_draw_line_key_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t *dsc, lv_coord_t length);
+
+static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_draw_line_dsc_t *dsc, lv_coord_t length);
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
+                           const lv_point_t * point2)
+{
+    lv_draw_sdl_ctx_t *sdl_ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
+    SDL_Renderer * renderer = sdl_ctx->renderer;
+    lv_coord_t x1 = point1->x, x2 = point2->x, y1 = point1->y, y2 = point2->y;
+    double length = SDL_sqrt(SDL_pow(x2 - x1, 2) + SDL_pow(y2 - y1, 2));
+    if (length - (long) length > 0.5) {
+        length = (long) length + 1;
+    }
+
+    double angle = SDL_atan2(y2 - y1, x2 - x1) * 180 / M_PI;
+    lv_draw_line_key_t key = line_key_create(dsc, length);
+    SDL_Texture *texture = lv_draw_sdl_texture_cache_get(sdl_ctx, &key, sizeof(key), NULL);
+    if (!texture) {
+        texture = line_texture_create(sdl_ctx, dsc, length);
+        lv_draw_sdl_texture_cache_put(sdl_ctx, &key, sizeof(key), texture);
+    }
+
+    lv_area_t coords = {x1, y1, x2, y2};
+    const lv_area_t * clip = draw_ctx->clip_area;
+
+    SDL_Rect coords_r, clip_r;
+    lv_area_to_sdl_rect(&coords, &coords_r);
+    lv_area_to_sdl_rect(clip, &clip_r);
+
+    lv_area_t t_coords = coords, t_clip = *clip, apply_area;
+    lv_area_t extension = {dsc->width / 2, dsc->width / 2, dsc->width / 2, dsc->width / 2};
+    bool has_mask = lv_draw_sdl_mask_begin(sdl_ctx, &coords, clip, &extension, &t_coords, &t_clip, &apply_area);
+
+    SDL_Color color;
+    lv_color_to_sdl_color(&dsc->color, &color);
+
+    SDL_Rect clip_rect;
+    lv_area_to_sdl_rect(&t_clip, &clip_rect);
+    SDL_RenderSetClipRect(renderer, &clip_rect);
+    SDL_SetTextureColorMod(texture, color.r, color.g, color.b);
+    SDL_SetTextureAlphaMod(texture, dsc->opa);
+    SDL_Rect srcrect = {0, 0, length + dsc->width + 2, dsc->width + 2},
+            dstrect = {t_coords.x1 - 1 - dsc->width / 2, t_coords.y1 - 1, srcrect.w, srcrect.h};
+    SDL_Point center = {1 + dsc->width / 2, 1 + dsc->width / 2};
+    SDL_RenderCopyEx(renderer, texture, &srcrect, &dstrect, angle, &center, 0);
+    SDL_RenderSetClipRect(renderer, NULL);
+
+    if(has_mask) {
+        lv_draw_sdl_mask_end(sdl_ctx, &apply_area);
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static lv_draw_line_key_t line_key_create(const lv_draw_line_dsc_t *dsc, lv_coord_t length)
+{
+    lv_draw_line_key_t key;
+    lv_memset_00(&key, sizeof(lv_draw_line_key_t));
+    key.magic = LV_GPU_CACHE_KEY_MAGIC_LINE;
+    key.length = length;
+    key.width = dsc->width;
+    key.round = (dsc->round_start ? ROUND_START : 0) | (dsc->round_end ? ROUND_END : 0);
+    return key;
+}
+
+static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t *sdl_ctx, const lv_draw_line_dsc_t *dsc, lv_coord_t length)
+{
+    SDL_Texture *texture = SDL_CreateTexture(sdl_ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, SDL_TEXTUREACCESS_TARGET,
+                                             length + dsc->width + 2, dsc->width + 2);
+    SDL_Texture *target = SDL_GetRenderTarget(sdl_ctx->renderer);
+    SDL_SetRenderTarget(sdl_ctx->renderer, texture);
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureScaleMode(texture, SDL_ScaleModeBest);
+    SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0x0);
+    SDL_RenderClear(sdl_ctx->renderer);
+    SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0xFF);
+    SDL_Rect line_rect = {1 + dsc->width / 2, 1, length, dsc->width};
+    SDL_RenderFillRect(sdl_ctx->renderer, &line_rect);
+    if (dsc->round_start || dsc->round_end) {
+        lv_draw_mask_radius_param_t param;
+        lv_area_t round_area = {0, 0, dsc->width - 1, dsc->width - 1};
+        lv_draw_mask_radius_init(&param, &round_area, LV_RADIUS_CIRCLE, false);
+
+        int16_t mask_id = lv_draw_mask_add(&param, NULL);
+        SDL_Texture *round_texture = lv_draw_sdl_mask_dump_texture(sdl_ctx->renderer, &round_area, &mask_id, 1);
+        lv_draw_mask_remove_id(mask_id);
+
+        SDL_Rect round_src = {0, 0, dsc->width, dsc->width};
+        SDL_Rect round_dst = {line_rect.x - dsc->width / 2, 1, dsc->width, dsc->width};
+        SDL_RenderCopy(sdl_ctx->renderer, round_texture, &round_src, &round_dst);
+        round_dst.x = line_rect.w + dsc->width / 2;
+        SDL_RenderCopy(sdl_ctx->renderer, round_texture, &round_src, &round_dst);
+        SDL_DestroyTexture(round_texture);
+    }
+
+    SDL_SetRenderTarget(sdl_ctx->renderer, target);
+    return texture;
+}
+
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -13,6 +13,7 @@
 #include "lv_draw_sdl.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl_composite.h"
 #include "lv_draw_sdl_mask.h"
 
 /*********************
@@ -78,7 +79,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
 
     lv_area_t t_coords = coords, t_clip = *clip, apply_area;
     lv_area_t extension = {dsc->width / 2, dsc->width / 2, dsc->width / 2, dsc->width / 2};
-    bool has_mask = lv_draw_sdl_mask_begin(sdl_ctx, &coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
+    bool has_mask = lv_draw_sdl_composite_begin(sdl_ctx, &coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
                                            &apply_area);
 
     SDL_Color color;
@@ -95,7 +96,7 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
     SDL_RenderCopyEx(renderer, texture, &srcrect, &dstrect, angle, &center, 0);
     SDL_RenderSetClipRect(renderer, NULL);
 
-    lv_draw_sdl_mask_end(sdl_ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(sdl_ctx, has_mask, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -11,11 +11,8 @@
 #if LV_USE_GPU_SDL
 
 #include "../../misc/lv_gc.h"
-#include "../../core/lv_refr.h"
 #include "lv_draw_sdl_mask.h"
 #include "lv_draw_sdl_utils.h"
-#include "lv_draw_sdl_priv.h"
-#include "lv_draw_sdl_texture_cache.h"
 
 /*********************
  *      DEFINES
@@ -26,20 +23,9 @@
  *      TYPEDEFS
  **********************/
 
-typedef struct {
-    lv_sdl_cache_key_magic_t magic;
-    lv_draw_sdl_mask_cache_type_t type;
-} lv_mask_key_t;
-
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-
-static lv_mask_key_t mask_key_create(lv_draw_sdl_mask_cache_type_t type);
-
-static lv_coord_t next_pow_of_2(lv_coord_t num);
-
-void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 
 /**********************
  *  STATIC VARIABLES
@@ -52,118 +38,6 @@ void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const i
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
-                            const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
-                            lv_area_t * clip_out, lv_area_t * apply_area)
-{
-    lv_area_t full_coords = *coords_in;
-
-    /* Normalize full_coords */
-    if(full_coords.x1 > full_coords.x2) {
-        lv_coord_t x2 = full_coords.x2;
-        full_coords.x2 = full_coords.x1;
-        full_coords.x1 = x2;
-    }
-    if(full_coords.y1 > full_coords.y2) {
-        lv_coord_t y2 = full_coords.y2;
-        full_coords.y2 = full_coords.y1;
-        full_coords.y1 = y2;
-    }
-
-    if(extension) {
-        full_coords.x1 -= extension->x1;
-        full_coords.x2 += extension->x2;
-        full_coords.y1 -= extension->y1;
-        full_coords.y2 += extension->y2;
-    }
-
-    if(!_lv_area_intersect(apply_area, &full_coords, clip_in)) return false;
-    bool has_mask = lv_draw_mask_is_any(apply_area);
-
-    if (has_mask || (blend_mode != LV_BLEND_MODE_NORMAL && blend_mode != LV_BLEND_MODE_REPLACE)) {
-        lv_draw_sdl_context_internals_t * internals = ctx->internals;
-        LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
-        lv_coord_t w = lv_area_get_width(apply_area), h = lv_area_get_height(apply_area);
-        internals->composition = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE, w, h);
-        /* Don't need to worry about overflow */
-        lv_coord_t ofs_x = (lv_coord_t) - apply_area->x1, ofs_y = (lv_coord_t) - apply_area->y1;
-        /* Offset draw area to start with (0,0) of coords */
-        lv_area_move(coords_out, ofs_x, ofs_y);
-        lv_area_move(clip_out, ofs_x, ofs_y);
-        SDL_SetRenderTarget(ctx->renderer, internals->composition);
-        SDL_SetRenderDrawColor(ctx->renderer, 255, 255, 255, 0);
-        SDL_RenderClear(ctx->renderer);
-#if HAS_CUSTOM_BLEND_MODE
-        internals->mask = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK, w, h);
-        texture_apply_mask(internals->mask, apply_area, NULL, 0);
-#else
-        /* Fallback mask handling. This will at least make bars looks less bad */
-        for(uint8_t i = 0; i < _LV_MASK_MAX_NUM; i++) {
-            _lv_draw_mask_common_dsc_t * comm_param = LV_GC_ROOT(_lv_draw_mask_list[i]).param;
-            if(comm_param == NULL) continue;
-            switch(comm_param->type) {
-                case LV_DRAW_MASK_TYPE_RADIUS: {
-                        const lv_draw_mask_radius_param_t * param = (const lv_draw_mask_radius_param_t *) comm_param;
-                        if(param->cfg.outer) break;
-                        _lv_area_intersect(clip_out, apply_area, &param->cfg.rect);
-                        break;
-                    }
-                default:
-                    break;
-            }
-        }
-#endif
-    }
-    return has_mask;
-}
-
-void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
-                          lv_blend_mode_t blend_mode)
-{
-    lv_draw_sdl_context_internals_t * internals = ctx->internals;
-    SDL_Rect src_rect = {0, 0, lv_area_get_width(apply_area), lv_area_get_height(apply_area)};
-#if HAS_CUSTOM_BLEND_MODE
-    if (internals->mask) {
-        SDL_BlendMode mode = SDL_ComposeCustomBlendMode(SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE,
-                                                        SDL_BLENDOPERATION_ADD, SDL_BLENDFACTOR_ZERO,
-                                                        SDL_BLENDFACTOR_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
-        SDL_SetTextureBlendMode(internals->mask, mode);
-        SDL_RenderCopy(ctx->renderer, internals->mask, &src_rect, &src_rect);
-    }
-#endif
-
-    /* Shapes are drawn on composite layer when mask or blend mode is present */
-    if (internals->composition) {
-        SDL_Rect dst_rect;
-        lv_area_to_sdl_rect(apply_area, &dst_rect);
-
-        SDL_SetRenderTarget(ctx->renderer, ctx->base_draw.base_draw.buf);
-        switch (blend_mode) {
-            case LV_BLEND_MODE_NORMAL:
-            case LV_BLEND_MODE_REPLACE:
-                SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
-                break;
-            case LV_BLEND_MODE_ADDITIVE:
-                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_ADD);
-                break;
-//#if HAS_CUSTOM_BLEND_MODE
-//        case LV_BLEND_MODE_SUBTRACTIVE:
-//            break;
-//        case LV_BLEND_MODE_MULTIPLY:
-//            break;
-//#endif
-            default:
-                LV_LOG_WARN("Doesn't support blend mode %d", blend_mode);
-                SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
-                /* Unsupported yet */
-                break;
-        }
-        SDL_RenderCopy(ctx->renderer, internals->composition, &src_rect, &dst_rect);
-    }
-
-    internals->mask = internals->composition = NULL;
-}
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count)
 {
@@ -201,84 +75,8 @@ SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_ar
     return texture;
 }
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_mask_cache_type_t type,
-                                          lv_coord_t w, lv_coord_t h)
-{
-    lv_point_t * tex_size = NULL;
-    lv_mask_key_t mask_key = mask_key_create(type);
-    SDL_Texture * result = lv_draw_sdl_texture_cache_get_with_userdata(ctx, &mask_key, sizeof(lv_mask_key_t), NULL,
-                                                                       (void **) &tex_size);
-    if(!result || tex_size->x < w || tex_size->y < h) {
-        lv_coord_t size = next_pow_of_2(LV_MAX(w, h));
-        int access = SDL_TEXTUREACCESS_STREAMING;
-        if(type == LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE) {
-            access = SDL_TEXTUREACCESS_TARGET;
-        }
-        result = SDL_CreateTexture(ctx->renderer, LV_DRAW_SDL_TEXTURE_FORMAT, access, size, size);
-        tex_size = lv_mem_alloc(sizeof(lv_point_t));
-        tex_size->x = tex_size->y = size;
-        lv_draw_sdl_texture_cache_put_advanced(ctx, &mask_key, sizeof(lv_mask_key_t), result, tex_size, lv_mem_free, 0);
-    }
-    return result;
-}
-
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-static lv_mask_key_t mask_key_create(lv_draw_sdl_mask_cache_type_t type)
-{
-    lv_mask_key_t key;
-    /* VERY IMPORTANT! Padding between members is uninitialized, so we have to wipe them manually */
-    SDL_memset(&key, 0, sizeof(key));
-    key.magic = LV_GPU_CACHE_KEY_MAGIC_MASK;
-    key.type = type;
-    return key;
-}
-
-static lv_coord_t next_pow_of_2(lv_coord_t num)
-{
-    lv_coord_t n = 128;
-    while(n < num && n < 16384) {
-        n = n << 1;
-    }
-    return n;
-}
-
-void texture_apply_mask(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids, int16_t ids_count)
-{
-    lv_coord_t w = lv_area_get_width(coords), h = lv_area_get_height(coords);
-    SDL_assert(w > 0 && h > 0);
-    SDL_Rect rect = {0, 0, w, h};
-    uint8_t * pixels;
-    int pitch;
-    if(SDL_LockTexture(texture, &rect, (void **) &pixels, &pitch) != 0) return;
-
-    lv_opa_t * line_buf = lv_mem_buf_get(rect.w);
-    for(lv_coord_t y = 0; y < rect.h; y++) {
-        lv_memset_ff(line_buf, rect.w);
-        lv_coord_t abs_x = (lv_coord_t) coords->x1, abs_y = (lv_coord_t)(y + coords->y1), len = (lv_coord_t) rect.w;
-        lv_draw_mask_res_t res;
-        if(ids) {
-            res = lv_draw_mask_apply_ids(line_buf, abs_x, abs_y, len, ids, ids_count);
-        }
-        else {
-            res = lv_draw_mask_apply(line_buf, abs_x, abs_y, len);
-        }
-        if(res == LV_DRAW_MASK_RES_TRANSP) {
-            lv_memset_00(&pixels[y * pitch], 4 * rect.w);
-        }
-        else if(res == LV_DRAW_MASK_RES_FULL_COVER) {
-            lv_memset_ff(&pixels[y * pitch], 4 * rect.w);
-        }
-        else {
-            for(int x = 0; x < rect.w; x++) {
-                pixels[y * pitch + x * 4] = line_buf[x];
-            }
-        }
-    }
-    lv_mem_buf_release(line_buf);
-    SDL_UnlockTexture(texture);
-}
 
 #endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_mask.c
+++ b/src/draw/sdl/lv_draw_sdl_mask.c
@@ -58,12 +58,26 @@ bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in
                             lv_area_t * apply_area)
 {
     lv_area_t full_area, full_coords = *coords_in;
+
+    /* Normalize full_coords */
+    if(full_coords.x1 > full_coords.x2) {
+        lv_coord_t x2 = full_coords.x2;
+        full_coords.x2 = full_coords.x1;
+        full_coords.x1 = x2;
+    }
+    if(full_coords.y1 > full_coords.y2) {
+        lv_coord_t y2 = full_coords.y2;
+        full_coords.y2 = full_coords.y1;
+        full_coords.y1 = y2;
+    }
+
     if(extension) {
         full_coords.x1 -= extension->x1;
         full_coords.x2 += extension->x2;
         full_coords.y1 -= extension->y1;
         full_coords.y2 += extension->y2;
     }
+
     if(!_lv_area_intersect(&full_area, &full_coords, clip_in)) return false;
     if(!lv_draw_mask_is_any(&full_area)) return false;
 #if HAS_CUSTOM_BLEND_MODE
@@ -71,6 +85,7 @@ bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in
     lv_draw_sdl_context_internals_t * internals = ctx->internals;
     LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
     lv_coord_t w = lv_area_get_width(&full_area), h = lv_area_get_height(&full_area);
+
 
     internals->mask = lv_draw_sdl_mask_tmp_obtain(ctx, LV_DRAW_SDL_MASK_KEY_ID_MASK, w, h);
     texture_apply_mask(internals->mask, &full_area, NULL, 0);

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -39,6 +39,9 @@ lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * i
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
+void lv_draw_sdl_mask_dump_to_texture(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids,
+                                      int16_t ids_count);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -39,8 +39,6 @@ lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * i
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
-void lv_draw_sdl_mask_dump_to_texture(SDL_Texture * texture, const lv_area_t * coords, const int16_t * ids,
-                                      int16_t ids_count);
 
 /**********************
  *      MACROS

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -30,40 +30,15 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef enum lv_draw_sdl_mask_cache_type_t {
-    LV_DRAW_SDL_MASK_KEY_ID_MASK,
-    LV_DRAW_SDL_MASK_KEY_ID_COMPOSITE,
-} lv_draw_sdl_mask_cache_type_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
-/**
- * Begin drawing with mask. Render target will be switched to a temporary texture,
- * and drawing coordinates may get clipped or translated
- * @param coords_in Original coordinates
- * @param clip_in Original clip area
- * @param extension Useful for shadows or outlines, can be NULL
- * @param coords_out Translated coords
- * @param clip_out Translated clip area
- * @param apply_area Area of actual composited texture will be drawn
- * @return true if there are any mask needs to be drawn, false otherwise
- */
-bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
-                            const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
-                            lv_area_t * clip_out, lv_area_t * apply_area);
-
-void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
-                          lv_blend_mode_t blend_mode);
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 
 SDL_Texture * lv_draw_sdl_mask_dump_texture(SDL_Renderer * renderer, const lv_area_t * coords, const int16_t * ids,
                                             int16_t ids_count);
 
-SDL_Texture * lv_draw_sdl_mask_tmp_obtain(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_mask_cache_type_t type,
-                                          lv_coord_t w, lv_coord_t h);
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sdl/lv_draw_sdl_mask.h
+++ b/src/draw/sdl/lv_draw_sdl_mask.h
@@ -51,10 +51,11 @@ typedef enum lv_draw_sdl_mask_cache_type_t {
  * @return true if there are any mask needs to be drawn, false otherwise
  */
 bool lv_draw_sdl_mask_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords_in, const lv_area_t * clip_in,
-                            const lv_area_t * extension, lv_area_t * coords_out, lv_area_t * clip_out,
-                            lv_area_t * apply_area);
+                            const lv_area_t * extension, lv_blend_mode_t blend_mode, lv_area_t * coords_out,
+                            lv_area_t * clip_out, lv_area_t * apply_area);
 
-void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_area);
+void lv_draw_sdl_mask_end(lv_draw_sdl_ctx_t * ctx, bool has_mask, const lv_area_t * apply_area,
+                          lv_blend_mode_t blend_mode);
 
 lv_opa_t * lv_draw_sdl_mask_dump_opa(const lv_area_t * coords, const int16_t * ids, int16_t ids_count);
 

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -18,6 +18,7 @@
 #include "../../core/lv_refr.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl_composite.h"
 #include "lv_draw_sdl_mask.h"
 #include "lv_draw_sdl_stack_blur.h"
 
@@ -141,7 +142,7 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
     }
     /* Coords will be translated so coords will start at (0,0) */
     lv_area_t t_coords = *coords, t_clip = *clip, apply_area, t_area;
-    bool has_mask = lv_draw_sdl_mask_begin(ctx, coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
+    bool has_mask = lv_draw_sdl_composite_begin(ctx, coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
                                            &apply_area);
     bool has_content = _lv_area_intersect(&t_area, &t_coords, &t_clip);
 
@@ -156,7 +157,7 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
     }
     draw_outline(ctx, &t_coords, &t_clip, dsc);
 
-    lv_draw_sdl_mask_end(ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(ctx, has_mask, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -15,6 +15,7 @@
 #include "../lv_draw_img.h"
 #include "../lv_draw_label.h"
 #include "../lv_draw_mask.h"
+#include "../../core/lv_refr.h"
 #include "lv_draw_sdl_utils.h"
 #include "lv_draw_sdl_texture_cache.h"
 #include "lv_draw_sdl_mask.h"
@@ -150,7 +151,6 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
 static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
                           const lv_draw_rect_dsc_t * dsc)
 {
-    if(dsc->bg_opa <= LV_OPA_TRANSP) return;
     SDL_Color bg_color;
     lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
     lv_coord_t radius = dsc->radius;
@@ -158,7 +158,23 @@ static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, con
         SDL_Rect rect;
         lv_area_to_sdl_rect(draw_area, &rect);
         SDL_SetRenderDrawColor(ctx->renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);
-        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
+        switch (dsc->blend_mode) {
+            case LV_BLEND_MODE_NORMAL:
+                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
+                break;
+            case LV_BLEND_MODE_ADDITIVE:
+                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_ADD);
+                break;
+            case LV_BLEND_MODE_MULTIPLY:
+                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_MUL);
+                break;
+            case LV_BLEND_MODE_REPLACE:
+                SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
+                break;
+            default:
+                /* Unsupported yet */
+                break;
+        }
         SDL_RenderFillRect(ctx->renderer, &rect);
         return;
     }

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -155,6 +155,9 @@ static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, con
     lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
     lv_coord_t radius = dsc->radius;
     if(radius <= 0) {
+        if (dsc->bg_opa == 0 && dsc->blend_mode != LV_BLEND_MODE_REPLACE) {
+            return;
+        }
         SDL_Rect rect;
         lv_area_to_sdl_rect(draw_area, &rect);
         SDL_SetRenderDrawColor(ctx->renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -143,7 +143,7 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
     /* Coords will be translated so coords will start at (0,0) */
     lv_area_t t_coords = *coords, t_clip = *clip, apply_area, t_area;
     bool has_mask = lv_draw_sdl_composite_begin(ctx, coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
-                                           &apply_area);
+                                                &apply_area);
     bool has_content = _lv_area_intersect(&t_area, &t_coords, &t_clip);
 
     SDL_Rect clip_rect;
@@ -167,7 +167,7 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
 static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
                           const lv_draw_rect_dsc_t * dsc)
 {
-    if (dsc->bg_opa == 0) {
+    if(dsc->bg_opa == 0) {
         return;
     }
     SDL_Color bg_color;

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -157,7 +157,7 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
     }
     draw_outline(ctx, &t_coords, &t_clip, dsc);
 
-    lv_draw_sdl_composite_end(ctx, has_mask, &apply_area, dsc->blend_mode);
+    lv_draw_sdl_composite_end(ctx, &apply_area, dsc->blend_mode);
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -165,9 +165,11 @@ static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, con
             case LV_BLEND_MODE_ADDITIVE:
                 SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_ADD);
                 break;
+#if SDL_VERSION_ATLEAST(2, 0, 12)
             case LV_BLEND_MODE_MULTIPLY:
                 SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_MUL);
                 break;
+#endif
             case LV_BLEND_MODE_REPLACE:
                 SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
                 break;

--- a/src/draw/sdl/lv_draw_sdl_utils.c
+++ b/src/draw/sdl/lv_draw_sdl_utils.c
@@ -77,12 +77,19 @@ void lv_area_to_sdl_rect(const lv_area_t * in, SDL_Rect * out)
 
 void lv_color_to_sdl_color(const lv_color_t * in, SDL_Color * out)
 {
+#if LV_COLOR_DEPTH == 32
+    out->a = in->ch.alpha;
+    out->r = in->ch.red;
+    out->g = in->ch.green;
+    out->b = in->ch.blue;
+#else
     uint32_t color32 = lv_color_to32(*in);
     lv_color32_t * color32_t = (lv_color32_t *) &color32;
     out->a = color32_t->ch.alpha;
     out->r = color32_t->ch.red;
     out->g = color32_t->ch.green;
     out->b = color32_t->ch.blue;
+#endif
 }
 
 void lv_area_zoom_to_sdl_rect(const lv_area_t * in, SDL_Rect * out, uint16_t zoom, const lv_point_t * pivot)
@@ -171,12 +178,6 @@ void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, 
             cur++;
         }
     }
-}
-
-lv_draw_sdl_ctx_t * lv_draw_sdl_get_context()
-{
-    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-    return (lv_draw_sdl_ctx_t *) disp->driver->draw_ctx;
 }
 
 /**********************

--- a/src/draw/sdl/lv_draw_sdl_utils.h
+++ b/src/draw/sdl/lv_draw_sdl_utils.h
@@ -53,8 +53,6 @@ SDL_Texture * lv_sdl_create_opa_texture(SDL_Renderer * renderer, lv_opa_t * pixe
 
 void lv_sdl_to_8bpp(uint8_t * dest, const uint8_t * src, int width, int height, int stride, uint8_t bpp);
 
-lv_draw_sdl_ctx_t * lv_draw_sdl_get_context();
-
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -58,7 +58,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, con
                                            const lv_point_t * point1, const lv_point_t * point2);
 
 void lv_draw_sw_polygon(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc,
-                        const lv_point_t points[], uint16_t point_cnt);
+                        const lv_point_t * points, uint16_t point_cnt);
 
 /***********************
  * GLOBAL VARIABLES

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -39,7 +39,6 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_sw_init(void);
 void lv_draw_sw_init_ctx(struct _lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx);
 void lv_draw_sw_deinit_ctx(struct _lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx);
 

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -211,8 +211,6 @@ static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_
 LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
                                               lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
 {
-    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-
     int32_t w = lv_area_get_width(dest_area);
     int32_t h = lv_area_get_height(dest_area);
 

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -211,6 +211,7 @@ static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_
 LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
                                               lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
 {
+    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
     int32_t w = lv_area_get_width(dest_area);
     int32_t h = lv_area_get_height(dest_area);
 
@@ -245,6 +246,8 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_ar
                                                     &last_res_color.ch.alpha);
                         }
                         else
+#else
+                        LV_UNUSED(disp);
 #endif
                         {
                             last_res_color = lv_color_mix_premult(color_premult, dest_buf[x], opa_inv);

--- a/src/draw/sw/lv_draw_sw_polygon.c
+++ b/src/draw/sw/lv_draw_sw_polygon.c
@@ -44,7 +44,7 @@
  * @param clip_area polygon will be drawn only in this area
  * @param draw_dsc pointer to an initialized `lv_draw_rect_dsc_t` variable
  */
-void lv_draw_sw_polygon(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_point_t points[],
+void lv_draw_sw_polygon(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_point_t * points,
                         uint16_t point_cnt)
 {
 #if LV_DRAW_COMPLEX

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -496,7 +496,7 @@ LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
     /*If the screen is transparent initialize it when the flushing is ready*/
 #if LV_COLOR_SCREEN_TRANSP
     if(disp_drv->screen_transp) {
-        if (disp_drv->clear_cb) {
+        if(disp_drv->clear_cb) {
             disp_drv->clear_cb(disp_drv, disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size);
         } else {
             lv_memset_00(disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size * sizeof(lv_color32_t));

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -496,7 +496,11 @@ LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
     /*If the screen is transparent initialize it when the flushing is ready*/
 #if LV_COLOR_SCREEN_TRANSP
     if(disp_drv->screen_transp) {
-        lv_memset_00(disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size * sizeof(lv_color32_t));
+        if (disp_drv->clear_cb) {
+            disp_drv->clear_cb(disp_drv, disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size);
+        } else {
+            lv_memset_00(disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size * sizeof(lv_color32_t));
+        }
     }
 #endif
 

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -498,7 +498,8 @@ LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
     if(disp_drv->screen_transp) {
         if(disp_drv->clear_cb) {
             disp_drv->clear_cb(disp_drv, disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size);
-        } else {
+        }
+        else {
             lv_memset_00(disp_drv->draw_buf->buf_act, disp_drv->draw_buf->size * sizeof(lv_color32_t));
         }
     }

--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -115,6 +115,9 @@ typedef struct _lv_disp_drv_t {
     void (*set_px_cb)(struct _lv_disp_drv_t * disp_drv, uint8_t * buf, lv_coord_t buf_w, lv_coord_t x, lv_coord_t y,
                       lv_color_t color, lv_opa_t opa);
 
+    void (*clear_cb)(struct _lv_disp_drv_t * disp_drv, uint8_t * buf, uint32_t size);
+
+
     /** OPTIONAL: Called after every refresh cycle to tell the rendering and flushing time + the
      * number of flushed pixels*/
     void (*monitor_cb)(struct _lv_disp_drv_t * disp_drv, uint32_t time, uint32_t px);

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -63,6 +63,7 @@ enum {
     LV_BLEND_MODE_ADDITIVE,   /**< Add the respective color channels*/
     LV_BLEND_MODE_SUBTRACTIVE,/**< Subtract the foreground from the background*/
     LV_BLEND_MODE_MULTIPLY,   /**< Multiply the foreground and background*/
+    LV_BLEND_MODE_REPLACE,    /**< Replace background with foreground in the area*/
 };
 
 typedef uint8_t lv_blend_mode_t;


### PR DESCRIPTION
### Description of the feature or fix

This is performance and feature improvement for SDL backend.

* LV_BLEND_MODE_REPLACE was added for transparent background. For screen background, it will completely replace frame buffer content, so if user needs transparency, it will work well.
* Added line/arc implementation - not fully hardware accelerated, but will work better even without mask support

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
