### PR TITLE
Fix the action to push v8.3.x tags to Espressif component registry

### DIFF
--- a/.github/workflows/esp_upload_component.yml
+++ b/.github/workflows/esp_upload_component.yml
@@ -3,21 +3,21 @@ name: Push LVGL release to Espressif Component Service
 # If the commit is tagged, it will be uploaded. Other scenario silently fail.
 on:
   push:
-    branches:
-      - master
+    tags:
+      - v*
 
 jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           submodules: "recursive"
 
       - name: Upload component to component registry
-        uses: espressif/github-actions/upload_components@master
+        uses: espressif/upload-components-ci-action@v1
         with:
           name: "lvgl"
-          version: "git"
+          version: ${{ github.ref_name }}
           namespace: "lvgl"
           api_token: ${{ secrets.ESP_IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
#3740 only works for the master branch, it should be backported to release/v8.3 to make the v8.3.x tags to be pushed to Espressif component registry, the recent version in Espressif component registry is just v8.3.0, which is uploaded 5 months ago.
This also closes #3885 .