### PR TITLE
When the bmp is 16 bit depth and use rgb565, the picture is not displayed properly due to no swap bytes

### DIFF
--- a/src/extra/libs/bmp/lv_bmp.c
+++ b/src/extra/libs/bmp/lv_bmp.c
@@ -204,7 +204,7 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
     lv_fs_read(&b->f, buf, len * (b->bpp / 8), NULL);
 
 #if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 1
-    for (int i = 0; i < len * (b->bpp / 8); i+=2) {
+    for(int i = 0; i < len * (b->bpp / 8); i += 2) {
         buf[i] = buf[i] ^ buf[i + 1];
         buf[i + 1] = buf[i] ^ buf[i + 1];
         buf[i] = buf[i] ^ buf[i + 1];

--- a/src/extra/libs/bmp/lv_bmp.c
+++ b/src/extra/libs/bmp/lv_bmp.c
@@ -204,7 +204,7 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
     lv_fs_read(&b->f, buf, len * (b->bpp / 8), NULL);
 
 #if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 1
-    for(int i = 0; i < len * (b->bpp / 8); i += 2) {
+    for(unsigned int i = 0; i < len * (b->bpp / 8); i += 2) {
         buf[i] = buf[i] ^ buf[i + 1];
         buf[i + 1] = buf[i] ^ buf[i + 1];
         buf[i] = buf[i] ^ buf[i + 1];

--- a/src/extra/libs/bmp/lv_bmp.c
+++ b/src/extra/libs/bmp/lv_bmp.c
@@ -202,8 +202,15 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
     p += x * (b->bpp / 8);
     lv_fs_seek(&b->f, p, LV_FS_SEEK_SET);
     lv_fs_read(&b->f, buf, len * (b->bpp / 8), NULL);
+    
+#if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 1
+    for (int i = 0; i < len * (b->bpp / 8); i+=2) {
+        buf[i] =  buf[i]^ buf[i+1];
+        buf[i+1] =  buf[i]^ buf[i+1];
+        buf[i] =  buf[i]^ buf[i+1];
+    }
 
-#if LV_COLOR_DEPTH == 32
+#elif LV_COLOR_DEPTH == 32
     if(b->bpp == 32) {
         lv_coord_t i;
         for(i = 0; i < len; i++) {

--- a/src/extra/libs/bmp/lv_bmp.c
+++ b/src/extra/libs/bmp/lv_bmp.c
@@ -202,12 +202,12 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
     p += x * (b->bpp / 8);
     lv_fs_seek(&b->f, p, LV_FS_SEEK_SET);
     lv_fs_read(&b->f, buf, len * (b->bpp / 8), NULL);
-    
+
 #if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 1
     for (int i = 0; i < len * (b->bpp / 8); i+=2) {
-        buf[i] = buf[i] ^ buf[i+1];
-        buf[i+1] = buf[i] ^ buf[i+1];
-        buf[i] = buf[i] ^ buf[i+1];
+        buf[i] = buf[i] ^ buf[i + 1];
+        buf[i + 1] = buf[i] ^ buf[i + 1];
+        buf[i] = buf[i] ^ buf[i + 1];
     }
 
 #elif LV_COLOR_DEPTH == 32

--- a/src/extra/libs/bmp/lv_bmp.c
+++ b/src/extra/libs/bmp/lv_bmp.c
@@ -205,9 +205,9 @@ static lv_res_t decoder_read_line(lv_img_decoder_t * decoder, lv_img_decoder_dsc
     
 #if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 1
     for (int i = 0; i < len * (b->bpp / 8); i+=2) {
-        buf[i] =  buf[i]^ buf[i+1];
-        buf[i+1] =  buf[i]^ buf[i+1];
-        buf[i] =  buf[i]^ buf[i+1];
+        buf[i] = buf[i] ^ buf[i+1];
+        buf[i+1] = buf[i] ^ buf[i+1];
+        buf[i] = buf[i] ^ buf[i+1];
     }
 
 #elif LV_COLOR_DEPTH == 32


### PR DESCRIPTION


### Description of the feature or fix
When the bmp is 16 bit depth and use rgb565, the picture is not displayed properly due to no swap bytes

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
