### PR TITLE
fix(pinyin) expose lv_ime_pinyin_class

### DIFF
--- a/src/others/ime/lv_ime_pinyin.h
+++ b/src/others/ime/lv_ime_pinyin.h
@@ -25,8 +25,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-const lv_obj_class_t lv_ime_pinyin_class;
-
 typedef enum {
     LV_IME_PINYIN_MODE_K26,
     LV_IME_PINYIN_MODE_K9,
@@ -70,6 +68,8 @@ typedef struct {
 /***********************
  * GLOBAL VARIABLES
  ***********************/
+
+extern const lv_obj_class_t lv_ime_pinyin_class;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/others/ime/lv_ime_pinyin.h
+++ b/src/others/ime/lv_ime_pinyin.h
@@ -25,6 +25,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+const lv_obj_class_t lv_ime_pinyin_class;
+
 typedef enum {
     LV_IME_PINYIN_MODE_K26,
     LV_IME_PINYIN_MODE_K9,


### PR DESCRIPTION
Micropython bindings requires the class prototype to be exposed in the header, so it could refer to it.

Related: https://github.com/lvgl/lvgl/issues/3535#issuecomment-1221318545