### PR TITLE
feat(porting): add a macro lv_run_timer_handler_in_period to simplify porting

### DIFF
--- a/docs/porting/os.md
+++ b/docs/porting/os.md
@@ -53,12 +53,12 @@ Try to avoid calling LVGL functions from interrupt handlers (except `lv_tick_inc
 
 It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).  
 
-Try to avoid calling `lv_timer_handler` in any interrupt handler. One of the recommend way is using `lv_run_timer_handler_in_period()` in a super loop. For example:
+Try to avoid calling `lv_timer_handler` in any interrupt handler. One of the recommend way is using `lv_timer_handler_run_in_period()` in a super loop. For example:
 
 ```c
 while(1) {
     ...
-    lv_run_timer_handler_in_period(5);
+    lv_timer_handler_run_in_period(5); /* run lv_timer_handler every 5ms */
     ...
 }
 ```

--- a/docs/porting/os.md
+++ b/docs/porting/os.md
@@ -51,4 +51,14 @@ void other_thread(void)
 ## Interrupts
 Try to avoid calling LVGL functions from interrupt handlers (except `lv_tick_inc()` and `lv_disp_flush_ready()`). But if you need to do this you have to disable the interrupt which uses LVGL functions while `lv_timer_handler` is running.
 
-It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).
+It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).  One of the recommend way of calling `lv_timer_handler` is using the helper macro `lv_run_timer_handler_in_period()` in a super loop. For example:
+
+```c
+while(1) {
+    ...
+    lv_run_timer_handler_in_period(5);
+    ...
+}
+```
+
+To learn more about this, please visit the [Task Handler](/porting/task-handler) section.

--- a/docs/porting/os.md
+++ b/docs/porting/os.md
@@ -51,16 +51,4 @@ void other_thread(void)
 ## Interrupts
 Try to avoid calling LVGL functions from interrupt handlers (except `lv_tick_inc()` and `lv_disp_flush_ready()`). But if you need to do this you have to disable the interrupt which uses LVGL functions while `lv_timer_handler` is running.
 
-It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).  
-
-Try to avoid calling `lv_timer_handler` in any interrupt handler. One of the recommend way is using `lv_timer_handler_run_in_period()` in a super loop. For example:
-
-```c
-while(1) {
-    ...
-    lv_timer_handler_run_in_period(5); /* run lv_timer_handler every 5ms */
-    ...
-}
-```
-
-To learn more about this, please visit the [Task Handler](/porting/task-handler) section.
+It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).

--- a/docs/porting/os.md
+++ b/docs/porting/os.md
@@ -51,7 +51,9 @@ void other_thread(void)
 ## Interrupts
 Try to avoid calling LVGL functions from interrupt handlers (except `lv_tick_inc()` and `lv_disp_flush_ready()`). But if you need to do this you have to disable the interrupt which uses LVGL functions while `lv_timer_handler` is running.
 
-It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).  One of the recommend way of calling `lv_timer_handler` is using the helper macro `lv_run_timer_handler_in_period()` in a super loop. For example:
+It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`).  
+
+Try to avoid calling `lv_timer_handler` in any interrupt handler. One of the recommend way is using `lv_run_timer_handler_in_period()` in a super loop. For example:
 
 ```c
 while(1) {

--- a/docs/porting/task-handler.md
+++ b/docs/porting/task-handler.md
@@ -19,5 +19,24 @@ while(1) {
 }
 ```
 
+If you intend to use `lv_timer_handler()` in a super-loop, a helper macro  `lv_run_timer_handler_in_period(__ms)` is provided to simplify the porting:
+
+```c
+while(1) {
+    ...
+    lv_run_timer_handler_in_period(5);
+    ...
+}
+```
+
+ In OS environment, you can use it together with the delay or sleep provided by OS:
+
+```c
+while (1) {
+    lv_run_timer_handler_in_period(5);
+    sleep(5);
+} 
+```
+
 To learn more about timers visit the [Timer](/overview/timer) section.
 

--- a/docs/porting/task-handler.md
+++ b/docs/porting/task-handler.md
@@ -24,7 +24,7 @@ If you intend to use `lv_timer_handler()` in a super-loop, a helper function`lv_
 ```c
 while(1) {
     ...
-    lv_run_timer_handler_in_period(5);
+    lv_timer_handler_run_period(5); /* run lv_timer_handler() every 5ms */
     ...
 }
 ```
@@ -33,8 +33,8 @@ while(1) {
 
 ```c
 while (1) {
-    lv_run_timer_handler_in_period(5);
-    sleep(5);
+    lv_timer_handler_run_in_period(5); /* run lv_timer_handler() every 5ms */
+    sleep(5); /* sleep 5ms */
 } 
 ```
 

--- a/docs/porting/task-handler.md
+++ b/docs/porting/task-handler.md
@@ -19,7 +19,7 @@ while(1) {
 }
 ```
 
