### PR TITLE
feat(gif): GIF controls

### DIFF
--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -101,6 +101,17 @@ void lv_gif_restart(lv_obj_t * obj)
     gd_rewind(gifobj->gif);
 }
 
+void lv_gif_start(lv_obj_t * obj){
+  lv_gif_t * gifobj = (lv_gif_t *) obj;
+  lv_timer_resume(gifobj->timer);
+  lv_timer_reset(gifobj->timer);
+}
+
+void lv_gif_stop(lv_obj_t * obj){
+  lv_gif_t * gifobj = (lv_gif_t *) obj;
+  lv_timer_pause(gifobj->timer);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -85,10 +85,10 @@ void lv_gif_set_src(lv_obj_t * obj, const void * src)
     gifobj->imgdsc.header.h = gifobj->gif->height;
     gifobj->imgdsc.header.w = gifobj->gif->width;
     gifobj->last_call = lv_tick_get();
-    if(gifobj->gif->loop_count == 0){
+    if(gifobj->gif->loop_count == 0) {
         gifobj->loop = LV_GIF_LOOP_ON;
     }
-    else{
+    else {
         gifobj->loop = LV_GIF_LOOP_DEFAULT;
     }
 
@@ -107,20 +107,23 @@ void lv_gif_restart(lv_obj_t * obj)
     gd_rewind(gifobj->gif);
 }
 
-void lv_gif_start(lv_obj_t * obj){
-  lv_gif_t * gifobj = (lv_gif_t *) obj;
-  lv_timer_resume(gifobj->timer);
-  lv_timer_reset(gifobj->timer);
+void lv_gif_start(lv_obj_t * obj)
+{
+    lv_gif_t * gifobj = (lv_gif_t *) obj;
+    lv_timer_resume(gifobj->timer);
+    lv_timer_reset(gifobj->timer);
 }
 
-void lv_gif_stop(lv_obj_t * obj){
-  lv_gif_t * gifobj = (lv_gif_t *) obj;
-  lv_timer_pause(gifobj->timer);
+void lv_gif_stop(lv_obj_t * obj)
+{
+    lv_gif_t * gifobj = (lv_gif_t *) obj;
+    lv_timer_pause(gifobj->timer);
 }
 
-void lv_gif_set_loop(lv_obj_t * obj, lv_gif_loop_t loop){
-  lv_gif_t * gifobj = (lv_gif_t *) obj;
-  gifobj->loop = loop;
+void lv_gif_set_loop(lv_obj_t * obj, lv_gif_loop_t loop)
+{
+    lv_gif_t * gifobj = (lv_gif_t *) obj;
+    gifobj->loop = loop;
 }
 
 /**********************
@@ -158,7 +161,7 @@ static void next_frame_task_cb(lv_timer_t * t)
     int has_next = gd_get_frame(gifobj->gif);
     if(has_next == 0) {
         /*It was the last repeat*/
-        if(gifobj->loop == LV_GIF_LOOP_DEFAULT){
+        if(gifobj->loop == LV_GIF_LOOP_DEFAULT) {
             if(gifobj->gif->loop_count == 1) {
                 lv_event_send(obj, LV_EVENT_READY, NULL);
                 return;
@@ -169,11 +172,11 @@ static void next_frame_task_cb(lv_timer_t * t)
                 gd_get_frame(gifobj->gif);
             }
         }
-        else if(gifobj->loop == LV_GIF_LOOP_ON){
+        else if(gifobj->loop == LV_GIF_LOOP_ON) {
             gd_rewind(gifobj->gif);
             gd_get_frame(gifobj->gif);
         }
-        else if(gifobj->loop == LV_GIF_LOOP_SINGLE){
+        else if(gifobj->loop == LV_GIF_LOOP_SINGLE) {
             lv_event_send(obj, LV_EVENT_READY, NULL);
             return;
         }

--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -85,7 +85,12 @@ void lv_gif_set_src(lv_obj_t * obj, const void * src)
     gifobj->imgdsc.header.h = gifobj->gif->height;
     gifobj->imgdsc.header.w = gifobj->gif->width;
     gifobj->last_call = lv_tick_get();
-    gifobj->loop = LV_GIF_LOOP_DEFAULT;
+    if(gifobj->gif->loop_count == 0){
+        gifobj->loop = LV_GIF_LOOP_ON;
+    }
+    else{
+        gifobj->loop = LV_GIF_LOOP_DEFAULT;
+    }
 
     lv_img_set_src(obj, &gifobj->imgdsc);
 

--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -155,8 +155,8 @@ static void next_frame_task_cb(lv_timer_t * t)
         /*It was the last repeat*/
         if(gifobj->loop == LV_GIF_LOOP_DEFAULT){
             if(gifobj->gif->loop_count == 1) {
-                lv_res_t res = lv_event_send(obj, LV_EVENT_READY, NULL);
-                if(res != LV_FS_RES_OK) return;
+                lv_event_send(obj, LV_EVENT_READY, NULL);
+                return;
             }
             else {
                 if(gifobj->gif->loop_count > 1)  gifobj->gif->loop_count--;

--- a/src/extra/libs/gif/lv_gif.h
+++ b/src/extra/libs/gif/lv_gif.h
@@ -27,12 +27,19 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef enum {
+  LV_GIF_LOOP_DEFAULT, // play gif as many times as is defined in the actual file
+  LV_GIF_LOOP_SINGLE, // play only one loop
+  LV_GIF_LOOP_ON // loop indefinitely
+} lv_gif_loop_t;
+
 typedef struct {
     lv_img_t img;
     gd_GIF * gif;
     lv_timer_t * timer;
     lv_img_dsc_t imgdsc;
     uint32_t last_call;
+    lv_gif_loop_t loop;
 } lv_gif_t;
 
 extern const lv_obj_class_t lv_gif_class;
@@ -46,6 +53,7 @@ void lv_gif_set_src(lv_obj_t * obj, const void * src);
 void lv_gif_restart(lv_obj_t * gif);
 void lv_gif_start(lv_obj_t * gif);
 void lv_gif_stop(lv_obj_t * gif);
+void lv_gif_set_loop(lv_obj_t * gif, lv_gif_loop_t loop);
 
 /**********************
  *      MACROS

--- a/src/extra/libs/gif/lv_gif.h
+++ b/src/extra/libs/gif/lv_gif.h
@@ -28,9 +28,9 @@ extern "C" {
  **********************/
 
 typedef enum {
-  LV_GIF_LOOP_DEFAULT, // play gif as many times as is defined in the actual file
-  LV_GIF_LOOP_SINGLE, // play only one loop
-  LV_GIF_LOOP_ON // loop indefinitely
+    LV_GIF_LOOP_DEFAULT, // play gif as many times as is defined in the actual file
+    LV_GIF_LOOP_SINGLE, // play only one loop
+    LV_GIF_LOOP_ON // loop indefinitely
 } lv_gif_loop_t;
 
 typedef struct {

--- a/src/extra/libs/gif/lv_gif.h
+++ b/src/extra/libs/gif/lv_gif.h
@@ -44,6 +44,8 @@ extern const lv_obj_class_t lv_gif_class;
 lv_obj_t * lv_gif_create(lv_obj_t * parent);
 void lv_gif_set_src(lv_obj_t * obj, const void * src);
 void lv_gif_restart(lv_obj_t * gif);
+void lv_gif_start(lv_obj_t * gif);
+void lv_gif_stop(lv_obj_t * gif);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

Hello! We've recently started using this library in our products and fell in love with it. However, the need for more control around GIFs has arisen.

This PR adds the following functions for controlling GIF playback:
* lv_gif_start - start GIF playback
* lv_gif_stop - stop GIF playback
* lv_gif_set_loop - set loop mode:
  * DEFAULT - loop as many times as defined in the file
  * SINGLE - loop once, draw last frame after that
  * ON - loop indefinitely

The code is tested and already used in production for one of our devices.

The code already existing in lv_gif.h didn't contain much documentation so I didn't bother with it either. Let me know if I should add documentation for the new functions before you can merge the PR.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
