### PR TITLE
feat(indev): add possibility to enable/disable all input devices at once

### DIFF
--- a/docs/overview/object.md
+++ b/docs/overview/object.md
@@ -171,6 +171,7 @@ A new screen can be loaded with animation by using `lv_scr_load_anim(scr, transi
 Setting `auto_del` to `true` will automatically delete the old screen when the animation is finished.
 
 The new screen will become active (returned by `lv_scr_act()`) when the animation starts after `delay` time.
+All inputs are disabled during the screen animation.
 
 ### Handling multiple displays
 Screens are created on the currently selected *default display*.

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -77,7 +77,6 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     indev_proc_reset_query_handler(indev_act);
 
     if(indev_act->proc.disabled ||
-       indev_disabled ||
        indev_act->driver->disp->prev_scr != NULL) return; /*Input disabled or screen animation active*/
     bool continue_reading;
     do {
@@ -122,16 +121,20 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     INDEV_TRACE("finished");
 }
 
-void lv_indev_globally_enable(bool en)
-{
-    indev_disabled = en ? false : true;
-}
-
 void lv_indev_enable(lv_indev_t * indev, bool en)
 {
-    if(!indev) return;
+    uint8_t enable = en ? 0 : 1
 
-    indev->proc.disabled = en ? 0 : 1;
+    if(indev) {
+        indev->proc.disabled = enable;
+    }
+    else {
+        lv_indev_t * i = lv_indev_get_next(NULL);
+        while(i) {
+            indev->proc.disabled = enable;
+            i = lv_indev_get_next(i);
+        }
+    }
 }
 
 lv_indev_t * lv_indev_get_act(void)

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -123,7 +123,7 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
 
 void lv_indev_enable(lv_indev_t * indev, bool en)
 {
-    uint8_t enable = en ? 0 : 1
+    uint8_t enable = en ? 0 : 1;
 
     if(indev) {
         indev->proc.disabled = enable;

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -47,6 +47,7 @@ static bool indev_reset_check(_lv_indev_proc_t * proc);
  **********************/
 static lv_indev_t * indev_act;
 static lv_obj_t * indev_obj_act = NULL;
+static bool indev_disabled = false;
 
 /**********************
  *      MACROS
@@ -76,6 +77,7 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     indev_proc_reset_query_handler(indev_act);
 
     if(indev_act->proc.disabled ||
+       indev_disabled ||
        indev_act->driver->disp->prev_scr != NULL) return; /*Input disabled or screen animation active*/
     bool continue_reading;
     do {
@@ -118,6 +120,11 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     indev_obj_act = NULL;
 
     INDEV_TRACE("finished");
+}
+
+void lv_indev_enable(bool en)
+{
+    indev_disabled = en ? false : true;
 }
 
 void lv_indev_enable(lv_indev_t * indev, bool en)

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -47,7 +47,6 @@ static bool indev_reset_check(_lv_indev_proc_t * proc);
  **********************/
 static lv_indev_t * indev_act;
 static lv_obj_t * indev_obj_act = NULL;
-static bool indev_disabled = false;
 
 /**********************
  *      MACROS

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -122,7 +122,7 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     INDEV_TRACE("finished");
 }
 
-void lv_indev_enable(bool en)
+void lv_indev_globally_enable(bool en)
 {
     indev_disabled = en ? false : true;
 }

--- a/src/core/lv_indev.h
+++ b/src/core/lv_indev.h
@@ -36,6 +36,12 @@ extern "C" {
 void lv_indev_read_timer_cb(lv_timer_t * timer);
 
 /**
+ * Enable or disable all input devices (default enabled)
+ * @param en true to enable, false to disable
+ */
+void lv_indev_globally_enable(bool en);
+
+/**
  * Enable or disable an input device (default enabled)
  * @param indev pointer to an input device
  * @param en true to enable, false to disable

--- a/src/core/lv_indev.h
+++ b/src/core/lv_indev.h
@@ -36,14 +36,8 @@ extern "C" {
 void lv_indev_read_timer_cb(lv_timer_t * timer);
 
 /**
- * Enable or disable all input devices (default enabled)
- * @param en true to enable, false to disable
- */
-void lv_indev_globally_enable(bool en);
-
-/**
- * Enable or disable an input device (default enabled)
- * @param indev pointer to an input device
+ * Enable or disable one or all input devices (default enabled)
+ * @param indev pointer to an input device or NULL to enable/disable all of them
  * @param en true to enable, false to disable
  */
 void lv_indev_enable(lv_indev_t * indev, bool en);


### PR DESCRIPTION
### Description of the feature or fix

Currently, inputs are disabled if:
* the specific input is disabled (`lv_indev_enable`)
* a screen animation is active (`driver->disp->prev_scr != NULL`)

This PR adds the possibility to the user to disable all input devices for his own purpose (e.g. own (screen) animations).

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
