### PR TITLE
fix(ci) set ubuntu version

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     name: Build ${{ matrix.port }} port
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
"Latest" version of ubuntu was updated for GitHub actions (see [the announcement](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/#:~:text=Ubuntu%2022.04%20became%20generally%20available,beginning%20on%20October%201%2C%202022.))  
The new version (22.04) is missing some packages that are available on 20.04.

Fix GH action version to 22.04 to prevent surprises.

---

This fixes the error:

```
timeout: failed to run command ‘catchsegv’: No such file or directory
```

See for example https://github.com/lvgl/lvgl/actions/runs/3668611696/jobs/6201859548