### PR TITLE
fix(msgbox): do not execute init obj when obj == NULL

### DIFF
--- a/src/extra/widgets/msgbox/lv_msgbox.c
+++ b/src/extra/widgets/msgbox/lv_msgbox.c
@@ -74,8 +74,8 @@ lv_obj_t * lv_msgbox_create(lv_obj_t * parent, const char * title, const char * 
 
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_msgbox_class, parent);
     LV_ASSERT_MALLOC(obj);
-    lv_obj_class_init_obj(obj);
     if(obj == NULL) return NULL;
+    lv_obj_class_init_obj(obj);
     lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
 
     if(auto_parent) lv_obj_add_flag(obj, LV_MSGBOX_FLAG_AUTO_PARENT);


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
