### PR TITLE
fix(draw): center imgfont's drawing position

### DIFF
--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -5,28 +5,19 @@
 #if LV_USE_IMGFONT
 
 LV_IMG_DECLARE(emoji_F617)
-static bool get_imgfont_path(const lv_font_t * font, void * img_src,
-                             uint16_t len, uint32_t unicode, uint32_t unicode_next,
+static bool get_imgfont_path(lv_imgfont_param_t * param,
                              void * user_data)
 {
-    LV_UNUSED(font);
-    LV_UNUSED(unicode_next);
-    LV_UNUSED(user_data);
-    LV_ASSERT_NULL(img_src);
-
-    if(unicode < 0xF000) return false;
-
-    if(unicode == 0xF617) {
-        memcpy(img_src, &emoji_F617, sizeof(lv_img_dsc_t));
+    if(param->unicode == 0xF617) {
+        memcpy(param->img_src, &emoji_F617, sizeof(lv_img_dsc_t));
     }
     else {
-        char * path = (char *)img_src;
+        char * path = (char *)param->img_src;
 #if LV_USE_FFMPEG
-        snprintf(path, len, "%s/%04X.%s", "lvgl/examples/assets/emoji", unicode, "png");
+        lv_snprintf(path, param->len, "%s/%04X.png", "lvgl/examples/assets/emoji", param->unicode);
 #elif LV_USE_PNG
-        snprintf(path, len, "%s/%04X.%s", "A:lvgl/examples/assets/emoji", unicode, "png");
+        lv_snprintf(path, param->len, "%s/%04X.png", "A:lvgl/examples/assets/emoji", param->unicode);
 #endif
-        path[len - 1] = '\0';
     }
 
     return true;
@@ -40,13 +31,16 @@ void lv_example_imgfont_1(void)
     lv_font_t * imgfont = lv_imgfont_create(80, get_imgfont_path, NULL);
     if(imgfont == NULL) {
         LV_LOG_ERROR("imgfont init error");
+        return;
     }
 
-    imgfont->fallback = LV_FONT_DEFAULT;
+    static lv_font_t user_font;
+    user_font = *(LV_FONT_DEFAULT);
+    user_font.fallback = imgfont;
 
     lv_obj_t * label1 = lv_label_create(lv_scr_act());
     lv_label_set_text(label1, "12\uF600\uF617AB");
-    lv_obj_set_style_text_font(label1, imgfont, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label1, &user_font, LV_PART_MAIN);
     lv_obj_center(label1);
 }
 #else

--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -5,18 +5,26 @@
 #if LV_USE_IMGFONT
 
 LV_IMG_DECLARE(emoji_F617)
-static bool get_imgfont_path(lv_imgfont_param_t * param,
-                             void * user_data)
+static bool get_imgfont_path(const lv_font_t * font, void * img_src,
+                             uint16_t len, uint32_t unicode, uint32_t unicode_next,
+                             lv_coord_t * offset_y, void * user_data)
 {
-    if(param->unicode == 0xF617) {
-        memcpy(param->img_src, &emoji_F617, sizeof(lv_img_dsc_t));
+    LV_UNUSED(font);
+    LV_UNUSED(unicode_next);
+    LV_UNUSED(offset_y);
+    LV_UNUSED(user_data);
+
+    LV_ASSERT_NULL(img_src);
+
+    if(unicode == 0xF617) {
+        memcpy(img_src, &emoji_F617, sizeof(lv_img_dsc_t));
     }
     else {
-        char * path = (char *)param->img_src;
+        char * path = (char *)img_src;
 #if LV_USE_FFMPEG
-        lv_snprintf(path, param->len, "%s/%04X.png", "lvgl/examples/assets/emoji", param->unicode);
+        lv_snprintf(path, len, "%s/%04X.png", "lvgl/examples/assets/emoji", unicode);
 #elif LV_USE_PNG
-        lv_snprintf(path, param->len, "%s/%04X.png", "A:lvgl/examples/assets/emoji", param->unicode);
+        lv_snprintf(path, len, "%s/%04X.png", "A:lvgl/examples/assets/emoji", unicode);
 #endif
     }
 

--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -13,8 +13,9 @@ static bool get_imgfont_path(const lv_font_t * font, void * img_src,
     LV_UNUSED(unicode_next);
     LV_UNUSED(offset_y);
     LV_UNUSED(user_data);
-
     LV_ASSERT_NULL(img_src);
+
+    if(unicode < 0xF000) return false;
 
     if(unicode == 0xF617) {
         memcpy(img_src, &emoji_F617, sizeof(lv_img_dsc_t));
@@ -42,13 +43,11 @@ void lv_example_imgfont_1(void)
         return;
     }
 
-    static lv_font_t user_font;
-    user_font = *(LV_FONT_DEFAULT);
-    user_font.fallback = imgfont;
+    imgfont->fallback = LV_FONT_DEFAULT;
 
     lv_obj_t * label1 = lv_label_create(lv_scr_act());
     lv_label_set_text(label1, "12\uF600\uF617AB");
-    lv_obj_set_style_text_font(label1, &user_font, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label1, imgfont, LV_PART_MAIN);
     lv_obj_center(label1);
 }
 #else

--- a/examples/others/imgfont/lv_example_imgfont_1.py
+++ b/examples/others/imgfont/lv_example_imgfont_1.py
@@ -14,7 +14,7 @@ try:
 except NameError: 
     script_path = ''
     
-def get_imgfont_path(font, img_src, length, unicode, unicode_next,user_data) :
+def get_imgfont_path(font, img_src, length, unicode, unicode_next, offset_y, user_data) :
     if unicode < 0xf600:
         return
     if LV_USE_FFMPEG:
@@ -31,6 +31,7 @@ def get_imgfont_path(font, img_src, length, unicode, unicode_next,user_data) :
 imgfont = lv.imgfont_create(80, get_imgfont_path, None)
 if imgfont == None:
     print("imgfont init error")
+    return
 
 imgfont.fallback = LV_FONT_DEFAULT
 

--- a/examples/others/imgfont/lv_example_imgfont_1.py
+++ b/examples/others/imgfont/lv_example_imgfont_1.py
@@ -31,6 +31,7 @@ def get_imgfont_path(font, img_src, length, unicode, unicode_next, offset_y, use
 imgfont = lv.imgfont_create(80, get_imgfont_path, None)
 if imgfont == None:
     print("imgfont init error")
+    sys.exit(1)
 
 imgfont.fallback = LV_FONT_DEFAULT
 

--- a/examples/others/imgfont/lv_example_imgfont_1.py
+++ b/examples/others/imgfont/lv_example_imgfont_1.py
@@ -31,7 +31,6 @@ def get_imgfont_path(font, img_src, length, unicode, unicode_next, offset_y, use
 imgfont = lv.imgfont_create(80, get_imgfont_path, None)
 if imgfont == None:
     print("imgfont init error")
-    return
 
 imgfont.fallback = LV_FONT_DEFAULT
 

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -130,9 +130,21 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
     /*Don't draw anything if the character is empty. E.g. space*/
     if((g.box_h == 0) || (g.box_w == 0)) return;
 
+    lv_coord_t real_h;
+#if LV_USE_IMGFONT
+    if(g.bpp == LV_IMGFONT_BPP) {
+        /*Center imgfont's drawing position*/
+        real_h = (dsc->font->line_height - g.box_h) / 2;
+    }
+    else
+#endif
+    {
+        real_h = (dsc->font->line_height - dsc->font->base_line) - g.box_h;
+    }
+
     lv_point_t gpos;
     gpos.x = pos_p->x + g.ofs_x;
-    gpos.y = pos_p->y + (dsc->font->line_height - dsc->font->base_line) - g.box_h - g.ofs_y;
+    gpos.y = pos_p->y + real_h - g.ofs_y;
 
     /*If the letter is completely out of mask don't draw it*/
     if(gpos.x + g.box_w < draw_ctx->clip_area->x1 ||

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -19,7 +19,7 @@
  **********************/
 typedef struct {
     lv_font_t * font;
-    lv_get_imgfont_path_cb_t path_cb;
+    lv_imgfont_get_dsc_cb_t get_dsc_cb;
     void * user_data;
     char path[LV_IMGFONT_PATH_MAX_LEN];
 } imgfont_dsc_t;
@@ -46,7 +46,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb, void * user_data)
+lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_dsc_cb_t get_dsc_cb, void * user_data)
 {
     LV_ASSERT_MSG(LV_IMGFONT_PATH_MAX_LEN > sizeof(lv_img_dsc_t),
                   "LV_IMGFONT_PATH_MAX_LEN must be greater than sizeof(lv_img_dsc_t)");
@@ -57,7 +57,7 @@ lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb,
     lv_memzero(dsc, size);
 
     dsc->font = (lv_font_t *)(((char *)dsc) + sizeof(imgfont_dsc_t));
-    dsc->path_cb = path_cb;
+    dsc->get_dsc_cb = get_dsc_cb;
     dsc->user_data = user_data;
 
     lv_font_t * font = dsc->font;
@@ -102,9 +102,17 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
 
     imgfont_dsc_t * dsc = (imgfont_dsc_t *)font->dsc;
     LV_ASSERT_NULL(dsc);
-    if(dsc->path_cb == NULL) return false;
+    if(dsc->get_dsc_cb == NULL) return false;
 
-    if(!dsc->path_cb(dsc->font, dsc->path, LV_IMGFONT_PATH_MAX_LEN, unicode, unicode_next, dsc->user_data)) {
+    lv_imgfont_param_t param;
+    lv_memzero(&param, sizeof(param));
+    param.font = dsc->font;
+    param.img_src = dsc->path;
+    param.len = LV_IMGFONT_PATH_MAX_LEN;
+    param.unicode = unicode;
+    param.unicode_next = unicode_next;
+
+    if(!dsc->get_dsc_cb(&param, dsc->user_data)) {
         return false;
     }
 
@@ -133,8 +141,8 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
     dsc_out->box_w = img_header->w;
     dsc_out->box_h = img_header->h;
     dsc_out->bpp = LV_IMGFONT_BPP;   /* is image identifier */
-    dsc_out->ofs_x = 0;
-    dsc_out->ofs_y = 0;
+    dsc_out->ofs_x = param.offset_x;
+    dsc_out->ofs_y = param.offset_y;
 
     return true;
 }

--- a/src/others/imgfont/lv_imgfont.h
+++ b/src/others/imgfont/lv_imgfont.h
@@ -25,19 +25,10 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-/* gets the image description of this character */
-
-typedef struct {
-    const lv_font_t * font;
-    void * img_src;
-    uint16_t len;
-    uint32_t unicode;
-    uint32_t unicode_next;
-    int16_t offset_x;
-    int16_t offset_y;
-} lv_imgfont_param_t;
-
-typedef bool (*lv_imgfont_get_dsc_cb_t)(lv_imgfont_param_t * param, void * user_data);
+/* gets the image path name of this character */
+typedef bool (*lv_imgfont_get_path_cb_t)(const lv_font_t * font, void * img_src,
+                                         uint16_t len, uint32_t unicode, uint32_t unicode_next,
+                                         lv_coord_t * offset_y, void * user_data);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -46,10 +37,10 @@ typedef bool (*lv_imgfont_get_dsc_cb_t)(lv_imgfont_param_t * param, void * user_
 /**
  * Creates a image font with info parameter specified.
  * @param height font size
- * @param get_dsc_cb a function to get the image description of character.
+ * @param path_cb a function to get the image path name of character.
  * @return pointer to the new imgfont or NULL if create error.
  */
-lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_dsc_cb_t get_dsc_cb, void * user_data);
+lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_path_cb_t path_cb, void * user_data);
 
 /**
  * Destroy a image font that has been created.

--- a/src/others/imgfont/lv_imgfont.h
+++ b/src/others/imgfont/lv_imgfont.h
@@ -25,10 +25,19 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-/* gets the image path name of this character */
-typedef bool (*lv_get_imgfont_path_cb_t)(const lv_font_t * font, void * img_src,
-                                         uint16_t len, uint32_t unicode, uint32_t unicode_next,
-                                         void * user_data);
+/* gets the image description of this character */
+
+typedef struct {
+    const lv_font_t * font;
+    void * img_src;
+    uint16_t len;
+    uint32_t unicode;
+    uint32_t unicode_next;
+    int16_t offset_x;
+    int16_t offset_y;
+} lv_imgfont_param_t;
+
+typedef bool (*lv_imgfont_get_dsc_cb_t)(lv_imgfont_param_t * param, void * user_data);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -37,10 +46,10 @@ typedef bool (*lv_get_imgfont_path_cb_t)(const lv_font_t * font, void * img_src,
 /**
  * Creates a image font with info parameter specified.
  * @param height font size
- * @param path_cb a function to get the image path name of character.
+ * @param get_dsc_cb a function to get the image description of character.
  * @return pointer to the new imgfont or NULL if create error.
  */
-lv_font_t * lv_imgfont_create(uint16_t height, lv_get_imgfont_path_cb_t path_cb, void * user_data);
+lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_dsc_cb_t get_dsc_cb, void * user_data);
 
 /**
  * Destroy a image font that has been created.


### PR DESCRIPTION
### Description of the feature or fix
imgfont needs to be centered in the line.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
