### PR TITLE
Minor fix for cmake

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -4,7 +4,7 @@ option(LV_LVGL_H_INCLUDE_SIMPLE
 
 # Option to define LV_CONF_INCLUDE_SIMPLE, default: ON
 option(LV_CONF_INCLUDE_SIMPLE
-       "Simple include of \"lv_conf.h\" and \"lv_drv_conf.h\"" ON)
+       "Use #include \"lv_conf.h\" instead of #include \"../../lv_conf.h\"" ON)
 
 # Option to set LV_CONF_PATH, if set parent path LV_CONF_DIR is added to
 # includes

--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -12,14 +12,6 @@ if(LV_MICROPYTHON)
     ${LVGL_ROOT_DIR}/../
     REQUIRES
     main)
-
-  target_compile_definitions(${COMPONENT_LIB}
-                             INTERFACE "-DLV_CONF_INCLUDE_SIMPLE")
-
-  if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
-    target_compile_definitions(${COMPONENT_LIB}
-                               INTERFACE "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
-  endif()
 else()
   if(CONFIG_LV_BUILD_EXAMPLES)
     file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
@@ -49,11 +41,11 @@ else()
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
       INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../
                    ${LVGL_ROOT_DIR}/examples ${LVGL_ROOT_DIR}/demos)
+endif()
 
-  target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
 
-  if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
-    target_compile_definitions(${COMPONENT_LIB}
-                               PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
-  endif()
+if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
+  target_compile_definitions(${COMPONENT_LIB}
+                             PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
 endif()

--- a/env_support/cmsis-pack/gen_pack.sh
+++ b/env_support/cmsis-pack/gen_pack.sh
@@ -53,7 +53,6 @@ PACK_DIRS="
 PACK_BASE_FILES="
   ../../LICENCE.txt
   ../../README.md
-  ../../README_zh.md
   ../../lvgl.h
   lv_conf_cmsis.h
   lv_cmsis_pack.txt


### PR DESCRIPTION
### Description of the feature or fix

- chore(cmake): correct LV_CONF_INCLUDE_SIMPLE prompt message in custom.cmake
- chore(cmake): remove the duplication statements in esp.cmake 
- chore(cmsis): remove README_zh.md reference from gen_pack.sh

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
