### PR TITLE
feat(log): improve log

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -780,6 +780,12 @@ static void scene_next_task_cb(lv_timer_t * timer)
         lv_table_add_cell_ctrl(table, row, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
         lv_table_set_cell_value(table, row, 0, "Slow but common cases");
 //        lv_table_set_cell_type(table, row, 0, 4);
+
+        LV_LOG("\r\n"
+                    "LVGL v%d.%d.%d " LVGL_VERSION_INFO 
+                    " Benchmark (in csv format)\r\n", 
+                    LVGL_VERSION_MAJOR, LVGL_VERSION_MINOR, LVGL_VERSION_PATCH);
+
         row++;
         char buf[256];
         for(i = 0; i < sizeof(scenes) / sizeof(scene_dsc_t) - 1; i++) {
@@ -793,19 +799,24 @@ static void scene_next_task_cb(lv_timer_t * timer)
 //                lv_table_set_cell_type(table, row, 0, 2);
 //                lv_table_set_cell_type(table, row, 1, 2);
 
+                LV_LOG("%s,%s\r\n", scenes[i].name, buf);
+                
                 row++;
             }
 
             if(scenes[i].fps_opa < 20 && LV_MAX(scenes[i].weight / 2, 1) >= 10) {
                 lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
                 lv_table_set_cell_value(table, row, 0, buf);
+                
+                LV_LOG("%s,", buf);
 
                 lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_opa);
                 lv_table_set_cell_value(table, row, 1, buf);
 
 //                lv_table_set_cell_type(table, row, 0, 2);
 //                lv_table_set_cell_type(table, row, 1, 2);
-
+                LV_LOG("%s\r\n", buf);
+                
                 row++;
             }
         }
@@ -836,12 +847,16 @@ static void scene_next_task_cb(lv_timer_t * timer)
 //                lv_table_set_cell_type(table, row, 0, 2);
 //                lv_table_set_cell_type(table, row, 1, 2);
             }
+            
+            LV_LOG("%s,%s\r\n", scenes[i].name, buf);
 
             row++;
 
             lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
             lv_table_set_cell_value(table, row, 0, buf);
 
+            LV_LOG("%s,", buf);
+            
             lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_opa);
             lv_table_set_cell_value(table, row, 1, buf);
 
@@ -854,6 +869,8 @@ static void scene_next_task_cb(lv_timer_t * timer)
 //                lv_table_set_cell_type(table, row, 0, 2);
 //                lv_table_set_cell_type(table, row, 1, 2);
             }
+            
+            LV_LOG("%s\r\n", buf);
 
             row++;
         }

