### PR TITLE
Fix string formatting compiler warnings and errors

### DIFF
--- a/examples/others/gridnav/lv_example_gridnav_1.c
+++ b/examples/others/gridnav/lv_example_gridnav_1.c
@@ -31,7 +31,7 @@ void lv_example_gridnav_1(void)
         lv_group_remove_obj(obj);   /*Not needed, we use the gridnav instead*/
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%" LV_PRIu32, i);
         lv_obj_center(label);
     }
 

--- a/examples/others/msg/lv_example_msg_3.c
+++ b/examples/others/msg/lv_example_msg_3.c
@@ -129,7 +129,7 @@ static void label_event_cb(lv_event_t * e)
         lv_msg_t * m = lv_event_get_msg(e);
         if(lv_msg_get_id(m) == MSG_UPDATE) {
             const int32_t * v = lv_msg_get_payload(m);
-            lv_label_set_text_fmt(label, "%d %%", *v);
+            lv_label_set_text_fmt(label, "%" LV_PRId32 " %%", *v);
         }
     }
 }

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -94,7 +94,7 @@ void lv_example_table_2(void)
     lv_obj_t * label = lv_label_create(lv_scr_act());
     lv_label_set_text_fmt(label, "%"LV_PRIu32" items were created in %"LV_PRIu32" ms\n"
                           "using %"LV_PRIu32" bytes of memory",
-                          ITEM_CNT, elaps, mem_used);
+                          (uint32_t)ITEM_CNT, elaps, mem_used);
 
     lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, -10);
 


### PR DESCRIPTION
The fix in #3654 should be backported to release/v8.3, otherwise, some warnings and errors will occur.