### PR TITLE
fix(style): Reset lookup table after gc sweep

### DIFF
--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -169,6 +169,9 @@ void lv_style_reset(lv_style_t * style)
 
 lv_style_prop_t lv_style_register_prop(uint8_t flag)
 {
+    if(LV_GC_ROOT(_lv_style_custom_prop_flag_lookup_table) == NULL) {
+        _lv_style_custom_prop_flag_lookup_table_size = 0;
+    }
     /*
      * Allocate the lookup table if it's not yet available.
      */


### PR DESCRIPTION
When a device goes through soft reset, all gc allocated memory is sweeped.
In such case, all LV_GC_ROOTs are set to NULL.

Consider the following scenario (related: https://github.com/lvgl/lv_binding_micropython/issues/213):
```
lv.init()
lv.deinit()
machine.soft_reset()
lv.init()
```

LVGL halts on the following assert:
```
[Error] (0.000, +0)      lv_style_register_prop: Asserted at expression: (mp_state_ctx.vm._lv_style_custom_prop_flag_lookup_table) != NULL (NULL pointer)       (in lv_style.c line #190)              
```

because [_lv_style_custom_prop_flag_lookup_table_size is set to 0](
https://github.com/lvgl/lvgl/blob/6be43b83b3dc9340263552167dbbb07c1069bdb0/src/misc/lv_style.c#L124) by static variable initialization, but is not reset again to 0 when `lv_deinit()` is called.  
But in this case the soft reset sweeps all gc allocated memory and `LV_GC_ROOT(_lv_style_custom_prop_flag_lookup_table)` is `NULL`, while `_lv_style_custom_prop_flag_lookup_table_size` is not 0.

To work around this, in case `LV_GC_ROOT(_lv_style_custom_prop_flag_lookup_table)` is `NULL`, we can assume a gc_sweep occured and force `_lv_style_custom_prop_flag_lookup_table_size` to 0.

In general, there may be a bigger issue here: How reliable is `lv_deinit()`?   
I think it should reset the entire state including global LVGL variables such as `_lv_style_custom_prop_flag_lookup_table_size`, and there are probably others.  
In any case, it's not safe to assume that any LV_GC_ROOT is valid after `lv_deinit` is called.


