### PR TITLE
fix(img_buf): add missing brackets for LV_IMG_BUF_SIZE_XXX

### DIFF
--- a/src/draw/lv_img_buf.h
+++ b/src/draw/lv_img_buf.h
@@ -29,21 +29,21 @@ extern "C" {
 #define LV_IMG_PX_SIZE_ALPHA_BYTE 4
 #endif
 
-#define LV_IMG_BUF_SIZE_TRUE_COLOR(w, h) ((LV_COLOR_SIZE / 8) * w * h)
-#define LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h) ((LV_COLOR_SIZE / 8) * w * h)
-#define LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h) (LV_IMG_PX_SIZE_ALPHA_BYTE * w * h)
+#define LV_IMG_BUF_SIZE_TRUE_COLOR(w, h) ((LV_COLOR_SIZE / 8) * (w) * (h))
+#define LV_IMG_BUF_SIZE_TRUE_COLOR_CHROMA_KEYED(w, h) ((LV_COLOR_SIZE / 8) * (w) * (h))
+#define LV_IMG_BUF_SIZE_TRUE_COLOR_ALPHA(w, h) (LV_IMG_PX_SIZE_ALPHA_BYTE * (w) * (h))
 
 /*+ 1: to be sure no fractional row*/
-#define LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h) ((((w + 7) / 8) * h))
-#define LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h) ((((w + 3) / 4) * h))
-#define LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h) ((((w + 1 ) / 2) * h))
-#define LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h) ((w * h))
+#define LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h) (((((w) + 7) / 8) * (h)))
+#define LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h) (((((w) + 3) / 4) * (h)))
+#define LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h) (((((w) + 1 ) / 2) * (h)))
+#define LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h) (((w) * (h)))
 
 /*4 * X: for palette*/
-#define LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_1BIT(w, h) + 4 * 2)
-#define LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_2BIT(w, h) + 4 * 4)
-#define LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_4BIT(w, h) + 4 * 16)
-#define LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_8BIT(w, h) + 4 * 256)
+#define LV_IMG_BUF_SIZE_INDEXED_1BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_1BIT((w), (h)) + 4 * 2)
+#define LV_IMG_BUF_SIZE_INDEXED_2BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_2BIT((w), (h)) + 4 * 4)
+#define LV_IMG_BUF_SIZE_INDEXED_4BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_4BIT((w), (h)) + 4 * 16)
+#define LV_IMG_BUF_SIZE_INDEXED_8BIT(w, h) (LV_IMG_BUF_SIZE_ALPHA_8BIT((w), (h)) + 4 * 256)
 
 #define _LV_ZOOM_INV_UPSCALE 5
 


### PR DESCRIPTION
### Description of the feature or fix

Missing brackets results in the following `buf_size` calculation error:

```c
static void buf_size_test()
{
    size_t buf_size;
    buf_size = LV_IMG_BUF_SIZE_TRUE_COLOR(120, 120);
    LV_LOG_USER("buf_size = %zu", buf_size);

    buf_size = LV_IMG_BUF_SIZE_TRUE_COLOR(100 + 20, 100 + 20);
    LV_LOG_USER("buf_size = %zu", buf_size);
}
```

```bash
[User] buf_size_test: buf_size = 57600  (in main.c line #89)
[User] buf_size_test: buf_size = 2420   (in main.c line #92)
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
