### PR TITLE
corrected examples to run on Linux

### DIFF
--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -1,5 +1,9 @@
 
 #include "../../lv_examples.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
 
 static void file_explorer_event_handler(lv_event_t * e)
@@ -43,15 +47,34 @@ void lv_example_file_explorer_1(void)
 
 #else
     /* linux */
-    lv_file_explorer_open_dir(file_explorer, "/");
+    lv_file_explorer_open_dir(file_explorer, "A:/");
 
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, "/home");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, "/home/Videos");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, "/home/Pictures");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, "/home/Music");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, "/home/Documents");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "/");
+    char *envvar = "HOME";
+    char home_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(home_dir,"A:");
+    // get the user's home directory from the HOME enviroment variable
+    strcat(home_dir,getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n",home_dir);
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
+    char video_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(video_dir,home_dir);
+    strcat(video_dir,"/Videos");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
+    char picture_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(picture_dir,home_dir);
+    strcat(picture_dir,"/Pictures");    
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
+    char music_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(music_dir,home_dir);
+    strcat(music_dir,"/Music");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
+    char document_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(document_dir,home_dir);
+    strcat(document_dir,"/Documents");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
+
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");
 #endif
 #endif
 

--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -50,28 +50,28 @@ void lv_example_file_explorer_1(void)
     lv_file_explorer_open_dir(file_explorer, "A:/");
 
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    char *envvar = "HOME";
+    char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(home_dir,"A:");
+    strcpy(home_dir, "A:");
     // get the user's home directory from the HOME enviroment variable
-    strcat(home_dir,getenv(envvar));
-    LV_LOG_USER("home_dir: %s\n",home_dir);
+    strcat(home_dir, getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
     char video_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(video_dir,home_dir);
-    strcat(video_dir,"/Videos");
+    strcpy(video_dir, home_dir);
+    strcat(video_dir, "/Videos");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
     char picture_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(picture_dir,home_dir);
-    strcat(picture_dir,"/Pictures");    
+    strcpy(picture_dir, home_dir);
+    strcat(picture_dir, "/Pictures");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
     char music_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(music_dir,home_dir);
-    strcat(music_dir,"/Music");
+    strcpy(music_dir, home_dir);
+    strcat(music_dir, "/Music");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
     char document_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(document_dir,home_dir);
-    strcat(document_dir,"/Documents");
+    strcpy(document_dir, home_dir);
+    strcat(document_dir, "/Documents");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
 
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");

--- a/examples/others/file_explorer/lv_example_file_explorer_1.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.py
@@ -1,0 +1,55 @@
+import fs_driver
+import os
+
+LV_FILE_EXPLORER_QUICK_ACCESS = True
+LV_USE_FS_WIN32 = False
+LV_FILE_EXPLORER_PATH_MAX_LEN = 128 
+
+def file_explorer_event_handler(e) :
+
+    code = e.get_code()
+    obj = e.get_target()
+
+    if code == lv.EVENT.VALUE_CHANGED:
+        cur_path =  obj.explorer_get_current_path()
+        sel_fn = obj.explorer_get_selected_file_name()
+        print("cur_path: " + cur_path, " sel_fn: " + sel_fn)
+        path_len = len(cur_path)
+        fn_len = len(sel_fn)
+        
+        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN :
+            file_info = cur_path + sel_fn
+            print(file_info);
+        else:
+            print(cur_path + sel_fn)
+
+
+file_explorer = lv.file_explorer(lv.scr_act())
+file_explorer.explorer_set_sort(lv.EXPLORER_SORT.KIND)
+
+
+if LV_USE_FS_WIN32 :
+    file_explorer.explorer_open_dir("D:")
+    if LV_FILE_EXPLORER_QUICK_ACCESS :
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, "C:/Users/Public/Desktop")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, "C:/Users/Public/Videos")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_PICTURES_DIR, "C:/Users/Public/Pictures");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_MUSIC_DIR, "C:/Users/Public/Music");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_DOCS_DIR, "C:/Users/Public/Documents");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_FS_DIR, "D:");
+
+# linux 
+file_explorer.explorer_open_dir("A:/")
+
+if LV_FILE_EXPLORER_QUICK_ACCESS :
+    home_dir = "A:" + os.getenv('HOME')
+    print("quick access: " + home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, home_dir + "/Videos")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.PICTURES_DIR, home_dir + "/Pictures")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.MUSIC_DIR, home_dir + "/Music")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.DOCS_DIR, home_dir + "/Documents")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.FS_DIR, "A:/")
+
+file_explorer.add_event_cb(file_explorer_event_handler, lv.EVENT.ALL, None)
+

