### PR TITLE
fix(porting): fix typo and an unmatched prototype

### DIFF
--- a/examples/porting/lv_port_fs_template.c
+++ b/examples/porting/lv_port_fs_template.c
@@ -25,7 +25,7 @@
  **********************/
 static void fs_init(void);
 
-static void * fs_open(lv_fs_drv_t * drv, void * file_p, const char * path, lv_fs_mode_t mode);
+static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
 static lv_fs_res_t fs_close(lv_fs_drv_t * drv, void * file_p);
 static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_t btr, uint32_t * br);
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw);
@@ -125,7 +125,7 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
         f = ...         /*Add your code here*/
     }
 
-    return file;
+    return f;
 }
 
 /**


### PR DESCRIPTION
### Description of the feature or fix

The prototype of function **_fs_open()_** unmatches the implementation.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
