### PR TITLE
fix lv_dropdown_get_selected_str

### DIFF
--- a/src/widgets/lv_dropdown.c
+++ b/src/widgets/lv_dropdown.c
@@ -372,8 +372,18 @@ void lv_dropdown_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf
 
     uint32_t i;
     uint32_t line        = 0;
-    size_t txt_len     = strlen(dropdown->options);
-
+    size_t txt_len;
+	
+	if (dropdown->options)
+	{
+		txt_len     = strlen(dropdown->options);	
+	}
+	else
+	{
+		buf[0] = '\0';
+		return;		
+	}
+	
     for(i = 0; i < txt_len && line != dropdown->sel_opt_id_orig; i++) {
         if(dropdown->options[i] == '\n') line++;
     }

--- a/src/widgets/lv_dropdown.c
+++ b/src/widgets/lv_dropdown.c
@@ -373,15 +373,15 @@ void lv_dropdown_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf
     uint32_t i;
     uint32_t line        = 0;
     size_t txt_len;
-	
-	if (dropdown->options)	{
-		txt_len     = strlen(dropdown->options);	
-	}
-	else {
-		buf[0] = '\0';
-		return;		
-	}
-	
+
+    if(dropdown->options)  {
+        txt_len     = strlen(dropdown->options);
+    }
+    else {
+        buf[0] = '\0';
+        return;
+    }
+
     for(i = 0; i < txt_len && line != dropdown->sel_opt_id_orig; i++) {
         if(dropdown->options[i] == '\n') line++;
     }

--- a/src/widgets/lv_dropdown.c
+++ b/src/widgets/lv_dropdown.c
@@ -374,12 +374,10 @@ void lv_dropdown_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf
     uint32_t line        = 0;
     size_t txt_len;
 	
-	if (dropdown->options)
-	{
+	if (dropdown->options)	{
 		txt_len     = strlen(dropdown->options);	
 	}
-	else
-	{
+	else {
 		buf[0] = '\0';
 		return;		
 	}


### PR DESCRIPTION
This fix checks for nullptr when the dropbox does not have content
Added a check for nullptr on dropdown->options if NULL then return buf[0]='\0';

