### PR TITLE
Use LV_DIR_VER instead of LV_DIR_TOP

### DIFF
--- a/docs/overview/scroll.md
+++ b/docs/overview/scroll.md
@@ -81,7 +81,7 @@ The following values are possible for the direction:
 - `LV_DIR_BOTTOM` only scroll down
 - `LV_DIR_RIGHT` only scroll right
 - `LV_DIR_HOR` only scroll horizontally
-- `LV_DIR_TOP` only scroll vertically
+- `LV_DIR_VER` only scroll vertically
 - `LV_DIR_ALL` scroll any directions
 
 OR-ed values are also possible. E.g. `LV_DIR_TOP | LV_DIR_LEFT`.


### PR DESCRIPTION
### Description of the feature or fix

Just a little problem with the documentation. Bad usage of LV_DIR_TOP

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation
