### PR TITLE
fix(draw): fix duplicate alpha overlay for draw letter

### DIFF
--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -257,7 +257,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, c
     lv_draw_sw_blend_dsc_t blend_dsc;
     lv_memzero(&blend_dsc, sizeof(blend_dsc));
     blend_dsc.color = dsc->color;
-    blend_dsc.opa = dsc->opa;
+    blend_dsc.opa = LV_OPA_COVER;
     blend_dsc.blend_mode = dsc->blend_mode;
 
     lv_coord_t hor_res = lv_disp_get_hor_res(_lv_refr_get_disp_refreshing());


### PR DESCRIPTION
### Description of the feature or fix

The displayed text transparency of `style_text_opa` and `style_opa` is inconsistent.

![image](https://user-images.githubusercontent.com/26767803/191020309-3ac139d9-6154-4e47-a35d-d4234a8cd4f3.png)

```c
void label_opa_test(void)
{
    lv_obj_set_flex_flow(lv_scr_act(), LV_FLEX_FLOW_COLUMN);

    lv_obj_t* label = lv_label_create(lv_scr_act());
    lv_obj_set_style_text_opa(label, LV_OPA_30, 0);
    lv_obj_set_style_text_color(label, lv_color_white(), 0);

    label = lv_label_create(lv_scr_act());
    lv_obj_set_style_opa(label, LV_OPA_30, 0);
    lv_obj_set_style_text_color(label, lv_color_white(), 0)
}
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
