### PR TITLE
fix(Kconfig): Add LV_USE_GRIDNAV and LV_USE_FRAGMENT to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -985,6 +985,14 @@ menu "LVGL configuration"
             bool "Enable Monkey test"
             default n
 
+        config LV_USE_GRIDNAV
+            bool "Enable grid navigation"
+            default n 
+
+        config LV_USE_FRAGMENT
+            bool "Enable lv_obj fragment"
+            default n 
+
         config LV_USE_IMGFONT
             bool "draw img in label or span obj"
             default n


### PR DESCRIPTION
Add `LV_USE_GRIDNAV` to Kconfig, which was missing as mentioned in #3207.
Also noticed that `LV_USE_FRAGMENT` was missing, so I've also added that one.
