### PR TITLE
chore(log): remove unnecessary prefixes in LV_LOG_XXX

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -93,7 +93,7 @@ lv_obj_t * lv_disp_get_layer_top(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) {
-        LV_LOG_WARN("lv_layer_top: no display registered to get its top layer");
+        LV_LOG_WARN("no display registered to get its top layer");
         return NULL;
     }
 
@@ -110,7 +110,7 @@ lv_obj_t * lv_disp_get_layer_sys(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) {
-        LV_LOG_WARN("lv_layer_sys: no display registered to get its sys. layer");
+        LV_LOG_WARN("no display registered to get its sys layer");
         return NULL;
     }
 
@@ -403,7 +403,7 @@ void lv_disp_trig_activity(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) {
-        LV_LOG_WARN("lv_disp_trig_activity: no display registered");
+        LV_LOG_WARN("no display registered");
         return;
     }
 
@@ -418,7 +418,7 @@ void lv_disp_clean_dcache(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) {
-        LV_LOG_WARN("lv_disp_clean_dcache: no display registered");
+        LV_LOG_WARN("no display registered");
         return;
     }
 
@@ -468,7 +468,7 @@ lv_timer_t * _lv_disp_get_refr_timer(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) {
-        LV_LOG_WARN("lv_disp_get_refr_timer: no display registered");
+        LV_LOG_WARN("no display registered");
         return NULL;
     }
 

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -209,7 +209,7 @@ lv_img_src_t lv_img_src_get_type(const void * src)
     }
 
     if(LV_IMG_SRC_UNKNOWN == img_src_type) {
-        LV_LOG_WARN("lv_img_src_get_type: unknown image type");
+        LV_LOG_WARN("unknown image type");
     }
 
     return img_src_type;

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -87,7 +87,7 @@ int16_t lv_draw_mask_add(void * param, void * custom_id)
     }
 
     if(i >= _LV_MASK_MAX_NUM) {
-        LV_LOG_WARN("lv_mask_add: no place to add the mask");
+        LV_LOG_WARN("no place to add the mask");
         return LV_MASK_ID_INV;
     }
 

