### PR TITLE
[FORUM-9364] led draw bg_color

### DIFF
--- a/src/widgets/led/lv_led.c
+++ b/src/widgets/led/lv_led.c
@@ -179,6 +179,7 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &rect_dsc);
 
         /*Use the original colors brightness to modify color->led*/
+        rect_dsc.bg_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.bg_color));
         rect_dsc.bg_grad.stops[0].color = lv_color_mix(led->color, lv_color_black(),
                                                        lv_color_brightness(rect_dsc.bg_grad.stops[0].color));
         rect_dsc.bg_grad.stops[1].color = lv_color_mix(led->color, lv_color_black(),
@@ -188,6 +189,7 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
         rect_dsc.outline_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.outline_color));
 
         /*Mix. the color with black proportionally with brightness*/
+        rect_dsc.bg_color = lv_color_mix(rect_dsc.bg_color, lv_color_black(), led->bright);
         rect_dsc.bg_grad.stops[0].color   = lv_color_mix(rect_dsc.bg_grad.stops[0].color, lv_color_black(), led->bright);
         rect_dsc.bg_grad.stops[1].color   = lv_color_mix(rect_dsc.bg_grad.stops[1].color, lv_color_black(), led->bright);
         rect_dsc.border_color = lv_color_mix(rect_dsc.border_color, lv_color_black(), led->bright);


### PR DESCRIPTION
### Description of the feature or fix

https://forum.lvgl.io/t/led-widget-lvgl-8-2-0-and-greater/9364

Prior to 8.2.0 release led draw worked with `LV_DRAW_COMPLEX 0` configuration. This PR adds bg_color draw descriptors back to led draw event to support `LV_DRAW_COMPLEX 0`.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
