### PR TITLE
fix(style): check style count overflow

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -89,6 +89,7 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
 
     /*Allocate space for the new style and shift the rest of the style to the end*/
     obj->style_cnt++;
+    LV_ASSERT(obj->style_cnt != 0);
     obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(_lv_obj_style_t));
     LV_ASSERT_MALLOC(obj->styles);
 
@@ -519,6 +520,7 @@ static lv_style_t * get_local_style(lv_obj_t * obj, lv_style_selector_t selector
     }
 
     obj->style_cnt++;
+    LV_ASSERT(obj->style_cnt != 0);
     obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(_lv_obj_style_t));
     LV_ASSERT_MALLOC(obj->styles);
 
@@ -556,6 +558,7 @@ static _lv_obj_style_t * get_trans_style(lv_obj_t * obj,  lv_style_selector_t se
     if(i != obj->style_cnt) return &obj->styles[i];
 
     obj->style_cnt++;
+    LV_ASSERT(obj->style_cnt != 0);
     obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(_lv_obj_style_t));
 
     for(i = obj->style_cnt - 1; i > 0 ; i--) {


### PR DESCRIPTION
### Description of the feature or fix

`style_cnt` is a 6-bit variable, which overflows after 64 styles. Although it is not realistic to have that many styles, it is possible to overflow this variable due to a leak of `lv_obj_add_style` without cleaning up, which breaks havoc as it is not checked. This PR adds checks for overflow.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [X] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the documentation
