### PR TITLE
fix: removed string format warnings for int32_t and uint32_t

### DIFF
--- a/examples/event/lv_example_event_1.c
+++ b/examples/event/lv_example_event_1.c
@@ -5,10 +5,10 @@ static void event_cb(lv_event_t * e)
 {
     LV_LOG_USER("Clicked");
 
-    static unsigned int cnt = 1;
+    static uint32_t cnt = 1;
     lv_obj_t * btn = lv_event_get_target(e);
     lv_obj_t * label = lv_obj_get_child(btn, 0);
-    lv_label_set_text_fmt(label, "%u", cnt);
+    lv_label_set_text_fmt(label, "%"LV_PRIu32, cnt);
     cnt++;
 }
 

--- a/examples/event/lv_example_event_3.c
+++ b/examples/event/lv_example_event_3.c
@@ -27,14 +27,14 @@ void lv_example_event_3(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 30; i++) {
         lv_obj_t * btn = lv_btn_create(cont);
         lv_obj_set_size(btn, 80, 50);
         lv_obj_add_flag(btn, LV_OBJ_FLAG_EVENT_BUBBLE);
 
         lv_obj_t * label = lv_label_create(btn);
-        lv_label_set_text_fmt(label, "%u", i);
+        lv_label_set_text_fmt(label, "%"LV_PRIu32, i);
         lv_obj_center(label);
     }
 

--- a/examples/get_started/lv_example_get_started_3.c
+++ b/examples/get_started/lv_example_get_started_3.c
@@ -8,7 +8,7 @@ static void slider_event_cb(lv_event_t * e)
     lv_obj_t * slider = lv_event_get_target(e);
 
     /*Refresh the text*/
-    lv_label_set_text_fmt(label, "%d", (int)lv_slider_get_value(slider));
+    lv_label_set_text_fmt(label, "%"LV_PRId32, lv_slider_get_value(slider));
     lv_obj_align_to(label, slider, LV_ALIGN_OUT_TOP_MID, 0, -15);    /*Align top of the slider*/
 }
 

