### PR TITLE
SDL Fix: Transformation With Alpha

### DIFF
--- a/src/draw/sdl/lv_draw_sdl_layer.c
+++ b/src/draw/sdl/lv_draw_sdl_layer.c
@@ -64,6 +64,9 @@ lv_draw_layer_ctx_t * lv_draw_sdl_layer_init(lv_draw_ctx_t * draw_ctx, lv_draw_l
     transform_ctx->target_rect.w = target_w;
     transform_ctx->target_rect.h = target_h;
 
+    layer_ctx->max_row_with_alpha = target_h;
+    layer_ctx->max_row_with_no_alpha = target_h;
+
     SDL_SetTextureBlendMode(transform_ctx->target, SDL_BLENDMODE_BLEND);
     SDL_SetRenderTarget(renderer, transform_ctx->target);
     SDL_RenderClear(renderer);
@@ -100,6 +103,7 @@ void lv_draw_sdl_layer_blend(lv_draw_ctx_t * draw_ctx, lv_draw_layer_ctx_t * lay
     lv_area_to_sdl_rect(layer_ctx->original.clip_area, &clip_rect);
     SDL_Point center = {.x = draw_dsc->pivot.x, .y = draw_dsc->pivot.y};
     SDL_RenderSetClipRect(renderer, &clip_rect);
+    SDL_SetTextureAlphaMod(transform_ctx->target, draw_dsc->opa);
     SDL_RenderCopyEx(renderer, transform_ctx->target, &transform_ctx->target_rect, &trans_rect,
                      draw_dsc->angle, &center, SDL_FLIP_NONE);
     SDL_RenderSetClipRect(renderer, NULL);


### PR DESCRIPTION
### Description of the feature or fix

When using SDL renderer, if an object has opacity, then program will hang in draw functions forever. This is because max_row_with_alpha was not set.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
