### PR TITLE
fix: Take border side into account in flex and scrolled objects

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -108,9 +108,7 @@ bool lv_obj_refr_size(lv_obj_t * obj)
             /*If parent has content size and the child has pct size
              *a circular dependency will occur. To solve it keep child size at zero */
             if(parent->w_layout == 0 && lv_obj_get_style_width(parent, 0) == LV_SIZE_CONTENT) {
-                lv_coord_t border_w = lv_obj_get_style_border_width(obj, 0);
-                w = lv_obj_get_style_pad_left(obj, 0) + border_w;
-                w += lv_obj_get_style_pad_right(obj, 0) + border_w;
+                w = lv_obj_get_style_space_left(obj, 0) + lv_obj_get_style_space_right(obj, 0);
             }
             else {
                 w = (LV_COORD_GET_PCT(w) * parent_w) / 100;
@@ -142,9 +140,7 @@ bool lv_obj_refr_size(lv_obj_t * obj)
             /*If parent has content size and the child has pct size
              *a circular dependency will occur. To solve it keep child size at zero */
             if(parent->h_layout == 0 && lv_obj_get_style_height(parent, 0) == LV_SIZE_CONTENT) {
-                lv_coord_t border_w = lv_obj_get_style_border_width(obj, 0);
-                h = lv_obj_get_style_pad_top(obj, 0) + border_w;
-                h += lv_obj_get_style_pad_bottom(obj, 0) + border_w;
+                h = lv_obj_get_style_space_top(obj, 0) + lv_obj_get_style_space_bottom(obj, 0);
             }
             else {
                 h = (LV_COORD_GET_PCT(h) * parent_h) / 100;
@@ -351,13 +347,11 @@ void lv_obj_align_to(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align, lv
     lv_coord_t y = 0;
 
     lv_obj_t * parent = lv_obj_get_parent(obj);
-    lv_coord_t pborder = lv_obj_get_style_border_width(parent, LV_PART_MAIN);
-    lv_coord_t pleft = lv_obj_get_style_pad_left(parent, LV_PART_MAIN) + pborder;
-    lv_coord_t ptop = lv_obj_get_style_pad_top(parent, LV_PART_MAIN) + pborder;
+    lv_coord_t pleft = lv_obj_get_style_space_left(parent, LV_PART_MAIN);
+    lv_coord_t ptop = lv_obj_get_style_space_top(parent, LV_PART_MAIN);
 
-    lv_coord_t bborder = lv_obj_get_style_border_width(base, LV_PART_MAIN);
-    lv_coord_t bleft = lv_obj_get_style_pad_left(base, LV_PART_MAIN) + bborder;
-    lv_coord_t btop = lv_obj_get_style_pad_top(base, LV_PART_MAIN) + bborder;
+    lv_coord_t bleft = lv_obj_get_style_space_left(base, LV_PART_MAIN);
+    lv_coord_t btop = lv_obj_get_style_space_top(base, LV_PART_MAIN);
 
     if(align == LV_ALIGN_DEFAULT) {
         if(lv_obj_get_style_base_dir(base, LV_PART_MAIN) == LV_BASE_DIR_RTL) align = LV_ALIGN_TOP_RIGHT;
@@ -496,8 +490,7 @@ lv_coord_t lv_obj_get_x(const lv_obj_t * obj)
     if(parent) {
         rel_x  = obj->coords.x1 - parent->coords.x1;
         rel_x += lv_obj_get_scroll_x(parent);
-        rel_x -= lv_obj_get_style_pad_left(parent, LV_PART_MAIN);
-        rel_x -= lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+        rel_x -= lv_obj_get_style_space_left(parent, LV_PART_MAIN);
     }
     else {
         rel_x = obj->coords.x1;
@@ -521,8 +514,7 @@ lv_coord_t lv_obj_get_y(const lv_obj_t * obj)
     if(parent) {
         rel_y = obj->coords.y1 - parent->coords.y1;
         rel_y += lv_obj_get_scroll_y(parent);
-        rel_y -= lv_obj_get_style_pad_top(parent, LV_PART_MAIN);
-        rel_y -= lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+        rel_y -= lv_obj_get_style_space_top(parent, LV_PART_MAIN);
     }
     else {
         rel_y = obj->coords.y1;
@@ -585,14 +577,12 @@ lv_coord_t lv_obj_get_content_height(const lv_obj_t * obj)
 void lv_obj_get_content_coords(const lv_obj_t * obj, lv_area_t * area)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
 
     lv_obj_get_coords(obj, area);
-    lv_area_increase(area, -border_width, -border_width);
-    area->x1 += lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
-    area->x2 -= lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
-    area->y1 += lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-    area->y2 -= lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
+    area->x1 += lv_obj_get_style_space_left(obj, LV_PART_MAIN);
+    area->x2 -= lv_obj_get_style_space_right(obj, LV_PART_MAIN);
+    area->y1 += lv_obj_get_style_space_top(obj, LV_PART_MAIN);
+    area->y2 -= lv_obj_get_style_space_bottom(obj, LV_PART_MAIN);
 
 }
 
@@ -706,21 +696,17 @@ void lv_obj_move_to(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
     lv_obj_t * parent = obj->parent;
 
     if(parent) {
-        lv_coord_t pad_left = lv_obj_get_style_pad_left(parent, LV_PART_MAIN);
-        lv_coord_t pad_top = lv_obj_get_style_pad_top(parent, LV_PART_MAIN);
-
         if(lv_obj_has_flag(obj, LV_OBJ_FLAG_FLOATING)) {
-            x += pad_left + parent->coords.x1;
-            y += pad_top + parent->coords.y1;
+            x += parent->coords.x1;
+            y += parent->coords.y1;
         }
         else {
-            x += pad_left + parent->coords.x1 - lv_obj_get_scroll_x(parent);
-            y += pad_top + parent->coords.y1 - lv_obj_get_scroll_y(parent);
+            x += parent->coords.x1 - lv_obj_get_scroll_x(parent);
+            y += parent->coords.y1 - lv_obj_get_scroll_y(parent);
         }
 
-        lv_coord_t border_width = lv_obj_get_style_border_width(parent, LV_PART_MAIN);
-        x += border_width;
-        y += border_width;
+        x += lv_obj_get_style_space_left(parent, LV_PART_MAIN);
+        y += lv_obj_get_style_space_top(parent, LV_PART_MAIN);
     }
 
     /*Calculate and set the movement*/
@@ -989,12 +975,11 @@ static lv_coord_t calc_content_width(lv_obj_t * obj)
 {
     lv_obj_scroll_to_x(obj, 0, LV_ANIM_OFF);
 
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
-    lv_coord_t pad_right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN) + border_width;
-    lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;
+    lv_coord_t space_right = lv_obj_get_style_space_right(obj, LV_PART_MAIN);
+    lv_coord_t space_left = lv_obj_get_style_space_left(obj, LV_PART_MAIN);
 
     lv_coord_t self_w;
-    self_w = lv_obj_get_self_width(obj) +  pad_left + pad_right;
+    self_w = lv_obj_get_self_width(obj) + space_left + space_right;
 
     lv_coord_t child_res = LV_COORD_MIN;
     uint32_t i;
@@ -1019,7 +1004,7 @@ static lv_coord_t calc_content_width(lv_obj_t * obj)
                         /* Consider other cases only if x=0 and use the width of the object.
                          * With x!=0 circular dependency could occur. */
                         if(lv_obj_get_style_x(child, 0) == 0) {
-                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + pad_right);
+                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + space_right);
                         }
                 }
             }
@@ -1028,7 +1013,7 @@ static lv_coord_t calc_content_width(lv_obj_t * obj)
             }
         }
         if(child_res != LV_COORD_MIN) {
-            child_res += pad_left;
+            child_res += space_left;
         }
     }
     /*Else find the right most coordinate*/
