### PR TITLE
chore(obj):delete duplicate code in lv_obj_del()

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -49,9 +49,6 @@ void lv_obj_del(lv_obj_t * obj)
     lv_obj_invalidate(obj);
 
     lv_obj_t * par = lv_obj_get_parent(obj);
-    if(par) {
-        lv_obj_scrollbar_invalidate(par);
-    }
 
     lv_disp_t * disp = NULL;
     bool act_scr_del = false;


### PR DESCRIPTION
### Description of the feature or fix

[line 69](https://github.com/lvgl/lvgl/blob/master/src/core/lv_obj_tree.c#L69) seems to have done the work of [line 52](https://github.com/lvgl/lvgl/blob/master/src/core/lv_obj_tree.c#L52~L54) .


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
