### PR TITLE
fix(arc): fix bug with LV_ARC_MODE_REVERSE (#3417)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ test_screenshot_error.h
 build/
 tests/build_*/
 tests/report/
+.DS_Store
+.vscode
+*.bak

--- a/Kconfig
+++ b/Kconfig
@@ -1018,6 +1018,27 @@ menu "LVGL configuration"
         config LV_USE_IMGFONT
             bool "draw img in label or span obj"
             default n
+
+        config LV_USE_MSG
+            bool "Enable a published subscriber based messaging system"
+            default n
+
+        config LV_USE_IME_PINYIN
+            bool "Enable Pinyin input method"
+            default n
+        config LV_IME_PINYIN_USE_DEFAULT_DICT
+            bool "Use built-in Thesaurus"
+            depends on LV_USE_IME_PINYIN
+            default y
+            help
+                If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss
+        config LV_IME_PINYIN_CAND_TEXT_NUM
+            int "maximum number of candidate panels"
+            depends on LV_USE_IME_PINYIN
+            default 6
+            help
+                Set the maximum number of candidate panels that can be displayed.
+                This needs to be adjusted according to the size of the screen.
     endmenu
 
     menu "Examples"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Just to mention some platforms:
 - STM32F1, STM32F3, STM32F4, STM32F7, STM32L4, STM32L5, STM32H7
 - Microchip dsPIC33, PIC24, PIC32MX, PIC32MZ
 - [Linux frame buffer](https://blog.lvgl.io/2018-01-03/linux_fb) (/dev/fb)
-- [Raspberry Pi](http://www.vk3erw.com/index.php/16-software/63-raspberry-pi-official-7-touchscreen-and-littlevgl)
+- [Raspberry Pi](https://github.com/lvgl/lv_port_linux_frame_buffer)
 - [Espressif ESP32](https://github.com/lvgl/lv_port_esp32)
 - [Infineon Aurix](https://github.com/lvgl/lv_port_aurix)
 - Nordic NRF52 Bluetooth modules

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Just to mention some platforms:
 - [Infineon Aurix](https://github.com/lvgl/lv_port_aurix)
 - Nordic NRF52 Bluetooth modules
 - Quectel modems
-- [SYNWIT SWM341](https://www.synwit.cn/)
+- [SYNWIT SWM341](http://www.synwit.cn/)
 
 LVGL is also available as:
 - [Arduino library](https://docs.lvgl.io/master/get-started/platforms/arduino.html)

--- a/docs/get-started/platforms/pc-simulator.md
+++ b/docs/get-started/platforms/pc-simulator.md
@@ -20,8 +20,13 @@ The simulator is ported to various IDEs (Integrated Development Environments). C
 - [PlatformIO with SDL driver](https://github.com/lvgl/lv_platformio): Recommended on Linux and Mac
 - [MDK with FastModel](https://github.com/lvgl/lv_port_an547_cm55_sim): For Windows
 
+External project not maintained by the LVGL organization:
+- [QT Creator](https://github.com/Varanda-Labs/lvgl-qt-sim): Cross platform
+
 You can use any IDE for development but, for simplicity, the configuration for Eclipse CDT is what we'll focus on in this tutorial.
 The following section describes the set-up guide of Eclipse CDT in more detail.
+
+
 
 **Note: If you are on Windows, it's usually better to use the Visual Studio or CodeBlocks projects instead. They work out of the box without requiring extra steps.**
 

--- a/docs/others/ime_pinyin.md
+++ b/docs/others/ime_pinyin.md
@@ -1,0 +1,136 @@
+# Pinyin IME
+
+Pinyin IME provides API to provide Chinese Pinyin input method (Chinese input) for keyboard object. You can think of `lv_ime_pinyin` as a Pinyin input method plug-in for keyboard objects.
+
+Normally, an environment where [lv_keyboard](/widgets/extra/keyboard) can run can also run `lv_ime_pinyin`. There are two main influencing factors: the size of the font file and the size of the dictionary.
+
+<details>
+<summary>中文</summary>
+<p>
+            
+`lv_ime_pinyin`为[键盘](/widgets/extra/keyboard)组件提供汉语拼音输入法（中文输入）的功能(后文简称为拼音输入法)。您可以将 `lv_ime_pinyin` 看成是键盘组件的汉语拼音输入法插件。
+ 
+一般情况下，只要是[键盘](/widgets/extra/keyboard)组件能运行的环境 `lv_ime_pinyin` 也能运行。有两个影响因素：字库的大小和词库的大小。
+            
+</p>
+</details>
+
+## Usage
+
+Enable `LV_USE_IME_PINYIN` in `lv_conf.h`.
+
+First use `lv_ime_pinyin_create(lv_scr_act())` to create a Pinyin input method plug-in, then use `lv_ime_pinyin_set_keyboard(pinyin_ime, kb)` to add the `keyboard` you created to the Pinyin input method plug-in.
+You can use `lv_ime_pinyin_set_dict(pinyin_ime, your_dict)` to use a custom dictionary (if you don't want to use the built-in dictionary at first, you can disable `LV_IME_PINYIN_USE_DEFAULT_DICT` in `lv_conf.h`, which can save a lot of memory space).
+
+The built-in thesaurus is customized based on the **LV_FONT_SIMSUN_16_CJK** font library, which currently only has more than `1,000` most common CJK radicals, so it is recommended to use custom fonts and thesaurus.
+
+In the process of using the Pinyin input method plug-in, you can change the keyboard and dictionary at any time.
+
+<details>
+<summary>中文</summary>
+<p>
+            
+在 `lv_conf.h` 中打开 `LV_USE_IME_PINYIN`。
+            
+首先，使用 `lv_ime_pinyin_create(lv_scr_act())` 函数创建一个拼音输入法插件，
+然后使用 `lv_ime_pinyin_set_keyboard(pinyin_ime, kb)` 函数将您创建的键盘组件添加到插件中。
+
+内置的词库是基于 LVGL 的 **LV_FONT_SIMSUN_16_CJK** 字库定制，这个字库目前只有 `1000` 多个最常见的 CJK 部首，所以建议使用自定义字库和词库。
+
+您可以使用 `lv_ime_pinyin_set_dict(pinyin_ime, your_dict)` 函数来设置使用自定义的词库，如果您一开始就不打算使用内置的词库，建议您在 `lv_conf.h` 中将 `LV_IME_PINYIN_USE_DEFAULT_DICT` 关闭，这可以节省一些内存空间。
+
+</p>
+</details>
+
+## Custom dictionary
+
+If you don't want to use the built-in Pinyin dictionary, you can use the custom dictionary.
+Or if you think that the built-in phonetic dictionary consumes a lot of memory, you can also use a custom dictionary.
+
+Customizing the dictionary is very simple.
+
+First, set `LV_IME_PINYIN_USE_DEFAULT_DICT` to `0` in `lv_conf.h`
+
+Then, write a dictionary in the following format.
+
+<details>
+<summary>中文</summary>
+<p>
+            
+如果您不想使用内置的词库，可以通过下面的方法自定义词库。
+
+自定义词典非常简单。
+首先，在 `lv_conf.h` 将 `LV_IME_PINYIN_USE_DEFAULT_DICT` 设置为 0。
+然后按照下面的格式编写词库。
+
+</p>
+</details>
+
+### Dictionary format
+
+The arrangement order of each pinyin syllable is very important. You need to customize your own thesaurus according to the Hanyu Pinyin syllable table. You can read [here](https://baike.baidu.com/item/%E6%B1%89%E8%AF%AD%E6%8B%BC%E9%9F%B3%E9%9F%B3%E8%8A%82/9167981) to learn about the Hanyu Pinyin syllables and the syllable table.
+
+Then, write your own dictionary according to the following format:
+
+<details>
+<summary>中文</summary>
+<p>
+
+**注意**，各个拼音音节的排列顺序非常重要，您需要按照汉语拼音音节表定制自己的词库，可以阅读[这里](https://baike.baidu.com/item/%E6%B1%89%E8%AF%AD%E6%8B%BC%E9%9F%B3%E9%9F%B3%E8%8A%82/9167981)了解[汉语拼音音节](https://baike.baidu.com/item/%E6%B1%89%E8%AF%AD%E6%8B%BC%E9%9F%B3%E9%9F%B3%E8%8A%82/9167981)以及[音节表](https://baike.baidu.com/item/%E6%B1%89%E8%AF%AD%E6%8B%BC%E9%9F%B3%E9%9F%B3%E8%8A%82/9167981#1)。
+
+然后，根据下面的格式编写自己的词库：
+
+</p>
+</details>
+
+```c
+lv_100ask_pinyin_dict_t your_pinyin_dict[] = {
+            { "a", "啊阿呵吖" },
+            { "ai", "埃挨哎唉哀皑蔼矮碍爱隘癌艾" },
+            { "an", "按安暗岸俺案鞍氨胺厂广庵揞犴铵桉谙鹌埯黯" },
+            { "ang", "昂肮盎仰" },
+            { "ao", "凹敖熬翱袄傲奥懊澳" },
+            { "ba", "芭捌叭吧笆八疤巴拔跋靶把坝霸罢爸扒耙" },
+            { "bai", "白摆佰败拜柏百稗伯" },
+            /* ...... */
+            { "zuo", "昨左佐做作坐座撮琢柞"},
+            {NULL, NULL}
+
+```
+
+**The last item** must end with `{null, null}` , or it will not work properly.
+
+### Apply new dictionary
+
+After writing a dictionary according to the above dictionary format, you only need to call this function to set up and use your dictionary:
+
+<details>
+<summary>中文</summary>
+<p>
+
+按照上面的词库格式编写好自己的词库之后，参考下面的用法，调用 `lv_100ask_pinyin_ime_set_dict(pinyin_ime, your_pinyin_dict)` 函数即可设置和使用新词库：
+
+</p>
+</details>
+
+```c
+    lv_obj_t * pinyin_ime = lv_100ask_pinyin_ime_create(lv_scr_act());
+    lv_100ask_pinyin_ime_set_dict(pinyin_ime, your_pinyin_dict);
+```
+
+## Example
+
+```eval_rst
+
+.. include:: ../../examples/others/ime/index.rst
+
+```
+
+## API
+
+```eval_rst
+
+.. doxygenfile:: lv_ime_pinyin.h
+  :project: lvgl
+
+```

--- a/docs/others/index.md
+++ b/docs/others/index.md
@@ -12,5 +12,6 @@
    fragment
    msg
    imgfont
+   ime_pinyin
 ```
 

--- a/docs/overview/timer.md
+++ b/docs/overview/timer.md
@@ -61,6 +61,7 @@ It can be misleading if you use an operating system and call `lv_timer_handler` 
 In some cases, you can't perform an action immediately. For example, you can't delete an object because something else is still using it, or you don't want to block the execution now.
 For these cases, `lv_async_call(my_function, data_p)` can be used to call `my_function` on the next invocation of `lv_timer_handler`. `data_p` will be passed to the function when it's called.
 Note that only the data pointer is saved, so you need to ensure that the variable will be "alive" while the function is called. It can be *static*, global or dynamically allocated data.
+If you want to cancel an asynchronous call, call `lv_async_call_cancel(my_function, data_p)`, which will clear all asynchronous calls matching `my_function` and `data_p`.
 
 For example:
 ```c

--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -5,6 +5,7 @@
 To register an input device an `lv_indev_drv_t` variable has to be initialized. **Be sure to register at least one display before you register any input devices.**
 
 ```c
+/*Register at least one display before you register any input devices*/
 lv_disp_drv_register(&disp_drv);
 
 static lv_indev_drv_t indev_drv;

--- a/docs/widgets/extra/chart.md
+++ b/docs/widgets/extra/chart.md
@@ -12,11 +12,11 @@ Charts can have:
 - scrolling and zooming
 
 ## Parts and Styles
-- `LV_PART_MAIN` The background of the chart. Uses all the typical background and *line* (for the division lines) related style properties. *Padding* makes the series area smaller.
+- `LV_PART_MAIN` The background of the chart. Uses all the typical background and *line* (for the division lines) related style properties. *Padding* makes the series area smaller. For column charts `pad_column` sets the space between the columns of the adjacent indices.
 - `LV_PART_SCROLLBAR` The scrollbar used if the chart is zoomed. See the [Base object](/widgets/obj)'s documentation for details.
 - `LV_PART_ITEMS` Refers to the line or bar series.
     - Line chart: The *line* properties are used by the lines. `width`, `height`, `bg_color` and `radius` is used to set the appearance of points.
-    - Bar chart: The typical background properties are used to style the bars.
+    - Bar chart: The typical background properties are used to style the bars. `pad_column` sets the space between the columns on the same index.
 - `LV_PART_INDICATOR` Refers to the points on line and scatter chart (small circles or squares).
 - `LV_PART_CURSOR` *Line* properties are used to style the cursors.  `width`, `height`, `bg_color` and `radius` are used to set the appearance of points.
 - `LV_PART_TICKS` *Line* and *Text* style properties are used to style the ticks

--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,9 +36,12 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2022-06-13" version="1.0.5-alpha1" url="https://github.com/lvgl/lvgl/raw/ce0605182c31e43abc8137ba21f237ec442735bc/env_support/cmsis-pack/LVGL.lvgl.1.0.5-alpha1.pack">
+    <release date="2022-06-29" version="1.0.5" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.5.pack">
       - LVGL 8.3.0-dev
       - Monthly update for June
+      - Add Pinyin as input method
+      - Update benchmark to support RGB565-A8
+      - Update support for layers
     </release>
     <release date="2022-05-31" version="1.0.4" url="https://github.com/lvgl/lvgl/raw/ce0605182c31e43abc8137ba21f237ec442735bc/env_support/cmsis-pack/LVGL.lvgl.1.0.4.pack">
       - LVGL 8.3.0-dev
@@ -209,6 +212,7 @@
                 <file category="sourceC"            name="src/draw/lv_draw_arc.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_img.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_label.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_layer.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_line.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_mask.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_rect.c" />
@@ -225,11 +229,13 @@
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_dither.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_gradient.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_img.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_layer.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_letter.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_line.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_polygon.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_rect.c" />
                 <file category="sourceC"            name="src/draw/sw/lv_draw_sw_transform.c" />
+                
 
                 <!-- src/font -->
                 <file category="sourceC"            name="src/font/lv_font.c" />
@@ -311,7 +317,7 @@
                 <file category="sourceC"            name="src/widgets/lv_textarea.c" />
 
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.1" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.2" />
                 <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
@@ -322,6 +328,7 @@
 
 /*! \brief use lv_config_cmsis.h which will be pre-included */
 #define LV_CONF_SKIP
+#define LV_LVGL_H_INCLUDE_SIMPLE    1
               </Pre_Include_Global_h>
 
                <RTE_Components_h>
@@ -603,6 +610,21 @@
 
             </component>
 
+            <component Cgroup="lvgl" Csub="Pinyin"  condition="LVGL-Essential">
+              <description>Add Pinyin input method</description>
+              <files>
+                <!-- src/extra/others/ime -->
+                <file category="sourceC"            name="src/extra/others/ime/lv_ime_pinyin.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable ffmpeg support */
+#define LV_USE_IME_PINYIN         1
+              </RTE_Components_h>
+
+            </component>
+
             <component Cgroup="lvgl" Csub="Benchmark"  condition="LVGL-Essential">
               <description>Add the official benchmark.</description>
               <files>
@@ -615,6 +637,8 @@
                 <file category="sourceC"            name="demos/benchmark/assets/img_benchmark_cogwheel_chroma_keyed.c" />
                 <file category="sourceC"            name="demos/benchmark/assets/img_benchmark_cogwheel_indexed16.c" />
                 <file category="sourceC"            name="demos/benchmark/assets/img_benchmark_cogwheel_rgb.c" />
+                <file category="sourceC"            name="demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c" />
+                
                 <file category="sourceC"            name="demos/benchmark/assets/lv_font_bechmark_montserrat_12_compr_az.c.c" />
                 <file category="sourceC"            name="demos/benchmark/assets/lv_font_bechmark_montserrat_16_compr_az.c.c" />
                 <file category="sourceC"            name="demos/benchmark/assets/lv_font_bechmark_montserrat_28_compr_az.c.c" />

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2022-06-13T00:17:59</timestamp>
+  <timestamp>2022-06-29T00:23:55</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.5-alpha1"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.5"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -45,6 +45,7 @@ remove the misleading guide above this code segment.
    - LV_USE_GPU_NXP_VG_LITE
    - LV_USE_GPU_SWM341_DMA2D
    - LV_USE_GPU_ARM2D
+   - LV_USE_IME_PINYIN
 5. Update macro `LV_ATTRIBUTE_MEM_ALIGN` and `LV_ATTRIBUTE_MEM_ALIGN_SIZE`  to force a WORD alignment.
 ```c
 #define LV_ATTRIBUTE_MEM_ALIGN_SIZE     4

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -132,8 +132,6 @@
  * and blend it as an image with the given opacity.
  * Note that `bg_opa`, `text_opa` etc don't require buffering into layer)
  * The widget can be buffered in smaller chunks to avoid using large buffers.
- * `draw_area` (`lv_area_t` meaning the area to draw and `px_size` (size of a pixel in bytes)
- * can be used the set the buffer size adaptively.
  *
  * - LV_LAYER_SIMPLE_BUF_SIZE: [bytes] the optimal target buffer size. LVGL will try to allocate it
  * - LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE: [bytes]  used if `LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
@@ -143,7 +141,7 @@
  * and can't be drawn in chunks. So these settings affects only widgets with opacity.
  */
 #define LV_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)
-#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE LV_MAX(lv_area_get_width(&draw_area) * px_size, 2048)
+#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)
 
 /*Default image cache size. Image caching keeps the images opened.
  *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
@@ -615,6 +613,17 @@
 
 /*1: Enable a published subscriber based messaging system */
 #define LV_USE_MSG 0
+
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+#endif
 
 /*==================
 * EXAMPLES

--- a/examples/others/fragment/lv_example_fragment_1.c
+++ b/examples/others/fragment/lv_example_fragment_1.c
@@ -10,6 +10,8 @@ static void sample_fragment_ctor(lv_fragment_t * self, void * args);
 
 static lv_obj_t * sample_fragment_create_obj(lv_fragment_t * self, lv_obj_t * parent);
 
+static void sample_container_del(lv_event_t * e);
+
 static lv_obj_t * root = NULL;
 
 struct sample_fragment_t {
@@ -28,6 +30,9 @@ void lv_example_fragment_1(void)
     root = lv_obj_create(lv_scr_act());
     lv_obj_set_size(root, LV_PCT(100), LV_PCT(100));
     lv_fragment_manager_t * manager = lv_fragment_manager_create(NULL);
+    /* Clean up the fragment manager before objects in containers got deleted */
+    lv_obj_add_event_cb(root, sample_container_del, LV_EVENT_DELETE, manager);
+
     lv_fragment_t * fragment = lv_fragment_create(&sample_cls, "Fragment");
     lv_fragment_manager_replace(manager, fragment, &root);
 }
@@ -44,6 +49,12 @@ static lv_obj_t * sample_fragment_create_obj(lv_fragment_t * self, lv_obj_t * pa
     lv_obj_set_style_bg_opa(label, LV_OPA_COVER, 0);;
     lv_label_set_text_fmt(label, "Hello, %s!", ((struct sample_fragment_t *) self)->name);
     return label;
+}
+
+static void sample_container_del(lv_event_t * e)
+{
+    lv_fragment_manager_t * manager = (lv_fragment_manager_t *) lv_event_get_user_data(e);
+    lv_fragment_manager_del(manager);
 }
 
 #endif

--- a/examples/others/fragment/lv_example_fragment_2.c
+++ b/examples/others/fragment/lv_example_fragment_2.c
@@ -14,6 +14,8 @@ static void sample_push_click(lv_event_t * e);
 
 static void sample_pop_click(lv_event_t * e);
 
+static void sample_container_del(lv_event_t * e);
+
 static void sample_fragment_inc_click(lv_event_t * e);
 
 typedef struct sample_fragment_t {
@@ -54,6 +56,9 @@ void lv_example_fragment_2(void)
     lv_obj_set_grid_cell(pop_btn, LV_GRID_ALIGN_END, 1, 1, LV_GRID_ALIGN_CENTER, 1, 1);
 
     lv_fragment_manager_t * manager = lv_fragment_manager_create(NULL);
+    /* Clean up the fragment manager before objects in containers got deleted */
+    lv_obj_add_event_cb(root, sample_container_del, LV_EVENT_DELETE, manager);
+
     int depth = 0;
     lv_fragment_t * fragment = lv_fragment_create(&sample_cls, &depth);
     lv_fragment_manager_push(manager, fragment, &container);
@@ -104,6 +109,12 @@ static void sample_pop_click(lv_event_t * e)
 {
     lv_fragment_manager_t * manager = (lv_fragment_manager_t *) lv_event_get_user_data(e);
     lv_fragment_manager_pop(manager);
+}
+
+static void sample_container_del(lv_event_t * e)
+{
+    lv_fragment_manager_t * manager = (lv_fragment_manager_t *) lv_event_get_user_data(e);
+    lv_fragment_manager_del(manager);
 }
 
 static void sample_fragment_inc_click(lv_event_t * e)

--- a/examples/others/ime/index.rst
+++ b/examples/others/ime/index.rst
@@ -1,0 +1,8 @@
+
+Simple Pinyin IME example 
+"""""""""""""""""""
+
+.. lv_example:: others/ime/lv_example_ime_pinyin_1
+  :language: c
+
+

--- a/examples/others/ime/lv_example_ime_pinyin.h
+++ b/examples/others/ime/lv_example_ime_pinyin.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_others.h
+ * @file lv_example_ime_pinyin.h
  *
  */
 
-#ifndef LV_OTHERS_H
-#define LV_OTHERS_H
+#ifndef LV_EX_IME_PINYIN_H
+#define LV_EX_IME_PINYIN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,13 +13,6 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "snapshot/lv_snapshot.h"
-#include "monkey/lv_monkey.h"
-#include "gridnav/lv_gridnav.h"
-#include "fragment/lv_fragment.h"
-#include "imgfont/lv_imgfont.h"
-#include "msg/lv_msg.h"
-#include "ime/lv_ime_pinyin.h"
 
 /*********************
  *      DEFINES
@@ -32,6 +25,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+void lv_example_ime_pinyin_1(void);
 
 /**********************
  *      MACROS
@@ -41,4 +35,4 @@ extern "C" {
 } /*extern "C"*/
 #endif
 
-#endif /*LV_OTHERS_H*/
+#endif /*LV_EX_IME_PINYIN_H*/

--- a/examples/others/ime/lv_example_ime_pinyin_1.c
+++ b/examples/others/ime/lv_example_ime_pinyin_1.c
@@ -1,0 +1,56 @@
+#include "../../lv_examples.h"
+#if LV_USE_LABEL && LV_USE_TEXTAREA && LV_FONT_SIMSUN_16_CJK  && LV_USE_IME_PINYIN && LV_BUILD_EXAMPLES
+
+static void ta_event_cb(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * ta = lv_event_get_target(e);
+    lv_obj_t * kb = lv_event_get_user_data(e);
+
+    if(code == LV_EVENT_FOCUSED) {
+        if(lv_indev_get_type(lv_indev_get_act()) != LV_INDEV_TYPE_KEYPAD) {
+            lv_keyboard_set_textarea(kb, ta);
+            lv_obj_clear_flag(kb, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+    else if(code == LV_EVENT_READY || code == LV_EVENT_CANCEL) {
+        lv_obj_add_flag(kb, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_state(ta, LV_STATE_FOCUSED);
+        lv_indev_reset(NULL, ta);   /*To forget the last clicked object to make it focusable again*/
+    }
+}
+
+void lv_example_ime_pinyin_1(void)
+{
+    lv_obj_t * pinyin_ime = lv_ime_pinyin_create(lv_scr_act());
+    lv_obj_set_style_text_font(pinyin_ime, &lv_font_simsun_16_cjk, 0);
+    //lv_ime_pinyin_set_dict(pinyin_ime, your_dict); // Use a custom dictionary. If it is not set, the built-in thesaurus will be used.
+
+    lv_obj_t * kb = lv_keyboard_create(lv_scr_act());
+    lv_ime_pinyin_set_keyboard(pinyin_ime, kb);
+
+    /* ta1 */
+    lv_obj_t * ta1 = lv_textarea_create(lv_scr_act());
+    lv_obj_set_style_text_font(ta1, &lv_font_simsun_16_cjk, 0);
+    lv_obj_align(ta1, LV_ALIGN_TOP_LEFT, 10, 10);
+
+    lv_keyboard_set_textarea(kb, ta1);
+
+    lv_obj_add_event_cb(ta1, ta_event_cb, LV_EVENT_ALL, kb);
+
+    /* ta2 */
+    lv_obj_t * ta2 = lv_textarea_create(lv_scr_act());
+    lv_obj_set_style_text_font(ta2, &lv_font_simsun_16_cjk, 0);
+    lv_obj_align_to(ta2, ta1, LV_ALIGN_OUT_RIGHT_MID, 10, 0);
+
+    lv_obj_add_event_cb(ta2, ta_event_cb, LV_EVENT_ALL, kb);
+
+    lv_obj_t * cz_label = lv_label_create(lv_scr_act());
+    lv_label_set_text(cz_label,
+                      "嵌入式系统（Embedded System），\n是一种嵌入机械或电气系统内部、具有专一功能和实时计算性能的计算机系统。");
+    lv_obj_set_style_text_font(cz_label, &lv_font_simsun_16_cjk, 0);
+    lv_obj_set_width(cz_label, 310);
+    lv_obj_align_to(cz_label, ta1, LV_ALIGN_OUT_BOTTOM_LEFT, 5, 5);
+}
+
+#endif

--- a/examples/others/ime/lv_example_ime_pinyin_1.c
+++ b/examples/others/ime/lv_example_ime_pinyin_1.c
@@ -26,31 +26,31 @@ void lv_example_ime_pinyin_1(void)
     lv_obj_set_style_text_font(pinyin_ime, &lv_font_simsun_16_cjk, 0);
     //lv_ime_pinyin_set_dict(pinyin_ime, your_dict); // Use a custom dictionary. If it is not set, the built-in thesaurus will be used.
 
-    lv_obj_t * kb = lv_keyboard_create(lv_scr_act());
-    lv_ime_pinyin_set_keyboard(pinyin_ime, kb);
-
     /* ta1 */
     lv_obj_t * ta1 = lv_textarea_create(lv_scr_act());
+    lv_textarea_set_one_line(ta1, true);
     lv_obj_set_style_text_font(ta1, &lv_font_simsun_16_cjk, 0);
-    lv_obj_align(ta1, LV_ALIGN_TOP_LEFT, 10, 10);
+    lv_obj_align(ta1, LV_ALIGN_TOP_LEFT, 0, 0);
 
+    /*Create a keyboard and add it to ime_pinyin*/
+    lv_obj_t * kb = lv_keyboard_create(lv_scr_act());
+    lv_ime_pinyin_set_keyboard(pinyin_ime, kb);
     lv_keyboard_set_textarea(kb, ta1);
 
     lv_obj_add_event_cb(ta1, ta_event_cb, LV_EVENT_ALL, kb);
 
-    /* ta2 */
-    lv_obj_t * ta2 = lv_textarea_create(lv_scr_act());
-    lv_obj_set_style_text_font(ta2, &lv_font_simsun_16_cjk, 0);
-    lv_obj_align_to(ta2, ta1, LV_ALIGN_OUT_RIGHT_MID, 10, 0);
+    /*Get the cand_panel, and adjust its size and position*/
+    lv_obj_t * cand_panel = lv_ime_pinyin_get_cand_panel(pinyin_ime);
+    lv_obj_set_size(cand_panel, LV_PCT(100), LV_PCT(10));
+    lv_obj_align_to(cand_panel, kb, LV_ALIGN_OUT_TOP_MID, 0, 0);
 
-    lv_obj_add_event_cb(ta2, ta_event_cb, LV_EVENT_ALL, kb);
-
+    /*Try using ime_pinyin to output the Chinese below in the ta1 above*/
     lv_obj_t * cz_label = lv_label_create(lv_scr_act());
     lv_label_set_text(cz_label,
                       "嵌入式系统（Embedded System），\n是一种嵌入机械或电气系统内部、具有专一功能和实时计算性能的计算机系统。");
     lv_obj_set_style_text_font(cz_label, &lv_font_simsun_16_cjk, 0);
     lv_obj_set_width(cz_label, 310);
-    lv_obj_align_to(cz_label, ta1, LV_ALIGN_OUT_BOTTOM_LEFT, 5, 5);
+    lv_obj_align_to(cz_label, ta1, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
 }
 
 #endif

--- a/examples/others/lv_example_others.h
+++ b/examples/others/lv_example_others.h
@@ -19,6 +19,7 @@ extern "C" {
 #include "fragment/lv_example_fragment.h"
 #include "imgfont/lv_example_imgfont.h"
 #include "msg/lv_example_msg.h"
+#include "ime/lv_example_ime_pinyin.h"
 
 /*********************
  *      DEFINES

--- a/examples/porting/lv_port_disp_template.c
+++ b/examples/porting/lv_port_disp_template.c
@@ -10,7 +10,6 @@
  *      INCLUDES
  *********************/
 #include "lv_port_disp_template.h"
-#include "../../lvgl.h"
 #include <stdbool.h>
 
 /*********************
@@ -121,7 +120,7 @@ void lv_port_disp_init(void)
     disp_drv.draw_buf = &draw_buf_dsc_1;
 
     /*Required for Example 3)*/
-    //disp_drv.full_refresh = 1
+    //disp_drv.full_refresh = 1;
 
     /* Fill a memory array with a color if you have GPU.
      * Note that, in lv_conf.h you can enable GPUs that has built-in support in LVGL.

--- a/examples/porting/lv_port_disp_template.h
+++ b/examples/porting/lv_port_disp_template.h
@@ -16,7 +16,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -691,6 +691,18 @@
 /*1: Enable a published subscriber based messaging system */
 #define LV_USE_MSG 0
 
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#define LV_USE_IME_PINYIN 0
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+#endif
+
 /*==================
 * EXAMPLES
 *==================*/

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -902,11 +902,8 @@ static void indev_proc_press(_lv_indev_proc_t * proc)
     proc->types.pointer.vect.x = proc->types.pointer.act_point.x - proc->types.pointer.last_point.x;
     proc->types.pointer.vect.y = proc->types.pointer.act_point.y - proc->types.pointer.last_point.y;
 
-    proc->types.pointer.scroll_throw_vect.x = (proc->types.pointer.scroll_throw_vect.x * 4) >> 3;
-    proc->types.pointer.scroll_throw_vect.y = (proc->types.pointer.scroll_throw_vect.y * 4) >> 3;
-
-    proc->types.pointer.scroll_throw_vect.x += (proc->types.pointer.vect.x * 4) >> 3;
-    proc->types.pointer.scroll_throw_vect.y += (proc->types.pointer.vect.y * 4) >> 3;
+    proc->types.pointer.scroll_throw_vect.x = (proc->types.pointer.scroll_throw_vect.x + proc->types.pointer.vect.x) / 2;
+    proc->types.pointer.scroll_throw_vect.y = (proc->types.pointer.scroll_throw_vect.y + proc->types.pointer.vect.y) / 2;
 
     proc->types.pointer.scroll_throw_vect_ori = proc->types.pointer.scroll_throw_vect;
 

--- a/src/core/lv_indev_scroll.c
+++ b/src/core/lv_indev_scroll.c
@@ -85,7 +85,8 @@ void _lv_indev_scroll_handler(_lv_indev_proc_t * proc)
         /*Respect the scroll limit area*/
         scroll_limit_diff(proc, &diff_x, &diff_y);
 
-        lv_obj_scroll_by(scroll_obj, diff_x, diff_y, LV_ANIM_OFF);
+        _lv_obj_scroll_by_raw(scroll_obj, diff_x, diff_y);
+        if(proc->reset_query) return;
         proc->types.pointer.scroll_sum.x += diff_x;
         proc->types.pointer.scroll_sum.y += diff_y;
     }

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -31,7 +31,6 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_res_t scroll_by_raw(lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
 static void scroll_x_anim(void * obj, int32_t v);
 static void scroll_y_anim(void * obj, int32_t v);
 static void scroll_anim_ready_cb(lv_anim_t * a);
@@ -352,7 +351,7 @@ void lv_obj_scroll_by(lv_obj_t * obj, lv_coord_t dx, lv_coord_t dy, lv_anim_enab
         res = lv_event_send(obj, LV_EVENT_SCROLL_BEGIN, NULL);
         if(res != LV_RES_OK) return;
 
-        res = scroll_by_raw(obj, dx, dy);
+        res = _lv_obj_scroll_by_raw(obj, dx, dy);
         if(res != LV_RES_OK) return;
 
         res = lv_event_send(obj, LV_EVENT_SCROLL_END, NULL);
@@ -409,6 +408,23 @@ void lv_obj_scroll_to_view_recursive(lv_obj_t * obj, lv_anim_enable_t anim_en)
         parent = lv_obj_get_parent(parent);
     }
 }
+
+lv_res_t _lv_obj_scroll_by_raw(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
+{
+    if(x == 0 && y == 0) return LV_RES_OK;
+
+    lv_obj_allocate_spec_attr(obj);
+
+    obj->spec_attr->scroll.x += x;
+    obj->spec_attr->scroll.y += y;
+
+    lv_obj_move_children_by(obj, x, y, true);
+    lv_res_t res = lv_event_send(obj, LV_EVENT_SCROLL, NULL);
+    if(res != LV_RES_OK) return res;
+    lv_obj_invalidate(obj);
+    return LV_RES_OK;
+}
+
 
 bool lv_obj_is_scrolling(const lv_obj_t * obj)
 {
@@ -652,30 +668,15 @@ void lv_obj_readjust_scroll(lv_obj_t * obj, lv_anim_enable_t anim_en)
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_res_t scroll_by_raw(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
-{
-    if(x == 0 && y == 0) return LV_RES_OK;
-
-    lv_obj_allocate_spec_attr(obj);
-
-    obj->spec_attr->scroll.x += x;
-    obj->spec_attr->scroll.y += y;
-
-    lv_obj_move_children_by(obj, x, y, true);
-    lv_res_t res = lv_event_send(obj, LV_EVENT_SCROLL, NULL);
-    if(res != LV_RES_OK) return res;
-    lv_obj_invalidate(obj);
-    return LV_RES_OK;
-}
 
 static void scroll_x_anim(void * obj, int32_t v)
 {
-    scroll_by_raw(obj, v + lv_obj_get_scroll_x(obj), 0);
+    _lv_obj_scroll_by_raw(obj, v + lv_obj_get_scroll_x(obj), 0);
 }
 
 static void scroll_y_anim(void * obj, int32_t v)
 {
-    scroll_by_raw(obj, 0, v + lv_obj_get_scroll_y(obj));
+    _lv_obj_scroll_by_raw(obj, 0, v + lv_obj_get_scroll_y(obj));
 }
 
 static void scroll_anim_ready_cb(lv_anim_t * a)

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../misc/lv_area.h"
 #include "../misc/lv_anim.h"
+#include "../misc/lv_types.h"
 
 /*********************
  *      DEFINES
@@ -247,6 +248,18 @@ void lv_obj_scroll_to_view(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
 void lv_obj_scroll_to_view_recursive(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+
+
+/**
+ * Low level function to scroll by given x and y coordinates.
+ * `LV_EVENT_SCROLL` is sent.
+ * @param obj       pointer to an object to scroll
+ * @param x         pixels to scroll horizontally
+ * @param y         pixels to scroll vertically
+ * @return          `LV_RES_INV`: to object was deleted in `LV_EVENT_SCROLL`;
+ *                  `LV_RES_OK`: if the object is still valid
+ */
+lv_res_t _lv_obj_scroll_by_raw(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
 
 /**
  * Tell whether an object is being scrolled or not at this moment

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -341,7 +341,7 @@ void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t 
     if(tr_dsc->prop == LV_STYLE_RADIUS) {
         if(v1.num == LV_RADIUS_CIRCLE || v2.num == LV_RADIUS_CIRCLE) {
             lv_coord_t whalf = lv_obj_get_width(obj) / 2;
-            lv_coord_t hhalf = lv_obj_get_width(obj) / 2;
+            lv_coord_t hhalf = lv_obj_get_height(obj) / 2;
             if(v1.num == LV_RADIUS_CIRCLE) v1.num = LV_MIN(whalf + 1, hhalf + 1);
             if(v2.num == LV_RADIUS_CIRCLE) v2.num = LV_MIN(whalf + 1, hhalf + 1);
         }

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -1335,6 +1335,28 @@ static void convert_cb(const lv_area_t * dest_area, const void * src_buf, lv_coo
             src_tmp8 += src_new_line_step_byte;
         }
     }
+    else if(cf == LV_IMG_CF_RGB565A8) {
+        src_tmp8 += (src_stride * dest_area->y1 * sizeof(lv_color_t)) + dest_area->x1 * sizeof(lv_color_t);
+
+        lv_coord_t src_stride_byte = src_stride * sizeof(lv_color_t);
+
+        lv_coord_t dest_h = lv_area_get_height(dest_area);
+        lv_coord_t dest_w = lv_area_get_width(dest_area);
+        for(y = 0; y < dest_h; y++) {
+            lv_memcpy(cbuf, src_tmp8, dest_w * sizeof(lv_color_t));
+            cbuf += dest_w;
+            src_tmp8 += src_stride_byte;
+        }
+
+        src_tmp8 = (const uint8_t *)src_buf;
+        src_tmp8 += sizeof(lv_color_t) * src_w * src_h;
+        src_tmp8 += src_stride * dest_area->y1 + dest_area->x1;
+        for(y = 0; y < dest_h; y++) {
+            lv_memcpy(abuf, src_tmp8, dest_w);
+            abuf += dest_w;
+            src_tmp8 += src_stride;
+        }
+    }
 }
 
 #if 0

--- a/src/draw/lv_draw_layer.c
+++ b/src/draw/lv_draw_layer.c
@@ -55,7 +55,11 @@ lv_draw_layer_ctx_t * lv_draw_layer_create(lv_draw_ctx_t * draw_ctx, const lv_ar
     layer_ctx->original.screen_transp = disp_refr->driver->screen_transp;
     layer_ctx->area_full = *layer_area;
 
-    return draw_ctx->layer_init(draw_ctx, layer_ctx, flags);
+    lv_draw_layer_ctx_t * init_layer_ctx =  draw_ctx->layer_init(draw_ctx, layer_ctx, flags);
+    if(NULL == init_layer_ctx) {
+        lv_mem_free(layer_ctx);
+    }
+    return init_layer_ctx;
 }
 
 void lv_draw_layer_adjust(struct _lv_draw_ctx_t * draw_ctx, struct _lv_draw_layer_ctx_t * layer_ctx,

--- a/src/draw/sw/lv_draw_sw_layer.c
+++ b/src/draw/sw/lv_draw_sw_layer.c
@@ -61,7 +61,6 @@ struct _lv_draw_layer_ctx_t * lv_draw_sw_layer_create(struct _lv_draw_ctx_t * dr
             layer_sw_ctx->buf_size_bytes = LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE;
             layer_sw_ctx->base_draw.buf = lv_mem_alloc(layer_sw_ctx->buf_size_bytes);
             if(layer_sw_ctx->base_draw.buf == NULL) {
-                lv_mem_free(layer_ctx);
                 return NULL;
             }
         }
@@ -78,7 +77,6 @@ struct _lv_draw_layer_ctx_t * lv_draw_sw_layer_create(struct _lv_draw_ctx_t * dr
         lv_memset_00(layer_sw_ctx->base_draw.buf, layer_sw_ctx->buf_size_bytes);
         layer_sw_ctx->has_alpha = flags & LV_DRAW_LAYER_FLAG_HAS_ALPHA ? 1 : 0;
         if(layer_sw_ctx->base_draw.buf == NULL) {
-            lv_mem_free(layer_ctx);
             return NULL;
         }
 

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -333,6 +333,14 @@ static void draw_bg_img(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
     if(dsc->bg_img_src == NULL) return;
     if(dsc->bg_img_opa <= LV_OPA_MIN) return;
 
+    lv_area_t clip_area;
+    if(!_lv_area_intersect(&clip_area, coords, draw_ctx->clip_area)) {
+        return;
+    }
+
+    const lv_area_t * clip_area_ori = draw_ctx->clip_area;
+    draw_ctx->clip_area = &clip_area;
+
     lv_img_src_t src_type = lv_img_src_get_type(dsc->bg_img_src);
     if(src_type == LV_IMG_SRC_SYMBOL) {
         lv_point_t size;
@@ -353,43 +361,45 @@ static void draw_bg_img(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
     else {
         lv_img_header_t header;
         lv_res_t res = lv_img_decoder_get_info(dsc->bg_img_src, &header);
-        if(res != LV_RES_OK) {
-            LV_LOG_WARN("Couldn't read the background image");
-            return;
-        }
+        if(res == LV_RES_OK) {
+            lv_draw_img_dsc_t img_dsc;
+            lv_draw_img_dsc_init(&img_dsc);
+            img_dsc.blend_mode = dsc->blend_mode;
+            img_dsc.recolor = dsc->bg_img_recolor;
+            img_dsc.recolor_opa = dsc->bg_img_recolor_opa;
+            img_dsc.opa = dsc->bg_img_opa;
 
-        lv_draw_img_dsc_t img_dsc;
-        lv_draw_img_dsc_init(&img_dsc);
-        img_dsc.blend_mode = dsc->blend_mode;
-        img_dsc.recolor = dsc->bg_img_recolor;
-        img_dsc.recolor_opa = dsc->bg_img_recolor_opa;
-        img_dsc.opa = dsc->bg_img_opa;
-
-        /*Center align*/
-        if(dsc->bg_img_tiled == false) {
-            lv_area_t area;
-            area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - header.w / 2;
-            area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - header.h / 2;
-            area.x2 = area.x1 + header.w - 1;
-            area.y2 = area.y1 + header.h - 1;
-
-            lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
-        }
-        else {
-            lv_area_t area;
-            area.y1 = coords->y1;
-            area.y2 = area.y1 + header.h - 1;
-
-            for(; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
-
-                area.x1 = coords->x1;
+            /*Center align*/
+            if(dsc->bg_img_tiled == false) {
+                lv_area_t area;
+                area.x1 = coords->x1 + lv_area_get_width(coords) / 2 - header.w / 2;
+                area.y1 = coords->y1 + lv_area_get_height(coords) / 2 - header.h / 2;
                 area.x2 = area.x1 + header.w - 1;
-                for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
-                    lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
+                area.y2 = area.y1 + header.h - 1;
+
+                lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
+            }
+            else {
+                lv_area_t area;
+                area.y1 = coords->y1;
+                area.y2 = area.y1 + header.h - 1;
+
+                for(; area.y1 <= coords->y2; area.y1 += header.h, area.y2 += header.h) {
+
+                    area.x1 = coords->x1;
+                    area.x2 = area.x1 + header.w - 1;
+                    for(; area.x1 <= coords->x2; area.x1 += header.w, area.x2 += header.w) {
+                        lv_draw_img(draw_ctx, &img_dsc, &area, dsc->bg_img_src);
+                    }
                 }
             }
         }
+        else {
+            LV_LOG_WARN("Couldn't read the background image");
+        }
     }
+
+    draw_ctx->clip_area = clip_area_ori;
 }
 
 static void draw_border(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords)

--- a/src/extra/others/gridnav/lv_gridnav.c
+++ b/src/extra/others/gridnav/lv_gridnav.c
@@ -348,7 +348,7 @@ static lv_obj_t * find_last_focusable(lv_obj_t * obj)
 {
     uint32_t child_cnt = lv_obj_get_child_cnt(obj);
     int32_t i;
-    for(i = child_cnt - 1; i >= 0; i++) {
+    for(i = child_cnt - 1; i >= 0; i--) {
         lv_obj_t * child = lv_obj_get_child(obj, i);
         if(obj_is_focuable(child)) return child;
     }

--- a/src/extra/others/ime/lv_ime_pinyin.c
+++ b/src/extra/others/ime/lv_ime_pinyin.c
@@ -1,0 +1,813 @@
+/**
+ * @file lv_ime_pinyin.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_ime_pinyin.h"
+#if LV_USE_IME_PINYIN != 0
+
+#include <stdio.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+#define MY_CLASS    &lv_ime_pinyin_class
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void lv_ime_pinyin_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
+static void lv_ime_pinyin_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
+static void lv_ime_pinyin_style_change_event(lv_event_t * e);
+static void lv_ime_pinyin_kb_event(lv_event_t * e);
+static void lv_ime_pinyin_cand_panel_event(lv_event_t * e);
+
+static void init_pinyin_dict(lv_obj_t * obj, lv_pinyin_dict_t * dict);
+static void pinyin_input_proc(lv_obj_t * obj);
+static void pinyin_page_proc(lv_obj_t * obj, uint16_t btn);
+static char * pinyin_search_matching(lv_obj_t * obj, char * strInput_py_str, uint16_t * cand_num);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+const lv_obj_class_t lv_ime_pinyin_class = {
+    .constructor_cb = lv_ime_pinyin_constructor,
+    .destructor_cb  = lv_ime_pinyin_destructor,
+    .width_def      = LV_SIZE_CONTENT,
+    .height_def     = LV_SIZE_CONTENT,
+    .group_def      = LV_OBJ_CLASS_GROUP_DEF_TRUE,
+    .instance_size  = sizeof(lv_ime_pinyin_t),
+    .base_class     = &lv_obj_class
+};
+
+static char   lv_pinyin_cand_str[LV_IME_PINYIN_CAND_TEXT_NUM][4];
+static char * lv_btnm_def_pinyin_sel_map[LV_IME_PINYIN_CAND_TEXT_NUM + 3];
+
+#if LV_IME_PINYIN_USE_DEFAULT_DICT
+lv_pinyin_dict_t lv_ime_pinyin_def_dict[] = {
+    { "a", "啊" },
+    { "ai", "愛" },
+    { "an", "安暗案" },
+    { "ba", "吧把爸八" },
+    { "bai", "百白敗" },
+    { "ban", "半般辦" },
+    { "bang", "旁" },
+    { "bao", "保薄包報" },
+    { "bei", "被背悲北杯備" },
+    { "ben", "本" },
+    { "bi", "必比避鼻彼筆秘閉" },
+    { "bian", "便邊變変辺" },
+    { "biao", "表標" },
+    { "bie", "別" },
+    { "bing", "病並氷" },
+    { "bo", "波薄泊" },
+    { "bu", "不布步部捕補歩" },
+    { "ca", "察" },
+    { "cai", "才材菜財採" },
+    { "can", "参残參" },
+    { "ce", "策側" },
+    { "ceng", "曾" },
+    { "cha", "差查茶" },
+    { "chai", "差" },
+    { "chan", "產産單" },
+    { "chang", "場廠" },
+    { "chao", "超朝" },
+    { "che", "車" },
+    { "cheng", "成程乗" },
+    { "chi", "尺吃持赤池遅歯" },
+    { "chong", "充种重種" },
+    { "chu", "出初楚触處処" },
+    { "chuan", "川船傳" },
+    { "chuang", "創窓" },
+    { "chun", "春" },
+    { "ci", "此次辞差" },
+    { "cong", "從従" },
+    { "cu", "卒" },
+    { "cun", "存村" },
+    { "cuo", "錯" },
+    { "da", "大打答達" },
+    { "dai", "代待帯帶貸" },
+    { "dan", "但担擔誕單単" },
+    { "dang", "当党當黨" },
+    { "dao", "到道盗導島辺" },
+    { "de", "的得" },
+    { "dei", "" },
+    { "deng", "等" },
+    { "di", "地得低底弟第締" },
+    { "dian", "点电店點電" },
+    { "diao", "調" },
+    { "ding", "定町" },
+    { "dong", "冬東動働凍" },
+    { "du", "独度都渡読" },
+    { "duan", "段断短斷" },
+    { "dui", "對対" },
+    { "duo", "多駄" },
+    { "e", "嗯悪" },
+    { "en", "嗯" },
+    { "er", "而耳二兒" },
+    { "fa", "乏法發発髪" },
+    { "fan", "反返犯番仮販飯範払" },
+    { "fang", "方放房坊訪" },
+    { "fei", "非飛費" },
+    { "fen", "分份" },
+    { "feng", "風豐" },
+    { "fou", "否不" },
+    { "fu", "父夫富服符付附府幅婦復複負払" },
+    { "gai", "改概該" },
+    { "gan", "甘感敢" },
+    { "gang", "港剛" },
+    { "gao", "告高" },
+    { "ge", "各格歌革割個" },
+    { "gei", "給" },
+    { "gen", "跟根" },
+    { "geng", "更" },
+    { "gong", "工共供功公" },
+    { "gou", "夠構溝" },
+    { "gu", "古故鼓" },
+    { "guai", "掛" },
+    { "guan", "官管慣館觀関關" },
+    { "guang", "光広" },
+    { "gui", "規帰" },
+    { "guo", "果国裏菓國過" },
+    { "hai", "孩海害還" },
+    { "han", "寒漢" },
+    { "hang", "航行" },
+    { "hao", "好号" },
+    { "he", "合和喝何荷" },
+    { "hei", "黒" },
+    { "hen", "很" },
+    { "heng", "行横" },
+    { "hou", "厚喉候後" },
+    { "hu", "乎呼湖護" },
+    { "hua", "化画花話畫劃" },
+    { "huai", "壊劃" },
+    { "huan", "緩環歡還換" },
+    { "huang", "黄" },
+    { "hui", "回会慧絵揮會" },
+    { "hun", "混婚" },
+    { "huo", "活或火獲" },
+    { "i", "" },
+    { "ji", "己计及机既急季寄技即集基祭系奇紀積計記済幾際極繼績機濟" },
+    { "jia", "家加價" },
+    { "jian", "件建健肩見減間検簡漸" },
+    { "jiang", "降強講將港" },
+    { "jiao", "叫教交角覚覺較學" },
+    { "jie", "介借接姐皆届界解結階節價" },
+    { "jin", "今近禁金僅進" },
+    { "jing", "京境景静精經経" },
+    { "jiu", "就久九酒究" },
+    { "ju", "句具局居決挙據舉" },
+    { "jue", "角覚覺" },
+    { "jun", "均" },
+    { "kai", "開" },
+    { "kan", "看刊" },
+    { "kang", "康" },
+    { "kao", "考" },
+    { "ke", "可刻科克客渇課" },
+    { "ken", "肯" },
+    { "kong", "空控" },
+    { "kou", "口" },
+    { "ku", "苦庫" },
+    { "kuai", "快塊会會" },
+    { "kuang", "況" },
+    { "kun", "困" },
+    { "kuo", "括拡適" },
+    { "la", "拉啦落" },
+    { "lai", "来來頼" },
+    { "lao", "老絡落" },
+    { "le", "了楽樂" },
+    { "lei", "類" },
+    { "leng", "冷" },
+    { "li", "力立利理例礼離麗裡勵歷" },
+    { "lian", "連練臉聯" },
+    { "liang", "良量涼兩両" },
+    { "liao", "料" },
+    { "lie", "列" },
+    { "lin", "林隣賃" },
+    { "ling", "另令領" },
+    { "liu", "六留流" },
+    { "lu", "律路録緑陸履慮" },
+    { "lv", "旅" },
+    { "lun", "輪論" },
+    { "luo", "落絡" },
+    { "ma", "媽嗎嘛" },
+    { "mai", "買売" },
+    { "man", "滿" },
+    { "mang", "忙" },
+    { "mao", "毛猫貿" },
+    { "me", "麼" },
+    { "mei", "美妹每沒毎媒" },
+    { "men", "們" },
+    { "mi", "米密秘" },
+    { "mian", "免面勉眠" },
+    { "miao", "描" },
+    { "min", "民皿" },
+    { "ming", "命明名" },
+    { "mo", "末模麼" },
+    { "mou", "某" },
+    { "mu", "母木目模" },
+    { "na", "那哪拿內南" },
+    { "nan", "男南難" },
+    { "nao", "腦" },
+    { "ne", "那哪呢" },
+    { "nei", "内那哪內" },
+    { "neng", "能" },
+    { "ni", "你妳呢" },
+    { "nian", "年念" },
+    { "niang", "娘" },
+    { "nin", "您" },
+    { "ning", "凝" },
+    { "niu", "牛" },
+    { "nong", "農濃" },
+    { "nu", "女努" },
+    { "nuan", "暖" },
+    { "o", "" },
+    { "ou", "歐" },
+    { "pa", "怕" },
+    { "pian", "片便" },
+    { "pai", "迫派排" },
+    { "pan", "判番" },
+    { "pang", "旁" },
+    { "pei", "配" },
+    { "peng", "朋" },
+    { "pi", "疲否" },
+    { "pin", "品貧" },
+    { "ping", "平評" },
+    { "po", "迫破泊頗" },
+    { "pu", "普僕" },
+    { "qi", "起其奇七气期泣企妻契気" },
+    { "qian", "嵌浅千前鉛錢針" },
+    { "qiang", "強將" },
+    { "qiao", "橋繰" },
+    { "qie", "且切契" },
+    { "qin", "寝勤親" },
+    { "qing", "青清情晴輕頃請軽" },
+    { "qiu", "求秋球" },
+    { "qu", "去取趣曲區" },
+    { "quan", "全犬券" },
+    { "que", "缺確卻" },
+    { "ran", "然" },
+    { "rang", "讓" },
+    { "re", "熱" },
+    { "ren", "人任認" },
+    { "reng", "仍" },
+    { "ri", "日" },
+    { "rong", "容" },
+    { "rou", "弱若肉" },
+    { "ru", "如入" },
+    { "ruan", "軟" },
+    { "sai", "賽" },
+    { "san", "三" },
+    { "sao", "騒繰" },
+    { "se", "色" },
+    { "sen", "森" },
+    { "sha", "砂" },
+    { "shan", "善山單" },
+    { "shang", "上尚商" },
+    { "shao", "少紹" },
+    { "shaung", "雙" },
+    { "she", "社射設捨渉" },
+    { "shei", "誰" },
+    { "shen", "什申深甚身伸沈神" },
+    { "sheng", "生声昇勝乗聲" },
+    { "shi", "是失示食时事式十石施使世实史室市始柿氏士仕拭時視師試適実實識" },
+    { "shou", "手首守受授" },
+    { "shu", "束数暑殊樹書屬輸術" },
+    { "shui", "水説說誰" },
+    { "shuo", "数説說" },
+    { "si", "思寺司四私似死価" },
+    { "song", "送" },
+    { "su", "速宿素蘇訴" },
+    { "suan", "算酸" },
+    { "sui", "隨雖歲歳" },
+    { "sun", "孫" },
+    { "suo", "所" },
+    { "ta", "她他它牠" },
+    { "tai", "太台態臺" },
+    { "tan", "探談曇" },
+    { "tang", "糖" },
+    { "tao", "桃逃套討" },
+    { "te", "特" },
+    { "ti", "体提替題體戻" },
+    { "tian", "天田" },
+    { "tiao", "条條調" },
+    { "tie", "鉄" },
+    { "ting", "停庭聽町" },
+    { "tong", "同童通痛统統" },
+    { "tou", "投透頭" },
+    { "tu", "土徒茶図" },
+    { "tuan", "團" },
+    { "tui", "推退" },
+    { "tuo", "脱駄" },
+    { "u", "" },
+    { "v", "" },
+    { "wai", "外" },
+    { "wan", "完万玩晩腕灣" },
+    { "wang", "忘望亡往網" },
+    { "wei", "危位未味委為謂維違圍" },
+    { "wen", "文温問聞" },
+    { "wo", "我" },
+    { "wu", "午物五無屋亡鳥務汚" },
+    { "xi", "夕息西洗喜系昔席希析嬉膝細習係" },
+    { "xia", "下夏狭暇" },
+    { "xian", "先限嫌洗現見線顯" },
+    { "xiang", "向相香像想象降項詳響" },
+    { "xiao", "小笑消效校削咲" },
+    { "xie", "写携些解邪械協謝寫契" },
+    { "xin", "心信新辛" },
+    { "xing", "行形性幸型星興" },
+    { "xiong", "兄胸" },
+    { "xiu", "休秀修" },
+    { "xu", "須需許續緒続" },
+    { "xuan", "選懸" },
+    { "xue", "学雪削靴學" },
+    { "xun", "訓訊" },
+    { "ya", "呀押壓" },
+    { "yan", "言顔研煙嚴厳験驗塩" },
+    { "yang", "央洋陽樣様" },
+    { "yao", "要揺腰薬曜" },
+    { "ye", "也野夜邪業葉" },
+    { "yi", "一已亦依以移意医易伊役異億義議藝醫訳" },
+    { "yin", "因引音飲銀" },
+    { "ying", "英迎影映應營営" },
+    { "yong", "永用泳擁" },
+    { "you", "又有右友由尤油遊郵誘優" },
+    { "yu", "予育余雨浴欲愈御宇域語於魚與込" },
+    { "yuan", "元原源院員円園遠猿願" },
+    { "yue", "月越約楽" },
+    { "yun", "雲伝運" },
+    { "za", "雑" },
+    { "zai", "在再載災" },
+    { "zang", "蔵" },
+    { "zao", "早造" },
+    { "ze", "則擇責" },
+    { "zen", "怎" },
+    { "zeng", "曾增増" },
+    { "zha", "札" },
+    { "zhai", "宅擇" },
+    { "zhan", "站展戰戦" },
+    { "zhang", "丈長障帳張" },
+    { "zhao", "找着朝招" },
+    { "zhe", "者這" },
+    { "zhen", "真震針" },
+    { "zheng", "正整争政爭" },
+    { "zhi", "之只知支止制至治直指值置智値紙製質誌織隻識職執" },
+    { "zhong", "中种終重種眾" },
+    { "zhou", "周州昼宙洲週" },
+    { "zhu", "助主住柱株祝逐注著諸屬術" },
+    { "zhuan", "专專転" },
+    { "zhuang", "状狀" },
+    { "zhui", "追" },
+    { "zhun", "準" },
+    { "zhuo", "着" },
+    { "zi", "子自字姉資" },
+    { "zong", "總" },
+    { "zuo", "左做昨坐座作" },
+    { "zu", "足祖族卒組" },
+    { "zui", "最酔" },
+    { "zou", "走" },
+    {NULL, NULL}
+};
+#endif
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+lv_obj_t * lv_ime_pinyin_create(lv_obj_t * parent)
+{
+    LV_LOG_INFO("begin");
+    lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
+    lv_obj_class_init_obj(obj);
+    return obj;
+}
+
+
+/*=====================
+ * Setter functions
+ *====================*/
+
+/**
+ * Set the keyboard of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @param dict pointer to a Pinyin input method keyboard
+ */
+void lv_ime_pinyin_set_keyboard(lv_obj_t * obj, lv_obj_t * kb)
+{
+    if(kb) {
+        LV_ASSERT_OBJ(kb, &lv_keyboard_class);
+    }
+
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    pinyin_ime->kb = kb;
+    lv_obj_add_event_cb(pinyin_ime->kb, lv_ime_pinyin_kb_event, LV_EVENT_VALUE_CHANGED, obj);
+    lv_obj_align_to(pinyin_ime->cand_panel, pinyin_ime->kb, LV_ALIGN_OUT_TOP_MID, 0, 0);
+}
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @param dict pointer to a Pinyin input method dictionary
+ */
+void lv_ime_pinyin_set_dict(lv_obj_t * obj, lv_pinyin_dict_t * dict)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    init_pinyin_dict(obj, dict);
+}
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin IME object
+ * @return     pointer to the Pinyin IME keyboard
+ */
+lv_obj_t * lv_ime_pinyin_get_kb(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    return pinyin_ime->kb;
+}
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @return     pointer to the Pinyin input method candidate panel
+ */
+lv_obj_t * lv_ime_pinyin_get_cand_panel(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    return pinyin_ime->cand_panel;
+}
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @return     pointer to the Pinyin input method dictionary
+ */
+lv_pinyin_dict_t * lv_ime_pinyin_get_dict(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    return pinyin_ime->dict;
+}
+
+/*=====================
+ * Other functions
+ *====================*/
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void lv_ime_pinyin_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
+{
+    LV_UNUSED(class_p);
+    LV_TRACE_OBJ_CREATE("begin");
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    uint16_t py_str_i = 0;
+    for(uint16_t btnm_i = 0; btnm_i < (LV_IME_PINYIN_CAND_TEXT_NUM + 3); btnm_i++) {
+        if(btnm_i == 0) {
+            lv_btnm_def_pinyin_sel_map[btnm_i] = "<";
+        }
+        else if(btnm_i == (LV_IME_PINYIN_CAND_TEXT_NUM + 1)) {
+            lv_btnm_def_pinyin_sel_map[btnm_i] = ">";
+        }
+        else if(btnm_i == (LV_IME_PINYIN_CAND_TEXT_NUM + 2)) {
+            lv_btnm_def_pinyin_sel_map[btnm_i] = "";
+        }
+        else {
+            lv_pinyin_cand_str[py_str_i][0] = ' ';
+            lv_btnm_def_pinyin_sel_map[btnm_i] = lv_pinyin_cand_str[py_str_i];
+            py_str_i++;
+        }
+    }
+
+    pinyin_ime->py_page = 0;
+    pinyin_ime->ta_count = 0;
+    pinyin_ime->cand_num = 0;
+    lv_memset_00(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
+    lv_memset_00(pinyin_ime->py_num, sizeof(pinyin_ime->py_num));
+    lv_memset_00(pinyin_ime->py_pos, sizeof(pinyin_ime->py_pos));
+
+    lv_obj_set_size(obj, LV_PCT(100), LV_PCT(55));
+    lv_obj_align(obj, LV_ALIGN_BOTTOM_MID, 0, 0);
+
+#if LV_IME_PINYIN_USE_DEFAULT_DICT
+    init_pinyin_dict(obj, lv_ime_pinyin_def_dict);
+#endif
+
+    /* Init pinyin_ime->cand_panel */
+    pinyin_ime->cand_panel = lv_btnmatrix_create(lv_scr_act());
+    lv_btnmatrix_set_map(pinyin_ime->cand_panel, (const char **)lv_btnm_def_pinyin_sel_map);
+    lv_obj_set_size(pinyin_ime->cand_panel, LV_PCT(100), LV_PCT(5));
+    lv_obj_add_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);
+
+    lv_btnmatrix_set_one_checked(pinyin_ime->cand_panel, true);
+
+    /* Set cand_panel style*/
+    // Default style
+    lv_obj_set_style_bg_opa(pinyin_ime->cand_panel, LV_OPA_0, 0);
+    lv_obj_set_style_border_width(pinyin_ime->cand_panel, 0, 0);
+    lv_obj_set_style_pad_all(pinyin_ime->cand_panel, 8, 0);
+    lv_obj_set_style_pad_gap(pinyin_ime->cand_panel, 0, 0);
+    lv_obj_set_style_radius(pinyin_ime->cand_panel, 0, 0);
+    lv_obj_set_style_pad_gap(pinyin_ime->cand_panel, 0, 0);
+    lv_obj_set_style_base_dir(pinyin_ime->cand_panel, LV_BASE_DIR_LTR, 0);
+
+    // LV_PART_ITEMS style
+    lv_obj_set_style_radius(pinyin_ime->cand_panel, 12, LV_PART_ITEMS);
+    lv_obj_set_style_bg_color(pinyin_ime->cand_panel, lv_color_white(), LV_PART_ITEMS);
+    lv_obj_set_style_bg_opa(pinyin_ime->cand_panel, LV_OPA_0, LV_PART_ITEMS);
+    lv_obj_set_style_shadow_opa(pinyin_ime->cand_panel, LV_OPA_0, LV_PART_ITEMS);
+
+    // LV_PART_ITEMS | LV_STATE_PRESSED style
+    lv_obj_set_style_bg_opa(pinyin_ime->cand_panel, LV_OPA_COVER, LV_PART_ITEMS | LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(pinyin_ime->cand_panel, lv_color_white(), LV_PART_ITEMS | LV_STATE_PRESSED);
+
+    /* event handler */
+    lv_obj_add_event_cb(pinyin_ime->cand_panel, lv_ime_pinyin_cand_panel_event, LV_EVENT_VALUE_CHANGED, obj);
+    lv_obj_add_event_cb(obj, lv_ime_pinyin_style_change_event, LV_EVENT_STYLE_CHANGED, NULL);
+}
+
+
+static void lv_ime_pinyin_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
+{
+    LV_UNUSED(class_p);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    if(lv_obj_is_valid(pinyin_ime->kb))
+        lv_obj_del(pinyin_ime->kb);
+
+    if(lv_obj_is_valid(pinyin_ime->cand_panel))
+        lv_obj_del(pinyin_ime->cand_panel);
+}
+
+
+static void lv_ime_pinyin_kb_event(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * kb = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_user_data(e);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    if(code == LV_EVENT_VALUE_CHANGED) {
+        uint16_t btn_id  = lv_btnmatrix_get_selected_btn(kb);
+        if(btn_id == LV_BTNMATRIX_BTN_NONE) return;
+
+        const char * txt = lv_btnmatrix_get_btn_text(kb, lv_btnmatrix_get_selected_btn(kb));
+        if(txt == NULL) return;
+
+        if(strcmp(txt, "Enter") == 0 || strcmp(txt, LV_SYMBOL_NEW_LINE) == 0) {
+            lv_memset_00(lv_pinyin_cand_str, (sizeof(lv_pinyin_cand_str)));
+            pinyin_ime->ta_count = 0;
+            lv_memset_00(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
+        }
+        else if(strcmp(txt, LV_SYMBOL_BACKSPACE) == 0) {
+            // del input char
+            for(int i = strlen(pinyin_ime->input_char) - 1; i >= 0; i--) {
+                if(pinyin_ime->input_char[i] != '\0') {
+                    pinyin_ime->input_char[i] = '\0';
+                    lv_obj_add_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);
+                    break;
+                }
+            }
+            pinyin_input_proc(obj);
+            pinyin_ime->ta_count--;
+        }
+        else if((strcmp(txt, "ABC") == 0) || (strcmp(txt, "abc") == 0) || (strcmp(txt, "1#") == 0)) {
+            pinyin_ime->ta_count = 0;
+            lv_memset_00(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
+            return;
+        }
+        else if((strcmp(txt, LV_SYMBOL_KEYBOARD) == 0) || (strcmp(txt, LV_SYMBOL_OK) == 0)) {
+            pinyin_ime->ta_count = 0;
+            lv_memset_00(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
+            lv_obj_add_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);
+        }
+        else if((txt[0] >= 'a' && txt[0] <= 'z') || (txt[0] >= 'A' && txt[0] <= 'Z')) {
+            strcat(pinyin_ime->input_char, txt);
+            pinyin_input_proc(obj);
+            pinyin_ime->ta_count++;
+        }
+    }
+}
+
+
+static void lv_ime_pinyin_cand_panel_event(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * cand_panel = lv_event_get_target(e);
+    lv_obj_t * obj = (lv_obj_t *)lv_event_get_user_data(e);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    if(code == LV_EVENT_VALUE_CHANGED) {
+        uint32_t id = lv_btnmatrix_get_selected_btn(cand_panel);
+        if(id == 0) {
+            pinyin_page_proc(obj, 0);
+            return;
+        }
+        if(id == (LV_IME_PINYIN_CAND_TEXT_NUM + 1)) {
+            pinyin_page_proc(obj, 1);
+            return;
+        }
+
+        const char * txt = lv_btnmatrix_get_btn_text(cand_panel, id);
+        lv_obj_t * ta = lv_keyboard_get_textarea(pinyin_ime->kb);
+
+        for(int i = 0; i < pinyin_ime->ta_count; i++) {
+            lv_textarea_del_char(ta);
+        }
+
+        lv_textarea_add_text(ta, txt);
+
+        pinyin_ime->ta_count = 0;
+        lv_memset_00(lv_pinyin_cand_str, (sizeof(lv_pinyin_cand_str)));
+        lv_memset_00(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
+        lv_obj_add_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+
+static void pinyin_input_proc(lv_obj_t * obj)
+{
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    pinyin_ime->cand_str = pinyin_search_matching(obj, pinyin_ime->input_char, &pinyin_ime->cand_num);
+    if(pinyin_ime->cand_str == NULL) {
+        return;
+    }
+
+    pinyin_ime->py_page = 0;
+
+    for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
+        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_pinyin_cand_str[i][0] = ' ';
+    }
+
+    // fill buf
+    for(uint8_t i = 0; (i < pinyin_ime->cand_num && i < LV_IME_PINYIN_CAND_TEXT_NUM); i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            lv_pinyin_cand_str[i][j] = pinyin_ime->cand_str[i * 3 + j];
+        }
+    }
+
+    lv_obj_clear_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void pinyin_page_proc(lv_obj_t * obj, uint16_t dir)
+{
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+    uint16_t page_num = pinyin_ime->cand_num / LV_IME_PINYIN_CAND_TEXT_NUM;
+    uint16_t sur = pinyin_ime->cand_num % LV_IME_PINYIN_CAND_TEXT_NUM;
+
+    if(dir == 0) {
+        if(pinyin_ime->py_page) {
+            pinyin_ime->py_page--;
+        }
+    }
+    else {
+        if(sur == 0) {
+            page_num -= 1;
+        }
+        if(pinyin_ime->py_page < page_num) {
+            pinyin_ime->py_page++;
+        }
+        else return;
+    }
+
+    for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
+        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_pinyin_cand_str[i][0] = ' ';
+    }
+
+    // fill buf
+    uint16_t offset = pinyin_ime->py_page * (3 * LV_IME_PINYIN_CAND_TEXT_NUM);
+    for(uint8_t i = 0; (i < pinyin_ime->cand_num && i < LV_IME_PINYIN_CAND_TEXT_NUM); i++) {
+        if((sur > 0) && (pinyin_ime->py_page == page_num)) {
+            if(i > sur)
+                break;
+        }
+        for(uint8_t j = 0; j < 3; j++) {
+            lv_pinyin_cand_str[i][j] = pinyin_ime->cand_str[offset + (i * 3) + j];
+        }
+    }
+}
+
+
+static void lv_ime_pinyin_style_change_event(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * obj = lv_event_get_target(e);
+
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    if(code == LV_EVENT_STYLE_CHANGED) {
+        const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
+        lv_obj_set_style_text_font(pinyin_ime->cand_panel, font, 0);
+    }
+}
+
+
+static void init_pinyin_dict(lv_obj_t * obj, lv_pinyin_dict_t * dict)
+{
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    char headletter = 'a';
+    uint16_t offset_sum = 0;
+    uint16_t offset_count = 0;
+    uint16_t letter_calc = 0;
+
+    pinyin_ime->dict = dict;
+
+    for(uint16_t i = 0; ; i++) {
+        if((NULL == (dict[i].py)) || (NULL == (dict[i].py_mb))) {
+            headletter = dict[i - 1].py[0];
+            letter_calc = headletter - 'a';
+            pinyin_ime->py_num[letter_calc] = offset_count;
+            break;
+        }
+
+        if(headletter == (dict[i].py[0])) {
+            offset_count++;
+        }
+        else {
+            headletter = dict[i].py[0];
+            letter_calc = headletter - 'a';
+            pinyin_ime->py_num[letter_calc - 1] = offset_count;
+            offset_sum += offset_count;
+            pinyin_ime->py_pos[letter_calc] = offset_sum;
+
+            offset_count = 1;
+        }
+    }
+}
+
+
+static char * pinyin_search_matching(lv_obj_t * obj, char * strInput_py_str, uint16_t * cand_num)
+{
+    lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
+
+    lv_pinyin_dict_t * cpHZ;
+    uint8_t i, cInputStrLength = 0, offset;
+    volatile uint8_t count = 0;
+
+    if(*strInput_py_str == '\0')    return NULL;
+    if(*strInput_py_str == 'i')     return NULL;
+    if(*strInput_py_str == 'u')     return NULL;
+    if(*strInput_py_str == 'v')     return NULL;
+
+    offset = strInput_py_str[0] - 'a';
+    cInputStrLength = strlen(strInput_py_str);
+
+    cpHZ  = &pinyin_ime->dict[pinyin_ime->py_pos[offset]];
+    count = pinyin_ime->py_num[offset];
+
+    while(count--) {
+        for(i = 0; i < cInputStrLength; i++) {
+            if(*(strInput_py_str + i) != *((cpHZ->py) + i)) {
+                break;
+            }
+        }
+
+        // perfect match
+        if(cInputStrLength == 1 || i == cInputStrLength) {
+            // The Chinese character in UTF-8 encoding format is 3 bytes
+            * cand_num = strlen((const char *)(cpHZ->py_mb)) / 3;
+            return (char *)(cpHZ->py_mb);
+        }
+        cpHZ++;
+    }
+    return NULL;
+}
+
+
+#endif  /*LV_USE_IME_PINYIN*/

--- a/src/extra/others/ime/lv_ime_pinyin.h
+++ b/src/extra/others/ime/lv_ime_pinyin.h
@@ -1,0 +1,117 @@
+/**
+ * @file lv_ime_pinyin.h
+ *
+ */
+#ifndef LV_IME_PINYIN_H
+#define LV_IME_PINYIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../../lvgl.h"
+
+#if LV_USE_IME_PINYIN != 0
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef struct {
+    const char * const py;
+    const char * const py_mb;
+} lv_pinyin_dict_t;
+
+/*Data of lv_ime_pinyin*/
+typedef struct {
+    lv_obj_t obj;
+    lv_obj_t * kb;
+    lv_obj_t * cand_panel;
+    lv_pinyin_dict_t * dict;
+    char * cand_str;            /* Candidate string */
+    char * btnm_pinyin_sel[LV_IME_PINYIN_CAND_TEXT_NUM + 3];
+    char   input_char[16];        /* Input box character */
+    uint16_t ta_count;          /* The number of characters entered in the text box this time */
+    uint16_t cand_num;          /* Number of candidates */
+    uint16_t py_page;           /* Current pinyin map pages */
+    uint16_t py_num[26];        /* Number and length of Pinyin */
+    uint16_t py_pos[26];        /* Pinyin position */
+} lv_ime_pinyin_t;
+
+/***********************
+ * GLOBAL VARIABLES
+ ***********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+lv_obj_t * lv_ime_pinyin_create(lv_obj_t * parent);
+
+/*=====================
+ * Setter functions
+ *====================*/
+
+/**
+ * Set the keyboard of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @param dict pointer to a Pinyin input method keyboard
+ */
+void lv_ime_pinyin_set_keyboard(lv_obj_t * obj, lv_obj_t * kb);
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @param dict pointer to a Pinyin input method dictionary
+ */
+void lv_ime_pinyin_set_dict(lv_obj_t * obj, lv_pinyin_dict_t * dict);
+
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin IME object
+ * @return     pointer to the Pinyin IME keyboard
+ */
+lv_obj_t * lv_ime_pinyin_get_kb(lv_obj_t * obj);
+
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @return     pointer to the Pinyin input method candidate panel
+ */
+lv_obj_t * lv_ime_pinyin_get_cand_panel(lv_obj_t * obj);
+
+
+/**
+ * Set the dictionary of Pinyin input method.
+ * @param obj  pointer to a Pinyin input method object
+ * @return     pointer to the Pinyin input method dictionary
+ */
+lv_pinyin_dict_t * lv_ime_pinyin_get_dict(lv_obj_t * obj);
+
+/*=====================
+ * Other functions
+ *====================*/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif  /*LV_IME_PINYIN*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_USE_IME_PINYIN*/
+

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -1197,11 +1197,13 @@ static void draw_series_bar(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
     int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj,
                                                               LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
     lv_coord_t block_w = (w - ((chart->point_cnt - 1) * block_gap)) / chart->point_cnt;
-    lv_coord_t col_w = block_w / ser_cnt;
     int32_t ser_gap = ((int32_t)lv_obj_get_style_pad_column(obj,
-                                                            LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the column on the ~same X*/
-    lv_coord_t x_ofs = pad_left - lv_obj_get_scroll_left(obj);
-    lv_coord_t y_ofs = pad_top - lv_obj_get_scroll_top(obj);
+                                                            LV_PART_ITEMS) * chart->zoom_x) >> 8; /*Gap between the columns on the ~same X*/
+    lv_coord_t col_w = (block_w - (ser_cnt - 1) * ser_gap) / ser_cnt;
+
+    lv_coord_t border_w = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t x_ofs = pad_left - lv_obj_get_scroll_left(obj) + border_w;
+    lv_coord_t y_ofs = pad_top - lv_obj_get_scroll_top(obj) + border_w;
 
     lv_draw_rect_dsc_t col_dsc;
     lv_draw_rect_dsc_init(&col_dsc);
@@ -1220,7 +1222,7 @@ static void draw_series_bar(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
 
     /*Go through all points*/
     for(i = 0; i < chart->point_cnt; i++) {
-        lv_coord_t x_act = (int32_t)((int32_t)(w + block_gap) * i) / (chart->point_cnt) + obj->coords.x1 + x_ofs;
+        lv_coord_t x_act = (int32_t)((int32_t)(w - block_w) * i) / (chart->point_cnt - 1) + obj->coords.x1 + x_ofs;
 
         part_draw_dsc.id = i;
 
@@ -1230,8 +1232,8 @@ static void draw_series_bar(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
             lv_coord_t start_point = chart->update_mode == LV_CHART_UPDATE_MODE_SHIFT ? ser->start_point : 0;
 
             col_a.x1 = x_act;
-            col_a.x2 = col_a.x1 + col_w - ser_gap - 1;
-            x_act += col_w;
+            col_a.x2 = col_a.x1 + col_w - 1;
+            x_act += col_w + ser_gap;
 
             if(col_a.x2 < clip_area.x1) continue;
             if(col_a.x1 > clip_area.x2) break;
@@ -1520,7 +1522,6 @@ static void draw_x_ticks(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, lv_chart_axis
     lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     lv_coord_t w     = ((int32_t)lv_obj_get_content_width(obj) * chart->zoom_x) >> 8;
 
-
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
     lv_obj_init_draw_label_dsc(obj, LV_PART_TICKS, &label_dsc);
@@ -1564,6 +1565,7 @@ static void draw_x_ticks(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, lv_chart_axis
         int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj,
                                                                   LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the columns on ~adjacent X*/
         lv_coord_t block_w = (w + block_gap) / (chart->point_cnt);
+
         x_ofs += (block_w - block_gap) / 2;
         w -= block_w - block_gap;
     }
@@ -1713,11 +1715,13 @@ static void invalidate_point(lv_obj_t * obj, uint16_t i)
         lv_area_t col_a;
         int32_t block_gap = ((int32_t)lv_obj_get_style_pad_column(obj,
                                                                   LV_PART_MAIN) * chart->zoom_x) >> 8;  /*Gap between the column on ~adjacent X*/
+
         lv_coord_t block_w = (w + block_gap) / chart->point_cnt;
 
+        lv_coord_t bwidth = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
         lv_coord_t x_act;
         x_act = (int32_t)((int32_t)(block_w) * i) ;
-        x_act += obj->coords.x1 + lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
+        x_act += obj->coords.x1 + bwidth + lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
 
         lv_obj_get_coords(obj, &col_a);
         col_a.x1 = x_act - scroll_left;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2243,6 +2243,40 @@
     #endif
 #endif
 
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#ifndef LV_USE_IME_PINYIN
+    #ifdef CONFIG_LV_USE_IME_PINYIN
+        #define LV_USE_IME_PINYIN CONFIG_LV_USE_IME_PINYIN
+    #else
+        #define LV_USE_IME_PINYIN 0
+    #endif
+#endif
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #ifndef LV_IME_PINYIN_USE_DEFAULT_DICT
+        #ifdef _LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_IME_PINYIN_USE_DEFAULT_DICT
+                #define LV_IME_PINYIN_USE_DEFAULT_DICT CONFIG_LV_IME_PINYIN_USE_DEFAULT_DICT
+            #else
+                #define LV_IME_PINYIN_USE_DEFAULT_DICT 0
+            #endif
+        #else
+            #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+        #endif
+    #endif
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #ifndef LV_IME_PINYIN_CAND_TEXT_NUM
+        #ifdef CONFIG_LV_IME_PINYIN_CAND_TEXT_NUM
+            #define LV_IME_PINYIN_CAND_TEXT_NUM CONFIG_LV_IME_PINYIN_CAND_TEXT_NUM
+        #else
+            #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+        #endif
+    #endif
+#endif
+
 /*==================
 * EXAMPLES
 *==================*/

--- a/src/misc/lv_async.c
+++ b/src/misc/lv_async.c
@@ -65,6 +65,33 @@ lv_res_t lv_async_call(lv_async_cb_t async_xcb, void * user_data)
     return LV_RES_OK;
 }
 
+lv_res_t lv_async_call_cancel(lv_async_cb_t async_xcb, void * user_data)
+{
+    lv_timer_t * timer = lv_timer_get_next(NULL);
+    lv_res_t res = LV_RES_INV;
+
+    while(timer != NULL) {
+        /*Find the next timer node*/
+        lv_timer_t * timer_next = lv_timer_get_next(timer);
+
+        /*Find async timer callback*/
+        if(timer->timer_cb == lv_async_timer_cb) {
+            lv_async_info_t * info = (lv_async_info_t *)timer->user_data;
+
+            /*Match user function callback and user data*/
+            if(info->cb == async_xcb && info->user_data == user_data) {
+                lv_timer_del(timer);
+                lv_mem_free(info);
+                res = LV_RES_OK;
+            }
+        }
+
+        timer = timer_next;
+    }
+
+    return res;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/lv_async.h
+++ b/src/misc/lv_async.h
@@ -43,6 +43,13 @@ typedef void (*lv_async_cb_t)(void *);
  */
 lv_res_t lv_async_call(lv_async_cb_t async_xcb, void * user_data);
 
+/**
+ * Cancel an asynchronous function call
+ * @param async_xcb a callback which is the task itself.
+ * @param user_data custom parameter
+ */
+lv_res_t lv_async_call_cancel(lv_async_cb_t async_xcb, void * user_data);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/widgets/lv_arc.c
+++ b/src/widgets/lv_arc.c
@@ -820,7 +820,7 @@ static void value_update(lv_obj_t * obj)
             }
             break;
         case LV_ARC_MODE_REVERSE:
-            angle = lv_map(arc->value, arc->min_value, arc->max_value, arc->bg_angle_start, bg_end);
+            angle = lv_map(arc->value, arc->min_value, arc->max_value, bg_end, arc->bg_angle_start);
             lv_arc_set_angles(obj, angle, arc->bg_angle_end);
             break;
         case LV_ARC_MODE_NORMAL:

--- a/src/widgets/lv_btnmatrix.c
+++ b/src/widgets/lv_btnmatrix.c
@@ -399,13 +399,10 @@ static void lv_btnmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e)
     lv_point_t p;
 
     if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
-        lv_coord_t * s = lv_event_get_param(e);
         if(has_popovers_in_top_row(obj)) {
             /*reserve one row worth of extra space to account for popovers in the top row*/
-            *s = btnm->row_cnt > 0 ? lv_obj_get_content_height(obj) / btnm->row_cnt : 0;
-        }
-        else {
-            *s = 0;
+            lv_coord_t s = btnm->row_cnt > 0 ? lv_obj_get_content_height(obj) / btnm->row_cnt : 0;
+            lv_event_set_ext_draw_size(e, s);
         }
     }
     if(code == LV_EVENT_STYLE_CHANGED) {

--- a/tests/src/test_cases/test_arc.c
+++ b/tests/src/test_cases/test_arc.c
@@ -105,7 +105,7 @@ void test_arc_should_update_angles_when_changing_to_symmetrical_mode_value_more_
 /* See #2522 for more information */
 void test_arc_angles_when_reversed(void)
 {
-    uint16_t expected_start_angle = 36;
+    uint16_t expected_start_angle = 54;
     uint16_t expected_end_angle = 90;
     int16_t expected_value = 40;
 


### PR DESCRIPTION
### Description of the feature or fix

This makes arcs show the correct value when reversed, as described in Issue #3417.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
