### PR TITLE
feat(imgfont): add option to use img cache to buffer img headers

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1016,6 +1016,14 @@ menu "LVGL configuration"
         config LV_USE_IMGFONT
             bool "draw img in label or span obj"
             default n
+        config LV_IMGFONT_PATH_MAX_LEN
+            int "Imgfont image file path maximum length"
+            depends on LV_USE_IMGFONT
+            default 64
+        config LV_IMGFONT_USE_IMG_CACHE_HEADER
+            bool "Use img cache to buffer header information"
+            depends on LV_USE_IMGFONT
+            default n
 
         config LV_USE_MSG
             bool "Enable a published subscriber based messaging system"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -690,6 +690,13 @@
 
 /*1: Support using images as font in label or span widgets */
 #define LV_USE_IMGFONT 0
+#if LV_USE_IMGFONT
+    /*Imgfont image file path maximum length*/
+    #define LV_IMGFONT_PATH_MAX_LEN 64
+
+    /*1: Use img cache to buffer header information*/
+    #define LV_IMGFONT_USE_IMG_CACHE_HEADER 0
+#endif
 
 /*1: Enable a published subscriber based messaging system */
 #define LV_USE_MSG 0

--- a/src/extra/others/imgfont/lv_imgfont.c
+++ b/src/extra/others/imgfont/lv_imgfont.c
@@ -13,7 +13,6 @@
 /*********************
  *      DEFINES
  *********************/
-#define LV_IMGFONT_PATH_MAX_LEN 64
 
 /**********************
  *      TYPEDEFS
@@ -107,15 +106,30 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
         return false;
     }
 
+    const lv_img_header_t * img_header;
+#if LV_IMGFONT_USE_IMG_CACHE_HEADER
+    lv_color_t color = { 0 };
+    _lv_img_cache_entry_t * entry = _lv_img_cache_open(dsc->path, color, 0);
+
+    if(entry == NULL) {
+        return false;
+    }
+
+    img_header = &entry->dec_dsc.header;
+#else
     lv_img_header_t header;
+
     if(lv_img_decoder_get_info(dsc->path, &header) != LV_RES_OK) {
         return false;
     }
 
+    img_header = &header;
+#endif
+
     dsc_out->is_placeholder = 0;
-    dsc_out->adv_w = header.w;
-    dsc_out->box_w = header.w;
-    dsc_out->box_h = header.h;
+    dsc_out->adv_w = img_header->w;
+    dsc_out->box_w = img_header->w;
+    dsc_out->box_h = img_header->h;
     dsc_out->bpp = LV_IMGFONT_BPP;   /* is image identifier */
     dsc_out->ofs_x = 0;
     dsc_out->ofs_y = 0;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2246,6 +2246,25 @@
         #define LV_USE_IMGFONT 0
     #endif
 #endif
+#if LV_USE_IMGFONT
+    /*Imgfont image file path maximum length*/
+    #ifndef LV_IMGFONT_PATH_MAX_LEN
+        #ifdef CONFIG_LV_IMGFONT_PATH_MAX_LEN
+            #define LV_IMGFONT_PATH_MAX_LEN CONFIG_LV_IMGFONT_PATH_MAX_LEN
+        #else
+            #define LV_IMGFONT_PATH_MAX_LEN 64
+        #endif
+    #endif
+
+    /*1: Use img cache to buffer header information*/
+    #ifndef LV_IMGFONT_USE_IMG_CACHE_HEADER
+        #ifdef CONFIG_LV_IMGFONT_USE_IMG_CACHE_HEADER
+            #define LV_IMGFONT_USE_IMG_CACHE_HEADER CONFIG_LV_IMGFONT_USE_IMG_CACHE_HEADER
+        #else
+            #define LV_IMGFONT_USE_IMG_CACHE_HEADER 0
+        #endif
+    #endif
+#endif
 
 /*1: Enable a published subscriber based messaging system */
 #ifndef LV_USE_MSG


### PR DESCRIPTION
### Description of the feature or fix

Use img cache to buffer headers to reduce file access.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
