### PR TITLE
fix(lv_arc): add get_rotation getter for lv_arc

### DIFF
--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -309,7 +309,7 @@
 #if LV_USE_DRAW_SW
 
     /*Enable complex draw engine.
-    *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+     *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
     #ifndef LV_DRAW_SW_COMPLEX
         #ifdef _LV_KCONFIG_PRESENT
             #ifdef CONFIG_LV_DRAW_SW_COMPLEX
@@ -323,9 +323,9 @@
     #endif
 
     /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-    * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-    * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
-    * and can't be drawn in chunks. */
+     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
+     * and can't be drawn in chunks. */
 
     /*The target buffer size for simple layer chunks.*/
     #ifndef LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
@@ -369,10 +369,10 @@
     #endif
 
     /*Default gradient buffer size.
-    *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
-    *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
-    *If the cache is too small the map will be allocated only while it's required for the drawing.
-    *0 mean no caching.*/
+     *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+     *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
+     *If the cache is too small the map will be allocated only while it's required for the drawing.
+     *0 mean no caching.*/
     #ifndef LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
         #ifdef CONFIG_LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
             #define LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE CONFIG_LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
@@ -382,8 +382,8 @@
     #endif
 
     /*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
-    *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
-    *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+     *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
+     *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
     #ifndef LV_DRAW_SW_GRADIENT_DITHER
         #ifdef CONFIG_LV_DRAW_SW_GRADIENT_DITHER
             #define LV_DRAW_SW_GRADIENT_DITHER CONFIG_LV_DRAW_SW_GRADIENT_DITHER
@@ -393,8 +393,8 @@
     #endif
     #if LV_DRAW_SW_GRADIENT_DITHER
         /*Add support for error diffusion dithering.
-        *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
-        *The increase in memory consumption is (24 bits * object's width)*/
+         *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+         *The increase in memory consumption is (24 bits * object's width)*/
         #ifndef LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
             #ifdef CONFIG_LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
                 #define LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION CONFIG_LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
@@ -585,7 +585,7 @@
     #endif
 
     /*1: Enable print timestamp;
-    *0: Disable print timestamp*/
+     *0: Disable print timestamp*/
     #ifndef LV_LOG_USE_TIMESTAMP
         #ifdef _LV_KCONFIG_PRESENT
             #ifdef CONFIG_LV_LOG_USE_TIMESTAMP

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -318,6 +318,12 @@ lv_arc_mode_t lv_arc_get_mode(const lv_obj_t * obj)
     return ((lv_arc_t *) obj)->type;
 }
 
+int16_t lv_arc_get_rotation(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    return ((lv_arc_t *)obj)->rotation;
+}
+
 /*=====================
  * Other functions
  *====================*/

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -223,6 +223,13 @@ int16_t lv_arc_get_max_value(const lv_obj_t * obj);
  */
 lv_arc_mode_t lv_arc_get_mode(const lv_obj_t * obj);
 
+/**
+ * Get whether the arc is type or not.
+ * @param arc       pointer to an arc object
+ * @return          arc's current rotation
+ */
+int16_t lv_arc_get_rotation(const lv_obj_t * obj)
+
 /*=====================
  * Other functions
  *====================*/

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -224,11 +224,11 @@ int16_t lv_arc_get_max_value(const lv_obj_t * obj);
 lv_arc_mode_t lv_arc_get_mode(const lv_obj_t * obj);
 
 /**
- * Get whether the arc is type or not.
+ * Get the rotation for the whole arc
  * @param arc       pointer to an arc object
  * @return          arc's current rotation
  */
-int16_t lv_arc_get_rotation(const lv_obj_t * obj)
+int16_t lv_arc_get_rotation(const lv_obj_t * obj);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
Adds a getter function for lv_arcs rotation property - I found this to be useful when animating an arc rotation from an unknown current rotation to a new rotation

### Description of the feature or fix
Adds a missing getter function for lv_arc rotation property

### Checkpoints
- [x ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x ] Update the documentation
