### PR TITLE
fix(btnmatrix): set btn_id_act on keypad press

### DIFF
--- a/src/lv_widgets/lv_btnmatrix.c
+++ b/src/lv_widgets/lv_btnmatrix.c
@@ -893,6 +893,7 @@ static lv_res_t lv_btnmatrix_signal(lv_obj_t * btnm, lv_signal_t sign, void * pa
         else if(indev_type == LV_INDEV_TYPE_KEYPAD || (indev_type == LV_INDEV_TYPE_ENCODER &&
                                                        lv_group_get_editing(lv_obj_get_group(btnm)))) {
             ext->btn_id_pr = ext->btn_id_focused;
+            ext->btn_id_act = ext->btn_id_focused;
             invalidate_button_area(btnm, ext->btn_id_focused);
         }
 #endif


### PR DESCRIPTION
### Description of the feature or fix

This fix is to correct the behavior of the keypad interface and bring it up to the same logic as other interfaces (ie pointer).

While using the btnmatrix component and the keypad interface it's possible that the first LV_EVENT_PRESSED event will fire with the incorrect btn_id_act if a call to lv_btnmatrix_set_btn_ctrl() was made beforehand (as set_btn_ctrl sets btn_id_act but not focus).

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
