### PR TITLE
fix(obj):scrolling exception when using lv_obj_set_parent() interface

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -65,6 +65,7 @@ void lv_obj_del(lv_obj_t * obj)
 
     /*Call the ancestor's event handler to the parent to notify it about the child delete*/
     if(par) {
+        lv_obj_update_layout(par);
         lv_obj_readjust_scroll(par, LV_ANIM_OFF);
         lv_obj_scrollbar_invalidate(par);
         lv_event_send(par, LV_EVENT_CHILD_CHANGED, NULL);


### PR DESCRIPTION
### Description of the feature or fix

Resetting parent may cause the relative coordinates of this obj to change, but `obj->coords` did not change. This sometimes leads to errors in the calculation of lv_obj_readjust_scroll() functions.

test code:
```c
lv_obj_t * obj0;
lv_obj_t * obj2;
lv_obj_t * obj3;
static void btn_cb(lv_event_t * e)
{
    lv_event_code_t code = lv_event_get_code(e);
    lv_obj_t * btn = lv_event_get_target(e);

    if(code == LV_EVENT_CLICKED) {
        lv_obj_set_parent(obj0, obj2);
        lv_obj_del_async(obj3);
    }
}

void lv_set_parent(void)
{
    obj0 = lv_obj_create(lv_scr_act());
    lv_obj_set_size(obj0, 100, 300);
    lv_obj_set_style_bg_color(obj0, lv_palette_main(LV_PALETTE_RED), LV_PART_MAIN);

    obj2 = lv_obj_create(lv_scr_act());
    lv_obj_set_size(obj2, 400, 400);
    lv_obj_set_style_border_color(obj2, lv_palette_main(LV_PALETTE_BLUE), LV_PART_MAIN);
    lv_obj_set_align(obj2, LV_ALIGN_TOP_RIGHT);

    obj3 = lv_obj_create(obj2);
    lv_obj_set_size(obj3, 200, 600);

    lv_obj_t * btn;
    btn = lv_btn_create(obj3);
    lv_obj_set_align(btn, LV_ALIGN_BOTTOM_MID);
    lv_obj_add_event_cb(btn, btn_cb, LV_EVENT_ALL, NULL);
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
