### PR TITLE
fix(slider): should send LV_EVENT_VALUE_CHANGED event on drag release

### DIFF
--- a/src/widgets/lv_slider.c
+++ b/src/widgets/lv_slider.c
@@ -253,6 +253,9 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         lv_obj_invalidate(obj);
 
+        res = lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
+        if(res != LV_RES_OK) return;
+
         /*Leave edit mode if released. (No need to wait for LONG_PRESS)*/
         lv_group_t * g   = lv_obj_get_group(obj);
         bool editing     = lv_group_get_editing(g);


### PR DESCRIPTION
### Description of the feature or fix

Per the documentation here:
https://docs.lvgl.io/8.2/widgets/core/slider.html?highlight=lv_slider_is_dragged
A LV_EVENT_VALUE_CHANGED event should be triggered on release:
"The event is sent continuously while the slider is dragged and once when released."
But it appears this event is not being triggered. I'm very new to this code base, so I'm not certain my fix is right, but it at least fixes the problem I was having. Seen in 8.2 release branch.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [n/a] Update the documentation
