### PR TITLE
fix(demo): added gaurd to prevent crash if default theme is not used

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -1064,9 +1064,9 @@ static void color_event_cb(lv_event_t * e)
         lv_palette_t * palette_primary = lv_event_get_user_data(e);
         lv_palette_t palette_secondary = (*palette_primary) + 3; /*Use another palette as secondary*/
         if(palette_secondary >= _LV_PALETTE_LAST) palette_secondary = 0;
-
+#if LV_USE_THEME_DEFAULT
         lv_theme_default_init(NULL, lv_palette_main(*palette_primary), lv_palette_main(palette_secondary), LV_THEME_DEFAULT_DARK, font_normal);
-
+#endif
         lv_color_t color = lv_palette_main(*palette_primary);
         lv_style_set_text_color(&style_icon, color);
         lv_chart_set_series_color(chart1, ser1, color);


### PR DESCRIPTION
### Fixes compilation error when LV_USE_THEME_DEFAULT=0

When LV_USE_THEME_DEFAULT=0 "lv_theme_default_init()" is not built.  However, lv_theme_default_init() is referenced in "demos/widgets/lv_demo_widgets.c" without checking if LV_USE_THEME_DEFAULT is set.  A check for this case was added.