### PR TITLE
Fix TLSF returning the wrong pointer when the requested size is too large

### DIFF
--- a/src/misc/lv_tlsf.c
+++ b/src/misc/lv_tlsf.c
@@ -1208,6 +1208,10 @@ void * lv_tlsf_realloc(lv_tlsf_t tlsf, void * ptr, size_t size)
         const size_t cursize = block_size(block);
         const size_t combined = cursize + block_size(next) + block_header_overhead;
         const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+        if(size > cursize && adjust == 0) {
+            /* The request is probably too large, fail */
+            return NULL;
+        }
 
         tlsf_assert(!block_is_free(block) && "block already marked as free");
 

--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -1,0 +1,26 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+}
+
+/* #3324 */
+void test_mem_buf_realloc(void)
+{
+#if LV_MEM_CUSTOM == 0
+    void * buf1 = lv_mem_alloc(20);
+    void * buf2 = lv_mem_realloc(buf1, LV_MEM_SIZE + 16384);
+    TEST_ASSERT_NULL(buf2);
+#endif
+}
+
+#endif


### PR DESCRIPTION
### Description of the feature or fix

* Limit test runs to 15 seconds so tests don't hang forever and instead fail.
* Make sure an  `LV_ASSERT_MSG` causes the test to fail instead of entering a `while(1);` loop.
* Add a test for #3324. Unfortunately it seems to pass at the moment.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
