### PR TITLE
fix(examples): fix invalid include for unistd.h in file_explorer example

### DIFF
--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -1,10 +1,10 @@
 
 #include "../../lv_examples.h"
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
+
+#include <stdlib.h>
+#include <string.h>
 
 static void file_explorer_event_handler(lv_event_t * e)
 {

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -1,10 +1,10 @@
 
 #include "../../lv_examples.h"
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
+
+#include <stdlib.h>
+#include <string.h>
 
 static void file_explorer_event_handler(lv_event_t * e)
 {

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -1,11 +1,10 @@
 
 #include "../../lv_examples.h"
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 
 #if LV_USE_TABLE && LV_USE_FILE_EXPLORER && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
 
+#include <stdlib.h>
+#include <string.h>
 
 static void exch_table_item(lv_obj_t * tb, int16_t i, int16_t j)
 {


### PR DESCRIPTION
### Description of the feature or fix

Include `unistd.h` will cause compilation errors on Windows platforms due to missing files.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
