### PR TITLE
fix(slider) fix potential FPE

### DIFF
--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -212,8 +212,10 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
                 /*Make the point relative to the indicator*/
                 new_value = p.x - (obj->coords.x1 + bg_left);
             }
-            new_value = (new_value * range) / indic_w;
-            new_value += slider->bar.min_value;
+            if(indic_w) {
+                new_value = (new_value * range) / indic_w;
+                new_value += slider->bar.min_value;
+            }
         }
         else {
             const lv_coord_t bg_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);


### PR DESCRIPTION
Fix a potential FPE.
It actually occurs with Micropython bindings automatic testing

```gdb
Thread 1 "micropython-dev" received signal SIGFPE, Arithmetic exception.                                                                                                               
0x0000555555705234 in lv_slider_event (class_p=<optimized out>, e=<optimized out>) at ../../lib/lv_bindings/lvgl/src/widgets/slider/lv_slider.c:215                                    
215                 new_value = (new_value * range) / indic_w;                                                                                                                         
(gdb) p indic_w                                                                                                                                                                        
$1 = 0                                                                                                                                                                                 
```