### PR TITLE
modified lv_obj_transform_point

### DIFF
--- a/lv_hal_indev.h
+++ b/lv_hal_indev.h
@@ -1,0 +1,242 @@
+/**
+ * @file lv_hal_indev.h
+ *
+ * @description Input Device HAL interface layer header file
+ *
+ */
+
+#ifndef LV_HAL_INDEV_H
+#define LV_HAL_INDEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lv_conf_internal.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "../misc/lv_area.h"
+#include "../misc/lv_timer.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/*Drag threshold in pixels*/
+#define LV_INDEV_DEF_SCROLL_LIMIT         10
+
+/*Drag throw slow-down in [%]. Greater value -> faster slow-down*/
+#define LV_INDEV_DEF_SCROLL_THROW         10
+
+/*Long press time in milliseconds.
+ *Time to send `LV_EVENT_LONG_PRESSSED`)*/
+#define LV_INDEV_DEF_LONG_PRESS_TIME      400
+
+/*Repeated trigger period in long press [ms]
+ *Time between `LV_EVENT_LONG_PRESSED_REPEAT*/
+#define LV_INDEV_DEF_LONG_PRESS_REP_TIME  100
+
+
+/*Gesture threshold in pixels*/
+#define LV_INDEV_DEF_GESTURE_LIMIT        50
+
+/*Gesture min velocity at release before swipe (pixels)*/
+#define LV_INDEV_DEF_GESTURE_MIN_VELOCITY 3
+
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+struct _lv_obj_t;
+struct _lv_disp_t;
+struct _lv_group_t;
+struct _lv_indev_t;
+struct _lv_indev_drv_t;
+
+/** Possible input device types*/
+typedef enum {
+    LV_INDEV_TYPE_NONE,    /**< Uninitialized state*/
+    LV_INDEV_TYPE_POINTER, /**< Touch pad, mouse, external button*/
+    LV_INDEV_TYPE_KEYPAD,  /**< Keypad or keyboard*/
+    LV_INDEV_TYPE_BUTTON,  /**< External (hardware button) which is assigned to a specific point of the screen*/
+    LV_INDEV_TYPE_ENCODER, /**< Encoder with only Left, Right turn and a Button*/
+} lv_indev_type_t;
+
+/** States for input devices*/
+typedef enum {
+    LV_INDEV_STATE_RELEASED = 0,
+    LV_INDEV_STATE_PRESSED
+} lv_indev_state_t;
+
+/** Data structure passed to an input driver to fill*/
+typedef struct {
+    lv_point_t point; /**< For LV_INDEV_TYPE_POINTER the currently pressed point*/
+    uint32_t key;     /**< For LV_INDEV_TYPE_KEYPAD the currently pressed key*/
+    uint32_t btn_id;  /**< For LV_INDEV_TYPE_BUTTON the currently pressed button*/
+    int16_t enc_diff; /**< For LV_INDEV_TYPE_ENCODER number of steps since the previous read*/
+
+    lv_indev_state_t state; /**< LV_INDEV_STATE_REL or LV_INDEV_STATE_PR*/
+    bool continue_reading;  /**< If set to true, the read callback is invoked again*/
+} lv_indev_data_t;
+
+/** Initialized by the user and registered by 'lv_indev_add()'*/
+typedef struct _lv_indev_drv_t {
+
+    /**< Input device type*/
+    lv_indev_type_t type;
+
+    /**< Function pointer to read input device data.*/
+    void (*read_cb)(struct _lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
+
+    /** Called when an action happened on the input device.
+     * The second parameter is the event from `lv_event_t`*/
+    void (*feedback_cb)(struct _lv_indev_drv_t *, uint8_t);
+
+#if LV_USE_USER_DATA
+    void * user_data;
+#endif
+
+    /**< Pointer to the assigned display*/
+    struct _lv_disp_t * disp;
+
+    /**< Timer to periodically read the input device*/
+    lv_timer_t * read_timer;
+
+    /**< Number of pixels to slide before actually drag the object*/
+    uint8_t scroll_limit;
+
+    /**< Drag throw slow-down in [%]. Greater value means faster slow-down*/
+    uint8_t scroll_throw;
+
+    /**< At least this difference should be between two points to evaluate as gesture*/
+    uint8_t gesture_min_velocity;
+
+    /**< At least this difference should be to send a gesture*/
+    uint8_t gesture_limit;
+
+    /**< Long press time in milliseconds*/
+    uint16_t long_press_time;
+
+    /**< Repeated trigger period in long press [ms]*/
+    uint16_t long_press_repeat_time;
+} lv_indev_drv_t;
+
+/** Run time data of input devices
+ * Internally used by the library, you should not need to touch it.
+ */
+typedef struct _lv_indev_proc_t {
+    lv_indev_state_t state; /**< Current state of the input device.*/
+    /*Flags*/
+    uint8_t long_pr_sent : 1;
+    uint8_t reset_query : 1;
+    uint8_t disabled : 1;
+    uint8_t wait_until_release : 1;
+
+    union {
+        struct {
+            /*Pointer and button data*/
+            lv_point_t act_point; /**< Current point of input device.*/
+            #ifdef LV_INDEV_TEST
+            lv_point_t indev_point; /**< Current point of input device.*/
+            #endif
+            lv_point_t last_point; /**< Last point of input device.*/
+            lv_point_t last_raw_point; /**< Last point read from read_cb. */
+            lv_point_t vect; /**< Difference between `act_point` and `last_point`.*/
+            lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
+            lv_point_t scroll_throw_vect;
+            lv_point_t scroll_throw_vect_ori;
+            struct _lv_obj_t * act_obj;      /*The object being pressed*/
+            struct _lv_obj_t * last_obj;     /*The last object which was pressed*/
+            struct _lv_obj_t * scroll_obj;   /*The object being scrolled*/
+            struct _lv_obj_t * last_pressed; /*The lastly pressed object*/
+            lv_area_t scroll_area;
+
+            lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
+            /*Flags*/
+            lv_dir_t scroll_dir : 4;
+            lv_dir_t gesture_dir : 4;
+            uint8_t gesture_sent : 1;
+        } pointer;
+        struct {
+            /*Keypad data*/
+            lv_indev_state_t last_state;
+            uint32_t last_key;
+        } keypad;
+    } types;
+
+    uint32_t pr_timestamp;         /**< Pressed time stamp*/
+    uint32_t longpr_rep_timestamp; /**< Long press repeat time stamp*/
+} _lv_indev_proc_t;
+
+/** The main input device descriptor with driver, runtime data ('proc') and some additional
+ * information*/
+typedef struct _lv_indev_t {
+    struct _lv_indev_drv_t * driver;
+    _lv_indev_proc_t proc;
+    struct _lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
+    struct _lv_group_t * group;    /**< Keypad destination group*/
+    const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed
+                                      here by the buttons*/
+} lv_indev_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Initialize an input device driver with default values.
+ * It is used to surely have known values in the fields and not memory junk.
+ * After it you can set the fields.
+ * @param driver pointer to driver variable to initialize
+ */
+void lv_indev_drv_init(struct _lv_indev_drv_t * driver);
+
+/**
+ * Register an initialized input device driver.
+ * @param driver pointer to an initialized 'lv_indev_drv_t' variable (can be local variable)
+ * @return pointer to the new input device or NULL on error
+ */
+lv_indev_t * lv_indev_drv_register(struct _lv_indev_drv_t * driver);
+
+/**
+ * Update the driver in run time.
+ * @param indev pointer to an input device. (return value of `lv_indev_drv_register`)
+ * @param new_drv pointer to the new driver
+ */
+void lv_indev_drv_update(lv_indev_t * indev, struct _lv_indev_drv_t * new_drv);
+
+/**
+* Remove the provided input device. Make sure not to use the provided input device afterwards anymore.
+* @param indev pointer to delete
+*/
+void lv_indev_delete(lv_indev_t * indev);
+
+/**
+ * Get the next input device.
+ * @param indev pointer to the current input device. NULL to initialize.
+ * @return the next input device or NULL if there are no more. Provide the first input device when
+ * the parameter is NULL
+ */
+lv_indev_t * lv_indev_get_next(lv_indev_t * indev);
+
+/**
+ * Read data from an input device.
+ * @param indev pointer to an input device
+ * @param data input device will write its data here
+ */
+void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif

--- a/lv_indev.c
+++ b/lv_indev.c
@@ -1,0 +1,1184 @@
+/**
+ * @file lv_indev.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ ********************/
+#include "lv_indev.h"
+#include "lv_disp.h"
+#include "lv_obj.h"
+#include "lv_indev_scroll.h"
+#include "lv_group.h"
+#include "lv_refr.h"
+
+#include "../hal/lv_hal_tick.h"
+#include "../misc/lv_timer.h"
+#include "../misc/lv_math.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+#if LV_INDEV_DEF_SCROLL_THROW <= 0
+    #warning "LV_INDEV_DRAG_THROW must be greater than 0"
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data);
+static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data);
+static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data);
+static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data);
+static void indev_proc_press(_lv_indev_proc_t * proc);
+static void indev_proc_release(_lv_indev_proc_t * proc);
+static void indev_proc_reset_query_handler(lv_indev_t * indev);
+static void indev_click_focus(_lv_indev_proc_t * proc);
+static void indev_gesture(_lv_indev_proc_t * proc);
+static bool indev_reset_check(_lv_indev_proc_t * proc);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+static lv_indev_t * indev_act;
+static lv_obj_t * indev_obj_act = NULL;
+
+/**********************
+ *      MACROS
+ **********************/
+#if LV_LOG_TRACE_INDEV
+    #define INDEV_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
+#else
+    #define INDEV_TRACE(...)
+#endif
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_indev_read_timer_cb(lv_timer_t * timer)
+{
+    INDEV_TRACE("begin");
+
+    lv_indev_data_t data;
+
+    indev_act = timer->user_data;
+
+    /*Read and process all indevs*/
+    if(indev_act->driver->disp == NULL) return; /*Not assigned to any displays*/
+
+    /*Handle reset query before processing the point*/
+    indev_proc_reset_query_handler(indev_act);
+
+    if(indev_act->proc.disabled ||
+       indev_act->driver->disp->prev_scr != NULL) return; /*Input disabled or screen animation active*/
+    bool continue_reading;
+    do {
+        /*Read the data*/
+        _lv_indev_read(indev_act, &data);
+        continue_reading = data.continue_reading;
+
+        /*The active object might be deleted even in the read function*/
+        indev_proc_reset_query_handler(indev_act);
+        indev_obj_act = NULL;
+
+        indev_act->proc.state = data.state;
+
+        /*Save the last activity time*/
+        if(indev_act->proc.state == LV_INDEV_STATE_PRESSED) {
+            indev_act->driver->disp->last_activity_time = lv_tick_get();
+        }
+        else if(indev_act->driver->type == LV_INDEV_TYPE_ENCODER && data.enc_diff) {
+            indev_act->driver->disp->last_activity_time = lv_tick_get();
+        }
+
+        if(indev_act->driver->type == LV_INDEV_TYPE_POINTER) {
+            indev_pointer_proc(indev_act, &data);
+        }
+        else if(indev_act->driver->type == LV_INDEV_TYPE_KEYPAD) {
+            indev_keypad_proc(indev_act, &data);
+        }
+        else if(indev_act->driver->type == LV_INDEV_TYPE_ENCODER) {
+            indev_encoder_proc(indev_act, &data);
+        }
+        else if(indev_act->driver->type == LV_INDEV_TYPE_BUTTON) {
+            indev_button_proc(indev_act, &data);
+        }
+        /*Handle reset query if it happened in during processing*/
+        indev_proc_reset_query_handler(indev_act);
+    } while(continue_reading);
+
+    /*End of indev processing, so no act indev*/
+    indev_act     = NULL;
+    indev_obj_act = NULL;
+
+    INDEV_TRACE("finished");
+}
+
+void lv_indev_enable(lv_indev_t * indev, bool en)
+{
+    uint8_t enable = en ? 0 : 1;
+
+    if(indev) {
+        indev->proc.disabled = enable;
+    }
+    else {
+        lv_indev_t * i = lv_indev_get_next(NULL);
+        while(i) {
+            i->proc.disabled = enable;
+            i = lv_indev_get_next(i);
+        }
+    }
+}
+
+lv_indev_t * lv_indev_get_act(void)
+{
+    return indev_act;
+}
+
+lv_indev_type_t lv_indev_get_type(const lv_indev_t * indev)
+{
+    if(indev == NULL) return LV_INDEV_TYPE_NONE;
+
+    return indev->driver->type;
+}
+
+void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
+{
+    if(indev) {
+        indev->proc.reset_query = 1;
+        if(indev_act == indev) indev_obj_act = NULL;
+        if(indev->driver->type == LV_INDEV_TYPE_POINTER || indev->driver->type == LV_INDEV_TYPE_KEYPAD) {
+            if(obj == NULL || indev->proc.types.pointer.last_pressed == obj) {
+                indev->proc.types.pointer.last_pressed = NULL;
+            }
+            if(obj == NULL || indev->proc.types.pointer.act_obj == obj) {
+                indev->proc.types.pointer.act_obj = NULL;
+            }
+            if(obj == NULL || indev->proc.types.pointer.last_obj == obj) {
+                indev->proc.types.pointer.last_obj = NULL;
+            }
+        }
+    }
+    else {
+        lv_indev_t * i = lv_indev_get_next(NULL);
+        while(i) {
+            i->proc.reset_query = 1;
+            if(i->driver->type == LV_INDEV_TYPE_POINTER || i->driver->type == LV_INDEV_TYPE_KEYPAD) {
+                if(obj == NULL || i->proc.types.pointer.last_pressed == obj) {
+                    i->proc.types.pointer.last_pressed = NULL;
+                }
+                if(obj == NULL || i->proc.types.pointer.act_obj == obj) {
+                    i->proc.types.pointer.act_obj = NULL;
+                }
+                if(obj == NULL || i->proc.types.pointer.last_obj == obj) {
+                    i->proc.types.pointer.last_obj = NULL;
+                }
+            }
+            i = lv_indev_get_next(i);
+        }
+        indev_obj_act = NULL;
+    }
+}
+
+void lv_indev_reset_long_press(lv_indev_t * indev)
+{
+    indev->proc.long_pr_sent         = 0;
+    indev->proc.longpr_rep_timestamp = lv_tick_get();
+    indev->proc.pr_timestamp         = lv_tick_get();
+}
+
+void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj)
+{
+    if(indev->driver->type != LV_INDEV_TYPE_POINTER) return;
+
+    indev->cursor = cur_obj;
+    lv_obj_set_parent(indev->cursor, lv_disp_get_layer_sys(indev->driver->disp));
+    lv_obj_set_pos(indev->cursor, indev->proc.types.pointer.act_point.x, indev->proc.types.pointer.act_point.y);
+    lv_obj_clear_flag(indev->cursor, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(indev->cursor, LV_OBJ_FLAG_IGNORE_LAYOUT | LV_OBJ_FLAG_FLOATING);
+}
+
+void lv_indev_set_group(lv_indev_t * indev, lv_group_t * group)
+{
+    if(indev->driver->type == LV_INDEV_TYPE_KEYPAD || indev->driver->type == LV_INDEV_TYPE_ENCODER) {
+        indev->group = group;
+    }
+}
+
+void lv_indev_set_button_points(lv_indev_t * indev, const lv_point_t points[])
+{
+    if(indev->driver->type == LV_INDEV_TYPE_BUTTON) {
+        indev->btn_points = points;
+    }
+}
+
+void lv_indev_get_point(const lv_indev_t * indev, lv_point_t * point)
+{
+    if(indev == NULL) {
+        point->x = 0;
+        point->y = 0;
+        return;
+    }
+    if(indev->driver->type != LV_INDEV_TYPE_POINTER && indev->driver->type != LV_INDEV_TYPE_BUTTON) {
+        point->x = -1;
+        point->y = -1;
+    }
+    else {
+        point->x = indev->proc.types.pointer.act_point.x;
+        point->y = indev->proc.types.pointer.act_point.y;
+    }
+}
+
+lv_dir_t lv_indev_get_gesture_dir(const lv_indev_t * indev)
+{
+    return indev->proc.types.pointer.gesture_dir;
+}
+
+uint32_t lv_indev_get_key(const lv_indev_t * indev)
+{
+    if(indev->driver->type != LV_INDEV_TYPE_KEYPAD)
+        return 0;
+    else
+        return indev->proc.types.keypad.last_key;
+}
+
+lv_dir_t lv_indev_get_scroll_dir(const lv_indev_t * indev)
+{
+    if(indev == NULL) return false;
+    if(indev->driver->type != LV_INDEV_TYPE_POINTER && indev->driver->type != LV_INDEV_TYPE_BUTTON) return false;
+    return indev->proc.types.pointer.scroll_dir;
+}
+
+lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev)
+{
+    if(indev == NULL) return NULL;
+    if(indev->driver->type != LV_INDEV_TYPE_POINTER && indev->driver->type != LV_INDEV_TYPE_BUTTON) return NULL;
+    return indev->proc.types.pointer.scroll_obj;
+}
+
+void lv_indev_get_vect(const lv_indev_t * indev, lv_point_t * point)
+{
+    point->x = 0;
+    point->y = 0;
+
+    if(indev == NULL) return;
+
+    if(indev->driver->type == LV_INDEV_TYPE_POINTER || indev->driver->type == LV_INDEV_TYPE_BUTTON) {
+        point->x = indev->proc.types.pointer.vect.x;
+        point->y = indev->proc.types.pointer.vect.y;
+    }
+}
+
+void lv_indev_wait_release(lv_indev_t * indev)
+{
+    if(indev == NULL)return;
+    indev->proc.wait_until_release = 1;
+}
+
+lv_obj_t * lv_indev_get_obj_act(void)
+{
+    return indev_obj_act;
+}
+
+lv_timer_t * lv_indev_get_read_timer(lv_disp_t * indev)
+{
+    if(!indev) {
+        LV_LOG_WARN("lv_indev_get_read_timer: indev was NULL");
+        return NULL;
+    }
+
+    return indev->refr_timer;
+}
+
+
+lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point)
+{
+    lv_obj_t * found_p = NULL;
+
+    /*If this obj is hidden the children are hidden too so return immediately*/
+    if(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN)) return NULL;
+
+    lv_point_t p_trans = *point;
+    #ifdef LV_INDEV_TEST
+    lv_obj_transform_point(obj, &p_trans, NULL, false, true);
+	#else
+    lv_obj_transform_point(obj, &p_trans, false, true);
+	#endif
+    bool hit_test_ok = lv_obj_hit_test(obj, &p_trans);
+
+    /*If the point is on this object or has overflow visible check its children too*/
+    if(_lv_area_is_point_on(&obj->coords, &p_trans, 0) || lv_obj_has_flag(obj, LV_OBJ_FLAG_OVERFLOW_VISIBLE)) {
+        int32_t i;
+        uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+
+        /*If a child matches use it*/
+        for(i = child_cnt - 1; i >= 0; i--) {
+            lv_obj_t * child = obj->spec_attr->children[i];
+            found_p = lv_indev_search_obj(child, &p_trans);
+            if(found_p) return found_p;
+        }
+    }
+
+    /*If not return earlier for a clicked child and this obj's hittest was ok use it
+     *else return NULL*/
+    if(hit_test_ok) return obj;
+    else return NULL;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/**
+ * Process a new point from LV_INDEV_TYPE_POINTER input device
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
+ */
+static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
+{
+    lv_disp_t * disp = i->driver->disp;
+    /*Save the raw points so they can be used again in _lv_indev_read*/
+    i->proc.types.pointer.last_raw_point.x = data->point.x;
+    i->proc.types.pointer.last_raw_point.y = data->point.y;
+
+    if(disp->driver->rotated == LV_DISP_ROT_180 || disp->driver->rotated == LV_DISP_ROT_270) {
+        data->point.x = disp->driver->hor_res - data->point.x - 1;
+        data->point.y = disp->driver->ver_res - data->point.y - 1;
+    }
+    if(disp->driver->rotated == LV_DISP_ROT_90 || disp->driver->rotated == LV_DISP_ROT_270) {
+        lv_coord_t tmp = data->point.y;
+        data->point.y = data->point.x;
+        data->point.x = disp->driver->ver_res - tmp - 1;
+    }
+
+    /*Simple sanity check*/
+    if(data->point.x < 0) {
+        LV_LOG_WARN("X is %d which is smaller than zero", data->point.x);
+    }
+    if(data->point.x >= lv_disp_get_hor_res(i->driver->disp)) {
+        LV_LOG_WARN("X is %d which is greater than hor. res", data->point.x);
+    }
+    if(data->point.y < 0) {
+        LV_LOG_WARN("Y is %d which is smaller than zero", data->point.y);
+    }
+    if(data->point.y >= lv_disp_get_ver_res(i->driver->disp)) {
+        LV_LOG_WARN("Y is %d which is greater than ver. res", data->point.y);
+    }
+
+    /*Move the cursor if set and moved*/
+    if(i->cursor != NULL &&
+       (i->proc.types.pointer.last_point.x != data->point.x || i->proc.types.pointer.last_point.y != data->point.y)) {
+        lv_obj_set_pos(i->cursor, data->point.x, data->point.y);
+    }
+
+    i->proc.types.pointer.act_point.x = data->point.x;
+    i->proc.types.pointer.act_point.y = data->point.y;
+
+    if(i->proc.state == LV_INDEV_STATE_PRESSED) {
+        indev_proc_press(&i->proc);
+    }
+    else {
+        indev_proc_release(&i->proc);
+    }
+#ifdef LV_INDEV_TEST
+	i->proc.types.pointer.indev_point.x = data->point.x;
+	i->proc.types.pointer.indev_point.y = data->point.y;
+#endif
+    i->proc.types.pointer.last_point.x = i->proc.types.pointer.act_point.x;
+    i->proc.types.pointer.last_point.y = i->proc.types.pointer.act_point.y;
+}
+
+/**
+ * Process a new point from LV_INDEV_TYPE_KEYPAD input device
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
+ */
+static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
+{
+    if(data->state == LV_INDEV_STATE_PRESSED && i->proc.wait_until_release) return;
+
+    if(i->proc.wait_until_release) {
+        i->proc.wait_until_release      = 0;
+        i->proc.pr_timestamp            = 0;
+        i->proc.long_pr_sent            = 0;
+        i->proc.types.keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
+    }
+
+    lv_group_t * g = i->group;
+    if(g == NULL) return;
+
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
+
+    bool dis = lv_obj_has_state(indev_obj_act, LV_STATE_DISABLED);
+
+    /*Save the last key to compare it with the current latter on RELEASE*/
+    uint32_t prev_key = i->proc.types.keypad.last_key;
+
+    /*Save the last key.
+     *It must be done here else `lv_indev_get_key` will return the last key in events*/
+    i->proc.types.keypad.last_key = data->key;
+
+    /*Save the previous state so we can detect state changes below and also set the last state now
+     *so if any event handler on the way returns `LV_RES_INV` the last state is remembered
+     *for the next time*/
+    uint32_t prev_state             = i->proc.types.keypad.last_state;
+    i->proc.types.keypad.last_state = data->state;
+
+    /*Key press happened*/
+    if(data->state == LV_INDEV_STATE_PRESSED && prev_state == LV_INDEV_STATE_RELEASED) {
+        LV_LOG_INFO("%" LV_PRIu32 " key is pressed", data->key);
+        i->proc.pr_timestamp = lv_tick_get();
+
+        /*Move the focus on NEXT*/
+        if(data->key == LV_KEY_NEXT) {
+            lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
+            lv_group_focus_next(g);
+            if(indev_reset_check(&i->proc)) return;
+        }
+        /*Move the focus on PREV*/
+        else if(data->key == LV_KEY_PREV) {
+            lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
+            lv_group_focus_prev(g);
+            if(indev_reset_check(&i->proc)) return;
+        }
+        else if(!dis) {
+            /*Simulate a press on the object if ENTER was pressed*/
+            if(data->key == LV_KEY_ENTER) {
+                /*Send the ENTER as a normal KEY*/
+                lv_group_send_data(g, LV_KEY_ENTER);
+                if(indev_reset_check(&i->proc)) return;
+
+                if(!dis) lv_event_send(indev_obj_act, LV_EVENT_PRESSED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            else if(data->key == LV_KEY_ESC) {
+                /*Send the ESC as a normal KEY*/
+                lv_group_send_data(g, LV_KEY_ESC);
+                if(indev_reset_check(&i->proc)) return;
+
+                lv_event_send(indev_obj_act, LV_EVENT_CANCEL, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            /*Just send other keys to the object (e.g. 'A' or `LV_GROUP_KEY_RIGHT`)*/
+            else {
+                lv_group_send_data(g, data->key);
+                if(indev_reset_check(&i->proc)) return;
+            }
+        }
+    }
+    /*Pressing*/
+    else if(!dis && data->state == LV_INDEV_STATE_PRESSED && prev_state == LV_INDEV_STATE_PRESSED) {
+
+        if(data->key == LV_KEY_ENTER) {
+            lv_event_send(indev_obj_act, LV_EVENT_PRESSING, indev_act);
+            if(indev_reset_check(&i->proc)) return;
+        }
+
+        /*Long press time has elapsed?*/
+        if(i->proc.long_pr_sent == 0 && lv_tick_elaps(i->proc.pr_timestamp) > i->driver->long_press_time) {
+            i->proc.long_pr_sent = 1;
+            if(data->key == LV_KEY_ENTER) {
+                i->proc.longpr_rep_timestamp = lv_tick_get();
+                lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+        }
+        /*Long press repeated time has elapsed?*/
+        else if(i->proc.long_pr_sent != 0 &&
+                lv_tick_elaps(i->proc.longpr_rep_timestamp) > i->driver->long_press_repeat_time) {
+
+            i->proc.longpr_rep_timestamp = lv_tick_get();
+
+            /*Send LONG_PRESS_REP on ENTER*/
+            if(data->key == LV_KEY_ENTER) {
+                lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED_REPEAT, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            /*Move the focus on NEXT again*/
+            else if(data->key == LV_KEY_NEXT) {
+                lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
+                lv_group_focus_next(g);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            /*Move the focus on PREV again*/
+            else if(data->key == LV_KEY_PREV) {
+                lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
+                lv_group_focus_prev(g);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            /*Just send other keys again to the object (e.g. 'A' or `LV_GROUP_KEY_RIGHT)*/
+            else {
+                lv_group_send_data(g, data->key);
+                if(indev_reset_check(&i->proc)) return;
+            }
+        }
+    }
+    /*Release happened*/
+    else if(!dis && data->state == LV_INDEV_STATE_RELEASED && prev_state == LV_INDEV_STATE_PRESSED) {
+        LV_LOG_INFO("%" LV_PRIu32 " key is released", data->key);
+        /*The user might clear the key when it was released. Always release the pressed key*/
+        data->key = prev_key;
+        if(data->key == LV_KEY_ENTER) {
+
+            lv_event_send(indev_obj_act, LV_EVENT_RELEASED, indev_act);
+            if(indev_reset_check(&i->proc)) return;
+
+            if(i->proc.long_pr_sent == 0) {
+                lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+
+            lv_event_send(indev_obj_act, LV_EVENT_CLICKED, indev_act);
+            if(indev_reset_check(&i->proc)) return;
+
+        }
+        i->proc.pr_timestamp = 0;
+        i->proc.long_pr_sent = 0;
+    }
+    indev_obj_act = NULL;
+}
+
+/**
+ * Process a new point from LV_INDEV_TYPE_ENCODER input device
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
+ */
+static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
+{
+    if(data->state == LV_INDEV_STATE_PRESSED && i->proc.wait_until_release) return;
+
+    if(i->proc.wait_until_release) {
+        i->proc.wait_until_release      = 0;
+        i->proc.pr_timestamp            = 0;
+        i->proc.long_pr_sent            = 0;
+        i->proc.types.keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
+    }
+
+    /*Save the last keys before anything else.
+     *They need to be already saved if the function returns for any reason*/
+    lv_indev_state_t last_state     = i->proc.types.keypad.last_state;
+    i->proc.types.keypad.last_state = data->state;
+    i->proc.types.keypad.last_key   = data->key;
+
+    lv_group_t * g = i->group;
+    if(g == NULL) return;
+
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
+
+    /*Process the steps they are valid only with released button*/
+    if(data->state != LV_INDEV_STATE_RELEASED) {
+        data->enc_diff = 0;
+    }
+
+    /*Refresh the focused object. It might change due to lv_group_focus_prev/next*/
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
+
+    /*Button press happened*/
+    if(data->state == LV_INDEV_STATE_PRESSED && last_state == LV_INDEV_STATE_RELEASED) {
+        LV_LOG_INFO("pressed");
+
+        i->proc.pr_timestamp = lv_tick_get();
+
+        if(data->key == LV_KEY_ENTER) {
+            bool editable_or_scrollable = lv_obj_is_editable(indev_obj_act) ||
+                                          lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_SCROLLABLE);
+            if(lv_group_get_editing(g) == true || editable_or_scrollable == false) {
+                lv_event_send(indev_obj_act, LV_EVENT_PRESSED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+        }
+        else if(data->key == LV_KEY_LEFT) {
+            /*emulate encoder left*/
+            data->enc_diff--;
+        }
+        else if(data->key == LV_KEY_RIGHT) {
+            /*emulate encoder right*/
+            data->enc_diff++;
+        }
+        else if(data->key == LV_KEY_ESC) {
+            /*Send the ESC as a normal KEY*/
+            lv_group_send_data(g, LV_KEY_ESC);
+            if(indev_reset_check(&i->proc)) return;
+
+            lv_event_send(indev_obj_act, LV_EVENT_CANCEL, indev_act);
+            if(indev_reset_check(&i->proc)) return;
+        }
+        /*Just send other keys to the object (e.g. 'A' or `LV_GROUP_KEY_RIGHT`)*/
+        else {
+            lv_group_send_data(g, data->key);
+            if(indev_reset_check(&i->proc)) return;
+        }
+    }
+    /*Pressing*/
+    else if(data->state == LV_INDEV_STATE_PRESSED && last_state == LV_INDEV_STATE_PRESSED) {
+        /*Long press*/
+        if(i->proc.long_pr_sent == 0 && lv_tick_elaps(i->proc.pr_timestamp) > i->driver->long_press_time) {
+
+            i->proc.long_pr_sent = 1;
+            i->proc.longpr_rep_timestamp = lv_tick_get();
+
+            if(data->key == LV_KEY_ENTER) {
+                bool editable_or_scrollable = lv_obj_is_editable(indev_obj_act) ||
+                                              lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_SCROLLABLE);
+
+                /*On enter long press toggle edit mode.*/
+                if(editable_or_scrollable) {
+                    /*Don't leave edit mode if there is only one object (nowhere to navigate)*/
+                    if(lv_group_get_obj_count(g) > 1) {
+                        LV_LOG_INFO("toggling edit mode");
+                        lv_group_set_editing(g, lv_group_get_editing(g) ? false : true); /*Toggle edit mode on long press*/
+                        lv_obj_clear_state(indev_obj_act, LV_STATE_PRESSED);    /*Remove the pressed state manually*/
+                    }
+                }
+                /*If not editable then just send a long press Call the ancestor's event handler*/
+                else {
+                    lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED, indev_act);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+            }
+
+            i->proc.long_pr_sent = 1;
+        }
+        /*Long press repeated time has elapsed?*/
+        else if(i->proc.long_pr_sent != 0 && lv_tick_elaps(i->proc.longpr_rep_timestamp) > i->driver->long_press_repeat_time) {
+
+            i->proc.longpr_rep_timestamp = lv_tick_get();
+
+            if(data->key == LV_KEY_ENTER) {
+                lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED_REPEAT, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+            }
+            else if(data->key == LV_KEY_LEFT) {
+                /*emulate encoder left*/
+                data->enc_diff--;
+            }
+            else if(data->key == LV_KEY_RIGHT) {
+                /*emulate encoder right*/
+                data->enc_diff++;
+            }
+            else {
+                lv_group_send_data(g, data->key);
+                if(indev_reset_check(&i->proc)) return;
+            }
+
+        }
+
+    }
+    /*Release happened*/
+    else if(data->state == LV_INDEV_STATE_RELEASED && last_state == LV_INDEV_STATE_PRESSED) {
+        LV_LOG_INFO("released");
+
+        if(data->key == LV_KEY_ENTER) {
+            bool editable_or_scrollable = lv_obj_is_editable(indev_obj_act) ||
+                                          lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_SCROLLABLE);
+
+            /*The button was released on a non-editable object. Just send enter*/
+            if(editable_or_scrollable == false) {
+                lv_event_send(indev_obj_act, LV_EVENT_RELEASED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+
+                if(i->proc.long_pr_sent == 0) lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+
+                lv_event_send(indev_obj_act, LV_EVENT_CLICKED, indev_act);
+                if(indev_reset_check(&i->proc)) return;
+
+            }
+            /*An object is being edited and the button is released.*/
+            else if(lv_group_get_editing(g)) {
+                /*Ignore long pressed enter release because it comes from mode switch*/
+                if(!i->proc.long_pr_sent || lv_group_get_obj_count(g) <= 1) {
+                    lv_event_send(indev_obj_act, LV_EVENT_RELEASED, indev_act);
+                    if(indev_reset_check(&i->proc)) return;
+
+                    lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, indev_act);
+                    if(indev_reset_check(&i->proc)) return;
+
+                    lv_event_send(indev_obj_act, LV_EVENT_CLICKED, indev_act);
+                    if(indev_reset_check(&i->proc)) return;
+
+                    lv_group_send_data(g, LV_KEY_ENTER);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+                else {
+                    lv_obj_clear_state(indev_obj_act, LV_STATE_PRESSED);    /*Remove the pressed state manually*/
+                }
+            }
+            /*If the focused object is editable and now in navigate mode then on enter switch edit
+               mode*/
+            else if(!i->proc.long_pr_sent) {
+                LV_LOG_INFO("entering edit mode");
+                lv_group_set_editing(g, true); /*Set edit mode*/
+            }
+        }
+
+        i->proc.pr_timestamp = 0;
+        i->proc.long_pr_sent = 0;
+    }
+    indev_obj_act = NULL;
+
+    /*if encoder steps or simulated steps via left/right keys*/
+    if(data->enc_diff != 0) {
+        /*In edit mode send LEFT/RIGHT keys*/
+        if(lv_group_get_editing(g)) {
+            LV_LOG_INFO("rotated by %+d (edit)", data->enc_diff);
+            int32_t s;
+            if(data->enc_diff < 0) {
+                for(s = 0; s < -data->enc_diff; s++) {
+                    lv_group_send_data(g, LV_KEY_LEFT);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+            }
+            else if(data->enc_diff > 0) {
+                for(s = 0; s < data->enc_diff; s++) {
+                    lv_group_send_data(g, LV_KEY_RIGHT);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+            }
+        }
+        /*In navigate mode focus on the next/prev objects*/
+        else {
+            LV_LOG_INFO("rotated by %+d (nav)", data->enc_diff);
+            int32_t s;
+            if(data->enc_diff < 0) {
+                for(s = 0; s < -data->enc_diff; s++) {
+                    lv_group_focus_prev(g);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+            }
+            else if(data->enc_diff > 0) {
+                for(s = 0; s < data->enc_diff; s++) {
+                    lv_group_focus_next(g);
+                    if(indev_reset_check(&i->proc)) return;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Process new points from an input device. indev->state.pressed has to be set
+ * @param indev pointer to an input device state
+ * @param x x coordinate of the next point
+ * @param y y coordinate of the next point
+ */
+static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
+{
+    /*Die gracefully if i->btn_points is NULL*/
+    if(i->btn_points == NULL) {
+        LV_LOG_WARN("btn_points is NULL");
+        return;
+    }
+
+    lv_coord_t x = i->btn_points[data->btn_id].x;
+    lv_coord_t y = i->btn_points[data->btn_id].y;
+
+    static lv_indev_state_t prev_state = LV_INDEV_STATE_RELEASED;
+    if(prev_state != data->state) {
+        if(data->state == LV_INDEV_STATE_PRESSED) {
+            LV_LOG_INFO("button %" LV_PRIu32 " is pressed (x:%d y:%d)", data->btn_id, x, y);
+        }
+        else {
+            LV_LOG_INFO("button %" LV_PRIu32 " is released (x:%d y:%d)", data->btn_id, x, y);
+        }
+    }
+
+    /*If a new point comes always make a release*/
+    if(data->state == LV_INDEV_STATE_PRESSED) {
+        if(i->proc.types.pointer.last_point.x != x ||
+           i->proc.types.pointer.last_point.y != y) {
+            indev_proc_release(&i->proc);
+        }
+    }
+
+    if(indev_reset_check(&i->proc)) return;
+
+    /*Save the new points*/
+    i->proc.types.pointer.act_point.x = x;
+    i->proc.types.pointer.act_point.y = y;
+
+    if(data->state == LV_INDEV_STATE_PRESSED) indev_proc_press(&i->proc);
+    else indev_proc_release(&i->proc);
+
+    if(indev_reset_check(&i->proc)) return;
+
+    i->proc.types.pointer.last_point.x = i->proc.types.pointer.act_point.x;
+    i->proc.types.pointer.last_point.y = i->proc.types.pointer.act_point.y;
+}
+
+/**
+ * Process the pressed state of LV_INDEV_TYPE_POINTER input devices
+ * @param indev pointer to an input device 'proc'
+ * @return LV_RES_OK: no indev reset required; LV_RES_INV: indev reset is required
+ */
+static void indev_proc_press(_lv_indev_proc_t * proc)
+{
+	#ifdef LV_INDEV_TEST
+	uint8_t indev_flag = false;
+	#endif
+	
+    LV_LOG_INFO("pressed at x:%d y:%d", proc->types.pointer.act_point.x, proc->types.pointer.act_point.y);
+    indev_obj_act = proc->types.pointer.act_obj;
+
+    if(proc->wait_until_release != 0) return;
+
+    lv_disp_t * disp = indev_act->driver->disp;
+    bool new_obj_searched = false;
+
+    /*If there is no last object then search*/
+    if(indev_obj_act == NULL) {
+        indev_obj_act = lv_indev_search_obj(lv_disp_get_layer_sys(disp), &proc->types.pointer.act_point);
+        if(indev_obj_act == NULL) indev_obj_act = lv_indev_search_obj(lv_disp_get_layer_top(disp),
+                                                                          &proc->types.pointer.act_point);
+        if(indev_obj_act == NULL) indev_obj_act = lv_indev_search_obj(lv_disp_get_scr_act(disp),
+                                                                          &proc->types.pointer.act_point);
+        new_obj_searched = true;
+    }
+    /*If there is last object but it is not scrolled and not protected also search*/
+    else if(proc->types.pointer.scroll_obj == NULL &&
+            lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_PRESS_LOCK) == false) {
+        indev_obj_act = lv_indev_search_obj(lv_disp_get_layer_sys(disp), &proc->types.pointer.act_point);
+        if(indev_obj_act == NULL) indev_obj_act = lv_indev_search_obj(lv_disp_get_layer_top(disp),
+                                                                          &proc->types.pointer.act_point);
+        if(indev_obj_act == NULL) indev_obj_act = lv_indev_search_obj(lv_disp_get_scr_act(disp),
+                                                                          &proc->types.pointer.act_point);
+        new_obj_searched = true;
+    }
+
+    /*The last object might have scroll throw. Stop it manually*/
+    if(new_obj_searched && proc->types.pointer.last_obj) {
+        proc->types.pointer.scroll_throw_vect.x = 0;
+        proc->types.pointer.scroll_throw_vect.y = 0;
+        _lv_indev_scroll_throw_handler(proc);
+        if(indev_reset_check(proc)) return;
+    }
+
+    #ifdef LV_INDEV_TEST
+    if((proc->types.pointer.act_point.x == proc->types.pointer.indev_point.x) && (proc->types.pointer.act_point.y == proc->types.pointer.indev_point.y))
+    	indev_flag = true;
+    	
+    lv_obj_transform_point(indev_obj_act, &proc->types.pointer.act_point, &proc->types.pointer.indev_point, true, true);
+    
+	if(indev_flag)
+    {
+		proc->types.pointer.last_point.x = proc->types.pointer.act_point.x;
+		proc->types.pointer.last_point.y = proc->types.pointer.act_point.y;
+    }
+    
+	#else
+    lv_obj_transform_point(indev_obj_act, &proc->types.pointer.act_point, true, true);
+	#endif
+    /*If a new object was found reset some variables and send a pressed event handler*/
+    if(indev_obj_act != proc->types.pointer.act_obj) {
+        proc->types.pointer.last_point.x = proc->types.pointer.act_point.x;
+        proc->types.pointer.last_point.y = proc->types.pointer.act_point.y;
+
+        /*If a new object found the previous was lost, so send a Call the ancestor's event handler*/
+        if(proc->types.pointer.act_obj != NULL) {
+            /*Save the obj because in special cases `act_obj` can change in the Call the ancestor's event handler function*/
+            lv_obj_t * last_obj = proc->types.pointer.act_obj;
+
+            lv_event_send(last_obj, LV_EVENT_PRESS_LOST, indev_act);
+            if(indev_reset_check(proc)) return;
+        }
+
+        proc->types.pointer.act_obj  = indev_obj_act; /*Save the pressed object*/
+        proc->types.pointer.last_obj = indev_obj_act;
+
+        if(indev_obj_act != NULL) {
+            /*Save the time when the obj pressed to count long press time.*/
+            proc->pr_timestamp                 = lv_tick_get();
+            proc->long_pr_sent                 = 0;
+            proc->types.pointer.scroll_sum.x     = 0;
+            proc->types.pointer.scroll_sum.y     = 0;
+            proc->types.pointer.scroll_dir = LV_DIR_NONE;
+            proc->types.pointer.gesture_dir = LV_DIR_NONE;
+            proc->types.pointer.gesture_sent   = 0;
+            proc->types.pointer.gesture_sum.x  = 0;
+            proc->types.pointer.gesture_sum.y  = 0;
+            proc->types.pointer.vect.x         = 0;
+            proc->types.pointer.vect.y         = 0;
+
+            /*Call the ancestor's event handler about the press*/
+            lv_event_send(indev_obj_act, LV_EVENT_PRESSED, indev_act);
+            if(indev_reset_check(proc)) return;
+
+            if(indev_act->proc.wait_until_release) return;
+
+            /*Handle focus*/
+            indev_click_focus(&indev_act->proc);
+            if(indev_reset_check(proc)) return;
+
+        }
+    }
+
+    /*Calculate the vector and apply a low pass filter: new value = 0.5 * old_value + 0.5 * new_value*/
+    proc->types.pointer.vect.x = proc->types.pointer.act_point.x - proc->types.pointer.last_point.x;
+    proc->types.pointer.vect.y = proc->types.pointer.act_point.y - proc->types.pointer.last_point.y;
+
+    proc->types.pointer.scroll_throw_vect.x = (proc->types.pointer.scroll_throw_vect.x + proc->types.pointer.vect.x) / 2;
+    proc->types.pointer.scroll_throw_vect.y = (proc->types.pointer.scroll_throw_vect.y + proc->types.pointer.vect.y) / 2;
+
+    proc->types.pointer.scroll_throw_vect_ori = proc->types.pointer.scroll_throw_vect;
+
+    if(indev_obj_act) {
+        lv_event_send(indev_obj_act, LV_EVENT_PRESSING, indev_act);
+        if(indev_reset_check(proc)) return;
+
+        if(indev_act->proc.wait_until_release) return;
+
+        _lv_indev_scroll_handler(proc);
+        if(indev_reset_check(proc)) return;
+        indev_gesture(proc);
+        if(indev_reset_check(proc)) return;
+
+        /*If there is no scrolling then check for long press time*/
+        if(proc->types.pointer.scroll_obj == NULL && proc->long_pr_sent == 0) {
+            /*Call the ancestor's event handler about the long press if enough time elapsed*/
+            if(lv_tick_elaps(proc->pr_timestamp) > indev_act->driver->long_press_time) {
+                lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED, indev_act);
+                if(indev_reset_check(proc)) return;
+
+                /*Mark the Call the ancestor's event handler sending to do not send it again*/
+                proc->long_pr_sent = 1;
+
+                /*Save the long press time stamp for the long press repeat handler*/
+                proc->longpr_rep_timestamp = lv_tick_get();
+            }
+        }
+
+        /*Send long press repeated Call the ancestor's event handler*/
+        if(proc->types.pointer.scroll_obj == NULL && proc->long_pr_sent == 1) {
+            /*Call the ancestor's event handler about the long press repeat if enough time elapsed*/
+            if(lv_tick_elaps(proc->longpr_rep_timestamp) > indev_act->driver->long_press_repeat_time) {
+                lv_event_send(indev_obj_act, LV_EVENT_LONG_PRESSED_REPEAT, indev_act);
+                if(indev_reset_check(proc)) return;
+                proc->longpr_rep_timestamp = lv_tick_get();
+            }
+        }
+    }
+}
+
+/**
+ * Process the released state of LV_INDEV_TYPE_POINTER input devices
+ * @param proc pointer to an input device 'proc'
+ */
+static void indev_proc_release(_lv_indev_proc_t * proc)
+{
+    if(proc->wait_until_release != 0) {
+        lv_event_send(proc->types.pointer.act_obj, LV_EVENT_PRESS_LOST, indev_act);
+        if(indev_reset_check(proc)) return;
+
+        proc->types.pointer.act_obj  = NULL;
+        proc->types.pointer.last_obj = NULL;
+        proc->pr_timestamp           = 0;
+        proc->longpr_rep_timestamp   = 0;
+        proc->wait_until_release     = 0;
+    }
+    indev_obj_act = proc->types.pointer.act_obj;
+    lv_obj_t * scroll_obj = proc->types.pointer.scroll_obj;
+
+    /*Forget the act obj and send a released Call the ancestor's event handler*/
+    if(indev_obj_act) {
+        LV_LOG_INFO("released");
+
+        /*Send RELEASE Call the ancestor's event handler and event*/
+        lv_event_send(indev_obj_act, LV_EVENT_RELEASED, indev_act);
+        if(indev_reset_check(proc)) return;
+
+        /*Send CLICK if no scrolling*/
+        if(scroll_obj == NULL) {
+            if(proc->long_pr_sent == 0) {
+                lv_event_send(indev_obj_act, LV_EVENT_SHORT_CLICKED, indev_act);
+                if(indev_reset_check(proc)) return;
+            }
+
+            lv_event_send(indev_obj_act, LV_EVENT_CLICKED, indev_act);
+            if(indev_reset_check(proc)) return;
+        }
+
+        proc->types.pointer.act_obj = NULL;
+        proc->pr_timestamp          = 0;
+        proc->longpr_rep_timestamp  = 0;
+
+    }
+
+    /*The reset can be set in the Call the ancestor's event handler function.
+     * In case of reset query ignore the remaining parts.*/
+    if(scroll_obj) {
+        _lv_indev_scroll_throw_handler(proc);
+        if(indev_reset_check(proc)) return;
+    }
+}
+
+/**
+ * Process a new point from LV_INDEV_TYPE_BUTTON input device
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
+ * Reset input device if a reset query has been sent to it
+ * @param indev pointer to an input device
+ */
+static void indev_proc_reset_query_handler(lv_indev_t * indev)
+{
+    if(indev->proc.reset_query) {
+        indev->proc.types.pointer.act_obj           = NULL;
+        indev->proc.types.pointer.last_obj          = NULL;
+        indev->proc.types.pointer.scroll_obj          = NULL;
+        indev->proc.long_pr_sent                    = 0;
+        indev->proc.pr_timestamp                    = 0;
+        indev->proc.longpr_rep_timestamp            = 0;
+        indev->proc.types.pointer.scroll_sum.x        = 0;
+        indev->proc.types.pointer.scroll_sum.y        = 0;
+        indev->proc.types.pointer.scroll_dir = LV_DIR_NONE;
+        indev->proc.types.pointer.scroll_throw_vect.x = 0;
+        indev->proc.types.pointer.scroll_throw_vect.y = 0;
+        indev->proc.types.pointer.gesture_sum.x     = 0;
+        indev->proc.types.pointer.gesture_sum.y     = 0;
+        indev->proc.reset_query                     = 0;
+        indev_obj_act                               = NULL;
+    }
+}
+
+/**
+ * Handle focus/defocus on click for POINTER input devices
+ * @param proc pointer to the state of the indev
+ */
+static void indev_click_focus(_lv_indev_proc_t * proc)
+{
+    /*Handle click focus*/
+    if(lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_CLICK_FOCUSABLE) == false ||
+       proc->types.pointer.last_pressed == indev_obj_act) {
+        return;
+    }
+
+    lv_group_t * g_act = lv_obj_get_group(indev_obj_act);
+    lv_group_t * g_prev = proc->types.pointer.last_pressed ? lv_obj_get_group(proc->types.pointer.last_pressed) : NULL;
+
+    /*If both the last and act. obj. are in the same group (or have no group)*/
+    if(g_act == g_prev) {
+        /*The objects are in a group*/
+        if(g_act) {
+            lv_group_focus_obj(indev_obj_act);
+            if(indev_reset_check(proc)) return;
+        }
+        /*The object are not in group*/
+        else {
+            if(proc->types.pointer.last_pressed) {
+                lv_event_send(proc->types.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+                if(indev_reset_check(proc)) return;
+            }
+
+            lv_event_send(indev_obj_act, LV_EVENT_FOCUSED, indev_act);
+            if(indev_reset_check(proc)) return;
+        }
+    }
+    /*The object are not in the same group (in different groups or one has no group)*/
+    else {
+        /*If the prev. obj. is not in a group then defocus it.*/
+        if(g_prev == NULL && proc->types.pointer.last_pressed) {
+            lv_event_send(proc->types.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+            if(indev_reset_check(proc)) return;
+        }
+        /*Focus on a non-group object*/
+        else {
+            if(proc->types.pointer.last_pressed) {
+                /*If the prev. object also wasn't in a group defocus it*/
+                if(g_prev == NULL) {
+                    lv_event_send(proc->types.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+                    if(indev_reset_check(proc)) return;
+                }
+                /*If the prev. object also was in a group at least "LEAVE" it instead of defocus*/
+                else {
+                    lv_event_send(proc->types.pointer.last_pressed, LV_EVENT_LEAVE, indev_act);
+                    if(indev_reset_check(proc)) return;
+                }
+            }
+        }
+
+        /*Focus to the act. in its group*/
+        if(g_act) {
+            lv_group_focus_obj(indev_obj_act);
+            if(indev_reset_check(proc)) return;
+        }
+        else {
+            lv_event_send(indev_obj_act, LV_EVENT_FOCUSED, indev_act);
+            if(indev_reset_check(proc)) return;
+        }
+    }
+    proc->types.pointer.last_pressed = indev_obj_act;
+}
+
+/**
+* Handle the gesture of indev_proc_p->types.pointer.act_obj
+* @param indev pointer to an input device state
+*/
+void indev_gesture(_lv_indev_proc_t * proc)
+{
+
+    if(proc->types.pointer.scroll_obj) return;
+    if(proc->types.pointer.gesture_sent) return;
+
+    lv_obj_t * gesture_obj = proc->types.pointer.act_obj;
+
+    /*If gesture parent is active check recursively the gesture attribute*/
+    while(gesture_obj && lv_obj_has_flag(gesture_obj, LV_OBJ_FLAG_GESTURE_BUBBLE)) {
+        gesture_obj = lv_obj_get_parent(gesture_obj);
+    }
+
+    if(gesture_obj == NULL) return;
+
+    if((LV_ABS(proc->types.pointer.vect.x) < indev_act->driver->gesture_min_velocity) &&
+       (LV_ABS(proc->types.pointer.vect.y) < indev_act->driver->gesture_min_velocity)) {
+        proc->types.pointer.gesture_sum.x = 0;
+        proc->types.pointer.gesture_sum.y = 0;
+    }
+
+    /*Count the movement by gesture*/
+    proc->types.pointer.gesture_sum.x += proc->types.pointer.vect.x;
+    proc->types.pointer.gesture_sum.y += proc->types.pointer.vect.y;
+
+    if((LV_ABS(proc->types.pointer.gesture_sum.x) > indev_act->driver->gesture_limit) ||
+       (LV_ABS(proc->types.pointer.gesture_sum.y) > indev_act->driver->gesture_limit)) {
+
+        proc->types.pointer.gesture_sent = 1;
+
+        if(LV_ABS(proc->types.pointer.gesture_sum.x) > LV_ABS(proc->types.pointer.gesture_sum.y)) {
+            if(proc->types.pointer.gesture_sum.x > 0)
+                proc->types.pointer.gesture_dir = LV_DIR_RIGHT;
+            else
+                proc->types.pointer.gesture_dir = LV_DIR_LEFT;
+        }
+        else {
+            if(proc->types.pointer.gesture_sum.y > 0)
+                proc->types.pointer.gesture_dir = LV_DIR_BOTTOM;
+            else
+                proc->types.pointer.gesture_dir = LV_DIR_TOP;
+        }
+
+        lv_event_send(gesture_obj, LV_EVENT_GESTURE, indev_act);
+        if(indev_reset_check(proc)) return;
+    }
+}
+
+/**
+ * Checks if the reset_query flag has been set. If so, perform necessary global indev cleanup actions
+ * @param proc pointer to an input device 'proc'
+ * @return true if indev query should be immediately truncated.
+ */
+static bool indev_reset_check(_lv_indev_proc_t * proc)
+{
+    if(proc->reset_query) {
+        indev_obj_act = NULL;
+    }
+
+    return proc->reset_query ? true : false;
+}

--- a/lv_obj_pos.c
+++ b/lv_obj_pos.c
@@ -1,0 +1,1227 @@
+/**
+ * @file lv_obj_pos.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_obj.h"
+#include "lv_disp.h"
+#include "lv_refr.h"
+#include "../misc/lv_gc.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+#define MY_CLASS &lv_obj_class
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static lv_coord_t calc_content_width(lv_obj_t * obj);
+static lv_coord_t calc_content_height(lv_obj_t * obj);
+static void layout_update_core(lv_obj_t * obj);
+#ifdef LV_INDEV_TEST
+static void transform_point(const lv_obj_t * obj, lv_point_t * p, lv_point_t * p1, bool inv);
+#else
+static void transform_point(const lv_obj_t * obj, lv_point_t * p, bool inv);
+#endif
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+static uint32_t layout_cnt;
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_obj_set_pos(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_obj_set_x(obj, x);
+    lv_obj_set_y(obj, y);
+}
+
+void lv_obj_set_x(lv_obj_t * obj, lv_coord_t x)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_res_t res_x;
+    lv_style_value_t v_x;
+
+    res_x = lv_obj_get_local_style_prop(obj, LV_STYLE_X, &v_x, 0);
+
+    if((res_x == LV_RES_OK && v_x.num != x) || res_x == LV_RES_INV) {
+        lv_obj_set_style_x(obj, x, 0);
+    }
+}
+
+void lv_obj_set_y(lv_obj_t * obj, lv_coord_t y)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_res_t res_y;
+    lv_style_value_t v_y;
+
+    res_y = lv_obj_get_local_style_prop(obj, LV_STYLE_Y, &v_y, 0);
+
+    if((res_y == LV_RES_OK && v_y.num != y) || res_y == LV_RES_INV) {
+        lv_obj_set_style_y(obj, y, 0);
+    }
+}
+
+bool lv_obj_refr_size(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    /*If the width or height is set by a layout do not modify them*/
+    if(obj->w_layout && obj->h_layout) return false;
+
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    if(parent == NULL) return false;
+
+    lv_coord_t sl_ori = lv_obj_get_scroll_left(obj);
+    bool w_is_content = false;
+    bool w_is_pct = false;
+
+    lv_coord_t w;
+    if(obj->w_layout) {
+        w = lv_obj_get_width(obj);
+    }
+    else {
+        w = lv_obj_get_style_width(obj, LV_PART_MAIN);
+        w_is_content = w == LV_SIZE_CONTENT ? true : false;
+        w_is_pct = LV_COORD_IS_PCT(w) ? true : false;
+        lv_coord_t parent_w = lv_obj_get_content_width(parent);
+
+        if(w_is_content) {
+            w = calc_content_width(obj);
+        }
+        else if(w_is_pct) {
+            /*If parent has content size and the child has pct size
+             *a circular dependency will occur. To solve it keep child size at zero */
+            if(parent->w_layout == 0 && lv_obj_get_style_width(parent, 0) == LV_SIZE_CONTENT) {
+                lv_coord_t border_w = lv_obj_get_style_border_width(obj, 0);
+                w = lv_obj_get_style_pad_left(obj, 0) + border_w;
+                w += lv_obj_get_style_pad_right(obj, 0) + border_w;
+            }
+            else {
+                w = (LV_COORD_GET_PCT(w) * parent_w) / 100;
+            }
+        }
+
+        lv_coord_t minw = lv_obj_get_style_min_width(obj, LV_PART_MAIN);
+        lv_coord_t maxw = lv_obj_get_style_max_width(obj, LV_PART_MAIN);
+        w = lv_clamp_width(w, minw, maxw, parent_w);
+    }
+
+    lv_coord_t st_ori = lv_obj_get_scroll_top(obj);
+    lv_coord_t h;
+    bool h_is_content = false;
+    bool h_is_pct = false;
+    if(obj->h_layout) {
+        h = lv_obj_get_height(obj);
+    }
+    else {
+        h = lv_obj_get_style_height(obj, LV_PART_MAIN);
+        h_is_content = h == LV_SIZE_CONTENT ? true : false;
+        h_is_pct = LV_COORD_IS_PCT(h) ? true : false;
+        lv_coord_t parent_h = lv_obj_get_content_height(parent);
+
+        if(h_is_content) {
+            h = calc_content_height(obj);
+        }
+        else if(h_is_pct) {
+            /*If parent has content size and the child has pct size
+             *a circular dependency will occur. To solve it keep child size at zero */
+            if(parent->h_layout == 0 && lv_obj_get_style_height(parent, 0) == LV_SIZE_CONTENT) {
+                lv_coord_t border_w = lv_obj_get_style_border_width(obj, 0);
+                h = lv_obj_get_style_pad_top(obj, 0) + border_w;
+                h += lv_obj_get_style_pad_bottom(obj, 0) + border_w;
+            }
+            else {
+                h = (LV_COORD_GET_PCT(h) * parent_h) / 100;
+            }
+        }
+
+        lv_coord_t minh = lv_obj_get_style_min_height(obj, LV_PART_MAIN);
+        lv_coord_t maxh = lv_obj_get_style_max_height(obj, LV_PART_MAIN);
+        h = lv_clamp_height(h, minh, maxh, parent_h);
+    }
+
+    /*calc_auto_size set the scroll x/y to 0 so revert the original value*/
+    if(w_is_content || h_is_content) {
+        lv_obj_scroll_to(obj, sl_ori, st_ori, LV_ANIM_OFF);
+    }
+
+    /*Do nothing if the size is not changed*/
+    /*It is very important else recursive resizing can occur without size change*/
+    if(lv_obj_get_width(obj) == w && lv_obj_get_height(obj) == h) return false;
+
+    /*Invalidate the original area*/
+    lv_obj_invalidate(obj);
+
+    /*Save the original coordinates*/
+    lv_area_t ori;
+    lv_obj_get_coords(obj, &ori);
+
+    /*Check if the object inside the parent or not*/
+    lv_area_t parent_fit_area;
+    lv_obj_get_content_coords(parent, &parent_fit_area);
+
+    /*If the object is already out of the parent and its position is changes
+     *surely the scrollbars also changes so invalidate them*/
+    bool on1 = _lv_area_is_in(&ori, &parent_fit_area, 0);
+    if(!on1) lv_obj_scrollbar_invalidate(parent);
+
+    /*Set the length and height
+     *Be sure the content is not scrolled in an invalid position on the new size*/
+    obj->coords.y2 = obj->coords.y1 + h - 1;
+    if(lv_obj_get_style_base_dir(obj, LV_PART_MAIN) == LV_BASE_DIR_RTL) {
+        obj->coords.x1 = obj->coords.x2 - w + 1;
+    }
+    else {
+        obj->coords.x2 = obj->coords.x1 + w - 1;
+    }
+
+    /*Call the ancestor's event handler to the object with its new coordinates*/
+    lv_event_send(obj, LV_EVENT_SIZE_CHANGED, &ori);
+
+    /*Call the ancestor's event handler to the parent too*/
+    lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
+
+    /*Invalidate the new area*/
+    lv_obj_invalidate(obj);
+
+    lv_obj_readjust_scroll(obj, LV_ANIM_OFF);
+
+    /*If the object was out of the parent invalidate the new scrollbar area too.
+     *If it wasn't out of the parent but out now, also invalidate the scrollbars*/
+    bool on2 = _lv_area_is_in(&obj->coords, &parent_fit_area, 0);
+    if(on1 || (!on1 && on2)) lv_obj_scrollbar_invalidate(parent);
+
+    lv_obj_refresh_ext_draw_size(obj);
+
+    return true;
+}
+
+void lv_obj_set_size(lv_obj_t * obj, lv_coord_t w, lv_coord_t h)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_obj_set_width(obj, w);
+    lv_obj_set_height(obj, h);
+}
+
+void lv_obj_set_width(lv_obj_t * obj, lv_coord_t w)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_res_t res_w;
+    lv_style_value_t v_w;
+
+    res_w = lv_obj_get_local_style_prop(obj, LV_STYLE_WIDTH, &v_w, 0);
+
+    if((res_w == LV_RES_OK && v_w.num != w) || res_w == LV_RES_INV) {
+        lv_obj_set_style_width(obj, w, 0);
+    }
+}
+
+void lv_obj_set_height(lv_obj_t * obj, lv_coord_t h)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_res_t res_h;
+    lv_style_value_t v_h;
+
+    res_h = lv_obj_get_local_style_prop(obj, LV_STYLE_HEIGHT, &v_h, 0);
+
+    if((res_h == LV_RES_OK && v_h.num != h) || res_h == LV_RES_INV) {
+        lv_obj_set_style_height(obj, h, 0);
+    }
+}
+
+void lv_obj_set_content_width(lv_obj_t * obj, lv_coord_t w)
+{
+    lv_coord_t pleft = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
+    lv_coord_t pright = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+
+    lv_obj_set_width(obj, w + pleft + pright + 2 * border_width);
+}
+
+void lv_obj_set_content_height(lv_obj_t * obj, lv_coord_t h)
+{
+    lv_coord_t ptop = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
+    lv_coord_t pbottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+
+    lv_obj_set_height(obj, h + ptop + pbottom + 2 * border_width);
+}
+
+void lv_obj_set_layout(lv_obj_t * obj, uint32_t layout)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_obj_set_style_layout(obj, layout, 0);
+
+    lv_obj_mark_layout_as_dirty(obj);
+}
+
+bool lv_obj_is_layout_positioned(const lv_obj_t * obj)
+{
+    if(lv_obj_has_flag_any(obj, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_IGNORE_LAYOUT | LV_OBJ_FLAG_FLOATING)) return false;
+
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    if(parent == NULL) return false;
+
+    uint32_t layout = lv_obj_get_style_layout(parent, LV_PART_MAIN);
+    if(layout) return true;
+    else return false;
+}
+
+void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
+{
+    obj->layout_inv = 1;
+
+    /*Mark the screen as dirty too to mark that there is something to do on this screen*/
+    lv_obj_t * scr = lv_obj_get_screen(obj);
+    scr->scr_layout_inv = 1;
+
+    /*Make the display refreshing*/
+    lv_disp_t * disp = lv_obj_get_disp(scr);
+    if(disp->refr_timer) lv_timer_resume(disp->refr_timer);
+}
+
+void lv_obj_update_layout(const lv_obj_t * obj)
+{
+    static bool mutex = false;
+    if(mutex) {
+        LV_LOG_TRACE("Already running, returning");
+        return;
+    }
+    mutex = true;
+
+    lv_obj_t * scr = lv_obj_get_screen(obj);
+
+    /*Repeat until there where layout invalidations*/
+    while(scr->scr_layout_inv) {
+        LV_LOG_INFO("Layout update begin");
+        scr->scr_layout_inv = 0;
+        layout_update_core(scr);
+        LV_LOG_TRACE("Layout update end");
+    }
+
+    mutex = false;
+}
+
+uint32_t lv_layout_register(lv_layout_update_cb_t cb, void * user_data)
+{
+    layout_cnt++;
+    LV_GC_ROOT(_lv_layout_list) = lv_mem_realloc(LV_GC_ROOT(_lv_layout_list), layout_cnt * sizeof(lv_layout_dsc_t));
+    LV_ASSERT_MALLOC(LV_GC_ROOT(_lv_layout_list));
+
+    LV_GC_ROOT(_lv_layout_list)[layout_cnt - 1].cb = cb;
+    LV_GC_ROOT(_lv_layout_list)[layout_cnt - 1].user_data = user_data;
+    return layout_cnt;  /*No -1 to skip 0th index*/
+}
+
+void lv_obj_set_align(lv_obj_t * obj, lv_align_t align)
+{
+    lv_obj_set_style_align(obj, align, 0);
+}
+
+void lv_obj_align(lv_obj_t * obj, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs)
+{
+    lv_obj_set_style_align(obj, align, 0);
+    lv_obj_set_pos(obj, x_ofs, y_ofs);
+}
+
+void lv_obj_align_to(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_obj_update_layout(obj);
+    if(base == NULL) base = lv_obj_get_parent(obj);
+
+    LV_ASSERT_OBJ(base, MY_CLASS);
+
+    lv_coord_t x = 0;
+    lv_coord_t y = 0;
+
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    lv_coord_t pborder = lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+    lv_coord_t pleft = lv_obj_get_style_pad_left(parent, LV_PART_MAIN) + pborder;
+    lv_coord_t ptop = lv_obj_get_style_pad_top(parent, LV_PART_MAIN) + pborder;
+
+    lv_coord_t bborder = lv_obj_get_style_border_width(base, LV_PART_MAIN);
+    lv_coord_t bleft = lv_obj_get_style_pad_left(base, LV_PART_MAIN) + bborder;
+    lv_coord_t btop = lv_obj_get_style_pad_top(base, LV_PART_MAIN) + bborder;
+
+    if(align == LV_ALIGN_DEFAULT) {
+        if(lv_obj_get_style_base_dir(base, LV_PART_MAIN) == LV_BASE_DIR_RTL) align = LV_ALIGN_TOP_RIGHT;
+        else align = LV_ALIGN_TOP_LEFT;
+    }
+
+    switch(align) {
+        case LV_ALIGN_CENTER:
+            x = lv_obj_get_content_width(base) / 2 - lv_obj_get_width(obj) / 2 + bleft;
+            y = lv_obj_get_content_height(base) / 2 - lv_obj_get_height(obj) / 2 + btop;
+            break;
+        case LV_ALIGN_TOP_LEFT:
+            x = bleft;
+            y = btop;
+            break;
+        case LV_ALIGN_TOP_MID:
+            x = lv_obj_get_content_width(base) / 2 - lv_obj_get_width(obj) / 2 + bleft;
+            y = btop;
+            break;
+
+        case LV_ALIGN_TOP_RIGHT:
+            x = lv_obj_get_content_width(base) - lv_obj_get_width(obj) + bleft;
+            y = btop;
+            break;
+
+        case LV_ALIGN_BOTTOM_LEFT:
+            x = bleft;
+            y = lv_obj_get_content_height(base) - lv_obj_get_height(obj) + btop;
+            break;
+        case LV_ALIGN_BOTTOM_MID:
+            x = lv_obj_get_content_width(base) / 2 - lv_obj_get_width(obj) / 2 + bleft;
+            y = lv_obj_get_content_height(base) - lv_obj_get_height(obj) + btop;
+            break;
+
+        case LV_ALIGN_BOTTOM_RIGHT:
+            x = lv_obj_get_content_width(base) - lv_obj_get_width(obj) + bleft;
+            y = lv_obj_get_content_height(base) - lv_obj_get_height(obj) + btop;
+            break;
+
+        case LV_ALIGN_LEFT_MID:
+            x = bleft;
+            y = lv_obj_get_content_height(base) / 2 - lv_obj_get_height(obj) / 2 + btop;
+            break;
+
+        case LV_ALIGN_RIGHT_MID:
+            x = lv_obj_get_content_width(base) - lv_obj_get_width(obj) + bleft;
+            y = lv_obj_get_content_height(base) / 2 - lv_obj_get_height(obj) / 2 + btop;
+            break;
+
+        case LV_ALIGN_OUT_TOP_LEFT:
+            x = 0;
+            y = -lv_obj_get_height(obj);
+            break;
+
+        case LV_ALIGN_OUT_TOP_MID:
+            x = lv_obj_get_width(base) / 2 - lv_obj_get_width(obj) / 2;
+            y = -lv_obj_get_height(obj);
+            break;
+
+        case LV_ALIGN_OUT_TOP_RIGHT:
+            x = lv_obj_get_width(base) - lv_obj_get_width(obj);
+            y = -lv_obj_get_height(obj);
+            break;
+
+        case LV_ALIGN_OUT_BOTTOM_LEFT:
+            x = 0;
+            y = lv_obj_get_height(base);
+            break;
+
+        case LV_ALIGN_OUT_BOTTOM_MID:
+            x = lv_obj_get_width(base) / 2 - lv_obj_get_width(obj) / 2;
+            y = lv_obj_get_height(base);
+            break;
+
+        case LV_ALIGN_OUT_BOTTOM_RIGHT:
+            x = lv_obj_get_width(base) - lv_obj_get_width(obj);
+            y = lv_obj_get_height(base);
+            break;
+
+        case LV_ALIGN_OUT_LEFT_TOP:
+            x = -lv_obj_get_width(obj);
+            y = 0;
+            break;
+
+        case LV_ALIGN_OUT_LEFT_MID:
+            x = -lv_obj_get_width(obj);
+            y = lv_obj_get_height(base) / 2 - lv_obj_get_height(obj) / 2;
+            break;
+
+        case LV_ALIGN_OUT_LEFT_BOTTOM:
+            x = -lv_obj_get_width(obj);
+            y = lv_obj_get_height(base) - lv_obj_get_height(obj);
+            break;
+
+        case LV_ALIGN_OUT_RIGHT_TOP:
+            x = lv_obj_get_width(base);
+            y = 0;
+            break;
+
+        case LV_ALIGN_OUT_RIGHT_MID:
+            x = lv_obj_get_width(base);
+            y = lv_obj_get_height(base) / 2 - lv_obj_get_height(obj) / 2;
+            break;
+
+        case LV_ALIGN_OUT_RIGHT_BOTTOM:
+            x = lv_obj_get_width(base);
+            y = lv_obj_get_height(base) - lv_obj_get_height(obj);
+            break;
+    }
+
+    if(lv_obj_get_style_base_dir(parent, LV_PART_MAIN) == LV_BASE_DIR_RTL) {
+        x += x_ofs + base->coords.x1 - parent->coords.x1 + lv_obj_get_scroll_right(parent) - pleft;
+    }
+    else {
+        x += x_ofs + base->coords.x1 - parent->coords.x1 + lv_obj_get_scroll_left(parent) - pleft;
+    }
+    y += y_ofs + base->coords.y1 - parent->coords.y1 + lv_obj_get_scroll_top(parent) - ptop;
+    lv_obj_set_style_align(obj, LV_ALIGN_TOP_LEFT, 0);
+    lv_obj_set_pos(obj, x, y);
+
+}
+
+void lv_obj_get_coords(const lv_obj_t * obj, lv_area_t * coords)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_area_copy(coords, &obj->coords);
+}
+
+lv_coord_t lv_obj_get_x(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_coord_t rel_x;
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    if(parent) {
+        rel_x  = obj->coords.x1 - parent->coords.x1;
+        rel_x += lv_obj_get_scroll_x(parent);
+        rel_x -= lv_obj_get_style_pad_left(parent, LV_PART_MAIN);
+        rel_x -= lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+    }
+    else {
+        rel_x = obj->coords.x1;
+    }
+    return rel_x;
+}
+
+lv_coord_t lv_obj_get_x2(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    return lv_obj_get_x(obj) + lv_obj_get_width(obj);
+}
+
+lv_coord_t lv_obj_get_y(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_coord_t rel_y;
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    if(parent) {
+        rel_y = obj->coords.y1 - parent->coords.y1;
+        rel_y += lv_obj_get_scroll_y(parent);
+        rel_y -= lv_obj_get_style_pad_top(parent, LV_PART_MAIN);
+        rel_y -= lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+    }
+    else {
+        rel_y = obj->coords.y1;
+    }
+    return rel_y;
+}
+
+lv_coord_t lv_obj_get_y2(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    return lv_obj_get_y(obj) + lv_obj_get_height(obj);
+}
+
+lv_coord_t lv_obj_get_x_aligned(const lv_obj_t * obj)
+{
+    return lv_obj_get_style_x(obj, LV_PART_MAIN);
+}
+
+lv_coord_t lv_obj_get_y_aligned(const lv_obj_t * obj)
+{
+    return lv_obj_get_style_y(obj, LV_PART_MAIN);
+}
+
+
+lv_coord_t lv_obj_get_width(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    return lv_area_get_width(&obj->coords);
+}
+
+lv_coord_t lv_obj_get_height(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    return lv_area_get_height(&obj->coords);
+}
+
+lv_coord_t lv_obj_get_content_width(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_coord_t left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
+    lv_coord_t right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+
+    return lv_obj_get_width(obj) - left - right - 2 * border_width;
+}
+
+lv_coord_t lv_obj_get_content_height(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_coord_t top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
+    lv_coord_t bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+
+    return lv_obj_get_height(obj) - top - bottom - 2 * border_width;
+}
+
+void lv_obj_get_content_coords(const lv_obj_t * obj, lv_area_t * area)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+
+    lv_obj_get_coords(obj, area);
+    lv_area_increase(area, -border_width, -border_width);
+    area->x1 += lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
+    area->x2 -= lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
+    area->y1 += lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
+    area->y2 -= lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
+
+}
+
+lv_coord_t lv_obj_get_self_width(const lv_obj_t * obj)
+{
+    lv_point_t p = {0, LV_COORD_MIN};
+    lv_event_send((lv_obj_t *)obj, LV_EVENT_GET_SELF_SIZE, &p);
+    return p.x;
+}
+
+lv_coord_t lv_obj_get_self_height(const lv_obj_t * obj)
+{
+    lv_point_t p = {LV_COORD_MIN, 0};
+    lv_event_send((lv_obj_t *)obj, LV_EVENT_GET_SELF_SIZE, &p);
+    return p.y;
+}
+
+bool lv_obj_refresh_self_size(lv_obj_t * obj)
+{
+    lv_coord_t w_set = lv_obj_get_style_width(obj, LV_PART_MAIN);
+    lv_coord_t h_set = lv_obj_get_style_height(obj, LV_PART_MAIN);
+    if(w_set != LV_SIZE_CONTENT && h_set != LV_SIZE_CONTENT) return false;
+
+    lv_obj_mark_layout_as_dirty(obj);
+    return true;
+}
+
+void lv_obj_refr_pos(lv_obj_t * obj)
+{
+    if(lv_obj_is_layout_positioned(obj)) return;
+
+
+    lv_obj_t * parent = lv_obj_get_parent(obj);
+    lv_coord_t x = lv_obj_get_style_x(obj, LV_PART_MAIN);
+    lv_coord_t y = lv_obj_get_style_y(obj, LV_PART_MAIN);
+
+    if(parent == NULL) {
+        lv_obj_move_to(obj, x, y);
+        return;
+    }
+
+    /*Handle percentage value*/
+    lv_coord_t pw = lv_obj_get_content_width(parent);
+    lv_coord_t ph = lv_obj_get_content_height(parent);
+    if(LV_COORD_IS_PCT(x)) x = (pw * LV_COORD_GET_PCT(x)) / 100;
+    if(LV_COORD_IS_PCT(y)) y = (ph * LV_COORD_GET_PCT(y)) / 100;
+
+    /*Handle percentage value of translate*/
+    lv_coord_t tr_x = lv_obj_get_style_translate_x(obj, LV_PART_MAIN);
+    lv_coord_t tr_y = lv_obj_get_style_translate_y(obj, LV_PART_MAIN);
+    lv_coord_t w = lv_obj_get_width(obj);
+    lv_coord_t h = lv_obj_get_height(obj);
+    if(LV_COORD_IS_PCT(tr_x)) tr_x = (w * LV_COORD_GET_PCT(tr_x)) / 100;
+    if(LV_COORD_IS_PCT(tr_y)) tr_y = (h * LV_COORD_GET_PCT(tr_y)) / 100;
+
+    /*Use the translation*/
+    x += tr_x;
+    y += tr_y;
+
+    lv_align_t align = lv_obj_get_style_align(obj, LV_PART_MAIN);
+
+    if(align == LV_ALIGN_DEFAULT) {
+        if(lv_obj_get_style_base_dir(parent, LV_PART_MAIN) == LV_BASE_DIR_RTL) align = LV_ALIGN_TOP_RIGHT;
+        else align = LV_ALIGN_TOP_LEFT;
+    }
+
+    if(align == LV_ALIGN_TOP_LEFT) {
+        lv_obj_move_to(obj, x, y);
+    }
+    else {
+
+        switch(align) {
+            case LV_ALIGN_TOP_MID:
+                x += pw / 2 - w / 2;
+                break;
+            case LV_ALIGN_TOP_RIGHT:
+                x += pw - w;
+                break;
+            case LV_ALIGN_LEFT_MID:
+                y += ph / 2 - h / 2;
+                break;
+            case LV_ALIGN_BOTTOM_LEFT:
+                y += ph - h;
+                break;
+            case LV_ALIGN_BOTTOM_MID:
+                x += pw / 2 - w / 2;
+                y += ph - h;
+                break;
+            case LV_ALIGN_BOTTOM_RIGHT:
+                x += pw - w;
+                y += ph - h;
+                break;
+            case LV_ALIGN_RIGHT_MID:
+                x += pw - w;
+                y += ph / 2 - h / 2;
+                break;
+            case LV_ALIGN_CENTER:
+                x += pw / 2 - w / 2;
+                y += ph / 2 - h / 2;
+                break;
+            default:
+                break;
+        }
+        lv_obj_move_to(obj, x, y);
+    }
+}
+
+void lv_obj_move_to(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
+{
+    /*Convert x and y to absolute coordinates*/
+    lv_obj_t * parent = obj->parent;
+
+    if(parent) {
+        lv_coord_t pad_left = lv_obj_get_style_pad_left(parent, LV_PART_MAIN);
+        lv_coord_t pad_top = lv_obj_get_style_pad_top(parent, LV_PART_MAIN);
+
+        if(lv_obj_has_flag(obj, LV_OBJ_FLAG_FLOATING)) {
+            x += pad_left + parent->coords.x1;
+            y += pad_top + parent->coords.y1;
+        }
+        else {
+            x += pad_left + parent->coords.x1 - lv_obj_get_scroll_x(parent);
+            y += pad_top + parent->coords.y1 - lv_obj_get_scroll_y(parent);
+        }
+
+        lv_coord_t border_width = lv_obj_get_style_border_width(parent, LV_PART_MAIN);
+        x += border_width;
+        y += border_width;
+    }
+
+    /*Calculate and set the movement*/
+    lv_point_t diff;
+    diff.x = x - obj->coords.x1;
+    diff.y = y - obj->coords.y1;
+
+    /*Do nothing if the position is not changed*/
+    /*It is very important else recursive positioning can
+     *occur without position change*/
+    if(diff.x == 0 && diff.y == 0) return;
+
+    /*Invalidate the original area*/
+    lv_obj_invalidate(obj);
+
+    /*Save the original coordinates*/
+    lv_area_t ori;
+    lv_obj_get_coords(obj, &ori);
+
+    /*Check if the object inside the parent or not*/
+    lv_area_t parent_fit_area;
+    bool on1 = false;
+    if(parent) {
+        lv_obj_get_content_coords(parent, &parent_fit_area);
+
+        /*If the object is already out of the parent and its position is changes
+         *surely the scrollbars also changes so invalidate them*/
+        on1 = _lv_area_is_in(&ori, &parent_fit_area, 0);
+        if(!on1) lv_obj_scrollbar_invalidate(parent);
+    }
+
+    obj->coords.x1 += diff.x;
+    obj->coords.y1 += diff.y;
+    obj->coords.x2 += diff.x;
+    obj->coords.y2 += diff.y;
+
+    lv_obj_move_children_by(obj, diff.x, diff.y, false);
+
+    /*Call the ancestor's event handler to the parent too*/
+    if(parent) lv_event_send(parent, LV_EVENT_CHILD_CHANGED, obj);
+
+    /*Invalidate the new area*/
+    lv_obj_invalidate(obj);
+
+    /*If the object was out of the parent invalidate the new scrollbar area too.
+     *If it wasn't out of the parent but out now, also invalidate the srollbars*/
+    if(parent) {
+        bool on2 = _lv_area_is_in(&obj->coords, &parent_fit_area, 0);
+        if(on1 || (!on1 && on2)) lv_obj_scrollbar_invalidate(parent);
+    }
+}
+
+void lv_obj_move_children_by(lv_obj_t * obj, lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating)
+{
+    uint32_t i;
+    uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+    for(i = 0; i < child_cnt; i++) {
+        lv_obj_t * child = obj->spec_attr->children[i];
+        if(ignore_floating && lv_obj_has_flag(child, LV_OBJ_FLAG_FLOATING)) continue;
+        child->coords.x1 += x_diff;
+        child->coords.y1 += y_diff;
+        child->coords.x2 += x_diff;
+        child->coords.y2 += y_diff;
+
+        lv_obj_move_children_by(child, x_diff, y_diff, false);
+    }
+}
+
+#ifdef LV_INDEV_TEST
+void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, lv_point_t * p1, bool recursive, bool inv)
+{
+    if(obj) {
+        lv_layer_type_t layer_type = _lv_obj_get_layer_type(obj);
+        bool do_tranf = layer_type == LV_LAYER_TYPE_TRANSFORM;
+        if(inv) {
+            if(recursive) lv_obj_transform_point(lv_obj_get_parent(obj), p, p1, recursive, inv);
+            if(do_tranf) transform_point(obj, p, p1, inv);
+        }
+        else {
+            if(do_tranf) transform_point(obj, p, p1, inv);
+            if(recursive) lv_obj_transform_point(lv_obj_get_parent(obj), p, p1, recursive, inv);
+        }
+    }
+}
+#else
+void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv)
+{
+    if(obj) {
+        lv_layer_type_t layer_type = _lv_obj_get_layer_type(obj);
+        bool do_tranf = layer_type == LV_LAYER_TYPE_TRANSFORM;
+        if(inv) {
+            if(recursive) lv_obj_transform_point(lv_obj_get_parent(obj), p, recursive, inv);
+            if(do_tranf) transform_point(obj, p, inv);
+        }
+        else {
+            if(do_tranf) transform_point(obj, p, inv);
+            if(recursive) lv_obj_transform_point(lv_obj_get_parent(obj), p, recursive, inv);
+        }
+    }
+}
+#endif
+
+void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, bool recursive,
+                                 bool inv)
+{
+    lv_point_t p[4] = {
+        {area->x1, area->y1},
+        {area->x1, area->y2},
+        {area->x2, area->y1},
+        {area->x2, area->y2},
+    };
+#ifdef LV_INDEV_TEST
+    lv_obj_transform_point(obj, &p[0], NULL, recursive, inv);
+    lv_obj_transform_point(obj, &p[1], NULL, recursive, inv);
+    lv_obj_transform_point(obj, &p[2], NULL, recursive, inv);
+    lv_obj_transform_point(obj, &p[3], NULL, recursive, inv);
+#else
+    lv_obj_transform_point(obj, &p[0], recursive, inv);
+    lv_obj_transform_point(obj, &p[1], recursive, inv);
+    lv_obj_transform_point(obj, &p[2], recursive, inv);
+    lv_obj_transform_point(obj, &p[3], recursive, inv);
+#endif
+    area->x1 = LV_MIN4(p[0].x, p[1].x, p[2].x, p[3].x);
+    area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x);
+    area->y1 = LV_MIN4(p[0].y, p[1].y, p[2].y, p[3].y);
+    area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);
+    lv_area_increase(area, 5, 5);
+}
+
+
+void lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_disp_t * disp   = lv_obj_get_disp(obj);
+    if(!lv_disp_is_invalidation_enabled(disp)) return;
+
+    lv_area_t area_tmp;
+    lv_area_copy(&area_tmp, area);
+    if(!lv_obj_area_is_visible(obj, &area_tmp)) return;
+
+    _lv_inv_area(lv_obj_get_disp(obj),  &area_tmp);
+}
+
+void lv_obj_invalidate(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    /*Truncate the area to the object*/
+    lv_area_t obj_coords;
+    lv_coord_t ext_size = _lv_obj_get_ext_draw_size(obj);
+    lv_area_copy(&obj_coords, &obj->coords);
+    obj_coords.x1 -= ext_size;
+    obj_coords.y1 -= ext_size;
+    obj_coords.x2 += ext_size;
+    obj_coords.y2 += ext_size;
+
+    lv_obj_invalidate_area(obj, &obj_coords);
+
+}
+
+bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area)
+{
+    if(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN)) return false;
+
+    /*Invalidate the object only if it belongs to the current or previous or one of the layers'*/
+    lv_obj_t * obj_scr = lv_obj_get_screen(obj);
+    lv_disp_t * disp   = lv_obj_get_disp(obj_scr);
+    if(obj_scr != lv_disp_get_scr_act(disp) &&
+       obj_scr != lv_disp_get_scr_prev(disp) &&
+       obj_scr != lv_disp_get_layer_top(disp) &&
+       obj_scr != lv_disp_get_layer_sys(disp)) {
+        return false;
+    }
+
+    /*Truncate the area to the object*/
+    if(!lv_obj_has_flag_any(obj, LV_OBJ_FLAG_OVERFLOW_VISIBLE)) {
+        lv_area_t obj_coords;
+        lv_coord_t ext_size = _lv_obj_get_ext_draw_size(obj);
+        lv_area_copy(&obj_coords, &obj->coords);
+        obj_coords.x1 -= ext_size;
+        obj_coords.y1 -= ext_size;
+        obj_coords.x2 += ext_size;
+        obj_coords.y2 += ext_size;
+
+        /*The area is not on the object*/
+        if(!_lv_area_intersect(area, area, &obj_coords)) return false;
+    }
+
+    lv_obj_get_transformed_area(obj, area, true, false);
+
+
+    /*Truncate recursively to the parents*/
+    lv_obj_t * par = lv_obj_get_parent(obj);
+    while(par != NULL) {
+        /*If the parent is hidden then the child is hidden and won't be drawn*/
+        if(lv_obj_has_flag(par, LV_OBJ_FLAG_HIDDEN)) return false;
+
+        /*Truncate to the parent and if no common parts break*/
+        if(!lv_obj_has_flag_any(par, LV_OBJ_FLAG_OVERFLOW_VISIBLE)) {
+            lv_area_t par_area = par->coords;
+            lv_obj_get_transformed_area(par, &par_area, true, false);
+            if(!_lv_area_intersect(area, area, &par_area)) return false;
+        }
+
+        par = lv_obj_get_parent(par);
+    }
+
+    return true;
+}
+
+bool lv_obj_is_visible(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_area_t obj_coords;
+    lv_coord_t ext_size = _lv_obj_get_ext_draw_size(obj);
+    lv_area_copy(&obj_coords, &obj->coords);
+    obj_coords.x1 -= ext_size;
+    obj_coords.y1 -= ext_size;
+    obj_coords.x2 += ext_size;
+    obj_coords.y2 += ext_size;
+
+    return lv_obj_area_is_visible(obj, &obj_coords);
+
+}
+
+void lv_obj_set_ext_click_area(lv_obj_t * obj, lv_coord_t size)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_obj_allocate_spec_attr(obj);
+    obj->spec_attr->ext_click_pad = size;
+}
+
+void lv_obj_get_click_area(const lv_obj_t * obj, lv_area_t * area)
+{
+    lv_area_copy(area, &obj->coords);
+    if(obj->spec_attr) {
+        area->x1 -= obj->spec_attr->ext_click_pad;
+        area->x2 += obj->spec_attr->ext_click_pad;
+        area->y1 -= obj->spec_attr->ext_click_pad;
+        area->y2 += obj->spec_attr->ext_click_pad;
+    }
+}
+
+bool lv_obj_hit_test(lv_obj_t * obj, const lv_point_t * point)
+{
+    if(!lv_obj_has_flag(obj, LV_OBJ_FLAG_CLICKABLE)) return false;
+    if(lv_obj_has_state(obj, LV_STATE_DISABLED)) return false;
+
+    lv_area_t a;
+    lv_obj_get_click_area(obj, &a);
+    bool res = _lv_area_is_point_on(&a, point, 0);
+    if(res == false) return false;
+
+    if(lv_obj_has_flag(obj, LV_OBJ_FLAG_ADV_HITTEST)) {
+        lv_hit_test_info_t hit_info;
+        hit_info.point = point;
+        hit_info.res = true;
+        lv_event_send(obj, LV_EVENT_HIT_TEST, &hit_info);
+        return hit_info.res;
+    }
+
+    return res;
+}
+
+lv_coord_t lv_clamp_width(lv_coord_t width, lv_coord_t min_width, lv_coord_t max_width, lv_coord_t ref_width)
+{
+    if(LV_COORD_IS_PCT(min_width)) min_width = (ref_width * LV_COORD_GET_PCT(min_width)) / 100;
+    if(LV_COORD_IS_PCT(max_width)) max_width = (ref_width * LV_COORD_GET_PCT(max_width)) / 100;
+    return LV_CLAMP(min_width, width, max_width);
+}
+
+lv_coord_t lv_clamp_height(lv_coord_t height, lv_coord_t min_height, lv_coord_t max_height, lv_coord_t ref_height)
+{
+    if(LV_COORD_IS_PCT(min_height)) min_height = (ref_height * LV_COORD_GET_PCT(min_height)) / 100;
+    if(LV_COORD_IS_PCT(max_height)) max_height = (ref_height * LV_COORD_GET_PCT(max_height)) / 100;
+    return LV_CLAMP(min_height, height, max_height);
+}
+
+
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static lv_coord_t calc_content_width(lv_obj_t * obj)
+{
+    lv_obj_scroll_to_x(obj, 0, LV_ANIM_OFF);
+
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t pad_right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN) + border_width;
+    lv_coord_t pad_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN) + border_width;
+
+    lv_coord_t self_w;
+    self_w = lv_obj_get_self_width(obj) +  pad_left + pad_right;
+
+    lv_coord_t child_res = LV_COORD_MIN;
+    uint32_t i;
+    uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+    /*With RTL find the left most coordinate*/
+    if(lv_obj_get_style_base_dir(obj, LV_PART_MAIN) == LV_BASE_DIR_RTL) {
+        for(i = 0; i < child_cnt; i++) {
+            lv_obj_t * child = obj->spec_attr->children[i];
+            if(lv_obj_has_flag_any(child,  LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_FLOATING)) continue;
+
+            if(!lv_obj_is_layout_positioned(child)) {
+                lv_align_t align = lv_obj_get_style_align(child, 0);
+                switch(align) {
+                    case LV_ALIGN_DEFAULT:
+                    case LV_ALIGN_TOP_RIGHT:
+                    case LV_ALIGN_BOTTOM_RIGHT:
+                    case LV_ALIGN_RIGHT_MID:
+                        /*Normal right aligns. Other are ignored due to possible circular dependencies*/
+                        child_res = LV_MAX(child_res, obj->coords.x2 - child->coords.x1 + 1);
+                        break;
+                    default:
+                        /* Consider other cases only if x=0 and use the width of the object.
+                         * With x!=0 circular dependency could occur. */
+                        if(lv_obj_get_style_x(child, 0) == 0) {
+                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + pad_right);
+                        }
+                }
+            }
+            else {
+                child_res = LV_MAX(child_res, obj->coords.x2 - child->coords.x1 + 1);
+            }
+        }
+        if(child_res != LV_COORD_MIN) {
+            child_res += pad_left;
+        }
+    }
+    /*Else find the right most coordinate*/
+    else {
+        for(i = 0; i < child_cnt; i++) {
+            lv_obj_t * child = obj->spec_attr->children[i];
+            if(lv_obj_has_flag_any(child,  LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_FLOATING)) continue;
+
+            if(!lv_obj_is_layout_positioned(child)) {
+                lv_align_t align = lv_obj_get_style_align(child, 0);
+                switch(align) {
+                    case LV_ALIGN_DEFAULT:
+                    case LV_ALIGN_TOP_LEFT:
+                    case LV_ALIGN_BOTTOM_LEFT:
+                    case LV_ALIGN_LEFT_MID:
+                        /*Normal left aligns.*/
+                        child_res = LV_MAX(child_res, child->coords.x2 - obj->coords.x1 + 1);
+                        break;
+                    default:
+                        /* Consider other cases only if x=0 and use the width of the object.
+                         * With x!=0 circular dependency could occur. */
+                        if(lv_obj_get_style_y(child, 0) == 0) {
+                            child_res = LV_MAX(child_res, lv_area_get_width(&child->coords) + pad_left);
+                        }
+                }
+            }
+            else {
+                child_res = LV_MAX(child_res, child->coords.x2 - obj->coords.x1 + 1);
+            }
+        }
+
+        if(child_res != LV_COORD_MIN) {
+            child_res += pad_right;
+        }
+    }
+
+    if(child_res == LV_COORD_MIN) return self_w;
+    else return LV_MAX(child_res, self_w);
+}
+
+static lv_coord_t calc_content_height(lv_obj_t * obj)
+{
+    lv_obj_scroll_to_y(obj, 0, LV_ANIM_OFF);
+
+    lv_coord_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+    lv_coord_t pad_top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN) + border_width;
+    lv_coord_t pad_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN) + border_width;
+
+    lv_coord_t self_h;
+    self_h = lv_obj_get_self_height(obj) + pad_top + pad_bottom;
+
+    lv_coord_t child_res = LV_COORD_MIN;
+    uint32_t i;
+    uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+    for(i = 0; i < child_cnt; i++) {
+        lv_obj_t * child = obj->spec_attr->children[i];
+        if(lv_obj_has_flag_any(child,  LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_FLOATING)) continue;
+
+
+        if(!lv_obj_is_layout_positioned(child)) {
+            lv_align_t align = lv_obj_get_style_align(child, 0);
+            switch(align) {
+                case LV_ALIGN_DEFAULT:
+                case LV_ALIGN_TOP_RIGHT:
+                case LV_ALIGN_TOP_MID:
+                case LV_ALIGN_TOP_LEFT:
+                    /*Normal top aligns. */
+                    child_res = LV_MAX(child_res, child->coords.y2 - obj->coords.y1 + 1);
+                    break;
+                default:
+                    /* Consider other cases only if y=0 and use the height of the object.
+                     * With y!=0 circular dependency could occur. */
+                    if(lv_obj_get_style_y(child, 0) == 0) {
+                        child_res = LV_MAX(child_res, lv_area_get_height(&child->coords) + pad_top);
+                    }
+                    break;
+            }
+        }
+        else {
+            child_res = LV_MAX(child_res, child->coords.y2 - obj->coords.y1 + 1);
+        }
+    }
+
+    if(child_res != LV_COORD_MIN) {
+        child_res += pad_bottom;
+        return LV_MAX(child_res, self_h);
+    }
+    else {
+        return self_h;
+    }
+
+}
+
+static void layout_update_core(lv_obj_t * obj)
+{
+    uint32_t i;
+    uint32_t child_cnt = lv_obj_get_child_cnt(obj);
+    for(i = 0; i < child_cnt; i++) {
+        lv_obj_t * child = obj->spec_attr->children[i];
+        layout_update_core(child);
+    }
+
+    if(obj->layout_inv == 0) return;
+
+    obj->layout_inv = 0;
+
+    lv_obj_refr_size(obj);
+    lv_obj_refr_pos(obj);
+
+    if(child_cnt > 0) {
+        uint32_t layout_id = lv_obj_get_style_layout(obj, LV_PART_MAIN);
+        if(layout_id > 0 && layout_id <= layout_cnt) {
+            void  * user_data = LV_GC_ROOT(_lv_layout_list)[layout_id - 1].user_data;
+            LV_GC_ROOT(_lv_layout_list)[layout_id - 1].cb(obj, user_data);
+        }
+    }
+}
+
+#ifdef LV_INDEV_TEST
+static void transform_point(const lv_obj_t * obj, lv_point_t * p, lv_point_t * p1, bool inv)
+{
+    int16_t angle = lv_obj_get_style_transform_angle(obj, 0);
+    int16_t zoom = lv_obj_get_style_transform_zoom(obj, 0);
+
+    if(angle == 0 && zoom == LV_IMG_ZOOM_NONE) return;
+
+    lv_point_t pivot;
+
+    if(p1)
+    {
+		pivot.x = obj->coords.x1 + (p->x - p1->x) + lv_obj_get_style_transform_pivot_x(obj, 0);
+		pivot.y = obj->coords.y1 + (p->y - p1->y) + lv_obj_get_style_transform_pivot_y(obj, 0);
+    }
+    else
+    {
+	    pivot.x = obj->coords.x1 + lv_obj_get_style_transform_pivot_x(obj, 0);
+	    pivot.y = obj->coords.y1 + lv_obj_get_style_transform_pivot_y(obj, 0);
+    }
+    if(inv) {
+        angle = -angle;
+        zoom = (256 * 256) / zoom;
+    }
+
+    lv_point_transform(p, angle, zoom, &pivot);
+}
+#else
+static void transform_point(const lv_obj_t * obj, lv_point_t * p, bool inv)
+{
+    int16_t angle = lv_obj_get_style_transform_angle(obj, 0);
+    int16_t zoom = lv_obj_get_style_transform_zoom(obj, 0);
+
+    if(angle == 0 && zoom == LV_IMG_ZOOM_NONE) return;
+
+    lv_point_t pivot;
+    pivot.x = obj->coords.x1 + lv_obj_get_style_transform_pivot_x(obj, 0);
+    pivot.y = obj->coords.y1 + lv_obj_get_style_transform_pivot_y(obj, 0);
+    if(inv) {
+        angle = -angle;
+        zoom = (256 * 256) / zoom;
+    }
+
+    lv_point_transform(p, angle, zoom, &pivot);
+}
+#endif

