### PR TITLE
pref(png): use lv_memcpy/memset to improve performance

### DIFF
--- a/src/extra/libs/png/lodepng.c
+++ b/src/extra/libs/png/lodepng.c
@@ -119,14 +119,12 @@ to something as fast. */
 
 static void lodepng_memcpy(void* LODEPNG_RESTRICT dst,
                            const void* LODEPNG_RESTRICT src, size_t size) {
-  size_t i;
-  for(i = 0; i < size; i++) ((char*)dst)[i] = ((const char*)src)[i];
+  lv_memcpy(dst, src, size);
 }
 
 static void lodepng_memset(void* LODEPNG_RESTRICT dst,
                            int value, size_t num) {
-  size_t i;
-  for(i = 0; i < num; i++) ((char*)dst)[i] = (char)value;
+  lv_memset(dst, value, num);
 }
 
 /* does not check memory out of bounds, do not use on untrusted data */


### PR DESCRIPTION
### Description of the feature or fix

The default implementation of lodepng's `memcpy()` and `memset()` is less efficient.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