--- a/examples/others/file_explorer/lv_example_file_explorer_1.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.py
@@ -13,18 +13,12 @@ def file_explorer_event_handler(e) :
     if code == lv.EVENT.VALUE_CHANGED:
         cur_path =  obj.explorer_get_current_path()
         sel_fn = obj.explorer_get_selected_file_name()
-        print("cur_path: " + cur_path, " sel_fn: " + sel_fn)
-        path_len = len(cur_path)
-        fn_len = len(sel_fn)
-        
-        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN :
-            file_info = cur_path + sel_fn
-            print(file_info);
-        else:
-            print(cur_path + sel_fn)
+        # print("cur_path: " + str(cur_path), " sel_fn: " + str(sel_fn))
+        print(str(cur_path) + str(sel_fn))
 
 file_explorer = lv.file_explorer(lv.scr_act())
 file_explorer.explorer_set_sort(lv.EXPLORER_SORT.KIND)
+
 
 if LV_USE_FS_WIN32 :
     file_explorer.explorer_open_dir("D:")

--- a/examples/others/file_explorer/lv_example_file_explorer_1.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.py
@@ -23,10 +23,8 @@ def file_explorer_event_handler(e) :
         else:
             print(cur_path + sel_fn)
 
-
 file_explorer = lv.file_explorer(lv.scr_act())
 file_explorer.explorer_set_sort(lv.EXPLORER_SORT.KIND)
-
 
 if LV_USE_FS_WIN32 :
     file_explorer.explorer_open_dir("D:")

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -80,28 +80,28 @@ void lv_example_file_explorer_2(void)
     /* linux */
     lv_file_explorer_open_dir(file_explorer, "A:/");
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    char *envvar = "HOME";
+    char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(home_dir,"A:");
+    strcpy(home_dir, "A:");
     // get the user's home directory from the HOME enviroment variable
