### PR TITLE
fix(config): remove LV_FONT_CUSTOM_DECLARE from Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -540,12 +540,6 @@ menu "LVGL configuration"
                 default y if LV_CONF_MINIMAL
             config LV_FONT_UNSCII_16
                 bool "Enable UNSCII 16 (Perfect monospace font)"
-
-            config LV_FONT_CUSTOM
-                bool "Enable the custom font"
-            config LV_FONT_CUSTOM_DECLARE
-                string "Header to include for the custom font"
-                depends on LV_FONT_CUSTOM
         endmenu
 
         choice LV_FONT_DEFAULT


### PR DESCRIPTION
### Description of the feature or fix

since the code doesn't expect it's type is string

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
