### PR TITLE
perf(label): add size cache for get self size event

### DIFF
--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -68,12 +68,14 @@ typedef struct {
     uint32_t sel_end;
 #endif
 
+    lv_point_t size_cache; /*Text size cache*/
     lv_point_t offset; /*Text draw position offset*/
     lv_label_long_mode_t long_mode : 3; /*Determine what to do with the long texts*/
     uint8_t static_txt : 1;             /*Flag to indicate the text is static*/
     uint8_t recolor : 1;                /*Enable in-line letter re-coloring*/
     uint8_t expand : 1;                 /*Ignore real width (used by the library with LV_LABEL_LONG_SCROLL)*/
-    uint8_t dot_tmp_alloc : 1;         /*1: dot is allocated, 0: dot directly holds up to 4 chars*/
+    uint8_t dot_tmp_alloc : 1;          /*1: dot is allocated, 0: dot directly holds up to 4 chars*/
+    uint8_t invalid_size_cache : 1;     /*1: Recalculate size and update cache*/
 } lv_label_t;
 
 extern const lv_obj_class_t lv_label_class;


### PR DESCRIPTION
### Description of the feature or fix

Reduce the overhead of getting complex long text self size.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
