### PR TITLE
fix: increase default value of LV_MEM_SIZE for demo:widgets #3057

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -53,10 +53,19 @@
 ## Demos
 
 ### Widgets
-Shows how the widgets look like out of the box using the built-in material theme.  
+Shows how the widgets look like out of the box using the built-in material theme.  
+
 See in [lv_demo_widgets](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_widgets) folder.
 
 <img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_widgets/screenshot1.png?raw=true" width=600px alt="Basic demo to show the widgets of LVGL">
+
+For running this demo properly, please make sure **LV_MEM_SIZE** is at least **38KB** (and **48KB** is recommended):
+
+```c
+#define LV_MEME_SIZE    (38ul * 1024ul)
+```
+
+
 
 ### Music player
 The music player demo shows what kind of modern, smartphone-like user interfaces can be created on LVGL. It works the best with display with 480x272 or 272x480 resolution. 

--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -11,7 +11,7 @@
 #if LV_USE_DEMO_WIDGETS
 
 #if LV_MEM_CUSTOM == 0 && LV_MEM_SIZE < (38ul * 1024ul)
-    #error Insufficient memory for demo:Widgets, please set LV_MEM_SIZE to at least 38KBte (38ul * 1024ul) and 48KB is recommended. 
+    #error Insufficient memory for lv_demo_widgets. Please set LV_MEM_SIZE to at least 38KB (38ul * 1024ul).  48KB is recommended. 
 #endif
 
 /*********************

--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -10,6 +10,10 @@
 
 #if LV_USE_DEMO_WIDGETS
 
+#if LV_MEM_CUSTOM == 0 && LV_MEM_SIZE < (38ul * 1024ul)
+    #error Insufficient memory for demo:Widgets, please set LV_MEM_SIZE to at least 38KBte (38ul * 1024ul) and 48KB is recommended. 
+#endif
+
 /*********************
  *      DEFINES
  *********************/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -49,7 +49,7 @@
 #define LV_MEM_CUSTOM 0
 #if LV_MEM_CUSTOM == 0
     /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (32U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
 
     /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
     #define LV_MEM_ADR 0     /*0: unused*/


### PR DESCRIPTION
### Description of the feature or fix

As described in #3057, the original default value of LV_MEM_SIZE is too small to run the demo:Widgets. 
Increase it to 48KB as suggested.  Demos/README.md is updated.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
