### PR TITLE
feat(malloc_builtin): add extended memory pool monitoring

### DIFF
--- a/src/misc/lv_malloc_builtin.c
+++ b/src/misc/lv_malloc_builtin.c
@@ -124,6 +124,7 @@ void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t pool)
     _LV_LL_READ(&pool_ll, pool_p) {
         if(*pool_p == pool) {
             _lv_ll_remove(&pool_ll, pool_p);
+            lv_free(pool_p);
             lv_tlsf_remove_pool(tlsf, pool);
             return;
         }

--- a/src/misc/lv_malloc_builtin.c
+++ b/src/misc/lv_malloc_builtin.c
@@ -11,6 +11,7 @@
 #include "lv_tlsf.h"
 #include "lv_assert.h"
 #include "lv_log.h"
+#include "lv_ll.h"
 #include "lv_math.h"
 
 #ifdef LV_MEM_POOL_INCLUDE
@@ -48,6 +49,7 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user);
 static lv_tlsf_t tlsf;
 static uint32_t cur_used;
 static uint32_t max_used;
+static lv_ll_t pool_ll;
 
 /**********************
  *      MACROS
@@ -82,6 +84,12 @@ void lv_mem_init_builtin(void)
 #else
     tlsf = lv_tlsf_create_with_pool((void *)LV_MEM_ADR, LV_MEM_SIZE);
 #endif
+    _lv_ll_init(&pool_ll, sizeof(lv_pool_t));
+
+    /*Record the first pool*/
+    lv_pool_t * pool_p = _lv_ll_ins_tail(&pool_ll);
+    LV_ASSERT_MALLOC(pool_p);
+    *pool_p = lv_tlsf_get_pool(tlsf);
 
 #if LV_MEM_ADD_JUNK
     LV_LOG_WARN("LV_MEM_ADD_JUNK is enabled which makes LVGL much slower");
@@ -90,18 +98,37 @@ void lv_mem_init_builtin(void)
 
 void lv_mem_deinit_builtin(void)
 {
+    _lv_ll_clear(&pool_ll);
     lv_tlsf_destroy(tlsf);
     lv_mem_init_builtin();
 }
 
-lv_mem_builtin_pool_t * lv_mem_builtin_add_pool(void * mem, size_t bytes)
+lv_mem_builtin_pool_t lv_mem_builtin_add_pool(void * mem, size_t bytes)
 {
-    return lv_tlsf_add_pool(tlsf, mem, bytes);
+    lv_mem_builtin_pool_t new_pool = lv_tlsf_add_pool(tlsf, mem, bytes);
+    if(!new_pool) {
+        LV_LOG_WARN("failed to add memory pool, address: %p, size: %zu", mem, bytes);
+        return NULL;
+    }
+
+    lv_pool_t * pool_p = _lv_ll_ins_tail(&pool_ll);
+    LV_ASSERT_MALLOC(pool_p);
+    *pool_p = new_pool;
+
+    return new_pool;
 }
 
-void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t * pool)
+void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t pool)
 {
-    lv_tlsf_remove_pool(tlsf, pool);
+    lv_pool_t * pool_p;
+    _LV_LL_READ(&pool_ll, pool_p) {
+        if(*pool_p == pool) {
+            _lv_ll_remove(&pool_ll, pool_p);
+            lv_tlsf_remove_pool(tlsf, pool);
+            return;
+        }
+    }
+    LV_LOG_WARN("invalid pool: %p", pool);
 }
 
 void lv_mem_monitor_builtin(lv_mem_monitor_t * mon_p)
@@ -110,9 +137,11 @@ void lv_mem_monitor_builtin(lv_mem_monitor_t * mon_p)
     lv_memset(mon_p, 0, sizeof(lv_mem_monitor_t));
     MEM_TRACE("begin");
 
-    lv_tlsf_walk_pool(lv_tlsf_get_pool(tlsf), lv_mem_walker, mon_p);
+    lv_pool_t * pool_p;
+    _LV_LL_READ(&pool_ll, pool_p) {
+        lv_tlsf_walk_pool(*pool_p, lv_mem_walker, mon_p);
+    }
 
-    mon_p->total_size = LV_MEM_SIZE;
     mon_p->used_pct = 100 - (100U * mon_p->free_size) / mon_p->total_size;
     if(mon_p->free_size > 0) {
         mon_p->frag_pct = mon_p->free_biggest_size * 100U / mon_p->free_size;
@@ -156,9 +185,12 @@ lv_res_t lv_mem_test_builtin(void)
         return LV_RES_INV;
     }
 
-    if(lv_tlsf_check_pool(lv_tlsf_get_pool(tlsf))) {
-        LV_LOG_WARN("pool failed");
-        return LV_RES_INV;
+    lv_pool_t * pool_p;
+    _LV_LL_READ(&pool_ll, pool_p) {
+        if(lv_tlsf_check_pool(*pool_p)) {
+            LV_LOG_WARN("pool failed");
+            return LV_RES_INV;
+        }
     }
 
     MEM_TRACE("passed");
@@ -174,6 +206,7 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user)
     LV_UNUSED(ptr);
 
     lv_mem_monitor_t * mon_p = user;
+    mon_p->total_size += size;
     if(used) {
         mon_p->used_cnt++;
     }

--- a/src/misc/lv_malloc_builtin.h
+++ b/src/misc/lv_malloc_builtin.h
@@ -46,13 +46,13 @@ void lv_mem_deinit_builtin(void);
  * @param bytes memory block size
  * @return pointer to lv_mem_builtin_pool handle
  */
-lv_mem_builtin_pool_t * lv_mem_builtin_add_pool(void * mem, size_t bytes);
+lv_mem_builtin_pool_t lv_mem_builtin_add_pool(void * mem, size_t bytes);
 
 /**
  * Remove the memory pool.
  * @param lv_mem_builtin_pool_t pointer to lv_mem_builtin_pool handle
  */
-void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t * pool);
+void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t pool);
 
 void * lv_malloc_builtin(size_t size);
 void * lv_realloc_builtin(void * p, size_t new_size);


### PR DESCRIPTION
### Description of the feature or fix

Added a pool list to record each newly added pool, traverse all pool nodes to get the total memory information.

cc @xiaoxiang781216 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
