### PR TITLE
fix(span): fix incomplete text display when disable the placeholder.

### DIFF
--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -606,7 +606,14 @@ static bool lv_txt_get_snippet(const char * txt, const lv_font_t * font,
         return false;
     }
 
-    uint32_t ofs = _lv_txt_get_next_line(txt, font, letter_space, max_width, use_width, flag);
+    lv_coord_t real_max_width = max_width;
+#if !LV_USE_FONT_PLACEHOLDER
+    /* fix incomplete text display when disable the placeholder. */
+    /* workaround by: https://github.com/lvgl/lvgl/issues/3685 */
+    real_max_width++;
+#endif
+
+    uint32_t ofs = _lv_txt_get_next_line(txt, font, letter_space, real_max_width, use_width, flag);
     *end_ofs = ofs;
 
     if(txt[ofs] == '\0' && *use_width < max_width) {


### PR DESCRIPTION
### Description of the feature or fix

Related discussion: #3685

I tried adding an extra pixel to the text measurement, which made it possible to include an imgfont with a width of 0 after `max_width` was reached, as expected. 
But this is obviously not the best solution, what do you think?
@kisvegabor 

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
