### PR TITLE
lvgl/lvgl: img cache open recolor add opa

### DIFF
--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -13,6 +13,7 @@
 #include "../core/lv_refr.h"
 #include "../misc/lv_mem.h"
 #include "../misc/lv_math.h"
+#include "../misc/lv_color.h"
 
 /*********************
  *      DEFINES
@@ -232,7 +233,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, 
 {
     if(draw_dsc->opa <= LV_OPA_MIN) return LV_RES_OK;
 
-    _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, draw_dsc->recolor, draw_dsc->frame_id);
+    lv_color32_t recolor = { .full = lv_color_to32(draw_dsc->recolor) };
+    LV_COLOR_SET_A32(recolor, draw_dsc->recolor_opa);
+    _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, recolor, draw_dsc->frame_id);
 
     if(cdsc == NULL) return LV_RES_INV;
 

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -60,7 +60,7 @@
  * @param color color The color of the image with `LV_IMG_CF_ALPHA_...`
  * @return pointer to the cache entry or NULL if can open the image
  */
-_lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, int32_t frame_id)
+_lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color32_t color, int32_t frame_id)
 {
     /*Is the image cached?*/
     _lv_img_cache_entry_t * cached_src = NULL;

--- a/src/draw/lv_img_cache.h
+++ b/src/draw/lv_img_cache.h
@@ -50,7 +50,7 @@ typedef struct {
  * @param frame_id the index of the frame. Used only with animated images, set 0 for normal images
  * @return pointer to the cache entry or NULL if can open the image
  */
-_lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, int32_t frame_id);
+_lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color32_t color, int32_t frame_id);
 
 /**
  * Set the number of images to be cached.

--- a/src/draw/lv_img_decoder.h
+++ b/src/draw/lv_img_decoder.h
@@ -104,7 +104,7 @@ typedef struct _lv_img_decoder_dsc_t {
     const void * src;
 
     /**Color to draw the image. USed when the image has alpha channel only*/
-    lv_color_t color;
+    lv_color32_t color;
 
     /**Frame of the image, using with animated images*/
     int32_t frame_id;

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -182,7 +182,8 @@ bool lv_draw_sdl_img_load_texture(lv_draw_sdl_ctx_t * ctx, lv_draw_sdl_cache_key
                                   const void * src, int32_t frame_id, SDL_Texture ** texture,
                                   lv_draw_sdl_img_header_t ** header)
 {
-    _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, lv_color_white(), frame_id);
+    lv_color32_t white = { .full = 0xFFFFFFFF };
+    _lv_img_cache_entry_t * cdsc = _lv_img_cache_open(src, white, frame_id);
     lv_draw_sdl_cache_flag_t tex_flags = 0;
     SDL_Rect rect;
     SDL_memset(&rect, 0, sizeof(SDL_Rect));


### PR DESCRIPTION
### Description of the feature or fix

Take recolor_opa into consideration when opening image.  The cache manager checks for a uint32_t match anyway, adding opacity information makes it easier for decoder to correctly cache recolored results.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation