### PR TITLE
Fix: Track multiple directory handles with win32 backends

### DIFF
--- a/src/extra/libs/fsdrv/lv_fs_stdio.c
+++ b/src/extra/libs/fsdrv/lv_fs_stdio.c
@@ -21,10 +21,19 @@
 /*********************
  *      DEFINES
  *********************/
+#define MAX_PATH_LEN 256
 
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+#ifdef WIN32
+    HANDLE dir_p;
+    char next_fn[MAX_PATH_LEN];
+#else
+    DIR * dir_p;
+#endif
+} dir_handle_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -105,7 +114,7 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
 
     /*Make the path relative to the current directory (the projects root folder)*/
 
-    char buf[256];
+    char buf[MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_STDIO_PATH "%s", path);
 
     return fopen(buf, flags);
@@ -188,10 +197,6 @@ static lv_fs_res_t fs_tell(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p)
     return LV_FS_RES_OK;
 }
 
-#ifdef WIN32
-    static char next_fn[256];
-#endif
-
 /**
  * Initialize a 'DIR' or 'HANDLE' variable for directory reading
  * @param drv pointer to a driver where this function belongs
@@ -201,37 +206,47 @@ static lv_fs_res_t fs_tell(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p)
 static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
 {
     LV_UNUSED(drv);
+    dir_handle_t * handle = (dir_handle_t *)lv_mem_alloc(sizeof(dir_handle_t));
 #ifndef WIN32
     /*Make the path relative to the current directory (the projects root folder)*/
-    char buf[256];
+    char buf[MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_STDIO_PATH "%s", path);
-    return opendir(buf);
+    handle->dir_p = opendir(buf);
+    if(handle->dir_p == NULL) {
+        lv_mem_free(handle);
+        return NULL;
+    }
+    return handle;
 #else
-    HANDLE d = INVALID_HANDLE_VALUE;
+    handle->dir_p = INVALID_HANDLE_VALUE;
     WIN32_FIND_DATA fdata;
 
     /*Make the path relative to the current directory (the projects root folder)*/
-    char buf[256];
+    char buf[MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_STDIO_PATH "%s\\*", path);
 
-    strcpy(next_fn, "");
-    d = FindFirstFile(buf, &fdata);
+    strcpy(handle->next_fn, "");
+    handle->dir_p = FindFirstFile(buf, &fdata);
     do {
         if(strcmp(fdata.cFileName, ".") == 0 || strcmp(fdata.cFileName, "..") == 0) {
             continue;
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "%s", fdata.cFileName);
             }
             break;
         }
-    } while(FindNextFileA(d, &fdata));
+    } while(FindNextFileA(handle->dir_p, &fdata));
 
-    return d;
+    if(handle->dir_p == INVALID_HANDLE_VALUE) {
+        lv_mem_free(handle);
+        return INVALID_HANDLE_VALUE;
+    }
+    return handle;
 #endif
 }
 
@@ -246,13 +261,13 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
 static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 {
     LV_UNUSED(drv);
-
+    dir_handle_t * handle = (dir_handle_t *)dir_p;
 #ifndef WIN32
     struct dirent * entry;
     do {
-        entry = readdir(dir_p);
+        entry = readdir(handle->dir_p);
         if(entry) {
-            if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) lv_snprintf(fn, MAX_PATH_LEN, "/%s", entry->d_name);
             else strcpy(fn, entry->d_name);
         }
         else {
@@ -260,26 +275,26 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
         }
     } while(strcmp(fn, "/.") == 0 || strcmp(fn, "/..") == 0);
 #else
-    strcpy(fn, next_fn);
+    strcpy(fn, handle->next_fn);
 
-    strcpy(next_fn, "");
+    strcpy(handle->next_fn, "");
     WIN32_FIND_DATA fdata;
 
-    if(FindNextFile(dir_p, &fdata) == false) return LV_FS_RES_OK;
+    if(FindNextFile(handle->dir_p, &fdata) == false) return LV_FS_RES_OK;
     do {
         if(strcmp(fdata.cFileName, ".") == 0 || strcmp(fdata.cFileName, "..") == 0) {
             continue;
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "%s", fdata.cFileName);
             }
             break;
         }
-    } while(FindNextFile(dir_p, &fdata));
+    } while(FindNextFile(handle->dir_p, &fdata));
 
 #endif
     return LV_FS_RES_OK;
@@ -294,11 +309,13 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 static lv_fs_res_t fs_dir_close(lv_fs_drv_t * drv, void * dir_p)
 {
     LV_UNUSED(drv);
+    dir_handle_t * handle = (dir_handle_t *)dir_p;
 #ifndef WIN32
-    closedir(dir_p);
+    closedir(handle->dir_p);
 #else
-    FindClose(dir_p);
+    FindClose(handle->dir_p);
 #endif
+    lv_mem_free(handle);
     return LV_FS_RES_OK;
 }
 

--- a/src/extra/libs/fsdrv/lv_fs_win32.c
+++ b/src/extra/libs/fsdrv/lv_fs_win32.c
@@ -16,10 +16,16 @@
 /*********************
  *      DEFINES
  *********************/
+#define MAX_PATH_LEN 256
 
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+    HANDLE dir_p;
+    char next_fn[MAX_PATH_LEN];
+    lv_fs_res_t next_error;
+} dir_handle_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -344,9 +350,6 @@ static lv_fs_res_t fs_tell(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p)
     }
 }
 
