### PR TITLE
feat(tabview): support vertical scrolling

### DIFF
--- a/src/extra/widgets/tabview/lv_tabview.c
+++ b/src/extra/widgets/tabview/lv_tabview.c
@@ -135,14 +135,22 @@ void lv_tabview_set_act(lv_obj_t * obj, uint32_t id, lv_anim_enable_t anim_en)
 
     lv_obj_t * cont = lv_tabview_get_content(obj);
     if(cont == NULL) return;
-    lv_coord_t gap = lv_obj_get_style_pad_column(cont, LV_PART_MAIN);
-    lv_coord_t w = lv_obj_get_content_width(cont);
-    if(lv_obj_get_style_base_dir(obj, LV_PART_MAIN) != LV_BASE_DIR_RTL) {
-        lv_obj_scroll_to_x(cont, id * (gap + w), anim_en);
+
+    if((tabview->tab_pos & LV_DIR_VER) != 0) {
+        lv_coord_t gap = lv_obj_get_style_pad_column(cont, LV_PART_MAIN);
+        lv_coord_t w = lv_obj_get_content_width(cont);
+        if(lv_obj_get_style_base_dir(obj, LV_PART_MAIN) != LV_BASE_DIR_RTL) {
+            lv_obj_scroll_to_x(cont, id * (gap + w), anim_en);
+        }
+        else {
+            int32_t id_rtl = -(int32_t)id;
+            lv_obj_scroll_to_x(cont, (gap + w) * id_rtl, anim_en);
+        }
     }
     else {
-        int32_t id_rtl = -(int32_t)id;
-        lv_obj_scroll_to_x(cont, (gap + w) * id_rtl, anim_en);
+        lv_coord_t gap = lv_obj_get_style_pad_row(cont, LV_PART_MAIN);
+        lv_coord_t h = lv_obj_get_content_height(cont);
+        lv_obj_scroll_to_y(cont, id * (gap + h), anim_en);
     }
 
     lv_obj_t * btns = lv_tabview_get_tab_btns(obj);
@@ -229,8 +237,14 @@ static void lv_tabview_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     lv_group_t * g = lv_group_get_default();
     if(g) lv_group_add_obj(g, btnm);
 
-    lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW);
-    lv_obj_set_scroll_snap_x(cont, LV_SCROLL_SNAP_CENTER);
+    if((tabview->tab_pos & LV_DIR_VER) != 0) {
+        lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW);
+        lv_obj_set_scroll_snap_x(cont, LV_SCROLL_SNAP_CENTER);
+    }
+    else {
+        lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_scroll_snap_y(cont, LV_SCROLL_SNAP_CENTER);
+    }
     lv_obj_add_flag(cont, LV_OBJ_FLAG_SCROLL_ONE);
     lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
 }
@@ -289,6 +303,7 @@ static void cont_scroll_end_event_cb(lv_event_t * e)
     lv_event_code_t code = lv_event_get_code(e);
 
     lv_obj_t * tv = lv_obj_get_parent(cont);
+    lv_tabview_t * tv_obj = (lv_tabview_t *)tv;
     if(code == LV_EVENT_LAYOUT_CHANGED) {
         lv_tabview_set_act(tv, lv_tabview_get_tab_act(tv), LV_ANIM_OFF);
     }
@@ -296,11 +311,16 @@ static void cont_scroll_end_event_cb(lv_event_t * e)
         lv_point_t p;
         lv_obj_get_scroll_end(cont, &p);
 
-        lv_coord_t w = lv_obj_get_content_width(cont);
         lv_coord_t t;
-
-        if(lv_obj_get_style_base_dir(tv, LV_PART_MAIN) == LV_BASE_DIR_RTL)  t = -(p.x - w / 2) / w;
-        else t = (p.x + w / 2) / w;
+        if((tv_obj->tab_pos & LV_DIR_VER) != 0) {
+            lv_coord_t w = lv_obj_get_content_width(cont);
+            if(lv_obj_get_style_base_dir(tv, LV_PART_MAIN) == LV_BASE_DIR_RTL)  t = -(p.x - w / 2) / w;
+            else t = (p.x + w / 2) / w;
+        }
+        else {
+            lv_coord_t h = lv_obj_get_content_height(cont);
+            t = (p.y + h / 2) / h;
+        }
 
         if(t < 0) t = 0;
         bool new_tab = false;


### PR DESCRIPTION
### Description of the feature or fix

This makes it so when the tabview has the tabs on the left or right
it will be scrolled up and down rather than left and right in all cases.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation - None to update

I couldn't see any reference in tabview that specifically documents the scroll direction to change. Please let me know what I'm meant to do for this case.

I appreciate this changes existing behaviour and I'm happy to modify this so that scroll direction could be passed as an option to keep the current behaviour. I'm also not convinced the code around RTL support when vertically scrolling is correct for my changes in cont_scroll_end_event_cb is correct.