### PR TITLE
fix(Kconfig):move LV_USE_IMGFONT to others menu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -964,9 +964,6 @@ menu "LVGL configuration"
             endmenu
         endif
 
-        config LV_USE_IMGFONT
-            bool "draw img in label or span obj"
-
         config LV_USE_RLOTTIE
             bool "Lottie library"
 
@@ -985,6 +982,10 @@ menu "LVGL configuration"
 
         config LV_USE_MONKEY
             bool "Enable Monkey test"
+            default n
+
+        config LV_USE_IMGFONT
+            bool "draw img in label or span obj"
             default n
     endmenu
 


### PR DESCRIPTION
### Description of the feature or fix

sorry, I forgot to move LV_USE_IMGFONT  to others menu in Kconfig

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
