### PR TITLE
Fix compiler errors when using -Werror=format

### DIFF
--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -277,7 +277,7 @@ void * lv_mem_buf_get(uint32_t size)
 {
     if(size == 0) return NULL;
 
-    MEM_TRACE("begin, getting %d bytes", size);
+    MEM_TRACE("begin, getting %ld bytes", size);
 
     /*Try to find a free buffer with suitable size*/
     int8_t i_guess = -1;

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -141,7 +141,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
 
     already_running = false; /*Release the mutex*/
 
-    TIMER_TRACE("finished (%d ms until the next timer call)", time_till_next);
+    TIMER_TRACE("finished (%ld ms until the next timer call)", time_till_next);
     return time_till_next;
 }
 


### PR DESCRIPTION
### Description of the feature or fix

Fixes compiler error due when using `-Werror=format` and `LV_USE_LOG`

```
lib/lvgl/src/misc/lv_mem.c:280:15: error: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  280 |     MEM_TRACE("begin, getting %d bytes", size);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                          |
      |                                          uint32_t {aka long unsigned int}
     
```

```
lib/lvgl/src/misc/lv_timer.c:144:17: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  144 |     TIMER_TRACE("finished (%d ms until the next timer call)", time_till_next);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~
      |                                                               |
      |                                                               uint32_t {aka long unsigned **int}**
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
