### PR TITLE
fix(slider): improved drag direction prediction

### DIFF
--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -141,7 +141,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(!slider->dragging) {
             lv_coord_t x_ofs = p.x - slider->pressed_point.x;
             lv_coord_t y_ofs = p.y - slider->pressed_point.y;
-            lv_coord_t drag_range = indev->driver->scroll_limit * 2;
+            lv_coord_t drag_range = indev->driver->scroll_limit;
 
             /*When drag is not out of range, it is not processed*/
             if(LV_ABS(x_ofs) < drag_range && LV_ABS(y_ofs) < drag_range) {

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -36,6 +36,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void position_knob(lv_obj_t * obj, lv_area_t * knob_area, const lv_coord_t knob_size, const bool hor);
 static void draw_knob(lv_event_t * e);
 static bool is_slider_horizontal(lv_obj_t * obj);
+static void drag_start(lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -126,80 +127,36 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_PRESSED) {
-        lv_obj_invalidate(obj);
-
-        lv_point_t p;
-        slider->dragging = true;
-        if(type == LV_SLIDER_MODE_NORMAL || type == LV_SLIDER_MODE_SYMMETRICAL) {
-            slider->value_to_set = &slider->bar.cur_value;
-        }
-        else if(type == LV_SLIDER_MODE_RANGE) {
-            lv_indev_get_point(lv_indev_get_act(), &p);
-            bool hor = lv_obj_get_width(obj) >= lv_obj_get_height(obj);
-            lv_base_dir_t base_dir = lv_obj_get_style_base_dir(obj, LV_PART_MAIN);
-
-            lv_coord_t dist_left, dist_right;
-            if(hor) {
-                if((base_dir != LV_BASE_DIR_RTL && p.x > slider->right_knob_area.x2) || (base_dir == LV_BASE_DIR_RTL &&
-                                                                                         p.x < slider->right_knob_area.x1)) {
-                    slider->value_to_set = &slider->bar.cur_value;
-                }
-                else if((base_dir != LV_BASE_DIR_RTL && p.x < slider->left_knob_area.x1) || (base_dir == LV_BASE_DIR_RTL &&
-                                                                                             p.x > slider->left_knob_area.x2)) {
-                    slider->value_to_set = &slider->bar.start_value;
-                }
-                else {
-                    /*Calculate the distance from each knob*/
-                    dist_left = LV_ABS((slider->left_knob_area.x1 + (slider->left_knob_area.x2 - slider->left_knob_area.x1) / 2) - p.x);
-                    dist_right = LV_ABS((slider->right_knob_area.x1 + (slider->right_knob_area.x2 - slider->right_knob_area.x1) / 2) - p.x);
-
-                    /*Use whichever one is closer*/
-                    if(dist_right < dist_left) {
-                        slider->value_to_set = &slider->bar.cur_value;
-                        slider->left_knob_focus = 0;
-                    }
-                    else {
-                        slider->value_to_set = &slider->bar.start_value;
-                        slider->left_knob_focus = 1;
-                    }
-                }
-            }
-            else {
-                if(p.y < slider->right_knob_area.y1) {
-                    slider->value_to_set = &slider->bar.cur_value;
-                }
-                else if(p.y > slider->left_knob_area.y2) {
-                    slider->value_to_set = &slider->bar.start_value;
-                }
-                else {
-                    /*Calculate the distance from each knob*/
-                    dist_left = LV_ABS((slider->left_knob_area.y1 + (slider->left_knob_area.y2 - slider->left_knob_area.y1) / 2) - p.y);
-                    dist_right = LV_ABS((slider->right_knob_area.y1 + (slider->right_knob_area.y2 - slider->right_knob_area.y1) / 2) - p.y);
-
-                    /*Use whichever one is closer*/
-                    if(dist_right < dist_left) {
-                        slider->value_to_set = &slider->bar.cur_value;
-                        slider->left_knob_focus = 0;
-                    }
-                    else {
-                        slider->value_to_set = &slider->bar.start_value;
-                        slider->left_knob_focus = 1;
-                    }
-                }
-            }
-        }
+        /*Save the pressed coordinates*/
+        lv_indev_get_point(lv_indev_get_act(), &slider->pressed_point);
     }
-    else if(code == LV_EVENT_PRESSING && slider->value_to_set != NULL) {
+    else if(code == LV_EVENT_PRESSING) {
         lv_indev_t * indev = lv_indev_get_act();
         if(lv_indev_get_type(indev) != LV_INDEV_TYPE_POINTER) return;
         if(lv_indev_get_scroll_obj(indev) != NULL) return;
 
         lv_point_t p;
         lv_indev_get_point(indev, &p);
-        int32_t new_value = 0;
 
-        const int32_t range = slider->bar.max_value - slider->bar.min_value;
+        if(!slider->dragging) {
+            lv_coord_t x_ofs = p.x - slider->pressed_point.x;
+            lv_coord_t y_ofs = p.y - slider->pressed_point.y;
+            lv_coord_t drag_range = indev->driver->scroll_limit * 2;
+
+            /*When drag is not out of range, it is not processed*/
+            if(LV_ABS(x_ofs) < drag_range && LV_ABS(y_ofs) < drag_range) {
+                return;
+            }
+        }
+
+        if(!slider->value_to_set) {
+            /*Ready to start drag*/
+            drag_start(obj);
+        }
+
+        int32_t new_value = 0;
         bool is_hor = is_slider_horizontal(obj);
+        const int32_t range = slider->bar.max_value - slider->bar.min_value;
         if(is_hor) {
             const lv_coord_t bg_left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
             const lv_coord_t bg_right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
@@ -251,7 +208,6 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
             res = lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
             if(res != LV_RES_OK) return;
         }
-
     }
     else if(code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
         slider->dragging = false;
@@ -281,7 +237,6 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
             if(is_slider_horizontal(obj)) lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
             else  lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
         }
-
     }
     else if(code == LV_EVENT_FOCUSED) {
         lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_get_act());
@@ -290,7 +245,6 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_SIZE_CHANGED) {
-
         if(is_slider_horizontal(obj)) {
             lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
             lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
@@ -458,6 +412,72 @@ static void position_knob(lv_obj_t * obj, lv_area_t * knob_area, const lv_coord_
 static bool is_slider_horizontal(lv_obj_t * obj)
 {
     return lv_obj_get_width(obj) >= lv_obj_get_height(obj);
+}
+
+static void drag_start(lv_obj_t * obj)
+{
+    lv_slider_t * slider = (lv_slider_t *)obj;
+    lv_slider_mode_t mode = lv_slider_get_mode(obj);
+    lv_point_t p;
+    slider->dragging = true;
+    if(mode == LV_SLIDER_MODE_NORMAL || mode == LV_SLIDER_MODE_SYMMETRICAL) {
+        slider->value_to_set = &slider->bar.cur_value;
+    }
+    else if(mode == LV_SLIDER_MODE_RANGE) {
+        lv_indev_get_point(lv_indev_get_act(), &p);
+        bool hor = is_slider_horizontal(obj);
+        lv_base_dir_t base_dir = lv_obj_get_style_base_dir(obj, LV_PART_MAIN);
+
+        lv_coord_t dist_left, dist_right;
+        if(hor) {
+            if((base_dir != LV_BASE_DIR_RTL && p.x > slider->right_knob_area.x2) || (base_dir == LV_BASE_DIR_RTL &&
+                                                                                     p.x < slider->right_knob_area.x1)) {
+                slider->value_to_set = &slider->bar.cur_value;
+            }
+            else if((base_dir != LV_BASE_DIR_RTL && p.x < slider->left_knob_area.x1) || (base_dir == LV_BASE_DIR_RTL &&
+                                                                                         p.x > slider->left_knob_area.x2)) {
+                slider->value_to_set = &slider->bar.start_value;
+            }
+            else {
+                /*Calculate the distance from each knob*/
+                dist_left = LV_ABS((slider->left_knob_area.x1 + (slider->left_knob_area.x2 - slider->left_knob_area.x1) / 2) - p.x);
+                dist_right = LV_ABS((slider->right_knob_area.x1 + (slider->right_knob_area.x2 - slider->right_knob_area.x1) / 2) - p.x);
+
+                /*Use whichever one is closer*/
+                if(dist_right < dist_left) {
+                    slider->value_to_set = &slider->bar.cur_value;
+                    slider->left_knob_focus = 0;
+                }
+                else {
+                    slider->value_to_set = &slider->bar.start_value;
+                    slider->left_knob_focus = 1;
+                }
+            }
+        }
+        else {
+            if(p.y < slider->right_knob_area.y1) {
+                slider->value_to_set = &slider->bar.cur_value;
+            }
+            else if(p.y > slider->left_knob_area.y2) {
+                slider->value_to_set = &slider->bar.start_value;
+            }
+            else {
+                /*Calculate the distance from each knob*/
+                dist_left = LV_ABS((slider->left_knob_area.y1 + (slider->left_knob_area.y2 - slider->left_knob_area.y1) / 2) - p.y);
+                dist_right = LV_ABS((slider->right_knob_area.y1 + (slider->right_knob_area.y2 - slider->right_knob_area.y1) / 2) - p.y);
+
+                /*Use whichever one is closer*/
+                if(dist_right < dist_left) {
+                    slider->value_to_set = &slider->bar.cur_value;
+                    slider->left_knob_focus = 0;
+                }
+                else {
+                    slider->value_to_set = &slider->bar.start_value;
+                    slider->left_knob_focus = 1;
+                }
+            }
+        }
+    }
 }
 
 #endif

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -42,6 +42,7 @@ typedef struct {
     lv_bar_t bar;       /*Add the ancestor's type first*/
     lv_area_t left_knob_area;
     lv_area_t right_knob_area;
+    lv_point_t pressed_point;
     int32_t * value_to_set; /*Which bar value to set*/
     uint8_t dragging : 1;       /*1: the slider is being dragged*/
     uint8_t left_knob_focus : 1; /*1: with encoder now the right knob can be adjusted*/


### PR DESCRIPTION
### Description of the feature or fix

After this [discussion](https://github.com/lvgl/lvgl/issues/3780), I continued to try to optimize the slider dragging, mainly by transferring the initial judgment of the drag from `LV_EVENT_PRESSED` to` LV_EVENT_PRESSING`, and adding the drag threshold detection, the drag experience has been greatly improved, see the following video:

@kisvegabor What do you think?

Before:

https://user-images.githubusercontent.com/26767803/208390740-563b4133-ac24-44cf-add1-8b0b08a9d44c.mp4

After:

https://user-images.githubusercontent.com/26767803/208390810-c74d1da6-502f-4ce4-899e-9b30d53195b7.mp4

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
