### PR TITLE
fix(demo): can not found lvgl.h file

### DIFF
--- a/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c
@@ -1,9 +1,4 @@
-#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
-#include "lvgl.h"
-#else
-#include "lvgl/lvgl.h"
-#endif
-
+#include "../../../lvgl.h"
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN


### PR DESCRIPTION
### Description of the feature or fix

When I build lvgl in rt-thread, I got an error:

```bash
CC packages/LVGL-latest/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.o
packages/LVGL-latest/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c:5:10: fatal error: lvgl/lvgl.h: No such file or directory
 #include "lvgl/lvgl.h"
          ^~~~~~~~~~~~~
compilation terminated.
```

So, I refer to another file (like demos/benchmark/assets/img_benchmark_cogwheel_rgb.c), and fix this error.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
