### PR TITLE
feat(demos): add a callback for benchmark

### DIFF
--- a/demos/benchmark/README.md
+++ b/demos/benchmark/README.md
@@ -15,6 +15,7 @@ On to top of the screen the title of the current test step, and the result of th
 - After `lv_init()` and initializing the drivers call `lv_demo_benchmark()`
 - If you only want to run a specific scene for any purpose (e.g. debug, performance optimization etc.), you can call `lv_demo_benchmark_run_scene()` instead of `lv_demo_benchmark()`and pass the scene number.
 - If you enabled trace output by setting macro `LV_USE_LOG` to `1` and trace level `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER` or higher, benchmark results are printed out in `csv` format.
+- If you want to know when the testing is finished, you can register a callback function via `lv_demo_benchmark_register_finished_handler()` before calling `lv_demo_benchmark()` or `lv_demo_benchmark_run_scene()`. 
 
 
 ## Interpret the result
@@ -36,25 +37,72 @@ By default, only the changed areas are refreshed. It means if only a few pixels 
 
 If you are doing performance analysis for 2D image processing optimization, LCD latency (flushing data to LCD) introduced by `disp_flush()` might dilute the performance results of the LVGL drawing process, hence make it harder to see your optimization results (gain or loss). To avoid such problem, please:
 
-1. Temporarily remove the code for flushing data to LCD inside `disp_flush()`. For example:
+1. Use a flag to control the LCD flushing inside `disp_flush()`. For example:
 
 ```c
+static volatile bool is_flush_enabled = true;
+
+void disp_enable(void)
+{
+    is_flush_enabled = true;
+}
+
+void disp_disable(void)
+{
+    is_flush_enabled = false;
+}
+
 static void disp_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
 {
-#if 0 //!< remove LCD latency
-    GLCD_DrawBitmap(area->x1,               //!< x
-                    area->y1,               //!< y
-                    area->x2 - area->x1 + 1,    //!< width
-                    area->y2 - area->y1 + 1,    //!< height
-                    (const uint8_t *)color_p);
-#endif
+    if(is_flush_enabled) {
+        GLCD_DrawBitmap(area->x1,                   //!< x
+                        area->y1,                   //!< y
+                        area->x2 - area->x1 + 1,    //!< width
+                        area->y2 - area->y1 + 1,    //!< height
+                        (const uint8_t *)color_p);
+    }
+
     /*IMPORTANT!!!
      *Inform the graphics library that you are ready with the flushing*/
     lv_disp_flush_ready(disp_drv);
 }
 ```
 
-2. Use trace output to get the benchmark results by:
+2. Disable flushing before calling `lv_demo_benchmark()` or `lv_demo_benchmark_run_scene()`, for example:
+
+```c
+extern void disp_enable(void);
+extern void disp_disable(void);
+
+static void on_benchmark_finished(void)
+{
+    disp_enable();
+}
+
+int main(void)
+{    
+    lv_init();
+    lv_port_disp_init();
+    lv_port_indev_init();
+
+    LV_LOG("Running LVGL Benchmark...");
+    LV_LOG("Please stand by...");
+    LV_LOG("NOTE: You will NOT see anything until the end.");
+
+    disp_disable();
+    
+    lv_demo_benchmark_register_finished_handler(&on_benchmark_finished);
+    lv_demo_benchmark();
+    
+    //lv_demo_benchmark_run_scene(43);      // run scene no 31
+
+    ...
+}
+```
+
+
+
+3. Alternatively, you can use trace output to get the benchmark results in csv format by:
    - Setting macro `LV_USE_LOG` to `1` 
    - Setting trace level `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER` or higher.
 

--- a/demos/benchmark/README.md
+++ b/demos/benchmark/README.md
@@ -91,7 +91,7 @@ int main(void)
 
     disp_disable();
     
-    lv_demo_benchmark_register_finished_handler(&on_benchmark_finished);
+    lv_demo_benchmark_set_finished_cb(&on_benchmark_finished);
     lv_demo_benchmark();
     
     //lv_demo_benchmark_run_scene(43);      // run scene no 31

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -69,7 +69,7 @@ typedef struct {
 
 static lv_style_t style_common;
 static bool opa_mode = true;
-static finished_cb_t *benchmark_finished_cb = NULL;
+static finished_cb_t * benchmark_finished_cb = NULL;
 
 LV_IMG_DECLARE(img_benchmark_cogwheel_argb);
 LV_IMG_DECLARE(img_benchmark_cogwheel_rgb);
@@ -692,7 +692,7 @@ void lv_demo_benchmark_run_scene(int_fast16_t scene_no)
 }
 
 
