### PR TITLE
feat(theme):add ability to inhrit theme from base class

### DIFF
--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -41,6 +41,11 @@ typedef enum {
     LV_OBJ_CLASS_GROUP_DEF_FALSE,
 } lv_obj_class_group_def_t;
 
+typedef enum {
+    LV_OBJ_CLASS_THEME_INHERITABLE_FALSE,    /**< Do not inherit theme from base class. */
+    LV_OBJ_CLASS_THEME_INHERITABLE_TRUE,
+} lv_obj_class_theme_inheritable_t;
+
 typedef void (*lv_obj_class_event_cb_t)(struct _lv_obj_class_t * class_p, struct _lv_event_t * e);
 /**
  * Describe the common methods of every object.
@@ -60,6 +65,7 @@ typedef struct _lv_obj_class_t {
     uint32_t editable : 2;             /**< Value from ::lv_obj_class_editable_t*/
     uint32_t group_def : 2;            /**< Value from ::lv_obj_class_group_def_t*/
     uint32_t instance_size : 16;
+    uint32_t theme_inheritable : 1;    /**< Value from ::lv_obj_class_theme_inheritable_t*/
 } lv_obj_class_t;
 
 /**********************

--- a/src/core/lv_theme.c
+++ b/src/core/lv_theme.c
@@ -20,6 +20,7 @@
  *  STATIC PROTOTYPES
  **********************/
 static void apply_theme(lv_theme_t * th, lv_obj_t * obj);
+static void apply_theme_recursion(lv_theme_t * th, lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -51,7 +52,7 @@ void lv_theme_apply(lv_obj_t * obj)
 
     lv_obj_remove_style_all(obj);
 
-    apply_theme(th, obj);    /*Apply the theme including the base theme(s)*/
+    apply_theme_recursion(th, obj);    /*Apply the theme including the base theme(s)*/
 }
 
 /**
@@ -115,4 +116,22 @@ static void apply_theme(lv_theme_t * th, lv_obj_t * obj)
 {
     if(th->parent) apply_theme(th->parent, obj);
     if(th->apply_cb) th->apply_cb(th, obj);
+}
+
+static void apply_theme_recursion(lv_theme_t * th, lv_obj_t * obj)
+{
+    const lv_obj_class_t * original_class_p = obj->class_p;
+
+    if(obj->class_p->base_class && obj->class_p->theme_inheritable == LV_OBJ_CLASS_THEME_INHERITABLE_TRUE) {
+        /*Apply the base class theme in obj*/
+        obj->class_p = obj->class_p->base_class;
+
+        /*apply the base first*/
+        apply_theme_recursion(th, obj);
+    }
+
+    /*Restore the original class*/
+    obj->class_p = original_class_p;
+
+    apply_theme(th, obj);
 }


### PR DESCRIPTION
Signed-off-by: wangxuedong <wangxuedong@xiaomi.com>

### Description of the feature or fix

Add a flag in lv_obj_class_t to enable the ability that inherit theme from base class. If we define a class like lv_btn_test_class which  its base class is lv_btn_class and we enable the theme_inheritable flag, we can apply all lv_btn's theme in lv_btn_test.
```C
const lv_obj_class_t lv_btn_class  = {
    .constructor_cb = lv_btn_constructor,
    .width_def = LV_SIZE_CONTENT,
    .height_def = LV_SIZE_CONTENT,
    .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE,
    .instance_size = sizeof(lv_btn_t),
    .base_class = &lv_obj_class
};

const lv_obj_class_t lv_btn_test_class  = {
    .constructor_cb = lv_btn_constructor,
    .theme_inheritable = LV_OBJ_CLASS_THEME_INHERITABLE_TRUE,
    .base_class = &lv_btn_class
};
```

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used.
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed: 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
