### PR TITLE
kconfig: fixes for Zephyr integration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -839,22 +839,19 @@ menu "LVGL configuration"
 
     menu "3rd Party Libraries"
         config LV_USE_FS_STDIO
-            int "File system on top of stdio API"
-            default 0
+            bool "File system on top of stdio API"
         config LV_FS_STDIO_PATH
             string "Set the working directory"
             depends on LV_USE_FS_STDIO
 
         config LV_USE_FS_POSIX
-            int "File system on top of posix API"
-            default 0
+            bool "File system on top of posix API"
         config LV_FS_POSIX_PATH
             string "Set the working directory"
             depends on LV_USE_FS_POSIX
 
         config LV_USE_FS_WIN32
-            int "File system on top of Win32 API"
-            default 0
+            bool "File system on top of Win32 API"
         config LV_FS_WIN32_PATH
             string "Set the working directory"
             depends on LV_USE_FS_WIN32

--- a/Kconfig
+++ b/Kconfig
@@ -13,7 +13,7 @@ menu "LVGL configuration"
         bool "LVGL minimal configuration."
 
     menu "Color settings"
-        choice
+        choice LV_COLOR_DEPTH
             prompt "Color depth."
             default LV_COLOR_DEPTH_16
             help


### PR DESCRIPTION
Here are two Kconfig fixes for bugs I noticed when integrating LVGL's Kconfig with Zephyr's.