### PR TITLE
test(table): Replicate issue when reducing table cells

### DIFF
--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -250,26 +250,20 @@ void lv_table_set_col_cnt(lv_obj_t * obj, uint16_t col_cnt)
 
     uint16_t old_col_cnt = table->col_cnt;
     table->col_cnt         = col_cnt;
-    table->col_w = lv_mem_realloc(table->col_w, col_cnt * sizeof(table->col_w[0]));
-    LV_ASSERT_MALLOC(table->col_w);
-    if(table->col_w == NULL) return;
+    uint32_t new_cell_cnt = table->col_cnt * table->row_cnt;
 
     /*Free the unused cells*/
     if(old_col_cnt > col_cnt) {
         uint16_t old_cell_cnt = old_col_cnt * table->row_cnt;
-        uint32_t new_cell_cnt = table->col_cnt * table->row_cnt;
         uint32_t i;
         for(i = new_cell_cnt; i < old_cell_cnt; i++) {
             lv_mem_free(table->cell_data[i]);
         }
     }
 
-    char ** new_cell_data = lv_mem_alloc(table->row_cnt * table->col_cnt * sizeof(char *));
-    LV_ASSERT_MALLOC(new_cell_data);
-    if(new_cell_data == NULL) return;
-    uint32_t new_cell_cnt = table->col_cnt * table->row_cnt;
-    lv_memset_00(new_cell_data, new_cell_cnt * sizeof(table->cell_data[0]));
-
+    table->col_w = lv_mem_realloc(table->col_w, col_cnt * sizeof(table->col_w[0]));
+    LV_ASSERT_MALLOC(table->col_w);
+    if(table->col_w == NULL) return;
     /*Initialize the new fields*/
     if(old_col_cnt < col_cnt) {
         uint32_t col;
@@ -277,6 +271,12 @@ void lv_table_set_col_cnt(lv_obj_t * obj, uint16_t col_cnt)
             table->col_w[col] = LV_DPI_DEF;
         }
     }
+
+    /* Try to allocate space for new_cell_cnt pointers */
+    char ** new_cell_data = lv_mem_alloc(new_cell_cnt * sizeof(char *));
+    LV_ASSERT_MALLOC(new_cell_data);
+    if(new_cell_data == NULL) return;
+    lv_memset_00(new_cell_data, new_cell_cnt * sizeof(table->cell_data[0]));
 
     /*The new column(s) messes up the mapping of `cell_data`*/
     uint32_t old_col_start;

--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -206,6 +206,9 @@ void lv_table_set_row_cnt(lv_obj_t * obj, uint16_t row_cnt)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_table_t * table = (lv_table_t *)obj;
+
+    if(table->row_cnt == row_cnt) return;
+
     uint16_t old_row_cnt = table->row_cnt;
     table->row_cnt         = row_cnt;
 
@@ -242,6 +245,9 @@ void lv_table_set_col_cnt(lv_obj_t * obj, uint16_t col_cnt)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_table_t * table = (lv_table_t *)obj;
+
+    if(table->col_cnt == col_cnt) return;
+
     uint16_t old_col_cnt = table->col_cnt;
     table->col_cnt         = col_cnt;
     table->col_w = lv_mem_realloc(table->col_w, col_cnt * sizeof(table->col_w[0]));

