### PR TITLE
feat(log): add log level parameters to custom_print_cb

### DIFF
--- a/docs/porting/log.md
+++ b/docs/porting/log.md
@@ -25,7 +25,7 @@ If you can't use `printf` or want to use a custom function to log, you can regis
 For example:
 
 ```c
-void my_log_cb(const char * buf)
+void my_log_cb(lv_log_level_t level, const char * buf)
 {
   serial_send(buf, strlen(buf));
 }

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -108,7 +108,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
             lv_vsnprintf(msg, sizeof(msg), format, args);
             lv_snprintf(buf, sizeof(buf), "[%s]" LOG_TIMESTAMP_FMT " %s: %s \t(in %s line #%d)\n",
                         lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg, &file[p], line);
-            custom_print_cb(buf);
+            custom_print_cb(level, buf);
         }
 #endif
 
@@ -132,7 +132,7 @@ void lv_log(const char * format, ...)
     if(custom_print_cb) {
         char buf[512];
         lv_vsnprintf(buf, sizeof(buf), format, args);
-        custom_print_cb(buf);
+        custom_print_cb(LV_LOG_LEVEL_USER, buf);
     }
 #endif
 

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -49,7 +49,7 @@ typedef int8_t lv_log_level_t;
 /**
  * Log print function. Receives a string buffer to print".
  */
-typedef void (*lv_log_print_g_cb_t)(const char * buf);
+typedef void (*lv_log_print_g_cb_t)(lv_log_level_t level, const char * buf);
 
 /**********************
  * GLOBAL PROTOTYPES


### PR DESCRIPTION
### Description of the feature or fix

Some log systems support filtering of logs of different levels. Adding the level parameter to `log_cb` can be easily mapped to the log level of the local log system.
Take `syslog` as an example:
```c
static void syslog_print_cb(lv_log_level_t level, const char * buf)
{
  static const int pri[_LV_LOG_LEVEL_NUM] = { LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR, LOG_CRIT, LOG_ALERT };
  syslog(pri[level], "[LVGL] %s", buf);
}
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