--- a/docs/porting/log.md
+++ b/docs/porting/log.md
@@ -50,4 +50,4 @@ You can also use the log module via the `LV_LOG_TRACE/INFO/WARN/ERROR/USER(text)
   - \_\_FILE\_\_
   - \_\_LINE\_\_
   - \_\_func\_\_
-- `LV_LOG(text)` is similar to a normal `printf()` with no extra information attached.
+- `LV_LOG(text)` is similar to `LV_LOG_USER` but has no extra information attached.

--- a/docs/porting/log.md
+++ b/docs/porting/log.md
@@ -43,4 +43,11 @@ lv_log_register_print_cb(my_log_cb);
 
 ## Add logs
 
-You can also use the log module via the `LV_LOG_TRACE/INFO/WARN/ERROR/USER(text)` functions.
+You can also use the log module via the `LV_LOG_TRACE/INFO/WARN/ERROR/USER(text)` or `LV_LOG(text)` functions. Here:
+
+-  `LV_LOG_TRACE/INFO/WARN/ERROR/USER(text)` append following information to your `text`
+  - Log Level
+  - \_\_FILE\_\_
+  - \_\_LINE\_\_
+  - \_\_func\_\_
+- `LV_LOG(text)` is similar to a normal `printf()` with no extra information attached.

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -123,16 +123,16 @@ void lv_log(const char * format, ...)
 #if LV_LOG_PRINTF
     vprintf(format, args);
 #else
-        if(custom_print_cb) {
-            char buf[512];
+    if(custom_print_cb) {
+        char buf[512];
 #if LV_SPRINTF_CUSTOM
-            lv_vsnprintf(buf, sizeof(buf), format, args);
+        lv_vsnprintf(buf, sizeof(buf), format, args);
 #else
-            lv_vaformat_t vaf = {format, &args};
-            lv_snprintf(buf, sizeof(buf), "%pV",(void *)&vaf);
+        lv_vaformat_t vaf = {format, &args};
+        lv_snprintf(buf, sizeof(buf), "%pV",(void *)&vaf);
 #endif
-            custom_print_cb(buf);
-        }
+        custom_print_cb(buf);
+    }
 #endif
     
     va_end(args);

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -112,14 +112,13 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
     }
 }
 
-LV_FORMAT_ATTRIBUTE(1, 2)
 void lv_log(const char * format, ...) 
 {
     if(LV_LOG_LEVEL >= LV_LOG_LEVEL_NONE) return; /* disable log */
-    
+
     va_list args;
     va_start(args, format);
-    
+
 #if LV_LOG_PRINTF
     vprintf(format, args);
 #else
@@ -129,12 +128,12 @@ void lv_log(const char * format, ...)
         lv_vsnprintf(buf, sizeof(buf), format, args);
 #else
         lv_vaformat_t vaf = {format, &args};
-        lv_snprintf(buf, sizeof(buf), "%pV",(void *)&vaf);
+        lv_snprintf(buf, sizeof(buf), "%pV", (void *)&vaf);
 #endif
         custom_print_cb(buf);
     }
 #endif
-    
+
     va_end(args);
 }
 

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -112,12 +112,30 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
     }
 }
 
-void lv_log(const char * buf)
+LV_FORMAT_ATTRIBUTE(1, 2)
+void lv_log(const char * format, ...) 
 {
+    if(LV_LOG_LEVEL >= LV_LOG_LEVEL_NONE) return; /* disable log */
+    
+    va_list args;
+    va_start(args, format);
+    
 #if LV_LOG_PRINTF
-    puts(buf);
+    vprintf(format, args);
+#else
+        if(custom_print_cb) {
+            char buf[512];
+#if LV_SPRINTF_CUSTOM
+            lv_vsnprintf(buf, sizeof(buf), format, args);
+#else
+            lv_vaformat_t vaf = {format, &args};
+            lv_snprintf(buf, sizeof(buf), "%pV",(void *)&vaf);
 #endif
-    if(custom_print_cb) custom_print_cb(buf);
+            custom_print_cb(buf);
+        }
+#endif
+    
+    va_end(args);
 }
 
 /**********************

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -112,7 +112,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
     }
 }
 
-void lv_log(const char * format, ...) 
+void lv_log(const char * format, ...)
 {
     if(LV_LOG_LEVEL >= LV_LOG_LEVEL_NONE) return; /* disable log */
 

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -137,7 +137,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 #    define LV_LOG_USER(...) do {}while(0)
 #  endif
 #endif
-    
+
 #ifndef LV_LOG
 #  if LV_LOG_LEVEL < LV_LOG_LEVEL_NONE
 #    define LV_LOG(...) lv_log(__VA_ARGS__)

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -66,9 +66,22 @@ void lv_log_register_print_cb(lv_log_print_g_cb_t print_cb);
 /**
  * Print a log message via `printf` if enabled with `LV_LOG_PRINTF` in `lv_conf.h`
  * and/or a print callback if registered with `lv_log_register_print_cb`
- * @param buf       a string message to print
+ * @param format    printf-like format string
+ * @param ...       parameters for `format`
  */
-void lv_log(const char * buf);
+void lv_log(const char * format, ...) LV_FORMAT_ATTRIBUTE(1, 2);
+
+/**
+ * Add a log
+ * @param level     the level of log. (From `lv_log_level_t` enum)
+ * @param file      name of the file when the log added
+ * @param line      line number in the source code where the log added
+ * @param func      name of the function when the log added
+ * @param format    printf-like format string
+ * @param ...       parameters for `format`
+ */
+void _lv_log_add(lv_log_level_t level, const char * file, int line,
+                 const char * func, const char * format, ...) LV_FORMAT_ATTRIBUTE(5, 6);
 
 /**
  * Add a log
@@ -124,6 +137,14 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 #    define LV_LOG_USER(...) do {}while(0)
 #  endif
 #endif
+    
+#ifndef LV_LOG
+#  if LV_LOG_LEVEL < LV_LOG_LEVEL_NONE
+#    define LV_LOG(...) lv_log(__VA_ARGS__)
+#  else
+#    define LV_LOG(...) do {} while(0)
+#  endif
+#endif
 
 #else /*LV_USE_LOG*/
 
@@ -134,6 +155,8 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 #define LV_LOG_WARN(...) do {}while(0)
 #define LV_LOG_ERROR(...) do {}while(0)
 #define LV_LOG_USER(...) do {}while(0)
+#define LV_LOG(...) do {}while(0)
+
 #endif /*LV_USE_LOG*/
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description of the feature or fix

Problems:

* The original `LV_LOG_TRACE/INFO/WARN/ERROR/USER(text)` always attach information to `text`.
* The original function `lv_log()` is too simple and almost no one uses it (inside the LVGL).
* The official benchmark prints test results in a list on the target screen. 
    - If a user hasn't yet port an input method for the platform, it is impossible to check the results.
    - If the framerate is too low, it is painful to check the result with a touch screen. 

Solution:

* improve the log capability 
    - enhance the `lv_log()` function and make it printf-like
    - the new `lv_log()` should only output strings without attaching other information, e.g. \_\_func\_\_, \_\_LINE\_\_ etc.
    - Add a new macro `LV_LOG()` as a wrapper for `lv_log()`
* Output benchmark results in csv format via `LV_LOG()` 
    - The output can be used directly in EXCEL. This is very friendly for performance analysis and optimisation. 

![image](https://user-images.githubusercontent.com/13148491/153284299-a6cbad50-f5e9-4836-b74a-9ec6b771a3f8.png)


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