--- a/examples/layouts/flex/lv_example_flex_1.c
+++ b/examples/layouts/flex/lv_example_flex_1.c
@@ -18,7 +18,7 @@ void lv_example_flex_1(void)
     lv_obj_align_to(cont_col, cont_row, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
     lv_obj_set_flex_flow(cont_col, LV_FLEX_FLOW_COLUMN);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 10; i++) {
         lv_obj_t * obj;
         lv_obj_t * label;
@@ -36,7 +36,7 @@ void lv_example_flex_1(void)
         lv_obj_set_size(obj, LV_PCT(100), LV_SIZE_CONTENT);
 
         label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %u", i);
+        lv_label_set_text_fmt(label, "Item: %"LV_PRIu32, i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_2.c
+++ b/examples/layouts/flex/lv_example_flex_2.c
@@ -17,13 +17,13 @@ void lv_example_flex_2(void)
     lv_obj_center(cont);
     lv_obj_add_style(cont, &style, 0);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 8; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%u", i);
+        lv_label_set_text_fmt(label, "%"LV_PRIu32, i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_4.c
+++ b/examples/layouts/flex/lv_example_flex_4.c
@@ -12,13 +12,13 @@ void lv_example_flex_4(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN_REVERSE);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 6; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 100, 50);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %u", i);
+        lv_label_set_text_fmt(label, "Item: %"LV_PRIu32, i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_5.c
+++ b/examples/layouts/flex/lv_example_flex_5.c
@@ -21,13 +21,13 @@ void lv_example_flex_5(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 9; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%u", i);
+        lv_label_set_text_fmt(label, "%"LV_PRIu32, i);
         lv_obj_center(label);
     }
 

--- a/examples/layouts/flex/lv_example_flex_6.c
+++ b/examples/layouts/flex/lv_example_flex_6.c
@@ -13,13 +13,13 @@ void lv_example_flex_6(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 20; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%u", i);
+        lv_label_set_text_fmt(label, "%"LV_PRIu32, i);
         lv_obj_center(label);
     }
 }

--- a/examples/scroll/lv_example_scroll_2.c
+++ b/examples/scroll/lv_example_scroll_2.c
@@ -25,17 +25,17 @@ void lv_example_scroll_2(void)
     lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_ROW);
     lv_obj_align(panel, LV_ALIGN_CENTER, 0, 20);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 10; i++) {
         lv_obj_t * btn = lv_btn_create(panel);
         lv_obj_set_size(btn, 150, lv_pct(100));
 
         lv_obj_t * label = lv_label_create(btn);
         if(i == 3) {
-            lv_label_set_text_fmt(label, "Panel %u\nno snap", i);
+            lv_label_set_text_fmt(label, "Panel %"LV_PRIu32"\nno snap", i);
             lv_obj_clear_flag(btn, LV_OBJ_FLAG_SNAPPABLE);
         } else {
-            lv_label_set_text_fmt(label, "Panel %u", i);
+            lv_label_set_text_fmt(label, "Panel %"LV_PRIu32, i);
         }
 
         lv_obj_center(label);

--- a/examples/scroll/lv_example_scroll_6.c
+++ b/examples/scroll/lv_example_scroll_6.c
@@ -60,13 +60,13 @@ void lv_example_scroll_6(void)
     lv_obj_set_scroll_snap_y(cont, LV_SCROLL_SNAP_CENTER);
     lv_obj_set_scrollbar_mode(cont, LV_SCROLLBAR_MODE_OFF);
 
-    unsigned int i;
+    uint32_t i;
     for(i = 0; i < 20; i++) {
         lv_obj_t * btn = lv_btn_create(cont);
         lv_obj_set_width(btn, lv_pct(100));
 
         lv_obj_t * label = lv_label_create(btn);
-        lv_label_set_text_fmt(label, "Button %u", i);
+        lv_label_set_text_fmt(label, "Button %"LV_PRIu32, i);
     }
 
     /*Update the buttons position manually for first*/

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -74,7 +74,7 @@ void lv_example_table_2(void)
 
     uint32_t i;
     for(i = 0; i < ITEM_CNT; i++) {
-        lv_table_set_cell_value_fmt(table, i, 0, "Item %d", i + 1);
+        lv_table_set_cell_value_fmt(table, i, 0, "Item %"LV_PRIu32, i + 1);
     }
 
     lv_obj_align(table, LV_ALIGN_CENTER, 0, -20);
@@ -86,13 +86,13 @@ void lv_example_table_2(void)
     lv_mem_monitor_t mon2;
     lv_mem_monitor(&mon2);
 
-    long unsigned int mem_used = mon1.free_size - mon2.free_size;
+    uint32_t mem_used = mon1.free_size - mon2.free_size;
 
-    unsigned int elaps = lv_tick_elaps(t);
+    uint32_t elaps = lv_tick_elaps(t);
 
     lv_obj_t * label = lv_label_create(lv_scr_act());
-    lv_label_set_text_fmt(label, "%d items were created in %u ms\n"
-                                  "using %lu bytes of memory",
+    lv_label_set_text_fmt(label, "%"LV_PRIu32" items were created in %"LV_PRIu32" ms\n"
+                                  "using %"LV_PRIu32" bytes of memory",
                                   ITEM_CNT, elaps, mem_used);
 
     lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, -10);

--- a/rt-thread/SConscript
+++ b/rt-thread/SConscript
@@ -10,14 +10,21 @@ src = []
 inc = []
 
 lvgl_cwd = cwd + '/../'
+
 lvgl_src_cwd = lvgl_cwd + 'src/'
-
 inc = inc + [lvgl_src_cwd]
-
 for root, dirs, files in os.walk(lvgl_src_cwd):
     for dir in dirs:
         src = src + Glob(os.path.join(root,dir,'*.c'))
         inc = inc + [os.path.join(root,dir)]
+
+if GetDepend('PKG_USING_LVGL_EXAMPLES'):
+    lvgl_src_cwd = lvgl_cwd + 'examples/'
+    inc = inc + [lvgl_src_cwd]
+    for root, dirs, files in os.walk(lvgl_src_cwd):
+        for dir in dirs:
+            src = src + Glob(os.path.join(root,dir,'*.c'))
+            inc = inc + [os.path.join(root,dir)]
 
 LOCAL_CCFLAGS = ''
 if rtconfig.PLATFORM == 'gcc': # GCC

--- a/rt-thread/lv_rt_thread_conf.h
+++ b/rt-thread/lv_rt_thread_conf.h
@@ -80,6 +80,14 @@
 
 #define LV_ATTRIBUTE_MEM_ALIGN ALIGN(4)
 
+/*==================
+* EXAMPLES
+*==================*/
+
+#ifdef PKG_USING_LVGL_EXAMPLES
+#  define LV_BUILD_EXAMPLES 1
+#endif
+
 /*--END OF LV_RT_THREAD_CONF_H--*/
 
 #endif /*__RTTHREAD__*/

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -272,7 +272,7 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     else {
         perf_last_time = lv_tick_get();
         uint32_t fps_limit = 1000 / disp_refr->refr_timer->period;
-        unsigned int fps;
+        uint32_t fps;
 
         if(elaps_sum == 0) elaps_sum = 1;
         if(frame_cnt == 0) fps = fps_limit;
@@ -283,8 +283,8 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
 
         fps_sum_all += fps;
         fps_sum_cnt ++;
-        unsigned int cpu = 100 - lv_timer_get_idle();
-        lv_label_set_text_fmt(perf_label, "%u FPS\n%u%% CPU", fps, cpu);
+        uint32_t cpu = 100 - lv_timer_get_idle();
+        lv_label_set_text_fmt(perf_label, "%"LV_PRIu32" FPS\n%"LV_PRIu32"%% CPU", fps, cpu);
     }
 #endif
 


### PR DESCRIPTION
re-handle #2722
related:  https://github.com/lvgl/lvgl/pull/2722#issuecomment-997612507
this PR https://github.com/lvgl/lv_demos/pull/146 gives us a good method to handle this kind of problems.

compiled successfully under GCC IAR and Keil-MDK with STM32L4

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
