### PR TITLE
feat(ime_pinyin): add API to use 9-key numeric keypad

### DIFF
--- a/src/extra/others/ime/lv_ime_pinyin.h
+++ b/src/extra/others/ime/lv_ime_pinyin.h
@@ -28,6 +28,7 @@ extern "C" {
 typedef enum {
     LV_IME_PINYIN_MODE_K26,
     LV_IME_PINYIN_MODE_K9,
+    LV_IME_PINYIN_MODE_K9_NUMBER,
 } lv_ime_pinyin_mode_t;
 
 /*Data of pinyin_dict*/
@@ -141,4 +142,3 @@ lv_pinyin_dict_t * lv_ime_pinyin_get_dict(lv_obj_t * obj);
 #endif
 
 #endif /*LV_USE_IME_PINYIN*/
-


### PR DESCRIPTION
Like the 9-key Pinyin input mode, it is customized to adapt to the small screen.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
