### PR TITLE
feat(img):do not show "no data" if src is NULL

### DIFF
--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -680,7 +680,8 @@ static void draw_img(lv_event_t * e)
                 lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &label_dsc);
 
                 lv_draw_label(draw_ctx, &label_dsc, &obj->coords, img->src, NULL);
-            } else if (img->src == NULL) {
+            }
+            else if(img->src == NULL) {
                 /*Do not need to draw image when src is NULL*/
                 LV_LOG_WARN("draw_img: image source is NULL");
             }

--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -680,6 +680,9 @@ static void draw_img(lv_event_t * e)
                 lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &label_dsc);
 
                 lv_draw_label(draw_ctx, &label_dsc, &obj->coords, img->src, NULL);
+            } else if (img->src == NULL) {
+                /*Do not need to draw image when src is NULL*/
+                LV_LOG_WARN("draw_img: image source is NULL");
             }
             else {
                 /*Trigger the error handler of image draw*/


### PR DESCRIPTION
No need to show "no data" when the source of the image is NULL.

Signed-off-by: wangxuedong <wangxuedong@xiaomi.com>

### Description of the feature or fix


### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
