### PR TITLE
fix: make 'lv_font_glyph_dsc_t' local variable initialized to zero

### DIFF
--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -96,6 +96,8 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
                        uint32_t letter)
 {
     lv_font_glyph_dsc_t g;
+    memset(&g, 0, sizeof(g));
+
     bool g_ret = lv_font_get_glyph_dsc(dsc->font, &g, letter, '\0');
     if(g_ret == false) {
         /*Add warning if the dsc is not found


### PR DESCRIPTION
### Description of the feature or fix

If an object that has automatic storage duration is not initialized explicitly, its value is indeterminate. Indeterminate means it can be anything (including 0). Just because it is zero in the tests you have performed, does not mean it will always be or that you can rely on that behaivour. The behaivour might change even with the same compiler depending on the compilation options and optimization level.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
