### PR TITLE
lv_conf_internal: fix some widget dependencies when using Kconfig

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -99,8 +99,8 @@ for line in fin.read().splitlines():
 
     #If the value should be 1 (enabled) by default use a more complex structure for Kconfig checks because
     #if a not defined CONFIG_... value should be interpreted as 0 and not the LVGL default
-    is_one = re.search(r'[\s]*#[\s]*define[\s]*[A-Z0-9_]+[\s]+1[\s]*$', line)
-    if(is_one):
+    is_one = re.search(r'[\s]*#[\s]*define[\s]*[A-Z0-9_]+[\s]+1([\s]*$|[\s]+)', line)
+    if is_one:
       #1. Use the value if already set from lv_conf.h or anything else (i.e. do nothing)
       #2. In Kconfig environment use the CONFIG_... value if set, else use 0
       #3. In not Kconfig environment use the LVGL's default value

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -4,15 +4,20 @@
 Generates lv_conf_internal.h from lv_conf_template.h to provide default values
 '''
 
+import os
 import sys
 import re
+
+SCRIPT_DIR = os.path.dirname(__file__)
+LV_CONF_TEMPLATE = os.path.join(SCRIPT_DIR, "..", "lv_conf_template.h")
+LV_CONF_INTERNAL = os.path.join(SCRIPT_DIR, "..", "src", "lv_conf_internal.h")
 
 if sys.version_info < (3,6,0):
   print("Python >=3.6 is required", file=sys.stderr)
   exit(1)
 
-fin = open("../lv_conf_template.h", "r")
-fout = open("../src/lv_conf_internal.h", "w")
+fin = open(LV_CONF_TEMPLATE)
+fout = open(LV_CONF_INTERNAL, "w")
 
 fout.write(
 '''/**

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -597,15 +597,23 @@
 /*Enable asserts if an operation is failed or an invalid data is found.
  *If LV_USE_LOG is enabled an error message will be printed on failure*/
 #ifndef LV_USE_ASSERT_NULL
-    #ifdef CONFIG_LV_USE_ASSERT_NULL
-        #define LV_USE_ASSERT_NULL CONFIG_LV_USE_ASSERT_NULL
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_ASSERT_NULL
+            #define LV_USE_ASSERT_NULL CONFIG_LV_USE_ASSERT_NULL
+        #else
+            #define LV_USE_ASSERT_NULL 0
+        #endif
     #else
         #define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
     #endif
 #endif
 #ifndef LV_USE_ASSERT_MALLOC
-    #ifdef CONFIG_LV_USE_ASSERT_MALLOC
-        #define LV_USE_ASSERT_MALLOC CONFIG_LV_USE_ASSERT_MALLOC
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_ASSERT_MALLOC
+            #define LV_USE_ASSERT_MALLOC CONFIG_LV_USE_ASSERT_MALLOC
+        #else
+            #define LV_USE_ASSERT_MALLOC 0
+        #endif
     #else
         #define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
     #endif
@@ -1341,16 +1349,24 @@
 #endif
 
 #ifndef LV_USE_DROPDOWN
-    #ifdef CONFIG_LV_USE_DROPDOWN
-        #define LV_USE_DROPDOWN CONFIG_LV_USE_DROPDOWN
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_DROPDOWN
+            #define LV_USE_DROPDOWN CONFIG_LV_USE_DROPDOWN
+        #else
+            #define LV_USE_DROPDOWN 0
+        #endif
     #else
         #define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
     #endif
 #endif
 
 #ifndef LV_USE_IMG
-    #ifdef CONFIG_LV_USE_IMG
-        #define LV_USE_IMG CONFIG_LV_USE_IMG
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_IMG
+            #define LV_USE_IMG CONFIG_LV_USE_IMG
+        #else
+            #define LV_USE_IMG 0
+        #endif
     #else
         #define LV_USE_IMG        1   /*Requires: lv_label*/
     #endif
@@ -1369,15 +1385,23 @@
 #endif
 #if LV_USE_LABEL
     #ifndef LV_LABEL_TEXT_SELECTION
