### PR TITLE
feat(cmsis-pack): update for v8.3.4

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,12 +36,10 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2022-07-06" version="1.0.6" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.6.pack">
-      - LVGL 8.3.0 release
-      - Apply patch for memory leaking issue
-      - Apply patch to speed up non normal blend mode
-      - Add 9-key input mode to pinyin
-      - Other minor changes
+    <release date="2022-12-31" version="1.0.6-p1" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.0.6-p1.pack">
+      - LVGL 8.3.4 release
+      - Update GPU Arm-2D support
+      - Various fixes
     </release>
     <release date="2022-06-29" version="1.0.5" url="https://github.com/GorgonMeducer/lvgl/raw/922108dbbe6d1c0be1069c342ca8693afee8c169/env_support/cmsis-pack/LVGL.lvgl.1.0.5.pack">
       - LVGL 8.3.0-dev

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2022-07-06T00:09:27</timestamp>
+  <timestamp>2022-12-31T23:17:00</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.6"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="1.0.6-p1"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/gen_pack.sh
+++ b/env_support/cmsis-pack/gen_pack.sh
@@ -21,8 +21,8 @@ if [ `uname -s` = "Linux" ]
   CMSIS_PACK_PATH="/home/$USER/.arm/Packs/ARM/CMSIS/5.7.0/"
   PATH_TO_ADD="$CMSIS_PACK_PATH/CMSIS/Utilities/Linux64/"
 else
-  CMSIS_PACK_PATH="/C/Users/gabriel/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0"
-  PATH_TO_ADD="/C/Program Files (x86)/7-Zip/:$CMSIS_PACK_PATH/CMSIS/Utilities/Win32/:/C/xmllint/"
+  CMSIS_PACK_PATH="/C/Users/$USER/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0"
+  PATH_TO_ADD="/C/Program Files (x86)/7-Zip/:/C/Program Files/7-Zip/:$CMSIS_PACK_PATH/CMSIS/Utilities/Win32/:/C/xmllint/"
 fi
 [[ ":$PATH:" != *":$PATH_TO_ADD}:"* ]] && PATH="${PATH}:${PATH_TO_ADD}"
 echo $PATH_TO_ADD appended to PATH

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.0
+ * Configuration file for v8.3.4
  */
 
 /* clang-format off */
@@ -82,13 +82,8 @@
     #define LV_TICK_CUSTOM 1
     #if LV_TICK_CUSTOM
         extern uint32_t SystemCoreClock;
-        #define LV_TICK_CUSTOM_INCLUDE             "perf_counter.h"
-
-        #if __PER_COUNTER_VER__ < 10902ul
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR    ((uint32_t)get_system_ticks() / (SystemCoreClock / 1000ul))
-        #else
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
-        #endif
+        #define LV_TICK_CUSTOM_INCLUDE          "perf_counter.h"
+        #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
     #endif   /*LV_TICK_CUSTOM*/
 #else
     #define LV_TICK_CUSTOM 0
@@ -227,11 +222,11 @@
     *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
     *LV_LOG_LEVEL_USER        Only logs added by the user
     *LV_LOG_LEVEL_NONE        Do not log anything*/
-    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_USER
 
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
-    #define LV_LOG_PRINTF 0
+    #define LV_LOG_PRINTF 1
 
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -39,6 +39,7 @@
 #include "../../core/lv_refr.h"
 
 #if LV_USE_GPU_ARM2D
+#define __ARM_2D_IMPL__
 #include "arm_2d.h"
 #include "__arm_2d_impl.h"
 
@@ -89,10 +90,12 @@
 #define __arm_2d_impl_cl_key_copy       __arm_2d_impl_rgb16_cl_key_copy
 #define __arm_2d_impl_alpha_blending_colour_keying                              \
     __arm_2d_impl_rgb565_alpha_blending_colour_keying
