### PR TITLE
feat(dma2d) add lv_draw_stm32_dma2d_buffer_copy function

### DIFF
--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -147,9 +147,9 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
     if(!done) lv_draw_sw_blend_basic(draw_ctx, dsc);
 }
 
-void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
-                                     void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
-                                     void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area)
+void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
+                                     void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
+                                     void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area)
 {
     LV_UNUSED(draw_ctx);
     lv_draw_stm32_dma2d_blend_map(dest_buf, dest_area, dest_stride, src_buf, src_stride, LV_OPA_MAX);

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -149,7 +149,7 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
 
 void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
                                      void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
-									 void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area)
+                                     void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area)
 {
     LV_UNUSED(draw_ctx);
     lv_draw_stm32_dma2d_blend_map(dest_buf, dest_area, dest_stride, src_buf, src_stride, LV_OPA_MAX);

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -103,6 +103,7 @@ void lv_draw_stm32_dma2d_ctx_init(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
     dma2d_draw_ctx->blend = lv_draw_stm32_dma2d_blend;
     //    dma2d_draw_ctx->base_draw.draw_img_decoded = lv_draw_stm32_dma2d_img_decoded;
     dma2d_draw_ctx->base_draw.wait_for_finish = lv_gpu_stm32_dma2d_wait_cb;
+    dma2d_draw_ctx->base_draw.buffer_copy = lv_draw_stm32_dma2d_buffer_copy;
 
 }
 
@@ -144,6 +145,14 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
     }
 
     if(!done) lv_draw_sw_blend_basic(draw_ctx, dsc);
+}
+
+void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
+                                     void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
+									 void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area)
+{
+    LV_UNUSED(draw_ctx);
+    lv_draw_stm32_dma2d_blend_map(dest_buf, dest_area, dest_stride, src_buf, src_stride, LV_OPA_MAX);
 }
 
 

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -53,7 +53,7 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
 
 void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
                                      void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
-									 void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area);
+                                     void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area);
 
 void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
 

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -51,9 +51,9 @@ void lv_draw_stm32_dma2d_ctx_deinit(struct _lv_disp_drv_t * drv, lv_draw_ctx_t *
 
 void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
-void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
-                                     void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
-                                     void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area);
+void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
+                                     void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
+                                     void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area);
 
 void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
 

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -51,6 +51,10 @@ void lv_draw_stm32_dma2d_ctx_deinit(struct _lv_disp_drv_t * drv, lv_draw_ctx_t *
 
 void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
+void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t *draw_ctx,
+                                     void *dest_buf, lv_coord_t dest_stride, const lv_area_t *dest_area,
+									 void *src_buf, lv_coord_t src_stride, const lv_area_t *src_area);
+
 void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

This allow to use DMA2D accelerated hardware from display driver flush callback.
Tested on STM32F746G_DISCO with Arduino core.

Related to issue #3087.

### Example

```cpp
void lvgl_disp_flush(lv_disp_drv_t* display, const lv_area_t* area, lv_color_t* color_p) {
#if LV_USE_GPU_STM32_DMA2D
#if LV_VERSION_CHECK(8,2,0)
	lv_draw_stm32_dma2d_buffer_copy(NULL,
			(lv_color_t *)tft.getBuffer() + area->y1 * LV_HOR_RES + area->x1,
			(lv_coord_t) LV_HOR_RES, area, color_p, area->x2 - area->x1 + 1, area);
#else
	lv_gpu_stm32_dma2d_copy((lv_color_t *)tft.getBuffer() + area->y1 * LV_HOR_RES + area->x1, (lv_coord_t)LV_HOR_RES, color_p, area->x2 - area->x1 + 1, area->x2 - area->x1 + 1, area->y2 - area->y1 + 1);
#endif
#else
	tft.drawBuffer(area->x1, area->y1, , area->y2 - area->y1 + 1, (uint16_t*)color_p);
#endif
	lv_disp_flush_ready(display);
}
```
Note
- `tft.getBuffer()` return the address of the display frame buffer.
- LV_VERSION_CHECK should be set with the version released with these changes.
- `lv_gpu_stm32_dma2d_copy` was working fine before version 8.2.0.