--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -811,8 +811,8 @@ static void refr_size(lv_obj_t * obj, uint32_t start_row)
 }
 
 static lv_coord_t get_row_height(lv_obj_t * obj, uint16_t row_id, const lv_font_t * font,
-        lv_coord_t letter_space, lv_coord_t line_space,
-        lv_coord_t cell_left, lv_coord_t cell_right, lv_coord_t cell_top, lv_coord_t cell_bottom)
+                                 lv_coord_t letter_space, lv_coord_t line_space,
+                                 lv_coord_t cell_left, lv_coord_t cell_right, lv_coord_t cell_top, lv_coord_t cell_bottom)
 {
     lv_table_t * table = (lv_table_t *)obj;
     lv_point_t txt_size;
@@ -851,14 +851,14 @@ static lv_coord_t get_row_height(lv_obj_t * obj, uint16_t row_id, const lv_font_
         /*With text crop assume 1 line*/
         if(ctrl & LV_TABLE_CELL_CTRL_TEXT_CROP) {
             h_max = LV_MAX(lv_font_get_line_height(font) + cell_top + cell_bottom,
-                    h_max);
+                           h_max);
         }
         /*Without text crop calculate the height of the text in the cell*/
         else {
             txt_w -= cell_left + cell_right;
 
             lv_txt_get_size(&txt_size, table->cell_data[cell] + 1, font,
-                    letter_space, line_space, txt_w, LV_TEXT_FLAG_NONE);
+                            letter_space, line_space, txt_w, LV_TEXT_FLAG_NONE);
 
             h_max = LV_MAX(txt_size.y + cell_top + cell_bottom, h_max);
             cell += col_merge;

--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -237,7 +237,7 @@ void lv_table_set_row_cnt(lv_obj_t * obj, uint16_t row_cnt)
         lv_memset_00(&table->cell_data[old_cell_cnt], (new_cell_cnt - old_cell_cnt) * sizeof(table->cell_data[0]));
     }
 
-    refr_size(obj, 0) ;
+    refr_size(obj, 0);
 }
 
 void lv_table_set_col_cnt(lv_obj_t * obj, uint16_t col_cnt)
@@ -294,8 +294,7 @@ void lv_table_set_col_cnt(lv_obj_t * obj, uint16_t col_cnt)
     lv_mem_free(table->cell_data);
     table->cell_data = new_cell_data;
 
-
-    refr_size(obj, 0) ;
+    refr_size(obj, 0);
 }
 
 void lv_table_set_col_width(lv_obj_t * obj, uint16_t col_id, lv_coord_t w)
@@ -935,7 +934,8 @@ static size_t get_cell_txt_len(const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     retval = _lv_txt_ap_calc_bytes_cnt(txt) + 1;
 #else
-    /* +1: trailing '\0'; +1: format byte */
+    /* cell_data layout: [ctrl][txt][trailing '\0' terminator]
+     * +2 because of the trailing '\0' and the ctrl */
     retval = strlen(txt) + 2;
 #endif
 

--- a/tests/src/test_cases/test_table.c
+++ b/tests/src/test_cases/test_table.c
@@ -215,4 +215,34 @@ void test_table_should_reduce_cells(void)
     }
 }
 
+/* See #3120 for context */
+void test_table_should_reduce_cells_with_more_than_one_row(void)
+{
+    const uint16_t initial_col_num = 8;
+    const uint16_t initial_row_num = 2;
+    const uint16_t final_col_num = 4;
+    const uint16_t final_row_num = 1;
+
+    lv_obj_center(table);
+
+    lv_table_set_col_cnt(table, initial_col_num);
+    lv_table_set_row_cnt(table, initial_row_num);
+
+    uint32_t row_idx, col_idx;
+    for(row_idx = 0; row_idx < initial_row_num; row_idx++) {
+        for(col_idx = 0; col_idx < initial_col_num; col_idx++) {
+            lv_table_set_cell_value(table, row_idx, col_idx, "00");
+        }
+    }
+
+    lv_table_set_col_cnt(table, final_col_num);
+    lv_table_set_row_cnt(table, final_row_num);
+
+    for(row_idx = 0; row_idx < final_row_num; row_idx++) {
+        for(col_idx = 0; col_idx < final_col_num; col_idx++) {
+            lv_table_set_cell_value(table, row_idx, col_idx, "00");
+        }
+    }
+}
+
 #endif

--- a/tests/src/test_cases/test_table.c
+++ b/tests/src/test_cases/test_table.c
@@ -184,4 +184,29 @@ void test_table_rendering(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("table_1.png");
 }
 
+/* See #3120 for context */
+void test_table_should_reduce_cells(void)
+{
+    lv_obj_center(table);
+
+    lv_table_set_col_cnt(table, 8);
+    lv_table_set_row_cnt(table, 8);
+
+    uint32_t i, j;
+    for(i = 0; i < 8; i ++) {
+        for(j = 0; j < 8; j ++) {
+            lv_table_set_cell_value(table, i, j, "00");
+        }
+    }
+
+    lv_table_set_col_cnt(table, 4); //If comment this line, it can run
+    lv_table_set_row_cnt(table, 4);
+
+    for(i = 0; i < 4; i ++) {
+        for(j = 0; j < 4; j ++) {
+            lv_table_set_cell_value(table, i, j, "00");
+        }
+    }
+}
+
 #endif

