### PR TITLE
fix(style) prevent overflow in the style count

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -75,6 +75,8 @@ void _lv_obj_style_init(void)
 
 void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
+    LV_ASSERT(obj->style_cnt < 63);
+
     trans_del(obj, selector, LV_STYLE_PROP_ANY, NULL);
 
     uint32_t i;


### PR DESCRIPTION
### Description of the feature or fix

Every time lv_obj_add_style is called on an object it increments style_cnt on that object. Once style_cnt hits 64, it wraps to 0 because 6 bits are allocated for it. In the call to realloc, style_cnt==0 is used in the realloc size calculation and lv_realloc returns the address of code as a sentinel in that case. If the return value from lv_realloc is not checked and data is written to the returned address, then code is stomped. This update adds a quick assert to ensure a fast fail in the event that somebody calls lv_obj_add_style many times (likely already a bug) so that the failure mode is more instant and clear. A further fix would be to audit all lv_realloc (and probably lv_alloc) calls and ensure the data returned is going to cause a fast crash (e.g., return NULL or NULL+1 as a sentinel).

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [n/a] Update the documentation
