### PR TITLE
fix(span): align the baselines

### DIFF
--- a/src/extra/widgets/span/lv_span.c
+++ b/src/extra/widgets/span/lv_span.c
@@ -780,6 +780,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
         bool is_end_line = false;
         bool ellipsis_valid = false;
         lv_coord_t max_line_h = 0;  /* the max height of span-font when a line have a lot of span */
+        lv_coord_t max_baseline = 0; /*baseline of the highest span*/
         lv_snippet_clear();
 
         /* the loop control to find a line and push the relevant span info into stack  */
@@ -860,6 +861,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
             cur_txt_ofs += next_ofs;
             if(max_line_h < snippet.line_h) {
                 max_line_h = snippet.line_h;
+                max_baseline = snippet.font->base_line;
             }
 
             lv_snippet_push(&snippet);
@@ -908,7 +910,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
 
             lv_point_t pos;
             pos.x = txt_pos.x;
-            pos.y = txt_pos.y + max_line_h - pinfo->line_h;
+            pos.y = txt_pos.y + max_line_h - pinfo->line_h - (max_baseline - pinfo->font->base_line);
             label_draw_dsc.color = lv_span_get_style_text_color(obj, pinfo->span);
             label_draw_dsc.opa = lv_span_get_style_text_opa(obj, pinfo->span);
             label_draw_dsc.font = lv_span_get_style_text_font(obj, pinfo->span);


### PR DESCRIPTION
### Description of the feature or fix

As the title says.

Before this change:
![image](https://user-images.githubusercontent.com/7599318/158023472-7efcf4f7-f891-486f-8852-f9b74383c2f3.png)


After this change:
![image](https://user-images.githubusercontent.com/7599318/158023431-1dc33d34-a1ef-4b3b-8256-5e45fb9ecc46.png)



@guoweilkd please review these changes.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
