### PR TITLE
feat(lv_rlottie): Lv rlottie utility functions

### DIFF
--- a/docs/libs/rlottie.md
+++ b/docs/libs/rlottie.md
@@ -24,6 +24,7 @@ And finally add the `-lrlottie` flag to your linker.
 
 On embedded systems you need to take care of integrating Rlottie to the given build system.
 
+ESP-IDF example at bottom
 
 ## Usage
 
@@ -90,6 +91,151 @@ The default animation mode is **play forward with loop**.
 If you don't enable looping, a `LV_EVENT_READY` is sent when the animation can not make more progress without looping.
 
 To get the number of frames in an animation or the current frame index, you can cast the `lv_obj_t` instance to a `lv_rlottie_t` instance and inspect the `current_frame` and `total_frames` members.
+
+## Additional rlottie utility
+```c
+lv_obj_t * lottie = lv_rlottie_create_from_file(scr, 128, 128, "test.json");
+lv_obj_center(lottie);
+
+//Adjusts the render size of animation to 128,50
+//This action to be used with an lvgl animation to smoothly resize from 128 to 50 over a period of time
+lv_rlottie_set_render_height(lottie, 50); 
+
+//adjusts the render width of the animation to 50,50
+//This action to be used with an lvgl animation to smoothly resize from 128 to 50 over a period of time
+lv_rlottie_set_render_width(lottie, 50); 
+
+//Changes the end frame of the animation - useful to chain animations into a single file for memory savings rather than creating a new animation
+lv_rlottie_set_dest_frame(lottie, 15); 
+
+//Changes the start frame of the animation - useful to chain animations into a single file for memory savings rather than creating a new animation
+lv_rlottie_set_start_frame(lottie, 15);
+
+//Example usage of start/dest frame utility
+//Frames 0-15 contain a loading animation
+//Frames 16-30 contain an green checkmark animation
+//Frames 31-45 contain a red x animation
+//Packing these into the same lottie file saves space and utilizes the same buffer while still allowing for dynamic changes in the animation to play, without needing to build 2-3 separate animations
+```
+
+# ESP-IDF Example
+
+## Background
+Rlottie can be expensive to render on embedded hardware. Lottie animations tend to use a large amount of CPU time and can use large portions of RAM. This will vary from lottie to lottie but in general for best performance:
+* Limit total # of frames in the animation
+* Where possible, try to avoid bezier type animations
+* Limit animation render size
+
+If your ESP32 chip does not have SPIRAM you will face severe limitations in render size.
+
+To give a better idea on this, lets assume you want to render a 240x320 lottie animation.
+
+In order to pass initialization of the lv_rlottie_t object, you need 240x320x32/8 (307k) available memory. The latest ESP32-S3 has 256kb RAM available for this (before freeRtos and any other initialization starts taking chunks out). So while you can probably start to render a 50x50 animation without SPIRAM, PSRAM is highly recommended.
+
+Additionally, while you might be able to pass initialization of the lv_rlottie_t object, as rlottie renders frame to frame, this consumes additional memory. A 30 frame animation that plays over 1 second probably has minimal issues, but a 300 frame animation playing over 10 seconds could very easily crash due to lack of memory as rlottie renders, depending on the complexity of the animation.
+
+Rlottie will not compile for the IDF using the -02 compiler option at this time.
+
+For stability in lottie animations, I found that they run best in the IDF when enabling LV_MEM_CUSTOM (using stdlib.h)
+
+## IDF Setup
+
+Where the LVGL simulator uses the installed rlottie project, with the IDF, recommended to use rlottie as a submodule under your components directory. You'll also need to add a CMakeLists.txt file to tell the idf how to build rlottie.
+
+```
+cd 'your-project-directory'
+git add submodule https://github.com/Samsung/rlottie.git ./components/rlottie/rlottie
+cd components/rlottie
+touch CMakeLists.txt
+```
+
+Inside the newly created CMakeLists.txt add the below:
+
+```
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS ${SOURCES}
+                    INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/rlottie/inc"
+                    )
+
+set(LOTTIE_MODULE OFF)
+set(LOTTIE_THREAD OFF)
+set(BUILD_SHARED_LIBS OFF)
+option(BUILD_TESTING OFF)
+
+function(install)
+endfunction()
+
+function(export)
+endfunction()
+
+add_subdirectory(rlottie)
+target_link_libraries(${COMPONENT_LIB} INTERFACE rlottie)
+```
+
+Now things get a little fuzzy, there is probably a much better way to go about this, but for now a few minor edits to rlottie:
+
+Open rlottie/rlottie/CMakeLists.txt and comment out, or remove lines 98-101. Dynamic linking will not work on the idf.
+
+```
+@98
+if (LOTTIE_MODULE)
+    # for dlopen, dlsym and dlclose dependancy
+     target_link_libraries(rlottie PRIVATE ${CMAKE_DL_LIBS})
+endif()
+```
+
+In order to get rlottie to compile in IDF land, we also need to remove references to the dynamic linking, specifically around how rlottie handles image loading.
+
+Open rlottie/rlottie/src/vector/vimageloader.cpp
+
+Comment lines 9, 64-69, 74, and 78-79. At time of writing, this has not caused any issues in rendering of lottie animations on an ESP.
+
+```
+@9 
+#include <dlfcn.h>
+
+@64 
+imageLoad = reinterpret_cast<lottie_image_load_f>(
+             dlsym(dl_handle, "lottie_image_load"));
+imageFree = reinterpret_cast<lottie_image_free_f>(
+             dlsym(dl_handle, "lottie_image_free"));
+imageFromData = reinterpret_cast<lottie_image_load_data_f>(
+             dlsym(dl_handle, "lottie_image_load_from_data"));
+
+@74
+if (dl_handle) dlclose(dl_handle);
+
+@78-79
+dl_handle = dlopen(LOTTIE_IMAGE_MODULE_PLUGIN, RTLD_LAZY);
+return (dl_handle == nullptr);
+```
+
+While unecessary, removing the rlottie/rlottie/example folder can remove many un-needed files for this embedded LVGL application
+
+Additionally, you'll need to enable LV_USE_RLOTTIE through idf.py menuconfig under LVGL component settings.
+
+From here, you can use the relevant LVGL lv_rlottie functions to create lottie animations in LVGL on embedded hardware!
+
+Please note, that while lottie animations are capable of running on many ESP chips, below is recommended for best performance. 
+
+* ESP32-S3-WROOM-1-N16R8
+  * 16mb quad spi flash
+  * 8mb octal spi PSRAM
+* IDF4.4 or higher
+
+The Esp-box devkit meets this spec and https://github.com/espressif/esp-box is a great starting point to adding lottie animations.
+
+## Additional changes to make use of SPIRAM
+
+lv_alloc/realloc do not make use of SPIRAM. Given the high memory usage of lottie animations, it is recommended to shift as much out of internal DRAM into SPIRAM as possible. In order to do so, SPIRAM will need to be enabled in the menuconfig options for your given espressif chip.
+
+There may be a better solution for this, but for the moment the recommendation is to make local modifications to the lvgl component in your espressif project. This is as simple as swapping lv_alloc/lv_realloc calls in lv_rlottie.c with heap_caps_malloc (for IDF) with the appropriate MALLOC_CAP call - for SPIRAM usage this is MALLOC_CAP_SPIRAM.
+
+```c
+rlottie->allocated_buf = heap_caps_malloc(allocaled_buf_size+1, MALLOC_CAP_SPIRAM);
+```
 
 ## Example
 ```eval_rst

--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -86,7 +86,7 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
 /**
  * Sets a new playmode for the animation (PAUSE/PLAY/LOOP/etc)
  * @param obj pointer to lv_rlottie obj
- * @param lv_rlottie_ctrl_t the new playmode to be set 
+ * @param lv_rlottie_ctrl_t the new playmode to be set
  */
 void lv_rlottie_set_play_mode(lv_obj_t * obj, const lv_rlottie_ctrl_t ctrl)
 {
@@ -108,7 +108,7 @@ void lv_rlottie_set_current_frame(lv_obj_t * obj, const size_t goto_frame)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->current_frame = goto_frame < rlottie->dest_frame ? goto_frame : rlottie->dest_frame - 1;
-    
+
     lottie_animation_render(
         rlottie->animation,
         rlottie->current_frame,
@@ -130,7 +130,7 @@ void lv_rlottie_set_current_frame(lv_obj_t * obj, const size_t goto_frame)
  * @param obj pointer to lv_rlottie obj
  * @param framerate the new frame rate to set
  */
-void lv_rlottie_set_framerate(lv_obj_t* obj, const int framerate)
+void lv_rlottie_set_framerate(lv_obj_t * obj, const int framerate)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->framerate = framerate;
@@ -148,7 +148,7 @@ void lv_rlottie_set_framerate(lv_obj_t* obj, const int framerate)
  * @param obj pointer to lv_rlottie obj
  * @param width the new width to render the lottie animation at
  */
-void lv_rlottie_set_render_width(lv_obj_t* obj, const int width)
+void lv_rlottie_set_render_width(lv_obj_t * obj, const int width)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->imgdsc.header.w = width;
@@ -158,12 +158,12 @@ void lv_rlottie_set_render_width(lv_obj_t* obj, const int width)
     if(rlottie->task) {
         size_t allocaled_buf_size = (width * rlottie->imgdsc.header.h * LV_ARGB32 / 8);
 
-        rlottie->allocated_buf = lv_realloc(rlottie->allocated_buf, allocaled_buf_size+1);
-        
+        rlottie->allocated_buf = lv_realloc(rlottie->allocated_buf, allocaled_buf_size + 1);
+
         rlottie->imgdsc.data = (void *)rlottie->allocated_buf;
         rlottie->imgdsc.data_size = allocaled_buf_size;
         lv_img_set_src(obj, &rlottie->imgdsc);
-        
+
         if(rlottie->allocated_buf != NULL) {
             rlottie->allocated_buffer_size = allocaled_buf_size;
             memset(rlottie->allocated_buf, 0, allocaled_buf_size);
@@ -176,7 +176,7 @@ void lv_rlottie_set_render_width(lv_obj_t* obj, const int width)
  * @param obj pointer to lv_rlottie obj
  * @param height the new height to render the lottie animation at
  */
-void lv_rlottie_set_render_height(lv_obj_t* obj, const int height)
+void lv_rlottie_set_render_height(lv_obj_t * obj, const int height)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->imgdsc.header.h = height;
@@ -184,7 +184,7 @@ void lv_rlottie_set_render_height(lv_obj_t* obj, const int height)
     if(rlottie->task) {
         size_t allocaled_buf_size = (rlottie->imgdsc.header.w * height * LV_ARGB32 / 8);
 
-        rlottie->allocated_buf = lv_realloc(rlottie->allocated_buf, allocaled_buf_size+1);
+        rlottie->allocated_buf = lv_realloc(rlottie->allocated_buf, allocaled_buf_size + 1);
 
         rlottie->imgdsc.data = (void *)rlottie->allocated_buf;
         rlottie->imgdsc.data_size = allocaled_buf_size;
@@ -195,7 +195,7 @@ void lv_rlottie_set_render_height(lv_obj_t* obj, const int height)
             memset(rlottie->allocated_buf, 0, allocaled_buf_size);
         }
     }
-    
+
 }
 
 /**
@@ -203,7 +203,7 @@ void lv_rlottie_set_render_height(lv_obj_t* obj, const int height)
  * @param obj pointer to lv_rlottie obj
  * @param dest_frame sets a new ending frame for a looping lottie animation
  */
-void lv_rlottie_set_dest_frame(lv_obj_t* obj, const int dest_frame)
+void lv_rlottie_set_dest_frame(lv_obj_t * obj, const int dest_frame)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->dest_frame = dest_frame;
@@ -219,7 +219,7 @@ void lv_rlottie_set_dest_frame(lv_obj_t* obj, const int dest_frame)
  * @param obj pointer to lv_rlottie obj
  * @param start_frame sets a new start frame for a looping lottie animation
  */
-void lv_rlottie_set_start_frame(lv_obj_t* obj, const int start_frame)
+void lv_rlottie_set_start_frame(lv_obj_t * obj, const int start_frame)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->start_frame = start_frame;
@@ -235,7 +235,7 @@ void lv_rlottie_set_start_frame(lv_obj_t* obj, const int start_frame)
  * @param obj pointer to an object
  * @return the current active rlottie_ctrl
  */
-lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t* obj)
+lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     return rlottie->play_ctrl;
@@ -246,10 +246,10 @@ lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current frame
  */
-size_t lv_rlottie_get_current_frame(lv_obj_t* obj)
+size_t lv_rlottie_get_current_frame(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    return rlottie->current_frame;   
+    return rlottie->current_frame;
 }
 
 /**
@@ -257,10 +257,10 @@ size_t lv_rlottie_get_current_frame(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current end frame of the animation
  */
-size_t lv_rlottie_get_dest_frame(lv_obj_t* obj)
+size_t lv_rlottie_get_dest_frame(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    return rlottie->dest_frame;   
+    return rlottie->dest_frame;
 }
 
 /**
@@ -268,10 +268,10 @@ size_t lv_rlottie_get_dest_frame(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current start frame of the animation
  */
-size_t lv_rlottie_get_start_frame(lv_obj_t* obj)
+size_t lv_rlottie_get_start_frame(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
-    return rlottie->start_frame;   
+    return rlottie->start_frame;
 }
 
 /**
@@ -279,7 +279,7 @@ size_t lv_rlottie_get_start_frame(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current render height of the animation
  */
-int lv_rlottie_get_render_height(lv_obj_t* obj)
+int lv_rlottie_get_render_height(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     return rlottie->imgdsc.header.h;
@@ -290,7 +290,7 @@ int lv_rlottie_get_render_height(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current render width of the animation
  */
-int lv_rlottie_get_render_width(lv_obj_t* obj)
+int lv_rlottie_get_render_width(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
 
@@ -302,7 +302,7 @@ int lv_rlottie_get_render_width(lv_obj_t* obj)
  * @param obj pointer to an object
  * @return the current render framerate of the animation
  */
-int lv_rlottie_get_framerate(lv_obj_t* obj)
+int lv_rlottie_get_framerate(lv_obj_t * obj)
 {
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     return rlottie->framerate;

--- a/src/libs/rlottie/lv_rlottie.h
+++ b/src/libs/rlottie/lv_rlottie.h
@@ -62,19 +62,19 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
 
 void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
-void lv_rlottie_set_framerate(lv_obj_t* obj, const int framerate);
-void lv_rlottie_set_render_width(lv_obj_t* obj, const int width);
-void lv_rlottie_set_render_height(lv_obj_t* obj, const int height);
-void lv_rlottie_set_dest_frame(lv_obj_t* obj, const int dest_frame);
-void lv_rlottie_set_start_frame(lv_obj_t* obj, const int start_frame);
+void lv_rlottie_set_framerate(lv_obj_t * obj, const int framerate);
+void lv_rlottie_set_render_width(lv_obj_t * obj, const int width);
+void lv_rlottie_set_render_height(lv_obj_t * obj, const int height);
+void lv_rlottie_set_dest_frame(lv_obj_t * obj, const int dest_frame);
+void lv_rlottie_set_start_frame(lv_obj_t * obj, const int start_frame);
 
-int lv_rlottie_get_framerate(lv_obj_t* obj);
-int lv_rlottie_get_render_width(lv_obj_t* obj);
-int lv_rlottie_get_render_height(lv_obj_t* obj);
-size_t lv_rlottie_get_start_frame(lv_obj_t* obj);
-size_t lv_rlottie_get_dest_frame(lv_obj_t* obj);
-size_t lv_rlottie_get_current_frame(lv_obj_t* obj);
-lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t* obj);
+int lv_rlottie_get_framerate(lv_obj_t * obj);
+int lv_rlottie_get_render_width(lv_obj_t * obj);
+int lv_rlottie_get_render_height(lv_obj_t * obj);
+size_t lv_rlottie_get_start_frame(lv_obj_t * obj);
+size_t lv_rlottie_get_dest_frame(lv_obj_t * obj);
+size_t lv_rlottie_get_current_frame(lv_obj_t * obj);
+lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/libs/rlottie/lv_rlottie.h
+++ b/src/libs/rlottie/lv_rlottie.h
@@ -46,6 +46,7 @@ typedef struct {
     size_t scanline_width;
     lv_rlottie_ctrl_t play_ctrl;
     size_t dest_frame;
+    size_t start_frame;
 } lv_rlottie_t;
 
 extern const lv_obj_class_t lv_rlottie_class;
@@ -61,6 +62,19 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_co
 
 void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
+void lv_rlottie_set_framerate(lv_obj_t* obj, const int framerate);
+void lv_rlottie_set_render_width(lv_obj_t* obj, const int width);
+void lv_rlottie_set_render_height(lv_obj_t* obj, const int height);
+void lv_rlottie_set_dest_frame(lv_obj_t* obj, const int dest_frame);
+void lv_rlottie_set_start_frame(lv_obj_t* obj, const int start_frame);
+
+int lv_rlottie_get_framerate(lv_obj_t* obj);
+int lv_rlottie_get_render_width(lv_obj_t* obj);
+int lv_rlottie_get_render_height(lv_obj_t* obj);
+size_t lv_rlottie_get_start_frame(lv_obj_t* obj);
+size_t lv_rlottie_get_dest_frame(lv_obj_t* obj);
+size_t lv_rlottie_get_current_frame(lv_obj_t* obj);
+lv_rlottie_ctrl_t lv_rlottie_get_play_mode(lv_obj_t* obj);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

Adding a set of lv_rlottie utility functions:
get/set framerate
get/set render height/width
get/set dest_frame
get/set start_frame
get playmode
get current frame

Updating lv_rlottie documentation for the added utilities
Updating lv_rlottie documentation to provide an example for compilation of rlottie lib for ESP-IDF (been sitting on this way too long) - this portion of the documentation may be better provided as a patch file for end users to optionally apply?

### Checkpoints
- [x ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ x] Update the documentation
