### PR TITLE
docs(pc-simulator): add MDK with FastModel

### DIFF
--- a/docs/get-started/platforms/pc-simulator.md
+++ b/docs/get-started/platforms/pc-simulator.md
@@ -22,6 +22,7 @@ The simulator is ported to various IDEs (Integrated Development Environments). C
 - [VisualStudio with SDL driver](https://github.com/lvgl/lv_sim_visual_studio_sdl): For Windows
 - [VSCode with SDL driver](https://github.com/lvgl/lv_sim_vscode_sdl): Recommended on Linux and Mac
 - [PlatformIO with SDL driver](https://github.com/lvgl/lv_platformio): Recommended on Linux and Mac
+- [MDK with FastModel](https://github.com/lvgl/lv_port_an547_cm55_sim): For Windows
 
 You can use any IDE for development but, for simplicity, the configuration for Eclipse CDT is what we'll focus on in this tutorial.
 The following section describes the set-up guide of Eclipse CDT in more detail.


### PR DESCRIPTION
### Description of the feature or fix

Add missing PC-simulator option: MDK with FastModel for windows

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