-        #ifdef CONFIG_LV_LABEL_TEXT_SELECTION
-            #define LV_LABEL_TEXT_SELECTION CONFIG_LV_LABEL_TEXT_SELECTION
+        #ifdef _LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_LABEL_TEXT_SELECTION
+                #define LV_LABEL_TEXT_SELECTION CONFIG_LV_LABEL_TEXT_SELECTION
+            #else
+                #define LV_LABEL_TEXT_SELECTION 0
+            #endif
         #else
             #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
         #endif
     #endif
     #ifndef LV_LABEL_LONG_TXT_HINT
-        #ifdef CONFIG_LV_LABEL_LONG_TXT_HINT
-            #define LV_LABEL_LONG_TXT_HINT CONFIG_LV_LABEL_LONG_TXT_HINT
+        #ifdef _LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_LABEL_LONG_TXT_HINT
+                #define LV_LABEL_LONG_TXT_HINT CONFIG_LV_LABEL_LONG_TXT_HINT
+            #else
+                #define LV_LABEL_LONG_TXT_HINT 0
+            #endif
         #else
             #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
         #endif
@@ -1397,8 +1421,12 @@
 #endif
 
 #ifndef LV_USE_ROLLER
-    #ifdef CONFIG_LV_USE_ROLLER
-        #define LV_USE_ROLLER CONFIG_LV_USE_ROLLER
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_ROLLER
+            #define LV_USE_ROLLER CONFIG_LV_USE_ROLLER
+        #else
+            #define LV_USE_ROLLER 0
+        #endif
     #else
         #define LV_USE_ROLLER     1   /*Requires: lv_label*/
     #endif
@@ -1414,8 +1442,12 @@
 #endif
 
 #ifndef LV_USE_SLIDER
-    #ifdef CONFIG_LV_USE_SLIDER
-        #define LV_USE_SLIDER CONFIG_LV_USE_SLIDER
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_SLIDER
+            #define LV_USE_SLIDER CONFIG_LV_USE_SLIDER
+        #else
+            #define LV_USE_SLIDER 0
+        #endif
     #else
         #define LV_USE_SLIDER     1   /*Requires: lv_bar*/
     #endif
@@ -1434,8 +1466,12 @@
 #endif
 
 #ifndef LV_USE_TEXTAREA
-    #ifdef CONFIG_LV_USE_TEXTAREA
-        #define LV_USE_TEXTAREA CONFIG_LV_USE_TEXTAREA
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_TEXTAREA
+            #define LV_USE_TEXTAREA CONFIG_LV_USE_TEXTAREA
+        #else
+            #define LV_USE_TEXTAREA 0
+        #endif
     #else
         #define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
     #endif

--- a/src/widgets/lv_img.h
+++ b/src/widgets/lv_img.h
@@ -17,6 +17,11 @@ extern "C" {
 
 #if LV_USE_IMG != 0
 
+/*Testing of dependencies*/
+#if LV_USE_LABEL == 0
+#error "lv_img: lv_label is required. Enable it in lv_conf.h (LV_USE_LABEL 1)"
+#endif
+
 #include "../core/lv_obj.h"
 #include "../misc/lv_fs.h"
 #include "../draw/lv_draw.h"

--- a/src/widgets/lv_roller.h
+++ b/src/widgets/lv_roller.h
@@ -17,6 +17,11 @@ extern "C" {
 
 #if LV_USE_ROLLER != 0
 
+/*Testing of dependencies*/
+#if LV_USE_LABEL == 0
+#error "lv_roller: lv_label is required. Enable it in lv_conf.h (LV_USE_ROLLER 1)"
+#endif
+
 #include "../core/lv_obj.h"
 #include "lv_label.h"
 


### PR DESCRIPTION
### Description of the feature or fix

This PR is making the widget selection consistent in `lv_conf_internal.h` when using Kconfig. Some widgets (slider I believe dropdown, roller, textarea, img have the same problem) are always selected even if unchecked in Kconfig, this results in a build failure for slider because bar is not selected.
The missing dependency checks are also added to some widgets headers.

Some context: I'm porting latest lvgl version to RIOT in https://github.com/RIOT-OS/RIOT/pull/17681 and got this issue when building the RIOT sample applications, that don't use the slider widget.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