-#define arm_2d_tile_transform_with_src_mask_and_opacity                         \
-    arm_2d_rgb565_tile_transform_with_src_mask_and_opacity
-#define arm_2d_tile_transform_with_opacity                                      \
-    arm_2d_rgb565_tile_transform_with_opacity
+#define arm_2d_tile_transform_with_src_mask_and_opacity_prepare                 \
+    arm_2dp_rgb565_tile_transform_with_src_mask_and_opacity_prepare
+#define arm_2d_tile_transform_with_opacity_prepare                              \
+    arm_2dp_rgb565_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_prepare                                           \
+    arm_2dp_rgb565_tile_transform_prepare
 
 #define __ARM_2D_PIXEL_BLENDING_OPA     __ARM_2D_PIXEL_BLENDING_OPA_RGB565
 
@@ -124,10 +127,12 @@
 #define __arm_2d_impl_cl_key_copy       __arm_2d_impl_rgb32_cl_key_copy
 #define __arm_2d_impl_alpha_blending_colour_keying                              \
     __arm_2d_impl_cccn888_alpha_blending_colour_keying
-#define arm_2d_tile_transform_with_src_mask_and_opacity                         \
-    arm_2d_cccn888_tile_transform_with_src_mask_and_opacity
-#define arm_2d_tile_transform_with_opacity                                      \
-    arm_2d_cccn888_tile_transform_with_opacity
+#define arm_2d_tile_transform_with_src_mask_and_opacity_prepare                 \
+    arm_2dp_cccn888_tile_transform_with_src_mask_and_opacity_prepare
+#define arm_2d_tile_transform_with_opacity_prepare                              \
+    arm_2dp_cccn888_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_prepare                                           \
+    arm_2dp_cccn888_tile_transform_prepare
 
 #define __ARM_2D_PIXEL_BLENDING_OPA     __ARM_2D_PIXEL_BLENDING_OPA_CCCN888
 
@@ -298,11 +303,88 @@
             /* replace src_buf for the following operation */                   \
             src_buf = (const uint8_t *)rgb_tmp_buf;                             \
         }                                                                       \
-        __VA_ARGS__                                                             \
+        do {                                                                    \
+            __VA_ARGS__                                                         \
+        } while(0);                                                             \
         if (NULL != rgb_tmp_buf) {                                              \
             lv_mem_buf_release(rgb_tmp_buf);                                    \
         }                                                                       \
