### PR TITLE
Add information about scroll coordinates

### DIFF
--- a/docs/overview/scroll.md
+++ b/docs/overview/scroll.md
@@ -141,7 +141,21 @@ The following API functions allow manual scrolling of objects:
 - `lv_obj_scroll_to_x(obj, x, LV_ANIM_ON/OFF)` scroll to bring the given coordinate to the left side
 - `lv_obj_scroll_to_y(obj, y, LV_ANIM_ON/OFF)` scroll to bring the given coordinate to the top side
 
-You're also able to retrieve scroll coordinates data:
+From time to time you may need to retrieve the scroll position of an element, either to restore it later, or to display dynamically some elements according to the current scroll.
+Here is an example to see how to combine scroll event and store the scroll top position.
+```c
+static int scroll_value = 0;
+
+static void store_scroll_value_event_cb(lv_event_t* e) {
+  lv_obj_t* screen = lv_event_get_target(e);
+  scroll_value = lv_obj_get_scroll_top(screen);
+}
+
+lv_obj_t* container = lv_obj_create(NULL);
+lv_obj_add_event_cb(container, store_scroll_value_event_cb, LV_EVENT_SCROLL, NULL);
+```
+
+Scrool coordinates can be retrieve from differents axes with these functions:
 - `lv_obj_get_scroll_x(obj)` Get the `x` coordinate of object
 - `lv_obj_get_scroll_y(obj)` Get the `y` coordinate of object
 - `lv_obj_get_scroll_top(obj)` Get the scroll coordinate from the top

--- a/docs/overview/scroll.md
+++ b/docs/overview/scroll.md
@@ -149,6 +149,7 @@ static int scroll_value = 0;
 static void store_scroll_value_event_cb(lv_event_t* e) {
   lv_obj_t* screen = lv_event_get_target(e);
   scroll_value = lv_obj_get_scroll_top(screen);
+  printf("%d pixels are scrolled out on the top\n", scroll_value);
 }
 
 lv_obj_t* container = lv_obj_create(NULL);

--- a/docs/overview/scroll.md
+++ b/docs/overview/scroll.md
@@ -141,6 +141,14 @@ The following API functions allow manual scrolling of objects:
 - `lv_obj_scroll_to_x(obj, x, LV_ANIM_ON/OFF)` scroll to bring the given coordinate to the left side
 - `lv_obj_scroll_to_y(obj, y, LV_ANIM_ON/OFF)` scroll to bring the given coordinate to the top side
 
+You're also able to retrieve scroll coordinates data:
+- `lv_obj_get_scroll_x(obj)` Get the `x` coordinate of object
+- `lv_obj_get_scroll_y(obj)` Get the `y` coordinate of object
+- `lv_obj_get_scroll_top(obj)` Get the scroll coordinate from the top
+- `lv_obj_get_scroll_bottom(obj)` Get the scroll coordinate from the bottom
+- `lv_obj_get_scroll_left(obj)` Get the scroll coordinate from the left
+- `lv_obj_get_scroll_right(obj)` Get the scroll coordinate from the right
+
 ## Self size
 
 Self size is a property of an object. Normally, the user shouldn't use this parameter but if a custom widget is created it might be useful.


### PR DESCRIPTION
### Description of the feature or fix

While I was checking the documentation about "how I can restore the scroll of my items list", I didn't find anything in the documentation, I had to check the source code in https://github.com/lvgl/lvgl/blob/master/src/core/lv_obj_scroll.c in order to find a way to retrieve the current scroll data.


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
