### PR TITLE
Fix trailing whitespaces in docs files

### DIFF
--- a/docs/overview/style-props.md
+++ b/docs/overview/style-props.md
@@ -367,7 +367,7 @@ Sets whether the border should be drawn before or after the children are drawn. 
 Properties to describe the outline. It's like a border but drawn outside of the rectangles.
 
 ### outline_width
-Set the width of the outline in pixels. 
+Set the width of the outline in pixels.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -415,7 +415,7 @@ Set the width of the shadow in pixels. The value should be >= 0.
 </ul>
 
 ### shadow_ofs_x
-Set an offset on the shadow in pixels in X direction. 
+Set an offset on the shadow in pixels in X direction.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -424,7 +424,7 @@ Set an offset on the shadow in pixels in X direction.
 </ul>
 
 ### shadow_ofs_y
-Set an offset on the shadow in pixels in Y direction. 
+Set an offset on the shadow in pixels in Y direction.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -520,7 +520,7 @@ Set the gap between dashes in pixel. Note that dash works only on horizontal and
 </ul>
 
 ### line_rounded
-Make the end points of the lines rounded. `true`: rounded, `false`: perpendicular line ending 
+Make the end points of the lines rounded. `true`: rounded, `false`: perpendicular line ending
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -559,7 +559,7 @@ Set the width (thickness) of the arcs in pixel.
 </ul>
 
 ### arc_rounded
-Make the end points of the arcs rounded. `true`: rounded, `false`: perpendicular line ending 
+Make the end points of the arcs rounded. `true`: rounded, `false`: perpendicular line ending
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -616,7 +616,7 @@ Set the opacity of the text. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully 
 </ul>
 
 ### text_font
-Set the font of the text (a pointer `lv_font_t *`). 
+Set the font of the text (a pointer `lv_font_t *`).
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FONT_DEFAULT`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>

--- a/docs/widgets/core/label.md
+++ b/docs/widgets/core/label.md
@@ -1,29 +1,29 @@
 ```eval_rst
-.. include:: /header.rst 
+.. include:: /header.rst
 :github_url: |github_link_base|/widgets/core/core/label.md
 ```
 # Label (lv_label)
 
 ## Overview
-A label is the basic object type that is used to display text. 
+A label is the basic object type that is used to display text.
 
 ## Parts and Styles
 - `LV_PART_MAIN`  Uses all the typical background properties and the text properties.  The padding values can be used to add space between the text and the background.
 - `LV_PART_SCROLLBAR` The scrollbar that is shown when the text is larger than the widget's size.
-- `LV_PART_SELECTED` Tells the style of the [selected text](#text-selection). Only `text_color` and `bg_color` style properties can be used. 
+- `LV_PART_SELECTED` Tells the style of the [selected text](#text-selection). Only `text_color` and `bg_color` style properties can be used.
 
 ## Usage
 
 ### Set text
-You can set the text on a label at runtime with `lv_label_set_text(label, "New text")`. 
-This will allocate a buffer dynamically, and the provided string will be copied into that buffer. 
+You can set the text on a label at runtime with `lv_label_set_text(label, "New text")`.
+This will allocate a buffer dynamically, and the provided string will be copied into that buffer.
 Therefore, you don't need to keep the text you pass to `lv_label_set_text` in scope after that function returns.
 
 With `lv_label_set_text_fmt(label, "Value: %d", 15)` printf formatting can be used to set the text.
 
-Labels are able to show text from a static character buffer.  To do so, use `lv_label_set_text_static(label, "Text")`. 
-In this case, the text is not stored in the dynamic memory and the given buffer is used directly instead. 
-This means that the array can't be a local variable which goes out of scope when the function exits. 
+Labels are able to show text from a static character buffer.  To do so, use `lv_label_set_text_static(label, "Text")`.
+In this case, the text is not stored in the dynamic memory and the given buffer is used directly instead.
+This means that the array can't be a local variable which goes out of scope when the function exits.
 Constant strings are safe to use with `lv_label_set_text_static` (except when used with `LV_LABEL_LONG_DOT`, as it modifies the buffer in-place), as they are stored in ROM memory, which is always accessible.
 
 ### Newline
@@ -31,30 +31,30 @@ Constant strings are safe to use with `lv_label_set_text_static` (except when us
 Newline characters are handled automatically by the label object. You can use `\n` to make a line break. For example: `"line1\nline2\n\nline4"`
 
 ### Long modes
-By default, the width and height of the label is set to `LV_SIZE_CONTENT`. Therefore, the size of the label is automatically expanded to the text size. 
-Otherwise, if the width or height are explicitly set (using  e.g.`lv_obj_set_width` or a layout), the lines wider than the label's width can be manipulated according to several long mode policies. 
+By default, the width and height of the label is set to `LV_SIZE_CONTENT`. Therefore, the size of the label is automatically expanded to the text size.
+Otherwise, if the width or height are explicitly set (using  e.g.`lv_obj_set_width` or a layout), the lines wider than the label's width can be manipulated according to several long mode policies.
 Similarly, the policies can be applied if the height of the text is greater than the height of the label.
 - `LV_LABEL_LONG_WRAP` Wrap too long lines. If the height is `LV_SIZE_CONTENT` the label's height will be expanded, otherwise the text will be clipped. (Default)
-- `LV_LABEL_LONG_DOT` Replaces the last 3 characters from bottom right corner of the label with dots (`.`) 
+- `LV_LABEL_LONG_DOT` Replaces the last 3 characters from bottom right corner of the label with dots (`.`)
 - `LV_LABEL_LONG_SCROLL` If the text is wider than the label scroll it horizontally back and forth. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
 - `LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continuously. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
 - `LV_LABEL_LONG_CLIP` Simply clip the parts of the text outside the label.
 
 You can specify the long mode with `lv_label_set_long_mode(label, LV_LABEL_LONG_...)`
 
