### PR TITLE
unit tests for textarea

### DIFF
--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -58,6 +58,7 @@ static lv_res_t insert_handler(lv_obj_t * obj, const char * txt);
 static void draw_placeholder(lv_event_t * e);
 static void draw_cursor(lv_event_t * e);
 static void auto_hide_characters(lv_obj_t * obj);
+static inline bool is_valid_but_non_printable_char(const uint32_t letter);
 
 /**********************
  *  STATIC VARIABLES
@@ -1025,14 +1026,11 @@ static void refr_cursor_area(lv_obj_t * obj)
     lv_coord_t letter_h = lv_font_get_line_height(font);
 
     /*Set letter_w (set not 0 on non printable but valid chars)*/
-    lv_coord_t letter_w;
-    if(letter == '\0' || letter == '\n' || letter == '\r') {
-        letter_w = lv_font_get_glyph_width(font, ' ', '\0');
+    uint32_t letter_space = letter;
+    if(is_valid_but_non_printable_char(letter)) {
+        letter_space = ' ';
     }
-    else {
-        /*`letter_next` parameter is '\0' to ignore kerning*/
-        letter_w = lv_font_get_glyph_width(font, letter, '\0');
-    }
+    lv_coord_t letter_w = lv_font_get_glyph_width(font, letter_space, IGNORE_KERNING);
 
     lv_point_t letter_pos;
     lv_label_get_letter_pos(ta->label, cur_pos, &letter_pos);
@@ -1050,12 +1048,11 @@ static void refr_cursor_area(lv_obj_t * obj)
             letter = _lv_txt_encoded_next(&txt[byte_pos], NULL);
         }
 
-        if(letter == '\0' || letter == '\n' || letter == '\r') {
-            letter_w = lv_font_get_glyph_width(font, ' ', '\0');
+        uint32_t tmp = letter;
+        if(is_valid_but_non_printable_char(letter)) {
+            tmp = ' ';
         }
-        else {
-            letter_w = lv_font_get_glyph_width(font, letter, '\0');
-        }
+        letter_w = lv_font_get_glyph_width(font, tmp, IGNORE_KERNING);
     }
 
     /*Save the byte position. It is required to draw `LV_CURSOR_BLOCK`*/
@@ -1315,6 +1312,15 @@ static void auto_hide_characters(lv_obj_t * obj)
         lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
         lv_anim_start(&a);
     }
+}
+
+static inline bool is_valid_but_non_printable_char(const uint32_t letter)
+{
+    if(letter == '\0' || letter == '\n' || letter == '\r') {
+        return true;
+    }
+
+    return false;
 }
 
 #endif

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -1205,6 +1205,8 @@ static void update_cursor_position_on_click(lv_event_t * e)
 #endif
 }
 
