### PR TITLE
feat(animimg): add getters for properties: duration and repeat count

### DIFF
--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -328,6 +328,26 @@ static inline uint32_t lv_anim_get_delay(lv_anim_t * a)
 uint32_t lv_anim_get_playtime(lv_anim_t * a);
 
 /**
+ * Get the duration of an animation
+ * @param a         pointer to an initialized `lv_anim_t` variable
+ * @return the duration of the animation in milliseconds
+ */
+static inline uint32_t lv_anim_get_time(lv_anim_t * a)
+{
+    return a->time;
+}
+
+/**
+ * Get the repeat count of the animation.
+ * @param a         pointer to an initialized `lv_anim_t` variable
+ * @return the repeat count or `LV_ANIM_REPEAT_INFINITE` for infinite repetition. 0: disabled repetition.
+ */
+static inline uint16_t lv_anim_get_repeat_count(lv_anim_t * a)
+{
+    return a->repeat_cnt;
+}
+
+/**
  * Get the user_data field of the animation
  * @param   a pointer to an initialized `lv_anim_t` variable
  * @return  the pointer to the custom user_data of the animation

--- a/src/widgets/animimg/lv_animimg.c
+++ b/src/widgets/animimg/lv_animimg.c
@@ -103,6 +103,34 @@ void lv_animimg_set_repeat_count(lv_obj_t * obj, uint16_t count)
  * Getter functions
  *====================*/
 
+lv_img_dsc_t ** lv_animimg_get_src(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return animimg->dsc;
+}
+
+uint8_t lv_animimg_get_src_count(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return animimg->pic_count;
+}
+
+uint32_t lv_animimg_get_duration(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return lv_anim_get_time(&animimg->anim);
+}
+
+uint16_t lv_animimg_get_repeat_count(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return lv_anim_get_repeat_count(&animimg->anim);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/widgets/animimg/lv_animimg.h
+++ b/src/widgets/animimg/lv_animimg.h
@@ -84,7 +84,7 @@ void lv_animimg_start(lv_obj_t * obj);
 void lv_animimg_set_duration(lv_obj_t * img, uint32_t duration);
 
 /**
- * Set the image animation reapeatly play times.
+ * Set the image animation repeatly play times.
  * @param img pointer to an animation image object
  * @param count the number of times to repeat the animation
  */
@@ -93,6 +93,34 @@ void lv_animimg_set_repeat_count(lv_obj_t * img, uint16_t count);
 /*=====================
  * Getter functions
  *====================*/
+
+/**
+ * Get the image animation images source.
+ * @param img pointer to an animation image object
+ * @return a pointer that will point to a series images
+ */
+lv_img_dsc_t ** lv_animimg_get_src(lv_obj_t * img);
+
+/**
+ * Get the image animation images source.
+ * @param img pointer to an animation image object
+ * @return the number of source images
+ */
+uint8_t lv_animimg_get_src_count(lv_obj_t * img);
+
+/**
+ * Get the image animation duration time. unit:ms
+ * @param img pointer to an animation image object
+ * @return the animation duration time
+ */
+uint32_t lv_animimg_get_duration(lv_obj_t * img);
+
+/**
+ * Get the image animation repeat play times.
+ * @param img pointer to an animation image object
+ * @return the repeat count
+ */
+uint16_t lv_animimg_get_repeat_count(lv_obj_t * img);
 
 #endif /*LV_USE_ANIMIMG*/
 


### PR DESCRIPTION
Add missing getters for properties duration and repeat count in widget animimg

This addition will improve the way unit tests (provided later in PR #3723) can be written (without messing with underlying implementation details) 