### PR TITLE
fix(demos): redirect url to the new location in README.md

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -55,9 +55,9 @@
 ### Widgets
 Shows how the widgets look like out of the box using the built-in material theme.  
 
-See in [lv_demo_widgets](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_widgets) folder.
+See in [widgets](https://github.com/lvgl/lvgl/tree/master/demos/widgets) folder.
 
-<img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_widgets/screenshot1.png?raw=true" width=600px alt="Basic demo to show the widgets of LVGL">
+<img src="https://github.com/lvgl/lvgl/tree/master/demos/widgets/screenshot1.png?raw=true" width=600px alt="Basic demo to show the widgets of LVGL">
 
 For running this demo properly, please make sure **LV_MEM_SIZE** is at least **38KB** (and **48KB** is recommended):
 
@@ -70,27 +70,27 @@ For running this demo properly, please make sure **LV_MEM_SIZE** is at least **3
 ### Music player
 The music player demo shows what kind of modern, smartphone-like user interfaces can be created on LVGL. It works the best with display with 480x272 or 272x480 resolution. 
 
-See in [lv_demo_music](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_music) folder.
+See in [music](https://github.com/lvgl/lvgl/tree/master/demos/music) folder.
 
-<img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_music/screenshot1.gif?raw=true" width=600px alt="Music player demo with LVGL">
+<img src="https://github.com/lvgl/lvgl/tree/master/demos/music/screenshot1.gif?raw=true" width=600px alt="Music player demo with LVGL">
 
 ### Keypad and encoder
 LVGL allows you to control the widgets with a keypad and/or encoder without a touchpad. This demo shows how to handle buttons, drop-down lists, rollers, sliders, switches, and text inputs without touchpad. 
-Learn more about the touchpad-less usage of LVGL [here](https://docs.lvgl.io/v7/en/html/overview/indev.html#keypad-and-encoder).
+Learn more about the touchpad-less usage of LVGL [here](https://docs.lvgl.io/master/overview/indev.html#keypad-and-encoder).
 
-See in [lv_demo_keypad_encoder](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_keypad_encoder) folder.
+See in [keypad_encoder](https://github.com/lvgl/lvgl/tree/master/demos/keypad_encoder) folder.
 
-<img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_keypad_encoder/screenshot1.png?raw=true" width=600px alt="Keypad and encoder navigation in LVGL embedded GUI library">
+<img src="https://github.com/lvgl/lvgl/tree/master/demos/keypad_encoder/screenshot1.png?raw=true" width=600px alt="Keypad and encoder navigation in LVGL embedded GUI library">
 
 ### Benchmark
 A demo to measure the performance of LVGL or to compare different settings. 
-See in [lv_demo_benchmark](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_benchmark) folder.
-<img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_benchmark/screenshot1.png?raw=true" width=600px alt="Benchmark demo with LVGL embedded GUI library">
+See in [benchmark](https://github.com/lvgl/lvgl/tree/master/demos/benchmark) folder.
+<img src="https://github.com/lvgl/lvgl/tree/master/demos/benchmark/screenshot1.png?raw=true" width=600px alt="Benchmark demo with LVGL embedded GUI library">
 
 ### Stress
 A stress test for LVGL. It contains a lot of object creation, deletion, animations, style usage, and so on. It can be used if there is any memory corruption during heavy usage or any memory leaks. 
-See in [lv_demo_stress](https://github.com/lvgl/lv_examples/tree/master/src/lv_demo_stress) folder.
-<img src="https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_stress/screenshot1.png?raw=true" width=600px alt="Stress test for LVGL">
+See in [stress](https://github.com/lvgl/lvgl/tree/master/demos/stress) folder.
+<img src="https://github.com/lvgl/lvgl/tree/master/demos/stress/screenshot1.png?raw=true" width=600px alt="Stress test for LVGL">
 
 ## Contributing
 For contribution and coding style guidelines, please refer to the file docs/CONTRIBUTING.md in the main LVGL repo:

--- a/demos/benchmark/README.md
+++ b/demos/benchmark/README.md
@@ -31,7 +31,7 @@ In other words, the benchmark shows the FPS from the pure rendering time.
 
 By default, only the changed areas are refreshed. It means if only a few pixels are changed in 1 ms the benchmark will show 1000 FPS. To measure the performance with full screen refresh uncomment `lv_obj_invalidate(lv_scr_act())` in `monitor_cb()` in `lv_demo_benchmark.c`.
 
-![LVGL benchmark running](https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_benchmark/screenshot1.png?raw=true)
+![LVGL benchmark running](https://github.com/lvgl/lvgl/tree/master/demos/benchmark/screenshot1.png?raw=true)
 
 
 ## Result summary 
@@ -48,4 +48,4 @@ In the first section of the table, "Slow but common cases", those cases are disp
 Below this in the "All cases section" all the results are shown. The < 10 FPS results are shown with red, the >= 10 but < 20 FPS values are displayed with orange.
 
 
-![LVGL benchmark result summary](https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_benchmark/screenshot2.png?raw=true)
+![LVGL benchmark result summary](https://github.com/lvgl/lvgl/tree/master/demos/benchmark/screenshot2.png?raw=true)

--- a/demos/keypad_encoder/README.md
+++ b/demos/keypad_encoder/README.md
@@ -4,7 +4,7 @@
 
 LVGL allows you to control the widgets with keypad and/or encoder without touchpad. 
 This demo shows how to handle buttons, drop-down lists, rollers, sliders, switches and text inputs without touchpad. 
-Learn more about the touchpad-less usage of LVGL [here](https://docs.lvgl.io/master/porting/indev.html#keypad-or-keyboard).
+Learn more about the touchpad-less usage of LVGL [here](https://docs.lvgl.io/master/overview/indev.html#keypad-and-encoder).
 
 ![Keypad and encoder navigation in LVGL embedded GUI library](screenshot1.gif)
 

--- a/demos/music/README.md
+++ b/demos/music/README.md
@@ -4,7 +4,7 @@
 The music player demo shows what kind of modern, smartphone-like user interfaces can be created on LVGL. It works the best with display with 480x272 or 272x480 resolution. 
 
 
-![Music player demo with LVGL embedded GUI library](https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_music/screenshot1.gif?raw=true)
+![Music player demo with LVGL embedded GUI library](https://github.com/lvgl/lvgl/tree/master/demos/music/screenshot1.gif?raw=true)
 
 ## Run the demo
 - In `lv_conf.h` or equivalent places set `LV_USE_DEMO_MUSIC 1`

--- a/demos/stress/README.md
+++ b/demos/stress/README.md
@@ -5,7 +5,7 @@
 A stress test for LVGL. 
 It contains a lot of object creation, deletion, animations, styles usage, and so on. It can be used if there is any memory corruption during heavy usage or any memory leaks. 
 
-![Printer demo with LVGL embedded GUI library](https://github.com/lvgl/lv_examples/blob/master/src/lv_demo_stress/screenshot1.gif?raw=true)
+![Printer demo with LVGL embedded GUI library](https://github.com/lvgl/lvgl/tree/master/demos/stress/screenshot1.gif?raw=true)
 
 ## Run the demo
 - In `lv_conf.h` or equivalent places set `LV_USE_DEMO_STRESS 1`


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation
