### PR TITLE
fix(draw_sw): fix image cache to access the freed stack space

### DIFF
--- a/src/draw/sw/lv_draw_sw_layer.c
+++ b/src/draw/sw/lv_draw_sw_layer.c
@@ -112,7 +112,6 @@ void lv_draw_sw_layer_blend(struct _lv_draw_ctx_t * draw_ctx, struct _lv_draw_la
     img.header.w = lv_area_get_width(draw_ctx->buf_area);
     img.header.h = lv_area_get_height(draw_ctx->buf_area);
     img.header.cf = draw_ctx->render_with_alpha ? LV_IMG_CF_TRUE_COLOR_ALPHA : LV_IMG_CF_TRUE_COLOR;
-    lv_img_cache_invalidate_src(&img);
 
     /*Restore the original draw_ctx*/
     draw_ctx->buf = layer_ctx->original.buf;
@@ -123,6 +122,7 @@ void lv_draw_sw_layer_blend(struct _lv_draw_ctx_t * draw_ctx, struct _lv_draw_la
     /*Blend the layer*/
     lv_draw_img(draw_ctx, draw_dsc, &layer_ctx->area_act, &img);
     lv_draw_wait_for_finish(draw_ctx);
+    lv_img_cache_invalidate_src(&img);
 }
 
 void lv_draw_sw_layer_destroy(lv_draw_ctx_t * draw_ctx, lv_draw_layer_ctx_t * layer_ctx)


### PR DESCRIPTION
### Description of the feature or fix

```c
#define LV_IMG_CACHE_DEF_SIZE 8
```

```c
lv_obj_t* obj = lv_obj_create(lv_scr_act());
lv_obj_set_style_opa(obj, LV_OPA_50, 0);
```
![image](https://user-images.githubusercontent.com/26767803/185099161-aafc4765-788b-488c-8653-31f5d60bc345.png)


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
