### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -9,7 +9,7 @@ You should read this first to get a general impression and read the detailed [Po
 Instead of porting LVGL to embedded hardware straight away, it's highly recommended to get started in a simulator first.
 
 LVGL is ported to many IDEs to be sure you will find your favorite one.
-Go to the [Simulators](/get-started/pc-simulator) section to get ready-to-use projects that can be run on your PC.
+Go to the [Simulators](/get-started/platforms/pc-simulator) section to get ready-to-use projects that can be run on your PC.
 This way you can save the time of porting for now and get some experience with LVGL immediately.
 
 ## Add LVGL into your project
@@ -251,7 +251,7 @@ The theme for your application is a compile time configuration set in `lv_conf.h
 ```
 
 ## Micropython
-Learn more about [Micropython](/get-started/micropython).
+Learn more about [Micropython](/get-started/bindings/micropython).
 ```python
 # Create a Button and a Label
 scr = lv.obj()

--- a/docs/porting/project.md
+++ b/docs/porting/project.md
@@ -25,7 +25,7 @@ include $(LVGL_DIR)/$(LVGL_DIR_NAME)/lvgl.mk
 For integration with CMake take a look this section of the [Documentation](/get-started/platforms/cmake).
 
 ### Other platforms and tools
-The [Get started](/get-started/index.html) section contains many platform specific descriptions e.g. for ESP32, Arduino, NXP, RT-Thread, NuttX, etc.
+The [Get started](/get-started/index) section contains many platform specific descriptions e.g. for ESP32, Arduino, NXP, RT-Thread, NuttX, etc.
 
 ### Demos and Examples
 


### PR DESCRIPTION
Some of the links present on quick overview and porting pages were leading to 404 instead of appropriate pages.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
