### PR TITLE
feat(lv_flex): added support for `lv_flex`

### DIFF
--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -61,6 +61,8 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
 static void place_content(lv_flex_align_t place, lv_coord_t max_size, lv_coord_t content_size, lv_coord_t item_cnt,
                           lv_coord_t * start_pos, lv_coord_t * gap);
 static lv_obj_t * get_next_item(lv_obj_t * cont, bool rev, int32_t * item_id);
+static lv_coord_t lv_obj_get_width_with_margin(const lv_obj_t * obj);
+static lv_coord_t lv_obj_get_height_with_margin(const lv_obj_t * obj);
 
 /**********************
  *  GLOBAL VARIABLES
@@ -327,8 +329,9 @@ static int32_t find_track_end(lv_obj_t * cont, flex_t * f, int32_t item_start_id
     if(f->wrap && ((f->row && w_set == LV_SIZE_CONTENT) || (!f->row && h_set == LV_SIZE_CONTENT))) {
         f->wrap = false;
     }
-    lv_coord_t(*get_main_size)(const lv_obj_t *) = (f->row ? lv_obj_get_width : lv_obj_get_height);
-    lv_coord_t(*get_cross_size)(const lv_obj_t *) = (!f->row ? lv_obj_get_width : lv_obj_get_height);
+    lv_coord_t(*get_main_size)(const lv_obj_t *) = (f->row ? lv_obj_get_width_with_margin : lv_obj_get_height_with_margin);
+    lv_coord_t(*get_cross_size)(const lv_obj_t *) = (!f->row ? lv_obj_get_width_with_margin :
+                                                     lv_obj_get_height_with_margin);
 
     t->track_main_size = 0;
     t->track_fix_main_size = 0;
@@ -407,6 +410,12 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
     void (*area_set_main_size)(lv_area_t *, lv_coord_t) = (f->row ? lv_area_set_width : lv_area_set_height);
     lv_coord_t (*area_get_main_size)(const lv_area_t *) = (f->row ? lv_area_get_width : lv_area_get_height);
     lv_coord_t (*area_get_cross_size)(const lv_area_t *) = (!f->row ? lv_area_get_width : lv_area_get_height);
+
+    typedef lv_coord_t (*margin_func_t)(const struct _lv_obj_t *, uint32_t);
+    margin_func_t get_margin_main_start = (f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);
+    margin_func_t get_margin_main_end = (f->row ? lv_obj_get_style_margin_right : lv_obj_get_style_margin_bottom);
+    margin_func_t get_margin_cross_start = (!f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);
+    margin_func_t get_margin_cross_end = (!f->row ? lv_obj_get_style_margin_right : lv_obj_get_style_margin_bottom);
 
     /*Calculate the size of grow items first*/
     uint32_t i;
@@ -500,11 +509,14 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
                 /*Round up the cross size to avoid rounding error when dividing by 2
                  *The issue comes up e,g, with column direction with center cross direction if an element's width changes*/
                 cross_pos = (((t->track_cross_size + 1) & (~1)) - area_get_cross_size(&item->coords)) / 2;
+                cross_pos += (get_margin_cross_start(item, LV_PART_MAIN) - get_margin_cross_end(item, LV_PART_MAIN)) / 2;
                 break;
             case LV_FLEX_ALIGN_END:
                 cross_pos = t->track_cross_size - area_get_cross_size(&item->coords);
+                cross_pos -= get_margin_cross_end(item, LV_PART_MAIN);
                 break;
             default:
+                cross_pos += get_margin_cross_start(item, LV_PART_MAIN);
                 break;
         }
 
@@ -521,8 +533,8 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
 
         lv_coord_t diff_x = abs_x - item->coords.x1 + tr_x;
         lv_coord_t diff_y = abs_y - item->coords.y1 + tr_y;
-        diff_x += f->row ? main_pos : cross_pos;
-        diff_y += f->row ? cross_pos : main_pos;
+        diff_x += f->row ? main_pos + get_margin_main_start(item, LV_PART_MAIN) : cross_pos;
+        diff_y += f->row ? cross_pos : main_pos + get_margin_main_start(item, LV_PART_MAIN);
 
         if(diff_x || diff_y) {
             lv_obj_invalidate(item);
@@ -534,7 +546,9 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
             lv_obj_move_children_by(item, diff_x, diff_y, false);
         }
 
-        if(!(f->row && rtl)) main_pos += area_get_main_size(&item->coords) + item_gap + place_gap;
+        if(!(f->row && rtl)) main_pos += area_get_main_size(&item->coords) + item_gap + place_gap
+                                             + get_margin_main_start(item, LV_PART_MAIN)
+                                             + get_margin_main_end(item, LV_PART_MAIN);
         else main_pos -= item_gap + place_gap;
 
         item = get_next_item(cont, f->rev, &item_first_id);
@@ -596,6 +610,20 @@ static lv_obj_t * get_next_item(lv_obj_t * cont, bool rev, int32_t * item_id)
         if((*item_id) < (int32_t)cont->spec_attr->child_cnt) return cont->spec_attr->children[*item_id];
         else return NULL;
     }
