### PR TITLE
fix(chart): Update chart to set LV_CHART_POINT_NONE correctly for LV_USE_LARGE_COORD

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -716,7 +716,7 @@ static void lv_chart_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         p.x -= obj->coords.x1;
         uint32_t id = get_index_from_x(obj, p.x + lv_obj_get_scroll_left(obj));
-        if(id != chart->pressed_point_id) {
+        if(id != (uint32_t)chart->pressed_point_id) {
             invalidate_point(obj, id);
             invalidate_point(obj, chart->pressed_point_id);
             chart->pressed_point_id = id;

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -904,7 +904,7 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
     if(LV_MIN(point_w, point_h) > line_dsc_default.width / 2) line_dsc_default.raw_end = 1;
     if(line_dsc_default.width == 1) line_dsc_default.raw_end = 1;
 
-    /*If there are mire points than pixels draw only vertical lines*/
+    /*If there are more points than pixels draw only vertical lines*/
     bool crowded_mode = chart->point_cnt >= w ? true : false;
 
     /*Go through all data lines*/

--- a/src/extra/widgets/chart/lv_chart.h
+++ b/src/extra/widgets/chart/lv_chart.h
@@ -22,7 +22,11 @@ extern "C" {
  *********************/
 
 /**Default value of points. Can be used to not draw a point*/
+#if LV_USE_LARGE_COORD
+#define LV_CHART_POINT_NONE (INT32_MAX)
+#else
 #define LV_CHART_POINT_NONE (INT16_MAX)
+#endif
 LV_EXPORT_CONST_INT(LV_CHART_POINT_NONE);
 
 /**********************
@@ -78,7 +82,7 @@ typedef struct {
 
 typedef struct {
     lv_point_t pos;
-    uint16_t point_id;
+    lv_coord_t point_id;
     lv_color_t color;
     lv_chart_series_t * ser;
     lv_dir_t dir;
@@ -104,7 +108,7 @@ typedef struct {
     lv_coord_t ymax[2];
     lv_coord_t xmin[2];
     lv_coord_t xmax[2];
-    uint16_t pressed_point_id;
+    lv_coord_t pressed_point_id;
     uint16_t hdiv_cnt;      /**< Number of horizontal division lines*/
     uint16_t vdiv_cnt;      /**< Number of vertical division lines*/
     uint16_t point_cnt;    /**< Point number in a data line*/


### PR DESCRIPTION
### Update chart to set LV_CHART_POINT_NONE correctly for LV_USE_LARGE_COORD

Set LV_CHART_POINT_NONE to INT32MAX instead of INT16MAX if LV USE_LARGE_COORD is selected.
