### PR TITLE
Add uint32_t lv_textarea_get_right_char(lv_obj_t * obj);

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -208,18 +208,6 @@ void lv_textarea_add_text(lv_obj_t * obj, const char * txt)
     lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
 }
 
-uint32_t lv_textarea_get_right_char(lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-    lv_textarea_t * ta = (lv_textarea_t *)obj;
-    const char * txt = lv_textarea_get_text(ta);
-    int pos = ta->cursor.pos;
-    if(_lv_txt_get_encoded_length(txt) >= pos && pos > 0)
-        return _lv_txt_encoded_prev(txt, &pos);
-    else
-        return 0;
-}
-
 void lv_textarea_del_char(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -714,6 +702,18 @@ uint16_t lv_textarea_get_password_show_time(lv_obj_t * obj)
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
     return ta->pwd_show_time;
+}
+
+uint32_t lv_textarea_get_right_char(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+    const char * txt = lv_textarea_get_text(ta);
+    int pos = ta->cursor.pos;
+    if(_lv_txt_get_encoded_length(txt) >= pos && pos > 0)
+        return _lv_txt_encoded_prev(txt, &pos);
+    else
+        return 0;
 }
 
 /*=====================

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -704,12 +704,13 @@ uint16_t lv_textarea_get_password_show_time(lv_obj_t * obj)
     return ta->pwd_show_time;
 }
 
-uint32_t lv_textarea_get_right_char(lv_obj_t * obj)
+uint32_t lv_textarea_get_current_char(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    const char * txt = lv_textarea_get_text(obj);
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    const char * txt = lv_textarea_get_text(ta);
-    int pos = ta->cursor.pos;
+    uint32_t pos = ta->cursor.pos;
     if(_lv_txt_get_encoded_length(txt) >= pos && pos > 0)
         return _lv_txt_encoded_prev(txt, &pos);
     else

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -208,6 +208,18 @@ void lv_textarea_add_text(lv_obj_t * obj, const char * txt)
     lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
 }
 
+uint32_t lv_textarea_get_right_char(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+    const char * txt = lv_textarea_get_text(ta);
+    int pos = ta->cursor.pos;
+    if(_lv_txt_get_encoded_length(txt) >= pos && pos > 0)
+        return _lv_txt_encoded_prev(txt, &pos);
+    else
+        return 0;
+}
+
 void lv_textarea_del_char(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -100,6 +100,13 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c);
 void lv_textarea_add_text(lv_obj_t * obj, const char * txt);
 
 /**
+ * Get a the right character from the current cursor position
+ * @param obj       pointer to a text area object
+ * @return          a the right character or 0
+ */
+uint32_t lv_textarea_get_right_char(lv_obj_t * obj);
+    
+/**
  * Delete a the left character from the current cursor position
  * @param obj       pointer to a text area object
  */

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -100,13 +100,6 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c);
 void lv_textarea_add_text(lv_obj_t * obj, const char * txt);
 
 /**
- * Get a the right character from the current cursor position
- * @param obj       pointer to a text area object
- * @return          a the right character or 0
- */
-uint32_t lv_textarea_get_right_char(lv_obj_t * obj);
-    
-/**
  * Delete a the left character from the current cursor position
  * @param obj       pointer to a text area object
  */
@@ -314,6 +307,13 @@ bool lv_textarea_get_text_selection(lv_obj_t * obj);
  * @return          show time in milliseconds. 0: hide immediately.
  */
 uint16_t lv_textarea_get_password_show_time(lv_obj_t * obj);
+
+/**
+ * Get a the right character from the current cursor position
+ * @param obj       pointer to a text area object
+ * @return          a the right character or 0
+ */
+uint32_t lv_textarea_get_right_char(lv_obj_t * obj);
 
 /*=====================
  * Other functions

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -309,11 +309,11 @@ bool lv_textarea_get_text_selection(lv_obj_t * obj);
 uint16_t lv_textarea_get_password_show_time(lv_obj_t * obj);
 
 /**
- * Get a the right character from the current cursor position
+ * Get a the character from the current cursor position
  * @param obj       pointer to a text area object
- * @return          a the right character or 0
+ * @return          a the character or 0
  */
-uint32_t lv_textarea_get_right_char(lv_obj_t * obj);
+uint32_t lv_textarea_get_current_char(lv_obj_t * obj);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
### Description of the feature or fix

Add a method:
/**
 * Get a the right character from the current cursor position
 * @param obj       pointer to a text area object
 * @return          a the right character or 0
 */
uint32_t lv_textarea_get_right_char(lv_obj_t * obj);

* This method is used in my embedded device, which uses LVGL 7.0 and 8.2

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
