### PR TITLE
fix(rt-thread): thread stack align to 8 bytes

### DIFF
--- a/env_support/rt-thread/lv_rt_thread_port.c
+++ b/env_support/rt-thread/lv_rt_thread_port.c
@@ -31,7 +31,7 @@ extern void lv_port_indev_init(void);
 extern void lv_user_gui_init(void);
 
 static struct rt_thread lvgl_thread;
-static rt_uint8_t lvgl_thread_stack[PKG_LVGL_THREAD_STACK_SIZE];
+static ALIGN(8) rt_uint8_t lvgl_thread_stack[PKG_LVGL_THREAD_STACK_SIZE];
 
 #if LV_USE_LOG
 static void lv_rt_log(const char *buf)


### PR DESCRIPTION
### Description of the feature or fix

For  RISC-V chips, thread stack needs to align to 8 bytes when use **float and double** data type variables;
for ARM chips, thread stack needs to align to 8 bytes when use **double** data type variables.


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
