### PR TITLE
Get key code from the actual event

### DIFF
--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -119,7 +119,7 @@ static void gridnav_event_cb(lv_event_t * e)
         if(dsc->focused_obj == NULL) dsc->focused_obj = find_first_focusable(obj);
         if(dsc->focused_obj == NULL) return;
 
-        uint32_t key = lv_indev_get_key(lv_indev_get_act());
+        uint32_t key = lv_event_get_key(e);
         lv_obj_t * guess = NULL;
 
         if(key == LV_KEY_RIGHT) {


### PR DESCRIPTION
### Description of the feature or fix
Currently, if you queue up a key to send to the gridnav at a later time (e.g., because you are performing an animation from a previous key press), by the time you go to send the event, the indev has lost its context and `lv_indev_get_act()` returns `NULL` and the key is not returned, so gridnav does nothing.

This change gets the key code directly from the event, so that it doesn't matter when it is received.

It will also enable programmatic key-driven automation, which we intend to use for some automated behavior while doing EMI testing.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation (no change required)
