### PR TITLE
fix(txt): return 0 if letter_uni is out of range

### DIFF
--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -547,6 +547,9 @@ static uint32_t lv_txt_unicode_to_utf8(uint32_t letter_uni)
         bytes[2] = ((letter_uni >> 6) & 0x3F) | 0x80;
         bytes[3] = ((letter_uni >> 0) & 0x3F) | 0x80;
     }
+    else {
+        return 0;
+    }
 
     uint32_t * res_p = (uint32_t *)bytes;
     return *res_p;


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
