### PR TITLE
fix(msg): able to create/delete msgs during notify

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -338,6 +338,11 @@ menu "LVGL configuration"
 				bool "Enable/Disable LV_LOG_TRACE in anim module"
 				default y
 				depends on LV_USE_LOG
+			
+			config LV_LOG_TRACE_MSG
+				bool "Enable/Disable LV_LOG_TRACE in msg module"
+				default y
+				depends on LV_USE_LOG
 		endmenu
 
 		menu "Asserts"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -242,6 +242,7 @@
     #define LV_LOG_TRACE_OBJ_CREATE 1
     #define LV_LOG_TRACE_LAYOUT     1
     #define LV_LOG_TRACE_ANIM       1
+	#define LV_LOG_TRACE_MSG		1
 
 #endif  /*LV_USE_LOG*/
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -724,6 +724,17 @@
             #define LV_LOG_TRACE_ANIM       1
         #endif
     #endif
+	#ifndef LV_LOG_TRACE_MSG
+	    #ifdef _LV_KCONFIG_PRESENT
+	        #ifdef CONFIG_LV_LOG_TRACE_MSG
+	            #define LV_LOG_TRACE_MSG CONFIG_LV_LOG_TRACE_MSG
+	        #else
+	            #define LV_LOG_TRACE_MSG 0
+	        #endif
+	    #else
+	        #define LV_LOG_TRACE_MSG		1
+	    #endif
+	#endif
 
 #endif  /*LV_USE_LOG*/
 


### PR DESCRIPTION
Creating or deleting subscription is now possible during a message notification.

Fixes: #3839
Co-Authored-By: [wrgallo](https://github.com/wrgallo) <28547933+wrgallo@users.noreply.github.com>