### PR TITLE
lv_txt_iso8859_1_next(..., NULL): fix returned value

### DIFF
--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -798,7 +798,7 @@ static uint32_t lv_txt_iso8859_1_conv_wc(uint32_t c)
  */
 static uint32_t lv_txt_iso8859_1_next(const char * txt, uint32_t * i)
 {
-    if(i == NULL) return txt[1]; /*Get the next char*/
+    if(i == NULL) return txt[0]; /*Get the next char*/
 
     uint8_t letter = txt[*i];
     (*i)++;


### PR DESCRIPTION
In LV_TXT_ENC_ASCII case, some labels can be are truncated, depending on the label text content.
The root cause is the incorrect lv_txt_iso8859_1_next(..., NULL) behavior which returns the next character instead of the current one.

Width computed by lv_txt_get_width() may become invalid.
