### PR TITLE
fix(draw): src_buf_tmp will be NULL when LV_DRAW_COMPLEX is '0'

### DIFF
--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -173,12 +173,14 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_c
 
                 _lv_img_buf_transform_init(&trans_dsc);
             }
-            else {
+            else
+#endif
+            {
                 src_buf_tmp = src_buf;
                 src_buf_tmp += src_stride * (draw_area.y1 - coords->y1) * px_size_byte;
                 src_buf_tmp += (draw_area.x1 - coords->x1) * px_size_byte;
             }
-#endif
+
             uint16_t recolor_premult[3] = {0};
             lv_opa_t recolor_opa_inv = 255 - draw_dsc->recolor_opa;
             if(draw_dsc->recolor_opa != 0) {


### PR DESCRIPTION
### Description of the feature or fix

If `LV_DRAW_COMPLEX` is `0`, then the local pointer `src_buf_tmp` will not be assigned with a proper address but used with `NULL`. 

It looks like this code is not well tested with `LV_DRAW_COMPLEX` set to `0`

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
