### PR TITLE
fix(obj): fix crash of lv_obj_move_foreground/background when the parent of obj is NULL

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -194,7 +194,7 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
     lv_obj_t * parent = lv_obj_get_parent(obj);
 
     if(!parent) {
-        LV_LOG_ERROR("parent is NULL");
+        LV_LOG_WARN("parent is NULL");
         return;
     }
 

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -191,13 +191,18 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+
+    if(!parent) {
+        LV_LOG_ERROR("parent is NULL");
+        return;
+    }
+
     if(index < 0) {
-        index = lv_obj_get_child_cnt(lv_obj_get_parent(obj)) + index;
+        index = lv_obj_get_child_cnt(parent) + index;
     }
 
     const int32_t old_index = lv_obj_get_index(obj);
-
-    lv_obj_t * parent = lv_obj_get_parent(obj);
 
     if(index < 0) return;
     if(index >= (int32_t) lv_obj_get_child_cnt(parent)) return;

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -56,7 +56,7 @@ static inline void lv_obj_move_foreground(lv_obj_t * obj)
 {
     lv_obj_t * parent = lv_obj_get_parent(obj);
     if(!parent) {
-        LV_LOG_ERROR("parent is NULL");
+        LV_LOG_WARN("parent is NULL");
         return;
     }
 

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -55,6 +55,11 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_task_handler(void)
 static inline void lv_obj_move_foreground(lv_obj_t * obj)
 {
     lv_obj_t * parent = lv_obj_get_parent(obj);
+    if(!parent) {
+        LV_LOG_ERROR("parent is NULL");
+        return;
+    }
+
     lv_obj_move_to_index(obj, lv_obj_get_child_cnt(parent) - 1);
 }
 


### PR DESCRIPTION
### Description of the feature or fix
```c
static void obj_test()
{
    lv_obj_t* obj = lv_obj_create(NULL);
    lv_obj_move_foreground(obj); // or lv_obj_move_background
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