@@ -1051,7 +1036,7 @@ static lv_coord_t calc_content_width(lv_obj_t * obj)
                         /* Consider other cases only if x=0 and use the width of the object.
                          * With x!=0 circular dependency could occur. */
                         if(lv_obj_get_style_y(child, 0) == 0) {
-                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + pad_left);
+                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + space_left);
                         }
                 }
             }
@@ -1061,7 +1046,7 @@ static lv_coord_t calc_content_width(lv_obj_t * obj)
         }
 
         if(child_res != LV_COORD_MIN) {
-            child_res += pad_right;
+            child_res += space_right;
         }
     }
 
@@ -1073,12 +1058,11 @@ static lv_coord_t calc_content_height(lv_obj_t * obj)
 {
     lv_obj_scroll_to_y(obj, 0, LV_ANIM_OFF);
 
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
-    lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
-    lv_coord_t pad_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN) + border_width;
+    lv_coord_t space_top = lv_obj_get_style_space_top(obj, LV_PART_MAIN);
+    lv_coord_t space_bottom = lv_obj_get_style_space_bottom(obj, LV_PART_MAIN);
 
     lv_coord_t self_h;
-    self_h = lv_obj_get_self_height(obj) + pad_top + pad_bottom;
+    self_h = lv_obj_get_self_height(obj) + space_top + space_bottom;
 
     lv_coord_t child_res = LV_COORD_MIN;
     uint32_t i;
