### PR TITLE
fix(ime_pinyin): fix the problem that lv_ime_pinyin is not hidden together with the keyboard

### DIFF
--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -562,8 +562,7 @@ static void lv_ime_pinyin_constructor(const lv_obj_class_t * class_p, lv_obj_t *
     lv_memzero(pinyin_ime->py_num, sizeof(pinyin_ime->py_num));
     lv_memzero(pinyin_ime->py_pos, sizeof(pinyin_ime->py_pos));
 
-    lv_obj_set_size(obj, LV_PCT(100), LV_PCT(55));
-    lv_obj_align(obj, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
 
 #if LV_IME_PINYIN_USE_DEFAULT_DICT
     init_pinyin_dict(obj, lv_ime_pinyin_def_dict);


### PR DESCRIPTION
…ether with the keyboard

In fact, the use of lv_ime_pinyin does not need to use the lv_ime_pinyin object itself, so we decided to hide it to avoid some other unnecessary problems.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
