### PR TITLE
fix(snapshot): fix memory leak

### DIFF
--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -142,6 +142,7 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
 
     _lv_refr_set_disp_refreshing(refr_ori);
     obj_disp->driver->draw_ctx_deinit(fake_disp.driver, draw_ctx);
+    lv_mem_free(draw_ctx);
 
     dsc->data = buf;
     dsc->header.w = w;

--- a/tests/src/test_cases/test_snapshot.c
+++ b/tests/src/test_cases/test_snapshot.c
@@ -1,0 +1,37 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+
+#define NUM_SNAPSHOTS 1
+
+void test_snapshot_should_not_leak_memory(void)
+{
+    uint32_t idx = 0;
+    uint32_t initial_available_memory = 0;
+    uint32_t final_available_memory = 0;
+    lv_mem_monitor_t monitor;
+
+    lv_img_dsc_t *snapshots[NUM_SNAPSHOTS] = {NULL};
+
+    lv_mem_monitor(&monitor);
+    initial_available_memory = monitor.free_size;
+
+    for(idx = 0; idx < NUM_SNAPSHOTS; idx++) {
+        snapshots[idx] = lv_snapshot_take(lv_scr_act(), LV_IMG_CF_TRUE_COLOR_ALPHA);
+        TEST_ASSERT_NOT_NULL(snapshots[idx]);
+    }
+    
+    for(idx = 0; idx < NUM_SNAPSHOTS; idx++) {
+        lv_snapshot_free(snapshots[idx]);
+    }
+    
+    lv_mem_monitor(&monitor);
+    final_available_memory = monitor.free_size;
+
+    TEST_ASSERT_EQUAL(initial_available_memory, final_available_memory);
+}
+
+
+#endif


### PR DESCRIPTION
Free draw_ctx after snapshot is over.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
