### PR TITLE
Update esp.cmake to add demos and examples in v8.3

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -12,22 +12,40 @@ if(LV_MICROPYTHON)
     ${LVGL_ROOT_DIR}/../
     REQUIRES
     main)
-
-  target_compile_definitions(${COMPONENT_LIB}
-                             INTERFACE "-DLV_CONF_INCLUDE_SIMPLE")
-
-  if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
-    target_compile_definitions(${COMPONENT_LIB}
-                               INTERFACE "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
-  endif()
 else()
-  idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS ${LVGL_ROOT_DIR}
-                         ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../)
-
-  target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
-
-  if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
-    target_compile_definitions(${COMPONENT_LIB}
-                               PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
+  if(CONFIG_LV_BUILD_EXAMPLES)
+    file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
   endif()
+
+  if(CONFIG_LV_USE_DEMO_WIDGETS)
+    file(GLOB_RECURSE DEMO_WIDGETS_SOURCES ${LVGL_ROOT_DIR}/demos/widgets/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_WIDGETS_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER)
+    file(GLOB_RECURSE DEMO_KEYPAD_AND_ENCODER_SOURCES ${LVGL_ROOT_DIR}/demos/keypad_encoder/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_KEYPAD_AND_ENCODER_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_BENCHMARK)
+    file(GLOB_RECURSE DEMO_BENCHMARK_SOURCES ${LVGL_ROOT_DIR}/demos/benchmark/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_BENCHMARK_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_STRESS)
+    file(GLOB_RECURSE DEMO_STRESS_SOURCES ${LVGL_ROOT_DIR}/demos/stress/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_STRESS_SOURCES})
+  endif()
+  if(CONFIG_LV_USE_DEMO_MUSIC)
+    file(GLOB_RECURSE DEMO_MUSIC_SOURCES ${LVGL_ROOT_DIR}/demos/music/*.c)
+    list(APPEND DEMO_SOURCES ${DEMO_MUSIC_SOURCES})
+  endif()
+
+  idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
+      INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../
+                   ${LVGL_ROOT_DIR}/examples ${LVGL_ROOT_DIR}/demos)
+endif()
+
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")
+
+if(CONFIG_LV_ATTRIBUTE_FAST_MEM_USE_IRAM)
+  target_compile_definitions(${COMPONENT_LIB}
+                             PUBLIC "-DLV_ATTRIBUTE_FAST_MEM=IRAM_ATTR")
 endif()


### PR DESCRIPTION
With these changes, demos and examples source code is added to esp build system when enabled.