### PR TITLE
chore(examples): fix unused-variable warning

### DIFF
--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_1.c
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_1.c
@@ -8,7 +8,7 @@ static void event_handler(lv_event_t * e)
     if(code == LV_EVENT_VALUE_CHANGED) {
         uint32_t id = lv_btnmatrix_get_selected_btn(obj);
         const char * txt = lv_btnmatrix_get_btn_text(obj, id);
-
+        LV_UNUSED(txt);
         LV_LOG_USER("%s was pressed\n", txt);
     }
 }

--- a/examples/widgets/checkbox/lv_example_checkbox_1.c
+++ b/examples/widgets/checkbox/lv_example_checkbox_1.c
@@ -5,9 +5,12 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_VALUE_CHANGED) {
         const char * txt = lv_checkbox_get_text(obj);
         const char * state = lv_obj_get_state(obj) & LV_STATE_CHECKED ? "Checked" : "Unchecked";
+        LV_UNUSED(txt);
+        LV_UNUSED(state);
         LV_LOG_USER("%s: %s", txt, state);
     }
 }

--- a/examples/widgets/list/lv_example_list_1.c
+++ b/examples/widgets/list/lv_example_list_1.c
@@ -6,6 +6,7 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_CLICKED) {
         LV_LOG_USER("Clicked: %s", lv_list_get_btn_text(list1, obj));
     }

--- a/examples/widgets/msgbox/lv_example_msgbox_1.c
+++ b/examples/widgets/msgbox/lv_example_msgbox_1.c
@@ -4,6 +4,7 @@
 static void event_cb(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_current_target(e);
+    LV_UNUSED(obj);
     LV_LOG_USER("Button %s clicked", lv_msgbox_get_active_btn_text(obj));
 }
 

--- a/examples/widgets/switch/lv_example_switch_1.c
+++ b/examples/widgets/switch/lv_example_switch_1.c
@@ -5,6 +5,7 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_VALUE_CHANGED) {
         LV_LOG_USER("State: %s\n", lv_obj_has_state(obj, LV_STATE_CHECKED) ? "On" : "Off");
     }

--- a/examples/widgets/textarea/lv_example_textarea_1.c
+++ b/examples/widgets/textarea/lv_example_textarea_1.c
@@ -4,6 +4,7 @@
 static void textarea_event_handler(lv_event_t * e)
 {
     lv_obj_t * ta = lv_event_get_target(e);
+    LV_UNUSED(ta);
     LV_LOG_USER("Enter was pressed. The current text is: %s", lv_textarea_get_text(ta));
 }
 

--- a/examples/widgets/win/lv_example_win_1.c
+++ b/examples/widgets/win/lv_example_win_1.c
@@ -5,6 +5,7 @@
 static void event_handler(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target(e);
+    LV_UNUSED(obj);
     LV_LOG_USER("Button %d clicked", (int)lv_obj_get_index(obj));
 }
 


### PR DESCRIPTION
### Description of the feature or fix

`CFLAGS += -Wunused-variable`

`#define LV_USE_LOG 0`

```bash
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/msgbox/lv_example_msgbox_1.c: In function ‘event_cb’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/msgbox/lv_example_msgbox_1.c:6:16: warning: unused variable ‘obj’ [-Wunused-variable]
    6 |     lv_obj_t * obj = lv_event_get_current_target(e);
      |                ^~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/switch/lv_example_switch_1.c: In function ‘event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/switch/lv_example_switch_1.c:7:16: warning: unused variable ‘obj’ [-Wunused-variable]
    7 |     lv_obj_t * obj = lv_event_get_target(e);
      |                ^~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/textarea/lv_example_textarea_1.c: In function ‘textarea_event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/textarea/lv_example_textarea_1.c:6:16: warning: unused variable ‘ta’ [-Wunused-variable]
    6 |     lv_obj_t * ta = lv_event_get_target(e);
      |                ^~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/checkbox/lv_example_checkbox_1.c: In function ‘event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/checkbox/lv_example_checkbox_1.c:10:22: warning: unused variable ‘state’ [-Wunused-variable]
   10 |         const char * state = lv_obj_get_state(obj) & LV_STATE_CHECKED ? "Checked" : "Unchecked";
      |                      ^~~~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/checkbox/lv_example_checkbox_1.c:9:22: warning: unused variable ‘txt’ [-Wunused-variable]
    9 |         const char * txt = lv_checkbox_get_text(obj);
      |                      ^~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/btnmatrix/lv_example_btnmatrix_1.c: In function ‘event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/btnmatrix/lv_example_btnmatrix_1.c:10:22: warning: unused variable ‘txt’ [-Wunused-variable]
   10 |         const char * txt = lv_btnmatrix_get_btn_text(obj, id);
      |                      ^~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/win/lv_example_win_1.c: In function ‘event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/win/lv_example_win_1.c:7:16: warning: unused variable ‘obj’ [-Wunused-variable]
    7 |     lv_obj_t * obj = lv_event_get_target(e);
      |                ^~~
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/list/lv_example_list_1.c: In function ‘event_handler’:
/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/examples/widgets/list/lv_example_list_1.c:8:16: warning: unused variable ‘obj’ [-Wunused-variable]
    8 |     lv_obj_t * obj = lv_event_get_target(e);
```

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
