### PR TITLE
Wrong parameters doc for fs_write in lv_port_fs_template.c

### DIFF
--- a/examples/porting/lv_port_fs_template.c
+++ b/examples/porting/lv_port_fs_template.c
@@ -163,8 +163,8 @@ static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_
  * @param drv       pointer to a driver where this function belongs
  * @param file_p    pointer to a file_t variable
  * @param buf       pointer to a buffer with the bytes to write
- * @param btr       Bytes To Write
- * @param br        the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw       Bytes To Write
+ * @param bw        the number of real written bytes (Bytes Written). NULL if unused.
  * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
  */
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw)

--- a/src/extra/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/extra/libs/fsdrv/lv_fs_fatfs.c
@@ -161,8 +161,8 @@ static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_
  * @param drv pointer to a driver where this function belongs
  * @param file_p pointer to a FIL variable
  * @param buf pointer to a buffer with the bytes to write
- * @param btr Bytes To Write
- * @param br the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw Bytes To Write
+ * @param bw the number of real written bytes (Bytes Written). NULL if unused.
  * @return LV_FS_RES_OK or any error from lv_fs_res_t enum
  */
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw)

--- a/src/extra/libs/fsdrv/lv_fs_posix.c
+++ b/src/extra/libs/fsdrv/lv_fs_posix.c
@@ -154,8 +154,8 @@ static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_
  * @param drv pointer to a driver where this function belongs
  * @param file_p a file handle variable
  * @param buf pointer to a buffer with the bytes to write
- * @param btr Bytes To Write
- * @param br the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw Bytes To Write
+ * @param bw the number of real written bytes (Bytes Written). NULL if unused.
  * @return LV_FS_RES_OK or any error from lv_fs_res_t enum
  */
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw)

--- a/src/extra/libs/fsdrv/lv_fs_stdio.c
+++ b/src/extra/libs/fsdrv/lv_fs_stdio.c
@@ -147,8 +147,8 @@ static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_
  * @param drv pointer to a driver where this function belongs
  * @param file_p pointer to a FILE variable
  * @param buf pointer to a buffer with the bytes to write
- * @param btr Bytes To Write
- * @param br the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw Bytes To Write
+ * @param bw the number of real written bytes (Bytes Written). NULL if unused.
  * @return LV_FS_RES_OK or any error from lv_fs_res_t enum
  */
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw)

--- a/src/extra/libs/fsdrv/lv_fs_win32.c
+++ b/src/extra/libs/fsdrv/lv_fs_win32.c
@@ -263,8 +263,8 @@ static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_
  * @param drv pointer to a driver where this function belongs
  * @param file_p pointer to a FILE variable
  * @param buf pointer to a buffer with the bytes to write
- * @param btr Bytes To Write
- * @param br the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw Bytes To Write
+ * @param bw the number of real written bytes (Bytes Written). NULL if unused.
  * @return LV_FS_RES_OK or any error from lv_fs_res_t enum
  */
 static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw)

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -176,8 +176,8 @@ lv_fs_res_t lv_fs_read(lv_fs_file_t * file_p, void * buf, uint32_t btr, uint32_t
  * Write into a file
  * @param file_p    pointer to a lv_fs_file_t variable
  * @param buf       pointer to a buffer with the bytes to write
- * @param btr       Bytes To Write
- * @param br        the number of real written bytes (Bytes Written). NULL if unused.
+ * @param btw       Bytes To Write
+ * @param bw        the number of real written bytes (Bytes Written). NULL if unused.
  * @return          LV_FS_RES_OK or any error from lv_fs_res_t enum
  */
 lv_fs_res_t lv_fs_write(lv_fs_file_t * file_p, const void * buf, uint32_t btw, uint32_t * bw);


### PR DESCRIPTION
### Description of the feature or fix

Wrong parameters doc for `fs_write` in `lv_port_fs_template.c`

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
