### PR TITLE
feat(lv_arc): add knob offset utility

### DIFF
--- a/docs/widgets/arc.md
+++ b/docs/widgets/arc.md
@@ -43,7 +43,7 @@ The change rate is defined in degree/second unit and can be set with `lv_arc_set
 
 ### Knob offset
 Changing the knob offset allows the location of the knob to be moved relative to the end of the arc
-The knob offset can be set by `lv_arc_set_knob_offset(arc, offset)`, will only be visible if LV_PART_KNOB is visible
+The knob offset can be set by `lv_arc_set_knob_offset(arc, offset_angle)`, will only be visible if LV_PART_KNOB is visible
 
 
 ### Setting the indicator manually

--- a/docs/widgets/arc.md
+++ b/docs/widgets/arc.md
@@ -41,6 +41,10 @@ The mode can be set by `lv_arc_set_mode(arc, LV_ARC_MODE_...)` and used only if 
 If the arc is pressed the current value will set with a limited speed according to the set *change rate*.
 The change rate is defined in degree/second unit and can be set with `lv_arc_set_change_rage(arc, rate)`
 
+### Knob offset
+Changing the knob offset allows the location of the knob to be moved relative to the end of the arc
+The knob offset can be set by `lv_arc_set_knob_offset(arc, offset)`, will only be visible if LV_PART_KNOB is visible
+
 
 ### Setting the indicator manually
 It's also possible to set the angles of the indicator arc directly with `lv_arc_set_angles(arc, start_angle, end_angle)` function or `lv_arc_set_start/end_angle(arc, start_angle)`.

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -799,7 +799,7 @@ static void get_knob_area(lv_obj_t * obj, const lv_point_t * center, lv_coord_t 
     r -= indic_width_half;
 
     lv_coord_t angle = get_angle(obj);
-    lv_coord_t knob_offset lv_arc_get_knob_offset(obj);
+    lv_coord_t knob_offset = lv_arc_get_knob_offset(obj);
     lv_coord_t knob_x = (r * lv_trigo_sin(knob_offset + angle + 90)) >> LV_TRIGO_SHIFT;
     lv_coord_t knob_y = (r * lv_trigo_sin(knob_offset + angle)) >> LV_TRIGO_SHIFT;
 

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -266,6 +266,14 @@ void lv_arc_set_change_rate(lv_obj_t * obj, uint16_t rate)
     arc->chg_rate = rate;
 }
 
+void lv_arc_set_knob_offset(lv_obj_t * obj, int16_t offset)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_arc_t * arc = (lv_arc_t *)obj;
+
+    arc->knob_offset = offset;
+}
+
 /*=====================
  * Getter functions
  *====================*/
@@ -322,6 +330,12 @@ int16_t lv_arc_get_rotation(const lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     return ((lv_arc_t *)obj)->rotation;
+}
+
+int16_t lv_arc_get_knob_offset(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    return ((lv_arc_t *)obj)->knob_offset;
 }
 
 /*=====================
@@ -785,8 +799,9 @@ static void get_knob_area(lv_obj_t * obj, const lv_point_t * center, lv_coord_t 
     r -= indic_width_half;
 
     lv_coord_t angle = get_angle(obj);
-    lv_coord_t knob_x = (r * lv_trigo_sin(angle + 90)) >> LV_TRIGO_SHIFT;
-    lv_coord_t knob_y = (r * lv_trigo_sin(angle)) >> LV_TRIGO_SHIFT;
+    lv_coord_t knob_offset lv_arc_get_knob_offset(obj);
+    lv_coord_t knob_x = (r * lv_trigo_sin(knob_offset + angle + 90)) >> LV_TRIGO_SHIFT;
+    lv_coord_t knob_y = (r * lv_trigo_sin(knob_offset + angle)) >> LV_TRIGO_SHIFT;
 
     lv_coord_t left_knob = lv_obj_get_style_pad_left(obj, LV_PART_KNOB);
     lv_coord_t right_knob = lv_obj_get_style_pad_right(obj, LV_PART_KNOB);

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -50,6 +50,7 @@ typedef struct {
     uint16_t chg_rate;          /*Drag angle rate of change of the arc (degrees/sec)*/
     uint32_t last_tick;         /*Last dragging event timestamp of the arc*/
     int16_t last_angle;         /*Last dragging angle of the arc*/
+    int16_t knob_offset;        /*knob offset from the main arc*/
 } lv_arc_t;
 
 extern const lv_obj_class_t lv_arc_class;
@@ -163,6 +164,13 @@ void lv_arc_set_range(lv_obj_t * obj, int16_t min, int16_t max);
  */
 void lv_arc_set_change_rate(lv_obj_t * obj, uint16_t rate);
 
+/**
+ * Set an offset for the knob from the main arc object
+ * @param arc       pointer to an arc object
+ * @param offset    knob offset from main arc
+ */
+void lv_arc_set_knob_offset(lv_obj_t * arc, int16_t offset);
+
 /*=====================
  * Getter functions
  *====================*/
@@ -229,6 +237,13 @@ lv_arc_mode_t lv_arc_get_mode(const lv_obj_t * obj);
  * @return          arc's current rotation
  */
 int16_t lv_arc_get_rotation(const lv_obj_t * obj);
+
+/**
+ * Get the current knob offset
+ * @param arc       pointer to an arc object
+ * @return          arc's current knob offset
+ */
+int16_t lv_arc_get_knob_offset(const lv_obj_t * obj);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
Edge case usage for use as decorative arc widget. Allows for the knob to be offset from the arc

### Description of the feature or fix

This change allows for the knob to be offset from the end of the arc. For most cases, it probably will remain unchanged.

Below is what this change enables:

![image](https://user-images.githubusercontent.com/89472323/185219392-9d14f519-da70-4fb4-b883-9e5ec5654bf0.png)

For frame of reference, this is an lv_arc object with the below properties:

rotation: 270
start_angle: 10
end_angle: 350
bg_start_angle: 10
bg_end_angle: 350

LV_PART_KNOB visible
knob_offset: -10
knob_padding: 2

Originally, I wanted to do this with an image, but rotating the image was not smooth so ended up going down a path to enable rotate the arc as a whole, with the rotation of the arc used to indicate value in place of using the actual value - it is not as performant as using lv_arc_value and filling the arc directly, but it does accomplish the desired look and feel of using the knob as an indicator

To further show usage, here is an example animation using the knob as the indicator for the arc:

Clarification: Design intent for this image was to have an circle widget, shown with a dot to indicate a given 0-100 value, with padding between the dot(knob) and the beginning/end of the circle

```
static int convert_value_to_degrees(int value)
{
    float percent = (float)value / 100.0;
    int degrees = (percent * 360);

    return degrees;
}

static void anim_set_arc_rotate_0_to_100_cb(void * var, int32_t v)
{

    int degrees = convert_value_to_degrees(v);
    int start_degree = ARC_START_ROTATION; //this is a define added for my purposes to indicate the initial rotation (270) of the arc
    int actual_rotation = (start_degree + degrees) % 360;
    
    LV_LOG_INFO("anim_set_arc_rotate_0_to_100_cb: act_rot %d\n", actual_rotation);

    lv_arc_set_rotation(var, actual_rotation);
};

lv_anim_t set_arc_rotate_0_to_100(lv_obj_t* obj, int start_rot, int target_rot, uint32_t anim_speed, uint32_t anim_delay, lv_anim_path_cb_t anim_path, uint16_t playcount)
{
    lv_anim_t a;
    printf("start rot for soc rotation: %d\n", start_rot);
    lv_anim_init(&a);
    lv_anim_set_var(&a, obj);
    lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)anim_set_arc_rotate_0_to_100_cb);
    lv_anim_set_path_cb(&a, (lv_anim_path_cb_t)anim_path);
    lv_anim_set_delay(&a, anim_delay);
    lv_anim_set_time(&a, anim_speed);
    lv_anim_set_values(&a, start_rot, target_rot);

    return a;
}

```

### Checkpoints
- [ x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ x] Update the documentation
