### PR TITLE
feat(log): add option to disable printing of timestamps

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -291,7 +291,9 @@ menu "LVGL configuration"
                     If not set the user needs to register a callback with `lv_log_register_print_cb`.
 
             config LV_LOG_USE_TIMESTAMP
-                bool "Enable print timestamp" if LV_USE_LOG
+                bool "Enable print timestamp"
+                default y
+                depends on LV_USE_LOG
 
             config LV_LOG_TRACE_MEM
                 bool "Enable/Disable LV_LOG_TRACE in mem module"

--- a/Kconfig
+++ b/Kconfig
@@ -290,6 +290,9 @@ menu "LVGL configuration"
                     Use printf for log output.
                     If not set the user needs to register a callback with `lv_log_register_print_cb`.
 
+            config LV_LOG_USE_TIMESTAMP
+                bool "Enable print timestamp" if LV_USE_LOG
+
             config LV_LOG_TRACE_MEM
                 bool "Enable/Disable LV_LOG_TRACE in mem module"
                 default y

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -216,6 +216,10 @@
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
     #define LV_LOG_PRINTF 0
 
+    /*1: Enable print timestamp;
+    *0: Disable print timestamp*/
+    #define LV_LOG_USE_TIMESTAMP 1
+
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1
     #define LV_LOG_TRACE_TIMER      1

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -217,7 +217,7 @@
     #define LV_LOG_PRINTF 0
 
     /*1: Enable print timestamp;
-    *0: Disable print timestamp*/
+     *0: Disable print timestamp*/
     #define LV_LOG_USE_TIMESTAMP 1
 
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -584,6 +584,20 @@
         #endif
     #endif
 
+    /*1: Enable print timestamp;
+    *0: Disable print timestamp*/
+    #ifndef LV_LOG_USE_TIMESTAMP
+        #ifdef _LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_LOG_USE_TIMESTAMP
+                #define LV_LOG_USE_TIMESTAMP CONFIG_LV_LOG_USE_TIMESTAMP
+            #else
+                #define LV_LOG_USE_TIMESTAMP 0
+            #endif
+        #else
+            #define LV_LOG_USE_TIMESTAMP 1
+        #endif
+    #endif
+
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #ifndef LV_LOG_TRACE_MEM
         #ifdef _LV_KCONFIG_PRESENT

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -23,7 +23,7 @@
  *********************/
 
 #if LV_LOG_USE_TIMESTAMP
-    #define LOG_TIMESTAMP_FMT  "(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t "
+    #define LOG_TIMESTAMP_FMT  "\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t"
     #define LOG_TIMESTAMP_EXPR t / 1000, t % 1000, t - last_log_time,
 #else
     #define LOG_TIMESTAMP_FMT
@@ -97,7 +97,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
         static const char * lvl_prefix[] = {"Trace", "Info", "Warn", "Error", "User"};
 
 #if LV_LOG_PRINTF
-        printf("[%s]\t" LOG_TIMESTAMP_FMT "%s: ",
+        printf("[%s]" LOG_TIMESTAMP_FMT " %s: ",
                lvl_prefix[level], LOG_TIMESTAMP_EXPR func);
         vprintf(format, args);
         printf(" \t(in %s line #%d)\n", &file[p], line);
@@ -106,7 +106,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
             char buf[512];
             char msg[256];
             lv_vsnprintf(msg, sizeof(msg), format, args);
-            lv_snprintf(buf, sizeof(buf), "[%s]\t" LOG_TIMESTAMP_FMT "%s: %s \t(in %s line #%d)\n",
+            lv_snprintf(buf, sizeof(buf), "[%s]" LOG_TIMESTAMP_FMT " %s: %s \t(in %s line #%d)\n",
                         lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg, &file[p], line);
             custom_print_cb(buf);
         }

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -22,6 +22,14 @@
  *      DEFINES
  *********************/
 
+#if LV_LOG_USE_TIMESTAMP
+    #define LOG_TIMESTAMP_FMT  "(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t "
+    #define LOG_TIMESTAMP_EXPR t / 1000, t % 1000, t - last_log_time,
+#else
+    #define LOG_TIMESTAMP_FMT
+    #define LOG_TIMESTAMP_EXPR
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -67,7 +75,9 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 {
     if(level >= _LV_LOG_LEVEL_NUM) return; /*Invalid level*/
 
+#if LV_LOG_USE_TIMESTAMP
     static uint32_t last_log_time = 0;
+#endif
 
     if(level >= LV_LOG_LEVEL) {
         va_list args;
@@ -81,13 +91,14 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
                 break;
             }
         }
-
+#if LV_LOG_USE_TIMESTAMP
         uint32_t t = lv_tick_get();
+#endif
         static const char * lvl_prefix[] = {"Trace", "Info", "Warn", "Error", "User"};
 
 #if LV_LOG_PRINTF
-        printf("[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: ",
-               lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func);
+        printf("[%s]\t" LOG_TIMESTAMP_FMT "%s: ",
+               lvl_prefix[level], LOG_TIMESTAMP_EXPR func);
         vprintf(format, args);
         printf(" \t(in %s line #%d)\n", &file[p], line);
 #else
@@ -95,13 +106,15 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
             char buf[512];
             char msg[256];
             lv_vsnprintf(msg, sizeof(msg), format, args);
-            lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %s \t(in %s line #%d)\n",
-                        lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, msg, &file[p], line);
+            lv_snprintf(buf, sizeof(buf), "[%s]\t" LOG_TIMESTAMP_FMT "%s: %s \t(in %s line #%d)\n",
+                        lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg, &file[p], line);
             custom_print_cb(buf);
         }
 #endif
 
+#if LV_LOG_USE_TIMESTAMP
         last_log_time = t;
+#endif
         va_end(args);
     }
 }


### PR DESCRIPTION
### Description of the feature or fix
Most log systems have their own timestamps. Adding this option can turn off unnecessary timestamp printing in lvgl log.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
