### PR TITLE
feat(cmake-build): build all libraries either SHARED or STATIC

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -18,16 +18,11 @@ file(GLOB_RECURSE SOURCES ${LVGL_ROOT_DIR}/src/*.c)
 file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
 file(GLOB_RECURSE DEMO_SOURCES ${LVGL_ROOT_DIR}/demos/*.c)
 
-if (BUILD_SHARED_LIBS)
-  add_library(lvgl SHARED ${SOURCES})
-else()
-  add_library(lvgl STATIC ${SOURCES})
-endif()
-
+add_library(lvgl ${SOURCES})
 add_library(lvgl::lvgl ALIAS lvgl)
-add_library(lvgl_examples STATIC ${EXAMPLE_SOURCES})
+add_library(lvgl_examples ${EXAMPLE_SOURCES})
 add_library(lvgl::examples ALIAS lvgl_examples)
-add_library(lvgl_demos STATIC ${DEMO_SOURCES})
+add_library(lvgl_demos ${DEMO_SOURCES})
 add_library(lvgl::demos ALIAS lvgl_demos)
 
 target_compile_definitions(


### PR DESCRIPTION
The CMake variable BUILD_SHARED_LIBS is used automatically by add_library() (to determine whether to build a static library or a shared library) if it was not set explicitly.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation (n/a)