-    } while(0);
+    } while(0);                                                                 \
+    src_buf = src_buf_org;
+
+#define __RECOLOUR_BEGIN()                                                      \
+    do {                                                                        \
+        lv_color_t *rgb_tmp_buf = NULL;                                         \
+        if(draw_dsc->recolor_opa > LV_OPA_MIN) {                                \
+            rgb_tmp_buf                                                         \
+                = lv_malloc(src_w * src_h * sizeof(lv_color_t));                \
+            if (NULL == rgb_tmp_buf) {                                          \
+                LV_LOG_WARN(                                                    \
+                    "Failed to allocate memory for accelerating recolour, "     \
+                    "use normal route instead.");                               \
+                break;                                                          \
+            }                                                                   \
+            lv_memcpy(rgb_tmp_buf, src_buf, src_w * src_h * sizeof(lv_color_t));\
+            arm_2d_size_t copy_size = {                                         \
+                .iWidth = src_w,                                                \
+                .iHeight = src_h,                                               \
+            };                                                                  \
+            /* apply re-colour */                                               \
+            __arm_2d_impl_colour_filling_with_opacity(                          \
+                (color_int *)rgb_tmp_buf,                                       \
+                src_w,                                                          \
+                &copy_size,                                                     \
+                (color_int)draw_dsc->recolor.full,                              \
+                draw_dsc->recolor_opa);                                         \
+                                                                                \
+            /* replace src_buf for the following operation */                   \
+            src_buf = (const uint8_t *)rgb_tmp_buf;                             \
+        }                                                                       \
+        do {
+
+#define __RECOLOUR_END()                                                        \
+        } while(0);                                                             \
+        if (NULL != rgb_tmp_buf) {                                              \
+            lv_free(rgb_tmp_buf);                                               \
+        }                                                                       \
+    } while(0);                                                                 \
+    src_buf = src_buf_org;
+
+#define __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(__TRANS_PREPARE, ...)          \
+        do {                                                                    \
+            __TRANS_PREPARE(                                                    \
+                    NULL,                                                       \
+                    __VA_ARGS__);                                               \
+                                                                                \
+            target_region = (arm_2d_region_t) {                                 \
+                .tLocation = {                                                  \
+                    .iX = coords->x1 - draw_ctx->clip_area->x1,                 \
+                    .iY = coords->y1 - draw_ctx->clip_area->y1,                 \
+                },                                                              \
+                .tSize = {                                                      \
+                    .iWidth = lv_area_get_width(coords),                        \
+                    .iHeight = lv_area_get_height(coords),                      \
+                },                                                              \
+            };                                                                  \
+                                                                                \
+            arm_2d_size_t tTransSize                                            \
+                = ARM_2D_CTRL.DefaultOP                                         \
+                    .tTransform.Source.ptTile->tRegion.tSize;                   \
+                                                                                \
+            if (target_region.tSize.iWidth < tTransSize.iWidth) {               \
+                int16_t iDelta = tTransSize.iWidth - target_region.tSize.iWidth;\
+                target_region.tLocation.iX -= iDelta / 2;                       \
+                target_region.tSize.iWidth = tTransSize.iWidth;                 \
+            }                                                                   \
+                                                                                \
+            if (target_region.tSize.iHeight < tTransSize.iHeight) {             \
+                int16_t iDelta                                                  \
+                    = tTransSize.iHeight - target_region.tSize.iHeight;         \
+                target_region.tLocation.iY -= iDelta / 2;                       \
+                target_region.tSize.iHeight = tTransSize.iHeight;               \
+            }                                                                   \
+        } while(0)
+
 /* *INDENT-ON* */
 
 /**********************
@@ -601,18 +683,26 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
     lv_area_t blend_area;
     if(!_lv_area_intersect(&blend_area, dsc->blend_area, draw_ctx->clip_area)) return;
 
-    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
+    //lv_disp_t * disp = _lv_refr_get_disp_refreshing();
 
     bool is_accelerated = false;
     do {
-        if(NULL != disp->driver->set_px_cb) {
-            break;
+
+        /* target buffer */
+        lv_color_t * dest_buf = draw_ctx->buf;
+        lv_disp_t * disp = _lv_refr_get_disp_refreshing();
+        if(disp->driver->screen_transp == 0) {
+            dest_buf += dest_stride * (blend_area.y1 - draw_ctx->buf_area->y1) + (blend_area.x1 - draw_ctx->buf_area->x1);
+        }
+        else {
+            /*With LV_COLOR_DEPTH 16 it means ARGB8565 (3 bytes format)*/
+            uint8_t * dest_buf8 = (uint8_t *) dest_buf;
+            dest_buf8 += dest_stride * (blend_area.y1 - draw_ctx->buf_area->y1) * LV_IMG_PX_SIZE_ALPHA_BYTE;
+            dest_buf8 += (blend_area.x1 - draw_ctx->buf_area->x1) * LV_IMG_PX_SIZE_ALPHA_BYTE;
+            dest_buf = (lv_color_t *)dest_buf8;
         }
 
