### PR TITLE
chore(config): change LV_FFMPEG_AV_DUMP_FORMAT to LV_FFMPEG_DUMP_FORMAT

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -969,8 +969,8 @@ menu "LVGL configuration"
 
         config LV_USE_FFMPEG
             bool "FFmpeg library"
-        config LV_FFMPEG_AV_DUMP_FORMAT
-            bool "Dump av format"
+        config LV_FFMPEG_DUMP_FORMAT
+            bool "Dump format"
             depends on LV_USE_FFMPEG
             default n
     endmenu

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -644,7 +644,7 @@
 #define LV_USE_FFMPEG  0
 #if LV_USE_FFMPEG
     /*Dump input information to stderr*/
-    #define LV_FFMPEG_AV_DUMP_FORMAT 0
+    #define LV_FFMPEG_DUMP_FORMAT 0
 #endif
 
 /*-----------

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2118,11 +2118,11 @@
 #endif
 #if LV_USE_FFMPEG
     /*Dump input information to stderr*/
-    #ifndef LV_FFMPEG_AV_DUMP_FORMAT
-        #ifdef CONFIG_LV_FFMPEG_AV_DUMP_FORMAT
-            #define LV_FFMPEG_AV_DUMP_FORMAT CONFIG_LV_FFMPEG_AV_DUMP_FORMAT
+    #ifndef LV_FFMPEG_DUMP_FORMAT
+        #ifdef CONFIG_LV_FFMPEG_DUMP_FORMAT
+            #define LV_FFMPEG_DUMP_FORMAT CONFIG_LV_FFMPEG_DUMP_FORMAT
         #else
-            #define LV_FFMPEG_AV_DUMP_FORMAT 0
+            #define LV_FFMPEG_DUMP_FORMAT 0
         #endif
     #endif
 #endif


### PR DESCRIPTION
### Description of the feature or fix

ensure all ffmpeg special config start with the prefix(LV_FFMPEG_)

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
