### PR TITLE
Fixes to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -884,33 +884,39 @@ menu "LVGL configuration"
             bool "File system on top of posix API"
         config LV_FS_POSIX_LETTER
             int "Set an upper cased letter on which the drive will accessible (e.g. 'A' i.e. 65)"
+            default 0
             depends on LV_USE_FS_POSIX != 0
         config LV_FS_POSIX_PATH
             string "Set the working directory"
             depends on LV_USE_FS_POSIX != 0
         config LV_FS_POSIX_CACHE_SIZE
             int ">0 to cache this number of bytes in lv_fs_read()"
+            default 0
             depends on LV_USE_FS_POSIX != 0
 
         config LV_USE_FS_WIN32
             bool "File system on top of Win32 API"
         config LV_FS_WIN32_LETTER
             int "Set an upper cased letter on which the drive will accessible (e.g. 'A' i.e. 65)"
+            default 0
             depends on LV_USE_FS_WIN32 != 0
         config LV_FS_WIN32_PATH
             string "Set the working directory"
             depends on LV_USE_FS_WIN32 != 0
         config LV_FS_WIN32_CACHE_SIZE
             int ">0 to cache this number of bytes in lv_fs_read()"
+            default 0
             depends on LV_USE_FS_WIN32 != 0
 
         config LV_USE_FS_FATFS
             bool "File system on top of FatFS"
         config LV_FS_FATFS_LETTER
             int "Set an upper cased letter on which the drive will accessible (e.g. 'A' i.e. 65)"
+            default 0
             depends on LV_USE_FS_FATFS != 0
         config LV_FS_FATFS_CACHE_SIZE
             int ">0 to cache this number of bytes in lv_fs_read()"
+            default 0
             depends on LV_USE_FS_FATFS != 0
 
         config LV_USE_PNG


### PR DESCRIPTION
Seems that esp-idf is processing LVGL Kconfig and fails with error on esp-idf 4.0.2:
```
-- Building ESP-IDF components for target esp32
Loading defaults file /home/runner/work/lv_micropython/lv_micropython/ports/esp32/build-GENERIC/sdkconfig.combined...
Traceback (most recent call last):
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/confgen.py", line 584, in <module>
    main()
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/confgen.py", line 282, in main
    output_function(deprecated_options, config, temp_file)
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/confgen.py", line 426, in write_json
    config_dict = get_json_values(config)
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/confgen.py", line 421, in get_json_values
    config.walk_menu(write_node)
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/kconfiglib.py", line 971, in walk_menu
    callback(node)
  File "/home/runner/work/lv_micropython/lv_micropython/esp-idf/tools/kconfig_new/confgen.py", line 419, in write_node
    val = int(val)
ValueError: invalid literal for int() with base 10: ''
```

Related: 
- https://github.com/lvgl/lv_micropython/pull/49
- https://github.com/lvgl/lv_micropython/runs/4958046580?check_suite_focus=true