-    strcat(home_dir,getenv(envvar));
-    LV_LOG_USER("home_dir: %s\n",home_dir);
+    strcat(home_dir, getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
     char video_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(video_dir,home_dir);
-    strcat(video_dir,"/Videos");
+    strcpy(video_dir, home_dir);
+    strcat(video_dir, "/Videos");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
     char picture_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(picture_dir,home_dir);
-    strcat(picture_dir,"/Pictures");    
+    strcpy(picture_dir, home_dir);
+    strcat(picture_dir, "/Pictures");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
     char music_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(music_dir,home_dir);
-    strcat(music_dir,"/Music");
+    strcpy(music_dir, home_dir);
+    strcat(music_dir, "/Music");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
     char document_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(document_dir,home_dir);
-    strcat(document_dir,"/Documents");
+    strcpy(document_dir, home_dir);
+    strcat(document_dir, "/Documents");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
 
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -1,5 +1,9 @@
 
 #include "../../lv_examples.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
 
 static void file_explorer_event_handler(lv_event_t * e)
@@ -74,15 +78,33 @@ void lv_example_file_explorer_2(void)
 
 #else
     /* linux */
-    lv_file_explorer_open_dir(file_explorer, "/");
-
+    lv_file_explorer_open_dir(file_explorer, "A:/");
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, "/home");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, "/home/Videos");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, "/home/Pictures");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, "/home/Music");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, "/home/Documents");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "/");
+    char *envvar = "HOME";
+    char home_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(home_dir,"A:");
+    // get the user's home directory from the HOME enviroment variable
+    strcat(home_dir,getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n",home_dir);
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
+    char video_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(video_dir,home_dir);
+    strcat(video_dir,"/Videos");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
+    char picture_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(picture_dir,home_dir);
+    strcat(picture_dir,"/Pictures");    
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
+    char music_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(music_dir,home_dir);
+    strcat(music_dir,"/Music");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
+    char document_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(document_dir,home_dir);
+    strcat(document_dir,"/Documents");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
+
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");
 #endif
 #endif
 

--- a/examples/others/file_explorer/lv_example_file_explorer_2.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.py
@@ -1,0 +1,110 @@
+import fs_driver
+import os
+
+LV_FILE_EXPLORER_QUICK_ACCESS = True
+LV_USE_FS_WIN32 = False
+LV_FILE_EXPLORER_PATH_MAX_LEN = 128
+
+def file_explorer_event_handler(e):
+    code = e.get_code()
+    obj = e.get_target()
+
+    if code == lv.EVENT.VALUE_CHANGED:
+        cur_path =  obj.explorer_get_current_path()
+        sel_fn = obj.explorer_get_selected_file_name()
+        print("cur_path: " + cur_path, " sel_fn: " + sel_fn)
+        path_len = len(cur_path)
+        fn_len = len(sel_fn)
+        
+        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN :
+            file_info = cur_path + sel_fn
+            print(file_info);
+        else:
+            print(cur_path + sel_fn)
+
+def btn_event_handler(e,fe_quick_access_obj):
+
+    code = e.get_code()
+    btn = e.get_target()
+    # lv_obj_t * file_explorer = lv_event_get_user_data(e);
+
+    if code == lv.EVENT.VALUE_CHANGED :
+        if btn.has_state(lv.STATE.CHECKED) :
+            fe_quick_access_obj.add_flag(lv.obj.FLAG.HIDDEN)
+        else :
+            fe_quick_access_obj.clear_flag(lv.obj.FLAG.HIDDEN)
+
+def dd_event_handler(e, file_explorer):
+
+    code = e.get_code()
+    dd = e.get_target()
+    # fe_quick_access_obj = lv_event_get_user_data(e);
+
+    if code == lv.EVENT.VALUE_CHANGED :
+        buf = bytearray(32)
+        lv.dropdown.get_selected_str(dd,buf,len(buf))
+
+        if buf[:4] == b"NONE":
+            # print("set sort to NONE")
+            file_explorer.explorer_set_sort(lv.EXPLORER_SORT.NONE)
+        elif buf[:4] == b"KIND" :
+            # print("set sort to KIND")
+            file_explorer.explorer_set_sort(lv.EXPLORER_SORT.KIND)
+
+file_explorer = lv.file_explorer(lv.scr_act())
+
+if LV_USE_FS_WIN32 :
+    file_explorer.explorer_open_dir("D:")
+    if LV_FILE_EXPLORER_QUICK_ACCESS :
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, "C:/Users/Public/Desktop")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, "C:/Users/Public/Videos")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_PICTURES_DIR, "C:/Users/Public/Pictures");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_MUSIC_DIR, "C:/Users/Public/Music");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_DOCS_DIR, "C:/Users/Public/Documents");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_FS_DIR, "D:");
+
+# linux 
+file_explorer.explorer_open_dir("A:/")
+
+if LV_FILE_EXPLORER_QUICK_ACCESS :
+    home_dir = "A:" + os.getenv('HOME')
+    print("quick access: " + home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, home_dir + "/Videos")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.PICTURES_DIR, home_dir + "/Pictures")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.MUSIC_DIR, home_dir + "/Music")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.DOCS_DIR, home_dir + "/Documents")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.FS_DIR, "A:/")
+
+file_explorer.add_event_cb(file_explorer_event_handler, lv.EVENT.ALL, None)
+
+# Quick access status control button
+fe_quick_access_obj = file_explorer.explorer_get_quick_access_area()
+fe_header_obj = file_explorer.explorer_get_header()
+btn = lv.btn(fe_header_obj)
+btn.set_style_radius(2, 0)
+btn.set_style_pad_all(4, 0)
+btn.align(lv.ALIGN.LEFT_MID, 0, 0)
+btn.add_flag(lv.obj.FLAG.CHECKABLE)
+
+label = lv.label(btn)
+label.set_text(lv.SYMBOL.LIST)
+label.center()
+
+btn.add_event_cb(lambda evt: btn_event_handler(evt,fe_quick_access_obj), lv.EVENT.VALUE_CHANGED, None)
+#btn.add_event_cb(lambda evt: btn_event_handler(evt,file_explorer), lv.EVENT.VALUE_CHANGED, None)
+
+# Sort control
+opts = "NONE\nKIND"
+
+dd = lv.dropdown(fe_header_obj)
+dd.set_style_radius(4, 0)
+dd.set_style_pad_all(0, 0)
+dd.set_size(lv.pct(30), lv.SIZE_CONTENT)
+dd.set_options_static(opts)
+dd.align(lv.ALIGN.RIGHT_MID, 0, 0)
+# lv_obj_align_to(dd, btn, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
+
+dd.add_event_cb(lambda evt: dd_event_handler(evt,file_explorer), lv.EVENT.VALUE_CHANGED, None)
+#dd.add_event_cb(lambda evt: dd_event_handler(evt,fe_quick_access_obj), lv.EVENT.VALUE_CHANGED, None)
+

