### PR TITLE
fix(printf): fix built-in snprintf cannot be disabled

### DIFF
--- a/src/misc/lv_printf.c
+++ b/src/misc/lv_printf.c
@@ -33,6 +33,9 @@
 /*Original repository: https://github.com/mpaland/printf*/
 
 #include "lv_printf.h"
+
+#if LV_USE_BUILTIN_SNPRINTF
+
 #include <stdbool.h>
 
 #define PRINTF_DISABLE_SUPPORT_FLOAT    (!LV_SPRINTF_USE_FLOAT)
@@ -872,3 +875,5 @@ int lv_vsnprintf_builtin(char * buffer, size_t count, const char * format, va_li
 {
     return _vsnprintf(_out_buffer, buffer, count, format, va);
 }
+
+#endif /*LV_USE_BUILTIN_SNPRINTF*/

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -62,9 +62,14 @@ extern "C" {
 
 #include "../lv_conf_internal.h"
 #include LV_STDIO_INCLUDE
+
+#define lv_snprintf LV_SNPRINTF
+#define lv_vsnprintf LV_VSNPRINTF
+
+#if LV_USE_BUILTIN_SNPRINTF
+
 #include <stdarg.h>
 #include <stddef.h>
-
 #include "lv_types.h"
 
 typedef struct {
@@ -75,9 +80,7 @@ typedef struct {
 int lv_snprintf_builtin(char * buffer, size_t count, const char * format, ...);
 int lv_vsnprintf_builtin(char * buffer, size_t count, const char * format, va_list va);
 
-#define lv_snprintf LV_SNPRINTF
-#define lv_vsnprintf LV_VSNPRINTF
-
+#endif /*LV_USE_BUILTIN_SNPRINTF*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -502,11 +502,11 @@ static void browser_file_event_handler(lv_event_t * e)
             strip_ext(explorer->current_path);
             /*Remove the last '/' character*/
             strip_ext(explorer->current_path);
-            lv_snprintf_builtin((char *)file_name, sizeof(file_name), "%s", explorer->current_path);
+            lv_snprintf((char *)file_name, sizeof(file_name), "%s", explorer->current_path);
         }
         else {
             if(strcmp(str_fn, "..") != 0) {
-                lv_snprintf_builtin((char *)file_name, sizeof(file_name), "%s%s", explorer->current_path, str_fn);
+                lv_snprintf((char *)file_name, sizeof(file_name), "%s%s", explorer->current_path, str_fn);
             }
         }
 


### PR DESCRIPTION
### Description of the feature or fix

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used.
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed: 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
