### PR TITLE
feat(textarea): add a read-only mode for textarea

### DIFF
--- a/docs/widgets/core/textarea.md
+++ b/docs/widgets/core/textarea.md
@@ -56,6 +56,9 @@ If `lv_textarea_set_cursor_click_pos(textarea, true)` is applied the cursor will
 ### Hide the cursor
 The cursor is always visible, however it can be a good idea to style it to be visible only in `LV_STATE_FOCUSED` state.
 
+### Read-only mode
+The text area can be configured to be a read-only mode with `lv_textarea_set_readonly_mode(textarea, true)`.
+
 ### One line mode
 The Text area can be configured to be on a single line with `lv_textarea_set_one_line(textarea, true)`.
 In this mode the height is set automatically to show only one line, line break characters are ignored, and word wrap is disabled.

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -341,6 +341,13 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
     lv_obj_invalidate(obj);
 }
 
+void lv_textarea_set_readonly_mode(lv_obj_t * obj, bool en)
+{
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+    ta->readonly_mode = en;
+    ta->cursor.show = ~en;
+}
+
 void lv_textarea_set_cursor_pos(lv_obj_t * obj, int32_t pos)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -821,6 +828,7 @@ static void lv_textarea_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
     ta->cursor.click_pos  = 1;
     ta->cursor.valid_x    = 0;
     ta->one_line          = 0;
+    ta->readonly_mode     = 0;
 #if LV_LABEL_TEXT_SELECTION
     ta->text_sel_en = 0;
 #endif
@@ -869,6 +877,9 @@ static void lv_textarea_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target(e);
+
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+    if(ta->readonly_mode) return;
 
     if(code == LV_EVENT_FOCUSED) {
         start_cursor_blink(obj);

--- a/src/widgets/lv_textarea.h
+++ b/src/widgets/lv_textarea.h
@@ -64,6 +64,7 @@ typedef struct {
 #endif
     uint8_t pwd_mode : 1; /*Replace characters with '*'*/
     uint8_t one_line : 1; /*One line mode (ignore line breaks)*/
+    uint8_t readonly_mode : 1; /*Read only mode*/
 } lv_textarea_t;
 
 extern const lv_obj_class_t lv_textarea_class;
@@ -131,6 +132,13 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt);
  * @param txt       pointer to the text
  */
 void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt);
+
+/**
+ * Enable/Disable read only mode
+ * @param obj       pointer to a text area object
+ * @param en        true: enable, false: disable
+ */
+void lv_textarea_set_readonly_mode(lv_obj_t * obj, bool en);
 
 /**
  * Set the cursor position


### PR DESCRIPTION
### Description of the feature or fix
feat(textarea): add a read-only mode for textarea

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
