### PR TITLE
fix(png) decode image size

### DIFF
--- a/src/libs/png/lv_png.c
+++ b/src/libs/png/lv_png.c
@@ -117,7 +117,7 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
         }
 
         if(img_dsc->header.w) {
-            header->w = img_dsc->header.w;         /*Save the color width*/
+            header->w = img_dsc->header.w;         /*Save the image width*/
         }
         else {
             header->w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);

--- a/src/libs/png/lv_png.c
+++ b/src/libs/png/lv_png.c
@@ -162,7 +162,7 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
 
             error = lodepng_load_file(&png_data, &png_data_size, fn);   /*Load the file*/
             if(error) {
-                LV_LOG_WARN("error %lu: %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %" LV_PRIu32 ": %s\n", error, lodepng_error_text(error));
                 return LV_RES_INV;
             }
 
@@ -177,7 +177,7 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
                 if(img_data != NULL) {
                     lv_free(img_data);
                 }
-                LV_LOG_WARN("error %lu: %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %" LV_PRIu32 ": %s\n", error, lodepng_error_text(error));
                 return LV_RES_INV;
             }
 

--- a/src/libs/png/lv_png.c
+++ b/src/libs/png/lv_png.c
@@ -162,13 +162,13 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
 
             error = lodepng_load_file(&png_data, &png_data_size, fn);   /*Load the file*/
             if(error) {
-                LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %lu: %s\n", error, lodepng_error_text(error));
                 return LV_RES_INV;
             }
 
             /*Decode the PNG image*/
-            uint32_t png_width;             /*Will be the width of the decoded image*/
-            uint32_t png_height;            /*Will be the width of the decoded image*/
+            unsigned png_width;             /*Will be the width of the decoded image*/
+            unsigned png_height;            /*Will be the width of the decoded image*/
 
             /*Decode the loaded image in ARGB8888 */
             error = lodepng_decode32(&img_data, &png_width, &png_height, png_data, png_data_size);
@@ -177,7 +177,7 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
                 if(img_data != NULL) {
                     lv_free(img_data);
                 }
-                LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %lu: %s\n", error, lodepng_error_text(error));
                 return LV_RES_INV;
             }
 

