### PR TITLE
fix(style) fix typo in value line spacing calculation

### DIFF
--- a/src/lv_core/lv_obj.c
+++ b/src/lv_core/lv_obj.c
@@ -3601,7 +3601,7 @@ lv_coord_t lv_obj_get_draw_rect_ext_pad_size(lv_obj_t * obj, uint8_t part)
         lv_opa_t value_opa = lv_obj_get_style_value_opa(obj, part);
         if(value_opa > LV_OPA_MIN) {
             lv_style_int_t letter_space = lv_obj_get_style_value_letter_space(obj, part);
-            lv_style_int_t line_space = lv_obj_get_style_value_letter_space(obj, part);
+            lv_style_int_t line_space = lv_obj_get_style_value_line_space(obj, part);
             const lv_font_t * font = lv_obj_get_style_value_font(obj, part);
 
             lv_point_t txt_size;


### PR DESCRIPTION
### Applicable version
This bug applies to the v7 release branch. The code in v8 is very different and this bug doesn't seem to apply there.

### Description of the feature or fix
The code for calculating the extra space around a 'value style' property contained a copy/paste error where the 'letter space' instead of the 'line space' was used in the vertical required size calculations.

