### PR TITLE
Little typo in the documentation add_close_btn instead of add_colse_btn

### DIFF
--- a/docs/widgets/extra/msgbox.md
+++ b/docs/widgets/extra/msgbox.md
@@ -27,7 +27,7 @@ The message box is built from other widgets, so you can check these widgets' doc
 
 If `parent` is `NULL` the message box will be modal. `title` and `txt` are strings for the title and the text. 
 `btn_txts[]` is an array with the buttons' text. E.g. `const char * btn_txts[] = {"Ok", "Cancel", NULL}`.
-`add_colse_btn` can be `true` or `false` to add/don't add a close button.
+`add_close_btn` can be `true` or `false` to add/don't add a close button.
 
 ### Get the parts
 The building blocks of the message box can be obtained using the following functions:


### PR DESCRIPTION
### Description of the feature or fix

Little typo in the documentation `add_close_btn` instead of `add_colse_btn`

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
