### PR TITLE
fix(Kconfig): remove the maximum limit on LV_MEM_SIZE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -62,7 +62,6 @@ menu "LVGL configuration"
 
 		config LV_MEM_SIZE_KILOBYTES
 			int "Size of the memory used by `lv_mem_alloc` in kilobytes (>= 2kB)"
-			range 2 128
 			default 32
 			depends on !LV_MEM_CUSTOM
 

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -38,6 +38,10 @@ extern "C" {
  *******************/
 
 #ifdef CONFIG_LV_MEM_SIZE_KILOBYTES
+#  if(CONFIG_LV_MEM_SIZE_KILOBYTES < 2)
+#    error "LV_MEM_SIZE >= 2kB is required"
+#  endif
+
 #  define CONFIG_LV_MEM_SIZE (CONFIG_LV_MEM_SIZE_KILOBYTES * 1024U)
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

Kconfig should not limit the memory pool maximum.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
