### PR TITLE
fix(porting): add missing function prototypes

### DIFF
--- a/examples/porting/lv_port_disp_template.h
+++ b/examples/porting/lv_port_disp_template.h
@@ -29,6 +29,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+extern void lv_port_disp_init(void);
 
 /**********************
  *      MACROS

--- a/examples/porting/lv_port_disp_template.h
+++ b/examples/porting/lv_port_disp_template.h
@@ -29,7 +29,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-extern void lv_port_disp_init(void);
+void lv_port_disp_init(void);
 
 /**********************
  *      MACROS

--- a/examples/porting/lv_port_fs_template.h
+++ b/examples/porting/lv_port_fs_template.h
@@ -29,7 +29,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
- extern void lv_port_fs_init(void);
+ void lv_port_fs_init(void);
 
 /**********************
  *      MACROS

--- a/examples/porting/lv_port_fs_template.h
+++ b/examples/porting/lv_port_fs_template.h
@@ -29,6 +29,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+ extern void lv_port_fs_init(void);
 
 /**********************
  *      MACROS

--- a/examples/porting/lv_port_indev_template.h
+++ b/examples/porting/lv_port_indev_template.h
@@ -30,6 +30,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+extern void lv_port_indev_init(void);
 
 /**********************
  *      MACROS

--- a/examples/porting/lv_port_indev_template.h
+++ b/examples/porting/lv_port_indev_template.h
@@ -30,7 +30,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-extern void lv_port_indev_init(void);
+void lv_port_indev_init(void);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

It appears that in the porting template header files, there is no function prototype for lv_port_xxx_init().

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
