### PR TITLE
fix(obj):old parent's scroll is not updated when selv_objt_parent() is called

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -172,6 +172,8 @@ void lv_obj_set_parent(lv_obj_t * obj, lv_obj_t * parent)
     obj->parent = parent;
 
     /*Notify the original parent because one of its children is lost*/
+    lv_obj_readjust_scroll(old_parent, LV_ANIM_OFF);
+    lv_obj_scrollbar_invalidate(old_parent);
     lv_event_send(old_parent, LV_EVENT_CHILD_CHANGED, obj);
     lv_event_send(old_parent, LV_EVENT_CHILD_DELETED, NULL);
 


### PR DESCRIPTION
### Description of the feature or fix

old parent's scroll is not updated when selv_objt_parent() is called. 

test code:
```c
static void scroll_test_timer(struct _lv_timer_t *t)
{
    lv_obj_t *obj = (lv_obj_t *)t->user_data;
    lv_obj_set_parent(obj, lv_scr_act());
    //lv_obj_del(obj);
}
static void scroll_test(void)
{
    lv_obj_t *par = lv_obj_create(lv_scr_act());
    lv_obj_center(par);
    lv_obj_set_size(par, 400, 400);
    lv_obj_set_style_border_width(par, 1, 0);
    lv_obj_set_style_border_color(par, lv_palette_main(LV_PALETTE_ORANGE), 0);
    lv_obj_t *child_obj[5];
    for (int col = 0; col < 5; col++) {
        lv_obj_t *child = lv_obj_create(par);
        lv_obj_set_pos(child, col * 230, 0);
        lv_obj_set_size(child, 200, 200);
        lv_obj_t *label = lv_label_create(child);
        char buff[16];
        snprintf(buff, 16, "%d", col);
        lv_label_set_text(label, buff);
        child_obj[col] = child;
    }

    lv_timer_t * timer = lv_timer_create(scroll_test_timer, 5000, child_obj[4]);
    lv_timer_set_repeat_count(timer, 1);
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
