### PR TITLE
fix(rt-thread): use ARCH_CPU_BIG_ENDIAN to replace RT_USING_BIG_ENDIAN

### DIFF
--- a/env_support/rt-thread/lv_rt_thread_conf.h
+++ b/env_support/rt-thread/lv_rt_thread_conf.h
@@ -71,7 +71,7 @@
  *  COMPILER SETTINGS
  *====================*/
 
-#ifdef RT_USING_BIG_ENDIAN
+#ifdef ARCH_CPU_BIG_ENDIAN
 #  define LV_BIG_ENDIAN_SYSTEM 1
 #else
 #  define LV_BIG_ENDIAN_SYSTEM 0


### PR DESCRIPTION
### Description of the feature or fix

This will be last PR before v8.2 released.
RT-Thread will also release v4.1.0 Beta in Jan.
Thanks.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
