### PR TITLE
fix(cmake-build): Add missing definition for LVGL conf path

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -29,6 +29,11 @@ target_compile_definitions(
   lvgl PUBLIC $<$<BOOL:${LV_LVGL_H_INCLUDE_SIMPLE}>:LV_LVGL_H_INCLUDE_SIMPLE>
               $<$<BOOL:${LV_CONF_INCLUDE_SIMPLE}>:LV_CONF_INCLUDE_SIMPLE>)
 
+# Add definition of LV_CONF_PATH only if needed
+if(LV_CONF_PATH)
+  target_compile_definitions(lvgl PUBLIC LV_CONF_PATH=${LV_CONF_PATH})
+endif()
+
 # Include root and optional parent path of LV_CONF_PATH
 target_include_directories(lvgl SYSTEM PUBLIC ${LVGL_ROOT_DIR} ${LV_CONF_DIR})
 


### PR DESCRIPTION
### Description of the feature or fix

When using [cmake.custom](https://github.com/lvgl/lvgl/blob/master/env_support/cmake/custom.cmake) file, option `LV_CONF_PATH` is not compiled.  

Example when repository is cloned and try to run cmake with custom LVGL configuration:
```shell
mkdir build
cd build/
cmake "-DLV_CONF_PATH=/home/<user>/Documents/workspaces/custom-lvgl/lvgl_conf.h" ..
cmake --build .
```
Output result:
```shell
[  0%] Building C object CMakeFiles/lvgl.dir/src/core/lv_disp.c.o
In file included from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/../hal/../draw/lv_draw.h:16,
                 from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/../hal/lv_hal_disp.h:21,
                 from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/../hal/lv_hal.h:16,
                 from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/lv_disp.h:16,
                 from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/lv_disp.c:9:
/home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/../hal/../draw/../lv_conf_internal.h:49:17: note: ‘#pragma message: Possible failure to include lv_conf.h, please read the comment in this file if you get errors’
   49 |         #pragma message("Possible failure to include lv_conf.h, please read the comment in this file if you get errors")
      |                 ^~~~~~~
[  0%] Building C object CMakeFiles/lvgl.dir/src/core/lv_event.c.o
In file included from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/lv_obj.h:16,
                 from /home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/lv_event.c:9:
/home/<user>/Documents/workspaces/workspace-vscode/lvgl/src/core/../lv_conf_internal.h:49:17: note: ‘#pragma message: Possible failure to include lv_conf.h, please read the comment in this file if you get errors’
   49 |         #pragma message("Possible failure to include lv_conf.h, please read the comment in this file if you get errors")
      |                 ^~~~~~~
...and so on...
```

This commit fix this behaviour by adding  `LV_CONF_PATH` definition.

### Checkpoints
- [ x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
