### PR TITLE
 chore: Fix missing include.

### DIFF
--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -481,6 +481,9 @@ def docs(p):
 base_dir = os.path.abspath(os.path.dirname(__file__))
 sys.stdout = open(base_dir + '/../src/core/lv_obj_style_gen.h', 'w')
 
+print("#include \"../misc/lv_area.h\"")
+print("#include \"../misc/lv_style.h\"")
+print("#include \"../core/lv_obj_style.h\"")
 for p in props:
   obj_style_get(p)
 

--- a/src/core/lv_event.h
+++ b/src/core/lv_event.h
@@ -14,6 +14,10 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdbool.h>
+#include "../misc/lv_area.h"
+#include "lv_obj_draw.h"
+#include "lv_obj_class.h"
+#include "../hal/lv_hal_indev.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include <stdint.h>
 #include <stdbool.h>
+#include "../misc/lv_area.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -16,6 +16,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include "../misc/lv_bidi.h"
+#include "../misc/lv_style.h"
 
 /*********************
  *      DEFINES
@@ -26,6 +27,8 @@ extern "C" {
  **********************/
 /*Can't include lv_obj.h because it includes this header file*/
 struct _lv_obj_t;
+typedef uint32_t lv_part_t;
+typedef uint16_t lv_state_t;
 
 typedef enum {
     _LV_STYLE_STATE_CMP_SAME,           /*The style properties in the 2 states are identical*/

--- a/src/core/lv_obj_style_gen.h
+++ b/src/core/lv_obj_style_gen.h
@@ -1,3 +1,6 @@
+#include "../misc/lv_area.h"
+#include "../misc/lv_style.h"
+#include "../core/lv_obj_style.h"
 static inline lv_coord_t lv_obj_get_style_width(const struct _lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_WIDTH);

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -15,6 +15,8 @@ extern "C" {
  *********************/
 #include <stddef.h>
 #include <stdbool.h>
+#include "../misc/lv_anim.h"
+#include "../hal/lv_hal_disp.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/lv_draw_layer.h
+++ b/src/draw/lv_draw_layer.h
@@ -14,6 +14,8 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "../misc/lv_area.h"
+#include "lv_draw_img.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/lv_draw_transform.h
+++ b/src/draw/lv_draw_transform.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 #include "../misc/lv_area.h"
+#include "lv_draw_img.h"
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
Fixed some header file parsing problems under pycparser.

### Description of the feature or fix

The specific repair content is the same as #3825, and fixed the path error based on it.

> Changes in src/core/lv_event.h fixed undefined type lv_point_t in [\lvgl\src\core\lv_event.h:129](https://github.com/lvgl/lvgl/blob/master/src/core/lv_event.h#L129) , lv_area_t in [\lvgl\src\core\lv_event.h:140](https://github.com/lvgl/lvgl/blob/master/src/core/lv_event.h#L140), lv_obj_class_t in [\lvgl\src\core\lv_event.h:162](https://github.com/lvgl/lvgl/blob/master/src/core/lv_event.h#L162), lv_indev_t in [\lvgl\src\core\lv_event.h:288](https://github.com/lvgl/lvgl/blob/master/src/core/lv_event.h#L288)
> 
> Changes in src/core/lv_obj_class.h fixed undefined type lv_coord_t in [\lvgl\src\core\lv_obj_class.h:63](https://github.com/lvgl/lvgl/blob/master/src/core/lv_obj_class.h#L63)
> 
> Other changes have also fixed similar problems.
> 
> The fixes to these problems can be used to generate thread safe secondary lvgl encapsulation using pycpraser and avoid some possible compilation errors

#### Description of "secondary lvgl encapsulation":
reply @amirgon 
> Hi @h13-0 !
> 
> > The fixes to these problems can be used to generate thread safe secondary lvgl encapsulation using pycpraser and avoid some possible compilation errors
> 
> Could you explain what's a "secondary lvgl encapsulation"? Is this related to the [Micropython Bindings](https://github.com/lvgl/lv_binding_micropython) or is this a different project that parses LVGL headers with pycparser?

These errors were found when I used [pycparser](https://github.com/eliben/pycparser) (a c language parsing library) to parse partial headers of lvgl.
And the same method is used for api binding in [lv_binding_micropython](https://github.com/lvgl/lv_binding_micropython) of lvgl, in [gen_mpy.py](https://github.com/lvgl/lv_binding_micropython/blob/master/gen/gen_mpy.py).
For me, I want to generate a second encapsulated thread safe function use pycparser in my project (for example, the demo below):
```C
// For example, thread safe encapsulation of lv_btn_create:
// lv_obj_t * lv_btn_create(lv_obj_t * parent);
lv_obj_t * safe_lv_btn_create(lv_obj_t * parent)
{
    lv_obj_t * obj = NULL;
    lv_recursive_mutex_lock();
    obj = lv_btn_create(parent);
    lv_recursive_mutex_unlock();
    return obj;
}
```
Of course, I haven't come up with a better way to solve the problem of multithreading safety.

#### Log checked with [tests/main.py](https://github.com/lvgl/lvgl/blob/master/tests/main.py)
Run with `python ./tests/main.py build`:
![MobaXterm_65LE6bh2kh](https://user-images.githubusercontent.com/61249472/204152744-d97869c4-caa9-4996-b708-3821ae367944.png)

Run with `python ./tests/main.py test`:
![MobaXterm_N7Ze4kz8jF](https://user-images.githubusercontent.com/61249472/204152682-5cbea1f9-42fa-4e95-9f33-8bb01b39c4d2.png)

Thank you.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
