### PR TITLE
Improve conversion from ARGB32 to RGB565A8 for Lottie

### DIFF
--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -209,7 +209,8 @@ static void convert_to_rgba5658(uint32_t * pix, const size_t width, const size_t
             uint32_t in = src[x];
             uint16_t r = (uint16_t)(((in & 0xF80000) >> 8) | ((in & 0xFC00) >> 5) | ((in & 0xFF) >> 3));
 
-            lv_memcpy(dest, &r, sizeof(r));
+            dest[0] = (uint8_t)(r & 0xFF);
+            dest[1] = (uint8_t)((r >> 8) & 0xFF);
             dest[sizeof(r)] = (uint8_t)(in >> 24);
             dest += LV_IMG_PX_SIZE_ALPHA_BYTE;
         }


### PR DESCRIPTION
### Description of the feature or fix

Explicitly copy the 2 color bytes (RGB565) to their destination instead of calling the generic lv_memcpy. This reduces the conversion time from ~15.8ms to ~9.5ms on an ESP32-S3.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