-Note that `LV_LABEL_LONG_DOT` manipulates the text buffer in-place in order to add/remove the dots.  
-When `lv_label_set_text` or `lv_label_set_array_text` are used, a separate buffer is allocated and this implementation detail is unnoticed. 
+Note that `LV_LABEL_LONG_DOT` manipulates the text buffer in-place in order to add/remove the dots.
+When `lv_label_set_text` or `lv_label_set_array_text` are used, a separate buffer is allocated and this implementation detail is unnoticed.
 This is not the case with `lv_label_set_text_static`. The buffer you pass to `lv_label_set_text_static` must be writable if you plan to use `LV_LABEL_LONG_DOT`.
 
 ### Text recolor
-In the text, you can use commands to recolor parts of the text. For example: `"Write a #ff0000 red# word"`. 
-This feature can be enabled individually for each label by `lv_label_set_recolor()` function. 
+In the text, you can use commands to recolor parts of the text. For example: `"Write a #ff0000 red# word"`.
+This feature can be enabled individually for each label by `lv_label_set_recolor()` function.
 
 ### Text selection
-If enabled by `LV_LABEL_TEXT_SELECTION` part of the text can be selected. It's similar to when you use your mouse on a PC to select a text. 
+If enabled by `LV_LABEL_TEXT_SELECTION` part of the text can be selected. It's similar to when you use your mouse on a PC to select a text.
 The whole mechanism (click and select the text as you drag your finger/mouse) is implemented in [Text area](/widgets/core/textarea) and the Label widget only allows manual text selection with
 `lv_label_get_text_selection_start(label, start_char_index)` and `lv_label_get_text_selection_start(label, end_char_index)`.
- 
+
 ### Very long texts
 LVGL can efficiently handle very long (e.g. > 40k characters) labels by saving some extra data (~12 bytes) to speed up drawing. To enable this feature, set `LV_LABEL_LONG_TXT_HINT   1` in `lv_conf.h`.
 
@@ -85,12 +85,12 @@ Learn more about [Keys](/overview/indev).
 
 ```
 
-## API 
+## API
 
 ```eval_rst
 
 .. doxygenfile:: lv_label.h
   :project: lvgl
-        
+
 ```
 

--- a/examples/widgets/label/index.rst
+++ b/examples/widgets/label/index.rst
@@ -1,16 +1,16 @@
-  
-Line wrap, recoloring and scrolling 
+
+Line wrap, recoloring and scrolling
 """""""""""""""""""""""""""""""""""
 
 .. lv_example:: widgets/label/lv_example_label_1
   :language: c
 
-Text shadow 
+Text shadow
 """"""""""""
 
 .. lv_example:: widgets/label/lv_example_label_2
   :language: c
-  
+
 Show LTR, RTL and Chinese texts
 """"""""""""""""""""""""""""""""""""
 


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
