### PR TITLE
fix(extra) adjust image decoder initialization order

### DIFF
--- a/src/extra/lv_extra.c
+++ b/src/extra/lv_extra.c
@@ -58,6 +58,10 @@ void lv_extra_init(void)
     lv_fs_win32_init();
 #endif
 
+#if LV_USE_FFMPEG
+    lv_ffmpeg_init();
+#endif
+
 #if LV_USE_PNG
     lv_png_init();
 #endif
@@ -77,10 +81,6 @@ void lv_extra_init(void)
 #  else
     lv_freetype_init(0, 0, 0);
 #  endif
-#endif
-
-#if LV_USE_FFMPEG
-    lv_ffmpeg_init();
 #endif
 }
 


### PR DESCRIPTION
### Description of the feature or fix

Let lvgl try to use a more compact picture decoder first to improve decoding speed.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