@@ -1102,7 +1086,7 @@ static lv_coord_t calc_content_height(lv_obj_t * obj)
                     /* Consider other cases only if y=0 and use the height of the object.
                      * With y!=0 circular dependency could occur. */
                     if(lv_obj_get_style_y(child, 0) == 0) {
-                        child_res = LV_MAX(child_res, lv_area_get_height(&child->coords) + pad_top);
+                        child_res = LV_MAX(child_res, lv_area_get_height(&child->coords) + space_top);
                     }
                     break;
             }
@@ -1113,7 +1097,7 @@ static lv_coord_t calc_content_height(lv_obj_t * obj)
     }
 
     if(child_res != LV_COORD_MIN) {
-        child_res += pad_bottom;
+        child_res += space_bottom;
         return LV_MAX(child_res, self_h);
     }
     else {

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -144,16 +144,15 @@ lv_coord_t lv_obj_get_scroll_bottom(lv_obj_t * obj)
         child_res = LV_MAX(child_res, child->coords.y2);
     }
 
-    lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-    lv_coord_t pad_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t space_top = lv_obj_get_style_space_top(obj, LV_PART_MAIN);
+    lv_coord_t space_bottom = lv_obj_get_style_space_bottom(obj, LV_PART_MAIN);
 
     if(child_res != LV_COORD_MIN) {
-        child_res -= (obj->coords.y2 - pad_bottom - border_width);
+        child_res -= (obj->coords.y2 - space_bottom);
     }
 
     lv_coord_t self_h = lv_obj_get_self_height(obj);
-    self_h = self_h - (lv_obj_get_height(obj) - pad_top - pad_bottom - 2 * border_width);
+    self_h = self_h - (lv_obj_get_height(obj) - space_top - space_bottom);
     self_h -= lv_obj_get_scroll_y(obj);
     return LV_MAX(child_res, self_h);
 }
@@ -170,9 +169,8 @@ lv_coord_t lv_obj_get_scroll_left(lv_obj_t * obj)
     }
 
     /*With RTL base direction scrolling the left is normal so find the left most coordinate*/
-    lv_coord_t pad_right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
-    lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t space_right = lv_obj_get_style_space_right(obj, LV_PART_MAIN);
+    lv_coord_t space_left = lv_obj_get_style_space_left(obj, LV_PART_MAIN);
 
     lv_coord_t child_res = 0;
 
@@ -188,14 +186,14 @@ lv_coord_t lv_obj_get_scroll_left(lv_obj_t * obj)
 
     if(x1 != LV_COORD_MAX) {
         child_res = x1;
-        child_res = (obj->coords.x1 + pad_left + border_width) - child_res;
+        child_res = (obj->coords.x1 + space_left) - child_res;
     }
     else {
         child_res = LV_COORD_MIN;
     }
 
     lv_coord_t self_w = lv_obj_get_self_width(obj);
