### PR TITLE
feat(cmsis-pack): last update for 2022

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,11 +36,9 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2022-12-18" version="1.0.12-alpha" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.12-alpha.pack">
+    <release date="2022-12-31" version="1.0.12" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.12.pack">
       - LVGL 9.0.0-dev
-      - Montyly update for December
-      - Fix ARM2D Transform Support
-      - Add Barcode
+      - The final update for 2022, Happy New Year
     </release>
     <release date="2022-11-28" version="1.0.11" url="https://github.com/lvgl/lvgl/raw/f433ed62248cafd915848ff4d0720f97fb0fc7fd/env_support/cmsis-pack/LVGL.lvgl.1.0.11.pack">
       - LVGL 9.0.0-dev
@@ -189,6 +187,72 @@
         <condition id="Arm-2D">
             <description>Require Arm-2D Support</description>
             <require Cclass="Acceleration" Cgroup="Arm-2D"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-Arm-2D">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-STM32-DMA2D">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-SWM341-DMA2D">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-NXP-PXP">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-NXP-VGLite">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+        </condition>
+        
+        <condition id="LVGL-GPU-GD32-IPA">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>-->
         </condition>
 
     </conditions>
@@ -443,10 +507,10 @@
               </files>
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU Arm-2D"  condition="LVGL-Essential" Cversion="1.2.0">
+            <component Cgroup="lvgl" Csub="GPU Arm-2D"  condition="LVGL-GPU-Arm-2D" Cversion="1.2.0">
               <description>A 2D image processing library from Arm (i.e. Arm-2D) for All Cortex-M processors including Cortex-M0</description>
               <files>
-              <file category="sourceC"      name="src/draw/arm2d/lv_gpu_arm2d.c" condition="Arm-2D"/>
+                <file category="sourceC"      name="src/draw/arm2d/lv_gpu_arm2d.c" condition="Arm-2D"/>
               </files>
 
               <RTE_Components_h>
@@ -458,10 +522,10 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU STM32-DMA2D"  condition="LVGL-Essential">
+            <component Cgroup="lvgl" Csub="GPU STM32-DMA2D"  condition="LVGL-GPU-STM32-DMA2D">
               <description>An hardware acceleration from STM32-DMA2D</description>
               <files>
-              <file category="sourceC"      name="src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c" />
+                <file category="sourceC"      name="src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c" />
               </files>
 
               <RTE_Components_h>
@@ -472,10 +536,10 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU SWM341-DMA2D"  condition="LVGL-Essential">
+            <component Cgroup="lvgl" Csub="GPU SWM341-DMA2D"  condition="LVGL-GPU-SWM341-DMA2D">
               <description>An hardware acceleration from SWM341-DMA2D</description>
               <files>
-              <file category="sourceC"      name="src/draw/swm341_dma2d/lv_gpu_swm341_dma2d.c" />
+                <file category="sourceC"      name="src/draw/swm341_dma2d/lv_gpu_swm341_dma2d.c" />
               </files>
 
               <RTE_Components_h>
@@ -486,13 +550,13 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU NXP-PXP"  condition="LVGL-Essential">
+            <component Cgroup="lvgl" Csub="GPU NXP-PXP"  condition="LVGL-GPU-NXP-PXP">
               <description>An hardware acceleration from NXP-PXP</description>
               <files>
-              <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
-              <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_blend.c" />
-              <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp.c" />
-              <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp_osa.c" />
+                <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_blend.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp_osa.c" />
               </files>
 
               <RTE_Components_h>
@@ -503,14 +567,14 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU NXP-VGLite"  condition="LVGL-Essential">
+            <component Cgroup="lvgl" Csub="GPU NXP-VGLite"  condition="LVGL-GPU-NXP-VGLite">
               <description>An hardware acceleration from NXP-VGLite</description>
               <files>
-              <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
-              <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_arc.c" />
-              <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_blend.c" />
-              <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_rect.c" />
-              <file category="sourceC"      name="src/draw/nxp/vglite/lv_gpu_nxp_vglite.c" />
+                <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_arc.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_blend.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_rect.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_gpu_nxp_vglite.c" />
               </files>
 
               <RTE_Components_h>
@@ -521,10 +585,10 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU GD32-IPA"  condition="LVGL-Essential">
+            <component Cgroup="lvgl" Csub="GPU GD32-IPA"  condition="LVGL-GPU-GD32-IPA">
               <description>An hardware acceleration from GD32-IPA</description>
               <files>
-              <file category="sourceC"      name="src/draw/gd32_ipa/lv_gpu_gd32_ipa.c" />
+                <file category="sourceC"      name="src/draw/gd32_ipa/lv_gpu_gd32_ipa.c" />
               </files>
 
               <RTE_Components_h>

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2022-12-18T21:03:00</timestamp>
+  <timestamp>2022-12-31T21:35:00</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.12-alpha"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.12"/>
   </pindex>
 </index>


### PR DESCRIPTION
### Description of the feature or fix

The last cmsis-pack update for 2022. Happy new year.
- catch up with the master
- introduce mutual-exclusive conditions for GPU supports

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
