### PR TITLE
feat(benchmark): add trace output for running a specific scenario

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -875,15 +875,17 @@ static void report_cb(lv_timer_t * timer)
     if(opa_mode) {
         lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
                               scenes[scene_act].fps_normal);
+        LV_LOG("Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
+                              scenes[scene_act].fps_normal);
+    }
+    else if(scene_act > 0) {
+        lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
+                              scenes[scene_act - 1].fps_opa);
+        LV_LOG("Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
+                              scenes[scene_act - 1].fps_opa);
     }
     else {
-        if(scene_act > 0) {
-            lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
-                                  scenes[scene_act - 1].fps_opa);
-        }
-        else {
-            lv_label_set_text(subtitle, "");
-        }
+        lv_label_set_text(subtitle, "");
     }
 }
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -876,13 +876,13 @@ static void report_cb(lv_timer_t * timer)
         lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
                               scenes[scene_act].fps_normal);
         LV_LOG("Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
-                              scenes[scene_act].fps_normal);
+               scenes[scene_act].fps_normal);
     }
     else if(scene_act > 0) {
         lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
                               scenes[scene_act - 1].fps_opa);
         LV_LOG("Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
-                              scenes[scene_act - 1].fps_opa);
+               scenes[scene_act - 1].fps_opa);
     }
     else {
         lv_label_set_text(subtitle, "");


### PR DESCRIPTION
### Description of the feature or fix

1. Add trace output capability for `lv_demo_benchmark_run_scene()`.
2. Add guidance for using `benchmark` as a way of performance analysis. 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
