### PR TITLE
fix(cmake-build): Fix example and demo build on esp-idf

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -21,8 +21,34 @@ if(LV_MICROPYTHON)
                                INTERFACE "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
   endif()
 else()
-  idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS ${LVGL_ROOT_DIR}
-                         ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../)
+  if(CONFIG_LV_BUILD_EXAMPLES)
+    file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
+  endif()
+
+  if(CONFIG_LV_USE_DEMO_WIDGETS)
+    file(GLOB_RECURSE DEMO_WIDGETS_SOURCES ${LVGL_ROOT_DIR}/demos/widgets/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_WIDGETS_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER)
+    file(GLOB_RECURSE DEMO_KEYPAD_AND_ENCODER_SOURCES ${LVGL_ROOT_DIR}/demos/keypad_encoder/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_KEYPAD_AND_ENCODER_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_BENCHMARK)
+    file(GLOB_RECURSE DEMO_BENCHMARK_SOURCES ${LVGL_ROOT_DIR}/demos/benchmark/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_BENCHMARK_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_STRESS)
+    file(GLOB_RECURSE DEMO_STRESS_SOURCES ${LVGL_ROOT_DIR}/demos/stress/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_STRESS_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_MUSIC)
+    file(GLOB_RECURSE DEMO_MUSIC_SOURCES ${LVGL_ROOT_DIR}/demos/music/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_MUSIC_SOURCES})
+  endif()
+
+  idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
+      INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../
+                   ${LVGL_ROOT_DIR}/examples ${LVGL_ROOT_DIR}/demos)
 
   target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 


### PR DESCRIPTION
### Description of the feature or fix

There are options in `Kconfig` files for users to choose whether to build examples and demos, and `esp-idf` supports `menuconfig`. However, when user enables example or demo to be built, they are actually not built, which is quite confusing. This PR fixes this issue.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
