### PR TITLE
fix(slider): fix documentation to match the code where a LV_EVENT_VAL…

### DIFF
--- a/docs/widgets/core/slider.md
+++ b/docs/widgets/core/slider.md
@@ -32,8 +32,8 @@ In the latter case the knob moves to the point clicked and slider value changes 
 The extended click area (set by `lv_obj_set_ext_click_area(slider, value)`) increases to knob's click area.
 
 ## Events
-- `LV_EVENT_VALUE_CHANGED` Sent while the slider is being dragged or changed with keys.
-The event is sent continuously while the slider is dragged and once when released. Use `lv_slider_is_dragged` to determine whether the Slider is still being dragged or has just been released.
+- `LV_EVENT_VALUE_CHANGED` Sent while the slider is being dragged or changed with keys. The event is sent continuously while the slider is being dragged.
+- `LV_EVENT_RELEASED` Sent when the slider has just been released.
 - `LV_EVENT_DRAW_PART_BEGIN` and `LV_EVENT_DRAW_PART_END` are sent for the following parts.
     - `LV_SLIDER_DRAW_PART_KNOB` The main (right) knob of the slider
         - `part`: `LV_PART_KNOB`


### PR DESCRIPTION
…UE_CHANGED event is not throw on slider release, but a LV_EVENT_RELEASED is.

### Description of the feature or fix

Fixing the documentation. The documentation [here](https://docs.lvgl.io/8.2/widgets/core/slider.html?highlight=lv_slider_is_dragged) specifies:
"The event is sent continuously while the slider is dragged and once when released. Use lv_slider_is_dragged to determine whether the Slider is still being dragged or has just been released."
But the code does not fire an LV_EVENT_VALUE_CHANGED event on release. Instead, a developer should just register for an LV_EVENT_RELEASED event.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
