### PR TITLE
fix(png): use LV_IMG_CF_TRUE_COLOR_ALPHA instead of LV_IMG_CF_RAW_ALPHA

### DIFF
--- a/src/extra/libs/png/lv_png.c
+++ b/src/extra/libs/png/lv_png.c
@@ -91,7 +91,7 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
 
             /*Save the data in the header*/
             header->always_zero = 0;
-            header->cf = LV_IMG_CF_RAW_ALPHA;
+            header->cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
             /*The width and height are stored in Big endian format so convert them to little endian*/
             header->w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);
             header->h = (lv_coord_t)((size[1] & 0xff000000) >> 24) + ((size[1] & 0x00ff0000) >> 8);


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
