### PR TITLE
fix(examples): resolve string formatting compiler warnings

### DIFF
--- a/examples/layouts/flex/lv_example_flex_1.c
+++ b/examples/layouts/flex/lv_example_flex_1.c
@@ -28,7 +28,7 @@ void lv_example_flex_1(void)
         lv_obj_set_size(obj, 100, LV_PCT(100));
 
         label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %lu", i);
+        lv_label_set_text_fmt(label, "Item: %"LV_PRIu32"", i);
         lv_obj_center(label);
 
         /*Add items to the column*/

--- a/examples/layouts/flex/lv_example_flex_1.c
+++ b/examples/layouts/flex/lv_example_flex_1.c
@@ -28,7 +28,7 @@ void lv_example_flex_1(void)
         lv_obj_set_size(obj, 100, LV_PCT(100));
 
         label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %u", i);
+        lv_label_set_text_fmt(label, "Item: %lu", i);
         lv_obj_center(label);
 
         /*Add items to the column*/

--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -31,7 +31,7 @@ void lv_example_gridnav_1(void)
         lv_group_remove_obj(obj);   /*Not needed, we use the gridnav instead*/
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%u", i);
+        lv_label_set_text_fmt(label, "%"LV_PRIu32"", i);
         lv_obj_center(label);
     }
 

--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -31,7 +31,7 @@ void lv_example_gridnav_1(void)
         lv_group_remove_obj(obj);   /*Not needed, we use the gridnav instead*/
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%u", i);
         lv_obj_center(label);
     }
 

--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -19,7 +19,7 @@ static bool get_imgfont_path(const lv_font_t * font, void * img_src,
     }
     else {
         char * path = (char *)img_src;
-        snprintf(path, len, "%s/%04X.%s", "A:lvgl/examples/assets/emoji", unicode, "png");
+        snprintf(path, len, "%s/%04"LV_PRIX32".%s", "A:lvgl/examples/assets/emoji", unicode, "png");
         path[len - 1] = '\0';
     }
 

--- a/examples/others/msg/lv_example_msg_3.c
+++ b/examples/others/msg/lv_example_msg_3.c
@@ -90,7 +90,7 @@ static void label_event_cb(lv_event_t * e)
     if(code == LV_EVENT_MSG_RECEIVED) {
         lv_msg_t * m = lv_event_get_msg(e);
         const int32_t * v = lv_msg_get_payload(m);
-        lv_label_set_text_fmt(label, "%ld %%", *v);
+        lv_label_set_text_fmt(label, "%"LV_PRId32" %%", *v);
     }
 }
 

--- a/examples/others/msg/lv_example_msg_3.c
+++ b/examples/others/msg/lv_example_msg_3.c
@@ -90,7 +90,7 @@ static void label_event_cb(lv_event_t * e)
     if(code == LV_EVENT_MSG_RECEIVED) {
         lv_msg_t * m = lv_event_get_msg(e);
         const int32_t * v = lv_msg_get_payload(m);
-        lv_label_set_text_fmt(label, "%d %%", *v);
+        lv_label_set_text_fmt(label, "%ld %%", *v);
     }
 }
 

--- a/examples/widgets/menu/lv_example_menu_4.c
+++ b/examples/widgets/menu/lv_example_menu_4.c
@@ -18,11 +18,11 @@ static void float_btn_event_cb(lv_event_t * e)
 
     cont = lv_menu_cont_create(sub_page);
     label = lv_label_create(cont);
-    lv_label_set_text_fmt(label, "Hello, I am hiding inside %i", btn_cnt);
+    lv_label_set_text_fmt(label, "Hello, I am hiding inside %"LV_PRIu32"", btn_cnt);
 
     cont = lv_menu_cont_create(main_page);
     label = lv_label_create(cont);
-    lv_label_set_text_fmt(label, "Item %i", btn_cnt);
+    lv_label_set_text_fmt(label, "Item %"LV_PRIu32"", btn_cnt);
     lv_menu_set_load_page_event(menu, cont, sub_page);
 
     lv_obj_scroll_to_view_recursive(cont, LV_ANIM_ON);

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -92,7 +92,7 @@ void lv_example_table_2(void)
     uint32_t elaps = lv_tick_elaps(t);
 
     lv_obj_t * label = lv_label_create(lv_scr_act());
-    lv_label_set_text_fmt(label, "%"LV_PRIu32" items were created in %"LV_PRIu32" ms\n"
+    lv_label_set_text_fmt(label, "%"LV_PRId32" items were created in %"LV_PRIu32" ms\n"
                           "using %"LV_PRIu32" bytes of memory",
                           ITEM_CNT, elaps, mem_used);
 

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -92,9 +92,9 @@ void lv_example_table_2(void)
     uint32_t elaps = lv_tick_elaps(t);
 
     lv_obj_t * label = lv_label_create(lv_scr_act());
-    lv_label_set_text_fmt(label, "%"LV_PRId32" items were created in %"LV_PRIu32" ms\n"
+    lv_label_set_text_fmt(label, "%"LV_PRIu32" items were created in %"LV_PRIu32" ms\n"
                           "using %"LV_PRIu32" bytes of memory",
-                          ITEM_CNT, elaps, mem_used);
+                          (uint32_t)ITEM_CNT, elaps, mem_used);
 
     lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, -10);
 


### PR DESCRIPTION
### Description of the feature or fix

This change resolves compiler warnings generated from string formatting operations in certain example files.
