### PR TITLE
fix(gradient): assert before dividing by 0

### DIFF
--- a/src/draw/sw/lv_draw_sw_gradient.c
+++ b/src/draw/sw/lv_draw_sw_gradient.c
@@ -326,6 +326,8 @@ LV_ATTRIBUTE_FAST_MEM lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t 
         }
     }
 
+    LV_ASSERT(d != 0);
+
     /*Then interpolate*/
     frac -= min;
     lv_opa_t mix = (frac * 255) / d;


### PR DESCRIPTION
### Description of the feature or fix
@X-Ryl669 
Is it possible to divide by 0 during operation?

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