--- a/tests/src/test_cases/test_table.c
+++ b/tests/src/test_cases/test_table.c
@@ -191,7 +191,6 @@ void test_table_should_reduce_cells(void)
     const uint16_t initial_row_num = 1;
     const uint16_t final_col_num = 4;
     const uint16_t final_row_num = 1;
-    lv_table_t * ptr = (lv_table_t *) table;
 
     lv_obj_center(table);
 

--- a/tests/src/test_cases/test_table.c
+++ b/tests/src/test_cases/test_table.c
@@ -187,24 +187,30 @@ void test_table_rendering(void)
 /* See #3120 for context */
 void test_table_should_reduce_cells(void)
 {
+    const uint16_t initial_col_num = 8;
+    const uint16_t initial_row_num = 1;
+    const uint16_t final_col_num = 4;
+    const uint16_t final_row_num = 1;
+    lv_table_t * ptr = (lv_table_t *) table;
+
     lv_obj_center(table);
 
-    lv_table_set_col_cnt(table, 8);
-    lv_table_set_row_cnt(table, 8);
+    lv_table_set_col_cnt(table, initial_col_num);
+    lv_table_set_row_cnt(table, initial_row_num);
 
-    uint32_t i, j;
-    for(i = 0; i < 8; i ++) {
-        for(j = 0; j < 8; j ++) {
-            lv_table_set_cell_value(table, i, j, "00");
+    uint32_t row_idx, col_idx;
+    for(row_idx = 0; row_idx < initial_row_num; row_idx++) {
+        for(col_idx = 0; col_idx < initial_col_num; col_idx++) {
+            lv_table_set_cell_value(table, row_idx, col_idx, "00");
         }
     }
 
-    lv_table_set_col_cnt(table, 4); //If comment this line, it can run
-    lv_table_set_row_cnt(table, 4);
+    lv_table_set_col_cnt(table, final_col_num);
+    lv_table_set_row_cnt(table, final_row_num);
 
-    for(i = 0; i < 4; i ++) {
-        for(j = 0; j < 4; j ++) {
-            lv_table_set_cell_value(table, i, j, "00");
+    for(row_idx = 0; row_idx < final_row_num; row_idx++) {
+        for(col_idx = 0; col_idx < final_col_num; col_idx++) {
+            lv_table_set_cell_value(table, row_idx, col_idx, "00");
         }
     }
 }


### PR DESCRIPTION
### Description of the feature or fix

See #3120 for report
Closes #3120 

Output when running the tests:
```console
==============================
Running tests for test_sysheap
==============================
Test project /home/d3bug/lvgl/tests/build_test_sysheap
      Start  1: test_arc
      Start  2: test_bar
      Start  3: test_checkbox
      Start  4: test_config
      Start  5: test_demo_stress
      Start  6: test_demo_widgets
      Start  7: test_dropdown
      Start  8: test_event
      Start  9: test_font_loader
      Start 10: test_obj_tree
      Start 11: test_slider
      Start 12: test_snapshot
      Start 13: test_style
      Start 14: test_switch
      Start 15: test_table
      Start 16: test_textarea
 1/17 Test  #1: test_arc .........................   Passed    0.28 sec
      Start 17: test_txt
 2/17 Test  #2: test_bar .........................   Passed    0.29 sec
 3/17 Test  #3: test_checkbox ....................   Passed    0.28 sec
 4/17 Test  #4: test_config ......................   Passed    0.27 sec
 5/17 Test  #6: test_demo_widgets ................   Passed    0.25 sec
 6/17 Test  #8: test_event .......................   Passed    0.23 sec
 7/17 Test  #9: test_font_loader .................   Passed    0.21 sec
 8/17 Test #10: test_obj_tree ....................   Passed    0.17 sec
 9/17 Test #11: test_slider ......................   Passed    0.17 sec
10/17 Test #12: test_snapshot ....................   Passed    0.13 sec
11/17 Test #14: test_switch ......................   Passed    0.13 sec
12/17 Test #15: test_table .......................***Failed    0.13 sec
=================================================================
==14424==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000001930 at pc 0x7ff09b8d218f bp 0x7fffe6a0d0b0 sp 0x7fffe6a0d0a0
READ of size 1 at 0x602000001930 thread T0
    #0 0x7ff09b8d218e in get_row_height /home/d3bug/lvgl/src/widgets/lv_table.c:835
    #1 0x7ff09b8d1cb7 in refr_size /home/d3bug/lvgl/src/widgets/lv_table.c:801
    #2 0x7ff09b8cc2b5 in lv_table_set_col_cnt /home/d3bug/lvgl/src/widgets/lv_table.c:292
    #3 0x7ff09b82355a in test_table_should_reduce_cells /home/d3bug/lvgl/tests/src/test_cases/test_table.c:201
    #4 0x7ff09b82398c in run_test /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:78
    #5 0x7ff09b823c34 in main /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:104
    #6 0x7ff09aad70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x7ff09b821a6d in _start (/home/d3bug/lvgl/tests/build_test_sysheap/test_table+0xbfa6d)

0x602000001930 is located 0 bytes inside of 4-byte region [0x602000001930,0x602000001934)
freed by thread T0 here:
    #0 0x7ff09adfd7cf in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf)
    #1 0x7ff09b8bbab7 in lv_mem_free /home/d3bug/lvgl/src/misc/lv_mem.c:171
    #2 0x7ff09b8cbeb5 in lv_table_set_col_cnt /home/d3bug/lvgl/src/widgets/lv_table.c:257
    #3 0x7ff09b82355a in test_table_should_reduce_cells /home/d3bug/lvgl/tests/src/test_cases/test_table.c:201
    #4 0x7ff09b82398c in run_test /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:78
    #5 0x7ff09b823c34 in main /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:104
    #6 0x7ff09aad70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

previously allocated by thread T0 here:
    #0 0x7ff09adfdffe in __interceptor_realloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dffe)
    #1 0x7ff09b8bbb74 in lv_mem_realloc /home/d3bug/lvgl/src/misc/lv_mem.c:196
    #2 0x7ff09b8caa46 in lv_table_set_cell_value /home/d3bug/lvgl/src/widgets/lv_table.c:102
    #3 0x7ff09b82350e in test_table_should_reduce_cells /home/d3bug/lvgl/tests/src/test_cases/test_table.c:197
    #4 0x7ff09b82398c in run_test /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:78
    #5 0x7ff09b823c34 in main /home/d3bug/lvgl/tests/src/test_runners/test_table_Runner.c:104
    #6 0x7ff09aad70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

SUMMARY: AddressSanitizer: heap-use-after-free /home/d3bug/lvgl/src/widgets/lv_table.c:835 in get_row_height
Shadow bytes around the buggy address:
  0x0c047fff82d0: fa fa 04 fa fa fa fd fd fa fa fd fd fa fa 04 fa
  0x0c047fff82e0: fa fa fd fd fa fa fd fd fa fa 04 fa fa fa fd fd
  0x0c047fff82f0: fa fa fd fd fa fa 04 fa fa fa fd fd fa fa fd fd
  0x0c047fff8300: fa fa 04 fa fa fa fd fd fa fa fd fd fa fa 04 fa
  0x0c047fff8310: fa fa fd fd fa fa fd fd fa fa 04 fa fa fa fd fd
=>0x0c047fff8320: fa fa fd fd fa fa[fd]fa fa fa fd fd fa fa fd fd
  0x0c047fff8330: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c047fff8340: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fd
  0x0c047fff8350: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fd
  0x0c047fff8360: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c047fff8370: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==14424==ABORTING

13/17 Test  #7: test_dropdown ....................   Passed    0.31 sec
14/17 Test #16: test_textarea ....................   Passed    0.13 sec
15/17 Test #17: test_txt .........................   Passed    0.10 sec
16/17 Test  #5: test_demo_stress .................   Passed    1.46 sec
17/17 Test #13: test_style .......................   Passed    1.46 sec

94% tests passed, 1 tests failed out of 17

Total Test time (real) =   1.69 sec

The following tests FAILED:
         15 - test_table (Failed)
```

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
