### PR TITLE
feat(cmsis-pack): monthly update for december

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,7 +36,13 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2022-11-28" version="1.0.11" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.11.pack">
+    <release date="2022-12-18" version="1.0.12-alpha" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.12-alpha.pack">
+      - LVGL 9.0.0-dev
+      - Montyly update for December
+      - Fix ARM2D Transform Support
+      - Add Barcode
+    </release>
+    <release date="2022-11-28" version="1.0.11" url="https://github.com/lvgl/lvgl/raw/f433ed62248cafd915848ff4d0720f97fb0fc7fd/env_support/cmsis-pack/LVGL.lvgl.1.0.11.pack">
       - LVGL 9.0.0-dev
       - Montyly update for November
     </release>
@@ -401,7 +407,7 @@
                 <file category="sourceC"            name="src/themes/default/lv_theme_default.c" />
 
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.1.5" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.1.6" />
                 <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
@@ -437,7 +443,7 @@
               </files>
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU Arm-2D"  condition="LVGL-Essential" Cversion="1.1.0">
+            <component Cgroup="lvgl" Csub="GPU Arm-2D"  condition="LVGL-Essential" Cversion="1.2.0">
               <description>A 2D image processing library from Arm (i.e. Arm-2D) for All Cortex-M processors including Cortex-M0</description>
               <files>
               <file category="sourceC"      name="src/draw/arm2d/lv_gpu_arm2d.c" condition="Arm-2D"/>
@@ -625,6 +631,22 @@
 
 /*! \brief enable BMP support */
 #define LV_USE_BMP          1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Libs Barcode"  condition="LVGL-Essential">
+              <description>Add BMP support</description>
+              <files>
+                <!-- src/libs/barcode -->
+                <file category="sourceC"    name="src/libs/barcode/lv_barcode.c" />
+                <file category="sourceC"    name="src/libs/barcode/code128.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable Barcode support */
+#define LV_USE_BARCODE          1
               </RTE_Components_h>
 
             </component>

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2022-11-28T21:03:00</timestamp>
+  <timestamp>2022-12-18T21:03:00</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.11"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.12-alpha"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -235,6 +235,7 @@
     #define LV_LOG_TRACE_OBJ_CREATE 1
     #define LV_LOG_TRACE_LAYOUT     1
     #define LV_LOG_TRACE_ANIM       1
+    #define LV_LOG_TRACE_MSG        1
 
 #endif  /*LV_USE_LOG*/
 

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -39,6 +39,7 @@
 #include "../../core/lv_refr.h"
 
 #if LV_USE_GPU_ARM2D
+#define __ARM_2D_IMPL__
 #include "arm_2d.h"
 #include "__arm_2d_impl.h"
 
@@ -89,10 +90,12 @@
 #define __arm_2d_impl_cl_key_copy       __arm_2d_impl_rgb16_cl_key_copy
 #define __arm_2d_impl_alpha_blending_colour_keying                              \
     __arm_2d_impl_rgb565_alpha_blending_colour_keying
-#define arm_2d_tile_transform_with_src_mask_and_opacity                         \
-    arm_2d_rgb565_tile_transform_with_src_mask_and_opacity
-#define arm_2d_tile_transform_with_opacity                                      \
-    arm_2d_rgb565_tile_transform_with_opacity
+#define arm_2d_tile_transform_with_src_mask_and_opacity_prepare                 \
+    arm_2dp_rgb565_tile_transform_with_src_mask_and_opacity_prepare
+#define arm_2d_tile_transform_with_opacity_prepare                              \
+    arm_2dp_rgb565_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_prepare                                           \
+    arm_2dp_rgb565_tile_transform_prepare
 
 #define __ARM_2D_PIXEL_BLENDING_OPA     __ARM_2D_PIXEL_BLENDING_OPA_RGB565
 
@@ -124,10 +127,12 @@
 #define __arm_2d_impl_cl_key_copy       __arm_2d_impl_rgb32_cl_key_copy
 #define __arm_2d_impl_alpha_blending_colour_keying                              \
     __arm_2d_impl_cccn888_alpha_blending_colour_keying
-#define arm_2d_tile_transform_with_src_mask_and_opacity                         \
-    arm_2d_cccn888_tile_transform_with_src_mask_and_opacity
-#define arm_2d_tile_transform_with_opacity                                      \
-    arm_2d_cccn888_tile_transform_with_opacity
+#define arm_2d_tile_transform_with_src_mask_and_opacity_prepare                 \
+    arm_2dp_cccn888_tile_transform_with_src_mask_and_opacity_prepare
+#define arm_2d_tile_transform_with_opacity_prepare                              \
+    arm_2dp_cccn888_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_prepare                                           \
+    arm_2dp_cccn888_tile_transform_prepare
 
 #define __ARM_2D_PIXEL_BLENDING_OPA     __ARM_2D_PIXEL_BLENDING_OPA_CCCN888
 
@@ -344,6 +349,41 @@
         }                                                                       \
     } while(0);                                                                 \
     src_buf = src_buf_org;