-void lv_demo_benchmark_register_finished_handler(finished_cb_t *finished_cb)
+void lv_demo_benchmark_register_finished_handler(finished_cb_t * finished_cb)
 {
     benchmark_finished_cb = finished_cb;
 }

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -69,6 +69,7 @@ typedef struct {
 
 static lv_style_t style_common;
 static bool opa_mode = true;
+static finished_cb_t *benchmark_finished_cb = NULL;
 
 LV_IMG_DECLARE(img_benchmark_cogwheel_argb);
 LV_IMG_DECLARE(img_benchmark_cogwheel_rgb);
@@ -90,6 +91,7 @@ static void arc_create(lv_style_t * style);
 static void fall_anim(lv_obj_t * obj);
 static void rnd_reset(void);
 static int32_t rnd_next(int32_t min, int32_t max);
+static void report_cb(lv_timer_t * timer);
 
 static void rectangle_cb(void)
 {
@@ -663,6 +665,39 @@ void lv_demo_benchmark(void)
     scene_next_task_cb(NULL);
 }
 
+
+void lv_demo_benchmark_run_scene(int_fast16_t scene_no)
+{
+    benchmark_init();
+
+    if(((scene_no >> 1) >= dimof(scenes))) {
+        /* invalid scene number */
+        return ;
+    }
+
+    opa_mode = scene_no & 0x01;
+    scene_act = scene_no >> 1;
+
+    if(scenes[scene_act].create_cb) {
+        lv_label_set_text_fmt(title, "%"LV_PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (int)(dimof(scenes) * 2) - 2,
+                              scenes[scene_act].name, opa_mode ? " + opa" : "");
+        lv_label_set_text(subtitle, "");
+
+        rnd_reset();
+        scenes[scene_act].create_cb();
+
+        lv_timer_t * t = lv_timer_create(report_cb, SCENE_TIME, NULL);
+        lv_timer_set_repeat_count(t, 1);
+    }
+}
+
+
+void lv_demo_benchmark_register_finished_handler(finished_cb_t *finished_cb)
+{
+    benchmark_finished_cb = finished_cb;
+}
+
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -710,6 +745,10 @@ static void generate_report(void)
     uint32_t fps_opa_unweighted = fps_opa_sum / weight_opa_sum;
 
     uint32_t opa_speed_pct = (fps_opa_unweighted * 100) / fps_normal_unweighted;
+
+    if(NULL != benchmark_finished_cb) {
+        (*benchmark_finished_cb)();
+    }
 
     lv_obj_clean(lv_scr_act());
     scene_bg = NULL;
@@ -857,6 +896,10 @@ static void generate_report(void)
 
 static void report_cb(lv_timer_t * timer)
 {
+    if(NULL != benchmark_finished_cb) {
+        (*benchmark_finished_cb)();
+    }
+
     if(opa_mode) {
         if(scene_act >= 0) {
             if(scenes[scene_act].time_sum_opa == 0) scenes[scene_act].time_sum_opa = 1;
@@ -888,31 +931,6 @@ static void report_cb(lv_timer_t * timer)
     }
     else {
         lv_label_set_text(subtitle, "");
-    }
-}
-
-void lv_demo_benchmark_run_scene(int_fast16_t scene_no)
-{
-    benchmark_init();
-
-    if(((scene_no >> 1) >= dimof(scenes))) {
-        /* invalid scene number */
-        return ;
-    }
-
-    opa_mode = scene_no & 0x01;
-    scene_act = scene_no >> 1;
-
-    if(scenes[scene_act].create_cb) {
-        lv_label_set_text_fmt(title, "%"LV_PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (int)(dimof(scenes) * 2) - 2,
-                              scenes[scene_act].name, opa_mode ? " + opa" : "");
-        lv_label_set_text(subtitle, "");
-
-        rnd_reset();
-        scenes[scene_act].create_cb();
-
-        lv_timer_t * t = lv_timer_create(report_cb, SCENE_TIME, NULL);
-        lv_timer_set_repeat_count(t, 1);
     }
 }
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -692,7 +692,7 @@ void lv_demo_benchmark_run_scene(int_fast16_t scene_no)
 }
 
 
-void lv_demo_benchmark_register_finished_handler(finished_cb_t * finished_cb)
+void lv_demo_benchmark_set_finished_cb(finished_cb_t * finished_cb);
 {
     benchmark_finished_cb = finished_cb;
 }

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -23,7 +23,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 typedef void finished_cb_t(void);
- 
+
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -22,6 +22,8 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+ typedef void finished_cb_t(void);
+ 
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -29,6 +31,8 @@ extern "C" {
 void lv_demo_benchmark(void);
 
 void lv_demo_benchmark_run_scene(int_fast16_t scene_no);
+
+void lv_demo_benchmark_register_finished_handler(finished_cb_t *finished_cb);
 
 /**********************
  *      MACROS

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -32,7 +32,7 @@ void lv_demo_benchmark(void);
 
 void lv_demo_benchmark_run_scene(int_fast16_t scene_no);
 
-void lv_demo_benchmark_register_finished_handler(finished_cb_t * finished_cb);
+void lv_demo_benchmark_set_finished_cb(finished_cb_t * finished_cb);
 
 /**********************
  *      MACROS

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -22,7 +22,7 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
- typedef void finished_cb_t(void);
+typedef void finished_cb_t(void);
  
 
 /**********************
@@ -32,7 +32,7 @@ void lv_demo_benchmark(void);
 
 void lv_demo_benchmark_run_scene(int_fast16_t scene_no);
 
-void lv_demo_benchmark_register_finished_handler(finished_cb_t *finished_cb);
+void lv_demo_benchmark_register_finished_handler(finished_cb_t * finished_cb);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

Add a callback to the benchmark project to indicate the testing is finished.
One application of this callback is using it to switching off flushing temporarily when testing and switch on the flushing when it is finished.

```c
#if LV_USE_DEMO_BENCHMARK
static void on_benchmark_finished(void)
{
    disp_enable();
}
#endif

int main(void)
{
    printf("Hello LVGL!!\r\n");
    
    __cycleof__("Draw strings on LCD") {
        __LL_LCD_PRINT_BANNER("Hello LVGL!!");
    }
    
    lv_init();
    lv_port_disp_init();
    lv_port_indev_init();
    
#if LV_USE_DEMO_BENCHMARK

    __LL_LCD_PRINT(24, 0, "Running LVGL Benchmark...");
    __LL_LCD_PRINT(25, 0, "Please stand by...");
    __LL_LCD_PRINT(28, 0, "NOTE: You will NOT see anything until the end.");

    disp_disable();
    
    lv_demo_benchmark_register_finished_handler(&on_benchmark_finished);
    lv_demo_benchmark();
    
    //lv_demo_benchmark_run_scene(43);      // run scene no 31
#endif
    ...
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
