### PR TITLE
Add preprocessing and stop bubbling features for events

### DIFF
--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -62,6 +62,8 @@ lv_res_t lv_event_send(lv_obj_t * obj, lv_event_code_t event_code, void * param)
     e.user_data = NULL;
     e.param = param;
     e.deleted = 0;
+    e.stop_bubbling = 0;
+    e.stop_processing = 0;
 
     /*Build a simple linked list from the objects used in the events
      *It's important to know if an this object was deleted by a nested event
@@ -115,7 +117,7 @@ lv_obj_t * lv_event_get_current_target(lv_event_t * e)
 
 lv_event_code_t lv_event_get_code(lv_event_t * e)
 {
-    return e->code;
+    return e->code & ~LV_EVENT_PREPROCESS;
 }
 
 void * lv_event_get_param(lv_event_t * e)
@@ -126,6 +128,16 @@ void * lv_event_get_param(lv_event_t * e)
 void * lv_event_get_user_data(lv_event_t * e)
 {
     return e->user_data;
+}
+
+void lv_event_stop_bubbling(lv_event_t * e)
+{
+    e->stop_bubbling = 1;
+}
+
+void lv_event_stop_processing(lv_event_t * e)
+{
+    e->stop_processing = 1;
 }
 
 
@@ -419,20 +431,42 @@ static lv_res_t event_send_core(lv_event_t * e)
     lv_indev_t * indev_act = lv_indev_get_act();
     if(indev_act) {
         if(indev_act->driver->feedback_cb) indev_act->driver->feedback_cb(indev_act->driver, e->code);
+        if(e->stop_processing) return LV_RES_OK;
         if(e->deleted) return LV_RES_INV;
     }
 
     lv_res_t res = LV_RES_OK;
-    res = lv_obj_event_base(NULL, e);
-
     lv_event_dsc_t * event_dsc = res == LV_RES_INV ? NULL : lv_obj_get_event_dsc(e->current_target, 0);
 
     uint32_t i = 0;
     while(event_dsc && res == LV_RES_OK) {
-        if(event_dsc->cb && (event_dsc->filter == LV_EVENT_ALL || event_dsc->filter == e->code)) {
+        if(event_dsc->cb  && ((event_dsc->filter & LV_EVENT_PREPROCESS) == LV_EVENT_PREPROCESS)
+           && (event_dsc->filter == (LV_EVENT_ALL | LV_EVENT_PREPROCESS) ||
+               (event_dsc->filter & ~LV_EVENT_PREPROCESS) == e->code)) {
             e->user_data = event_dsc->user_data;
             event_dsc->cb(e);
 
+            if(e->stop_processing) return LV_RES_OK;
+            /*Stop if the object is deleted*/
+            if(e->deleted) return LV_RES_INV;
+        }
+
+        i++;
+        event_dsc = lv_obj_get_event_dsc(e->current_target, i);
+    }
+
+    res = lv_obj_event_base(NULL, e);
+
+    event_dsc = res == LV_RES_INV ? NULL : lv_obj_get_event_dsc(e->current_target, 0);
+
+    i = 0;
+    while(event_dsc && res == LV_RES_OK) {
+        if(event_dsc->cb && ((event_dsc->filter & LV_EVENT_PREPROCESS) == 0)
+           && (event_dsc->filter == LV_EVENT_ALL || event_dsc->filter == e->code)) {
+            e->user_data = event_dsc->user_data;
+            event_dsc->cb(e);
+
+            if(e->stop_processing) return LV_RES_OK;
             /*Stop if the object is deleted*/
             if(e->deleted) return LV_RES_INV;
         }
@@ -445,7 +479,6 @@ static lv_res_t event_send_core(lv_event_t * e)
         e->current_target = e->current_target->parent;
         res = event_send_core(e);
         if(res != LV_RES_OK) return LV_RES_INV;
-
     }
 
     return res;
@@ -453,6 +486,8 @@ static lv_res_t event_send_core(lv_event_t * e)
 
 static bool event_is_bubbled(lv_event_t * e)
 {
+    if(e->stop_bubbling) return false;
+
     /*Event codes that always bubble*/
     switch(e->code) {
         case LV_EVENT_CHILD_CREATED:

--- a/src/core/lv_event.h
+++ b/src/core/lv_event.h
@@ -84,7 +84,11 @@ typedef enum {
     LV_EVENT_LAYOUT_CHANGED,      /**< The children position has changed due to a layout recalculation*/
     LV_EVENT_GET_SELF_SIZE,       /**< Get the internal size of a widget*/
 
-    _LV_EVENT_LAST                /** Number of default events*/
+    _LV_EVENT_LAST,               /** Number of default events*/
+
+
+    LV_EVENT_PREPROCESS = 0x80,   /** This is a flag that can be set with a event so it's processed
+                                      before the class default event processing */
 } lv_event_code_t;
 
 typedef struct _lv_event_t {
@@ -95,6 +99,8 @@ typedef struct _lv_event_t {
     void * param;
     struct _lv_event_t * prev;
     uint8_t deleted : 1;
+    uint8_t stop_processing : 1;
+    uint8_t stop_bubbling : 1;
 } lv_event_t;
 
 /**
@@ -183,6 +189,19 @@ void * lv_event_get_param(lv_event_t * e);
  */
 void * lv_event_get_user_data(lv_event_t * e);
 
+/**
+ * Stop the event from bubbling.
+ * This is only valid when called in the middle of a event processing chain.
+ * @param e     pointer to the event descriptor
+ */
+void lv_event_stop_bubbling(lv_event_t * e);
+
+/**
+ * Stop processing this event.
+ * This is only valid when called in the middle of a event processing chain.
+ * @param e     pointer to the event descriptor
+ */
+void lv_event_stop_processing(lv_event_t * e);
 
 /**
  * Register a new, custom event ID.


### PR DESCRIPTION
### Description of the feature or fix

Fix #2985 

Example code:
```cpp
lv_obj_t * toggle = 0;

static void event_handler(lv_event_t * e)
{
    lv_event_code_t code = lv_event_get_code(e);
    lv_obj_t * obj = lv_event_get_target(e);
    if (obj != toggle && toggle && !(lv_obj_get_state(toggle) & LV_STATE_CHECKED) && code == LV_EVENT_PRESSED) {
      /*Don't process this event, so the button will be inert unless the other button is toggled*/
      lv_event_stop_processing(e);
      LV_LOG_USER("Pressed, but ignored");
      return;
    }

    if(code == LV_EVENT_CLICKED) {
        LV_LOG_USER("Clicked");
    }
    else if(code == LV_EVENT_VALUE_CHANGED) {
        LV_LOG_USER("Toggled");
    }
}

void example_event(void)
{
    lv_obj_t * label;

    lv_obj_t * btn1 = lv_btn_create(lv_scr_act());
    lv_obj_add_event_cb(btn1, event_handler, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
    lv_obj_align(btn1, LV_ALIGN_CENTER, 0, -40);

    label = lv_label_create(btn1);
    lv_label_set_text(label, "Button");
    lv_obj_center(label);

    lv_obj_t * btn2 = lv_btn_create(lv_scr_act());
    lv_obj_add_event_cb(btn2, event_handler, LV_EVENT_ALL, NULL);
    lv_obj_align(btn2, LV_ALIGN_CENTER, 0, 40);
    lv_obj_add_flag(btn2, LV_OBJ_FLAG_CHECKABLE);
    lv_obj_set_height(btn2, LV_SIZE_CONTENT);

    label = lv_label_create(btn2);
    lv_label_set_text(label, "Toggle");
    lv_obj_center(label);
    toggle = btn2;
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
