### PR TITLE
fix(draw): fix colour supports for indexed and alpha-only

### DIFF
--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -236,7 +236,12 @@ LV_ATTRIBUTE_FAST_MEM static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, 
 
     if(cdsc == NULL) return LV_RES_INV;
 
-    lv_img_cf_t cf = cdsc->dec_dsc.header.cf;
+    lv_img_cf_t cf;
+    if(lv_img_cf_is_chroma_keyed(cdsc->dec_dsc.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
+    else if(LV_IMG_CF_ALPHA_8BIT == cdsc->dec_dsc.header.cf) cf = LV_IMG_CF_ALPHA_8BIT;
+    else if(LV_IMG_CF_RGB565A8 == cdsc->dec_dsc.header.cf) cf = LV_IMG_CF_RGB565A8;
+    else if(lv_img_cf_has_alpha(cdsc->dec_dsc.header.cf)) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+    else cf = LV_IMG_CF_TRUE_COLOR;
 
     if(cf == LV_IMG_CF_ALPHA_8BIT) {
         if(draw_dsc->angle || draw_dsc->zoom != LV_IMG_ZOOM_NONE) {


### PR DESCRIPTION
### Description of the feature or fix

A recent update https://github.com/lvgl/lvgl/commit/b7733302348adc9379eaedd81c9914f1cc84a361 has broken the colour supports for indexed and alpha-only. 

#3370 

<img width="871" alt="image" src="https://user-images.githubusercontent.com/13148491/169424636-895af76e-0942-4c7d-b092-4b8d875dffc0.png">


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
