### PR TITLE
fix(Makefile): add missing lv_draw_transform and lv_draw_sw_transform

### DIFF
--- a/src/draw/lv_draw.mk
+++ b/src/draw/lv_draw.mk
@@ -5,6 +5,7 @@ CSRCS += lv_draw_label.c
 CSRCS += lv_draw_line.c
 CSRCS += lv_draw_mask.c
 CSRCS += lv_draw_rect.c
+CSRCS += lv_draw_transform.c
 CSRCS += lv_draw_triangle.c
 CSRCS += lv_img_buf.c
 CSRCS += lv_img_cache.c

--- a/src/draw/sw/lv_draw_sw.mk
+++ b/src/draw/sw/lv_draw_sw.mk
@@ -1,13 +1,14 @@
 CSRCS += lv_draw_sw.c
 CSRCS += lv_draw_sw_arc.c
 CSRCS += lv_draw_sw_blend.c
+CSRCS += lv_draw_sw_dither.c
+CSRCS += lv_draw_sw_gradient.c
 CSRCS += lv_draw_sw_img.c
 CSRCS += lv_draw_sw_letter.c
 CSRCS += lv_draw_sw_line.c
-CSRCS += lv_draw_sw_rect.c
 CSRCS += lv_draw_sw_polygon.c
-CSRCS += lv_draw_sw_gradient.c
-CSRCS += lv_draw_sw_dither.c
+CSRCS += lv_draw_sw_rect.c
+CSRCS += lv_draw_sw_transform.c
 
 DEPPATH += --dep-path $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sw
 VPATH += :$(LVGL_DIR)/$(LVGL_DIR_NAME)/src/draw/sw


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
