### PR TITLE
fix(Kconfig): change the type of LV_FS_STDIO_LETTER from string to int

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -881,7 +881,8 @@ menu "LVGL configuration"
         config LV_USE_FS_STDIO
             bool "File system on top of stdio API"
         config LV_FS_STDIO_LETTER
-            string "Set an upper cased letter on which the drive will accessible (e.g. 'A' i.e. 65 )"
+            int "Set an upper cased letter on which the drive will accessible (e.g. 'A' i.e. 65 )"
+            default 0
             depends on LV_USE_FS_STDIO
         config LV_FS_STDIO_PATH
             string "Set the working directory"


### PR DESCRIPTION
### Description of the fix

Same to the [Issue #3060](https://github.com/lvgl/lvgl/issues/3060). 
As the type of **LV_FS_STDIO_LETTER** is _string_, the **lv_fs_open** will always fail with the warning: 
`Can't open file (%s): unknown driver letter`

To fix it, the following modifications are taken.

- Change the type of **LV_FS_STDIO_LETTER** from _string_ to _int_
- Add the default value to follow the style of other **LV_FS_XXX_LETTER**s

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