-    self_w = self_w - (lv_obj_get_width(obj) - pad_right - pad_left - 2 * border_width);
+    self_w = self_w - (lv_obj_get_width(obj) - space_right - space_left);
     self_w += lv_obj_get_scroll_x(obj);
 
     return LV_MAX(child_res, self_w);
@@ -222,17 +220,16 @@ lv_coord_t lv_obj_get_scroll_right(lv_obj_t * obj)
         child_res = LV_MAX(child_res, child->coords.x2);
     }
 
-    lv_coord_t pad_right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
-    lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
-    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t space_right = lv_obj_get_style_space_right(obj, LV_PART_MAIN);
+    lv_coord_t space_left = lv_obj_get_style_space_left(obj, LV_PART_MAIN);
 
     if(child_res != LV_COORD_MIN) {
-        child_res -= (obj->coords.x2 - pad_right - border_width);
+        child_res -= (obj->coords.x2 - space_right);
     }
 
     lv_coord_t self_w;
     self_w = lv_obj_get_self_width(obj);
-    self_w = self_w - (lv_obj_get_width(obj) - pad_right - pad_left - 2 * border_width);
+    self_w = self_w - (lv_obj_get_width(obj) - space_right - space_left);
     self_w -= lv_obj_get_scroll_x(obj);
     return LV_MAX(child_res, self_w);
 }
@@ -700,12 +697,11 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
     if(snap_y != LV_SCROLL_SNAP_NONE) area_tmp = &child->coords;
     else area_tmp = area;
 
