### PR TITLE
perf(imgbtn): add img header cache to reduces file access

### DIFF
--- a/src/widgets/imgbtn/lv_imgbtn.c
+++ b/src/widgets/imgbtn/lv_imgbtn.c
@@ -29,7 +29,7 @@ static void lv_imgbtn_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void refr_img(lv_obj_t * imgbtn);
 static lv_imgbtn_state_t suggest_state(lv_obj_t * imgbtn, lv_imgbtn_state_t state);
 static lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn);
-static void update_src_pair(lv_imgbtn_src_pair_t * pair, const void * src);
+static void update_src_info(lv_imgbtn_src_info_t * info, const void * src);
 
 /**********************
  *  STATIC VARIABLES
@@ -84,9 +84,9 @@ void lv_imgbtn_set_src(lv_obj_t * obj, lv_imgbtn_state_t state, const void * src
 
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
 
-    update_src_pair(&imgbtn->src_left[state], src_left);
-    update_src_pair(&imgbtn->src_mid[state], src_mid);
-    update_src_pair(&imgbtn->src_right[state], src_right);
+    update_src_info(&imgbtn->src_left[state], src_left);
+    update_src_info(&imgbtn->src_mid[state], src_mid);
+    update_src_info(&imgbtn->src_right[state], src_right);
 
     refr_img(obj);
 }
@@ -214,7 +214,7 @@ static void draw_main(lv_event_t * e)
     lv_imgbtn_state_t state  = suggest_state(obj, get_state(obj));
 
     /*Simply draw the middle src if no tiled*/
-    lv_imgbtn_src_pair_t * src_pair = &imgbtn->src_left[state];
+    lv_imgbtn_src_info_t * src_info = &imgbtn->src_left[state];
 
     lv_coord_t tw = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
     lv_coord_t th = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
@@ -233,27 +233,27 @@ static void draw_main(lv_event_t * e)
     lv_coord_t left_w = 0;
     lv_coord_t right_w = 0;
 
-    if(src_pair->img_src) {
-        left_w = src_pair->header.w;
+    if(src_info->img_src) {
+        left_w = src_info->header.w;
         coords_part.x1 = coords.x1;
         coords_part.y1 = coords.y1;
-        coords_part.x2 = coords.x1 + src_pair->header.w - 1;
-        coords_part.y2 = coords.y1 + src_pair->header.h - 1;
-        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
+        coords_part.x2 = coords.x1 + src_info->header.w - 1;
+        coords_part.y2 = coords.y1 + src_info->header.h - 1;
+        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_info->img_src);
     }
 
-    src_pair = &imgbtn->src_right[state];
-    if(src_pair->img_src) {
-        right_w = src_pair->header.w;
-        coords_part.x1 = coords.x2 - src_pair->header.w + 1;
+    src_info = &imgbtn->src_right[state];
+    if(src_info->img_src) {
+        right_w = src_info->header.w;
+        coords_part.x1 = coords.x2 - src_info->header.w + 1;
         coords_part.y1 = coords.y1;
         coords_part.x2 = coords.x2;
-        coords_part.y2 = coords.y1 + src_pair->header.h - 1;
-        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
+        coords_part.y2 = coords.y1 + src_info->header.h - 1;
+        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_info->img_src);
     }
 
-    src_pair = &imgbtn->src_mid[state];
-    if(src_pair->img_src) {
+    src_info = &imgbtn->src_mid[state];
+    if(src_info->img_src) {
         lv_area_t clip_area_center;
         clip_area_center.x1 = coords.x1 + left_w;
         clip_area_center.x2 = coords.x2 - right_w;
@@ -271,13 +271,13 @@ static void draw_main(lv_event_t * e)
 
             coords_part.x1 = coords.x1 + left_w;
             coords_part.y1 = coords.y1;
-            coords_part.x2 = coords_part.x1 + src_pair->header.w - 1;
-            coords_part.y2 = coords_part.y1 + src_pair->header.h - 1;
+            coords_part.x2 = coords_part.x1 + src_info->header.w - 1;
+            coords_part.y2 = coords_part.y1 + src_info->header.h - 1;
 
-            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + src_pair->header.w - 1); i += src_pair->header.w) {
-                lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
+            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + src_info->header.w - 1); i += src_info->header.w) {
+                lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_info->img_src);
                 coords_part.x1 = coords_part.x2 + 1;
-                coords_part.x2 += src_pair->header.w;
+                coords_part.x2 += src_info->header.w;
             }
             draw_ctx->clip_area = clip_area_ori;
         }
@@ -357,20 +357,20 @@ static lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn)
     }
 }
 
-static void update_src_pair(lv_imgbtn_src_pair_t * pair, const void * src)
+static void update_src_info(lv_imgbtn_src_info_t * info, const void * src)
 {
     if(!src) {
-        lv_memzero(pair, sizeof(lv_imgbtn_src_pair_t));
+        lv_memzero(info, sizeof(lv_imgbtn_src_info_t));
         return;
     }
 
-    lv_res_t res = lv_img_decoder_get_info(src, &pair->header);
+    lv_res_t res = lv_img_decoder_get_info(src, &info->header);
     if(res != LV_RES_OK) {
         LV_LOG_WARN("can't get info");
         return;
     }
 
-    pair->img_src = src;
+    info->img_src = src;
 }
 
 #endif

--- a/src/widgets/imgbtn/lv_imgbtn.c
+++ b/src/widgets/imgbtn/lv_imgbtn.c
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file lv_imgbtn.c
  *
  */
@@ -28,7 +28,8 @@ static void draw_main(lv_event_t * e);
 static void lv_imgbtn_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void refr_img(lv_obj_t * imgbtn);
 static lv_imgbtn_state_t suggest_state(lv_obj_t * imgbtn, lv_imgbtn_state_t state);
-lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn);
+static lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn);
+static void update_src_pair(lv_imgbtn_src_pair_t * pair, const void * src);
 
 /**********************
  *  STATIC VARIABLES
@@ -83,9 +84,9 @@ void lv_imgbtn_set_src(lv_obj_t * obj, lv_imgbtn_state_t state, const void * src
 
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
 
-    imgbtn->img_src_left[state] = src_left;
-    imgbtn->img_src_mid[state] = src_mid;
-    imgbtn->img_src_right[state] = src_right;
+    update_src_pair(&imgbtn->src_left[state], src_left);
+    update_src_pair(&imgbtn->src_mid[state], src_mid);
+    update_src_pair(&imgbtn->src_right[state], src_right);
 
     refr_img(obj);
 }
@@ -125,7 +126,7 @@ const void * lv_imgbtn_get_src_left(lv_obj_t * obj, lv_imgbtn_state_t state)
 
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
 
-    return imgbtn->img_src_left[state];
+    return imgbtn->src_left[state].img_src;
 }
 
 /**
@@ -139,7 +140,7 @@ const void * lv_imgbtn_get_src_middle(lv_obj_t * obj, lv_imgbtn_state_t state)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
 
-    return imgbtn->img_src_mid[state];
+    return imgbtn->src_mid[state].img_src;
 }
 
 /**
@@ -153,7 +154,7 @@ const void * lv_imgbtn_get_src_right(lv_obj_t * obj, lv_imgbtn_state_t state)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
 
-    return imgbtn->img_src_right[state];
+    return imgbtn->src_right[state].img_src;
 }
 
 
@@ -166,11 +167,9 @@ static void lv_imgbtn_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     LV_UNUSED(class_p);
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
     /*Initialize the allocated 'ext'*/
-    lv_memzero((void *)imgbtn->img_src_mid, sizeof(imgbtn->img_src_mid));
-    lv_memzero(imgbtn->img_src_left, sizeof(imgbtn->img_src_left));
-    lv_memzero(imgbtn->img_src_right, sizeof(imgbtn->img_src_right));
-
-    imgbtn->act_cf = LV_IMG_CF_UNKNOWN;
+    lv_memzero(&imgbtn->src_mid, sizeof(imgbtn->src_mid));
+    lv_memzero(&imgbtn->src_left, sizeof(imgbtn->src_left));
+    lv_memzero(&imgbtn->src_right, sizeof(imgbtn->src_right));
 }
 
 
@@ -197,12 +196,10 @@ static void lv_imgbtn_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_point_t * p = lv_event_get_self_size_info(e);
         lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
         lv_imgbtn_state_t state  = suggest_state(obj, get_state(obj));
-        if(imgbtn->img_src_left[state] == NULL &&
-           imgbtn->img_src_mid[state] != NULL &&
-           imgbtn->img_src_right[state] == NULL) {
-            lv_img_header_t header;
-            lv_img_decoder_get_info(imgbtn->img_src_mid[state], &header);
-            p->x = LV_MAX(p->x, header.w);
+        if(imgbtn->src_left[state].img_src == NULL &&
+           imgbtn->src_mid[state].img_src != NULL &&
+           imgbtn->src_right[state].img_src == NULL) {
+            p->x = LV_MAX(p->x, imgbtn->src_mid[state].header.w);
         }
     }
 }
@@ -217,7 +214,7 @@ static void draw_main(lv_event_t * e)
     lv_imgbtn_state_t state  = suggest_state(obj, get_state(obj));
 
     /*Simply draw the middle src if no tiled*/
-    const void * src = imgbtn->img_src_left[state];
+    lv_imgbtn_src_pair_t * src_pair = &imgbtn->src_left[state];
 
     lv_coord_t tw = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
     lv_coord_t th = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
@@ -232,34 +229,31 @@ static void draw_main(lv_event_t * e)
     lv_draw_img_dsc_init(&img_dsc);
     lv_obj_init_draw_img_dsc(obj, LV_PART_MAIN, &img_dsc);
 
-    lv_img_header_t header;
     lv_area_t coords_part;
     lv_coord_t left_w = 0;
     lv_coord_t right_w = 0;
 
-    if(src) {
-        lv_img_decoder_get_info(src, &header);
-        left_w = header.w;
+    if(src_pair->img_src) {
+        left_w = src_pair->header.w;
         coords_part.x1 = coords.x1;
         coords_part.y1 = coords.y1;
-        coords_part.x2 = coords.x1 + header.w - 1;
-        coords_part.y2 = coords.y1 + header.h - 1;
-        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
+        coords_part.x2 = coords.x1 + src_pair->header.w - 1;
+        coords_part.y2 = coords.y1 + src_pair->header.h - 1;
+        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
     }
 
-    src = imgbtn->img_src_right[state];
-    if(src) {
-        lv_img_decoder_get_info(src, &header);
-        right_w = header.w;
-        coords_part.x1 = coords.x2 - header.w + 1;
+    src_pair = &imgbtn->src_right[state];
+    if(src_pair->img_src) {
+        right_w = src_pair->header.w;
+        coords_part.x1 = coords.x2 - src_pair->header.w + 1;
         coords_part.y1 = coords.y1;
         coords_part.x2 = coords.x2;
-        coords_part.y2 = coords.y1 + header.h - 1;
-        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
+        coords_part.y2 = coords.y1 + src_pair->header.h - 1;
+        lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
     }
 
-    src = imgbtn->img_src_mid[state];
-    if(src) {
+    src_pair = &imgbtn->src_mid[state];
+    if(src_pair->img_src) {
         lv_area_t clip_area_center;
         clip_area_center.x1 = coords.x1 + left_w;
         clip_area_center.x2 = coords.x2 - right_w;
@@ -271,20 +265,19 @@ static void draw_main(lv_event_t * e)
         comm_res = _lv_area_intersect(&clip_area_center, &clip_area_center, draw_ctx->clip_area);
         if(comm_res) {
             lv_coord_t i;
-            lv_img_decoder_get_info(src, &header);
 
             const lv_area_t * clip_area_ori = draw_ctx->clip_area;
             draw_ctx->clip_area = &clip_area_center;
 
             coords_part.x1 = coords.x1 + left_w;
             coords_part.y1 = coords.y1;
-            coords_part.x2 = coords_part.x1 + header.w - 1;
-            coords_part.y2 = coords_part.y1 + header.h - 1;
+            coords_part.x2 = coords_part.x1 + src_pair->header.w - 1;
+            coords_part.y2 = coords_part.y1 + src_pair->header.h - 1;
 
-            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + header.w - 1); i += header.w) {
-                lv_draw_img(draw_ctx, &img_dsc, &coords_part, src);
+            for(i = coords_part.x1; i < (lv_coord_t)(clip_area_center.x2 + src_pair->header.w - 1); i += src_pair->header.w) {
+                lv_draw_img(draw_ctx, &img_dsc, &coords_part, src_pair->img_src);
                 coords_part.x1 = coords_part.x2 + 1;
-                coords_part.x2 += header.w;
+                coords_part.x2 += src_pair->header.w;
             }
             draw_ctx->clip_area = clip_area_ori;
         }
@@ -295,22 +288,12 @@ static void refr_img(lv_obj_t * obj)
 {
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
     lv_imgbtn_state_t state  = suggest_state(obj, get_state(obj));
-    lv_img_header_t header;
 
-    const void * src = imgbtn->img_src_mid[state];
+    const void * src = imgbtn->src_mid[state].img_src;
     if(src == NULL) return;
 
-    lv_res_t info_res = LV_RES_OK;
-    info_res = lv_img_decoder_get_info(src, &header);
-
-    if(info_res == LV_RES_OK) {
-        imgbtn->act_cf = header.cf;
-        lv_obj_refresh_self_size(obj);
-        lv_obj_set_height(obj, header.h); /*Keep the user defined width*/
-    }
-    else {
-        imgbtn->act_cf = LV_IMG_CF_UNKNOWN;
-    }
+    lv_obj_refresh_self_size(obj);
+    lv_obj_set_height(obj, imgbtn->src_mid[state].header.h); /*Keep the user defined width*/
 
     lv_obj_invalidate(obj);
 }
@@ -325,25 +308,25 @@ static void refr_img(lv_obj_t * obj)
 static lv_imgbtn_state_t suggest_state(lv_obj_t * obj, lv_imgbtn_state_t state)
 {
     lv_imgbtn_t * imgbtn = (lv_imgbtn_t *)obj;
-    if(imgbtn->img_src_mid[state] == NULL) {
+    if(imgbtn->src_mid[state].img_src == NULL) {
         switch(state) {
             case LV_IMGBTN_STATE_PRESSED:
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_RELEASED]) return LV_IMGBTN_STATE_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_RELEASED].img_src) return LV_IMGBTN_STATE_RELEASED;
                 break;
             case LV_IMGBTN_STATE_CHECKED_RELEASED:
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_RELEASED]) return LV_IMGBTN_STATE_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_RELEASED].img_src) return LV_IMGBTN_STATE_RELEASED;
                 break;
             case LV_IMGBTN_STATE_CHECKED_PRESSED:
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_CHECKED_RELEASED]) return LV_IMGBTN_STATE_CHECKED_RELEASED;
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_PRESSED]) return LV_IMGBTN_STATE_PRESSED;
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_RELEASED]) return LV_IMGBTN_STATE_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_CHECKED_RELEASED].img_src) return LV_IMGBTN_STATE_CHECKED_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_PRESSED].img_src) return LV_IMGBTN_STATE_PRESSED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_RELEASED].img_src) return LV_IMGBTN_STATE_RELEASED;
                 break;
             case LV_IMGBTN_STATE_DISABLED:
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_RELEASED]) return LV_IMGBTN_STATE_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_RELEASED].img_src) return LV_IMGBTN_STATE_RELEASED;
                 break;
             case LV_IMGBTN_STATE_CHECKED_DISABLED:
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_CHECKED_RELEASED]) return LV_IMGBTN_STATE_CHECKED_RELEASED;
-                if(imgbtn->img_src_mid[LV_IMGBTN_STATE_RELEASED]) return LV_IMGBTN_STATE_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_CHECKED_RELEASED].img_src) return LV_IMGBTN_STATE_CHECKED_RELEASED;
+                if(imgbtn->src_mid[LV_IMGBTN_STATE_RELEASED].img_src) return LV_IMGBTN_STATE_RELEASED;
                 break;
             default:
                 break;
@@ -353,7 +336,7 @@ static lv_imgbtn_state_t suggest_state(lv_obj_t * obj, lv_imgbtn_state_t state)
     return state;
 }
 
-lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn)
+static lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn)
 {
     LV_ASSERT_OBJ(imgbtn, MY_CLASS);
 
@@ -372,6 +355,22 @@ lv_imgbtn_state_t get_state(const lv_obj_t * imgbtn)
         if(obj_state & LV_STATE_PRESSED) return LV_IMGBTN_STATE_PRESSED;
         else return LV_IMGBTN_STATE_RELEASED;
     }
+}
+
+static void update_src_pair(lv_imgbtn_src_pair_t * pair, const void * src)
+{
+    if(!src) {
+        lv_memzero(pair, sizeof(lv_imgbtn_src_pair_t));
+        return;
+    }
+
+    lv_res_t res = lv_img_decoder_get_info(src, &pair->header);
+    if(res != LV_RES_OK) {
+        LV_LOG_WARN("can't get info");
+        return;
+    }
+
+    pair->img_src = src;
 }
 
 #endif

--- a/src/widgets/imgbtn/lv_imgbtn.h
+++ b/src/widgets/imgbtn/lv_imgbtn.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file lv_imgbtn.h
  *
  */
@@ -13,8 +13,8 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-
 #include "../../core/lv_obj.h"
+
 #if LV_USE_IMGBTN != 0
 
 /*********************
@@ -30,16 +30,20 @@ typedef enum {
     _LV_IMGBTN_STATE_NUM,
 } lv_imgbtn_state_t;
 
+typedef struct {
+    const void * img_src;
+    lv_img_header_t header;
+} lv_imgbtn_src_pair_t;
+
 /**********************
  *      TYPEDEFS
  **********************/
 /*Data of image button*/
 typedef struct {
     lv_obj_t obj;
-    const void * img_src_mid[_LV_IMGBTN_STATE_NUM];   /*Store center images to each state*/
-    const void * img_src_left[_LV_IMGBTN_STATE_NUM];  /*Store left side images to each state*/
-    const void * img_src_right[_LV_IMGBTN_STATE_NUM]; /*Store right side images to each state*/
-    lv_img_cf_t act_cf; /*Color format of the currently active image*/
+    lv_imgbtn_src_pair_t src_mid[_LV_IMGBTN_STATE_NUM];   /*Store center images to each state*/
+    lv_imgbtn_src_pair_t src_left[_LV_IMGBTN_STATE_NUM];  /*Store left side images to each state*/
+    lv_imgbtn_src_pair_t src_right[_LV_IMGBTN_STATE_NUM]; /*Store right side images to each state*/
 } lv_imgbtn_t;
 
 extern const lv_obj_class_t lv_imgbtn_class;

--- a/src/widgets/imgbtn/lv_imgbtn.h
+++ b/src/widgets/imgbtn/lv_imgbtn.h
@@ -33,7 +33,7 @@ typedef enum {
 typedef struct {
     const void * img_src;
     lv_img_header_t header;
-} lv_imgbtn_src_pair_t;
+} lv_imgbtn_src_info_t;
 
 /**********************
  *      TYPEDEFS
@@ -41,9 +41,9 @@ typedef struct {
 /*Data of image button*/
 typedef struct {
     lv_obj_t obj;
-    lv_imgbtn_src_pair_t src_mid[_LV_IMGBTN_STATE_NUM];   /*Store center images to each state*/
-    lv_imgbtn_src_pair_t src_left[_LV_IMGBTN_STATE_NUM];  /*Store left side images to each state*/
-    lv_imgbtn_src_pair_t src_right[_LV_IMGBTN_STATE_NUM]; /*Store right side images to each state*/
+    lv_imgbtn_src_info_t src_mid[_LV_IMGBTN_STATE_NUM];   /*Store center images to each state*/
+    lv_imgbtn_src_info_t src_left[_LV_IMGBTN_STATE_NUM];  /*Store left side images to each state*/
+    lv_imgbtn_src_info_t src_right[_LV_IMGBTN_STATE_NUM]; /*Store right side images to each state*/
 } lv_imgbtn_t;
 
 extern const lv_obj_class_t lv_imgbtn_class;


### PR DESCRIPTION
### Description of the feature or fix

The current `lv_imgbtn` only saves the img src pointer. Due to frequent dimensional measurements, `lv_img_decoder_get_info` are called frequently, which can lead to a loss of performance.
Header caching needs to be added to reduce file access.

test code:
```c
#define ICON_EMOJI_STROE_ADD_NOR "/png/add_nor.png"
#define ICON_EMOJI_STROE_ADD_PRE "/png/add_pressed.png"
void imgbtn_test(void)
{
    lv_obj_t* emoji_btn = lv_imgbtn_create(lv_scr_act());
    lv_obj_set_size(emoji_btn, 40, 40);
    lv_imgbtn_set_state(emoji_btn, LV_IMGBTN_STATE_RELEASED);
    lv_imgbtn_set_src(emoji_btn, LV_IMGBTN_STATE_RELEASED, NULL, ICON_EMOJI_STROE_ADD_NOR, NULL);
    lv_imgbtn_set_src(emoji_btn, LV_IMGBTN_STATE_PRESSED, NULL, ICON_EMOJI_STROE_ADD_PRE, NULL);
    lv_obj_center(emoji_btn);
}
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
