### PR TITLE
fix(lv_obj_style): move lv_obj_remove_style_all implementation to c file

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -152,6 +152,11 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
     }
 }
 
+void lv_obj_remove_style_all(struct _lv_obj_t * obj)
+{
+    lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);
+}
+
 void lv_obj_report_style_change(lv_style_t * style)
 {
     if(!style_refr) return;

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -89,10 +89,7 @@ void lv_obj_remove_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_st
  * Remove all styles from an object
  * @param obj       pointer to an object
  */
-static inline void lv_obj_remove_style_all(struct _lv_obj_t * obj)
-{
-    lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);
-}
+void lv_obj_remove_style_all(struct _lv_obj_t * obj);
 
 /**
  * Notify all object if a style is modified


### PR DESCRIPTION
### Description of the feature or fix

The PR fixes #3708.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [] Update the documentation