--- a/src/draw/lv_img_buf.c
+++ b/src/draw/lv_img_buf.c
@@ -310,7 +310,7 @@ void lv_img_buf_set_palette(lv_img_dsc_t * dsc, uint8_t id, lv_color_t c)
 {
     if((dsc->header.cf == LV_IMG_CF_ALPHA_1BIT && id > 1) || (dsc->header.cf == LV_IMG_CF_ALPHA_2BIT && id > 3) ||
        (dsc->header.cf == LV_IMG_CF_ALPHA_4BIT && id > 15) || (dsc->header.cf == LV_IMG_CF_ALPHA_8BIT)) {
-        LV_LOG_WARN("lv_img_buf_set_px_alpha: invalid 'id'");
+        LV_LOG_WARN("invalid 'id'");
         return;
     }
 

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -67,7 +67,7 @@ _lv_img_cache_entry_t * _lv_img_cache_open(const void * src, lv_color_t color, i
 
 #if LV_IMG_CACHE_DEF_SIZE
     if(entry_cnt == 0) {
-        LV_LOG_WARN("lv_img_cache_open: the cache size is 0");
+        LV_LOG_WARN("the cache size is 0");
         return NULL;
     }
 

--- a/src/draw/lv_img_decoder.c
+++ b/src/draw/lv_img_decoder.c
@@ -63,7 +63,7 @@ void _lv_img_decoder_init(void)
     decoder = lv_img_decoder_create();
     LV_ASSERT_MALLOC(decoder);
     if(decoder == NULL) {
-        LV_LOG_WARN("lv_img_decoder_init: out of memory");
+        LV_LOG_WARN("out of memory");
         return;
     }
 
@@ -124,7 +124,7 @@ lv_res_t lv_img_decoder_open(lv_img_decoder_dsc_t * dsc, const void * src, lv_co
         dsc->src = lv_malloc(fnlen + 1);
         LV_ASSERT_MALLOC(dsc->src);
         if(dsc->src == NULL) {
-            LV_LOG_WARN("lv_img_decoder_open: out of memory");
+            LV_LOG_WARN("out of memory");
             return LV_RES_INV;
         }
         strcpy((char *)dsc->src, src);
@@ -342,7 +342,7 @@ lv_res_t lv_img_decoder_built_in_open(lv_img_decoder_t * decoder, lv_img_decoder
             dsc->user_data = lv_malloc(sizeof(lv_img_decoder_built_in_data_t));
             LV_ASSERT_MALLOC(dsc->user_data);
             if(dsc->user_data == NULL) {
-                LV_LOG_ERROR("img_decoder_built_in_open: out of memory");
+                LV_LOG_ERROR("out of memory");
                 lv_fs_close(&f);
                 return LV_RES_INV;
             }
@@ -386,7 +386,7 @@ lv_res_t lv_img_decoder_built_in_open(lv_img_decoder_t * decoder, lv_img_decoder
             dsc->user_data = lv_malloc(sizeof(lv_img_decoder_built_in_data_t));
             LV_ASSERT_MALLOC(dsc->user_data);
             if(dsc->user_data == NULL) {
-                LV_LOG_ERROR("img_decoder_built_in_open: out of memory");
+                LV_LOG_ERROR("out of memory");
                 return LV_RES_INV;
             }
             lv_memzero(dsc->user_data, sizeof(lv_img_decoder_built_in_data_t));
@@ -398,7 +398,7 @@ lv_res_t lv_img_decoder_built_in_open(lv_img_decoder_t * decoder, lv_img_decoder
         user_data->opa                             = lv_malloc(palette_size * sizeof(lv_opa_t));
         LV_ASSERT_MALLOC(user_data->opa);
         if(user_data->palette == NULL || user_data->opa == NULL) {
-            LV_LOG_ERROR("img_decoder_built_in_open: out of memory");
+            LV_LOG_ERROR("out of memory");
             lv_img_decoder_built_in_close(decoder, dsc);
             return LV_RES_INV;
         }

--- a/src/draw/sdl/lv_draw_sdl_label.c
+++ b/src/draw/sdl/lv_draw_sdl_label.c
@@ -65,7 +65,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
     if(opa > LV_OPA_MAX) opa = LV_OPA_COVER;
 
     if(font_p == NULL) {
-        LV_LOG_WARN("lv_draw_letter: font is NULL");
+        LV_LOG_WARN("font is NULL");
         return;
     }
 
@@ -77,7 +77,7 @@ void lv_draw_sdl_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t
         if(letter >= 0x20 &&
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", letter);
+            LV_LOG_WARN("glyph dsc not found for U+%X", letter);
 
             /* draw placeholder */
             lv_area_t glyph_coords;

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -477,7 +477,7 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area,
             blend_fp = color_blend_true_color_multiply;
             break;
         default:
-            LV_LOG_WARN("fill_blended: unsupported blend mode");
+            LV_LOG_WARN("unsupported blend mode");
             return;
     }
 
@@ -779,7 +779,7 @@ static void map_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_c
             blend_fp = color_blend_true_color_multiply;
             break;
         default:
-            LV_LOG_WARN("fill_blended: unsupported blend mode");
+            LV_LOG_WARN("unsupported blend mode");
             return;
     }
 

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -105,7 +105,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
         if(letter >= 0x20 &&
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_INFO("lv_draw_letter: glyph dsc. not found for U+%" LV_PRIX32, letter);
+            LV_LOG_INFO("glyph dsc not found for U+%" LV_PRIX32, letter);
 
 #if LV_USE_FONT_PLACEHOLDER
             /* draw placeholder */
@@ -156,7 +156,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
 
     const uint8_t * map_p = lv_font_get_glyph_bitmap(g.resolved_font, letter);
     if(map_p == NULL) {
-        LV_LOG_WARN("lv_draw_letter: character's bitmap not found");
+        LV_LOG_WARN("character's bitmap not found");
         return;
     }
 
@@ -228,7 +228,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, c
             shades = 256;
             break;       /*No opa table, pixel value will be used directly*/
         default:
-            LV_LOG_WARN("lv_draw_letter: invalid bpp");
+            LV_LOG_WARN("invalid bpp");
             return; /*Invalid bpp. Can't render the letter*/
     }
 
@@ -394,7 +394,7 @@ static void draw_letter_subpx(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_
             bitmask_init  = 0xFF;
             break;       /*No opa table, pixel value will be used directly*/
         default:
-            LV_LOG_WARN("lv_draw_letter: invalid bpp not found");
+            LV_LOG_WARN("invalid bpp not found");
             return; /*Invalid bpp. Can't render the letter*/
     }
 

--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -78,8 +78,7 @@ lv_indev_t * lv_indev_drv_register(lv_indev_drv_t * driver)
     if(driver->disp == NULL) driver->disp = lv_disp_get_default();
 
     if(driver->disp == NULL) {
-        LV_LOG_WARN("lv_indev_drv_register: no display registered hence can't attach the indev to "
-                    "a display");
+        LV_LOG_WARN("no display registered hence can't attach the indev to a display");
         return NULL;
     }
 
@@ -115,8 +114,7 @@ void lv_indev_drv_update(lv_indev_t * indev, lv_indev_drv_t * new_drv)
         new_drv->disp = lv_disp_get_default();
     }
     if(new_drv->disp == NULL) {
-        LV_LOG_WARN("lv_indev_drv_register: no display registered hence can't attach the indev to "
-                    "a display");
+        LV_LOG_WARN("no display registered hence can't attach the indev to a display");
         indev->proc.disabled = true;
         return;
     }

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -108,7 +108,7 @@ void lv_txt_get_size(lv_point_t * size_res, const char * text, const lv_font_t *
         new_line_start += _lv_txt_get_next_line(&text[line_start], font, letter_space, max_width, NULL, flag);
 
         if((unsigned long)size_res->y + (unsigned long)letter_height + (unsigned long)line_space > LV_MAX_OF(lv_coord_t)) {
-            LV_LOG_WARN("lv_txt_get_size: integer overflow while calculating text height");
+            LV_LOG_WARN("integer overflow while calculating text height");
             return;
         }
         else {

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -142,7 +142,7 @@ void lv_canvas_copy_buf(lv_obj_t * obj, const void * to_copy, lv_coord_t x, lv_c
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
 
     if(x + w - 1 >= (lv_coord_t)canvas->dsc.header.w || y + h - 1 >= (lv_coord_t)canvas->dsc.header.h) {
-        LV_LOG_WARN("lv_canvas_copy_buf: x or y out of the canvas");
+        LV_LOG_WARN("x or y out of the canvas");
         return;
     }
 
@@ -484,7 +484,7 @@ void lv_canvas_draw_rect(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_rect: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 
@@ -528,7 +528,7 @@ void lv_canvas_draw_text(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_text: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 
@@ -564,14 +564,14 @@ void lv_canvas_draw_img(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, const voi
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_img: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 
     lv_img_header_t header;
     lv_res_t res = lv_img_decoder_get_info(src, &header);
     if(res != LV_RES_OK) {
-        LV_LOG_WARN("lv_canvas_draw_img: Couldn't get the image data.");
+        LV_LOG_WARN("couldn't get the image data.");
         return;
     }
     /*Create a dummy display to fool the lv_draw function.
@@ -607,7 +607,7 @@ void lv_canvas_draw_line(lv_obj_t * canvas, const lv_point_t points[], uint32_t 
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_line: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 
@@ -649,7 +649,7 @@ void lv_canvas_draw_polygon(lv_obj_t * canvas, const lv_point_t points[], uint32
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_polygon: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 
@@ -688,7 +688,7 @@ void lv_canvas_draw_arc(lv_obj_t * canvas, lv_coord_t x, lv_coord_t y, lv_coord_
     lv_img_dsc_t * dsc = lv_canvas_get_img(canvas);
 
     if(dsc->header.cf >= LV_IMG_CF_INDEXED_1BIT && dsc->header.cf <= LV_IMG_CF_INDEXED_8BIT) {
-        LV_LOG_WARN("lv_canvas_draw_arc: can't draw to LV_IMG_CF_INDEXED canvas");
+        LV_LOG_WARN("can't draw to LV_IMG_CF_INDEXED canvas");
         return;
     }
 

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -389,7 +389,7 @@ void lv_dropdown_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf
     uint32_t c;
     for(c = 0; i < txt_len && dropdown->options[i] != '\n'; c++, i++) {
         if(buf_size && c >= buf_size - 1) {
-            LV_LOG_WARN("lv_dropdown_get_selected_str: the buffer was too small");
+            LV_LOG_WARN("the buffer was too small");
             break;
         }
         buf[c] = dropdown->options[i];

--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -79,22 +79,22 @@ void lv_img_set_src(lv_obj_t * obj, const void * src)
 #if LV_USE_LOG && LV_LOG_LEVEL >= LV_LOG_LEVEL_INFO
     switch(src_type) {
         case LV_IMG_SRC_FILE:
-            LV_LOG_TRACE("lv_img_set_src: `LV_IMG_SRC_FILE` type found");
+            LV_LOG_TRACE("`LV_IMG_SRC_FILE` type found");
             break;
         case LV_IMG_SRC_VARIABLE:
-            LV_LOG_TRACE("lv_img_set_src: `LV_IMG_SRC_VARIABLE` type found");
+            LV_LOG_TRACE("`LV_IMG_SRC_VARIABLE` type found");
             break;
         case LV_IMG_SRC_SYMBOL:
-            LV_LOG_TRACE("lv_img_set_src: `LV_IMG_SRC_SYMBOL` type found");
+            LV_LOG_TRACE("`LV_IMG_SRC_SYMBOL` type found");
             break;
         default:
-            LV_LOG_WARN("lv_img_set_src: unknown type");
+            LV_LOG_WARN("unknown type");
     }
 #endif
 
     /*If the new source type is unknown free the memories of the old source*/
     if(src_type == LV_IMG_SRC_UNKNOWN) {
-        LV_LOG_WARN("lv_img_set_src: unknown image type");
+        LV_LOG_WARN("unknown image type");
         if(img->src_type == LV_IMG_SRC_SYMBOL || img->src_type == LV_IMG_SRC_FILE) {
             lv_free((void *)img->src);
         }
@@ -683,11 +683,11 @@ static void draw_img(lv_event_t * e)
             }
             else if(img->src == NULL) {
                 /*Do not need to draw image when src is NULL*/
-                LV_LOG_WARN("draw_img: image source is NULL");
+                LV_LOG_WARN("image source is NULL");
             }
             else {
                 /*Trigger the error handler of image draw*/
-                LV_LOG_WARN("draw_img: image source type is unknown");
+                LV_LOG_WARN("image source type is unknown");
                 lv_draw_img(draw_ctx, NULL, &obj->coords, NULL);
             }
         }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -252,7 +252,7 @@ void lv_roller_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf_s
     uint32_t c;
     for(c = 0; i < txt_len && opt_txt[i] != '\n'; c++, i++) {
         if(buf_size && c >= buf_size - 1) {
-            LV_LOG_WARN("lv_dropdown_get_selected_str: the buffer was too small");
+            LV_LOG_WARN("the buffer was too small");
             break;
         }
         buf[c] = opt_txt[i];

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -381,7 +381,7 @@ lv_coord_t lv_table_get_col_width(lv_obj_t * obj, uint16_t col)
     lv_table_t * table = (lv_table_t *)obj;
 
     if(col >= table->col_cnt) {
-        LV_LOG_WARN("lv_table_set_col_width: too big 'col_id'. Must be < LV_TABLE_COL_MAX.");
+        LV_LOG_WARN("too big 'col_id'. Must be < LV_TABLE_COL_MAX.");
         return 0;
     }
 
@@ -394,7 +394,7 @@ bool lv_table_has_cell_ctrl(lv_obj_t * obj, uint16_t row, uint16_t col, lv_table
 
     lv_table_t * table = (lv_table_t *)obj;
     if(row >= table->row_cnt || col >= table->col_cnt) {
-        LV_LOG_WARN("lv_table_get_cell_crop: invalid row or column");
+        LV_LOG_WARN("invalid row or column");
         return false;
     }
     uint32_t cell = row * table->col_cnt + col;

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -330,7 +330,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
         ta->placeholder_txt = lv_realloc(ta->placeholder_txt, txt_len + 1);
         LV_ASSERT_MALLOC(ta->placeholder_txt);
         if(ta->placeholder_txt == NULL) {
-            LV_LOG_ERROR("lv_textarea_set_placeholder_text: couldn't allocate memory for placeholder");
+            LV_LOG_ERROR("couldn't allocate memory for placeholder");
             return;
         }
 
@@ -454,7 +454,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
         ta->pwd_bullet = lv_realloc(ta->pwd_bullet, txt_len + 1);
         LV_ASSERT_MALLOC(ta->pwd_bullet);
         if(ta->pwd_bullet == NULL) {
-            LV_LOG_ERROR("lv_textarea_set_password_bullet: couldn't allocate memory for bullet");
+            LV_LOG_ERROR("couldn't allocate memory for bullet");
             return;
         }
 


### PR DESCRIPTION
### Description of the feature or fix

After deletion, repeated character printing can be reduced.
It seems to be a historical legacy of LOG?

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