+/* Returns LV_RES_OK when no operation were performed
+ * Returns LV_RES_INV when a user defined text was inserted */
 static lv_res_t insert_handler(lv_obj_t * obj, const char * txt)
 {
     ta_insert_replace = NULL;

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -1209,9 +1209,12 @@ static lv_res_t insert_handler(lv_obj_t * obj, const char * txt)
 {
     ta_insert_replace = NULL;
     lv_event_send(obj, LV_EVENT_INSERT, (char *)txt);
-    if(ta_insert_replace) {
-        if(ta_insert_replace[0] == '\0') return LV_RES_INV; /*Drop this text*/
 
+    /* Drop txt if insert replace is set to '\0' */
+    if(ta_insert_replace && ta_insert_replace[0] == '\0')
+        return LV_RES_INV;
+
+    if(ta_insert_replace) {
         /*Add the replaced text directly it's different from the original*/
         if(strcmp(ta_insert_replace, txt)) {
             lv_textarea_add_text(obj, ta_insert_replace);

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -975,7 +975,7 @@ static bool char_is_accepted(lv_obj_t * obj, uint32_t c)
     }
 
     /*Accepted character?*/
-    // We're sure ta->accepted_chars != NULL
+    /*We're sure ta->accepted_chars != NULL*/
     uint32_t i = 0;
 
     while(ta->accepted_chars[i] != '\0') {

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -103,6 +103,11 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
+    if(ta->one_line && (c == '\n' || c == '\r')) {
+        LV_LOG_INFO("Text area: line break ignored in one-line mode");
+        return;
+    }
+
     uint32_t u32_buf[2];
     u32_buf[0] = c;
     u32_buf[1] = 0;
@@ -115,11 +120,6 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
 
     lv_res_t res = insert_handler(obj, letter_buf);
     if(res != LV_RES_OK) return;
-
-    if(ta->one_line && (c == '\n' || c == '\r')) {
-        LV_LOG_INFO("Text area: line break ignored in one-line mode");
-        return;
-    }
 
     uint32_t c_uni = _lv_txt_encoded_next((const char *)&c, NULL);
 

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -279,7 +279,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
     if(lv_textarea_get_accepted_chars(obj) || lv_textarea_get_max_length(obj)) {
         lv_label_set_text(ta->label, "");
         lv_textarea_set_cursor_pos(obj, LV_TEXTAREA_CURSOR_LAST);
-        if(ta->pwd_mode != 0) {
+        if(ta->pwd_mode) {
             ta->pwd_tmp[0] = '\0'; /*Clear the password too*/
         }
         uint32_t i = 0;
@@ -1037,7 +1037,7 @@ static void refr_cursor_area(lv_obj_t * obj)
 
     /*If the cursor is out of the text (most right) draw it to the next line*/
     if(((letter_pos.x + ta->label->coords.x1) + letter_w > ta->label->coords.x2) &&
-        (ta->one_line == 0 && align != LV_TEXT_ALIGN_RIGHT)) {
+       (ta->one_line == 0 && align != LV_TEXT_ALIGN_RIGHT)) {
 
         letter_pos.x = 0;
         letter_pos.y += letter_h + line_space;

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -440,7 +440,7 @@ void lv_textarea_set_cursor_click_pos(lv_obj_t * obj, bool en)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    ta->cursor.click_pos = en ? 1 : 0;
+    ta->cursor.click_pos = en ? 1U : 0U;
 }
 
 void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -450,11 +450,12 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     if(ta->pwd_mode == en) return;
 
-    ta->pwd_mode = en == false ? 0 : 1;
+    ta->pwd_mode = en ? 1U : 0U;
     /*Pwd mode is now enabled*/
-    if(en != false) {
-        char * txt   = lv_label_get_text(ta->label);
+    if(en) {
+        char * txt = lv_label_get_text(ta->label);
         size_t len = strlen(txt);
+
         ta->pwd_tmp = lv_mem_alloc(len + 1);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
@@ -628,7 +629,7 @@ bool lv_textarea_get_password_mode(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    return ta->pwd_mode == 0 ? false : true;
+    return ta->pwd_mode == 1U;
 }
 
 bool lv_textarea_get_one_line(const lv_obj_t * obj)
@@ -963,33 +964,34 @@ static void pwd_char_hider_anim_ready(lv_anim_t * a)
 static void pwd_char_hider(lv_obj_t * obj)
 {
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    if(ta->pwd_mode != 0) {
-        char * txt  = lv_label_get_text(ta->label);
-        int32_t enc_len = _lv_txt_get_encoded_length(txt);
-        if(enc_len == 0) return;
-
-        /*If the textarea's font has "bullet" character use it else fallback to "*"*/
-        const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
-        lv_font_glyph_dsc_t g;
-        bool has_bullet;
-        has_bullet = lv_font_get_glyph_dsc(font, &g, LV_TEXTAREA_PWD_BULLET_UNICODE, 0);
-        const char * bullet;
-        if(has_bullet) bullet = LV_SYMBOL_BULLET;
-        else bullet = "*";
-
-        size_t bullet_len = strlen(bullet);
-        char * txt_tmp = lv_mem_buf_get(enc_len * bullet_len + 1);
-        int32_t i;
-        for(i = 0; i < enc_len; i++) {
-            lv_memcpy(&txt_tmp[i * bullet_len], bullet, bullet_len);
-        }
-
-        txt_tmp[i * bullet_len] = '\0';
-
-        lv_label_set_text(ta->label, txt_tmp);
-        lv_mem_buf_release(txt_tmp);
-        refr_cursor_area(obj);
+    if(ta->pwd_mode == 0) {
+        return;
     }
+
+    char * txt = lv_label_get_text(ta->label);
+    uint32_t enc_len = _lv_txt_get_encoded_length(txt);
+    if(enc_len == 0) return;
+
+    /*If the textarea's font has "bullet" character use it else fallback to "*"*/
+    lv_font_glyph_dsc_t g;
+    const char * bullet = "*";
+
+    const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
+    if(lv_font_get_glyph_dsc(font, &g, LV_TEXTAREA_PWD_BULLET_UNICODE, 0)) bullet = LV_SYMBOL_BULLET;
+
+    const size_t bullet_len = strlen(bullet);
+    char * txt_tmp = lv_mem_buf_get(enc_len * bullet_len + 1);
+
+    uint32_t i;
+    for(i = 0; i < enc_len; i++) {
+        lv_memcpy(&txt_tmp[i * bullet_len], bullet, bullet_len);
+    }
+    txt_tmp[i * bullet_len] = '\0';
+
+    lv_label_set_text(ta->label, txt_tmp);
+    lv_mem_buf_release(txt_tmp);
+
+    refr_cursor_area(obj);
 }
 
 /**

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -484,21 +484,21 @@ void lv_textarea_set_one_line(lv_obj_t * obj, bool en)
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     if(ta->one_line == en) return;
 
-    if(en) {
-        ta->one_line = 1;
-        lv_obj_set_width(ta->label, LV_SIZE_CONTENT);
-        lv_obj_set_style_min_width(ta->label, lv_pct(100), 0);
+    ta->one_line = en ? 1U : 0U;
+    lv_coord_t width = en ? LV_SIZE_CONTENT : lv_pct(100);
+    lv_coord_t min_width_value = en ? lv_pct(100) : 0;
 
+    lv_obj_set_width(ta->label, width);
+    lv_obj_set_style_min_width(ta->label, min_width_value, 0);
+
+    if(en) {
         lv_obj_set_height(obj, LV_SIZE_CONTENT);
-        lv_obj_scroll_to(obj, 0, 0, LV_ANIM_OFF);
     }
     else {
-        ta->one_line = 0;
-        lv_obj_set_width(ta->label, lv_pct(100));
-        lv_obj_set_style_min_width(ta->label, 0, 0);
         lv_obj_remove_local_style_prop(obj, LV_STYLE_HEIGHT, LV_PART_MAIN);
-        lv_obj_scroll_to(obj, 0, 0, LV_ANIM_OFF);
     }
+
+    lv_obj_scroll_to(obj, 0, 0, LV_ANIM_OFF);
 }
 
 void lv_textarea_set_accepted_chars(lv_obj_t * obj, const char * list)
@@ -637,7 +637,7 @@ bool lv_textarea_get_one_line(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    return ta->one_line == 0 ? false : true;
+    return ta->one_line == 1U;
 }
 
 const char * lv_textarea_get_accepted_chars(lv_obj_t * obj)

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -317,7 +317,6 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
     size_t txt_len = strlen(txt);
-
     if(txt_len == 0) {
         if(ta->placeholder_txt) {
             lv_mem_free(ta->placeholder_txt);
@@ -325,21 +324,17 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
         }
     }
     else {
-
         /*Allocate memory for the placeholder_txt text*/
-        if(ta->placeholder_txt == NULL) {
-            ta->placeholder_txt = lv_mem_alloc(txt_len + 1);
-        }
-        else {
-            ta->placeholder_txt = lv_mem_realloc(ta->placeholder_txt, txt_len + 1);
-
-        }
+        /*NOTE: Using special realloc behavior, malloc-like when data_p is NULL*/
+        ta->placeholder_txt = lv_mem_realloc(ta->placeholder_txt, txt_len + 1);
         LV_ASSERT_MALLOC(ta->placeholder_txt);
         if(ta->placeholder_txt == NULL) {
             LV_LOG_ERROR("lv_textarea_set_placeholder_text: couldn't allocate memory for placeholder");
             return;
         }
+
         strcpy(ta->placeholder_txt, txt);
+        ta->placeholder_txt[txt_len] = '\0';
     }
 
     lv_obj_invalidate(obj);

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -57,6 +57,7 @@ static void update_cursor_position_on_click(lv_event_t * e);
 static lv_res_t insert_handler(lv_obj_t * obj, const char * txt);
 static void draw_placeholder(lv_event_t * e);
 static void draw_cursor(lv_event_t * e);
+static void auto_hide_characters(lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -146,20 +147,7 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
         _lv_txt_ins(ta->pwd_tmp, ta->cursor.pos, (const char *)letter_buf);
 
         /*Auto hide characters*/
-        if(ta->pwd_show_time == 0) {
-            pwd_char_hider(obj);
-        }
-        else {
-            lv_anim_t a;
-            lv_anim_init(&a);
-            lv_anim_set_var(&a, ta);
-            lv_anim_set_exec_cb(&a, pwd_char_hider_anim);
-            lv_anim_set_time(&a, ta->pwd_show_time);
-            lv_anim_set_values(&a, 0, 1);
-            lv_anim_set_path_cb(&a, lv_anim_path_step);
-            lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
-            lv_anim_start(&a);
-        }
+        auto_hide_characters(obj);
     }
 
     /*Move the cursor after the new character*/
@@ -208,20 +196,7 @@ void lv_textarea_add_text(lv_obj_t * obj, const char * txt)
         _lv_txt_ins(ta->pwd_tmp, ta->cursor.pos, txt);
 
         /*Auto hide characters*/
-        if(ta->pwd_show_time == 0) {
-            pwd_char_hider(obj);
-        }
-        else {
-            lv_anim_t a;
-            lv_anim_init(&a);
-            lv_anim_set_var(&a, ta);
-            lv_anim_set_exec_cb(&a, pwd_char_hider_anim);
-            lv_anim_set_time(&a, ta->pwd_show_time);
-            lv_anim_set_values(&a, 0, 1);
-            lv_anim_set_path_cb(&a, lv_anim_path_step);
-            lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
-            lv_anim_start(&a);
-        }
+        auto_hide_characters(obj);
     }
 
     /*Move the cursor after the new text*/
@@ -328,20 +303,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
         strcpy(ta->pwd_tmp, txt);
 
         /*Auto hide characters*/
-        if(ta->pwd_show_time == 0) {
-            pwd_char_hider(obj);
-        }
-        else {
-            lv_anim_t a;
-            lv_anim_init(&a);
-            lv_anim_set_var(&a, ta);
-            lv_anim_set_exec_cb(&a, pwd_char_hider_anim);
-            lv_anim_set_time(&a, ta->pwd_show_time);
-            lv_anim_set_values(&a, 0, 1);
-            lv_anim_set_path_cb(&a, lv_anim_path_step);
-            lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
-            lv_anim_start(&a);
-        }
+        auto_hide_characters(obj);
     }
 
     lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
@@ -1337,6 +1299,26 @@ static void draw_cursor(lv_event_t * e)
     lv_obj_init_draw_label_dsc(obj, LV_PART_CURSOR, &cur_label_dsc);
     if(cur_dsc.bg_opa > LV_OPA_MIN || cur_label_dsc.color.full != label_color.full) {
         lv_draw_label(draw_ctx, &cur_label_dsc, &cur_area, letter_buf, NULL);
+    }
+}
+
+static void auto_hide_characters(lv_obj_t * obj)
+{
+    lv_textarea_t * ta = (lv_textarea_t *) obj;
+
+    if(ta->pwd_show_time == 0) {
+        pwd_char_hider(obj);
+    }
+    else {
+        lv_anim_t a;
+        lv_anim_init(&a);
+        lv_anim_set_var(&a, ta);
+        lv_anim_set_exec_cb(&a, pwd_char_hider_anim);
+        lv_anim_set_time(&a, ta->pwd_show_time);
+        lv_anim_set_values(&a, 0, 1);
+        lv_anim_set_path_cb(&a, lv_anim_path_step);
+        lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
+        lv_anim_start(&a);
     }
 }
 

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -6,6 +6,8 @@
 static lv_obj_t * active_screen = NULL;
 static lv_obj_t * textarea = NULL;
 
+static const char *textarea_default_text = "";
+
 void setUp(void)
 {
     active_screen = lv_scr_act();
@@ -22,8 +24,8 @@ void test_textarea_should_have_valid_documented_defualt_values(void)
     TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
     TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
     /* No placeholder text should be set on widget creation */
-    TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_placeholder_text(textarea));
-    TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_text(textarea));
+    TEST_ASSERT_EQUAL_STRING(textarea_default_text, lv_textarea_get_placeholder_text(textarea));
+    TEST_ASSERT_EQUAL_STRING(textarea_default_text, lv_textarea_get_text(textarea));
 }
 
 /* When in password mode the lv_textarea_get_text function returns

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -1,0 +1,33 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+static lv_obj_t * active_screen = NULL;
+static lv_obj_t * textarea = NULL;
+
+void setUp(void)
+{
+    active_screen = lv_scr_act();
+    textarea = lv_textarea_create(active_screen);
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+}
+
+/* When in password mode the lv_textarea_get_text function returns
+ * the actual text, not the bullet characters. */
+void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
+{
+    const char * text = "Hello LVGL!";
+
+    lv_textarea_add_text(textarea, text);
+    lv_textarea_set_password_mode(textarea, true);
+
+    TEST_ASSERT_TRUE(lv_textarea_get_password_mode(textarea));
+    TEST_ASSERT_EQUAL_STRING(text, lv_textarea_get_text(textarea));
+}
+
+#endif

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -41,11 +41,19 @@ void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
 
 void test_textarea_should_update_label_style_with_one_line_enabled(void)
 {
+    lv_textarea_t * txt_ptr = (lv_textarea_t *) textarea;
+
     lv_textarea_add_text(textarea, "Hi");
     lv_textarea_set_one_line(textarea, true);
 
+    lv_coord_t left_padding = lv_obj_get_style_pad_left(txt_ptr->label, LV_PART_MAIN);
+    lv_coord_t right_padding = lv_obj_get_style_pad_right(txt_ptr->label, LV_PART_MAIN);
+    lv_coord_t line_width = lv_obj_get_width(txt_ptr->label);
+    lv_coord_t expected_size = left_padding + right_padding + line_width;
+
     TEST_ASSERT(lv_textarea_get_one_line(textarea));
-    // TEST_ASSERT_EQUAL_UINT16(LV_SIZE_CONTENT, lv_obj_get_width(ta->label));
+    TEST_ASSERT_EQUAL_UINT16(expected_size, lv_obj_get_width(txt_ptr->label));
+    TEST_ASSERT_EQUAL_UINT16(lv_pct(100), lv_obj_get_style_min_width(txt_ptr->label, LV_PART_MAIN));
 }
 
 void test_textarea_cursor_click_pos_field_update(void)

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -72,4 +72,14 @@ void test_textarea_should_update_placeholder_text(void)
     TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_placeholder_text(textarea));
 }
 
+void test_textarea_should_keep_only_accepted_chars(void)
+{
+    const char * accepted_list = "abcd";
+
+    lv_textarea_set_accepted_chars(textarea, accepted_list);
+    lv_textarea_set_text(textarea, "abcde");
+
+    TEST_ASSERT_EQUAL_STRING(accepted_list, lv_textarea_get_text(textarea));
+}
+
 #endif

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -42,4 +42,14 @@ void test_textarea_should_update_label_style_with_one_line_enabled(void)
     // TEST_ASSERT_EQUAL(lv_pct(100), label_style_min_width)
 }
 
+void test_textarea_cursor_click_pos_field_update(void)
+{
+    /* Enabled in the constructor */
+    TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
+
+    lv_textarea_set_cursor_click_pos(textarea, false);
+
+    TEST_ASSERT_FALSE(lv_textarea_get_cursor_click_pos(textarea));
+}
+
 #endif

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -42,14 +42,13 @@ void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
 
 void test_textarea_should_update_label_style_with_one_line_enabled(void)
 {
-    TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
+    lv_textarea_t * ta = (lv_textarea_t *) textarea;
 
     lv_textarea_add_text(textarea, "Hi");
     lv_textarea_set_one_line(textarea, true);
 
     TEST_ASSERT(lv_textarea_get_one_line(textarea));
-    // TEST_ASSERT_EQUAL(LV_SIZE_CONTENT, label_width)
-    // TEST_ASSERT_EQUAL(lv_pct(100), label_style_min_width)
+    // TEST_ASSERT_EQUAL_UINT16(LV_SIZE_CONTENT, lv_obj_get_width(ta->label));
 }
 
 void test_textarea_cursor_click_pos_field_update(void)

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -30,4 +30,16 @@ void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
     TEST_ASSERT_EQUAL_STRING(text, lv_textarea_get_text(textarea));
 }
 
