### PR TITLE
cmake: Add missing "REQUIRES main" for ESP-IDF

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -22,7 +22,7 @@ if(LV_MICROPYTHON)
   endif()
 else()
   idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS ${LVGL_ROOT_DIR}
-                         ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../)
+                         ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../ REQUIRES main)
 
   target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 


### PR DESCRIPTION
### Description of the feature or fix

Hi there,

I realised that it may be necessary to add `REQUIRES main` in `idf_component_register()` in `env_support/cmake/esp.cmake`. Otherwise if I need to use any external libraries such as `freetype2`, the LVGL adapters like `lv_freetype.c` will complain about missing headers.

For example, I have a project that needs FreeType2, and I wrote a interface library (see here: https://github.com/huming2207/esp-ft2). I make it as a Git submodule and clone it into `components` directory of my ESP-IDF project. Meanwhile I also have a LVGL copy as a submodule in the `components` directory together. Now, if I enable the `LV_USE_FREETYPE` and start playing with the FreeType stuff, the compiler will complain something like this:

```
../components/lvgl/src/extra/libs/freetype/lv_freetype.c:12:10: fatal error: ft2build.h: No such file or directory
```

Even if I get the `main/CMakeLists.txt` to `REQUIRE` both `lvgl` and `freetype`, when compiling, the compiler will still complain the same error.

That is due to the LVGL component doesn't know the existence of my FreeType component. So we need to let `lvgl` component to know the existence of the project's `main` component, and since `main` component knows `freetype`, then `lvgl` component also knows the `freetype`.

Regards,
Jackson

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
