### PR TITLE
fix(ffmpeg) Ignore deprecated warning

### DIFF
--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -520,7 +520,7 @@ static int ffmpeg_open_codec_context(int * stream_idx,
     int ret;
     int stream_index;
     AVStream * st;
-    AVCodec * dec = NULL;
+    const AVCodec * dec = NULL;
     AVDictionary * opts = NULL;
 
     ret = av_find_best_stream(fmt_ctx, type, -1, -1, NULL, 0);
@@ -764,7 +764,14 @@ static int ffmpeg_image_allocate(struct ffmpeg_context_s * ffmpeg_ctx)
     }
 
     /* initialize packet, set data to NULL, let the demuxer fill it */
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     av_init_packet(&ffmpeg_ctx->pkt);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     ffmpeg_ctx->pkt.data = NULL;
     ffmpeg_ctx->pkt.size = 0;
 


### PR DESCRIPTION
When building LVGL with Micropython, warnings are treated as errors by default.

This fix works around the following warnings/errors:

```
CC ../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c
../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c: In function ‘ffmpeg_open_codec_context’:
../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c:537:13: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  537 |         dec = avcodec_find_decoder(st->codecpar->codec_id);
      |             ^
../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c: In function ‘ffmpeg_image_allocate’:
../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c:767:5: error: ‘av_init_packet’ is deprecated [-Werror=deprecated-declarations]
  767 |     av_init_packet(&ffmpeg_ctx->pkt);
      |     ^~~~~~~~~~~~~~
In file included from /usr/local/include/libavcodec/avcodec.h:45,
                 from ../../lib/lv_bindings/lvgl/src/libs/ffmpeg/lv_ffmpeg.c:12:
/usr/local/include/libavcodec/packet.h:512:6: note: declared here
  512 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