--- a/src/libs/png/lv_png.c
+++ b/src/libs/png/lv_png.c
@@ -103,13 +103,33 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
     else if(src_type == LV_IMG_SRC_VARIABLE) {
         const lv_img_dsc_t * img_dsc = src;
         const uint32_t data_size = img_dsc->data_size;
+        const uint32_t * size = ((uint32_t *)img_dsc->data) + 4;
         const uint8_t magic[] = {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
         if(data_size < sizeof(magic)) return LV_RES_INV;
         if(memcmp(magic, img_dsc->data, sizeof(magic))) return LV_RES_INV;
         header->always_zero = 0;
-        header->cf = img_dsc->header.cf;       /*Save the color format*/
-        header->w = img_dsc->header.w;         /*Save the color width*/
-        header->h = img_dsc->header.h;         /*Save the color height*/
+
+        if(img_dsc->header.cf) {
+            header->cf = img_dsc->header.cf;       /*Save the color format*/
+        }
+        else {
+            header->cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+        }
+
+        if(img_dsc->header.w) {
+            header->w = img_dsc->header.w;         /*Save the color width*/
+        }
+        else {
+            header->w = (lv_coord_t)((size[0] & 0xff000000) >> 24) + ((size[0] & 0x00ff0000) >> 8);
+        }
+
+        if(img_dsc->header.h) {
+            header->h = img_dsc->header.h;         /*Save the color height*/
+        }
+        else {
+            header->h = (lv_coord_t)((size[1] & 0xff000000) >> 24) + ((size[1] & 0x00ff0000) >> 8);
+        }
+
         return LV_RES_OK;
     }
 


### PR DESCRIPTION
Related: https://github.com/lvgl/lvgl/pull/3294#issuecomment-1209924716

In order to support LVGL PNG in Micropython, improve lv_png to decode image size on `decoder_info`, [as done today on the Micropython bindings](https://github.com/lvgl/lv_binding_micropython/blob/51b666f3868d52bd3d64e6b28b9243f643af73df/lib/imagetools.py#L53)

Also fix RP2 compilation errors: 

```
2022-08-27T16:18:49.3673777Z In file included from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/../../../lvgl.h:25,
2022-08-27T16:18:49.3674259Z                  from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:9:
2022-08-27T16:18:49.3675141Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c: In function 'decoder_open':
2022-08-27T16:18:49.3676006Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:165:29: error: format '%u' expects argument of type 'unsigned int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
2022-08-27T16:18:49.3676574Z   165 |                 LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
2022-08-27T16:18:49.3676909Z       |                             ^~~~~~~~~~~~~~~~  ~~~~~
2022-08-27T16:18:49.3677203Z       |                                               |
2022-08-27T16:18:49.3677519Z       |                                               uint32_t {aka long unsigned int}
2022-08-27T16:18:49.3678114Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/../../../src/misc/lv_log.h:107:91: note: in definition of macro 'LV_LOG_WARN'
2022-08-27T16:18:49.3678605Z   107 | #    define LV_LOG_WARN(...) _lv_log_add(LV_LOG_LEVEL_WARN, __FILE__, __LINE__, __func__, __VA_ARGS__)
2022-08-27T16:18:49.3678972Z       |                                                                                           ^~~~~~~~~~~
2022-08-27T16:18:49.3679385Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:165:37: note: format string is defined here
2022-08-27T16:18:49.3679827Z   165 |                 LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
2022-08-27T16:18:49.3680152Z       |                                    ~^
2022-08-27T16:18:49.3680421Z       |                                     |
2022-08-27T16:18:49.3680687Z       |                                     unsigned int
2022-08-27T16:18:49.3680974Z       |                                    %lu
2022-08-27T16:18:49.3681611Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:174:49: error: passing argument 2 of 'lodepng_decode32' from incompatible pointer type [-Werror=incompatible-pointer-types]
2022-08-27T16:18:49.3682181Z   174 |             error = lodepng_decode32(&img_data, &png_width, &png_height, png_data, png_data_size);
2022-08-27T16:18:49.3682539Z       |                                                 ^~~~~~~~~~
2022-08-27T16:18:49.3682827Z       |                                                 |
2022-08-27T16:18:49.3683142Z       |                                                 uint32_t * {aka long unsigned int *}
2022-08-27T16:18:49.3683558Z In file included from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:13:
2022-08-27T16:18:49.3684274Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lodepng.h:136:60: note: expected 'unsigned int *' but argument is of type 'uint32_t *' {aka 'long unsigned int *'}
2022-08-27T16:18:49.3685064Z   136 | unsigned lodepng_decode32(unsigned char ** out, unsigned * w, unsigned * h,
2022-08-27T16:18:49.3685395Z       |                                                 ~~~~~~~~~~~^
2022-08-27T16:18:49.3686182Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:174:61: error: passing argument 3 of 'lodepng_decode32' from incompatible pointer type [-Werror=incompatible-pointer-types]
2022-08-27T16:18:49.3686759Z   174 |             error = lodepng_decode32(&img_data, &png_width, &png_height, png_data, png_data_size);
2022-08-27T16:18:49.3687120Z       |                                                             ^~~~~~~~~~~
2022-08-27T16:18:49.3687423Z       |                                                             |
2022-08-27T16:18:49.3688017Z       |                                                             uint32_t * {aka long unsigned int *}
2022-08-27T16:18:49.3688670Z In file included from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:13:
2022-08-27T16:18:49.3689440Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lodepng.h:136:74: note: expected 'unsigned int *' but argument is of type 'uint32_t *' {aka 'long unsigned int *'}
2022-08-27T16:18:49.3689952Z   136 | unsigned lodepng_decode32(unsigned char ** out, unsigned * w, unsigned * h,
2022-08-27T16:18:49.3690302Z       |                                                               ~~~~~~~~~~~^
2022-08-27T16:18:49.3693173Z In file included from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/../../../lvgl.h:25,
2022-08-27T16:18:49.3693578Z                  from /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:9:
2022-08-27T16:18:49.3694367Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:180:29: error: format '%u' expects argument of type 'unsigned int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
2022-08-27T16:18:49.3694865Z   180 |                 LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
2022-08-27T16:18:49.3695141Z       |                             ^~~~~~~~~~~~~~~~  ~~~~~
2022-08-27T16:18:49.3695363Z       |                                               |
2022-08-27T16:18:49.3695614Z       |                                               uint32_t {aka long unsigned int}
2022-08-27T16:18:49.3696144Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/../../../src/misc/lv_log.h:107:91: note: in definition of macro 'LV_LOG_WARN'
2022-08-27T16:18:49.3696561Z   107 | #    define LV_LOG_WARN(...) _lv_log_add(LV_LOG_LEVEL_WARN, __FILE__, __LINE__, __func__, __VA_ARGS__)
2022-08-27T16:18:49.3696858Z       |                                                                                           ^~~~~~~~~~~
2022-08-27T16:18:49.3697275Z /home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c:180:37: note: format string is defined here
2022-08-27T16:18:49.3697817Z   180 |                 LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
2022-08-27T16:18:49.3698134Z       |                                    ~^
2022-08-27T16:18:49.3698343Z       |                                     |
2022-08-27T16:18:49.3698558Z       |                                     unsigned int
2022-08-27T16:18:49.3698762Z       |                                    %lu
2022-08-27T16:18:49.4033592Z cc1: all warnings being treated as errors
2022-08-27T16:18:49.4046214Z make[3]: *** [CMakeFiles/firmware.dir/build.make:6107: CMakeFiles/firmware.dir/home/runner/work/lv_micropython/lv_micropython/lib/lv_bindings/lvgl/src/libs/png/lv_png.c.obj] Error 1
2022-08-27T16:18:49.4046905Z make[3]: *** Waiting for unfinished jobs....
2022-08-27T16:18:50.6818190Z make[3]: Leaving directory '/home/runner/work/lv_micropython/lv_micropython/ports/rp2/build-PICO'
2022-08-27T16:18:50.6819043Z make[2]: *** [CMakeFiles/Makefile2:1329: CMakeFiles/firmware.dir/all] Error 2
2022-08-27T16:18:50.6819649Z make[2]: Leaving directory '/home/runner/work/lv_micropython/lv_micropython/ports/rp2/build-PICO'
2022-08-27T16:18:50.6824944Z make[1]: *** [Makefile:91: all] Error 2
2022-08-27T16:18:50.6825823Z make[1]: Leaving directory '/home/runner/work/lv_micropython/lv_micropython/ports/rp2/build-PICO'
2022-08-27T16:18:50.6826283Z make: *** [Makefile:27: all] Error 2
2022-08-27T16:18:50.6826879Z make: Leaving directory '/home/runner/work/lv_micropython/lv_micropython/ports/rp2'
2022-08-27T16:18:50.6843423Z ##[error]Process completed with exit code 2.
```