### PR TITLE
chore(docs): remove [lv_sim_...] and [lv_...] from "Repository layout"

### DIFF
--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -70,10 +70,8 @@ You will find these repositories there:
 - [lv_drivers](https://github.com/lvgl/lv_drivers) Display and input device drivers
 - [blog](https://github.com/lvgl/blog) Source of the blog's site (https://blog.lvgl.io)
 - [sim](https://github.com/lvgl/sim) Source of the online simulator's site (https://sim.lvgl.io)
-- [lv_sim_...](https://github.com/lvgl?q=lv_sim&type=&language=) Simulator projects for various IDEs and platforms
 - [lv_port_...](https://github.com/lvgl?q=lv_port&type=&language=) LVGL ports to development boards
 - [lv_binding_..](https://github.com/lvgl?q=lv_binding&type=&language=l) Bindings to other languages
-- [lv_...](https://github.com/lvgl?q=lv_&type=&language=) Ports to other platforms
 
 ## Release policy
 

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -70,7 +70,7 @@ You will find these repositories there:
 - [lv_drivers](https://github.com/lvgl/lv_drivers) Display and input device drivers
 - [blog](https://github.com/lvgl/blog) Source of the blog's site (https://blog.lvgl.io)
 - [sim](https://github.com/lvgl/sim) Source of the online simulator's site (https://sim.lvgl.io)
-- [lv_port_...](https://github.com/lvgl?q=lv_port&type=&language=) LVGL ports to development boards
+- [lv_port_...](https://github.com/lvgl?q=lv_port&type=&language=) LVGL ports to development boards or environments
 - [lv_binding_..](https://github.com/lvgl?q=lv_binding&type=&language=l) Bindings to other languages
 
 ## Release policy


### PR DESCRIPTION
### Description of the feature or fix
since [lv_sim_...] is part of [lv_port...] and [lv_...] just equals no filter at all

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation
