### PR TITLE
chore(fsdrv): fix warning

### DIFF
--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -267,7 +267,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
     do {
         entry = readdir(handle->dir_p);
         if(entry) {
-            if(entry->d_type == DT_DIR) lv_snprintf(fn, MAX_PATH_LEN, "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
             else strcpy(fn, entry->d_name);
         }
         else {


### PR DESCRIPTION
### Description of the feature or fix

```bash
lvgl/src/libs/fsdrv/lv_fs_stdio.c: In function ‘fs_dir_read’:
lvgl/src/libs/fsdrv/lv_fs_stdio.c:270:75: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  270 |             if(entry->d_type == DT_DIR) lv_snprintf(fn, MAX_PATH_LEN, "/%s", entry->d_name);
      |                                                                           ^
In file included from lvgl/src/libs/fsdrv/../../../src/misc/../lv_conf_internal.h:39,
                 from lvgl/src/libs/fsdrv/../../../src/misc/lv_log.h:16,
                 from lvgl/src/libs/fsdrv/../../../lvgl.h:24,
                 from lvgl/src/libs/fsdrv/lv_fs_stdio.c:10:
lv_conf.h:80:25: note: ‘snprintf’ output between 2 and 257 bytes into a destination of size 256
   80 | #define LV_SNPRINTF     snprintf
lvgl/src/libs/fsdrv/../../../src/misc/lv_printf.h:66:21: note: in expansion of macro ‘LV_SNPRINTF’
   66 | #define lv_snprintf LV_SNPRINTF
      |                     ^~~~~~~~~~~
lvgl/src/libs/fsdrv/lv_fs_stdio.c:270:41: note: in expansion of macro ‘lv_snprintf’
  270 |             if(entry->d_type == DT_DIR) lv_snprintf(fn, MAX_PATH_LEN, "/%s", entry->d_name);
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
