### PR TITLE
feat(font): add font placeholder drawing configuration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -657,8 +657,8 @@ menu "LVGL configuration"
                 With "normal" font it doesn't matter.
 
         config LV_USE_FONT_PLACEHOLDER
-            bool "Enable drawing placeholders when glyph dsc is not found"
-            default n
+            bool "Enable drawing placeholders when glyph dsc is not found."
+            default y
     endmenu
 
     menu "Text Settings"

--- a/Kconfig
+++ b/Kconfig
@@ -655,6 +655,10 @@ menu "LVGL configuration"
                 Set the pixel order of the display.
                 Important only if "subpx fonts" are used.
                 With "normal" font it doesn't matter.
+
+        config LV_USE_FONT_PLACEHOLDER
+            bool "Enable drawing placeholders when glyph dsc is not found"
+            default n
     endmenu
 
     menu "Text Settings"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -405,6 +405,9 @@
     #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
 #endif
 
+/*Enable drawing placeholders when glyph dsc is not found*/
+#define LV_USE_FONT_PLACEHOLDER 1
+
 /*=================
  *  TEXT SETTINGS
  *=================*/

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -105,6 +105,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
             LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" PRIX32, letter);
 
+#if LV_USE_FONT_PLACEHOLDER
             /* draw placeholder */
             lv_area_t glyph_coords;
             lv_draw_rect_dsc_t glyph_dsc;
@@ -119,6 +120,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
             glyph_dsc.border_color = dsc->color;
             glyph_dsc.border_width = 1;
             draw_ctx->draw_rect(draw_ctx, &glyph_dsc, &glyph_coords);
+#endif
         }
         return;
     }

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -102,7 +102,11 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
     }
     else {
         dsc_out->box_w = font_p->line_height / 2;
+#if LV_USE_FONT_PLACEHOLDER
         dsc_out->adv_w = dsc_out->box_w + 2;
+#else
+        dsc_out->adv_w = 0;
+#endif
     }
 
     dsc_out->resolved_font = NULL;

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -101,10 +101,11 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
         dsc_out->adv_w = 0;
     }
     else {
-        dsc_out->box_w = font_p->line_height / 2;
 #if LV_USE_FONT_PLACEHOLDER
+        dsc_out->box_w = font_p->line_height / 2;
         dsc_out->adv_w = dsc_out->box_w + 2;
 #else
+        dsc_out->box_w = 0;
         dsc_out->adv_w = 0;
 #endif
     }

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -68,7 +68,10 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
     LV_ASSERT_NULL(font_p);
     LV_ASSERT_NULL(dsc_out);
 
+#if LV_USE_FONT_PLACEHOLDER
     const lv_font_t * placeholder_font = NULL;
+#endif
+
     const lv_font_t * f = font_p;
 
     dsc_out->resolved_font = NULL;
@@ -80,19 +83,22 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
                 dsc_out->resolved_font = f;
                 return true;
             }
+#if LV_USE_FONT_PLACEHOLDER
             else if(placeholder_font == NULL) {
                 placeholder_font = f;
             }
+#endif
         }
         f = f->fallback;
     }
 
+#if LV_USE_FONT_PLACEHOLDER
     if(placeholder_font != NULL) {
         placeholder_font->get_glyph_dsc(placeholder_font, dsc_out, letter, letter_next);
         dsc_out->resolved_font = placeholder_font;
         return true;
     }
-
+#endif
 
     if(letter < 0x20 ||
        letter == 0xf8ff || /*LV_SYMBOL_DUMMY*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1225,6 +1225,19 @@
     #endif
 #endif
 
+/*Enable drawing placeholders when glyph dsc is not found*/
+#ifndef LV_USE_FONT_PLACEHOLDER
+    #ifdef _LV_KCONFIG_PRESENT
+        #ifdef CONFIG_LV_USE_FONT_PLACEHOLDER
+            #define LV_USE_FONT_PLACEHOLDER CONFIG_LV_USE_FONT_PLACEHOLDER
+        #else
+            #define LV_USE_FONT_PLACEHOLDER 0
+        #endif
+    #else
+        #define LV_USE_FONT_PLACEHOLDER 1
+    #endif
+#endif
+
 /*=================
  *  TEXT SETTINGS
  *=================*/


### PR DESCRIPTION
### Description of the feature or fix

Enable `LV_USE_FONT_PLACEHOLDER`:

![image](https://user-images.githubusercontent.com/26767803/177279382-09365fce-f951-47fe-b2f6-713c3c81b721.png)

Disable `LV_USE_FONT_PLACEHOLDER`:

![image](https://user-images.githubusercontent.com/26767803/177279068-c9d7f197-498b-4b2f-a823-d4fae36c6031.png)

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
