### PR TITLE
Swap high and low bytes when macro LV_COLOR_16_SWAP is 1

### DIFF
--- a/src/extra/libs/sjpg/lv_sjpg.c
+++ b/src/extra/libs/sjpg/lv_sjpg.c
@@ -766,7 +766,7 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
             uint16_t col_16bit = (*cache++ & 0xf8) << 8;
             col_16bit |= (*cache++ & 0xFC) << 3;
             col_16bit |= (*cache++ >> 3);
-#if  LV_BIG_ENDIAN_SYSTEM == 1
+#if  LV_BIG_ENDIAN_SYSTEM == 1 || LV_COLOR_16_SWAP == 1
             buf[offset++] = col_16bit >> 8;
             buf[offset++] = col_16bit & 0xff;
 #else
@@ -830,7 +830,7 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
             uint16_t col_8bit = (*cache++ & 0xf8) << 8;
             col_8bit |= (*cache++ & 0xFC) << 3;
             col_8bit |= (*cache++ >> 3);
-#if  LV_BIG_ENDIAN_SYSTEM == 1
+#if  LV_BIG_ENDIAN_SYSTEM == 1 || LV_COLOR_16_SWAP == 1
             buf[offset++] = col_8bit >> 8;
             buf[offset++] = col_8bit & 0xff;
 #else


### PR DESCRIPTION
### Description of the feature or fix

Image color is not normal when using SPI screen to display JPG

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
