### PR TITLE
fix(benchmark): add missing LV_USE_DEMO_BENCHMARK

### DIFF
--- a/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c
@@ -1,5 +1,7 @@
 #include "../../../lvgl.h"
 
+#if LV_USE_DEMO_BENCHMARK
+
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN
 #endif
@@ -222,3 +224,5 @@ const lv_img_dsc_t img_benchmark_cogwheel_rgb565a8 = {
   .data_size = 30000,
   .data = img_benchmark_cogwheel_rgb565a8_map,
 };
+
+#endif


### PR DESCRIPTION
### Description of the feature or fix

The demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c missing LV_USE_DEMO_BENCHMARK check.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
