### PR TITLE
fix(cmsis-pack): add PIDX for cmsis-pack

### DIFF
--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
+  <vendor>LVGL</vendor>
+  <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
+  <timestamp>2022-01-31T12:31:00</timestamp>
+  <pindex>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.0"/>
+  </pindex>
+</index>


### PR DESCRIPTION
### Description of the feature or fix

Listing cmsis-pack on Arm website need a LVGL.pidx file.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
