### PR TITLE
fix(rlottie): fix variable name

### DIFF
--- a/src/extra/libs/rlottie/lv_rlottie.c
+++ b/src/extra/libs/rlottie/lv_rlottie.c
@@ -211,7 +211,7 @@ static void convert_to_rgba5658(uint32_t * pix, const size_t width, const size_t
             uint16_t r = (uint16_t)(((in & 0xF80000) >> 8) | ((in & 0xFC00) >> 5) | ((in & 0xFF) >> 3));
 #else
             /* We want: rrrr rrrr GGGg gggg bbbb bbbb => gggb bbbb rrrr rGGG */
-            uint16_t r = (uint16_t)(((c & 0xF80000) >> 16) | ((c & 0xFC00) >> 13) | ((c & 0x1C00) << 3) | ((c & 0xF8) << 5));
+            uint16_t r = (uint16_t)(((in & 0xF80000) >> 16) | ((in & 0xFC00) >> 13) | ((in & 0x1C00) << 3) | ((in & 0xF8) << 5));
 #endif
 
             lv_memcpy(dest, &r, sizeof(r));


### PR DESCRIPTION
### Description of the feature or fix

Couldn't compile because `'c': undeclared identifier` error if `LV_COLOR_16_SWAP` is enabled. Variable `c` was probably a leftover from previous version of the code.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