+
+#define __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(__TRANS_PREPARE, ...)          \
+        do {                                                                    \
+            __TRANS_PREPARE(                                                    \
+                    NULL,                                                       \
+                    __VA_ARGS__);                                               \
+                                                                                \
+            target_region = (arm_2d_region_t) {                                 \
+                .tLocation = {                                                  \
+                    .iX = coords->x1 - draw_ctx->clip_area->x1,                 \
+                    .iY = coords->y1 - draw_ctx->clip_area->y1,                 \
+                },                                                              \
+                .tSize = {                                                      \
+                    .iWidth = lv_area_get_width(coords),                        \
+                    .iHeight = lv_area_get_height(coords),                      \
+                },                                                              \
+            };                                                                  \
+                                                                                \
+            arm_2d_size_t tTransSize                                            \
+                = ARM_2D_CTRL.DefaultOP                                         \
+                    .tTransform.Source.ptTile->tRegion.tSize;                   \
+                                                                                \
+            if (target_region.tSize.iWidth < tTransSize.iWidth) {               \
+                int16_t iDelta = tTransSize.iWidth - target_region.tSize.iWidth;\
+                target_region.tLocation.iX -= iDelta / 2;                       \
+                target_region.tSize.iWidth = tTransSize.iWidth;                 \
+            }                                                                   \
+                                                                                \
+            if (target_region.tSize.iHeight < tTransSize.iHeight) {             \
+                int16_t iDelta                                                  \
+                    = tTransSize.iHeight - target_region.tSize.iHeight;         \
+                target_region.tLocation.iY -= iDelta / 2;                       \
+                target_region.tSize.iHeight = tTransSize.iHeight;               \
+            }                                                                   \
+        } while(0)
 
 /* *INDENT-ON* */
 
@@ -868,6 +908,12 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
     blend_dsc.blend_mode = draw_dsc->blend_mode;
     blend_dsc.blend_area = &blend_area;
 
+    if(lv_img_cf_is_chroma_keyed(cf)) cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
+    else if(cf == LV_IMG_CF_ALPHA_8BIT) {}
+    else if(cf == LV_IMG_CF_RGB565A8) {}
+    else if(lv_img_cf_has_alpha(cf)) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+    else cf = LV_IMG_CF_TRUE_COLOR;
+
 
     /*The simplest case just copy the pixels into the draw_buf*/
     if(!mask_any && !transform && cf == LV_IMG_CF_TRUE_COLOR && draw_dsc->recolor_opa == LV_OPA_TRANSP) {
@@ -1206,17 +1252,6 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                            &target_tile,
                                            false);
 
-                target_region = (arm_2d_region_t) {
-                    .tLocation = {
-                        .iX = coords->x1 - draw_ctx->clip_area->x1,
-                        .iY = coords->y1 - draw_ctx->clip_area->y1,
-                    },
-                    .tSize = {
-                        .iWidth = lv_area_get_width(coords),
-                        .iHeight = lv_area_get_height(coords),
-                    },
-                };
-
                 static arm_2d_tile_t source_tile;
 
                 source_tile = (arm_2d_tile_t) {
@@ -1234,19 +1269,23 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                 source_center.iX = draw_dsc->pivot.x;
                 source_center.iY = draw_dsc->pivot.y;
 
-
                 if((LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED == cf) ||
                    (LV_IMG_CF_TRUE_COLOR == cf)) {
-                    arm_2d_tile_transform_with_opacity(
+
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_opacity_prepare,
                         &source_tile,
-                        &target_tile,
-                        &target_region,
                         source_center,
                         ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
                         draw_dsc->zoom / 256.0f,
                         (color_int)LV_COLOR_CHROMA_KEY.full,
                         blend_dsc.opa);
 
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
                     is_accelerated = true;
                 }
                 else if (LV_IMG_CF_RGB565A8 == cf) {
@@ -1257,15 +1296,21 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                     mask_tile.tInfo.tColourInfo.chScheme = ARM_2D_COLOUR_GRAY8;
                     mask_tile.pchBuffer = mask_after_rgb;
 
-                    arm_2d_tile_transform_with_src_mask_and_opacity(
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_src_mask_and_opacity_prepare,
                         &source_tile,
                         &mask_tile,
-                        &target_tile,
-                        &target_region,
                         source_center,
                         ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
                         draw_dsc->zoom / 256.0f,
-                        blend_dsc.opa);
+                        blend_dsc.opa
+                        );
+
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
 
                     is_accelerated = true;
                 }
@@ -1280,15 +1325,21 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                     mask_tile.tInfo.tColourInfo.chScheme = ARM_2D_CHANNEL_8in32;
                     mask_tile.pchBuffer += 3;
 
-                    arm_2d_tile_transform_with_src_mask_and_opacity(
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_src_mask_and_opacity_prepare,
                         &source_tile,
                         &mask_tile,
-                        &target_tile,
-                        &target_region,
                         source_center,
                         ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
                         draw_dsc->zoom / 256.0f,
-                        blend_dsc.opa);
+                        blend_dsc.opa
+                        );
+
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
 
                     is_accelerated = true;
                 }


### PR DESCRIPTION
### Description of the feature or fix

The alpha version of cmsis-pack monthly update for December
- Add barcode support
- Fixed transform support in lv_gpu_arm2d
- Catch up with the main 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
