### PR TITLE
fix(switch): fix knob overflow on right edge

### DIFF
--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -191,7 +191,7 @@ static void draw_main(lv_event_t * e)
 
     lv_area_t knob_area;
     knob_area.x1 = obj->coords.x1 + anim_value_x;
-    knob_area.x2 = knob_area.x1 + knob_size;
+    knob_area.x2 = knob_area.x1 + (knob_size > 0 ? knob_size - 1 : 0);
 
     knob_area.y1 = obj->coords.y1;
     knob_area.y2 = obj->coords.y2;


### PR DESCRIPTION
### Description of the feature or fix'

![image](https://user-images.githubusercontent.com/26767803/189040400-2bff2a5d-b687-42ac-b995-ee88eef4a38e.png)


```c
#define COLOR_WHITE lv_color_white()
#define COLOR_BLUE lv_palette_main(LV_PALETTE_BLUE)
#define COLOR_GREY lv_palette_main(LV_PALETTE_GREY)

#define PART_TRACK (LV_PART_INDICATOR | LV_STATE_CHECKED)

static void switch_test(void)
{
    lv_obj_set_style_bg_color(lv_scr_act(), lv_color_black(), 0);

    lv_obj_t* native_ = lv_obj_create(lv_scr_act());
    lv_obj_remove_style_all(native_);
    lv_obj_clear_flag(native_, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_clear_flag(native_, LV_OBJ_FLAG_CLICKABLE);
    lv_obj_set_size(native_, 90, 56);
    lv_obj_center(native_);

    lv_obj_t* switch_ = lv_switch_create(native_);
    lv_obj_remove_style_all(switch_);
    lv_obj_set_pos(switch_, 0, 0);
    lv_obj_set_size(switch_, 90, 56);

    /* part main */
    lv_obj_set_style_radius(switch_, LV_RADIUS_CIRCLE, 0);
    lv_obj_set_style_bg_color(switch_, COLOR_GREY, 0);
    lv_obj_set_style_bg_opa(switch_, LV_OPA_COVER, 0);
    lv_obj_set_style_anim_time(switch_, 100, 0);

    /* knob */
    lv_obj_set_style_radius(switch_, LV_RADIUS_CIRCLE, LV_PART_KNOB);
    lv_obj_set_style_bg_color(switch_, COLOR_WHITE, LV_PART_KNOB);
    lv_obj_set_style_bg_opa(switch_, LV_OPA_COVER, LV_PART_KNOB);

    /* indicator */
    lv_obj_set_style_radius(switch_, LV_RADIUS_CIRCLE, LV_PART_INDICATOR);
    lv_obj_set_style_bg_color(switch_, COLOR_BLUE, PART_TRACK);
    lv_obj_set_style_bg_opa(switch_, LV_OPA_COVER, PART_TRACK);
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
