### PR TITLE
feat(img_cache): limit the number of caches based on the total memory

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -167,6 +167,11 @@ menu "LVGL configuration"
                     save the continuous open/decode of images.
                     However the opened images might consume additional RAM.
 
+            config LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
+                int "Limit the total memory used by images."
+                depends on LV_IMG_CACHE_DEF_SIZE > 0
+                default 16384
+
             config LV_GRADIENT_MAX_STOPS
                 int "Number of stops allowed per gradient."
                 default 2

--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_2.c
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_2.c
@@ -39,15 +39,15 @@ static void event_cb(lv_event_t * e)
         /*Add custom content to the 4th button when the button itself was drawn*/
         if(dsc->id == 3) {
             LV_IMG_DECLARE(img_star);
-            lv_img_header_t header;
-            lv_res_t res = lv_img_decoder_get_info(&img_star, &header);
+            lv_img_decoder_info_t info;
+            lv_res_t res = lv_img_decoder_get_info(&img_star, &info);
             if(res != LV_RES_OK) return;
 
             lv_area_t a;
-            a.x1 = dsc->draw_area->x1 + (lv_area_get_width(dsc->draw_area) - header.w) / 2;
-            a.x2 = a.x1 + header.w - 1;
-            a.y1 = dsc->draw_area->y1 + (lv_area_get_height(dsc->draw_area) - header.h) / 2;
-            a.y2 = a.y1 + header.h - 1;
+            a.x1 = dsc->draw_area->x1 + (lv_area_get_width(dsc->draw_area) - info.header.w) / 2;
+            a.x2 = a.x1 + info.header.w - 1;
+            a.y1 = dsc->draw_area->y1 + (lv_area_get_height(dsc->draw_area) - info.header.h) / 2;
+            a.y2 = a.y1 + info.header.h - 1;
 
             lv_draw_img_dsc_t img_draw_dsc;
             lv_draw_img_dsc_init(&img_draw_dsc);

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -129,7 +129,7 @@
 #if LV_IMG_CACHE_DEF_SIZE != 0
 
     /*Limit the total memory used by images*/
-    #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE (64 * 1024)
+    #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE 16384
 #endif
 
 /*Number of stops allowed per gradient. Increase this to allow more stops.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -126,6 +126,11 @@
  *However the opened images might consume additional RAM.
  *0: to disable caching*/
 #define LV_IMG_CACHE_DEF_SIZE   0
+#if LV_IMG_CACHE_DEF_SIZE != 0
+
+    /*Limit the total memory used by images*/
+    #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE (64 * 1024)
+#endif
 
 /*Number of stops allowed per gradient. Increase this to allow more stops.
  *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -133,7 +133,7 @@ void lv_init(void)
 
     _lv_img_decoder_init();
 #if LV_IMG_CACHE_DEF_SIZE
-    lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE);
+    lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE, LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE);
 #endif
     /*Test if the IDE has UTF-8 encoding*/
     char * txt = "Á";

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -645,12 +645,12 @@ static void lv_refr_area_part(lv_draw_ctx_t * draw_ctx)
             draw_ctx->draw_bg(draw_ctx, &dsc, draw_ctx->buf_area);
         }
         else if(disp_refr->bg_img) {
-            lv_img_header_t header;
+            lv_img_decoder_info_t info;
             lv_res_t res;
-            res = lv_img_decoder_get_info(disp_refr->bg_img, &header);
+            res = lv_img_decoder_get_info(disp_refr->bg_img, &info);
             if(res == LV_RES_OK) {
                 lv_area_t a;
-                lv_area_set(&a, 0, 0, header.w - 1, header.h - 1);
+                lv_area_set(&a, 0, 0, info.header.w - 1, info.header.h - 1);
                 lv_draw_img_dsc_t dsc;
                 lv_draw_img_dsc_init(&dsc);
                 dsc.opa = disp_refr->bg_opa;

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -238,8 +238,8 @@ LV_ATTRIBUTE_FAST_MEM static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, 
 
 
     lv_img_cf_t cf;
-    if(lv_img_cf_is_chroma_keyed(cdsc->dec_dsc.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
-    else if(lv_img_cf_has_alpha(cdsc->dec_dsc.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+    if(lv_img_cf_is_chroma_keyed(cdsc->dec_dsc.info.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
+    else if(lv_img_cf_has_alpha(cdsc->dec_dsc.info.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
     else cf = LV_IMG_CF_TRUE_COLOR;
 
     if(cdsc->dec_dsc.error_msg != NULL) {

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -160,7 +160,7 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
     /*If the number of cache entries is insufficient, look for the entry that can be reused*/
     if(cached_src == NULL) {
         cached_src = find_reuse_entry();
-        LV_LOG_INFO("cache entry is full, find reuse entry: %p", cached_src);
+        LV_LOG_INFO("cache entry is full, find reuse entry");
     }
 
 #else

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -114,11 +114,15 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
     }
 
     /*Calculate the memory usage of an image*/
-    uint32_t img_req_size = lv_img_buf_get_img_size(header.w, header.h, header.cf);
+    uint32_t img_req_size = 0;
 
-    if(img_req_size == 0) {
-        LV_LOG_WARN("can't get image require memory size, cf = %" PRIu32, header.cf);
-        return NULL;
+    if(lv_img_src_get_type(src) == LV_IMG_SRC_FILE) {
+        img_req_size = lv_img_buf_get_img_size(header.w, header.h, header.cf);
+
+        if(img_req_size == 0) {
+            LV_LOG_WARN("can't get image require memory size, cf = %" PRIu32, header.cf);
+            return NULL;
+        }
     }
 
     /*Do not decode image that exceed the limit*/
@@ -280,7 +284,6 @@ static void lv_img_cache_close(_lv_img_cache_entry_t * cached_src)
     /*Mark the entry to be released*/
     lv_memset_00(cached_src, sizeof(_lv_img_cache_entry_t));
 }
-
 
 static _lv_img_cache_entry_t * find_reuse_entry(void)
 {

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -105,8 +105,8 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
     if(cached_src)
         return cached_src;
 
-    lv_img_header_t header;
-    lv_res_t res = lv_img_decoder_get_info(src, &header);
+    lv_img_decoder_info_t info;
+    lv_res_t res = lv_img_decoder_get_info(src, &info);
 
     if(res != LV_RES_OK) {
         LV_LOG_WARN("can't get image info");
@@ -114,16 +114,7 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
     }
 
     /*Calculate the memory usage of an image*/
-    uint32_t img_req_size = 0;
-
-    if(lv_img_src_get_type(src) == LV_IMG_SRC_FILE) {
-        img_req_size = lv_img_buf_get_img_size(header.w, header.h, header.cf);
-
-        if(img_req_size == 0) {
-            LV_LOG_WARN("can't get image require memory size, cf = %" PRIu32, header.cf);
-            return NULL;
-        }
-    }
+    uint32_t img_req_size = info.mem_cost_size;
 
     /*Do not decode image that exceed the limit*/
     if(img_req_size > cache_total_size) {

--- a/src/draw/lv_img_cache.h
+++ b/src/draw/lv_img_cache.h
@@ -35,6 +35,8 @@ typedef struct {
      * Decrement all lifes by one every in every ::lv_img_cache_open.
      * If life == 0 the entry can be reused*/
     int32_t life;
+
+    uint32_t mem_cost_size;
 } _lv_img_cache_entry_t;
 
 /**********************
@@ -57,8 +59,9 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
  * More cached images mean more opened image at same time which might mean more memory usage.
  * E.g. if 20 PNG or JPG images are open in the RAM they consume memory while opened in the cache.
  * @param new_entry_cnt number of image to cache
+ * @param new_total_size cache total memory size
  */
-void lv_img_cache_set_size(uint16_t new_slot_num);
+void lv_img_cache_set_size(uint16_t new_entry_cnt, uint32_t new_total_size);
 
 /**
  * Invalidate an image source in the cache.

--- a/src/draw/lv_img_decoder.h
+++ b/src/draw/lv_img_decoder.h
@@ -42,6 +42,7 @@ typedef uint8_t lv_img_src_t;
 
 /*Decoder function definitions*/
 struct _lv_img_decoder_dsc_t;
+struct _lv_img_decoder_info_t;
 struct _lv_img_decoder_t;
 
 /**
@@ -52,7 +53,7 @@ struct _lv_img_decoder_t;
  * @return LV_RES_OK: info written correctly; LV_RES_INV: failed
  */
 typedef lv_res_t (*lv_img_decoder_info_f_t)(struct _lv_img_decoder_t * decoder, const void * src,
-                                            lv_img_header_t * header);
+                                            struct _lv_img_decoder_info_t * info);
 
 /**
  * Open an image for decoding. Prepare it as it is required to read it later
@@ -94,6 +95,11 @@ typedef struct _lv_img_decoder_t {
 #endif
 } lv_img_decoder_t;
 
+typedef struct _lv_img_decoder_info_t {
+    lv_img_header_t header;
+
+    uint32_t mem_cost_size;
+} lv_img_decoder_info_t;
 
 /**Describe an image decoding session. Stores data about the decoding*/
 typedef struct _lv_img_decoder_dsc_t {
@@ -113,7 +119,7 @@ typedef struct _lv_img_decoder_dsc_t {
     lv_img_src_t src_type;
 
     /**Info about the opened image: color format, size, etc. MUST be set in `open` function*/
-    lv_img_header_t header;
+    lv_img_decoder_info_t info;
 
     /** Pointer to a buffer where the image's data (pixels) are stored in a decoded, plain format.
      *  MUST be set in `open` function*/
@@ -150,7 +156,7 @@ void _lv_img_decoder_init(void);
  * @param header the image info will be stored here
  * @return LV_RES_OK: success; LV_RES_INV: wasn't able to get info about the image
  */
-lv_res_t lv_img_decoder_get_info(const void * src, lv_img_header_t * header);
+lv_res_t lv_img_decoder_get_info(const void * src, lv_img_decoder_info_t * info);
 
 /**
  * Open an image.
@@ -232,7 +238,7 @@ void lv_img_decoder_set_close_cb(lv_img_decoder_t * decoder, lv_img_decoder_clos
  * @param header store the image data here
  * @return LV_RES_OK: the info is successfully stored in `header`; LV_RES_INV: unknown format or other error.
  */
-lv_res_t lv_img_decoder_built_in_info(lv_img_decoder_t * decoder, const void * src, lv_img_header_t * header);
+lv_res_t lv_img_decoder_built_in_info(lv_img_decoder_t * decoder, const void * src, lv_img_decoder_info_t * info);
 
 /**
  * Open a built in image

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -351,8 +351,8 @@ static void draw_bg_img(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
         lv_draw_label(draw_ctx, &label_draw_dsc, &a, dsc->bg_img_src, NULL);
     }
     else {
-        lv_img_header_t header;
-        lv_res_t res = lv_img_decoder_get_info(dsc->bg_img_src, &header);
+        lv_img_decoder_info_t info;
+        lv_res_t res = lv_img_decoder_get_info(dsc->bg_img_src, &info);
         if(res != LV_RES_OK) {
             LV_LOG_WARN("Couldn't read the background image");
             return;
@@ -368,23 +368,23 @@ static void draw_bg_img(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
         /*Center align*/
         if(dsc->bg_img_tiled == false) {
             lv_area_t area;
-            area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - header.w / 2;
-            area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - header.h / 2;
-            area.x2 = area.x1 + header.w - 1;
-            area.y2 = area.y1 + header.h - 1;
+            area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - info.header.w / 2;
+            area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - info.header.h / 2;
+            area.x2 = area.x1 + info.header.w - 1;
+            area.y2 = area.y1 + info.header.h - 1;
 
             lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
         }
         else {
             lv_area_t area;
             area.y1 = coords->y1;
-            area.y2 = area.y1 + header.h - 1;
+            area.y2 = area.y1 + info.header.h - 1;
 
-            for(; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
+            for(; area.y1 <= coords->y2; area.y1 += info.header.h, area.y2 += info.header.h) {
 
                 area.x1 = coords->x1;
-                area.x2 = area.x1 + header.w - 1;
-                for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
+                area.x2 = area.x1 + info.header.w - 1;
+                for(; area.x1 <= coords->x2; area.x1 += info.header.w, area.x2 += info.header.w) {
                     lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
                 }
             }

--- a/src/extra/libs/png/lv_png.c
+++ b/src/extra/libs/png/lv_png.c
@@ -87,7 +87,7 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
             lv_fs_close(&f);
             /*Save the data in the header*/
             header->always_zero = 0;
-            header->cf = LV_IMG_CF_RAW_ALPHA;
+            header->cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
             /*The width and height are stored in Big endian format so convert them to little endian*/
             header->w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);
             header->h = (lv_coord_t)((size[1] & 0xff000000) >> 24) + ((size[1] & 0x00ff0000) >> 8);

--- a/src/extra/libs/png/lv_png.c
+++ b/src/extra/libs/png/lv_png.c
@@ -24,7 +24,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * src, lv_img_header_t * header);
+static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * src, lv_img_decoder_info_t * info);
 static lv_res_t decoder_open(lv_img_decoder_t * dec, lv_img_decoder_dsc_t * dsc);
 static void decoder_close(lv_img_decoder_t * dec, lv_img_decoder_dsc_t * dsc);
 static void convert_color_depth(uint8_t * img, uint32_t px_cnt);
@@ -62,7 +62,7 @@ void lv_png_init(void)
  * @param header store the info here
  * @return LV_RES_OK: no error; LV_RES_INV: can't get the info
  */
-static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * src, lv_img_header_t * header)
+static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * src, lv_img_decoder_info_t * info)
 {
     (void) decoder; /*Unused*/
     lv_img_src_t src_type = lv_img_src_get_type(src);          /*Get the source type*/
@@ -86,11 +86,12 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
             if(rn != 8) return LV_RES_INV;
             lv_fs_close(&f);
             /*Save the data in the header*/
-            header->always_zero = 0;
-            header->cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+            info->header.always_zero = 0;
+            info->header.cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
             /*The width and height are stored in Big endian format so convert them to little endian*/
-            header->w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);
-            header->h = (lv_coord_t)((size[1] & 0xff000000) >> 24) + ((size[1] & 0x00ff0000) >> 8);
+            info->header.w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);
+            info->header.h = (lv_coord_t)((size[1] & 0xff000000) >> 24) + ((size[1] & 0x00ff0000) >> 8);
+            info->mem_cost_size = info->header.w * info->header.h * 4;
 
             return LV_RES_OK;
         }
@@ -100,10 +101,11 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
         const lv_img_dsc_t * img_dsc = src;
         const uint8_t magic[] = {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
         if(memcmp(magic, img_dsc->data, sizeof(magic))) return LV_RES_INV;
-        header->always_zero = 0;
-        header->cf = img_dsc->header.cf;       /*Save the color format*/
-        header->w = img_dsc->header.w;         /*Save the color width*/
-        header->h = img_dsc->header.h;         /*Save the color height*/
+        info->header.always_zero = 0;
+        info->header.cf = img_dsc->header.cf;       /*Save the color format*/
+        info->header.w = img_dsc->header.w;         /*Save the color width*/
+        info->header.h = img_dsc->header.h;         /*Save the color height*/
+        info->mem_cost_size = info->header.w * info->header.h * 4;
         return LV_RES_OK;
     }
 

--- a/src/extra/widgets/imgbtn/lv_imgbtn.c
+++ b/src/extra/widgets/imgbtn/lv_imgbtn.c
@@ -200,9 +200,9 @@ static void lv_imgbtn_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(imgbtn->img_src_left[state] == NULL &&
            imgbtn->img_src_mid[state] != NULL &&
            imgbtn->img_src_right[state] == NULL) {
-            lv_img_header_t header;
-            lv_img_decoder_get_info(imgbtn->img_src_mid[state], &header);
-            p->x = LV_MAX(p->x, header.w);
+            lv_img_decoder_info_t info;
+            lv_img_decoder_get_info(imgbtn->img_src_mid[state], &info);
+            p->x = LV_MAX(p->x, info.header.w);
         }
     }
 }
@@ -232,29 +232,29 @@ static void draw_main(lv_event_t * e)
     lv_draw_img_dsc_init(&img_dsc);
     lv_obj_init_draw_img_dsc(obj, LV_PART_MAIN, &img_dsc);
 
-    lv_img_header_t header;
+    lv_img_decoder_info_t info;
     lv_area_t coords_part;
     lv_coord_t left_w = 0;
     lv_coord_t right_w = 0;
 
     if(src) {
-        lv_img_decoder_get_info(src, &header);
-        left_w = header.w;
+        lv_img_decoder_get_info(src, &info);
+        left_w = info.header.w;
         coords_part.x1 = coords.x1;
         coords_part.y1 = coords.y1;
-        coords_part.x2 = coords.x1 + header.w - 1;
-        coords_part.y2 = coords.y1 + header.h - 1;
+        coords_part.x2 = coords.x1 + info.header.w - 1;
+        coords_part.y2 = coords.y1 + info.header.h - 1;
         lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
     }
 
     src = imgbtn->img_src_right[state];
     if(src) {
-        lv_img_decoder_get_info(src, &header);
-        right_w = header.w;
-        coords_part.x1 = coords.x2 - header.w + 1;
+        lv_img_decoder_get_info(src, &info);
+        right_w = info.header.w;
+        coords_part.x1 = coords.x2 - info.header.w + 1;
         coords_part.y1 = coords.y1;
         coords_part.x2 = coords.x2;
-        coords_part.y2 = coords.y1 + header.h - 1;
+        coords_part.y2 = coords.y1 + info.header.h - 1;
         lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
     }
 
@@ -271,20 +271,20 @@ static void draw_main(lv_event_t * e)
         comm_res = _lv_area_intersect(&clip_area_center, &clip_area_center, draw_ctx->clip_area);
         if(comm_res) {
             lv_coord_t i;
-            lv_img_decoder_get_info(src, &header);
+            lv_img_decoder_get_info(src, &info);
 
             const lv_area_t * clip_area_ori = draw_ctx->clip_area;
             draw_ctx->clip_area = &clip_area_center;
 
             coords_part.x1 = coords.x1 + left_w;
             coords_part.y1 = coords.y1;
-            coords_part.x2 = coords_part.x1 + header.w - 1;
-            coords_part.y2 = coords_part.y1 + header.h - 1;
+            coords_part.x2 = coords_part.x1 + info.header.w - 1;
+            coords_part.y2 = coords_part.y1 + info.header.h - 1;
 
-            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + header.w - 1); i += header.w) {
+            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + info.header.w - 1); i += info.header.w) {
                 lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
                 coords_part.x1 = coords_part.x2 + 1;
-                coords_part.x2 += header.w;
+                coords_part.x2 += info.header.w;
             }
             draw_ctx->clip_area = clip_area_ori;
         }
@@ -295,18 +295,18 @@ static void refr_img(lv_obj_t * obj)
 {
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
     lv_imgbtn_state_t state  = suggest_state(obj, get_state(obj));
-    lv_img_header_t header;
+    lv_img_decoder_info_t info;
 
     const void * src = imgbtn->img_src_mid[state];
     if(src == NULL) return;
 
     lv_res_t info_res = LV_RES_OK;
-    info_res = lv_img_decoder_get_info(src, &header);
+    info_res = lv_img_decoder_get_info(src, &info);
 
     if(info_res == LV_RES_OK) {
-        imgbtn->act_cf = header.cf;
+        imgbtn->act_cf = info.header.cf;
         lv_obj_refresh_self_size(obj);
-        lv_obj_set_height(obj, header.h); /*Keep the user defined width*/
+        lv_obj_set_height(obj, info.header.h); /*Keep the user defined width*/
     }
     else {
         imgbtn->act_cf = LV_IMG_CF_UNKNOWN;

--- a/src/extra/widgets/meter/lv_meter.c
+++ b/src/extra/widgets/meter/lv_meter.c
@@ -609,13 +609,13 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
             if(indic->type_data.needle_img.src == NULL) continue;
 
             int32_t angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
-            lv_img_header_t info;
+            lv_img_decoder_info_t info;
             lv_img_decoder_get_info(indic->type_data.needle_img.src, &info);
             lv_area_t a;
             a.x1 = scale_center.x - indic->type_data.needle_img.pivot.x;
             a.y1 = scale_center.y - indic->type_data.needle_img.pivot.y;
-            a.x2 = a.x1 + info.w - 1;
-            a.y2 = a.y1 + info.h - 1;
+            a.x2 = a.x1 + info.header.w - 1;
+            a.y2 = a.y1 + info.header.h - 1;
 
             img_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
             img_dsc.pivot.x = indic->type_data.needle_img.pivot.x;
@@ -688,7 +688,7 @@ static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value
     }
     else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG) {
         int32_t angle = lv_map(value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
-        lv_img_header_t info;
+        lv_img_decoder_info_t info;
         lv_img_decoder_get_info(indic->type_data.needle_img.src, &info);
 
         angle = angle * 10;
@@ -697,7 +697,8 @@ static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value
         scale_center.x -= indic->type_data.needle_img.pivot.x;
         scale_center.y -= indic->type_data.needle_img.pivot.y;
         lv_area_t a;
-        _lv_img_buf_get_transformed_area(&a, info.w, info.h, angle, LV_IMG_ZOOM_NONE, &indic->type_data.needle_img.pivot);
+        _lv_img_buf_get_transformed_area(&a, info.header.w, info.header.h, angle, LV_IMG_ZOOM_NONE,
+                                         &indic->type_data.needle_img.pivot);
         a.x1 += scale_center.x - 2;
         a.y1 += scale_center.y - 2;
         a.x2 += scale_center.x + 2;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -319,7 +319,7 @@
         #ifdef CONFIG_LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
             #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE CONFIG_LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
         #else
-            #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE (64 * 1024)
+            #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE 16384
         #endif
     #endif
 #endif

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -312,6 +312,17 @@
         #define LV_IMG_CACHE_DEF_SIZE   0
     #endif
 #endif
+#if LV_IMG_CACHE_DEF_SIZE != 0
+
+    /*Limit the total memory used by images*/
+    #ifndef LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
+        #ifdef CONFIG_LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
+            #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE CONFIG_LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE
+        #else
+            #define LV_IMG_CACHE_DEF_MEM_TOTAL_SIZE (64 * 1024)
+        #endif
+    #endif
+#endif
 
 /*Number of stops allowed per gradient. Increase this to allow more stops.
  *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/

--- a/src/widgets/lv_canvas.c
+++ b/src/widgets/lv_canvas.c
@@ -642,8 +642,8 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
         return;
     }
 
-    lv_img_header_t header;
-    lv_res_t res = lv_img_decoder_get_info(src, &header);
+    lv_img_decoder_info_t info;
+    lv_res_t res = lv_img_decoder_get_info(src, &info);
     if(res != LV_RES_OK) {
         LV_LOG_WARN("lv_canvas_draw_img: Couldn't get the image data.");
         return;
@@ -661,8 +661,8 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
     lv_area_t coords;
     coords.x1 = x;
     coords.y1 = y;
-    coords.x2 = x + header.w - 1;
-    coords.y2 = y + header.h - 1;
+    coords.x2 = x + info.header.w - 1;
+    coords.y2 = y + info.header.h - 1;
 
     lv_draw_img(driver.draw_ctx, draw_dsc, &coords, src);
 

--- a/src/widgets/lv_dropdown.c
+++ b/src/widgets/lv_dropdown.c
@@ -790,11 +790,11 @@ static void draw_main(lv_event_t * e)
             symbol_h = size.y;
         }
         else {
-            lv_img_header_t header;
-            lv_res_t res = lv_img_decoder_get_info(dropdown->symbol, &header);
+            lv_img_decoder_info_t info;
+            lv_res_t res = lv_img_decoder_get_info(dropdown->symbol, &info);
             if(res == LV_RES_OK) {
-                symbol_w = header.w;
-                symbol_h = header.h;
+                symbol_w = info.header.w;
+                symbol_h = info.header.h;
             }
             else {
                 symbol_w = -1;

--- a/src/widgets/lv_img.c
+++ b/src/widgets/lv_img.c
@@ -102,8 +102,8 @@ void lv_img_set_src(lv_obj_t * obj, const void * src)
         return;
     }
 
-    lv_img_header_t header;
-    lv_img_decoder_get_info(src, &header);
+    lv_img_decoder_info_t info;
+    lv_img_decoder_get_info(src, &info);
 
     /*Save the source*/
     if(src_type == LV_IMG_SRC_VARIABLE) {
@@ -140,16 +140,16 @@ void lv_img_set_src(lv_obj_t * obj, const void * src)
         lv_coord_t line_space = lv_obj_get_style_text_line_space(obj, LV_PART_MAIN);
         lv_point_t size;
         lv_txt_get_size(&size, src, font, letter_space, line_space, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
-        header.w = size.x;
-        header.h = size.y;
+        info.header.w = size.x;
+        info.header.h = size.y;
     }
 
     img->src_type = src_type;
-    img->w        = header.w;
-    img->h        = header.h;
-    img->cf       = header.cf;
-    img->pivot.x = header.w / 2;
-    img->pivot.y = header.h / 2;
+    img->w        = info.header.w;
+    img->h        = info.header.h;
+    img->cf       = info.header.cf;
+    img->pivot.x = info.header.w / 2;
+    img->pivot.y = info.header.h / 2;
 
     lv_obj_refresh_self_size(obj);
 


### PR DESCRIPTION
### Description of the feature or fix
**Do not merge this PR**

Related discussion: https://github.com/lvgl/lvgl/issues/3041

The practice of this PR is a new idea for cache management. The number of caches is limited according to the memory occupied by the picture to prevent the decoder from occupying too much memory.

I tested with `libs/png` decoder and it seems to work fine so far.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
