### PR TITLE
docs(links): fix outdated links and imrpove formatting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1682,7 +1682,7 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 ## v7.0.0 (18.05.2020)
 
 ### Documentation
-The docs for v7 is available at https://docs.littlevgl.com/v7/en/html/index.html
+The docs for v7 is available at https://docs.lvgl.io/7.11/index.html
 
 ### Legal changes
 
@@ -1721,7 +1721,7 @@ As part of these updates, a lot of objects were reworked and the APIs have been 
 - *value* display a text which is stored in the style. It can be used e.g. as a light-weighted text on buttons too.
 - *margin*: similar to *padding* but used to keep space outside the object
 
-Read the [Style](https://docs.littlevgl.com/v7/en/html/overview/style.html) section of the documentation to learn how the new styles system works.
+Read the [Style](https://docs.lvgl.io/7.11/overview/style.html) section of the documentation to learn how the new styles system works.
 
 ### GPU integration
 To better utilize GPUs, from this version GPU usage can be integrated into LVGL. In `lv_conf.h` any supported GPUs can be enabled with a single configuration option.

--- a/docs/README_pt_BR.md
+++ b/docs/README_pt_BR.md
@@ -52,7 +52,7 @@ SquareLine Studio é um editor de interface do usuário de (arrasta e solta) pro
 
 Nossa equipe está pronta para ajudá-lo com design gráfico, implementação de UI e serviços de consultoria. Entre em contato conosco se precisar de algum suporte durante o desenvolvimento de seu próximo projeto de GUI.
 
-## :rocket: Recursos 
+## :rocket: Recursos
 
 **Gratuito e portátil**
 
@@ -73,7 +73,7 @@ Nossa equipe está pronta para ajudá-lo com design gráfico, implementação de
   - Mecanismo de renderização que suporta animações, anti-aliasing, opacidade, rolagem suave (smooth scroll), sombras, transformação de imagens, etc.
   - Suporta mouse, touchpad, teclado, botões externos, dispositivos de entrada codificadores (encoders).
   - Suporta vários monitores.
-  
+
 **Suporte de vinculação (binding) e compilação de arquivos**
 
   - Exposição da API do LVGL com o [Micropython](https://blog.lvgl.io/2019-02-20/micropython-bindings)
@@ -107,13 +107,13 @@ Se alguém implementar ou corrigir um problema rotulado como [Patrocinado](https
 **Pessoas que apoiam o projeto LVGL**<br>
 [![Backers of LVGL](https://opencollective.com/lvgl/individuals.svg?width=600)](https://opencollective.com/lvgl)
 
-## :package: Pacotes 
+## :package: Pacotes
 
 LVGL está disponível para:
 
 - [Arduino library](https://docs.lvgl.io/master/get-started/platforms/arduino.html)
 - [PlatformIO package](https://registry.platformio.org/libraries/lvgl/lvgl)
-- [Zephyr library](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_LVGL.html)
+- [Zephyr library](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_LVGL)
 - [ESP32 component](https://docs.lvgl.io/master/get-started/platforms/espressif.html)
 - [NXP MCUXpresso component](https://www.nxp.com/design/software/embedded-software/lvgl-open-source-graphics-library:LITTLEVGL-OPEN-SOURCE-GRAPHICS-LIBRARY)
 - [NuttX library](https://docs.lvgl.io/master/get-started/os/nuttx.html)
@@ -405,7 +405,7 @@ Esta lista irá guiá-lo para começar com o LVGL passo a passo.
   3. Familiarize-se com o básico na página de [visão geral rápida](https://docs.lvgl.io/master/get-started/quick-overview.html) (~15 minutos)
 
 **Começando a usar o LVGL**
-  
+
   4. Configure um [simulador](https://docs.lvgl.io/master/get-started/platforms/pc-simulator.html) (~10 minutos)
   5. Experimente alguns [exemplos](https://github.com/lvgl/lvgl/tree/master/examples)
   6. Porte o LVGL para uma placa. Veja o guia [portando o LVGL](https://docs.lvgl.io/master/porting/index.html) ou veja um projeto pronto para usar em [projetos](https://github.com/lvgl?q=lv_port_)

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -121,7 +121,7 @@ LVGL本身并不依赖特定的硬件平台，任何满足LVGL硬件配置要求
 
 LVGL也支持：
 - [Arduino library](https://docs.lvgl.io/master/get-started/platforms/arduino.html)
-- [PlatformIO package](https://platformio.org/lib/show/12440/lvgl)
+- [PlatformIO package](https://registry.platformio.org/libraries/lvgl/lvgl)
 - [Zephyr library](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_LVGL)
 - [ESP32 component](https://docs.lvgl.io/master/get-started/platforms/espressif.html)
 - [NXP MCUXpresso component](https://www.nxp.com/design/software/embedded-software/lvgl-open-source-graphics-library:LITTLEVGL-OPEN-SOURCE-GRAPHICS-LIBRARY)

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -122,7 +122,7 @@ LVGL本身并不依赖特定的硬件平台，任何满足LVGL硬件配置要求
 LVGL也支持：
 - [Arduino library](https://docs.lvgl.io/master/get-started/platforms/arduino.html)
 - [PlatformIO package](https://platformio.org/lib/show/12440/lvgl)
-- [Zephyr library](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_LVGL.html)
+- [Zephyr library](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_LVGL)
 - [ESP32 component](https://docs.lvgl.io/master/get-started/platforms/espressif.html)
 - [NXP MCUXpresso component](https://www.nxp.com/design/software/embedded-software/lvgl-open-source-graphics-library:LITTLEVGL-OPEN-SOURCE-GRAPHICS-LIBRARY)
 - [NuttX library](https://docs.lvgl.io/master/get-started/os/nuttx.html)

--- a/docs/get-started/platforms/pc-simulator.md
+++ b/docs/get-started/platforms/pc-simulator.md
@@ -58,7 +58,7 @@ On **Linux** you can easily install SDL2 using a terminal:
 4. If build essentials are not installed yet: `sudo apt-get install build-essential`
 
 #### Windows
-If you are using **Windows** firstly you need to install MinGW ([64 bit version](http://mingw-w64.org/doku.php/download)). After installing MinGW, do the following steps to add SDL2:
+If you are using **Windows** firstly you need to install MinGW ([64 bit version](https://www.mingw-w64.org/downloads/#msys2)). After installing MinGW, do the following steps to add SDL2:
 
 1. Download the development libraries of SDL.
 Go to [https://www.libsdl.org/download-2.0.php](https://www.libsdl.org/download-2.0.php) and download _Development Libraries: SDL2-devel-2.0.5-mingw.tar.gz_

--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -115,7 +115,7 @@ Along with the basic attributes, widgets can have type specific parameters which
 lv_slider_set_value(slider1, 70, LV_ANIM_ON);
 ```
 
-To see the full API visit the documentation of the widgets or the related header file (e.g. [lvgl/src/widgets/lv_slider.h](https://github.com/lvgl/lvgl/blob/master/src/widgets/lv_slider.h)).
+To see the full API visit the documentation of the widgets or the related header file (e.g. [lvgl/src/widgets/slider/lv_slider.h](https://github.com/lvgl/lvgl/blob/master/src/widgets/slider/lv_slider.h)).
 
 
 

--- a/docs/libs/freetype.md
+++ b/docs/libs/freetype.md
@@ -41,7 +41,7 @@ You can simply pass the path to the font as usual on your operating system or pl
 
 ## Learn more
 - FreeType [tutorial](https://www.freetype.org/freetype2/docs/tutorial/step1.html)
-- LVGL's [font interface](https://docs.lvgl.io/v7/en/html/overview/font.html#add-a-new-font-engine)
+- LVGL's [font interface](https://docs.lvgl.io/master/overview/font.html#add-a-new-font-engine)
 
 
 ## API

--- a/docs/overview/indev.md
+++ b/docs/overview/indev.md
@@ -126,7 +126,7 @@ If an object is focused either by clicking it via touchpad or focused via an enc
 
 If an object switches to edit mode it enters the `LV_STATE_FOCUSED | LV_STATE_EDITED` states so these style properties will be shown.
 
-For a more detailed description read the [Style](https://docs.lvgl.io/v7/en/html/overview/style.html) section.
+For a more detailed description read the [Style](https://docs.lvgl.io/master/overview/style.html) section.
 
 ## API
 

--- a/docs/porting/display.md
+++ b/docs/porting/display.md
@@ -200,7 +200,9 @@ There is a noticeable amount of overhead to performing rotation in software. Har
 
 The default rotation of your display when it is initialized can be set using the `rotated` flag. The available options are `LV_DISP_ROT_NONE`, `LV_DISP_ROT_90`, `LV_DISP_ROT_180`, or `LV_DISP_ROT_270`. The rotation values are relative to how you would rotate the physical display in the clockwise direction. Thus, `LV_DISP_ROT_90` means you rotate the hardware 90 degrees clockwise, and the display rotates 90 degrees counterclockwise to compensate.
 
-(Note for users upgrading from 7.10.0 and older: these new rotation enum values match up with the old 0/1 system for rotating 90 degrees, so legacy code should continue to work as expected. Software rotation is also disabled by default for compatibility.)
+
+```note::  For users upgrading from 7.10.0 and older: these new rotation enum values match up with the old 0/1 system for rotating 90 degrees, so legacy code should continue to work as expected. Software rotation is also disabled by default for compatibility.
+```
 
 Display rotation can also be changed at runtime using the `lv_disp_set_rotation(disp, rot)` API.
 

--- a/docs/porting/display.md
+++ b/docs/porting/display.md
@@ -60,11 +60,11 @@ Therefore the 2 buffers needs to synchronized in `flush_cb` like this:
 1. Display the frame buffer pointed by `color_p`
 2. Copy the redrawn areas from `color_p` to the other buffer.
 
-The get the redrawn areas to copy use the following functions
-`_lv_refr_get_disp_refreshing()` returns the display being refreshed
-`disp->inv_areas[LV_INV_BUF_SIZE]` contains the invalidated areas
-`disp->inv_area_joined[LV_INV_BUF_SIZE]` if 1 that area was joined into another one and should be ignored
-`disp->inv_p` number of valid elements in `inv_areas`
+To get the redrawn areas to copy use the following functions:
+- `_lv_refr_get_disp_refreshing()` returns the display being refreshed
+- `disp->inv_areas[LV_INV_BUF_SIZE]` contains the invalidated areas
+- `disp->inv_area_joined[LV_INV_BUF_SIZE]` if 1 that area was joined into another one and should be ignored
+- `disp->inv_p` number of valid elements in `inv_areas`
 
 ## Display driver
 

--- a/docs/porting/sleep.md
+++ b/docs/porting/sleep.md
@@ -11,7 +11,7 @@ while(1) {
   /*Sleep after 1 sec inactivity*/
   else {
 	  timer_stop();   /*Stop the timer where lv_tick_inc() is called*/
-	  sleep();		    /*Sleep the MCU*/
+	  sleep();        /*Sleep the MCU*/
   }
   my_delay_ms(5);
 }


### PR DESCRIPTION
### Description of the feature or fix

While reading through the documentation, I've noticed some links were not working, and I started to look for other links not working anymore as well. Additionally, I've fixed some small formatting issues. 

### Checkpoints

- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