-        lv_color_t * dest_buf = draw_ctx->buf;
-        dest_buf += dest_stride * (blend_area.y1 - draw_ctx->buf_area->y1)
-                    + (blend_area.x1 - draw_ctx->buf_area->x1);
-
+        /* source buffer */
         const lv_color_t * src_buf = dsc->src_buf;
         lv_coord_t src_stride;
         if(src_buf) {
@@ -634,7 +724,9 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
 
         lv_area_move(&blend_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-
+        if(disp->driver->screen_transp) {
+            break;
+        }
         if(dsc->src_buf == NULL) {
             if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
                 is_accelerated = arm_2d_fill_normal(dest_buf,
@@ -645,14 +737,8 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
                                                     mask,
                                                     mask_stride);
             }
-#if LV_DRAW_COMPLEX
-            else {
-                break;
-            }
-#endif
         }
         else {
-
             if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
                 is_accelerated = arm_2d_copy_normal(dest_buf,
                                                     &blend_area,
@@ -663,11 +749,6 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
                                                     mask,
                                                     mask_stride);
             }
-#if LV_DRAW_COMPLEX
-            else {
-                break;
-            }
-#endif
         }
     } while(0);
 
@@ -698,15 +779,11 @@ static bool arm_2d_fill_normal(lv_color_t * dest_buf,
         }
         /*Has opacity*/
         else {
-#if LV_COLOR_SCREEN_TRANSP
-            return false;
-#else
             __arm_2d_impl_colour_filling_with_opacity((color_int *)dest_buf,
                                                       dest_stride,
                                                       &target_size,
                                                       color.full,
                                                       opa);
-#endif
         }
     }
     /*Masked*/
@@ -722,9 +799,6 @@ static bool arm_2d_fill_normal(lv_color_t * dest_buf,
         }
         /*With opacity*/
         else {
-#if LV_COLOR_SCREEN_TRANSP
-            return false;
-#else
             __arm_2d_impl_colour_filling_mask_opacity((color_int *)dest_buf,
                                                       dest_stride,
                                                       (uint8_t *)mask,
@@ -732,7 +806,6 @@ static bool arm_2d_fill_normal(lv_color_t * dest_buf,
                                                       &target_size,
                                                       color.full,
                                                       opa);
-#endif
         }
     }
 
@@ -759,10 +832,6 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
         .iHeight = lv_area_get_height(dest_area),
     };
 
-#if LV_COLOR_SCREEN_TRANSP
-    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-#endif
-
     /*Simple fill (maybe with opacity), no masking*/
     if(mask == NULL) {
         if(opa >= LV_OPA_MAX) {
@@ -773,25 +842,18 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                &copy_size);
         }
         else {
-#if LV_COLOR_SCREEN_TRANSP
-            return false;
-#else
             __arm_2d_impl_alpha_blending((color_int *)src_buf,
                                          src_stride,
                                          (color_int *)dest_buf,
                                          dest_stride,
                                          &copy_size,
                                          opa);
-#endif
         }
     }
     /*Masked*/
     else {
         /*Only the mask matters*/
         if(opa > LV_OPA_MAX) {
-#if LV_COLOR_SCREEN_TRANSP
-            return false;
-#else
             __arm_2d_impl_src_msk_copy((color_int *)src_buf,
                                        src_stride,
                                        (uint8_t *)mask,
@@ -800,13 +862,9 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                        (color_int *)dest_buf,
                                        dest_stride,
                                        &copy_size);
-#endif
         }
         /*Handle opa and mask values too*/
         else {
-#if LV_COLOR_SCREEN_TRANSP
-            return false;
-#else
             __arm_2d_impl_gray8_alpha_blending((uint8_t *)mask,
                                                mask_stride,
                                                (uint8_t *)mask,
@@ -822,7 +880,6 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                        (color_int *)dest_buf,
                                        dest_stride,
                                        &copy_size);
-#endif
         }
     }
 
@@ -839,6 +896,7 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
     /*Use the clip area as draw area*/
     lv_area_t draw_area;
     lv_area_copy(&draw_area, draw_ctx->clip_area);
+    const uint8_t * src_buf_org = src_buf;
 
     bool mask_any = lv_draw_mask_is_any(&draw_area);
     bool transform = draw_dsc->angle != 0 || draw_dsc->zoom != LV_IMG_ZOOM_NONE ? true : false;