-    lv_coord_t border_width = lv_obj_get_style_border_width(parent, LV_PART_MAIN);
-    lv_coord_t ptop = lv_obj_get_style_pad_top(parent, LV_PART_MAIN) + border_width;
-    lv_coord_t pbottom = lv_obj_get_style_pad_bottom(parent, LV_PART_MAIN) + border_width;
-    lv_coord_t top_diff = parent->coords.y1 + ptop - area_tmp->y1 - scroll_value->y;
-    lv_coord_t bottom_diff = -(parent->coords.y2 - pbottom - area_tmp->y2 - scroll_value->y);
-    lv_coord_t parent_h = lv_obj_get_height(parent) - ptop - pbottom;
+    lv_coord_t stop = lv_obj_get_style_space_top(parent, LV_PART_MAIN);
+    lv_coord_t sbottom = lv_obj_get_style_space_bottom(parent, LV_PART_MAIN);
+    lv_coord_t top_diff = parent->coords.y1 + stop - area_tmp->y1 - scroll_value->y;
+    lv_coord_t bottom_diff = -(parent->coords.y2 - sbottom - area_tmp->y2 - scroll_value->y);
+    lv_coord_t parent_h = lv_obj_get_height(parent) - stop - sbottom;
     if((top_diff >= 0 && bottom_diff >= 0)) y_scroll = 0;
     else if(top_diff > 0) {
         y_scroll = top_diff;
@@ -722,17 +718,17 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
 
     switch(snap_y) {
         case LV_SCROLL_SNAP_START:
-            snap_goal = parent->coords.y1 + ptop;
+            snap_goal = parent->coords.y1 + stop;
             act = area_tmp->y1 + y_scroll;
             y_scroll += snap_goal - act;
             break;
         case LV_SCROLL_SNAP_END:
-            snap_goal = parent->coords.y2 - pbottom;
+            snap_goal = parent->coords.y2 - sbottom;
             act = area_tmp->y2 + y_scroll;
             y_scroll += snap_goal - act;
             break;
         case LV_SCROLL_SNAP_CENTER:
-            snap_goal = parent->coords.y1 + ptop + parent_h / 2;
+            snap_goal = parent->coords.y1 + stop + parent_h / 2;
             act = lv_area_get_height(area_tmp) / 2 + area_tmp->y1 + y_scroll;
             y_scroll += snap_goal - act;
             break;
@@ -743,10 +739,10 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
     if(snap_x != LV_SCROLL_SNAP_NONE) area_tmp = &child->coords;
     else area_tmp = area;
 
-    lv_coord_t pleft = lv_obj_get_style_pad_left(parent, LV_PART_MAIN) + border_width;
-    lv_coord_t pright = lv_obj_get_style_pad_right(parent, LV_PART_MAIN) + border_width;
-    lv_coord_t left_diff = parent->coords.x1 + pleft - area_tmp->x1 - scroll_value->x;
-    lv_coord_t right_diff = -(parent->coords.x2 - pright - area_tmp->x2 - scroll_value->x);
+    lv_coord_t sleft = lv_obj_get_style_space_left(parent, LV_PART_MAIN);
+    lv_coord_t sright = lv_obj_get_style_space_right(parent, LV_PART_MAIN);
+    lv_coord_t left_diff = parent->coords.x1 + sleft - area_tmp->x1 - scroll_value->x;
+    lv_coord_t right_diff = -(parent->coords.x2 - sright - area_tmp->x2 - scroll_value->x);
     if((left_diff >= 0 && right_diff >= 0)) x_scroll = 0;
     else if(left_diff > 0) {
         x_scroll = left_diff;
@@ -761,20 +757,20 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
         if(sr + x_scroll < 0) x_scroll = 0;
     }
 
-    lv_coord_t parent_w = lv_obj_get_width(parent) - pleft - pright;
+    lv_coord_t parent_w = lv_obj_get_width(parent) - sleft - sright;
     switch(snap_x) {
         case LV_SCROLL_SNAP_START:
-            snap_goal = parent->coords.x1 + pleft;
+            snap_goal = parent->coords.x1 + sleft;
             act = area_tmp->x1 + x_scroll;
             x_scroll += snap_goal - act;
             break;
         case LV_SCROLL_SNAP_END:
-            snap_goal = parent->coords.x2 - pright;
+            snap_goal = parent->coords.x2 - sright;
             act = area_tmp->x2 + x_scroll;
             x_scroll += snap_goal - act;
             break;
         case LV_SCROLL_SNAP_CENTER:
-            snap_goal = parent->coords.x1 + pleft + parent_w / 2;
+            snap_goal = parent->coords.x1 + sleft + parent_w / 2;
             act = lv_area_get_width(area_tmp) / 2 + area_tmp->x1 + x_scroll;
             x_scroll += snap_goal - act;
             break;

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -230,11 +230,10 @@ static void flex_update(lv_obj_t * cont, void * user_data)
     lv_coord_t item_gap = f.row ? lv_obj_get_style_pad_column(cont, LV_PART_MAIN) : lv_obj_get_style_pad_row(cont,
                                                                                                              LV_PART_MAIN);
     lv_coord_t max_main_size = (f.row ? lv_obj_get_content_width(cont) : lv_obj_get_content_height(cont));
-    lv_coord_t border_width = lv_obj_get_style_border_width(cont, LV_PART_MAIN);
-    lv_coord_t abs_y = cont->coords.y1 + lv_obj_get_style_pad_top(cont,
-                                                                  LV_PART_MAIN) + border_width - lv_obj_get_scroll_y(cont);
-    lv_coord_t abs_x = cont->coords.x1 + lv_obj_get_style_pad_left(cont,
-                                                                   LV_PART_MAIN) + border_width - lv_obj_get_scroll_x(cont);
+    lv_coord_t abs_y = cont->coords.y1 + lv_obj_get_style_space_top(cont,
+                                                                    LV_PART_MAIN) - lv_obj_get_scroll_y(cont);
+    lv_coord_t abs_x = cont->coords.x1 + lv_obj_get_style_space_left(cont,
+                                                                     LV_PART_MAIN) - lv_obj_get_scroll_x(cont);
 
     lv_flex_align_t track_cross_place = f.track_place;
     lv_coord_t * cross_pos = (f.row ? &abs_y : &abs_x);


### PR DESCRIPTION
### Description of the feature or fix

This fixes an issue similar to #3721 that I found in flex / scrolled objects. The root cause was that the borer side wasn't taken into account. With the new utility functions added in #3721 this luckily was easy to fix. I did fix a few similar cases along the way. Let me know if you'd want me to take these out.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