-If you intend to use `lv_timer_handler()` in a super-loop, a helper macro  `lv_run_timer_handler_in_period(__ms)` is provided to simplify the porting:
+If you intend to use `lv_timer_handler()` in a super-loop, a helper function`lv_run_timer_handler_in_period(__ms)` is provided to simplify the porting:
 
 ```c
 while(1) {

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -28,21 +28,24 @@ extern "C" {
 
 /**
  * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
- * with a given period in ms.
- * This macro is used to simplify the porting.
+ * with a given period in ms. You can use it with sleep or delay in OS environment.
+ * This function is used to simplify the porting.
  * @param __ms the period for running lv_timer_handler()
  */
-#define lv_run_timer_handler_in_period(__ms)                                    \
-        do {                                                                    \
-            static uint32_t last_tick = 0;                                      \
-            uint32_t curr_tick = lv_tick_get();                                 \
-                                                                                \
-            if ((curr_tick - last_tick) >= (__ms)) {                            \
-                last_tick = curr_tick;                                          \
-                lv_timer_handler();                                             \
-            }                                                                   \
-        } while(0)
         
+static inline LV_ATTRIBUTE_TIMER_HANDLER 
+uint32_t lv_timer_handler_run_in_period(uint32_t ms)
+{
+    static uint32_t last_tick = 0;
+    uint32_t curr_tick = lv_tick_get();
+
+    if ((curr_tick - last_tick) >= (__ms)) {
+        last_tick = curr_tick;
+        return lv_timer_handler();
+    }
+    return 1;
+}
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -26,6 +26,23 @@ extern "C" {
 
 #define LV_NO_TIMER_READY 0xFFFFFFFF
 
+/**
+ * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
+ * with a given period in ms.
+ * This macro is used to simplify the porting.
+ * @param __ms the period for running lv_timer_handler()
+ */
+#define lv_run_timer_handler_in_period(__ms)                                    \
+        do {                                                                    \
+            static uint32_t last_tick = 0;                                      \
+            uint32_t curr_tick = lv_tick_get();                                 \
+                                                                                \
+            if ((curr_tick - last_tick) >= (__ms)) {                            \
+                last_tick = curr_tick;                                          \
+                lv_timer_handler();                                             \
+            }                                                                   \
+        } while(0)
+        
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -13,6 +13,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "../hal/lv_hal_tick.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -25,26 +26,6 @@ extern "C" {
 #endif
 
 #define LV_NO_TIMER_READY 0xFFFFFFFF
-
-/**
- * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
- * with a given period in ms. You can use it with sleep or delay in OS environment.
- * This function is used to simplify the porting.
- * @param __ms the period for running lv_timer_handler()
- */
-        
-static inline LV_ATTRIBUTE_TIMER_HANDLER 
-uint32_t lv_timer_handler_run_in_period(uint32_t ms)
-{
-    static uint32_t last_tick = 0;
-    uint32_t curr_tick = lv_tick_get();
-
-    if ((curr_tick - last_tick) >= (ms)) {
-        last_tick = curr_tick;
-        return lv_timer_handler();
-    }
-    return 1;
-}
 
 /**********************
  *      TYPEDEFS
@@ -87,6 +68,24 @@ void _lv_timer_core_init(void);
 LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
 
 //! @endcond
+
+/**
+ * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
+ * with a given period in ms. You can use it with sleep or delay in OS environment.
+ * This function is used to simplify the porting.
+ * @param __ms the period for running lv_timer_handler()
+ */
+static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period(uint32_t ms)
+{
+    static uint32_t last_tick = 0;
+    uint32_t curr_tick = lv_tick_get();
+
+    if ((curr_tick - last_tick) >= (ms)) {
+        last_tick = curr_tick;
+        return lv_timer_handler();
+    }
+    return 1;
+}
 
 /**
  * Create an "empty" timer. It needs to initialized with at least

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -39,7 +39,7 @@ uint32_t lv_timer_handler_run_in_period(uint32_t ms)
     static uint32_t last_tick = 0;
     uint32_t curr_tick = lv_tick_get();
 
-    if ((curr_tick - last_tick) >= (__ms)) {
+    if ((curr_tick - last_tick) >= (ms)) {
         last_tick = curr_tick;
         return lv_timer_handler();
     }


### PR DESCRIPTION
### Description of the feature or fix

In the past, a recommended way to call `lv_timer_handler()` is 
> ...It's a better approach to simply set a flag or some value in the interrupt, and periodically check it in an LVGL timer (which is run by `lv_timer_handler`)...

A helper macro `lv_run_timer_handler_in_period()` provide a simplified way to call `lv_timer_handler()` repeatedly in a given period. It uses lv_tick_get() to avoid using flags+Timer ISR. 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
