### PR TITLE
fix(disp):automatically delete the old screen when not using animation

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -274,6 +274,7 @@ void lv_scr_load_anim(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t
     /*Shortcut for immediate load*/
     if(time == 0 && delay == 0) {
         scr_load_internal(new_scr);
+        if(auto_del) lv_obj_del(act_scr);
         return;
     }
 
@@ -488,16 +489,11 @@ static void scr_load_internal(lv_obj_t * scr)
     if(d->act_scr) lv_event_send(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL);
     if(d->act_scr) lv_event_send(scr, LV_EVENT_SCREEN_LOAD_START, NULL);
 
-    d->prev_scr = old_scr;
     d->act_scr = scr;
 
     if(d->act_scr) lv_event_send(scr, LV_EVENT_SCREEN_LOADED, NULL);
     if(d->act_scr) lv_event_send(old_scr, LV_EVENT_SCREEN_UNLOADED, NULL);
 
-    if(d->prev_scr && d->del_prev) lv_obj_del(d->prev_scr);
-    d->prev_scr = NULL;
-    d->draw_prev_over_act = false;
-    d->scr_to_load = NULL;
     lv_obj_invalidate(scr);
 }
 

--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -488,11 +488,16 @@ static void scr_load_internal(lv_obj_t * scr)
     if(d->act_scr) lv_event_send(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL);
     if(d->act_scr) lv_event_send(scr, LV_EVENT_SCREEN_LOAD_START, NULL);
 
+    d->prev_scr = old_scr;
     d->act_scr = scr;
 
     if(d->act_scr) lv_event_send(scr, LV_EVENT_SCREEN_LOADED, NULL);
     if(d->act_scr) lv_event_send(old_scr, LV_EVENT_SCREEN_UNLOADED, NULL);
 
+    if(d->prev_scr && d->del_prev) lv_obj_del(d->prev_scr);
+    d->prev_scr = NULL;
+    d->draw_prev_over_act = false;
+    d->scr_to_load = NULL;
     lv_obj_invalidate(scr);
 }
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -309,7 +309,7 @@
 #if LV_USE_DRAW_SW
 
     /*Enable complex draw engine.
-    *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+     *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
     #ifndef LV_DRAW_SW_COMPLEX
         #ifdef _LV_KCONFIG_PRESENT
             #ifdef CONFIG_LV_DRAW_SW_COMPLEX
@@ -323,9 +323,9 @@
     #endif
 
     /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-    * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-    * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
-    * and can't be drawn in chunks. */
+     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
+     * and can't be drawn in chunks. */
 
     /*The target buffer size for simple layer chunks.*/
     #ifndef LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
@@ -369,10 +369,10 @@
     #endif
 
     /*Default gradient buffer size.
-    *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
-    *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
-    *If the cache is too small the map will be allocated only while it's required for the drawing.
-    *0 mean no caching.*/
+     *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+     *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
+     *If the cache is too small the map will be allocated only while it's required for the drawing.
+     *0 mean no caching.*/
     #ifndef LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
         #ifdef CONFIG_LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
             #define LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE CONFIG_LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE
@@ -382,8 +382,8 @@
     #endif
 
     /*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
-    *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
-    *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+     *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
+     *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
     #ifndef LV_DRAW_SW_GRADIENT_DITHER
         #ifdef CONFIG_LV_DRAW_SW_GRADIENT_DITHER
             #define LV_DRAW_SW_GRADIENT_DITHER CONFIG_LV_DRAW_SW_GRADIENT_DITHER
@@ -393,8 +393,8 @@
     #endif
     #if LV_DRAW_SW_GRADIENT_DITHER
         /*Add support for error diffusion dithering.
-        *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
-        *The increase in memory consumption is (24 bits * object's width)*/
+         *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+         *The increase in memory consumption is (24 bits * object's width)*/
         #ifndef LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
             #ifdef CONFIG_LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
                 #define LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION CONFIG_LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION
@@ -585,7 +585,7 @@
     #endif
 
     /*1: Enable print timestamp;
-    *0: Disable print timestamp*/
+     *0: Disable print timestamp*/
     #ifndef LV_LOG_USE_TIMESTAMP
         #ifdef _LV_KCONFIG_PRESENT
             #ifdef CONFIG_LV_LOG_USE_TIMESTAMP


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.
When I use lv_scr_load_anim(obj, LV_SCR_LOAD_ANIM_NONE, 0, 0, true) to load a new screen, an old screen doesn't be deleted automatically.
### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
