### PR TITLE
fix(imgfont) Add user_data argument to callback

### DIFF
--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -6,10 +6,12 @@
 
 LV_IMG_DECLARE(emoji_F617)
 static bool get_imgfont_path(const lv_font_t * font, void * img_src,
-                             uint16_t len, uint32_t unicode, uint32_t unicode_next)
+                             uint16_t len, uint32_t unicode, uint32_t unicode_next,
+                             void * user_data)
 {
     LV_UNUSED(font);
     LV_UNUSED(unicode_next);
+    LV_UNUSED(user_data);
     LV_ASSERT_NULL(img_src);
 
     if(unicode == 0xF617) {
@@ -29,7 +31,7 @@ static bool get_imgfont_path(const lv_font_t * font, void * img_src,
  */
 void lv_example_imgfont_1(void)
 {
-    lv_font_t * imgfont = lv_imgfont_create(80, get_imgfont_path);
+    lv_font_t * imgfont = lv_imgfont_create(80, get_imgfont_path, NULL);
     if(imgfont == NULL) {
         LV_LOG_ERROR("imgfont init error");
     }

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -20,6 +20,7 @@
 typedef struct {
     lv_font_t * font;
     lv_get_imgfont_path_cb_t path_cb;
+    void * user_data;
     char path[LV_IMGFONT_PATH_MAX_LEN];
 } imgfont_dsc_t;
 
@@ -45,7 +46,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb)
+lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb, void * user_data)
 {
     LV_ASSERT_MSG(LV_IMGFONT_PATH_MAX_LEN > sizeof(lv_img_dsc_t),
                   "LV_IMGFONT_PATH_MAX_LEN must be greater than sizeof(lv_img_dsc_t)");
@@ -57,6 +58,7 @@ lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb)
 
     dsc->font = (lv_font_t *)(((char *)dsc) + sizeof(imgfont_dsc_t));
     dsc->path_cb = path_cb;
+    dsc->user_data = user_data;
 
     lv_font_t * font = dsc->font;
     font->dsc = dsc;
@@ -102,7 +104,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
     LV_ASSERT_NULL(dsc);
     if(dsc->path_cb == NULL) return false;
 
-    if(!dsc->path_cb(dsc->font, dsc->path, LV_IMGFONT_PATH_MAX_LEN, unicode, unicode_next)) {
+    if(!dsc->path_cb(dsc->font, dsc->path, LV_IMGFONT_PATH_MAX_LEN, unicode, unicode_next, dsc->user_data)) {
         return false;
     }
 

--- a/src/others/imgfont/lv_imgfont.h
+++ b/src/others/imgfont/lv_imgfont.h
@@ -27,7 +27,8 @@ extern "C" {
 
 /* gets the image path name of this character */
 typedef bool (*lv_get_imgfont_path_cb_t)(const lv_font_t * font, void * img_src,
-                                         uint16_t len, uint32_t unicode, uint32_t unicode_next);
+                                         uint16_t len, uint32_t unicode, uint32_t unicode_next,
+                                         void * user_data);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -39,7 +40,7 @@ typedef bool (*lv_get_imgfont_path_cb_t)(const lv_font_t * font, void * img_src,
  * @param path_cb a function to get the image path name of character.
  * @return pointer to the new imgfont or NULL if create error.
  */
-lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb);
+lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb, void * user_data);
 
 /**
  * Destroy a image font that has been created.


### PR DESCRIPTION
The Micropython bindings requires following the callback conventions.

This fix adds the missing `user_data` field for the callback.

Related: https://github.com/lvgl/lvgl/issues/3535#issuecomment-1219465477