### PR TITLE
fix unhandled branch

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -309,6 +309,11 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
 
         p_out->x += (col_w - ser_gap) / 2;
     }
+    else {
+        p_out->x = 0;
+        p_out->y = 0;
+        return;
+    }
 
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
     p_out->x += lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;


### PR DESCRIPTION
If chart->type != LV_CHART_TYPE_LINE and != LV_CHART_TYPE_SCATTER and != LV_CHART_TYPE_BAR return sane values

Fixes GCC warning p_out->x may be used uninitialized in this function

A alternative fix is to remove the last if and assume it's LV_CHART_TYPE_BAR.