--- a/lv_obj_pos.h
+++ b/lv_obj_pos.h
@@ -1,0 +1,452 @@
+/**
+ * @file lv_obj_pos.h
+ *
+ */
+
+#ifndef LV_OBJ_POS_H
+#define LV_OBJ_POS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../misc/lv_area.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+struct _lv_obj_t;
+
+typedef void (*lv_layout_update_cb_t)(struct _lv_obj_t *, void * user_data);
+typedef struct {
+    lv_layout_update_cb_t cb;
+    void * user_data;
+} lv_layout_dsc_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Set the position of an object relative to the set alignment.
+ * @param obj       pointer to an object
+ * @param x         new x coordinate
+ * @param y         new y coordinate
+ * @note            With default alignment it's the distance from the top left corner
+ * @note            E.g. LV_ALIGN_CENTER alignment it's the offset from the center of the parent
+ * @note            The position is interpreted on the content area of the parent
+ * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
+ */
+void lv_obj_set_pos(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
+
+/**
+ * Set the x coordinate of an object
+ * @param obj       pointer to an object
+ * @param x         new x coordinate
+ * @note            With default alignment it's the distance from the top left corner
+ * @note            E.g. LV_ALIGN_CENTER alignment it's the offset from the center of the parent
+ * @note            The position is interpreted on the content area of the parent
+ * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
+ */
+void lv_obj_set_x(struct _lv_obj_t * obj, lv_coord_t x);
+
+/**
+ * Set the y coordinate of an object
+ * @param obj       pointer to an object
+ * @param y         new y coordinate
+ * @note            With default alignment it's the distance from the top left corner
+ * @note            E.g. LV_ALIGN_CENTER alignment it's the offset from the center of the parent
+ * @note            The position is interpreted on the content area of the parent
+ * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
+ */
+void lv_obj_set_y(struct _lv_obj_t * obj, lv_coord_t y);
+
+/**
+ * Set the size of an object.
+ * @param obj       pointer to an object
+ * @param w         the new width
+ * @param h         the new height
+ * @note            possible values are:
+ *                  pixel               simple set the size accordingly
+ *                  LV_SIZE_CONTENT     set the size to involve all children in the given direction
+ *                  LV_SIZE_PCT(x)     to set size in percentage of the parent's content area size (the size without paddings).
+ *                                      x should be in [0..1000]% range
+ */
+void lv_obj_set_size(struct _lv_obj_t * obj, lv_coord_t w, lv_coord_t h);
+
+/**
+ * Recalculate the size of the object
+ * @param obj       pointer to an object
+ * @return          true: the size has been changed
+ */
+bool lv_obj_refr_size(struct _lv_obj_t * obj);
+
+/**
+ * Set the width of an object
+ * @param obj       pointer to an object
+ * @param w         the new width
+ * @note            possible values are:
+ *                  pixel               simple set the size accordingly
+ *                  LV_SIZE_CONTENT     set the size to involve all children in the given direction
+ *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
+ *                                      x should be in [0..1000]% range
+ */
+void lv_obj_set_width(struct _lv_obj_t * obj, lv_coord_t w);
+
+/**
+ * Set the height of an object
+ * @param obj       pointer to an object
+ * @param h         the new height
+ * @note            possible values are:
+ *                  pixel               simple set the size accordingly
+ *                  LV_SIZE_CONTENT     set the size to involve all children in the given direction
+ *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
+ *                                      x should be in [0..1000]% range
+ */
+void lv_obj_set_height(struct _lv_obj_t * obj, lv_coord_t h);
+
+/**
+ * Set the width reduced by the left and right padding and the border width.
+ * @param obj       pointer to an object
+ * @param w         the width without paddings in pixels
+ */
+void lv_obj_set_content_width(struct _lv_obj_t * obj, lv_coord_t w);
+
+/**
+ * Set the height reduced by the top and bottom padding and the border width.
+ * @param obj       pointer to an object
+ * @param h         the height without paddings in pixels
+ */
+void lv_obj_set_content_height(struct _lv_obj_t * obj, lv_coord_t h);
+
+/**
+ * Set a layout for an object
+ * @param obj       pointer to an object
+ * @param layout    pointer to a layout descriptor to set
+ */
+void lv_obj_set_layout(struct _lv_obj_t * obj, uint32_t layout);
+
+/**
+ * Test whether the and object is positioned by a layout or not
+ * @param obj       pointer to an object to test
+ * @return true:    positioned by a layout; false: not positioned by a layout
+ */
+bool lv_obj_is_layout_positioned(const struct _lv_obj_t * obj);
+
+/**
+ * Mark the object for layout update.
+ * @param obj      pointer to an object whose children needs to be updated
+ */
+void lv_obj_mark_layout_as_dirty(struct _lv_obj_t * obj);
+
+/**
+ * Update the layout of an object.
+ * @param obj      pointer to an object whose children needs to be updated
+ */
+void lv_obj_update_layout(const struct _lv_obj_t * obj);
+
+/**
+ * Register a new layout
+ * @param cb        the layout update callback
+ * @param user_data custom data that will be passed to `cb`
+ * @return          the ID of the new layout
+ */
+uint32_t lv_layout_register(lv_layout_update_cb_t cb, void * user_data);
+
+/**
+ * Change the alignment of an object.
+ * @param obj       pointer to an object to align
+ * @param align     type of alignment (see 'lv_align_t' enum) `LV_ALIGN_OUT_...` can't be used.
+ */
+void lv_obj_set_align(struct _lv_obj_t * obj, lv_align_t align);
+
+/**
+ * Change the alignment of an object and set new coordinates.
+ * Equivalent to:
+ * lv_obj_set_align(obj, align);
+ * lv_obj_set_pos(obj, x_ofs, y_ofs);
+ * @param obj       pointer to an object to align
+ * @param align     type of alignment (see 'lv_align_t' enum) `LV_ALIGN_OUT_...` can't be used.
+ * @param x_ofs     x coordinate offset after alignment
+ * @param y_ofs     y coordinate offset after alignment
+ */
+void lv_obj_align(struct _lv_obj_t * obj, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs);
+
+/**
+ * Align an object to an other object.
+ * @param obj       pointer to an object to align
+ * @param base      pointer to an other object (if NULL `obj`s parent is used). 'obj' will be aligned to it.
+ * @param align     type of alignment (see 'lv_align_t' enum)
+ * @param x_ofs     x coordinate offset after alignment
+ * @param y_ofs     y coordinate offset after alignment
+ * @note            if the position or size of `base` changes `obj` needs to be aligned manually again
+ */
+void lv_obj_align_to(struct _lv_obj_t * obj, const struct _lv_obj_t * base, lv_align_t align, lv_coord_t x_ofs,
+                     lv_coord_t y_ofs);
+
+/**
+ * Align an object to the center on its parent.
+ * @param obj       pointer to an object to align
+ * @note            if the parent size changes `obj` needs to be aligned manually again
+ */
+static inline void lv_obj_center(struct _lv_obj_t * obj)
+{
+    lv_obj_align(obj, LV_ALIGN_CENTER, 0, 0);
+}
+
+
+/**
+ * Copy the coordinates of an object to an area
+ * @param obj       pointer to an object
+ * @param coords    pointer to an area to store the coordinates
+ */
+void lv_obj_get_coords(const struct _lv_obj_t * obj, lv_area_t * coords);
+
+/**
+ * Get the x coordinate of object.
+ * @param obj       pointer to an object
+ * @return          distance of `obj` from the left side of its parent plus the parent's left padding
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @note            Zero return value means the object is on the left padding of the parent, and not on the left edge.
+ * @note            Scrolling of the parent doesn't change the returned value.
+ * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
+ */
+lv_coord_t lv_obj_get_x(const struct _lv_obj_t * obj);
+
+/**
+ * Get the x2 coordinate of object.
+ * @param obj       pointer to an object
+ * @return          distance of `obj` from the right side of its parent plus the parent's right padding
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @note            Zero return value means the object is on the right padding of the parent, and not on the right edge.
+ * @note            Scrolling of the parent doesn't change the returned value.
+ * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
+ */
+lv_coord_t lv_obj_get_x2(const struct _lv_obj_t * obj);
+
+/**
+ * Get the y coordinate of object.
+ * @param obj       pointer to an object
+ * @return          distance of `obj` from the top side of its parent plus the parent's top padding
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @note            Zero return value means the object is on the top padding of the parent, and not on the top edge.
+ * @note            Scrolling of the parent doesn't change the returned value.
+ * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
+ */
+lv_coord_t lv_obj_get_y(const struct _lv_obj_t * obj);
+
+/**
+ * Get the y2 coordinate of object.
+ * @param obj       pointer to an object
+ * @return          distance of `obj` from the bottom side of its parent plus the parent's bottom padding
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @note            Zero return value means the object is on the bottom padding of the parent, and not on the bottom edge.
+ * @note            Scrolling of the parent doesn't change the returned value.
+ * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
+ */
+lv_coord_t lv_obj_get_y2(const struct _lv_obj_t * obj);
+
+/**
+ * Get the actually set x coordinate of object, i.e. the offset form the set alignment
+ * @param obj       pointer to an object
+ * @return          the set x coordinate
+ */
+lv_coord_t lv_obj_get_x_aligned(const struct _lv_obj_t * obj);
+
+/**
+ * Get the actually set y coordinate of object, i.e. the offset form the set alignment
+ * @param obj       pointer to an object
+ * @return          the set y coordinate
+ */
+lv_coord_t lv_obj_get_y_aligned(const struct _lv_obj_t * obj);
+
+/**
+ * Get the width of an object
+ * @param obj       pointer to an object
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @return          the width in pixels
+ */
+lv_coord_t lv_obj_get_width(const struct _lv_obj_t * obj);
+
+/**
+ * Get the height of an object
+ * @param obj       pointer to an object
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @return          the height in pixels
+ */
+lv_coord_t lv_obj_get_height(const struct _lv_obj_t * obj);
+
+/**
+ * Get the width reduced by the left and right padding and the border width.
+ * @param obj       pointer to an object
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @return          the width which still fits into its parent without causing overflow (making the parent scrollable)
+ */
+lv_coord_t lv_obj_get_content_width(const struct _lv_obj_t * obj);
+
+/**
+ * Get the height reduced by the top and bottom padding and the border width.
+ * @param obj       pointer to an object
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @return          the height which still fits into the parent without causing overflow (making the parent scrollable)
+ */
+lv_coord_t lv_obj_get_content_height(const struct _lv_obj_t * obj);
+
+/**
+ * Get the area reduced by the paddings and the border width.
+ * @param obj       pointer to an object
+ * @note            The position of the object is recalculated only on the next redraw. To force coordinate recalculation
+ *                  call `lv_obj_update_layout(obj)`.
+ * @param area      the area which still fits into the parent without causing overflow (making the parent scrollable)
+ */
+void lv_obj_get_content_coords(const struct _lv_obj_t * obj, lv_area_t * area);
+
+/**
+ * Get the width occupied by the "parts" of the widget. E.g. the width of all columns of a table.
+ * @param obj       pointer to an objects
+ * @return          the width of the virtually drawn content
+ * @note            This size independent from the real size of the widget.
+ *                  It just tells how large the internal ("virtual") content is.
+ */
+lv_coord_t lv_obj_get_self_width(const struct _lv_obj_t * obj);
+
+/**
+ * Get the height occupied by the "parts" of the widget. E.g. the height of all rows of a table.
+ * @param obj       pointer to an objects
+ * @return          the width of the virtually drawn content
+ * @note            This size independent from the real size of the widget.
+ *                  It just tells how large the internal ("virtual") content is.
+ */
+lv_coord_t lv_obj_get_self_height(const struct _lv_obj_t * obj);
+
+/**
+ * Handle if the size of the internal ("virtual") content of an object has changed.
+ * @param obj       pointer to an object
+ * @return          false: nothing happened; true: refresh happened
+ */
+bool lv_obj_refresh_self_size(struct _lv_obj_t * obj);
+
+void lv_obj_refr_pos(struct _lv_obj_t * obj);
+
+void lv_obj_move_to(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
+
+
+void lv_obj_move_children_by(struct _lv_obj_t * obj, lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating);
+
+/**
+ * Transform a point using the angle and zoom style properties of an object
+ * @param obj           pointer to an object whose style properties should be used
+ * @param p             a point to transform, the result will be written back here too
+ * @param recursive     consider the transformation properties of the parents too
+ * @param inv           do the inverse of the transformation (-angle and 1/zoom)
+ */
+#ifdef LV_INDEV_TEST
+void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, lv_point_t * p1, bool recursive, bool inv);
+#else
+void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
+#endif
+/**
+ * Transform an area using the angle and zoom style properties of an object
+ * @param obj           pointer to an object whose style properties should be used
+ * @param area          an area to transform, the result will be written back here too
+ * @param recursive     consider the transformation properties of the parents too
+ * @param inv           do the inverse of the transformation (-angle and 1/zoom)
+ */
+void lv_obj_get_transformed_area(const struct _lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
+
+/**
+ * Mark an area of an object as invalid.
+ * The area will be truncated to the object's area and marked for redraw.
+ * @param obj       pointer to an object
+ * @param           area the area to redraw
+ */
+void lv_obj_invalidate_area(const struct _lv_obj_t * obj, const lv_area_t * area);
+
+/**
+ * Mark the object as invalid to redrawn its area
+ * @param obj       pointer to an object
+ */
+void lv_obj_invalidate(const struct _lv_obj_t * obj);
+
+/**
+ * Tell whether an area of an object is visible (even partially) now or not
+ * @param obj       pointer to an object
+ * @param area      the are to check. The visible part of the area will be written back here.
+ * @return true     visible; false not visible (hidden, out of parent, on other screen, etc)
+ */
+bool lv_obj_area_is_visible(const struct _lv_obj_t * obj, lv_area_t * area);
+
+/**
+ * Tell whether an object is visible (even partially) now or not
+ * @param obj       pointer to an object
+ * @return      true: visible; false not visible (hidden, out of parent, on other screen, etc)
+ */
+bool lv_obj_is_visible(const struct _lv_obj_t * obj);
+
+/**
+ * Set the size of an extended clickable area
+ * @param obj       pointer to an object
+ * @param size      extended clickable area in all 4 directions [px]
+ */
+void lv_obj_set_ext_click_area(struct _lv_obj_t * obj, lv_coord_t size);
+
+/**
+ * Get the an area where to object can be clicked.
+ * It's the object's normal area plus the extended click area.
+ * @param obj       pointer to an object
+ * @param area      store the result area here
+ */
+void lv_obj_get_click_area(const struct _lv_obj_t * obj, lv_area_t * area);
+
+/**
+ * Hit-test an object given a particular point in screen space.
+ * @param obj       object to hit-test
+ * @param point     screen-space point (absolute coordinate)
+ * @return          true: if the object is considered under the point
+ */
+bool lv_obj_hit_test(struct _lv_obj_t * obj, const lv_point_t * point);
+
+/**
+ * Clamp a width between min and max width. If the min/max width is in percentage value use the ref_width
+ * @param width         width to clamp
+ * @param min_width     the minimal width
+ * @param max_width     the maximal width
+ * @param ref_width     the reference width used when min/max width is in percentage
+ * @return              the clamped width
+ */
+lv_coord_t lv_clamp_width(lv_coord_t width, lv_coord_t min_width, lv_coord_t max_width, lv_coord_t ref_width);
+
+/**
+ * Clamp a height between min and max height. If the min/max height is in percentage value use the ref_height
+ * @param height         height to clamp
+ * @param min_height     the minimal height
+ * @param max_height     the maximal height
+ * @param ref_height     the reference height used when min/max height is in percentage
+ * @return              the clamped height
+ */
+lv_coord_t lv_clamp_height(lv_coord_t height, lv_coord_t min_height, lv_coord_t max_height, lv_coord_t ref_height);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_OBJ_POS_H*/


### PR DESCRIPTION
Try to modify the problem that the coordinates are calculated incorrectly when the object is zoomed out and dragged.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
