### PR TITLE
fix(misc): Remove duplicate declaration of _lv_log_add.

### DIFF
--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -83,18 +83,6 @@ void lv_log(const char * format, ...) LV_FORMAT_ATTRIBUTE(1, 2);
 void _lv_log_add(lv_log_level_t level, const char * file, int line,
                  const char * func, const char * format, ...) LV_FORMAT_ATTRIBUTE(5, 6);
 
-/**
- * Add a log
- * @param level     the level of log. (From `lv_log_level_t` enum)
- * @param file      name of the file when the log added
- * @param line      line number in the source code where the log added
- * @param func      name of the function when the log added
- * @param format    printf-like format string
- * @param ...       parameters for `format`
- */
-void _lv_log_add(lv_log_level_t level, const char * file, int line,
-                 const char * func, const char * format, ...) LV_FORMAT_ATTRIBUTE(5, 6);
-
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
Commit ba38a4b appears to have accidentally added a duplicate declaration of
_lv_log_add. With -Wredundant-decls, this causes warnings to spam the terminal.

    warning: redundant redeclaration of ‘_lv_log_add’ [-Wredundant-decls]

### Description of the feature or fix

Commit ba38a4b appears to have accidentally added a duplicate declaration of _lv_log_add. This removes the extra declaration.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
