### PR TITLE
fix(btnmatrix) issue #3480: Tapping just outside a button in a button…

### DIFF
--- a/src/widgets/lv_btnmatrix.c
+++ b/src/widgets/lv_btnmatrix.c
@@ -422,6 +422,7 @@ static void lv_btnmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e)
             lv_indev_get_point(param, &p);
             btn_pr = get_button_from_point(obj, &p);
             /*Handle the case where there is no button there*/
+            btnm->btn_id_sel = LV_BTNMATRIX_BTN_NONE;
             if(btn_pr != LV_BTNMATRIX_BTN_NONE) {
                 if(button_is_inactive(btnm->ctrl_bits[btn_pr]) == false &&
                    button_is_hidden(btnm->ctrl_bits[btn_pr]) == false) {


### PR DESCRIPTION
… matrix can cause the last tapped button to repeat.

### Description of the feature or fix

Addresses [issue 3480](https://github.com/lvgl/lvgl/issues/3480).


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [n/a] Update the documentation
