### PR TITLE
fix(benchmark): remove redundant string for the small screens 

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -873,13 +873,13 @@ static void report_cb(lv_timer_t * timer)
     }
 
     if(opa_mode) {
-        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS", 
+        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS",
                               scenes[scene_act].fps_normal);
         LV_LOG("Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
                scenes[scene_act].fps_normal);
     }
     else if(scene_act > 0) {
-        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS", 
+        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS",
                               scenes[scene_act - 1].fps_opa);
         LV_LOG("Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
                scenes[scene_act - 1].fps_opa);

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -873,13 +873,13 @@ static void report_cb(lv_timer_t * timer)
     }
 
     if(opa_mode) {
-        lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
+        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS", 
                               scenes[scene_act].fps_normal);
         LV_LOG("Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
                scenes[scene_act].fps_normal);
     }
     else if(scene_act > 0) {
-        lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
+        lv_label_set_text_fmt(subtitle, "Result : %"LV_PRId32" FPS", 
                               scenes[scene_act - 1].fps_opa);
         LV_LOG("Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
                scenes[scene_act - 1].fps_opa);
@@ -904,19 +904,7 @@ void lv_demo_benchmark_run_scene(int_fast16_t scene_no)
     if(scenes[scene_act].create_cb) {
         lv_label_set_text_fmt(title, "%"LV_PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (int)(dimof(scenes) * 2) - 2,
                               scenes[scene_act].name, opa_mode ? " + opa" : "");
-        if(opa_mode) {
-            lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name,
-                                  scenes[scene_act].fps_normal);
-        }
-        else {
-            if(scene_act > 0) {
-                lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name,
-                                      scenes[scene_act - 1].fps_opa);
-            }
-            else {
-                lv_label_set_text(subtitle, "");
-            }
-        }
+        lv_label_set_text(subtitle, "");
 
         rnd_reset();
         scenes[scene_act].create_cb();


### PR DESCRIPTION
### Description of the feature or fix

When using `lv_demo_benchmark_run_scene()` to run a specified scene, the test result was shown with a redundant string (the same as the title) in the subtle, it is unreadable for small screens. 

By only keeping the "Result: " part, it is readable. 

![image](https://user-images.githubusercontent.com/13148491/166973284-6697dc8b-6c4c-4aac-96af-0d6844bbc14f.png)

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
