### PR TITLE
v8.3.1 Backport: Clear streaming/target texture with FillRect

### DIFF
--- a/src/draw/sdl/lv_draw_sdl_composite.c
+++ b/src/draw/sdl/lv_draw_sdl_composite.c
@@ -95,7 +95,10 @@ bool lv_draw_sdl_composite_begin(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coor
         internals->target_backup = SDL_GetRenderTarget(ctx->renderer);
         SDL_SetRenderTarget(ctx->renderer, internals->composition);
         SDL_SetRenderDrawColor(ctx->renderer, 255, 255, 255, 0);
-        SDL_RenderClear(ctx->renderer);
+        /* SDL_RenderClear is not working properly, so we overwrite the target with solid color */
+        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
+        SDL_RenderFillRect(ctx->renderer, NULL);
+        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
 #if LV_GPU_SDL_CUSTOM_BLEND_MODE
         internals->mask = lv_draw_sdl_composite_texture_obtain(ctx, LV_DRAW_SDL_COMPOSITE_TEXTURE_ID_STREAM0, w, h);
         dump_masks(internals->mask, apply_area);

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -390,7 +390,10 @@ static SDL_Texture * img_rounded_frag_obtain(lv_draw_sdl_ctx_t * ctx, SDL_Textur
         SDL_Texture * old_target = SDL_GetRenderTarget(ctx->renderer);
         SDL_SetRenderTarget(ctx->renderer, img_frag);
         SDL_SetRenderDrawColor(ctx->renderer, 0, 0, 0, 0);
-        SDL_RenderClear(ctx->renderer);
+        /* SDL_RenderClear is not working properly, so we overwrite the target with solid color */
+        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_NONE);
+        SDL_RenderFillRect(ctx->renderer, NULL);
+        SDL_SetRenderDrawBlendMode(ctx->renderer, SDL_BLENDMODE_BLEND);
 
         lv_area_t coords = {0, 0, w - 1, h - 1}, clip;
         lv_area_t frag_coords = {0, 0, full_frag_size - 1, full_frag_size - 1};

--- a/src/draw/sdl/lv_draw_sdl_layer.c
+++ b/src/draw/sdl/lv_draw_sdl_layer.c
@@ -69,7 +69,12 @@ lv_draw_layer_ctx_t * lv_draw_sdl_layer_init(lv_draw_ctx_t * draw_ctx, lv_draw_l
 
     SDL_SetTextureBlendMode(transform_ctx->target, SDL_BLENDMODE_BLEND);
     SDL_SetRenderTarget(renderer, transform_ctx->target);
-    SDL_RenderClear(renderer);
+
+    /* SDL_RenderClear is not working properly, so we overwrite the target with solid color */
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderFillRect(renderer, NULL);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 
     /* Set proper drawing context for transform layer */
     ctx->internals->transform_count += 1;

--- a/src/draw/sdl/lv_draw_sdl_line.c
+++ b/src/draw/sdl/lv_draw_sdl_line.c
@@ -126,7 +126,10 @@ static SDL_Texture * line_texture_create(lv_draw_sdl_ctx_t * sdl_ctx, const lv_d
     SDL_SetRenderTarget(sdl_ctx->renderer, texture);
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0x0);
-    SDL_RenderClear(sdl_ctx->renderer);
+    /* SDL_RenderClear is not working properly, so we overwrite the target with solid color */
+    SDL_SetRenderDrawBlendMode(sdl_ctx->renderer, SDL_BLENDMODE_NONE);
+    SDL_RenderFillRect(sdl_ctx->renderer, NULL);
+    SDL_SetRenderDrawBlendMode(sdl_ctx->renderer, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawColor(sdl_ctx->renderer, 0xFF, 0xFF, 0xFF, 0xFF);
     SDL_Rect line_rect = {1 + dsc->width / 2, 1, length, dsc->width};
     SDL_RenderFillRect(sdl_ctx->renderer, &line_rect);


### PR DESCRIPTION
### Description of the feature or fix

See #3608.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
