### PR TITLE
fix GCC warning cell_area.x1 and x2 may be used uninitialized in this function

### DIFF
--- a/src/widgets/lv_table.c
+++ b/src/widgets/lv_table.c
@@ -610,6 +610,8 @@ static void draw_main(lv_event_t * e)
     uint16_t cell = 0;
 
     cell_area.y2 = obj->coords.y1 + bg_top - 1 - lv_obj_get_scroll_y(obj) + border_width;
+    cell_area.x1 = 0;
+    cell_area.x2 = 0;
     lv_coord_t scroll_x = lv_obj_get_scroll_x(obj) ;
     bool rtl = lv_obj_get_style_base_dir(obj, LV_PART_MAIN) == LV_BASE_DIR_RTL;
 


### PR DESCRIPTION
While the code is correct the rtl depedent initialization can't be tracked by GCC
