### PR TITLE
test(cmake): capitalize Ruby_EXECUTABLE variable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -380,7 +380,7 @@ foreach( test_case_fname ${TEST_CASE_FILES} )
     # Run ruby to generate source in build directory
     add_custom_command(
         OUTPUT ${test_runner_fname}
-        COMMAND ${Ruby_EXECUTABLE} ${generate_test_runner_rb}
+        COMMAND ${RUBY_EXECUTABLE} ${generate_test_runner_rb}
                 ${test_case_fname} ${test_runner_fname}
                 ${generate_test_runner_config}
         DEPENDS ${generate_test_runner_rb} ${test_case_fname}


### PR DESCRIPTION
The variable name was changed in CMake version 3.18. Before that only RUBY_EXECUTABLE is set. Since 3.13 is required by the project the capital name must be used.

Fixes issue found during #2337.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
