### PR TITLE
fix(obj_style): prevent access to class null pointer

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -241,7 +241,12 @@ lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_
                 cls = cls->base_class;
             }
 
-            value_act.num = prop == LV_STYLE_WIDTH ? cls->width_def : cls->height_def;
+            if(cls) {
+                value_act.num = prop == LV_STYLE_WIDTH ? cls->width_def : cls->height_def;
+            }
+            else {
+                value_act.num = 0;
+            }
         }
         else {
             value_act = lv_style_prop_get_default(prop);


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
