### PR TITLE
fix(refr) prevent refresh of inactive objects

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -585,34 +585,35 @@ bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area)
     /*Invalidate the object only if it belongs to the current or previous'*/
     lv_obj_t * obj_scr = lv_obj_get_screen(obj);
     lv_disp_t * disp   = lv_obj_get_disp(obj_scr);
-    if(obj_scr == lv_disp_get_scr_act(disp) ||
-       obj_scr == lv_disp_get_scr_prev(disp) ||
-       obj_scr == lv_disp_get_layer_top(disp) ||
-       obj_scr == lv_disp_get_layer_sys(disp)) {
+    if(obj_scr != lv_disp_get_scr_act(disp) &&
+       obj_scr != lv_disp_get_scr_prev(disp) &&
+       obj_scr != lv_disp_get_layer_top(disp) &&
+       obj_scr != lv_disp_get_layer_sys(disp)) {
+        return false;
+    }
 
-        /*Truncate the area to the object*/
-        lv_area_t obj_coords;
-        lv_coord_t ext_size = obj->ext_draw_pad;
-        lv_area_copy(&obj_coords, &obj->coords);
-        obj_coords.x1 -= ext_size;
-        obj_coords.y1 -= ext_size;
-        obj_coords.x2 += ext_size;
-        obj_coords.y2 += ext_size;
+    /*Truncate the area to the object*/
+    lv_area_t obj_coords;
+    lv_coord_t ext_size = obj->ext_draw_pad;
+    lv_area_copy(&obj_coords, &obj->coords);
+    obj_coords.x1 -= ext_size;
+    obj_coords.y1 -= ext_size;
+    obj_coords.x2 += ext_size;
+    obj_coords.y2 += ext_size;
 
-        bool is_common;
+    bool is_common;
 
-        is_common = _lv_area_intersect(area, area, &obj_coords);
-        if(is_common == false) return false;  /*The area is not on the object*/
+    is_common = _lv_area_intersect(area, area, &obj_coords);
+    if(is_common == false) return false;  /*The area is not on the object*/
 
-        /*Truncate recursively to the parents*/
-        lv_obj_t * par = lv_obj_get_parent(obj);
-        while(par != NULL) {
-            is_common = _lv_area_intersect(area, area, &par->coords);
-            if(is_common == false) return false;       /*If no common parts with parent break;*/
-            if(lv_obj_get_hidden(par)) return false; /*If the parent is hidden then the child is hidden and won't be drawn*/
+    /*Truncate recursively to the parents*/
+    lv_obj_t * par = lv_obj_get_parent(obj);
+    while(par != NULL) {
+        is_common = _lv_area_intersect(area, area, &par->coords);
+        if(is_common == false) return false;       /*If no common parts with parent break;*/
+        if(lv_obj_get_hidden(par)) return false; /*If the parent is hidden then the child is hidden and won't be drawn*/
 
-            par = lv_obj_get_parent(par);
-        }
+        par = lv_obj_get_parent(par);
     }
 
     return true;


### PR DESCRIPTION
### Description of the feature or fix

release/v7 allows area refresh if it is inactive

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