--- a/examples/others/file_explorer/lv_example_file_explorer_2.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.py
@@ -12,15 +12,7 @@ def file_explorer_event_handler(e):
     if code == lv.EVENT.VALUE_CHANGED:
         cur_path =  obj.explorer_get_current_path()
         sel_fn = obj.explorer_get_selected_file_name()
-        print("cur_path: " + cur_path, " sel_fn: " + sel_fn)
-        path_len = len(cur_path)
-        fn_len = len(sel_fn)
-        
-        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN :
-            file_info = cur_path + sel_fn
-            print(file_info);
-        else:
-            print(cur_path + sel_fn)
+        print(str(cur_path) + str(sel_fn))
 
 def btn_event_handler(e,fe_quick_access_obj):
 

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -1,5 +1,9 @@
 
 #include "../../lv_examples.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
 
 
@@ -89,15 +93,33 @@ void lv_example_file_explorer_3(void)
 
 #else
     /* linux */
-    lv_file_explorer_open_dir(file_explorer, "/");
-
+    lv_file_explorer_open_dir(file_explorer, "A:/");
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, "/home");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, "/home/Videos");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, "/home/Pictures");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, "/home/Music");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, "/home/Documents");
-    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "/");
+    char *envvar = "HOME";
+    char home_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(home_dir,"A:");
+    // get the user's home directory from the HOME enviroment variable
+    strcat(home_dir,getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n",home_dir);
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
+    char video_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(video_dir,home_dir);
+    strcat(video_dir,"/Videos");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
+    char picture_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(picture_dir,home_dir);
+    strcat(picture_dir,"/Pictures");    
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
+    char music_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(music_dir,home_dir);
+    strcat(music_dir,"/Music");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
+    char document_dir[LV_FS_MAX_PATH_LENGTH];
+    strcpy(document_dir,home_dir);
+    strcat(document_dir,"/Documents");
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
+
+    lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");
 #endif
 #endif
 

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -95,28 +95,28 @@ void lv_example_file_explorer_3(void)
     /* linux */
     lv_file_explorer_open_dir(file_explorer, "A:/");
 #if LV_FILE_EXPLORER_QUICK_ACCESS
-    char *envvar = "HOME";
+    char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(home_dir,"A:");
+    strcpy(home_dir, "A:");
     // get the user's home directory from the HOME enviroment variable
-    strcat(home_dir,getenv(envvar));
-    LV_LOG_USER("home_dir: %s\n",home_dir);
+    strcat(home_dir, getenv(envvar));
+    LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);
     char video_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(video_dir,home_dir);
-    strcat(video_dir,"/Videos");
+    strcpy(video_dir, home_dir);
+    strcat(video_dir, "/Videos");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_VIDEO_DIR, video_dir);
     char picture_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(picture_dir,home_dir);
-    strcat(picture_dir,"/Pictures");    
+    strcpy(picture_dir, home_dir);
+    strcat(picture_dir, "/Pictures");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_PICTURES_DIR, picture_dir);
     char music_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(music_dir,home_dir);
-    strcat(music_dir,"/Music");
+    strcpy(music_dir, home_dir);
+    strcat(music_dir, "/Music");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_MUSIC_DIR, music_dir);
     char document_dir[LV_FS_MAX_PATH_LENGTH];
-    strcpy(document_dir,home_dir);
-    strcat(document_dir,"/Documents");
+    strcpy(document_dir, home_dir);
+    strcat(document_dir, "/Documents");
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_DOCS_DIR, document_dir);
 
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_FS_DIR, "A:/");