-static char next_fn[256];
-static lv_fs_res_t next_error = LV_FS_RES_OK;
-
 /**
  * Initialize a 'DIR' or 'HANDLE' variable for directory reading
  * @param drv pointer to a driver where this function belongs
@@ -356,38 +359,45 @@ static lv_fs_res_t next_error = LV_FS_RES_OK;
 static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
 {
     LV_UNUSED(drv);
-
-    HANDLE d = INVALID_HANDLE_VALUE;
-    WIN32_FIND_DATAA fdata;
+    dir_handle_t * handle = (dir_handle_t *)lv_mem_alloc(sizeof(dir_handle_t));
+    handle->dir_p = INVALID_HANDLE_VALUE;
+    handle->next_error = LV_FS_RES_OK;
+    WIN32_FIND_DATA fdata;
 
     /*Make the path relative to the current directory (the projects root folder)*/
-    char buf[256];
+    char buf[MAX_PATH_LEN];
 #ifdef LV_FS_WIN32_PATH
     lv_snprintf(buf, sizeof(buf), LV_FS_WIN32_PATH "%s\\*", path);
 #else
     lv_snprintf(buf, sizeof(buf), "%s\\*", path);
 #endif
 
-    strcpy(next_fn, "");
-    d = FindFirstFileA(buf, &fdata);
+    strcpy(handle->next_fn, "");
+    handle->dir_p = FindFirstFile(buf, &fdata);
     do {
         if(is_dots_name(fdata.cFileName)) {
             continue;
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "%s", fdata.cFileName);
             }
             break;
         }
+    } while(FindNextFileA(handle->dir_p, &fdata));
 
-    } while(FindNextFileA(d, &fdata));
-
-    next_error = fs_error_from_win32(GetLastError());
-    return d;
+    if(handle->dir_p == INVALID_HANDLE_VALUE) {
+        lv_mem_free(handle);
+        handle->next_error = fs_error_from_win32(GetLastError());
+        return INVALID_HANDLE_VALUE;
+    }
+    else {
+        handle->next_error = LV_FS_RES_OK;
+        return handle;
+    }
 }
 
 /**
@@ -401,31 +411,30 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
 static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 {
     LV_UNUSED(drv);
+    dir_handle_t * handle = (dir_handle_t *)dir_p;
+    strcpy(fn, handle->next_fn);
+    lv_fs_res_t current_error = handle->next_error;
+    strcpy(handle->next_fn, "");
 
-    strcpy(fn, next_fn);
-    lv_fs_res_t current_error = next_error;
-    next_error = LV_FS_RES_OK;
+    WIN32_FIND_DATA fdata;
 
-    strcpy(next_fn, "");
-    WIN32_FIND_DATAA fdata;
-
-    while(FindNextFileA(dir_p, &fdata)) {
+    while(FindNextFileA(handle->dir_p, &fdata)) {
         if(is_dots_name(fdata.cFileName)) {
             continue;
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(handle->next_fn, sizeof(handle->next_fn), "%s", fdata.cFileName);
             }
             break;
         }
     }
 
-    if(next_fn[0] == '\0') {
-        next_error = fs_error_from_win32(GetLastError());
+    if(handle->next_fn[0] == '\0') {
+        handle->next_error = fs_error_from_win32(GetLastError());
     }
 
     return current_error;
@@ -440,9 +449,12 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 static lv_fs_res_t fs_dir_close(lv_fs_drv_t * drv, void * dir_p)
 {
     LV_UNUSED(drv);
-    return FindClose((HANDLE)dir_p)
-           ? LV_FS_RES_OK
-           : fs_error_from_win32(GetLastError());
+    dir_handle_t * handle = (dir_handle_t *)dir_p;
+    lv_fs_res_t res = FindClose(handle->dir_p)
+                      ? LV_FS_RES_OK
+                      : fs_error_from_win32(GetLastError());
+    lv_mem_free(handle);
+    return res;
 }
 
 #else /*LV_USE_FS_WIN32 == 0*/


### PR DESCRIPTION
### Description of the feature or fix

Described in https://github.com/lvgl/lvgl/issues/3149.

Due to using a shared static `next_fn` buffer, tracking multiple directories at once was broken. This fix allocates a new `next_fn` buffer for each directory handle. On the win32 backend it also allocates a new `next_error` variable for each directory.
As this code is in the stdio backend and the win32 backend, there is two commits, one for each file.

I could not get the win32 backend to work at all for me, but I included some fixes and it works now. Namely we were calling `GetLastError()` in dir_open even when no error occured, so successful operations were reporting the last unrelated error that occured even if successful. https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea implies we should only call this if the function fails or fails to locate files instead of all the time. This PR includes this fix.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation

Test code now works as expected:
```
lv_fs_dir_t dir_a;
lv_fs_dir_t dir_b;
lv_fs_dir_open(&dir_a, "A:folder1");
lv_fs_dir_open(&dir_b, "A:folder2");

char fname[256];
lv_fs_dir_read(&dir_a, fname); //Read 1st file in dir_a;
lv_log("dir_a, first file: %s\n", fname);
lv_fs_dir_read(&dir_a, fname); //Read 2nd file in dir_a;
lv_log("dir_a, second file: %s\n", fname);

lv_fs_dir_read(&dir_b, fname); //Read 1st file in dir_b;
lv_log("dir_b, first file: %s\n", fname);
lv_fs_dir_read(&dir_a, fname); //Read 3rd file in dir_a;
lv_log("dir_a, third file: %s\n", fname);
```
Output on win32 and stdio backends built with mingw:
```
dir_a, first file: 1file1.txt
dir_a, second file: 1file2.txt
dir_b, first file: 2file1.txt
dir_a, third file: 1file3.txt
```
Each folder contains 1file1/2/3.txt and 2file1/2/3.txt for folder1 and folder2 respectively.