@@ -851,6 +909,13 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
     blend_dsc.blend_mode = draw_dsc->blend_mode;
     blend_dsc.blend_area = &blend_area;
 
+    if(lv_img_cf_is_chroma_keyed(cf)) cf = LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED;
+    else if(cf == LV_IMG_CF_ALPHA_8BIT) {}
+    else if(cf == LV_IMG_CF_RGB565A8) {}
+    else if(lv_img_cf_has_alpha(cf)) cf = LV_IMG_CF_TRUE_COLOR_ALPHA;
+    else cf = LV_IMG_CF_TRUE_COLOR;
+
+
     /*The simplest case just copy the pixels into the draw_buf*/
     if(!mask_any && !transform && cf == LV_IMG_CF_TRUE_COLOR && draw_dsc->recolor_opa == LV_OPA_TRANSP) {
         blend_dsc.src_buf = (const lv_color_t *)src_buf;
@@ -859,6 +924,9 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
         lv_draw_sw_blend(draw_ctx, &blend_dsc);
     }
     else if(!mask_any && !transform && cf == LV_IMG_CF_ALPHA_8BIT) {
+        lv_area_t clipped_coords;
+        if(!_lv_area_intersect(&clipped_coords, coords, draw_ctx->clip_area)) return;
+
         blend_dsc.mask_buf = (lv_opa_t *)src_buf;
         blend_dsc.mask_area = coords;
         blend_dsc.src_buf = NULL;
@@ -869,7 +937,8 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
         lv_draw_sw_blend(draw_ctx, &blend_dsc);
     }
 #if LV_COLOR_DEPTH == 16
