### PR TITLE
chore(lvgl.[h|mk]): don't include the grandchildren file

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -67,11 +67,6 @@ extern "C" {
  * EXTRAS
  *----------------*/
 #include "src/extra/lv_extra.h"
-#include "src/extra/widgets/lv_widgets.h"
-#include "src/extra/layouts/lv_layouts.h"
-#include "src/extra/themes/lv_themes.h"
-#include "src/extra/others/lv_others.h"
-#include "src/extra/libs/lv_libs.h"
 
 /*********************
  *      DEFINES

--- a/lvgl.mk
+++ b/lvgl.mk
@@ -1,9 +1,8 @@
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/demos/lv_demos.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/examples/examples.mk
-include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/extra/extra.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/core/lv_core.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/lv_draw.mk
-include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sw/lv_draw_sw.mk
+include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/extra/extra.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/font/lv_font.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/hal/lv_hal.mk
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/misc/lv_misc.mk

--- a/src/draw/lv_draw.mk
+++ b/src/draw/lv_draw.mk
@@ -16,3 +16,4 @@ VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw
 CFLAGS += "-I$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw"
 
 include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sdl/lv_draw_sdl.mk
+include $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sw/lv_draw_sw.mk

--- a/src/extra/lv_extra.h
+++ b/src/extra/lv_extra.h
@@ -14,6 +14,12 @@ extern "C" {
  *      INCLUDES
  *********************/
 
+#include "layouts/lv_layouts.h"
+#include "libs/lv_libs.h"
+#include "others/lv_others.h"
+#include "themes/lv_themes.h"
+#include "widgets/lv_widgets.h"
+
 /*********************
  *      DEFINES
  *********************/


### PR DESCRIPTION
### Description of the feature or fix

let's include the file layer by layer

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
