### PR TITLE
fix(font):may crash if f->fallback == NULL

### DIFF
--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -77,6 +77,21 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
             LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", letter);
+
+            /* draw placeholder */
+            lv_area_t glyph_coords;
+            lv_draw_rect_dsc_t glyph_dsc;
+            lv_coord_t begin_x = pos_p->x + g.ofs_x;
+            lv_coord_t begin_y = pos_p->y + g.ofs_y;
+            lv_area_set(&glyph_coords, begin_x, begin_y, begin_x + g.box_w, begin_y + g.box_h);
+            lv_draw_rect_dsc_init(&glyph_dsc);
+            glyph_dsc.bg_opa = LV_OPA_MIN;
+            glyph_dsc.outline_opa = LV_OPA_MIN;
+            glyph_dsc.shadow_opa = LV_OPA_MIN;
+            glyph_dsc.bg_img_opa = LV_OPA_MIN;
+            glyph_dsc.border_color = dsc->color;
+            glyph_dsc.border_width = 1;
+            draw_ctx->draw_rect(draw_ctx, &glyph_dsc, &glyph_coords);
         }
         return;
     }

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -97,13 +97,28 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
 {
     lv_font_glyph_dsc_t g;
     bool g_ret = lv_font_get_glyph_dsc(dsc->font, &g, letter, '\0');
-    if(g_ret == false)  {
+    if(g_ret == false) {
         /*Add warning if the dsc is not found
          *but do not print warning for non printable ASCII chars (e.g. '\n')*/
         if(letter >= 0x20 &&
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", (unsigned int)letter);
+            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" PRIX32, letter);
+
+            /* draw placeholder */
+            lv_area_t glyph_coords;
+            lv_draw_rect_dsc_t glyph_dsc;
+            lv_coord_t begin_x = pos_p->x + g.ofs_x;
+            lv_coord_t begin_y = pos_p->y + g.ofs_y;
+            lv_area_set(&glyph_coords, begin_x, begin_y, begin_x + g.box_w, begin_y + g.box_h);
+            lv_draw_rect_dsc_init(&glyph_dsc);
+            glyph_dsc.bg_opa = LV_OPA_MIN;
+            glyph_dsc.outline_opa = LV_OPA_MIN;
+            glyph_dsc.shadow_opa = LV_OPA_MIN;
+            glyph_dsc.bg_img_opa = LV_OPA_MIN;
+            glyph_dsc.border_color = dsc->color;
+            glyph_dsc.border_width = 1;
+            draw_ctx->draw_rect(draw_ctx, &glyph_dsc, &glyph_coords);
         }
         return;
     }


### PR DESCRIPTION
### Description of the feature or fix

dsc_out->resolved_font should point to the previous font if f->fallback == NULL

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