+}
+
+static lv_coord_t lv_obj_get_width_with_margin(const lv_obj_t * obj)
+{
+    return lv_obj_get_style_margin_left(obj, LV_PART_MAIN)
+           + lv_obj_get_width(obj)
+           + lv_obj_get_style_margin_right(obj, LV_PART_MAIN);
+}
+
+static lv_coord_t lv_obj_get_height_with_margin(const lv_obj_t * obj)
+{
+    return lv_obj_get_style_margin_top(obj, LV_PART_MAIN)
+           + lv_obj_get_height(obj)
+           + lv_obj_get_style_margin_bottom(obj, LV_PART_MAIN);
 }
 
 #endif /*LV_USE_FLEX*/

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -109,10 +109,11 @@ void lv_flex_init(void)
     LV_STYLE_FLEX_CROSS_PLACE = lv_style_register_prop(LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
     LV_STYLE_FLEX_TRACK_PLACE = lv_style_register_prop(LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
 
-    LV_STYLE_FLEX_MARGIN_LEFT = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
-    LV_STYLE_FLEX_MARGIN_TOP = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
-    LV_STYLE_FLEX_MARGIN_RIGHT = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
-    LV_STYLE_FLEX_MARGIN_BOTTOM = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
+    uint8_t flag = LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE;
+    LV_STYLE_FLEX_MARGIN_LEFT = lv_style_register_prop(flag);
+    LV_STYLE_FLEX_MARGIN_TOP = lv_style_register_prop(flag);
+    LV_STYLE_FLEX_MARGIN_RIGHT = lv_style_register_prop(flag);
+    LV_STYLE_FLEX_MARGIN_BOTTOM = lv_style_register_prop(flag);
 }
 
 void lv_obj_set_flex_flow(lv_obj_t * obj, lv_flex_flow_t flow)
@@ -489,7 +490,8 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
     margin_func_t get_margin_main_start = (f->row ? lv_obj_get_style_flex_margin_left : lv_obj_get_style_flex_margin_top);
     margin_func_t get_margin_main_end = (f->row ? lv_obj_get_style_flex_margin_right : lv_obj_get_style_flex_margin_bottom);
     margin_func_t get_margin_cross_start = (!f->row ? lv_obj_get_style_flex_margin_left : lv_obj_get_style_flex_margin_top);
-    margin_func_t get_margin_cross_end = (!f->row ? lv_obj_get_style_flex_margin_right : lv_obj_get_style_flex_margin_bottom);
+    margin_func_t get_margin_cross_end = (!f->row ? lv_obj_get_style_flex_margin_right
+                                          : lv_obj_get_style_flex_margin_bottom);
 
     /*Calculate the size of grow items first*/
     uint32_t i;

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -73,6 +73,11 @@ lv_style_prop_t LV_STYLE_FLEX_MAIN_PLACE;
 lv_style_prop_t LV_STYLE_FLEX_CROSS_PLACE;
 lv_style_prop_t LV_STYLE_FLEX_TRACK_PLACE;
 lv_style_prop_t LV_STYLE_FLEX_GROW;
+lv_style_prop_t LV_STYLE_FLEX_MARGIN_LEFT;
+lv_style_prop_t LV_STYLE_FLEX_MARGIN_TOP;
+lv_style_prop_t LV_STYLE_FLEX_MARGIN_RIGHT;
+lv_style_prop_t LV_STYLE_FLEX_MARGIN_BOTTOM;
+
 
 /**********************
  *  STATIC VARIABLES
@@ -103,6 +108,11 @@ void lv_flex_init(void)
     LV_STYLE_FLEX_MAIN_PLACE = lv_style_register_prop(LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
     LV_STYLE_FLEX_CROSS_PLACE = lv_style_register_prop(LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
     LV_STYLE_FLEX_TRACK_PLACE = lv_style_register_prop(LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
+
+    LV_STYLE_FLEX_MARGIN_LEFT = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
+    LV_STYLE_FLEX_MARGIN_TOP = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
+    LV_STYLE_FLEX_MARGIN_RIGHT = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
+    LV_STYLE_FLEX_MARGIN_BOTTOM = lv_style_register_prop(LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE | LV_STYLE_PROP_FLAG_LAYOUT_UPDATE);
 }
 
 void lv_obj_set_flex_flow(lv_obj_t * obj, lv_flex_flow_t flow)
@@ -167,6 +177,37 @@ void lv_style_set_flex_grow(lv_style_t * style, uint8_t value)
     lv_style_set_prop(style, LV_STYLE_FLEX_GROW, v);
 }
 
+void lv_style_set_flex_margin_top(lv_style_t * style, lv_coord_t value)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_style_set_prop(style, LV_STYLE_FLEX_MARGIN_TOP, v);
+}
+
+void lv_style_set_flex_margin_bottom(lv_style_t * style, lv_coord_t value)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_style_set_prop(style, LV_STYLE_FLEX_MARGIN_BOTTOM, v);
+}
+
+void lv_style_set_flex_margin_left(lv_style_t * style, lv_coord_t value)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_style_set_prop(style, LV_STYLE_FLEX_MARGIN_LEFT, v);
+}
+
+void lv_style_set_flex_margin_right(lv_style_t * style, lv_coord_t value)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_style_set_prop(style, LV_STYLE_FLEX_MARGIN_RIGHT, v);
+}
 
 void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector)
 {
@@ -207,6 +248,39 @@ void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector
     };
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_GROW, v, selector);
 }
+
+void lv_obj_set_style_flex_margin_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_MARGIN_TOP, v, selector);
+}
+
+void lv_obj_set_style_flex_margin_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_MARGIN_BOTTOM, v, selector);
+}
+
+void lv_obj_set_style_flex_margin_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_MARGIN_LEFT, v, selector);
+}
+
+void lv_obj_set_style_flex_margin_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_MARGIN_RIGHT, v, selector);
+}
+
 
 /**********************
  *   STATIC FUNCTIONS
@@ -412,10 +486,10 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
     lv_coord_t (*area_get_cross_size)(const lv_area_t *) = (!f->row ? lv_area_get_width : lv_area_get_height);
 
     typedef lv_coord_t (*margin_func_t)(const struct _lv_obj_t *, uint32_t);
-    margin_func_t get_margin_main_start = (f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);
-    margin_func_t get_margin_main_end = (f->row ? lv_obj_get_style_margin_right : lv_obj_get_style_margin_bottom);
-    margin_func_t get_margin_cross_start = (!f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);
-    margin_func_t get_margin_cross_end = (!f->row ? lv_obj_get_style_margin_right : lv_obj_get_style_margin_bottom);
+    margin_func_t get_margin_main_start = (f->row ? lv_obj_get_style_flex_margin_left : lv_obj_get_style_flex_margin_top);
+    margin_func_t get_margin_main_end = (f->row ? lv_obj_get_style_flex_margin_right : lv_obj_get_style_flex_margin_bottom);
+    margin_func_t get_margin_cross_start = (!f->row ? lv_obj_get_style_flex_margin_left : lv_obj_get_style_flex_margin_top);
+    margin_func_t get_margin_cross_end = (!f->row ? lv_obj_get_style_flex_margin_right : lv_obj_get_style_flex_margin_bottom);
 
     /*Calculate the size of grow items first*/
     uint32_t i;
@@ -614,16 +688,16 @@ static lv_obj_t * get_next_item(lv_obj_t * cont, bool rev, int32_t * item_id)
 
 static lv_coord_t lv_obj_get_width_with_margin(const lv_obj_t * obj)
 {
-    return lv_obj_get_style_margin_left(obj, LV_PART_MAIN)
+    return lv_obj_get_style_flex_margin_left(obj, LV_PART_MAIN)
            + lv_obj_get_width(obj)
-           + lv_obj_get_style_margin_right(obj, LV_PART_MAIN);
+           + lv_obj_get_style_flex_margin_right(obj, LV_PART_MAIN);
 }
 
 static lv_coord_t lv_obj_get_height_with_margin(const lv_obj_t * obj)
 {
-    return lv_obj_get_style_margin_top(obj, LV_PART_MAIN)
+    return lv_obj_get_style_flex_margin_top(obj, LV_PART_MAIN)
            + lv_obj_get_height(obj)
-           + lv_obj_get_style_margin_bottom(obj, LV_PART_MAIN);
+           + lv_obj_get_style_flex_margin_bottom(obj, LV_PART_MAIN);
 }
 
 #endif /*LV_USE_FLEX*/

--- a/src/layouts/flex/lv_flex.h
+++ b/src/layouts/flex/lv_flex.h
@@ -63,6 +63,10 @@ extern lv_style_prop_t LV_STYLE_FLEX_MAIN_PLACE;
 extern lv_style_prop_t LV_STYLE_FLEX_CROSS_PLACE;
 extern lv_style_prop_t LV_STYLE_FLEX_TRACK_PLACE;
 extern lv_style_prop_t LV_STYLE_FLEX_GROW;
+extern lv_style_prop_t LV_STYLE_FLEX_MARGIN_LEFT;
+extern lv_style_prop_t LV_STYLE_FLEX_MARGIN_TOP;
+extern lv_style_prop_t LV_STYLE_FLEX_MARGIN_RIGHT;
+extern lv_style_prop_t LV_STYLE_FLEX_MARGIN_BOTTOM;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -103,11 +107,19 @@ void lv_style_set_flex_main_place(lv_style_t * style, lv_flex_align_t value);
 void lv_style_set_flex_cross_place(lv_style_t * style, lv_flex_align_t value);
 void lv_style_set_flex_track_place(lv_style_t * style, lv_flex_align_t value);
 void lv_style_set_flex_grow(lv_style_t * style, uint8_t value);
+void lv_style_set_flex_margin_left(lv_style_t * style, lv_coord_t value);
+void lv_style_set_flex_margin_top(lv_style_t * style, lv_coord_t value);
+void lv_style_set_flex_margin_right(lv_style_t * style, lv_coord_t value);
+void lv_style_set_flex_margin_bottom(lv_style_t * style, lv_coord_t value);
 void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector);
 void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 void lv_obj_set_style_flex_cross_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 void lv_obj_set_style_flex_track_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_margin_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_margin_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_margin_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_margin_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
 
 static inline lv_flex_flow_t lv_obj_get_style_flex_flow(const lv_obj_t * obj, uint32_t part)
 {
@@ -139,6 +151,30 @@ static inline uint8_t lv_obj_get_style_flex_grow(const lv_obj_t * obj, uint32_t 
     return (uint8_t)v.num;
 }
 
+static inline lv_coord_t lv_obj_get_style_flex_margin_top(const struct _lv_obj_t * obj, uint32_t part)
+{
+    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_MARGIN_TOP);
+    return (lv_coord_t)v.num;
+}
+
+static inline lv_coord_t lv_obj_get_style_flex_margin_bottom(const struct _lv_obj_t * obj, uint32_t part)
+{
+    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_MARGIN_BOTTOM);
+    return (lv_coord_t)v.num;
+}
+
+static inline lv_coord_t lv_obj_get_style_flex_margin_left(const struct _lv_obj_t * obj, uint32_t part)
+{
+    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_MARGIN_LEFT);
+    return (lv_coord_t)v.num;
+}
+
+static inline lv_coord_t lv_obj_get_style_flex_margin_right(const struct _lv_obj_t * obj, uint32_t part)
+{
+    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_MARGIN_RIGHT);
+    return (lv_coord_t)v.num;
+}
+
 /**********************
  *      MACROS
  **********************/
