### PR TITLE
feat(timer): add `lv_timer_get_user_data`

### DIFF
--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -174,10 +174,10 @@ lv_timer_t * lv_timer_get_next(lv_timer_t * timer);
 
 /**
  * Get the user_data passed when the timer was created
- * @param timer     pointer to the lv_timer
- * @return      pointer to the user_data
+ * @param timer pointer to the lv_timer
+ * @return pointer to the user_data
  */
-static void * lv_timer_get_user_data(lv_timer_t * timer)
+static inline void * lv_timer_get_user_data(lv_timer_t * timer)
 {
     return timer->user_data;
 }

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -172,6 +172,16 @@ uint8_t lv_timer_get_idle(void);
  */
 lv_timer_t * lv_timer_get_next(lv_timer_t * timer);
 
+/**
+ * Get the user_data passed when the timer was created
+ * @param timer     pointer to the lv_timer
+ * @return      pointer to the user_data
+ */
+static void * lv_timer_get_user_data(lv_timer_t * timer)
+{
+    return timer->user_data;
+}
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

add `lv_timer_get_user_data`

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
