### PR TITLE
fix(player demo): encoding problem

### DIFF
--- a/demos/music/lv_demo_music.c
+++ b/demos/music/lv_demo_music.c
@@ -70,20 +70,20 @@ static const char * artist_list[] = {
 };
 
 static const char * genre_list[] = {
-    "Rock • 1997",
-    "Drum'n bass • 2016",
-    "Psy trance • 2020",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
-    "Metal • 2015",
+    "Rock - 1997",
+    "Drum'n bass - 2016",
+    "Psy trance - 2020",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
+    "Metal - 2015",
 };
 
 static const uint32_t time_list[] = {


### PR DESCRIPTION
Some compilers don't recognize • because of different encoding solutions (e.g. vs2019's encoding is 936 by default if using Chinese Language Windows OS)
I suggest that use FULL ASCII to write demos and examples to avoid encoding issues, in order to let different areas and countires people to run demos and examples easily and perfectly.
![image](https://user-images.githubusercontent.com/34888354/146866410-e3de1bb3-bb46-4e4f-b605-d76cd17a6b3a.png)

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
