### PR TITLE
docs(intro) Fix HTML escaped characters in code

### DIFF
--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -170,9 +170,9 @@ Probably there a bug in your display driver. Try the following code without usin
 lv_color_t buf[BUF_W * BUF_H];
 lv_color_t * buf_p = buf;
 uint16_t x, y;
-for(y = 0; y &lt; BUF_H; y++) {
+for(y = 0; y < BUF_H; y++) {
     lv_color_t c = lv_color_mix(LV_COLOR_BLUE, LV_COLOR_RED, (y * 255) / BUF_H);
-    for(x = 0; x &lt; BUF_W; x++){
+    for(x = 0; x < BUF_W; x++){
         (*buf_p) =  c;
         buf_p++;
     }


### PR DESCRIPTION
### Description of the feature or fix

Fixed some "<" characters that got HTML escaped to "&lt".

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
