### PR TITLE
[rt-thread][squareline] support squareline studio for every rt-thread bsp which has supported LVGL

### DIFF
--- a/env_support/rt-thread/squareline/README.md
+++ b/env_support/rt-thread/squareline/README.md
@@ -1,0 +1,4 @@
+This folder is for LVGL SquareLine Studio
+
+SquareLine Studio can automatically put the generated C files into `ui` folder, so that rt-thread will automatically detect them; or, as a user, you can move the generated C files into `ui` folder manually.
+

--- a/env_support/rt-thread/squareline/SConscript
+++ b/env_support/rt-thread/squareline/SConscript
@@ -1,0 +1,13 @@
+from building import *
+
+cwd = GetCurrentDir()
+group = []
+src = []
+CPPPATH =[]
+
+src += Glob(cwd + '/ui/*.c')
+CPPPATH += [cwd+'/ui']
+
+group = group + DefineGroup('LVGL-SquareLine', src, depend = ['PKG_USING_LVGL_SQUARELINE'], CPPPATH = CPPPATH)
+
+Return('group')

--- a/env_support/rt-thread/squareline/ui/lv_ui_entry.c
+++ b/env_support/rt-thread/squareline/ui/lv_ui_entry.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author        Notes
+ * 2022-05-13     Meco Man      First version
+ */
+
+#ifdef __RTTHREAD__
+
+void lv_user_gui_init(void)
+{
+    extern void ui_init(void);
+    ui_init();
+}
+
+#endif /* __RTTHREAD__ */


### PR DESCRIPTION
Squareline Studio can automatically put the generated C files into `ui` folder, which is located in `env_support/rt-thread/squareline/ui`, so that rt-thread will automatically detect them; or, as a user,  you can move all the generated C files into `ui` folder manually.

RT-Thread side related PR: 
https://github.com/RT-Thread/packages/pull/1321
https://github.com/RT-Thread/rt-thread/pull/6261

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