--- a/examples/others/file_explorer/lv_example_file_explorer_3.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.py
@@ -1,0 +1,96 @@
+import fs_driver
+import os
+
+LV_FILE_EXPLORER_QUICK_ACCESS = True
+LV_USE_FS_WIN32 = False
+LV_FILE_EXPLORER_PATH_MAX_LEN = 128 
+
+def exch_table_item(tb, i, j):
+    tmp = tb.get_cell_value(i, 0)
+    tb.set_cell_value(0, 2, tmp)
+    tb.set_cell_value(i, 0, tb.get_cell_value(j, 0))
+    tb.set_cell_value(j, 0, tb.get_cell_value(0, 2))
+
+    tmp = tb.get_cell_value(i, 1)
+    tb.set_cell_value(0, 2, tmp)
+    tb.set_cell_value(i, 1, tb.get_cell_value(j, 1))
+    tb.set_cell_value(j, 1, tb.get_cell_value(0, 2))
+
+# Quick sort 3 way
+def sort_by_file_kind(tb, lo, hi) :
+    if lo >= hi:
+        return;
+
+    lt = lo
+    i = lo + 1
+    gt = hi
+    v = tb.get_cell_value(lo, 1)
+    
+    while i <= gt :
+        
+        if tb.get_cell_value(i, 1) < v :
+            lt += 1
+            i  += 1
+            exch_table_item(tb, lt, i)
+        elif tb.get_cell_value(i, 1) >  v:
+            gt -= 1
+            exch_table_item(tb, i, gt)
+        else :
+            i += 1
+    sort_by_file_kind(tb, lo, lt - 1);
+    sort_by_file_kind(tb, gt + 1, hi);
+
+
+def file_explorer_event_handler(e) :
+
+    code = e.get_code()
+    obj = e.get_target()
+
+    if code == lv.EVENT.VALUE_CHANGED:
+        cur_path =  obj.explorer_get_current_path()
+        sel_fn = obj.get_selected_file_name()
+        path_len = len(cur_path)
+        fn_len = len(sel_fn)
+
+        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN:
+            file_info = cur_path + sel_fn
+            print(file_info)
+        else:
+            print(cur_path + sel_fn)
+
+    elif code == lv.EVENT.READY :
+        tb = obj.explorer_get_file_table()
+        sum = tb.get_row_cnt()
+        # print("sum: ",sum)
+        sort_by_file_kind(tb, 0, (sum - 1));
+
+file_explorer = lv.file_explorer(lv.scr_act())
+# Before custom sort, please set the default sorting to NONE. The default is NONE.
+file_explorer.explorer_set_sort(lv.EXPLORER_SORT.NONE)
+
+file_explorer = lv.file_explorer(lv.scr_act())
+
+if LV_USE_FS_WIN32 :
+    file_explorer.explorer_open_dir("D:")
+    if LV_FILE_EXPLORER_QUICK_ACCESS :
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, "C:/Users/Public/Desktop")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, "C:/Users/Public/Videos")
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_PICTURES_DIR, "C:/Users/Public/Pictures");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_MUSIC_DIR, "C:/Users/Public/Music");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_DOCS_DIR, "C:/Users/Public/Documents");
+        file_explorer.explorer_set_quick_access_path(lv.EXPLORER_FS_DIR, "D:");
+
+# linux 
+file_explorer.explorer_open_dir("A:/")
+
+if LV_FILE_EXPLORER_QUICK_ACCESS :
+    home_dir = "A:" + os.getenv('HOME')    
+    print("quick access: " + home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.HOME_DIR, home_dir)
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.VIDEO_DIR, home_dir + "/Videos")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.PICTURES_DIR, home_dir + "/Pictures")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.MUSIC_DIR, home_dir + "/Music")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.DOCS_DIR, home_dir + "/Documents")
+    file_explorer.explorer_set_quick_access_path(lv.EXPLORER.FS_DIR, "A:/")
+
+    file_explorer.add_event_cb(file_explorer_event_handler, lv.EVENT.ALL, None)

--- a/examples/others/file_explorer/lv_example_file_explorer_3.py
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.py
@@ -48,15 +48,8 @@ def file_explorer_event_handler(e) :
 
     if code == lv.EVENT.VALUE_CHANGED:
         cur_path =  obj.explorer_get_current_path()
-        sel_fn = obj.get_selected_file_name()
-        path_len = len(cur_path)
-        fn_len = len(sel_fn)
-
-        if path_len + fn_len <= LV_FILE_EXPLORER_PATH_MAX_LEN:
-            file_info = cur_path + sel_fn
-            print(file_info)
-        else:
-            print(cur_path + sel_fn)
+        sel_fn = obj.explorer_get_selected_file_name()
+        print(str(cur_path) + str(sel_fn))
 
     elif code == lv.EVENT.READY :
         tb = obj.explorer_get_file_table()


### PR DESCRIPTION
added micropython variants

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
The file explorer examples did not work on Linux because the path to the standard home folders were incorrect. The user's home directory is not /home, but /home/username. I get the username from the HOME environment variable and I append it the die driver letter, which was also missing. Like this the examples work for me.
I also added the MicroPython equivalents to the file_explorer folder.