@@ -161,6 +197,26 @@ static inline uint8_t lv_obj_get_style_flex_grow(const lv_obj_t * obj, uint32_t 
 #define LV_STYLE_CONST_FLEX_CROSS_PLACE(val) \
     { \
         .prop_ptr = &LV_STYLE_FLEX_CROSS_PLACE, .value = { .num = (lv_flex_flow_t)val } \
+    }
+
+#define LV_STYLE_CONST_FLEX_MARGIN_TOP(val) \
+    { \
+        .prop_ptr = &LV_STYLE_FLEX_MARGIN_TOP, .value = { .num = (int32_t)val } \
+    }
+
+#define LV_STYLE_CONST_FLEX_MARGIN_BOTTOM(val) \
+    { \
+        .prop_ptr = &LV_STYLE_FLEX_MARGIN_BOTTOM, .value = { .num = (int32_t)val } \
+    }
+
+#define LV_STYLE_CONST_FLEX_MARGIN_LEFT(val) \
+    { \
+        .prop_ptr = &LV_STYLE_FLEX_MARGIN_LEFT, .value = { .num = (int32_t)val } \
+    }
+
+#define LV_STYLE_CONST_FLEX_MARGIN_RIGHT(val) \
+    { \
+        .prop_ptr = &LV_STYLE_FLEX_MARGIN_RIGHT, .value = { .num = (int32_t)val } \
     }
 
 


### PR DESCRIPTION
### Description of the feature or fix

> **Options**
> 
> 1. Support `margin` everywhere just like CSS. I'm definitely against it because it brings a lot of complication everywhere. E.g. a simple `lv_obj_set_pos()` shouldn't care about `margin`
> 2. Support margin only in `flex` and `grid`. It makes more sense as it's a local complication.
> 3. Offer a straight forward `margin` replacement workaround.  Usually I wrap the widget into a transparent container and set the `padding` on the wrapper. It has the same effect as `margin`. It works with LVGL only but it messes up the hierarchy and it's hacky.
> 
> **Solution** I could be ok with 2) if we really keep is as local as possible:

https://github.com/lvgl/lvgl/pull/3807#issuecomment-1329602031

I only added margin to the lv_flex according to option 2, and it seemed to work fine. 

But there are some problems with it: 

Under `LTR`, `margin bottom` and `margin right` cannot participate in the calculation of scrolling and content width and height. At the same time, the problems also exist in `margin bottom` and `margin left`. 

As shown in the figure:
![image](https://user-images.githubusercontent.com/24841247/204801324-73ec4f0e-4bd3-467f-a373-d226c6ae02c3.png)
It realized with `lv_scroll` and `lv_pos` modified 👆
![image](https://user-images.githubusercontent.com/24841247/204801297-90a36c59-5957-4fc4-bbff-615afef0c267.png)
It realized without `lv_scroll` and `lv_pos` modified 👆

Notice the last pink square. In the first picture, there is a certain amount of white space on the right, which is generated by margin-right. 
In the second picture, there is no space on the right, which is due to the fact that margin is not involved in the calculation.

### Discussion 

Whether we should add an interface, after the layout calculation is completed, let the layout affect the width and height of the parent component and affect the calculation of scroll.
Or do you have other methods to solve the above problems?


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
