### PR TITLE
Fix push to the component registry on tag

### DIFF
--- a/.github/workflows/esp_upload_component.yml
+++ b/.github/workflows/esp_upload_component.yml
@@ -3,21 +3,21 @@ name: Push LVGL release to Espressif Component Service
 # If the commit is tagged, it will be uploaded. Other scenario silently fail.
 on:
   push:
-    branches:
-      - master
+    tags:
+      - v*
 
 jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           submodules: "recursive"
 
       - name: Upload component to component registry
-        uses: espressif/github-actions/upload_components@master
+        uses: espressif/upload-components-ci-action@v1
         with:
           name: "lvgl"
-          version: "git"
+          version: ${{ github.ref_name }}
           namespace: "lvgl"
           api_token: ${{ secrets.ESP_IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
Run `esp_upload_component.yml` only when a tag is pushed. 
A clear and concise description of what the bug or new feature is.

Previously job failed, because `actions/checkout` by default creates a shallow copy and doesn't fetch tags. 
There are 2 ways to fix it:
1. Use the `fetch-depth: '0'` option for checkout action, but this will result in extra work being done on every commit.
2. A leaner solution is to run the workflow only on tags and get tag names from `github.ref_name`  

+ Versions of actions are now fixed, to avoid breaking changes in the future.