### PR TITLE
fix(draw) avoid use-after-free when drawing arcs

### DIFF
--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -97,8 +97,10 @@ void lv_draw_sw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, con
     /*Create inner the mask*/
     int16_t mask_in_id = LV_MASK_ID_INV;
     lv_draw_mask_radius_param_t mask_in_param;
+    bool mask_in_param_valid = false;
     if(lv_area_get_width(&area_in) > 0 && lv_area_get_height(&area_in) > 0) {
         lv_draw_mask_radius_init(&mask_in_param, &area_in, LV_RADIUS_CIRCLE, true);
+        mask_in_param_valid = true;
         mask_in_id = lv_draw_mask_add(&mask_in_param, NULL);
     }
 
@@ -115,7 +117,9 @@ void lv_draw_sw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, con
         if(mask_in_id != LV_MASK_ID_INV) lv_draw_mask_remove_id(mask_in_id);
 
         lv_draw_mask_free_param(&mask_out_param);
-        lv_draw_mask_free_param(&mask_in_param);
+        if(mask_in_param_valid) {
+           lv_draw_mask_free_param(&mask_in_param);
+        }
 
         return;
     }
@@ -162,7 +166,9 @@ void lv_draw_sw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, con
 
     lv_draw_mask_free_param(&mask_angle_param);
     lv_draw_mask_free_param(&mask_out_param);
-    lv_draw_mask_free_param(&mask_in_param);
+    if(mask_in_param_valid) {
+       lv_draw_mask_free_param(&mask_in_param);
+    }
 
     lv_draw_mask_remove_id(mask_angle_id);
     lv_draw_mask_remove_id(mask_out_id);

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -118,7 +118,7 @@ void lv_draw_sw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, con
 
         lv_draw_mask_free_param(&mask_out_param);
         if(mask_in_param_valid) {
-           lv_draw_mask_free_param(&mask_in_param);
+            lv_draw_mask_free_param(&mask_in_param);
         }
 
         return;
@@ -167,7 +167,7 @@ void lv_draw_sw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, con
     lv_draw_mask_free_param(&mask_angle_param);
     lv_draw_mask_free_param(&mask_out_param);
     if(mask_in_param_valid) {
-       lv_draw_mask_free_param(&mask_in_param);
+        lv_draw_mask_free_param(&mask_in_param);
     }
 
     lv_draw_mask_remove_id(mask_angle_id);


### PR DESCRIPTION
Fixed problem with freeing uninitialized mask_in_param, probably not in the most efficient way, as I do not really know the internal workings of this lvgl (Just started using it)

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
