### PR TITLE
fix(txt): append ')]}' to LV_TXT_BREAK_CHARS

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -654,7 +654,7 @@ menu "LVGL configuration"
 
         config LV_TXT_BREAK_CHARS
             string "Can break (wrap) texts on these chars"
-            default " ,.;:-_"
+            default " ,.;:-_)]}"
 
         config LV_TXT_LINE_BREAK_LONG_LEN
             int "Line break long length"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -407,7 +407,7 @@
 #define LV_TXT_ENC LV_TXT_ENC_UTF8
 
 /*Can break (wrap) texts on these chars*/
-#define LV_TXT_BREAK_CHARS " ,.;:-_"
+#define LV_TXT_BREAK_CHARS " ,.;:-_)]}"
 
 /*If a word is at least this long, will break wherever "prettiest"
  *To disable, set to a value <= 0*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1271,7 +1271,7 @@
     #ifdef CONFIG_LV_TXT_BREAK_CHARS
         #define LV_TXT_BREAK_CHARS CONFIG_LV_TXT_BREAK_CHARS
     #else
-        #define LV_TXT_BREAK_CHARS " ,.;:-_"
+        #define LV_TXT_BREAK_CHARS " ,.;:-_)]}"
     #endif
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

lvgl regards ']' and ',' as a whole, adding this configuration makes it disconnectable.

```c
void label_test(void)
{
    lv_obj_t* label = lv_label_create(lv_scr_act());
    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
    lv_label_set_text(label, "a [中文信息], hello!");
    lv_obj_set_width(label, 65);
    lv_obj_center(label);
    lv_obj_set_style_border_color(label, lv_color_black(), 0);
    lv_obj_set_style_border_width(label, 1, 0);
}
```

Before fix:
![image](https://user-images.githubusercontent.com/26767803/189066199-1252b740-1801-4cd4-931d-990cbaf84bfa.png)


After fix:
![image](https://user-images.githubusercontent.com/26767803/189066342-d4d71e98-9236-4c4b-a549-31db175dd4d0.png)


### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
