### PR TITLE
fix(config): add LV_LAYER_SIMPLE_BUF_SIZE to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -214,9 +214,6 @@ menu "LVGL configuration"
         endmenu
 
         menu "GPU"
-            config LV_USE_EXTERNAL_RENDERER
-                bool
-                
             config LV_USE_GPU_ARM2D
                 bool "Enable Arm's 2D image processing library (Arm-2D) for all Cortex-M processors."
                 default n
@@ -263,7 +260,6 @@ menu "LVGL configuration"
 
             config LV_USE_GPU_SDL
                 bool "Use SDL renderer API"
-                select LV_USE_EXTERNAL_RENDERER
                 default n
             config LV_GPU_SDL_INCLUDE_PATH
                 string "include path of SDL header"

--- a/Kconfig
+++ b/Kconfig
@@ -156,6 +156,15 @@ menu "LVGL configuration"
                     radiuses are saved).
                     Set to 0 to disable caching.
 
+            config LV_LAYER_SIMPLE_BUF_SIZE
+                int "Optimal size to buffer the widget with opacity"
+                default 24576
+                help
+                    "Simple layers" are used when a widget has `style_opa < 255`
+                    to buffer the widget into a layer and blend it as an image
+                    with the given opacity. Note that `bg_opa`, `text_opa` etc
+                    don't require buffering into layer.
+
             config LV_IMG_CACHE_DEF_SIZE
                 int "Default image cache size. 0 to disable caching."
                 default 0


### PR DESCRIPTION
### Description of the feature or fix

- fix(config): remove LV_USE_EXTERNAL_RENDERER which is unused anymore 

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
