### PR TITLE
replaced av_init_packet by av_packet_alloc to get rid of deprecation …

### DIFF
--- a/examples/libs/ffmpeg/lv_example_ffmpeg_1.py
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_1.py
@@ -1,0 +1,21 @@
+#!/opt/bin/lv_micropython-ffmpeg -i
+import sys
+import lvgl as lv
+import display_driver
+
+try:
+    #
+    # Open an image from a file
+    #
+    img = lv.img(lv.scr_act())
+    img.set_src("ffmpeg.png")
+    img.center()
+except Exception as e:
+    print(e)
+    # TODO
+    # fallback for online examples
+
+    label = lv.label(lv.scr_act())
+    label.set_text("FFmpeg is not installed")
+    label.center()
+

--- a/examples/libs/ffmpeg/lv_example_ffmpeg_2.py
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_2.py
@@ -1,0 +1,17 @@
+#!/opt/bin/lv_micropython-ffmpeg -i
+import sys
+import lvgl as lv
+import display_driver
+
+#
+# Open a video from a file
+#
+
+# birds.mp4 is downloaded from http://www.videezy.com (Free Stock Footage by Videezy!)
+# https://www.videezy.com/abstract/44864-silhouettes-of-birds-over-the-sunset
+player = lv.ffmpeg_player(lv.scr_act())
+player.player_set_src("birds.mp4")
+player.player_set_auto_restart(True)
+player.player_set_cmd(lv.ffmpeg_player.PLAYER_CMD.START)
+# player.player_set_cmd(0)
+player.center()


### PR DESCRIPTION
### Description of the feature or fix
Replaced av_init_packet by av_packet_alloc to get rid of the deprecation warning
added ffmpeg micropython examples
### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