+void test_textarea_should_update_label_style_with_one_line_enabled(void)
+{
+    TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
+
+    lv_textarea_add_text(textarea, "Hi");
+    lv_textarea_set_one_line(textarea, true);
+
+    TEST_ASSERT(lv_textarea_get_one_line(textarea));
+    // TEST_ASSERT_EQUAL(LV_SIZE_CONTENT, label_width)
+    // TEST_ASSERT_EQUAL(lv_pct(100), label_style_min_width)
+}
+
 #endif

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -23,6 +23,7 @@ void test_textarea_should_have_valid_documented_defualt_values(void)
     TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
     /* No placeholder text should be set on widget creation */
     TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_placeholder_text(textarea));
+    TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_text(textarea));
 }
 
 /* When in password mode the lv_textarea_get_text function returns

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -44,12 +44,27 @@ void test_textarea_should_update_label_style_with_one_line_enabled(void)
 
 void test_textarea_cursor_click_pos_field_update(void)
 {
-    /* Enabled in the constructor */
-    TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
-
     lv_textarea_set_cursor_click_pos(textarea, false);
 
     TEST_ASSERT_FALSE(lv_textarea_get_cursor_click_pos(textarea));
+}
+
+void test_textarea_should_update_placeholder_text(void)
+{
+    const char * new_placeholder = "LVGL Rocks!!!!!";
+    const char * text = "Hello LVGL!";
+
+    /* Allocating memory for placeholder text */
+    lv_textarea_set_placeholder_text(textarea, text);
+    TEST_ASSERT_EQUAL_STRING(text, lv_textarea_get_placeholder_text(textarea));
+
+    /* Reallocating memory for the new placeholder text */
+    lv_textarea_set_placeholder_text(textarea, new_placeholder);
+    TEST_ASSERT_EQUAL_STRING(new_placeholder, lv_textarea_get_placeholder_text(textarea));
+
+    /* Freeing allocated memory for placeholder text */
+    lv_textarea_set_placeholder_text(textarea, "");
+    TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_placeholder_text(textarea));
 }
 
 #endif

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -19,8 +19,6 @@ void tearDown(void)
 
 void test_textarea_should_have_valid_documented_defualt_values(void)
 {
-    lv_textarea_t * ta = (lv_textarea_t *) textarea;
-
     TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
     TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
     /* No placeholder text should be set on widget creation */
@@ -42,8 +40,6 @@ void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
 
 void test_textarea_should_update_label_style_with_one_line_enabled(void)
 {
-    lv_textarea_t * ta = (lv_textarea_t *) textarea;
-
     lv_textarea_add_text(textarea, "Hi");
     lv_textarea_set_one_line(textarea, true);
 

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -17,6 +17,16 @@ void tearDown(void)
     /* Function run after every test */
 }
 
+void test_textarea_should_have_valid_documented_defualt_values(void)
+{
+    lv_textarea_t * ta = (lv_textarea_t *) textarea;
+
+    TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
+    TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));
+    /* No placeholder text should be set on widget creation */
+    TEST_ASSERT_EQUAL_STRING("", lv_textarea_get_placeholder_text(textarea));
+}
+
 /* When in password mode the lv_textarea_get_text function returns
  * the actual text, not the bullet characters. */
 void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -6,7 +6,7 @@
 static lv_obj_t * active_screen = NULL;
 static lv_obj_t * textarea = NULL;
 
-static const char *textarea_default_text = "";
+static const char * textarea_default_text = "";
 
 void setUp(void)
 {

--- a/tests/src/test_cases/test_textarea.c
+++ b/tests/src/test_cases/test_textarea.c
@@ -93,4 +93,15 @@ void test_textarea_should_keep_only_accepted_chars(void)
     TEST_ASSERT_EQUAL_STRING(accepted_list, lv_textarea_get_text(textarea));
 }
 
+void test_textarea_in_one_line_mode_should_ignore_line_break_characters(void)
+{
+    lv_textarea_set_one_line(textarea, true);
+
+    lv_textarea_add_char(textarea, '\n');
+    TEST_ASSERT_EQUAL_STRING(textarea_default_text, lv_textarea_get_text(textarea));
+
+    lv_textarea_add_char(textarea, '\r');
+    TEST_ASSERT_EQUAL_STRING(textarea_default_text, lv_textarea_get_text(textarea));
+}
+
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Initial unit tests for textarea widget and some refactoring/cleaning of `lv_textarea.c`

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