-    else if(!mask_any && !transform && cf == LV_IMG_CF_RGB565A8 && draw_dsc->recolor_opa == LV_OPA_TRANSP) {
+    else if(!mask_any && !transform && cf == LV_IMG_CF_RGB565A8 && draw_dsc->recolor_opa == LV_OPA_TRANSP &&
+            blend_dsc.opa >= LV_OPA_MAX) {
         lv_coord_t src_w = lv_area_get_width(coords);
         lv_coord_t src_h = lv_area_get_height(coords);
         blend_dsc.src_buf = (const lv_color_t *)src_buf;
@@ -922,6 +991,23 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                           LV_DRAW_MASK_RES_CHANGED : LV_DRAW_MASK_RES_FULL_COVER;
         blend_dsc.mask_res = mask_res_def;
 
+        if(cf == LV_IMG_CF_ALPHA_8BIT) {
+            /* original code:
+               lv_color_fill(rgb_buf, draw_dsc->recolor, buf_size);
+             */
+            arm_2d_size_t copy_size = {
+                .iWidth = buf_w,
+                .iHeight = buf_h,
+            };
+
+            /* apply re-colour */
+            __arm_2d_impl_colour_filling(
+                (color_int *)rgb_buf,
+                buf_w,
+                &copy_size,
+                (color_int)draw_dsc->recolor.full);
+        }
+
         bool is_accelerated = false;
 
         if(!transform) {
@@ -968,7 +1054,7 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
             }
             else if((LV_COLOR_DEPTH == 32)
                     &&     !mask_any
-                    && (cf == LV_IMG_CF_TRUE_COLOR_ALPHA)) {
+                    && (LV_IMG_CF_TRUE_COLOR_ALPHA == cf)) {
                 /* accelerate copy-with-source-masks-and-opacity */
 
                 /* *INDENT-OFF* */
@@ -1025,6 +1111,63 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                 )
                 /* *INDENT-ON* */
             }
+            else if(!mask_any
+                    && (LV_IMG_CF_RGB565A8 == cf)) {
+                /* accelerate copy-with-source-masks-and-opacity */
+
+                uint8_t * mask_after_rgb = src_buf + sizeof(lv_color_t) * src_w * src_h;
+                /* *INDENT-OFF* */
+                __RECOLOUR_WRAPPER(
+                    __PREPARE_LL_ACCELERATION__();
+
+                    uint8_t * mask_temp_buf = NULL;
+                    if(blend_dsc.opa < LV_OPA_MAX) {
+                        mask_temp_buf = lv_mem_buf_get(copy_size.iHeight * copy_size.iWidth);
+                        if(NULL == mask_temp_buf) {
+                            LV_LOG_WARN(
+                                "Failed to allocate memory for alpha mask,"
+                                " use normal route instead.");
+                            break;
+                        }
+                        lv_memset_00(mask_temp_buf, copy_size.iHeight * copy_size.iWidth);
+
+                        __arm_2d_impl_gray8_colour_filling_mask_opacity(
+                            mask_temp_buf,
+                            src_stride,
+                            mask_after_rgb,
+                            src_stride,
+                            &copy_size,
+                            0xFF,
+                            blend_dsc.opa);
+
+                        __arm_2d_impl_src_msk_copy(
+                            (color_int *)src_buf_tmp,
+                            src_stride,
+                            mask_temp_buf,
+                            src_stride,
+                            &copy_size,
+                            (color_int *)dest_buf,
+                            dest_stride,
+                            &copy_size);
+
+                        lv_mem_buf_release(mask_temp_buf);
+                    }
+                    else {
+                        __arm_2d_impl_src_msk_copy(
+                            (color_int *)src_buf_tmp,
+                            src_stride,
+                            mask_after_rgb,
+                            src_stride,
+                            &copy_size,
+                            (color_int *)dest_buf,
+                            dest_stride,
+                            &copy_size);
+                    }
+
+                    is_accelerated = true;
+                )
+                /* *INDENT-ON* */
+            }
             else if(!mask_any && (cf == LV_IMG_CF_TRUE_COLOR)) {
                 /* accelerate copy-with-source-masks-and-opacity */
 
@@ -1063,6 +1206,7 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                 && (draw_dsc->recolor_opa == LV_OPA_TRANSP)
                 && (((LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED == cf)
                      || (LV_IMG_CF_TRUE_COLOR == cf))
+                    || (LV_IMG_CF_RGB565A8 == cf)
 #if defined(__ARM_2D_CFG_SUPPORT_COLOUR_CHANNEL_ACCESS__) &&  __ARM_2D_CFG_SUPPORT_COLOUR_CHANNEL_ACCESS__
                     || ((LV_IMG_CF_TRUE_COLOR_ALPHA == cf)
                         && (LV_COLOR_DEPTH == 32))
@@ -1070,6 +1214,7 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                    )
                ) {
 
+            uint8_t * mask_after_rgb = src_buf + sizeof(lv_color_t) * src_w * src_h;
             /* *INDENT-OFF* */
             __RECOLOUR_WRAPPER(
                 /* accelerate transform without re-color */
@@ -1108,17 +1253,6 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                            &target_tile,
                                            false);
 
-                target_region = (arm_2d_region_t) {
-                    .tLocation = {
-                        .iX = coords->x1 - draw_ctx->clip_area->x1,
-                        .iY = coords->y1 - draw_ctx->clip_area->y1,
-                    },
-                    .tSize = {
-                        .iWidth = lv_area_get_width(coords),
-                        .iHeight = lv_area_get_height(coords),
-                    },
-                };
-
                 static arm_2d_tile_t source_tile;
 
                 source_tile = (arm_2d_tile_t) {
@@ -1132,45 +1266,81 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                     .pchBuffer = (uint8_t *)src_buf,
                 };
 
-                static arm_2d_tile_t mask_tile;
-                mask_tile = source_tile;
-
-                mask_tile.tInfo.bHasEnforcedColour = true;
-                mask_tile.tInfo.tColourInfo.chScheme = ARM_2D_CHANNEL_8in32;
-                mask_tile.pchBuffer += 3;
-
                 static arm_2d_location_t source_center, target_center;
                 source_center.iX = draw_dsc->pivot.x;
                 source_center.iY = draw_dsc->pivot.y;
 
-
-                if((LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED == cf) || 
+                if((LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED == cf) ||
                    (LV_IMG_CF_TRUE_COLOR == cf)) {
-                    arm_2d_tile_transform_with_opacity(
+
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_opacity_prepare,
                         &source_tile,
-                        &target_tile,
-                        &target_region,
                         source_center,
                         ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
                         draw_dsc->zoom / 256.0f,
                         (color_int)LV_COLOR_CHROMA_KEY.full,
                         blend_dsc.opa);
 
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
+                    is_accelerated = true;
+                }
+                else if (LV_IMG_CF_RGB565A8 == cf) {
+                    static arm_2d_tile_t mask_tile;
+                    mask_tile = source_tile;
+
+                    mask_tile.tInfo.bHasEnforcedColour = true;
+                    mask_tile.tInfo.tColourInfo.chScheme = ARM_2D_COLOUR_GRAY8;
+                    mask_tile.pchBuffer = mask_after_rgb;
+
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_src_mask_and_opacity_prepare,
+                        &source_tile,
+                        &mask_tile,
+                        source_center,
+                        ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
+                        draw_dsc->zoom / 256.0f,
+                        blend_dsc.opa
+                        );
+
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
+
                     is_accelerated = true;
                 }
     #if defined(__ARM_2D_CFG_SUPPORT_COLOUR_CHANNEL_ACCESS__)          \
                 &&  __ARM_2D_CFG_SUPPORT_COLOUR_CHANNEL_ACCESS__
-                else if((LV_IMG_CF_TRUE_COLOR_ALPHA == cf) && 
+                else if((LV_IMG_CF_TRUE_COLOR_ALPHA == cf) &&
                         (LV_COLOR_DEPTH == 32)) {
-                    arm_2d_tile_transform_with_src_mask_and_opacity(
+                    static arm_2d_tile_t mask_tile;
+                    mask_tile = source_tile;
+
+                    mask_tile.tInfo.bHasEnforcedColour = true;
+                    mask_tile.tInfo.tColourInfo.chScheme = ARM_2D_CHANNEL_8in32;
+                    mask_tile.pchBuffer += 3;
+
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_with_src_mask_and_opacity_prepare,
                         &source_tile,
                         &mask_tile,
-                        &target_tile,
-                        &target_region,
                         source_center,
                         ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
                         draw_dsc->zoom / 256.0f,
-                        blend_dsc.opa);
+                        blend_dsc.opa
+                        );
+
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
 
                     is_accelerated = true;
                 }
@@ -1208,7 +1378,7 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                     (color_int)draw_dsc->recolor.full,
                     draw_dsc->recolor_opa);
             }
-#if LV_DRAW_COMPLEX
+#if LV_USE_DRAW_MASKS
             /*Apply the masks if any*/
             if(mask_any) {
                 lv_coord_t y;
@@ -1275,7 +1445,7 @@ static void convert_cb(const lv_area_t * dest_area, const void * src_buf, lv_coo
 
     if(cf == LV_IMG_CF_TRUE_COLOR || cf == LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED) {
         uint32_t px_cnt = lv_area_get_size(dest_area);
-        lv_memset_ff(abuf, px_cnt);
+        lv_memset(abuf, 0xff, px_cnt);
 
         src_tmp8 += (src_stride * dest_area->y1 * sizeof(lv_color_t)) + dest_area->x1 * sizeof(lv_color_t);
         uint32_t dest_w = lv_area_get_width(dest_area);


### PR DESCRIPTION
### Description of the feature or fix

Update cmsis-pack for v8.3.4
- catchup with existing fixes of v8.3.x
- fix arm-2d support

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
