### PR TITLE
lvgl.h include path fix

### DIFF
--- a/examples/assets/emoji/img_emoji_F617.c
+++ b/examples/assets/emoji/img_emoji_F617.c
@@ -1,7 +1,7 @@
 #ifdef LV_LVGL_H_INCLUDE_SIMPLE
 #include "lvgl.h"
 #else
-#include "lvgl/lvgl.h"
+#include "../../../lvgl.h"
 #endif
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN


### PR DESCRIPTION
### Description of the feature or fix

When LV_LVGL_H_INCLUDE_SIMPLE is not defined, the path to the lvgl.h gives a compilation error. I fixed the path

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
