### PR TITLE
fix(mem): add missing stdio.h and string.h include

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -57,6 +57,8 @@
 #endif  /*LV_USE_BUILTIN_SNPRINTF*/
 
 #define LV_STDLIB_INCLUDE <stdint.h>
+#define LV_STDIO_INCLUDE  <stdint.h>
+#define LV_STRING_INCLUDE <stdint.h>
 #define LV_MALLOC       lv_malloc_builtin
 #define LV_REALLOC      lv_realloc_builtin
 #define LV_FREE         lv_free_builtin

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -173,6 +173,20 @@
         #define LV_STDLIB_INCLUDE <stdint.h>
     #endif
 #endif
+#ifndef LV_STDIO_INCLUDE
+    #ifdef CONFIG_LV_STDIO_INCLUDE
+        #define LV_STDIO_INCLUDE CONFIG_LV_STDIO_INCLUDE
+    #else
+        #define LV_STDIO_INCLUDE  <stdint.h>
+    #endif
+#endif
+#ifndef LV_STRING_INCLUDE
+    #ifdef CONFIG_LV_STRING_INCLUDE
+        #define LV_STRING_INCLUDE CONFIG_LV_STRING_INCLUDE
+    #else
+        #define LV_STRING_INCLUDE <stdint.h>
+    #endif
+#endif
 #ifndef LV_MALLOC
     #ifdef CONFIG_LV_MALLOC
         #define LV_MALLOC CONFIG_LV_MALLOC

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -12,6 +12,8 @@
 #include "lv_assert.h"
 #include "lv_log.h"
 #include LV_STDLIB_INCLUDE
+#include LV_STRING_INCLUDE
+
 #if LV_USE_BUILTIN_MALLOC
     #include "lv_malloc_builtin.h"
 #endif
@@ -147,9 +149,9 @@ size_t lv_strlen(const char * str)
     return LV_STRLEN(str);
 }
 
-size_t lv_strncpy(char * dst, size_t dest_size, const char * src)
+char * lv_strncpy(char * dst, const char * src, size_t dest_size)
 {
-    return LV_STRNCPY(dst, dest_size, src);
+    return LV_STRNCPY(dst, src, dest_size);
 }
 
 lv_res_t lv_mem_test(void)

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -86,9 +86,7 @@ static inline void lv_memzero(void * dst, size_t len)
 
 size_t lv_strlen(const char * str);
 
-size_t lv_strncpy(char * dst, size_t dest_size, const char * src);
-
-
+char * lv_strncpy(char * dst, const char * src, size_t dest_size);
 
 /**
  *

--- a/src/misc/lv_memcpy_builtin.c
+++ b/src/misc/lv_memcpy_builtin.c
@@ -158,14 +158,14 @@ size_t lv_strlen_builtin(const char * str)
     return i + 1;
 }
 
-size_t lv_strncpy_builtin(char * dst, size_t dest_size, const char * src)
+char * lv_strncpy_builtin(char * dst, const char * src, size_t dest_size)
 {
     size_t i;
     for(i = 0; i < dest_size - 1 && *src; i++) {
         dst[i] = src[i];
     }
     dst[i] = '\0';
-    return i;
+    return dst;
 }
 
 /**********************

--- a/src/misc/lv_memcpy_builtin.h
+++ b/src/misc/lv_memcpy_builtin.h
@@ -46,7 +46,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset_builtin(void * dst, uint8_t v, size_t len);
 
 size_t lv_strlen_builtin(const char * str);
 
-size_t lv_strncpy_builtin(char * dst, size_t dest_size, const char * src);
+char * lv_strncpy_builtin(char * dst, const char * src, size_t dest_size);
 
 /**********************
  *      MACROS

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -61,6 +61,7 @@ extern "C" {
 #endif
 
 #include "../lv_conf_internal.h"
+#include LV_STDIO_INCLUDE
 #include <stdarg.h>
 #include <stddef.h>
 


### PR DESCRIPTION
### Description of the feature or fix

1. Add missing stdio.h and string.h include.
2. Fix wrong implementation of `lv_strncpy_builtin()`, see: https://cplusplus.com/reference/cstring/strncpy.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
