### PR TITLE
fix(bar): stop animation when set with LV_ANIM_OFF

### DIFF
--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -584,6 +584,11 @@ static void lv_bar_set_value_with_anim(lv_obj_t * obj, int32_t new_value, int32_
     if(en == LV_ANIM_OFF) {
         *value_ptr = new_value;
         lv_obj_invalidate((lv_obj_t *)obj);
+
+        /*Stop the previous animation if it exists*/
+        lv_anim_del(anim_info, NULL);
+        /*Reset animation state*/
+        lv_bar_init_anim(obj, anim_info);
     }
     else {
         /*No animation in progress -> simply set the values*/


### PR DESCRIPTION
### Description of the feature or fix

Fixes #3537

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
