### PR TITLE
fix(lv_obj_style): initialise value_act with default values

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -224,7 +224,7 @@ void lv_obj_enable_style_refresh(bool en)
 
 lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
 {
-    lv_style_value_t value_act = { .num = 0 };
+    lv_style_value_t value_act = { .ptr = NULL };
     bool inheritable = lv_style_prop_has_flag(prop, LV_STYLE_PROP_FLAG_INHERITABLE);
     lv_style_res_t found = LV_STYLE_RES_NOT_FOUND;
     while(obj) {

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -224,7 +224,7 @@ void lv_obj_enable_style_refresh(bool en)
 
 lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
 {
-    lv_style_value_t value_act;
+    lv_style_value_t value_act = { .num = 0 };
     bool inheritable = lv_style_prop_has_flag(prop, LV_STYLE_PROP_FLAG_INHERITABLE);
     lv_style_res_t found = LV_STYLE_RES_NOT_FOUND;
     while(obj) {


### PR DESCRIPTION
### Description of the feature or fix
This change fixes a compiler warning indicating that `value_act` may be used uninitialised.
When declaring `value_act` initialise it with default values.