### PR TITLE
fix(meter): fix typo

### DIFF
--- a/src/extra/widgets/meter/lv_meter.c
+++ b/src/extra/widgets/meter/lv_meter.c
@@ -497,7 +497,6 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
             p_outer.x = (int32_t)(((int32_t)cos_mid * (r_out + line_width) + 127) >> (LV_TRIGO_SHIFT)) + p_center.x;
             p_outer.y = (int32_t)(((int32_t)sin_mid * (r_out + line_width) + 127) >> (LV_TRIGO_SHIFT)) + p_center.y;
 
-            part_draw_dsc.p1 = &p_outer;
             part_draw_dsc.p1 = &p_center;
             part_draw_dsc.id = i;
             part_draw_dsc.label_dsc = &label_dsc;

--- a/src/extra/widgets/meter/lv_meter.c
+++ b/src/extra/widgets/meter/lv_meter.c
@@ -498,6 +498,7 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
             p_outer.y = (int32_t)(((int32_t)sin_mid * (r_out + line_width) + 127) >> (LV_TRIGO_SHIFT)) + p_center.y;
 
             part_draw_dsc.p1 = &p_center;
+            part_draw_dsc.p2 = &p_outer;
             part_draw_dsc.id = i;
             part_draw_dsc.label_dsc = &label_dsc;
 


### PR DESCRIPTION
### Description of the feature or fix
Is it a typo?

```c
part_draw_dsc.p1 = &p_outer;
part_draw_dsc.p2 = &p_center;
part_draw_dsc.id = i;
part_draw_dsc.label_dsc = &label_dsc;
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
