### PR TITLE
Run valgrind on tests and fix current issues

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -742,7 +742,7 @@ static void trans_anim_cb(void * _tr, int32_t v)
     for(i = 0; i < obj->style_cnt; i++) {
         if(obj->styles[i].is_trans == 0 || obj->styles[i].selector != tr->selector) continue;
 
-        lv_style_value_t value_final;
+        lv_style_value_t value_final = {0};
         switch(tr->prop) {
 
             case LV_STYLE_BORDER_SIDE:

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -1384,7 +1384,9 @@ static void circ_calc_aa4(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_t radi
         return;
     }
 
-    lv_coord_t * cir_x = lv_malloc((radius + 1) * 2 * 2 * sizeof(lv_coord_t));
+    const size_t cir_xy_size = (radius + 1) * 2 * 2 * sizeof(lv_coord_t);
+    lv_coord_t * cir_x = lv_malloc(cir_xy_size);
+    lv_memset(cir_x, 0, cir_xy_size);
     lv_coord_t * cir_y = &cir_x[(radius + 1) * 2];
 
     uint32_t y_8th_cnt = 0;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -287,6 +287,7 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
         dsc_out->ofs_x = 0;                                           /*X offset of the bitmap in [pf]*/
         dsc_out->ofs_y = 0;                                           /*Y offset of the bitmap in [pf]*/
         dsc_out->bpp = 0;
+        dsc_out->is_placeholder = false;
         return true;
     }
     ttf_font_desc_t * dsc = (ttf_font_desc_t *)font->dsc;

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -313,7 +313,7 @@ void lv_style_transition_dsc_init(lv_style_transition_dsc_t * tr, const lv_style
 
 lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
 {
-    lv_style_value_t value;
+    lv_style_value_t value = {0};
     switch(prop) {
         case LV_STYLE_TRANSFORM_ZOOM:
             value.num = LV_IMG_ZOOM_NONE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -354,8 +354,12 @@ get_filename_component(LVGL_PARENT_DIR ${LVGL_DIR} DIRECTORY)
 target_include_directories(lvgl_examples PUBLIC $<BUILD_INTERFACE:${LVGL_PARENT_DIR}>)
 
 # Generate one test executable for each source file pair.
-# The sources in src/test_runners is auto-generated, the
+# The sources in ${CMAKE_CURRENT_BINARY_DIR} is auto-generated, the
 # sources in src/test_cases is the actual test case.
+find_package(Ruby REQUIRED)
+set(generate_test_runner_rb
+    ${CMAKE_CURRENT_SOURCE_DIR}/unity/generate_test_runner.rb)
+set(generate_test_runner_config ${CMAKE_CURRENT_SOURCE_DIR}/config.yml)
 file( GLOB TEST_CASE_FILES src/test_cases/*.c )
 foreach( test_case_fname ${TEST_CASE_FILES} )
     # If test file is foo/bar/baz.c then test_name is "baz".
@@ -364,7 +368,16 @@ foreach( test_case_fname ${TEST_CASE_FILES} )
         continue()
     endif()
     # Create path to auto-generated source file.
-    set(test_runner_fname src/test_runners/${test_name}_Runner.c)
+    set(test_runner_fname ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_Runner.c)
+    # Run ruby to generate source in build directory
+    add_custom_command(
+        OUTPUT ${test_runner_fname}
+        COMMAND ${Ruby_EXECUTABLE} ${generate_test_runner_rb}
+                ${test_case_fname} ${test_runner_fname}
+                ${generate_test_runner_config}
+        DEPENDS ${generate_test_runner_rb} ${test_case_fname}
+                ${generate_test_runner_config}
+    )
     add_executable( ${test_name}
         ${test_case_fname}
         ${test_runner_fname}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,11 @@ else()
 cmake_minimum_required(VERSION 3.13)
 project(lvgl_tests LANGUAGES C)
 
+find_program(VALGRIND_EXECUTABLE valgrind)
+if (VALGRIND_EXECUTABLE)
+    set(MEMORYCHECK_COMMAND ${VALGRIND_EXECUTABLE})
+    set(MEMORYCHECK_COMMAND_OPTIONS --error-exitcode=1)
+endif()
 include(CTest)
 
 set(LVGL_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -200,7 +205,6 @@ set(LVGL_TEST_OPTIONS_FULL_32BIT
 )
 
 set(LVGL_TEST_OPTIONS_TEST_COMMON
-    --coverage
     -DLV_COLOR_DEPTH=32
     -DLV_MEM_SIZE=2097152
     -DLV_SHADOW_CACHE_SIZE=10240
@@ -252,7 +256,6 @@ set(LVGL_TEST_OPTIONS_TEST_SYSHEAP
     ${LVGL_TEST_OPTIONS_TEST_COMMON}
     -DLVGL_CI_USING_SYS_HEAP
     -DLV_MEM_CUSTOM=1
-    -fsanitize=address
 )
 
 set(LVGL_TEST_OPTIONS_TEST_DEFHEAP
@@ -260,6 +263,7 @@ set(LVGL_TEST_OPTIONS_TEST_DEFHEAP
     -DLVGL_CI_USING_DEF_HEAP
     -DLV_MEM_SIZE=2097152
     -fsanitize=address
+    --coverage
 )
 
 if (OPTIONS_MINIMAL_MONOCHROME)
@@ -273,11 +277,15 @@ elseif (OPTIONS_16BIT_SWAP)
 elseif (OPTIONS_FULL_32BIT)
     set (BUILD_OPTIONS ${LVGL_TEST_OPTIONS_FULL_32BIT})
 elseif (OPTIONS_TEST_SYSHEAP)
-    set (BUILD_OPTIONS ${LVGL_TEST_OPTIONS_TEST_SYSHEAP})
+    set (BUILD_OPTIONS ${LVGL_TEST_OPTIONS_TEST_SYSHEAP} -fsanitize=address --coverage)
     set (TEST_LIBS --coverage -fsanitize=address)
 elseif (OPTIONS_TEST_DEFHEAP)
     set (BUILD_OPTIONS ${LVGL_TEST_OPTIONS_TEST_DEFHEAP})
     set (TEST_LIBS --coverage -fsanitize=address)
+elseif (OPTIONS_TEST_MEMORYCHECK)
+    # sanitizer is disabled because valgrind uses LD_PRELOAD and the
+    # sanitizer lib needs to load first
+    set (BUILD_OPTIONS ${LVGL_TEST_OPTIONS_TEST_SYSHEAP})
 else()
     message(FATAL_ERROR "Must provide a known options value (check main.py?).")
 endif()

--- a/tests/main.py
+++ b/tests/main.py
@@ -2,7 +2,6 @@
 
 import argparse
 import errno
-import glob
 import shutil
 import subprocess
 import sys
@@ -41,22 +40,6 @@ def delete_dir_ignore_missing(dir_path):
         shutil.rmtree(dir_path)
     except FileNotFoundError:
         pass
-
-
-def generate_test_runners():
-    '''Generate the test runner source code.'''
-    global lvgl_test_dir
-    os.chdir(lvgl_test_dir)
-    delete_dir_ignore_missing('src/test_runners')
-    os.mkdir('src/test_runners')
-
-    # TODO: Intermediate files should be in the build folders, not alongside
-    #       the other repo source.
-    for f in glob.glob("./src/test_cases/test_*.c"):
-        r = f[:-2] + "_Runner.c"
-        r = r.replace("/test_cases/", "/test_runners/")
-        subprocess.check_call(['ruby', 'unity/generate_test_runner.rb',
-                               f, r, 'config.yml'])
 
 
 def options_abbrev(options_name):
@@ -189,8 +172,6 @@ if __name__ == "__main__":
         if not is_valid_option_name(opt):
             print('Invalid build option "%s"' % opt, file=sys.stderr)
             sys.exit(errno.EINVAL)
-
-    generate_test_runners()
 
     for options_name in options_to_build:
         is_test = options_name in test_options

--- a/tests/main.py
+++ b/tests/main.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import os
+from itertools import chain
 
 lvgl_test_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -22,10 +23,6 @@ test_options = {
     'OPTIONS_TEST_SYSHEAP': 'Test config, system heap, 32 bit color depth',
     'OPTIONS_TEST_DEFHEAP': 'Test config, LVGL heap, 32 bit color depth',
 }
-
-
-def is_valid_option_name(option_name):
-    return option_name in build_only_options or option_name in test_options
 
 
 def get_option_description(option_name):
@@ -145,6 +142,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Build and/or run LVGL tests.', epilog=epilog)
     parser.add_argument('--build-options', nargs=1,
+                        choices=list(chain(build_only_options, test_options)),
                         help='''the build option name to build or run. When
                         omitted all build configurations are used.
                         ''')
@@ -167,11 +165,6 @@ if __name__ == "__main__":
                 options_to_build = build_only_options
         else:
             options_to_build = test_options
-
-    for opt in options_to_build:
-        if not is_valid_option_name(opt):
-            print('Invalid build option "%s"' % opt, file=sys.stderr)
-            sys.exit(errno.EINVAL)
 
     for options_name in options_to_build:
         is_test = options_name in test_options

--- a/tests/unity/generate_test_runner.rb
+++ b/tests/unity/generate_test_runner.rb
@@ -341,7 +341,7 @@ class UnityTestRunnerGenerator
 
   def create_run_test(output)
     require 'erb'
-    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')), nil, '<>')
+    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')), trim_mode: '<>')
     output.puts("\n" + template.result(binding))
   end
 


### PR DESCRIPTION
### Description of the feature or fix

New test option in the CMakeLists.txt for running the ExperimentalMemCheck target. I decided not to include it in tests/main.py to avoided possible timing issues.
Fixes for a few uninitialized value errors found during local runs. The exact errors are included in the commit messages.
First three commits aren't strictly related. I'm happy to move them to a separate PR if requested.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation