### PR TITLE
feat(benchmark): make lvgl render at the highest frame rate

### DIFF
--- a/demos/benchmark/README.md
+++ b/demos/benchmark/README.md
@@ -16,7 +16,7 @@ On to top of the screen the title of the current test step, and the result of th
 - If you only want to run a specific scene for any purpose (e.g. debug, performance optimization etc.), you can call `lv_demo_benchmark_run_scene()` instead of `lv_demo_benchmark()`and pass the scene number.
 - If you enabled trace output by setting macro `LV_USE_LOG` to `1` and trace level `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER` or higher, benchmark results are printed out in `csv` format.
 - If you want to know when the testing is finished, you can register a callback function via `lv_demo_benchmark_register_finished_handler()` before calling `lv_demo_benchmark()` or `lv_demo_benchmark_run_scene()`. 
-
+- If you want to know the maximum rendering performance of the system, call `lv_demo_benchmark_set_max_speed(true)` before `lv_demo_benchmark()`.
 
 ## Interpret the result
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -69,6 +69,7 @@ typedef struct {
 
 static lv_style_t style_common;
 static bool opa_mode = true;
+static bool run_max_speed = false;
 static finished_cb_t * benchmark_finished_cb = NULL;
 static uint32_t disp_ori_timer_period;
 static uint32_t anim_ori_timer_period;
@@ -637,14 +638,18 @@ static void benchmark_init(void)
 {
     lv_disp_t * disp = lv_disp_get_default();
     disp->driver->monitor_cb = monitor_cb;
-    if(disp->refr_timer) {
-        disp_ori_timer_period = disp->refr_timer->period;
-        lv_timer_set_period(disp->refr_timer, 1);
-    }
 
-    lv_timer_t * anim_timer = lv_anim_get_timer();
-    anim_ori_timer_period = anim_timer->period;
-    lv_timer_set_period(anim_timer, 1);
+    /*Force to run at maximum frame rate*/
+    if(run_max_speed) {
+        if(disp->refr_timer) {
+            disp_ori_timer_period = disp->refr_timer->period;
+            lv_timer_set_period(disp->refr_timer, 1);
+        }
+
+        lv_timer_t * anim_timer = lv_anim_get_timer();
+        anim_ori_timer_period = anim_timer->period;
+        lv_timer_set_period(anim_timer, 1);
+    }
 
     lv_obj_t * scr = lv_scr_act();
     lv_obj_remove_style_all(scr);
@@ -707,6 +712,10 @@ void lv_demo_benchmark_set_finished_cb(finished_cb_t * finished_cb)
     benchmark_finished_cb = finished_cb;
 }
 
+void lv_demo_benchmark_set_max_speed(bool en)
+{
+    run_max_speed = en;
+}
 
 /**********************
  *   STATIC FUNCTIONS
@@ -991,13 +1000,17 @@ static void scene_next_task_cb(lv_timer_t * timer)
     }
     /*Ready*/
     else {
-        lv_timer_t * anim_timer = lv_anim_get_timer();
-        lv_timer_set_period(anim_timer, anim_ori_timer_period);
 
-        lv_disp_t * disp = lv_disp_get_default();
-        lv_timer_t * refr_timer = _lv_disp_get_refr_timer(disp);
-        if(refr_timer) {
-            lv_timer_set_period(refr_timer, disp_ori_timer_period);
+        /*Restore original frame rate*/
+        if(run_max_speed) {
+            lv_timer_t * anim_timer = lv_anim_get_timer();
+            lv_timer_set_period(anim_timer, anim_ori_timer_period);
+
+            lv_disp_t * disp = lv_disp_get_default();
+            lv_timer_t * refr_timer = _lv_disp_get_refr_timer(disp);
+            if(refr_timer) {
+                lv_timer_set_period(refr_timer, disp_ori_timer_period);
+            }
         }
 
         generate_report();      /* generate report */

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -70,6 +70,8 @@ typedef struct {
 static lv_style_t style_common;
 static bool opa_mode = true;
 static finished_cb_t * benchmark_finished_cb = NULL;
+static uint32_t disp_ori_timer_period;
+static uint32_t anim_ori_timer_period;
 
 LV_IMG_DECLARE(img_benchmark_cogwheel_argb);
 LV_IMG_DECLARE(img_benchmark_cogwheel_rgb);
@@ -635,6 +637,14 @@ static void benchmark_init(void)
 {
     lv_disp_t * disp = lv_disp_get_default();
     disp->driver->monitor_cb = monitor_cb;
+    if(disp->refr_timer) {
+        disp_ori_timer_period = disp->refr_timer->period;
+        lv_timer_set_period(disp->refr_timer, 1);
+    }
+
+    lv_timer_t * anim_timer = lv_anim_get_timer();
+    anim_ori_timer_period = anim_timer->period;
+    lv_timer_set_period(anim_timer, 1);
 
     lv_obj_t * scr = lv_scr_act();
     lv_obj_remove_style_all(scr);
@@ -981,6 +991,15 @@ static void scene_next_task_cb(lv_timer_t * timer)
     }
     /*Ready*/
     else {
+        lv_timer_t * anim_timer = lv_anim_get_timer();
+        lv_timer_set_period(anim_timer, anim_ori_timer_period);
+
+        lv_disp_t * disp = lv_disp_get_default();
+        lv_timer_t * refr_timer = _lv_disp_get_refr_timer(disp);
+        if(refr_timer) {
+            lv_timer_set_period(refr_timer, disp_ori_timer_period);
+        }
+
         generate_report();      /* generate report */
     }
 }

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -34,6 +34,8 @@ void lv_demo_benchmark_run_scene(int_fast16_t scene_no);
 
 void lv_demo_benchmark_set_finished_cb(finished_cb_t * finished_cb);
 
+void lv_demo_benchmark_set_max_speed(bool en);
+
 /**********************
  *      MACROS
  **********************/

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -34,6 +34,10 @@ void lv_demo_benchmark_run_scene(int_fast16_t scene_no);
 
 void lv_demo_benchmark_set_finished_cb(finished_cb_t * finished_cb);
 
+/**
+ * Make the benchmark work at the highest frame rate
+ * @param en true: highest frame rate; false: default frame rate
+ */
 void lv_demo_benchmark_set_max_speed(bool en);
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix
The score calculated by the old benchmark program will be affected by the value set by `LV_DISP_DEF_REFR_PERIOD` and cannot reflect the real performance of the system.
The purpose of this PR is to force lvgl to render at the highest frame rate.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
