### PR TITLE
fix(draw): compile error with color depth 8

### DIFF
--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -421,7 +421,7 @@ static inline void set_px_argb_blend(uint8_t * buf, lv_color_t color, lv_opa_t o
 
     /*Set the result color*/
 #if LV_COLOR_DEPTH == 8
-    buf[0] = res_color.full;
+    buf[0] = last_res_color.full;
 #elif LV_COLOR_DEPTH == 16
     buf[0] = last_res_color.full & 0xff;
     buf[1] = last_res_color.full >> 8;


### PR DESCRIPTION
### Description of the feature or fix

I updated to 8.3 today and I got a compile error because of a non-existent variable. It looks like someone forgot to rename that variable at some point.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
