### PR TITLE
BG redraw patch for #2934

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -601,7 +601,16 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
 
     /*Draw a display background if there is no top object*/
     if(top_act_scr == NULL && top_prev_scr == NULL) {
-        if(disp_refr->bg_img) {
+        if (draw_ctx->draw_bg) {
+            lv_draw_rect_dsc_t dsc;
+            lv_draw_rect_dsc_init(&dsc);
+            dsc.bg_img_src = disp_refr->bg_img;
+            dsc.bg_img_opa = disp_refr->bg_opa;
+            dsc.bg_color = disp_refr->bg_color;
+            dsc.bg_opa = disp_refr->bg_opa;
+            draw_ctx->draw_bg(draw_ctx, &dsc, draw_ctx->buf_area);
+        }
+        else if(disp_refr->bg_img) {
             lv_img_header_t header;
             lv_res_t res;
             res = lv_img_decoder_get_info(disp_refr->bg_img, &header);
@@ -611,9 +620,6 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
                 lv_draw_img_dsc_t dsc;
                 lv_draw_img_dsc_init(&dsc);
                 dsc.opa = disp_refr->bg_opa;
-                if(dsc.opa < LV_OPA_COVER) {
-                    dsc.blend_mode = LV_BLEND_MODE_REPLACE;
-                }
                 lv_draw_img(draw_ctx, &dsc, &a, disp_refr->bg_img);
             }
             else {
@@ -625,9 +631,6 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
             lv_draw_rect_dsc_init(&dsc);
             dsc.bg_color = disp_refr->bg_color;
             dsc.bg_opa = disp_refr->bg_opa;
-            if(dsc.bg_opa < LV_OPA_COVER) {
-                dsc.blend_mode = LV_BLEND_MODE_REPLACE;
-            }
             lv_draw_rect(draw_ctx, &dsc, draw_ctx->buf_area);
         }
     }

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -601,7 +601,7 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
 
     /*Draw a display background if there is no top object*/
     if(top_act_scr == NULL && top_prev_scr == NULL) {
-        if (draw_ctx->draw_bg) {
+        if(draw_ctx->draw_bg) {
             lv_draw_rect_dsc_t dsc;
             lv_draw_rect_dsc_init(&dsc);
             dsc.bg_img_src = disp_refr->bg_img;

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -81,6 +81,11 @@ typedef struct _lv_draw_ctx_t  {
                          const lv_point_t * points, uint16_t point_cnt);
 
     /**
+     * Replace the buffer with a rect without decoration like radius or borders
+     */
+    void (*draw_bg)(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_area_t * coords);
+
+    /**
      * Wait until all background operation are finished. (E.g. GPU opertions)
      */
     void (*wait_for_finish)(struct _lv_draw_ctx_t * draw);

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -33,6 +33,8 @@ void lv_draw_sdl_draw_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * 
 void lv_draw_sdl_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
                           uint16_t radius, uint16_t start_angle, uint16_t end_angle);
 
+void lv_draw_sdl_draw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords);
+
 void lv_draw_sdl_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
@@ -65,6 +67,7 @@ void lv_draw_sdl_init_ctx(lv_disp_drv_t * disp_drv, lv_draw_ctx_t * draw_ctx)
     draw_ctx->draw_letter = lv_draw_sdl_draw_letter;
     draw_ctx->draw_line = lv_draw_sdl_draw_line;
     draw_ctx->draw_arc = lv_draw_sdl_draw_arc;
+    draw_ctx->draw_bg = lv_draw_sdl_draw_bg;
     lv_draw_sdl_ctx_t * draw_ctx_sdl = (lv_draw_sdl_ctx_t *) draw_ctx;
     draw_ctx_sdl->renderer = ((lv_draw_sdl_drv_param_t *) disp_drv->user_data)->renderer;
     draw_ctx_sdl->base_draw.blend = lv_draw_sdl_blend;

--- a/src/draw/sdl/lv_draw_sdl.mk
+++ b/src/draw/sdl/lv_draw_sdl.mk
@@ -1,4 +1,6 @@
 CSRCS += lv_draw_sdl.c
+CSRCS += lv_draw_sdl_arc.c
+CSRCS += lv_draw_sdl_bg.c
 CSRCS += lv_draw_sdl_blend.c
 CSRCS += lv_draw_sdl_composite.c
 CSRCS += lv_draw_sdl_img.c

--- a/src/draw/sdl/lv_draw_sdl_bg.c
+++ b/src/draw/sdl/lv_draw_sdl_bg.c
@@ -60,7 +60,7 @@ void lv_draw_sdl_draw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * ds
 
     /* Shadows and outlines will also draw in extended area */
     if(has_content) {
-        if (dsc->bg_img_src) {
+        if(dsc->bg_img_src) {
             draw_bg_img(ctx, coords, &t_area, dsc);
         }
         else {

--- a/src/draw/sdl/lv_draw_sdl_bg.c
+++ b/src/draw/sdl/lv_draw_sdl_bg.c
@@ -1,0 +1,106 @@
+/**
+ * @file lv_draw_sdl_bg.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_GPU_SDL
+
+#include "../lv_draw_rect.h"
+#include "../lv_draw_img.h"
+#include "../lv_draw_label.h"
+#include "../lv_draw_mask.h"
+#include "../../core/lv_refr.h"
+#include "lv_draw_sdl_utils.h"
+#include "lv_draw_sdl_texture_cache.h"
+#include "lv_draw_sdl_composite.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                          const lv_draw_rect_dsc_t * dsc);
+
+static void draw_bg_img(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                        const lv_draw_rect_dsc_t * dsc);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sdl_draw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords)
+{
+    const lv_area_t * clip = draw_ctx->clip_area;
+    lv_draw_sdl_ctx_t * ctx = (lv_draw_sdl_ctx_t *) draw_ctx;
+    /* Coords will be translated so coords will start at (0,0) */
+    lv_area_t t_area;
+    bool has_content = _lv_area_intersect(&t_area, coords, clip);
+
+    /* Shadows and outlines will also draw in extended area */
+    if(has_content) {
+        if (dsc->bg_img_src) {
+            draw_bg_img(ctx, coords, &t_area, dsc);
+        }
+        else {
+            draw_bg_color(ctx, coords, &t_area, dsc);
+        }
+    }
+
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void draw_bg_color(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                          const lv_draw_rect_dsc_t * dsc)
+{
+    SDL_Color bg_color;
+    lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
+    SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(ctx->renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);
+
+    SDL_Rect rect;
+    lv_area_to_sdl_rect(draw_area, &rect);
+    SDL_RenderFillRect(ctx->renderer, &rect);
+
+    SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
+}
+
+static void draw_bg_img(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, const lv_area_t * draw_area,
+                        const lv_draw_rect_dsc_t * dsc)
+{
+    SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(ctx->renderer, 0, 0, 0, 0);
+
+    SDL_Rect rect;
+    lv_area_to_sdl_rect(draw_area, &rect);
+    SDL_RenderFillRect(ctx->renderer, &rect);
+
+    SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
+    lv_draw_rect((lv_draw_ctx_t *) ctx, dsc, coords);
+}
+
+#endif /*LV_USE_GPU_SDL*/

--- a/src/draw/sdl/lv_draw_sdl_blend.c
+++ b/src/draw/sdl/lv_draw_sdl_blend.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_draw_blend.c
+ * @file lv_draw_sdl_blend.c
  *
  */
 

--- a/src/draw/sdl/lv_draw_sdl_composite.c
+++ b/src/draw/sdl/lv_draw_sdl_composite.c
@@ -82,7 +82,7 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
     bool has_mask = lv_draw_mask_is_any(apply_area);
 
     const bool draw_mask = has_mask && HAS_CUSTOM_BLEND_MODE;
-    const bool draw_blend = blend_mode != LV_BLEND_MODE_NORMAL && blend_mode != LV_BLEND_MODE_REPLACE;
+    const bool draw_blend = blend_mode != LV_BLEND_MODE_NORMAL;
     if(draw_mask || draw_blend) {
         lv_draw_sdl_context_internals_t * internals = ctx->internals;
         LV_ASSERT(internals->mask == NULL && internals->composition == NULL);
@@ -144,7 +144,6 @@ void lv_draw_sdl_composite_end(lv_draw_sdl_ctx_t * ctx, const lv_area_t * apply_
         SDL_SetRenderTarget(ctx->renderer, ctx->base_draw.base_draw.buf);
         switch(blend_mode) {
             case LV_BLEND_MODE_NORMAL:
-            case LV_BLEND_MODE_REPLACE:
                 SDL_SetTextureBlendMode(internals->composition, SDL_BLENDMODE_BLEND);
                 break;
             case LV_BLEND_MODE_ADDITIVE:

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_draw_img.c
+ * @file lv_draw_sdl_img.c
  *
  */
 

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_draw_label.c
+ * @file lv_draw_sdl_label.c
  *
  */
 

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_draw_sdl_draw_rect.c
+ * @file lv_draw_sdl_rect.c
  *
  */
 
@@ -124,26 +124,9 @@ void lv_draw_sdl_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * 
         extension.y1 = LV_MAX(extension.y1, ext);
         extension.y2 = LV_MAX(extension.y2, ext);
     }
-    if(dsc->blend_mode == LV_BLEND_MODE_REPLACE) {
-        /* Remove all pixels for draw area first */
-        SDL_Rect re_coords, re_clip, re_area;
-        lv_area_to_sdl_rect(coords, &re_coords);
-        lv_area_to_sdl_rect(clip, &re_clip);
-        re_coords.x -= extension.x1;
-        re_coords.w += extension.x1 + extension.x2;
-        re_coords.y -= extension.y1;
-        re_coords.h += extension.y1 + extension.y2;
-        SDL_IntersectRect(&re_coords, &re_clip, &re_area);
-        SDL_Color bg_color;
-        lv_color_to_sdl_color(&dsc->bg_color, &bg_color);
-        SDL_SetRenderDrawColor(ctx->renderer, bg_color.r, bg_color.g, bg_color.b, dsc->bg_opa);
-        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
-        SDL_RenderFillRect(ctx->renderer, &re_area);
-    }
     /* Coords will be translated so coords will start at (0,0) */
     lv_area_t t_coords = *coords, t_clip = *clip, apply_area, t_area;
-    bool has_mask = lv_draw_sdl_composite_begin(ctx, coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip,
-                                                &apply_area);
+    lv_draw_sdl_composite_begin(ctx, coords, clip, &extension, dsc->blend_mode, &t_coords, &t_clip, &apply_area);
     bool has_content = _lv_area_intersect(&t_area, &t_coords, &t_clip);
 
     SDL_Rect clip_rect;

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -46,7 +46,6 @@ static void map_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_c
 static inline lv_color_t color_blend_true_color_additive(lv_color_t fg, lv_color_t bg, lv_opa_t opa);
 static inline lv_color_t color_blend_true_color_subtractive(lv_color_t fg, lv_color_t bg, lv_opa_t opa);
 static inline lv_color_t color_blend_true_color_multiply(lv_color_t fg, lv_color_t bg, lv_opa_t opa);
-static inline lv_color_t color_blend_true_color_replace(lv_color_t fg, lv_color_t bg, lv_opa_t opa);
 #endif /*LV_DRAW_COMPLEX*/
 
 /**********************
@@ -384,9 +383,6 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area,
         case LV_BLEND_MODE_MULTIPLY:
             blend_fp = color_blend_true_color_multiply;
             break;
-        case LV_BLEND_MODE_REPLACE:
-            blend_fp = color_blend_true_color_replace;
-            break;
         default:
             LV_LOG_WARN("fill_blended: unsupported blend mode");
             return;
@@ -623,9 +619,6 @@ static void map_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_c
         case LV_BLEND_MODE_MULTIPLY:
             blend_fp = color_blend_true_color_multiply;
             break;
-        case LV_BLEND_MODE_REPLACE:
-            blend_fp = color_blend_true_color_replace;
-            break;
         default:
             LV_LOG_WARN("fill_blended: unsupported blend mode");
             return;
@@ -758,13 +751,6 @@ static inline lv_color_t color_blend_true_color_multiply(lv_color_t fg, lv_color
     if(opa == LV_OPA_COVER) return fg;
 
     return lv_color_mix(fg, bg, opa);
-}
-
-static inline lv_color_t color_blend_true_color_replace(lv_color_t fg, lv_color_t bg, lv_opa_t opa)
-{
-    LV_UNUSED(bg);
-    LV_UNUSED(opa);
-    return fg;
 }
 
 #endif


### PR DESCRIPTION
reduced usage of blend mode
introduced draw_bg for draw_ctx

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
