### PR TITLE
fix(demo): fix warning.

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1049,6 +1049,11 @@ static void line_create(lv_style_t * style)
 }
 
 
+static void arc_anim_end_angle_cb(void * var, int32_t v)
+{
+    lv_arc_set_end_angle(var, v);
+}
+
 static void arc_create(lv_style_t * style)
 {
     uint32_t i;
@@ -1066,7 +1071,7 @@ static void arc_create(lv_style_t * style)
         lv_anim_t a;
         lv_anim_init(&a);
         lv_anim_set_var(&a, obj);
-        lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t) lv_arc_set_end_angle);
+        lv_anim_set_exec_cb(&a, arc_anim_end_angle_cb);
         lv_anim_set_values(&a, 0, 359);
         lv_anim_set_time(&a, t);
         lv_anim_set_playback_time(&a, t);
@@ -1078,6 +1083,11 @@ static void arc_create(lv_style_t * style)
 }
 
 
+static void fall_anim_y_cb(void * var, int32_t v)
+{
+    lv_obj_set_y(var, v);
+}
+
 static void fall_anim(lv_obj_t * obj)
 {
     lv_obj_set_x(obj, rnd_next(0, lv_obj_get_width(scene_bg) - lv_obj_get_width(obj)));
@@ -1087,7 +1097,7 @@ static void fall_anim(lv_obj_t * obj)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, obj);
-    lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t) lv_obj_set_y);
+    lv_anim_set_exec_cb(&a, fall_anim_y_cb);
     lv_anim_set_values(&a, 0, lv_obj_get_height(scene_bg) - lv_obj_get_height(obj));
     lv_anim_set_time(&a, t);
     lv_anim_set_playback_time(&a, t);

--- a/demos/keypad_encoder/lv_demo_keypad_encoder.c
+++ b/demos/keypad_encoder/lv_demo_keypad_encoder.c
@@ -166,9 +166,6 @@ static void msgbox_create(void)
     lv_obj_add_event_cb(mbox, msgbox_event_cb, LV_EVENT_ALL, NULL);
     lv_group_focus_obj(lv_msgbox_get_btns(mbox));
     lv_obj_add_state(lv_msgbox_get_btns(mbox), LV_STATE_FOCUS_KEY);
-#if LV_EX_MOUSEWHEEL
-    lv_group_set_editing(g, true);
-#endif
     lv_group_focus_freeze(g, true);
 
     lv_obj_align(mbox, LV_ALIGN_CENTER, 0, 0);


### PR DESCRIPTION
### Description of the feature or fix

~/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c:169:5: warning: "LV_EX_MOUSEWHEEL" is not defined, evaluates to 0 [-Wundef]
  169 | #if LV_EX_MOUSEWHEEL
      |     ^~~~~~~~~~~~~~~~

~/lvgl/demos/benchmark/lv_demo_benchmark.c:1069:33: warning: cast between incompatible function types from ‘void (*)(lv_obj_t *, uint16_t)’ {aka ‘void (*)(struct _lv_obj_t *, short unsigned int)’} to ‘void (*)(void *, int32_t)’ {aka ‘void (*)(void *, int)’} [-Wcast-function-type]
 1069 |         lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t) lv_arc_set_end_angle);
      |                                 ^
~/lvgl/demos/benchmark/lv_demo_benchmark.c: In function ‘fall_anim’:
~/lvgl/demos/benchmark/lv_demo_benchmark.c:1090:29: warning: cast between incompatible function types from ‘void (*)(struct _lv_obj_t *, lv_coord_t)’ {aka ‘void (*)(struct _lv_obj_t *, short int)’} to ‘void (*)(void *, int32_t)’ {aka ‘void (*)(void *, int)’} [-Wcast-function-type]
 1090 |     lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t) lv_obj_set_y);
      |

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
