### PR TITLE
Missing semicolons in Animation Image example

### DIFF
--- a/examples/widgets/animimg/lv_example_animimg_1.c
+++ b/examples/widgets/animimg/lv_example_animimg_1.c
@@ -1,8 +1,8 @@
 #include "../../lv_examples.h"
 #if LV_USE_ANIMIMG && LV_BUILD_EXAMPLES
-LV_IMG_DECLARE(animimg001)
-LV_IMG_DECLARE(animimg002)
-LV_IMG_DECLARE(animimg003)
+LV_IMG_DECLARE(animimg001);
+LV_IMG_DECLARE(animimg002);
+LV_IMG_DECLARE(animimg003);
 
 static const lv_img_dsc_t* anim_imgs[3] = {
     &animimg001,


### PR DESCRIPTION
### Description of the feature or fix
As far as I know, semicolons are mandatory here.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
