### PR TITLE
stm32 dma2d rework (8.3)

### DIFF
--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -68,13 +68,13 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     }
 
     if(dsc->opa <= LV_OPA_MIN) return;
-    
+
     lv_res_t res = LV_RES_INV;
 
     if(draw_ctx->draw_img) {
         res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
     }
-    
+
     if(res != LV_RES_OK) {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
     }

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -73,8 +73,8 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     if(draw_ctx->draw_img) {
         res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
     }
-    
-    if (res != LV_RES_OK) {
+
+    if(res != LV_RES_OK) {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
     }
 

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -68,10 +68,13 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     }
 
     if(dsc->opa <= LV_OPA_MIN) return;
-    if(!(draw_ctx->draw_img)) return;
+    
+    lv_res_t res = LV_RES_INV;
 
-    lv_res_t res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
-
+    if(draw_ctx->draw_img) {
+        res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
+    }
+    
     if(res != LV_RES_OK) {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
     }

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -68,11 +68,9 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     }
 
     if(dsc->opa <= LV_OPA_MIN) return;
+    if(!(draw_ctx->draw_img)) return;
 
-    lv_res_t res;
-    if(draw_ctx->draw_img) {
-        res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
-    }
+    lv_res_t res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
 
     if(res != LV_RES_OK) {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
@@ -81,7 +79,6 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     if(res != LV_RES_OK) {
         LV_LOG_WARN("Image draw error");
         show_error(draw_ctx, coords, "No\ndata");
-        return;
     }
 }
 

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -73,11 +73,12 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     if(draw_ctx->draw_img) {
         res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
     }
-    else {
+    
+    if (res != LV_RES_OK) {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
     }
 
-    if(res == LV_RES_INV) {
+    if(res != LV_RES_OK) {
         LV_LOG_WARN("Image draw error");
         show_error(draw_ctx, coords, "No\ndata");
         return;

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -72,6 +72,7 @@ void lv_draw_stm32_dma2d_ctx_init(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
 
     dma2d_draw_ctx->blend = lv_draw_stm32_dma2d_blend;
     dma2d_draw_ctx->base_draw.draw_img_decoded = lv_draw_stm32_dma2d_img_decoded;
+    //dma2d_draw_ctx->base_draw.draw_img = lv_draw_stm32_dma2d_img;
     // Note: currently it does not make sense use lv_gpu_stm32_dma2d_wait_cb() since waiting starts right after the dma2d transfer
     //dma2d_draw_ctx->base_draw.wait_for_finish = lv_gpu_stm32_dma2d_wait_cb;
     dma2d_draw_ctx->base_draw.buffer_copy = lv_draw_stm32_dma2d_buffer_copy;
@@ -90,11 +91,11 @@ static void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw
         return;
     }
     // Note: x1 must be zero. Otherwise, there is no way to correctly calculate dest_stride.
-    //LV_ASSERT_MSG(draw_ctx->buf_area->x1 == 0); // critical
+    //LV_ASSERT_MSG(draw_ctx->buf_area->x1 == 0); // critical?
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
     //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
+    //LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical?
 
     if(dsc->src_buf) {
         // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
@@ -199,7 +200,7 @@ static void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx, void * des
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
     //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
+    //LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical?
     // FIXME:
     // 1. Both src_buf and dest_buf pixel size *must* be known to use DMA2D.
     // 2. Verify both buffers start addresses and lengths are 32-byte (cache row size) aligned.
@@ -235,6 +236,7 @@ static void lv_draw_stm32_dma2d_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_d
                                        img_dsc->opa, bitmapColorFormat, ignoreBitmapAlpha);
     }
     else {
+        // all more complex cases which require additional image transformations
         lv_draw_sw_img_decoded(draw_ctx, img_dsc, coords, src_buf, color_format);
 
     }
@@ -295,7 +297,7 @@ static lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
     //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
+    //LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical?
 
     // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
     //uint32_t srcBufferLength = lv_area_get_size(src_area) * sizeof(lv_color_t); // TODO: verify src pixel size = sizeof(lv_color_t)

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -11,100 +11,75 @@
 
 #if LV_USE_GPU_STM32_DMA2D
 
+#include "stdio.h"
+#include "main.h"
 #include LV_GPU_DMA2D_CMSIS_INCLUDE
 
 /*********************
  *      DEFINES
  *********************/
-
 #if LV_COLOR_16_SWAP
-    // TODO: F7 has red blue swap bit in control register for all layers and output
-    #error "Can't use DMA2D with LV_COLOR_16_SWAP 1"
-#endif
-
-#if LV_COLOR_DEPTH == 8
-    #error "Can't use DMA2D with LV_COLOR_DEPTH == 8"
+    // Note: DMA2D red/blue swap (RBS) works for all color modes
+    #define RBS_BIT 1U
+#else
+    #define RBS_BIT 0U
 #endif
 
 #if LV_COLOR_DEPTH == 16
-    #define LV_DMA2D_COLOR_FORMAT LV_DMA2D_RGB565
+    #define DMA2D_INPUT_COLOR DMA2D_INPUT_RGB565
+    #define DMA2D_OUTPUT_COLOR DMA2D_OUTPUT_RGB565
 #elif LV_COLOR_DEPTH == 32
-    #define LV_DMA2D_COLOR_FORMAT LV_DMA2D_ARGB8888
+    #define DMA2D_INPUT_COLOR DMA2D_INPUT_ARGB8888
+    #define DMA2D_OUTPUT_COLOR DMA2D_OUTPUT_ARGB8888
 #else
-    /*Can't use GPU with other formats*/
+    #error "Cannot use DMA2D with LV_COLOR_DEPTH other than 16 or 32"
 #endif
 
-/**********************
- *      TYPEDEFS
- **********************/
+#define CACHE_ROW_SIZE 32U // cache row size in Bytes
 
-/**********************
- *  STATIC PROTOTYPES
- **********************/
+// For code/implementation discussion refer to https://github.com/lvgl/lvgl/issues/3714#issuecomment-1365187036
+// astyle --options=lvgl/scripts/code-format.cfg --ignore-exclude-errors lvgl/src/draw/stm32_dma2d/*.c lvgl/src/draw/stm32_dma2d/*.h
 
-static void lv_draw_stm32_dma2d_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_area_t * fill_area,
-                                           lv_color_t color);
-
-
-static void lv_draw_stm32_dma2d_blend_map(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                          const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa);
-
-static void lv_draw_stm32_dma2d_img_decoded(lv_draw_ctx_t * draw, const lv_draw_img_dsc_t * dsc,
-                                            const lv_area_t * coords, const uint8_t * map_p, lv_img_cf_t color_format);
-
-
-static void invalidate_cache(void);
-
-/**********************
- *  STATIC VARIABLES
- **********************/
-
-/**********************
- *      MACROS
- **********************/
-
-/**********************
- *   GLOBAL FUNCTIONS
- **********************/
+static bool isDma2dInProgess = false; // indicates whether DMA2D transfer *initiated here* is in progress
 
 /**
  * Turn on the peripheral and set output color mode, this only needs to be done once
  */
 void lv_draw_stm32_dma2d_init(void)
 {
-    /*Enable DMA2D clock*/
+    // Enable DMA2D clock
 #if defined(STM32F4) || defined(STM32F7)
-    RCC->AHB1ENR |= RCC_AHB1ENR_DMA2DEN;
+    RCC->AHB1ENR |= RCC_AHB1ENR_DMA2DEN; // enable DMA2D
 #elif defined(STM32H7)
     RCC->AHB3ENR |= RCC_AHB3ENR_DMA2DEN;
 #else
 # warning "LVGL can't enable the clock of DMA2D"
 #endif
 
-    /*Wait for hardware access to complete*/
+    // Wait for hardware access to complete
     __asm volatile("DSB\n");
 
-    /*Delay after setting peripheral clock*/
+    // Delay after setting peripheral clock
     volatile uint32_t temp = RCC->AHB1ENR;
     LV_UNUSED(temp);
 
-    /*set output colour mode*/
-    DMA2D->OPFCCR = LV_DMA2D_COLOR_FORMAT;
+    // AHB master timer configuration
+    DMA2D->AMTCR = 0; // AHB bus guaranteed dead time disabled
+#if defined(LV_STM32_DMA2D_TEST)
+    _lv_gpu_stm32_dwt_init(); // init µs timer
+#endif
 }
-
 
 void lv_draw_stm32_dma2d_ctx_init(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
 {
-
     lv_draw_sw_init_ctx(drv, draw_ctx);
 
     lv_draw_stm32_dma2d_ctx_t * dma2d_draw_ctx = (lv_draw_sw_ctx_t *)draw_ctx;
 
     dma2d_draw_ctx->blend = lv_draw_stm32_dma2d_blend;
-    //    dma2d_draw_ctx->base_draw.draw_img_decoded = lv_draw_stm32_dma2d_img_decoded;
+    dma2d_draw_ctx->base_draw.draw_img = lv_draw_stm32_dma2d_img;
     dma2d_draw_ctx->base_draw.wait_for_finish = lv_gpu_stm32_dma2d_wait_cb;
     dma2d_draw_ctx->base_draw.buffer_copy = lv_draw_stm32_dma2d_buffer_copy;
-
 }
 
 void lv_draw_stm32_dma2d_ctx_deinit(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
@@ -113,153 +88,560 @@ void lv_draw_stm32_dma2d_ctx_deinit(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ct
     LV_UNUSED(draw_ctx);
 }
 
-
 void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
-    lv_area_t blend_area;
-    if(!_lv_area_intersect(&blend_area, dsc->blend_area, draw_ctx->clip_area)) return;
+    if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) {
+        lv_draw_sw_blend_basic(draw_ctx, dsc);
+        return;
+    }
+    // Note: x1 must be zero. Otherwise, there is no way to correctly calculate dest_stride.
+    //assert_param(draw_ctx->buf_area->x1 == 0); // critical
+    // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
+    uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
+    //assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical
+    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
 
-    bool done = false;
-
-    if(dsc->mask_buf == NULL && dsc->blend_mode == LV_BLEND_MODE_NORMAL && lv_area_get_size(&blend_area) > 100) {
-        lv_coord_t dest_stride = lv_area_get_width(draw_ctx->buf_area);
-
-        lv_color_t * dest_buf = draw_ctx->buf;
-        dest_buf += dest_stride * (blend_area.y1 - draw_ctx->buf_area->y1) + (blend_area.x1 - draw_ctx->buf_area->x1);
-
-        const lv_color_t * src_buf = dsc->src_buf;
-        if(src_buf) {
-            lv_draw_sw_blend_basic(draw_ctx, dsc);
-            lv_coord_t src_stride;
-            src_stride = lv_area_get_width(dsc->blend_area);
-            src_buf += src_stride * (blend_area.y1 - dsc->blend_area->y1) + (blend_area.x1 -  dsc->blend_area->x1);
-            lv_area_move(&blend_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
-            lv_draw_stm32_dma2d_blend_map(dest_buf, &blend_area, dest_stride, src_buf, src_stride, dsc->opa);
-            done = true;
-        }
-        else if(dsc->opa >= LV_OPA_MAX) {
-            lv_area_move(&blend_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
-            lv_draw_stm32_dma2d_blend_fill(dest_buf, dest_stride, &blend_area, dsc->color);
-            done = true;
-        }
+    if(dsc->src_buf) {
+        // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
+        uint32_t srcBufferLength = lv_area_get_size(dsc->blend_area) * sizeof(lv_color_t);
+        //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //assert_param((uint32_t)dsc->src_buf % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
     }
 
-    if(!done) lv_draw_sw_blend_basic(draw_ctx, dsc);
-}
+    lv_area_t draw_area;
+    if(!_lv_area_intersect(&draw_area, dsc->blend_area, draw_ctx->clip_area)) return;
+    // + draw_ctx->buf_area has the entire draw buffer location
+    // + draw_ctx->clip_area has the current draw buffer location
+    // + dsc->blend_area has the location of the area intended to be painted - image etc.
+    // + draw_area has the area actually being painted
+    // All coordinates are relative to the screen.
 
-void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
-                                     void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
-                                     void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area)
-{
-    LV_UNUSED(draw_ctx);
-    lv_draw_stm32_dma2d_blend_map(dest_buf, dest_area, dest_stride, src_buf, src_stride, LV_OPA_MAX);
-}
+    const lv_opa_t * mask = dsc->mask_buf;
 
-
-static void lv_draw_stm32_dma2d_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc,
-                                            const lv_area_t * coords, const uint8_t * map_p, lv_img_cf_t color_format)
-{
-    /*TODO basic ARGB8888 image can be handles here*/
-
-    lv_draw_sw_img_decoded(draw_ctx, dsc, coords, map_p, color_format);
-}
-
-static void lv_draw_stm32_dma2d_blend_fill(lv_color_t * dest_buf, lv_coord_t dest_stride, const lv_area_t * fill_area,
-                                           lv_color_t color)
-{
-    /*Simply fill an area*/
-    int32_t area_w = lv_area_get_width(fill_area);
-    int32_t area_h = lv_area_get_height(fill_area);
-    invalidate_cache();
-
-    DMA2D->CR = 0x30000;
-    DMA2D->OMAR = (uint32_t)dest_buf;
-    /*as input color mode is same as output we don't need to convert here do we?*/
-    DMA2D->OCOLR = color.full;
-    DMA2D->OOR = dest_stride - area_w;
-    DMA2D->NLR = (area_w << DMA2D_NLR_PL_Pos) | (area_h << DMA2D_NLR_NL_Pos);
-
-    /*start transfer*/
-    DMA2D->CR |= DMA2D_CR_START_Msk;
-
-}
+    if(dsc->mask_buf && dsc->mask_res == LV_DRAW_MASK_RES_TRANSP) return;
+    else if(dsc->mask_res == LV_DRAW_MASK_RES_FULL_COVER) mask = NULL;
 
 
-static void lv_draw_stm32_dma2d_blend_map(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                          const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa)
-{
+    lv_coord_t dest_stride = lv_area_get_width(draw_ctx->buf_area);
+    if(mask != NULL) {
+        // For performance reasons, both mask buffer start address and buffer size *should* be 32-byte aligned since mask buffer cache is being cleaned.
+        uint32_t srcBufferLength = lv_area_get_size(dsc->mask_area) * sizeof(lv_opa_t);
+        //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //assert_param((uint32_t)mask % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
 
-    /*Simple copy*/
-    int32_t dest_w = lv_area_get_width(dest_area);
-    int32_t dest_h = lv_area_get_height(dest_area);
+        lv_coord_t mask_stride = lv_area_get_width(dsc->mask_area);
+        lv_point_t mask_offset; // mask offset in relation to draw_area
+        mask_offset.x = draw_area.x1 - dsc->mask_area->x1;
+        mask_offset.y = draw_area.y1 - dsc->mask_area->y1;
 
-    invalidate_cache();
-    if(opa >= LV_OPA_MAX) {
-        DMA2D->CR = 0;
-        /*copy output colour mode, this register controls both input and output colour format*/
-        DMA2D->FGPFCCR = LV_DMA2D_COLOR_FORMAT;
-        DMA2D->FGMAR = (uint32_t)src_buf;
-        DMA2D->FGOR = src_stride - dest_w;
-        DMA2D->OMAR = (uint32_t)dest_buf;
-        DMA2D->OOR = dest_stride - dest_w;
-        DMA2D->NLR = (dest_w << DMA2D_NLR_PL_Pos) | (dest_h << DMA2D_NLR_NL_Pos);
+        if(dsc->src_buf == NULL) {  // 93.5%
+            lv_area_move(&draw_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
+            _lv_draw_stm32_dma2d_blend_paint(draw_ctx->buf, dest_stride, &draw_area, mask, mask_stride, &mask_offset, dsc->color,
+                                             dsc->opa);
+        }
+        else {   // 0.2%
+            // note: (x)RGB dsc->src_buf does not carry alpha channel bytes,
+            // alpha channel bytes are carried in dsc->mask_buf
+#if LV_COLOR_DEPTH == 32
+            lv_coord_t src_stride = lv_area_get_width(dsc->blend_area);
+            lv_point_t src_offset; // source image offset in relation to draw_area
+            src_offset.x = draw_area.x1 - dsc->blend_area->x1;
+            src_offset.y = draw_area.y1 - dsc->blend_area->y1;
+            lv_coord_t draw_width = lv_area_get_width(&draw_area);
+            lv_coord_t draw_height = lv_area_get_height(&draw_area);
 
-        /*start transfer*/
-        DMA2D->CR |= DMA2D_CR_START_Msk;
+            // merge mask alpha bytes with src RGB bytes
+            // TODO: optimize by reading 4 or 8 mask bytes at a time
+            mask += (mask_stride * mask_offset.y) + mask_offset.x;
+            lv_color_t * src_buf = (lv_color_t *)dsc->src_buf;
+            src_buf += (src_stride * src_offset.y) + src_offset.x;
+            uint16_t mask_buffer_offset = mask_stride - draw_width;
+            uint16_t src_buffer_offset = src_stride - draw_width;
+            while(draw_height > 0) {
+                draw_height--;
+                for(uint16_t x = 0; x < draw_width; x++) {
+                    (*src_buf).ch.alpha = *mask;
+                    src_buf++;
+                    mask++;
+                }
+                mask += mask_buffer_offset;
+                src_buf += src_buffer_offset;
+            }
+
+            lv_area_move(&draw_area, -draw_ctx->buf_area->x1,
+                         -draw_ctx->buf_area->y1); // translate the screen draw area to the origin of the buffer area
+            _lv_draw_stm32_dma2d_blend_map(draw_ctx->buf, dest_stride, &draw_area, dsc->src_buf, src_stride, &src_offset, dsc->opa,
+                                           true);
+#else
+            // Note: 16-bit bitmap hardware blending with mask and background is possible, but requires a temp 24 or 32-bit buffer to combine bitmap with mask first.
+            // In case of 32-bit bitmap existing buffer is used
+            lv_draw_sw_blend_basic(draw_ctx, dsc); // (e.g. Shop Items)
+#endif
+        }
     }
     else {
-        DMA2D->CR = 0x20000;
-
-        DMA2D->BGPFCCR = LV_DMA2D_COLOR_FORMAT;
-        DMA2D->BGMAR = (uint32_t)dest_buf;
-        DMA2D->BGOR = dest_stride - dest_w;
-
-        DMA2D->FGPFCCR = (uint32_t)LV_DMA2D_COLOR_FORMAT
-                         /*alpha mode 2, replace with foreground * alpha value*/
-                         | (2 << DMA2D_FGPFCCR_AM_Pos)
-                         /*alpha value*/
-                         | (opa << DMA2D_FGPFCCR_ALPHA_Pos);
-        DMA2D->FGMAR = (uint32_t)src_buf;
-        DMA2D->FGOR = src_stride - dest_w;
-
-        DMA2D->OMAR = (uint32_t)dest_buf;
-        DMA2D->OOR = dest_stride - dest_w;
-        DMA2D->NLR = (dest_w << DMA2D_NLR_PL_Pos) | (dest_h << DMA2D_NLR_NL_Pos);
-
-        /*start transfer*/
-        DMA2D->CR |= DMA2D_CR_START_Msk;
+        if(dsc->src_buf == NULL) {  // 6.1%
+            lv_coord_t dest_stride = lv_area_get_width(draw_ctx->buf_area);
+            lv_area_move(&draw_area, -draw_ctx->buf_area->x1,
+                         -draw_ctx->buf_area->y1); // translate the screen draw area to the origin of the buffer area
+            _lv_draw_stm32_dma2d_blend_fill(draw_ctx->buf, dest_stride, &draw_area, dsc->color, dsc->opa);
+        }
+        else {   // 0.2%
+            lv_coord_t src_stride = lv_area_get_width(dsc->blend_area);
+            lv_point_t src_offset; // source image offset in relation to draw_area
+            src_offset.x = draw_area.x1 - dsc->blend_area->x1;
+            src_offset.y = draw_area.y1 - dsc->blend_area->y1;
+            lv_area_move(&draw_area, -draw_ctx->buf_area->x1,
+                         -draw_ctx->buf_area->y1); // translate the screen draw area to the origin of the buffer area
+            if(dsc->opa >= LV_OPA_MAX) {
+                // note: buffer can be simply copied since alpha channel is not in use
+                _lv_draw_stm32_dma2d_copy_buffer(draw_ctx->buf, dest_stride, &draw_area, dsc->src_buf, src_stride, &src_offset);
+            }
+            else
+                _lv_draw_stm32_dma2d_blend_map(draw_ctx->buf, dest_stride, &draw_area, dsc->src_buf, src_stride, &src_offset, dsc->opa,
+                                               false);
+        }
     }
+}
+
+// Does dest_area = intersect(draw_ctx->clip_area, src_area) ?
+// See: https://github.com/lvgl/lvgl/issues/3714#issuecomment-1331710788
+void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx, void * dest_buf, lv_coord_t dest_stride,
+                                     const lv_area_t * dest_area, void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area)
+{
+    // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
+    uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
+    assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical
+    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
+    // FIXME:
+    // 1. Both src_buf and dest_buf pixel size *must* be known to use DMA2D.
+    // 2. Verify both buffers start addresses and lengths are 32-byte (cache row size) aligned.
+    LV_UNUSED(draw_ctx);
+    lv_point_t src_offset;
+    src_offset.x = dest_area->x1 - src_area->x1;
+    src_offset.y = dest_area->y1 - src_area->y1;
+    // FIXME: use lv_area_move(dest_area, -dest_area->x1, -dest_area->y1) here ?
+    // TODO: It is assumed that dest_buf and src_buf buffers are of lv_color_t type. Verify it, this assumption may be incorrect.
+    _lv_draw_stm32_dma2d_copy_buffer(dest_buf, dest_stride, dest_area, (const lv_color_t *)src_buf, src_stride,
+                                     &src_offset);
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL); // TODO: is this line needed here?
+}
+
+lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const lv_area_t * src_area,
+                                 const void * src)
+{
+    // FIXME: src pixel size *must* be known to use DMA2D
+
+    // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
+    uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
+    assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical
+    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
+
+    // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
+    uint32_t srcBufferLength = lv_area_get_size(src_area) * sizeof(
+                                   lv_color_t); // TODO: verify src pixel size = sizeof(lv_color_t)
+    //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+    //assert_param((uint32_t)src % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+
+    if(lv_img_src_get_type(src) == LV_IMG_SRC_VARIABLE) {
+        lv_area_t draw_area;
+        if(!_lv_area_intersect(&draw_area, src_area, draw_ctx->clip_area)) return LV_RES_OK;
+        const lv_img_dsc_t * img = src;
+
+        if(img->header.cf == LV_IMG_CF_RGBA8888 && dsc->angle == 0 && dsc->zoom == 256) {
+            // note: LV_IMG_CF_RGBA8888 is actually ARGB8888
+            lv_coord_t dest_stride = lv_area_get_width(draw_ctx->buf_area);
+            lv_point_t src_offset; // source image offset in relation to draw_area
+            src_offset.x = draw_area.x1 - src_area->x1;
+            src_offset.y = draw_area.y1 - src_area->y1;
+            lv_area_move(&draw_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
+            // TODO: It is assumed that img->data buffer is of lv_color_t type. This assumption may be incorrect.
+            _lv_draw_stm32_dma2d_blend_map(draw_ctx->buf, dest_stride, &draw_area, (lv_color_t *)img->data, img->header.w,
+                                           &src_offset, dsc->opa, true);
+            return LV_RES_OK;
+        }
+    }
+
+    return LV_RES_INV;
 }
 
 void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx)
 {
     lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-    if(disp->driver && disp->driver->wait_cb) {
-        while(DMA2D->CR & DMA2D_CR_START_Msk) {
-            disp->driver->wait_cb(disp->driver);
-        }
-    }
-    else {
-        while(DMA2D->CR & DMA2D_CR_START_Msk);
-    }
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(disp->driver);
     lv_draw_sw_wait_for_finish(draw_ctx);
-
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static void invalidate_cache(void)
+/**
+ * @brief Fills draw_area with specified color.
+ * @param color color to be painted, note: alpha is ignored
+ */
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                           const lv_area_t * draw_area, lv_color_t color, lv_opa_t opa)
 {
-    lv_disp_t * disp = _lv_refr_get_disp_refreshing();
-    if(disp->driver->clean_dcache_cb) disp->driver->clean_dcache_cb(disp->driver);
-    else {
-#if __CORTEX_M >= 0x07
-        if((SCB->CCR) & (uint32_t)SCB_CCR_DC_Msk)
-            SCB_CleanInvalidateDCache();
+    assert_param(!isDma2dInProgess); // critical
+    lv_coord_t draw_width = lv_area_get_width(draw_area);
+    lv_coord_t draw_height = lv_area_get_height(draw_area);
+
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL);
+
+    if(opa >= LV_OPA_MAX) {
+        DMA2D->CR = 0x3UL << DMA2D_CR_MODE_Pos; // Register-to-memory (no FG nor BG, only output stage active)
+
+        DMA2D->OPFCCR = DMA2D_OUTPUT_COLOR;
+        DMA2D->OPFCCR |= (RBS_BIT << DMA2D_OPFCCR_RBS_Pos);
+        DMA2D->OMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
+        DMA2D->OOR = dest_stride - draw_width;  // out buffer offset
+        // Note: unlike FGCOLR and BGCOLR, OCOLR bits must match DMA2D_OUTPUT_COLOR, alpha can be specified
+#if RBS_BIT
+        DMA2D->OCOLR = (color.ch.blue << 11) | (color.ch.green_l << 5 | color.ch.green_h << 8) | (color.ch.red);
+#else
+        DMA2D->OCOLR = color.full;
 #endif
     }
+    else {
+        DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos; // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
+
+        DMA2D->FGPFCCR = DMA2D_INPUT_A8;
+        DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
+        DMA2D->FGPFCCR |= (0x1UL <<
+                           DMA2D_FGPFCCR_AM_Pos); // Alpha Mode 1: Replace original foreground image alpha channel value by FGPFCCR.ALPHA
+        //DMA2D->FGPFCCR |= (RBS_BIT << DMA2D_FGPFCCR_RBS_Pos);
+
+        // Note: in Alpha Mode 1 FGMAR and FGOR are not used to supply foreground A8 bytes,
+        // those bytes are replaced by constant ALPHA defined in FGPFCCR
+        DMA2D->FGMAR = (uint32_t)dest_buf;
+        DMA2D->FGOR = dest_stride;
+        DMA2D->FGCOLR = lv_color_to32(color) & 0x00ffffff; // swap FGCOLR R/B bits if FGPFCCR.RBS (RBS_BIT) bit is set
+
+        DMA2D->BGPFCCR = DMA2D_INPUT_COLOR;
+        DMA2D->BGPFCCR |= (RBS_BIT << DMA2D_BGPFCCR_RBS_Pos);
+        DMA2D->BGMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
+        DMA2D->BGOR = dest_stride - draw_width;
+        DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
+        _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+
+        DMA2D->OPFCCR = DMA2D_OUTPUT_COLOR;
+        DMA2D->OPFCCR |= (RBS_BIT << DMA2D_OPFCCR_RBS_Pos);
+        DMA2D->OMAR = DMA2D->BGMAR;
+        DMA2D->OOR = DMA2D->BGOR;
+        DMA2D->OCOLR = 0;
+    }
+    // PL - pixel per lines (14 bit), NL - number of lines (16 bit)
+    DMA2D->NLR = (draw_width << DMA2D_NLR_PL_Pos) | (draw_height << DMA2D_NLR_NL_Pos);
+
+    _lv_gpu_stm32_dma2d_start_dma_transfer();
+}
+
+/**
+ * @brief Draws src (foreground) map on dst (background) map.
+ * @param src_offset src offset in relation to dst, useful when src is larger than draw_area
+ * @param opa constant opacity to be applied
+ * @param isSrcArgb32 If TRUE, source buffer is ARGB32(8888), regardless of LV_COLOR_DEPTH.
+ * If FALSE, source buffer is described by LV_COLOR_DEPTH.
+ */
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                          const lv_area_t * draw_area, const void * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset, lv_opa_t opa,
+                                                          bool isSrcArgb32)
+{
+    assert_param(!isDma2dInProgess); // critical
+    lv_coord_t draw_width = lv_area_get_width(draw_area);
+    lv_coord_t draw_height = lv_area_get_height(draw_area);
+
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL);
+
+    if(opa >= LV_OPA_MAX) opa = 0xff;
+
+    if(isSrcArgb32) {
+        // src is ARGB32
+        DMA2D->FGPFCCR = DMA2D_INPUT_ARGB8888;
+        DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos; // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
+        DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
+        DMA2D->FGPFCCR |= (0x2UL <<
+                           DMA2D_FGPFCCR_AM_Pos); // Alpha Mode 2: Replace original foreground image alpha channel value by FGPFCCR.ALPHA multiplied with original alpha channel value
+    }
+    else {
+        DMA2D->FGPFCCR = DMA2D_INPUT_COLOR;
+        // src is RGB or xRGB
+        if(opa == 0xff) {
+            // no need to blend
+            DMA2D->CR = 0x1UL << DMA2D_CR_MODE_Pos; // Memory-to-memory with PFC (FG fetch only with FG PFC active)
+            // Alpha Mode 0: No modification of the foreground image alpha channel value
+        }
+        else {
+            // blend with constant ALPHA only
+            DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos; // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
+            DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
+            DMA2D->FGPFCCR |= (0x1UL <<
+                               DMA2D_FGPFCCR_AM_Pos); // Alpha Mode 1: Replace original foreground image alpha channel value by FGPFCCR.ALPHA
+        }
+    }
+
+    DMA2D->FGPFCCR |= (RBS_BIT << DMA2D_FGPFCCR_RBS_Pos);
+    if(isSrcArgb32) {
+        DMA2D->FGMAR = (uint32_t)(((lv_color32_t *)src_buf) + (src_stride * src_offset->y) + src_offset->x);
+    }
+    else {
+        DMA2D->FGMAR = (uint32_t)(((lv_color_t *)src_buf) + (src_stride * src_offset->y) + src_offset->x);
+    }
+    DMA2D->FGOR = src_stride - draw_width;
+    DMA2D->FGCOLR = 0;  // used in A4 and A8 modes only
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height,
+                                    (isSrcArgb32 ? 4 : sizeof(lv_color_t)));
+
+    DMA2D->BGPFCCR = DMA2D_INPUT_COLOR;
+    DMA2D->BGPFCCR |= (RBS_BIT << DMA2D_BGPFCCR_RBS_Pos);
+    DMA2D->BGMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
+    DMA2D->BGOR = dest_stride - draw_width;
+    DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+
+    DMA2D->OPFCCR = DMA2D_OUTPUT_COLOR;
+    DMA2D->OPFCCR |= (RBS_BIT << DMA2D_OPFCCR_RBS_Pos);
+    DMA2D->OMAR = DMA2D->BGMAR;
+    DMA2D->OOR = DMA2D->BGOR;
+    DMA2D->OCOLR = 0;
+
+    // PL - pixel per lines (14 bit), NL - number of lines (16 bit)
+    DMA2D->NLR = (draw_width << DMA2D_NLR_PL_Pos) | (draw_height << DMA2D_NLR_NL_Pos);
+
+    _lv_gpu_stm32_dma2d_start_dma_transfer();
+}
+
+/**
+ * @brief Paints solid color with alpha mask with additional constant opacity. Useful e.g. for painting anti-aliased fonts.
+ * @param src_offset src offset in relation to dst, useful when src (alpha mask) is larger than draw_area
+ * @param color color to paint, note: alpha is ignored
+ * @param opa constant opacity to be applied
+ */
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                            const lv_area_t * draw_area, const lv_opa_t * mask_buf, lv_coord_t mask_stride, const lv_point_t * mask_offset,
+                                                            lv_color_t color, lv_opa_t opa)
+{
+    assert_param(!isDma2dInProgess); // critical
+    lv_coord_t draw_width = lv_area_get_width(draw_area);
+    lv_coord_t draw_height = lv_area_get_height(draw_area);
+
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL);
+
+    DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos;  // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
+
+    DMA2D->FGPFCCR = DMA2D_INPUT_A8;
+    if(opa < LV_OPA_MAX) {
+        DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
+        DMA2D->FGPFCCR |= (0x2UL <<
+                           DMA2D_FGPFCCR_AM_Pos); // Alpha Mode: Replace original foreground image alpha channel value by FGPFCCR.ALPHA multiplied with original alpha channel value
+    }
+    //DMA2D->FGPFCCR |= (RBS_BIT << DMA2D_FGPFCCR_RBS_Pos);
+    DMA2D->FGMAR = (uint32_t)(mask_buf + (mask_stride * mask_offset->y) + mask_offset->x);
+    DMA2D->FGOR = mask_stride - draw_width;
+    DMA2D->FGCOLR = lv_color_to32(color) & 0x00ffffff;  // swap FGCOLR R/B bits if FGPFCCR.RBS (RBS_BIT) bit is set
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_opa_t));
+
+    DMA2D->BGPFCCR = DMA2D_INPUT_COLOR;
+    DMA2D->BGPFCCR |= (RBS_BIT << DMA2D_BGPFCCR_RBS_Pos);
+    DMA2D->BGMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
+    DMA2D->BGOR = dest_stride - draw_width;
+    DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+
+    DMA2D->OPFCCR = DMA2D_OUTPUT_COLOR;
+    DMA2D->OPFCCR |= (RBS_BIT << DMA2D_OPFCCR_RBS_Pos);
+    DMA2D->OMAR = DMA2D->BGMAR;
+    DMA2D->OOR = DMA2D->BGOR;
+    DMA2D->OCOLR = 0;
+    // PL - pixel per lines (14 bit), NL - number of lines (16 bit)
+    DMA2D->NLR = (draw_width << DMA2D_NLR_PL_Pos) | (draw_height << DMA2D_NLR_NL_Pos);
+
+    _lv_gpu_stm32_dma2d_start_dma_transfer();
+}
+
+/**
+ * @brief Copies src (foreground) map to the dst (background) map.
+ * @param src_offset src offset in relation to dst, useful when src is larger than draw_area
+ */
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                            const lv_area_t * draw_area, const lv_color_t * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset)
+{
+    assert_param(!isDma2dInProgess); // critical
+    lv_coord_t draw_width = lv_area_get_width(draw_area);
+    lv_coord_t draw_height = lv_area_get_height(draw_area);
+
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL);
+
+    DMA2D->CR = 0x0UL; // Memory-to-memory (FG fetch only)
+
+    DMA2D->FGPFCCR = DMA2D_INPUT_COLOR;
+    DMA2D->FGPFCCR |= (RBS_BIT << DMA2D_FGPFCCR_RBS_Pos);
+    DMA2D->FGMAR = (uint32_t)(src_buf + (src_stride * src_offset->y) + src_offset->x);
+    DMA2D->FGOR = src_stride - draw_width;
+    DMA2D->FGCOLR = 0;  // used in A4 and A8 modes only
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_color_t));
+
+    // Note BG* registers do not need to be set up since BG is not used
+
+    DMA2D->OPFCCR = DMA2D_OUTPUT_COLOR;
+    DMA2D->OPFCCR |= (RBS_BIT << DMA2D_OPFCCR_RBS_Pos);
+    DMA2D->OMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
+    DMA2D->OOR = dest_stride - draw_width;
+    DMA2D->OCOLR = 0;
+
+    // PL - pixel per lines (14 bit), NL - number of lines (16 bit)
+    DMA2D->NLR = (draw_width << DMA2D_NLR_PL_Pos) | (draw_height << DMA2D_NLR_NL_Pos);
+
+    _lv_gpu_stm32_dma2d_start_dma_transfer();
+}
+
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void)
+{
+    assert_param(!isDma2dInProgess);
+    isDma2dInProgess = true;
+    DMA2D->IFCR = 0x3FU; // trigger ISR flags reset
+    // Note: cleaning output buffer cache is needed only because buffer may be misaligned or adjacent area may be drawn in sw-fashion
+    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos,
+                                    (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
+    DMA2D->CR |= DMA2D_CR_START;
+    // Note: for some reason mask buffer gets damaged during transfer if waiting is postponed
+    _lv_gpu_stm32_dma2d_await_dma_transfer_finish(NULL); // FIXME: this line should not be needed here, but it is
+}
+
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_await_dma_transfer_finish(lv_disp_drv_t * disp_drv)
+{
+    if(disp_drv && disp_drv->wait_cb) {
+        while((DMA2D->CR & DMA2D_CR_START) != 0U) {
+            disp_drv->wait_cb(disp_drv);
+        }
+    }
+    else {
+        while((DMA2D->CR & DMA2D_CR_START) != 0U);
+    }
+
+    __IO uint32_t isrFlags = DMA2D->ISR;
+
+    if(isrFlags & DMA2D_ISR_CEIF) {
+        printf("DMA2D config error\n");
+    }
+
+    if(isrFlags & DMA2D_ISR_TEIF) {
+        printf("DMA2D transfer error\n");
+    }
+
+    DMA2D->IFCR = 0x3FU; // trigger ISR flags reset
+
+    if(isDma2dInProgess) {
+        // invalidate output buffer cached memory ONLY after DMA2D transfer
+        _lv_gpu_stm32_dma2d_invalidate_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos,
+                                             (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
+        isDma2dInProgess = false;
+    }
+}
+
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
+                                                                lv_coord_t height, uint8_t pixelSize)
+{
+    if(((SCB->CCR) & SCB_CCR_DC_Msk) == 0) return; // L1 data cache is disabled
+    uint16_t stride = pixelSize * (width + offset); // in bytes
+    uint16_t ll = pixelSize * width; // line length in bytes
+    uint32_t n = 0; // address of the next cache row after the last invalidated row
+    lv_coord_t h = 0;
+
+    __DSB();
+
+    while(h < height) {
+        uint32_t a = address + (h * stride);
+        uint32_t e = a + ll; // end address, address of the first byte after the current line
+        a &= ~(CACHE_ROW_SIZE - 1U);
+        if(a < n) a = n;  // prevent the previous last cache row from being invalidated again
+
+        while(a < e) {
+            SCB->DCIMVAC = a;
+            a += CACHE_ROW_SIZE;
+        }
+
+        n = a;
+        h++;
+    };
+
+    __DSB();
+    __ISB();
+}
+
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
+                                                           lv_coord_t height, uint8_t pixelSize)
+{
+    if(((SCB->CCR) & SCB_CCR_DC_Msk) == 0) return; // L1 data cache is disabled
+    uint16_t stride = pixelSize * (width + offset); // in bytes
+    uint16_t ll = pixelSize * width; // line length in bytes
+    uint32_t n = 0; // address of the next cache row after the last cleaned row
+    lv_coord_t h = 0;
+    __DSB();
+
+    while(h < height) {
+        uint32_t a = address + (h * stride);
+        uint32_t e = a + ll; // end address, address of the first byte after the current line
+        a &= ~(CACHE_ROW_SIZE - 1U);
+        if(a < n) a = n;  // prevent the previous last cache row from being cleaned again
+
+        while(a < e) {
+            SCB->DCCMVAC = a;
+            a += CACHE_ROW_SIZE;
+        }
+
+        n = a;
+        h++;
+    };
+
+    __DSB();
+    __ISB();
+}
+
+// initialize µs timer
+LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void)
+{
+    // disable TRC
+    CoreDebug->DEMCR &= ~CoreDebug_DEMCR_TRCENA_Msk;
+    // enable TRC
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+
+    DWT->LAR = 0xC5ACCE55;
+
+    // disable clock cycle counter
+    DWT->CTRL &= ~DWT_CTRL_CYCCNTENA_Msk;
+    // enable  clock cycle counter
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    // reset the clock cycle counter value
+    DWT->CYCCNT = 0;
+
+    // 3 NO OPERATION instructions
+    __ASM volatile("NOP");
+    __ASM volatile("NOP");
+    __ASM volatile("NOP");
+
+    // check if clock cycle counter has started
+    if(DWT->CYCCNT) {
+        return true; // clock cycle counter started
+    }
+    else {
+        return false; // clock cycle counter not started
+    }
+}
+
+// get elapsed µs since reset
+LV_STM32_DMA2D_STATIC uint32_t _lv_gpu_stm32_dwt_get_us(void)
+{
+    uint32_t us = (DWT->CYCCNT * 1000000) / HAL_RCC_GetHCLKFreq();
+    return us;
+}
+
+// reset µs timer
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void)
+{
+    DWT->CYCCNT = 0;
 }
 
 #endif

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -248,17 +248,16 @@ lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc
             bitmapColorCode = DMA2D_INPUT_COLOR;
             break;
         case LV_IMG_CF_TRUE_COLOR_ALPHA:
-            if(DMA2D_INPUT_COLOR == DMA2D_INPUT_ARGB8888) {
-                bitmapColorCode = ARGB8888;
-                break;
-            }
-            else if(DMA2D_INPUT_COLOR == DMA2D_INPUT_RGB565) {
-                // bitmap color is 24b ARGB8565 - dma2d unsupported
-                return LV_RES_INV;
-            }
-            else {
-                return LV_RES_INV;
-            }
+#if LV_COLOR_DEPTH == 16
+            // bitmap color format is 24b ARGB8565 - dma2d unsupported
+            return LV_RES_INV;
+#elif LV_COLOR_DEPTH == 32
+            bitmapColorCode = ARGB8888;
+            break;
+#else
+            // unknown bitmap color format
+            return LV_RES_INV;
+#endif
         default:
             return LV_RES_INV;
     }

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -330,7 +330,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * de
     else {
         DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos; // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
 
-        DMA2D->FGPFCCR = DMA2D_INPUT_A8;
+        DMA2D->FGPFCCR = A8;
         DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
         // Alpha Mode 1: Replace original foreground image alpha channel value by FGPFCCR.ALPHA
         DMA2D->FGPFCCR |= (0x1UL << DMA2D_FGPFCCR_AM_Pos);
@@ -474,7 +474,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * d
 
     DMA2D->CR = 0x2UL << DMA2D_CR_MODE_Pos;  // Memory-to-memory with blending (FG and BG fetch with PFC and blending)
 
-    DMA2D->FGPFCCR = DMA2D_INPUT_A8;
+    DMA2D->FGPFCCR = A8;
     if(opa < LV_OPA_MAX) {
         DMA2D->FGPFCCR |= (opa << DMA2D_FGPFCCR_ALPHA_Pos);
         DMA2D->FGPFCCR |= (0x2UL <<

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -90,17 +90,17 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
         return;
     }
     // Note: x1 must be zero. Otherwise, there is no way to correctly calculate dest_stride.
-    //assert_param(draw_ctx->buf_area->x1 == 0); // critical
+    //LV_ASSERT_MSG(draw_ctx->buf_area->x1 == 0); // critical
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
-    //assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
+    //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
+    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
 
     if(dsc->src_buf) {
         // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
         //uint32_t srcBufferLength = lv_area_get_size(dsc->blend_area) * sizeof(lv_color_t);
-        //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
-        //assert_param((uint32_t)dsc->src_buf % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //LV_ASSERT_MSG(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //LV_ASSERT_MSG((uint32_t)dsc->src_buf % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
     }
 
     lv_area_t draw_area;
@@ -121,8 +121,8 @@ void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_
     if(mask != NULL) {
         // For performance reasons, both mask buffer start address and buffer size *should* be 32-byte aligned since mask buffer cache is being cleaned.
         //uint32_t srcBufferLength = lv_area_get_size(dsc->mask_area) * sizeof(lv_opa_t);
-        //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
-        //assert_param((uint32_t)mask % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //LV_ASSERT_MSG(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+        //LV_ASSERT_MSG((uint32_t)mask % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
 
         lv_coord_t mask_stride = lv_area_get_width(dsc->mask_area);
         lv_point_t mask_offset; // mask offset in relation to draw_area
@@ -206,8 +206,8 @@ void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx, void * dest_buf, 
 {
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
-    //assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
+    //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
+    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
     // FIXME:
     // 1. Both src_buf and dest_buf pixel size *must* be known to use DMA2D.
     // 2. Verify both buffers start addresses and lengths are 32-byte (cache row size) aligned.
@@ -268,13 +268,13 @@ lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc
     // FIXME: If image is drawn by SW, then output cache needs to be cleaned next. Currently it is not possible.
     // Both draw buffer start address and buffer size *must* be 32-byte aligned since draw buffer cache is being invalidated.
     //uint32_t drawBufferLength = lv_area_get_size(draw_ctx->buf_area) * sizeof(lv_color_t);
-    //assert_param(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
-    assert_param((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0); // critical
+    //LV_ASSERT_MSG(drawBufferLength % CACHE_ROW_SIZE == 0); // critical, but this is not the way to test it
+    LV_ASSERT_MSG((uint32_t)draw_ctx->buf % CACHE_ROW_SIZE == 0, "draw_ctx.buf is not 32B aligned"); // critical
 
     // For performance reasons, both source buffer start address and buffer size *should* be 32-byte aligned since source buffer cache is being cleaned.
     //uint32_t srcBufferLength = lv_area_get_size(src_area) * sizeof(lv_color_t); // TODO: verify src pixel size = sizeof(lv_color_t)
-    //assert_param(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
-    //assert_param((uint32_t)src % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+    //LV_ASSERT_MSG(srcBufferLength % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
+    //LV_ASSERT_MSG((uint32_t)src % CACHE_ROW_SIZE == 0); // FIXME: assert fails (performance, non-critical)
 
     lv_area_t draw_area;
     if(!_lv_area_intersect(&draw_area, src_area, draw_ctx->clip_area)) return LV_RES_OK;
@@ -307,7 +307,7 @@ void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx)
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * dest_buf, lv_coord_t dest_stride,
                                                            const lv_area_t * draw_area, lv_color_t color, lv_opa_t opa)
 {
-    assert_param(!isDma2dInProgess); // critical
+    LV_ASSERT_MSG(!isDma2dInProgess, "dma2d transfer has not finished"); // critical
     lv_coord_t draw_width = lv_area_get_width(draw_area);
     lv_coord_t draw_height = lv_area_get_height(draw_area);
 
@@ -372,7 +372,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * des
                                                           const lv_area_t * draw_area, const void * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset, lv_opa_t opa,
                                                           dma2d_color_format_t src_color_format, bool ignore_src_alpha)
 {
-    assert_param(!isDma2dInProgess); // critical
+    LV_ASSERT_MSG(!isDma2dInProgess, "dma2d transfer has not finished"); // critical
     if(opa <= LV_OPA_MIN) return;
     lv_coord_t draw_width = lv_area_get_width(draw_area);
     lv_coord_t draw_height = lv_area_get_height(draw_area);
@@ -466,7 +466,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * d
                                                             const lv_area_t * draw_area, const lv_opa_t * mask_buf, lv_coord_t mask_stride, const lv_point_t * mask_offset,
                                                             lv_color_t color, lv_opa_t opa)
 {
-    assert_param(!isDma2dInProgess); // critical
+    LV_ASSERT_MSG(!isDma2dInProgess, "dma2d transfer has not finished"); // critical
     lv_coord_t draw_width = lv_area_get_width(draw_area);
     lv_coord_t draw_height = lv_area_get_height(draw_area);
 
@@ -511,7 +511,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * d
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * dest_buf, lv_coord_t dest_stride,
                                                             const lv_area_t * draw_area, const lv_color_t * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset)
 {
-    assert_param(!isDma2dInProgess); // critical
+    LV_ASSERT_MSG(!isDma2dInProgess, "dma2d transfer has not finished"); // critical
     lv_coord_t draw_width = lv_area_get_width(draw_area);
     lv_coord_t draw_height = lv_area_get_height(draw_area);
 
@@ -542,7 +542,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * d
 
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void)
 {
-    assert_param(!isDma2dInProgess);
+    LV_ASSERT_MSG(!isDma2dInProgess, "dma2d transfer has not finished");
     isDma2dInProgess = true;
     DMA2D->IFCR = 0x3FU; // trigger ISR flags reset
     // Note: cleaning output buffer cache is needed only when buffer may be misaligned or adjacent area may have been drawn in sw-fashion, e.g. using lv_draw_sw_blend_basic()

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -35,12 +35,13 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 enum dma2d_color_format {
-    ARGB8888 = 0x00000000U,
-    RGB888 = 0x00000001U,
-    RGB565 = 0x00000002U,
-    ARGB1555 = 0x00000003U,
-    ARGB4444 = 0x00000004U,
-    A8 = 0x00000009U
+    ARGB8888 = 0x0,
+    RGB888 = 0x01,
+    RGB565 = 0x02,
+    ARGB1555 = 0x03,
+    ARGB4444 = 0x04,
+    A8 = 0x09,
+    UNSUPPORTED = 0xff,
 };
 typedef enum dma2d_color_format dma2d_color_format_t;
 typedef lv_draw_sw_ctx_t lv_draw_stm32_dma2d_ctx_t;
@@ -50,21 +51,19 @@ struct _lv_disp_drv_t;
  * GLOBAL PROTOTYPES
  **********************/
 void lv_draw_stm32_dma2d_init(void);
-
 void lv_draw_stm32_dma2d_ctx_init(struct _lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx);
-
 void lv_draw_stm32_dma2d_ctx_deinit(struct _lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx);
-
-void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
-
-void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
-                                     void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
-                                     void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area);
-
-lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc,
-                                 const lv_area_t * src_area, const void * src);
-
-void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
+static void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+static void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
+                                            void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
+                                            void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area);
+static lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * img_dsc,
+                                        const lv_area_t * src_area, const void * src);
+static void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
+static void lv_draw_stm32_dma2d_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * img_dsc,
+                                            const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t color_format);
+static dma2d_color_format_t lv_color_format_to_dma2d_color_format(lv_img_cf_t color_format);
+static lv_point_t lv_area_get_offset(const lv_area_t * area1, const lv_area_t * area2);
 
 /**********************
  *  STATIC PROTOTYPES
@@ -85,7 +84,6 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address
                                                                 lv_coord_t width, lv_coord_t height, uint8_t pixel_size);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
                                                            lv_coord_t height, uint8_t pixel_size);
-
 LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void);
 LV_STM32_DMA2D_STATIC uint32_t _lv_gpu_stm32_dwt_get_us(void);

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include LV_GPU_DMA2D_CMSIS_INCLUDE
-//#include "stm32f7xx_hal.h"
+//#include "stm32f7xx.h"
 
 /*********************
  *      DEFINES
@@ -36,11 +36,12 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 enum dma2d_color_format {
-    ARGB8888 = DMA2D_INPUT_ARGB8888,
-    RGB888 = DMA2D_INPUT_RGB888,
-    RGB565 = DMA2D_INPUT_RGB565,
-    ARGB1555 = DMA2D_INPUT_ARGB1555,
-    ARGB4444 = DMA2D_INPUT_ARGB4444
+    ARGB8888 = 0x00000000U,
+    RGB888 = 0x00000001U,
+    RGB565 = 0x00000002U,
+    ARGB1555 = 0x00000003U,
+    ARGB4444 = 0x00000004U,
+    A8 = 0x00000009U
 };
 typedef enum dma2d_color_format dma2d_color_format_t;
 typedef lv_draw_sw_ctx_t lv_draw_stm32_dma2d_ctx_t;

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -20,7 +20,6 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include LV_GPU_DMA2D_CMSIS_INCLUDE
-//#include "stm32f7xx.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -35,15 +35,14 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-LV_STM32_DMA2D_STATIC enum bitmap_color_code {
+enum dma2d_color_format {
     ARGB8888 = DMA2D_INPUT_ARGB8888,
     RGB888 = DMA2D_INPUT_RGB888,
     RGB565 = DMA2D_INPUT_RGB565,
     ARGB1555 = DMA2D_INPUT_ARGB1555,
-    ARGB4444 = DMA2D_INPUT_ARGB4444,
+    ARGB4444 = DMA2D_INPUT_ARGB4444
 };
-typedef enum bitmap_color_code bitmap_color_code_t;
-
+typedef enum dma2d_color_format dma2d_color_format_t;
 typedef lv_draw_sw_ctx_t lv_draw_stm32_dma2d_ctx_t;
 struct _lv_disp_drv_t;
 
@@ -74,7 +73,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * ds
                                                            const lv_area_t * draw_area, lv_color_t color, lv_opa_t opa);
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * dest_buf, lv_coord_t dest_stride,
                                                           const lv_area_t * draw_area, const void * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset, lv_opa_t opa,
-                                                          bitmap_color_code_t src_color_code, bool ignore_src_alpha);
+                                                          dma2d_color_format_t src_color_format, bool ignore_src_alpha);
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * dst_buf, lv_coord_t dst_stride,
                                                             const lv_area_t * draw_area, const lv_opa_t * mask_buf, lv_coord_t mask_stride, const lv_point_t * mask_offset,
                                                             lv_color_t color, lv_opa_t opa);

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -22,27 +22,22 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
-
-#define LV_DMA2D_ARGB8888 0
-#define LV_DMA2D_RGB888 1
-#define LV_DMA2D_RGB565 2
-#define LV_DMA2D_ARGB1555 3
-#define LV_DMA2D_ARGB4444 4
+#if defined(LV_STM32_DMA2D_TEST)
+// removes "static" modifier for some internal methods in order to test them
+#define LV_STM32_DMA2D_STATIC
+#else
+#define LV_STM32_DMA2D_STATIC static
+#endif
 
 /**********************
  *      TYPEDEFS
  **********************/
 typedef lv_draw_sw_ctx_t lv_draw_stm32_dma2d_ctx_t;
-
 struct _lv_disp_drv_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
-/**
- * Turn on the peripheral and set output color mode, this only needs to be done once
- */
 void lv_draw_stm32_dma2d_init(void);
 
 void lv_draw_stm32_dma2d_ctx_init(struct _lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx);
@@ -55,7 +50,36 @@ void lv_draw_stm32_dma2d_buffer_copy(lv_draw_ctx_t * draw_ctx,
                                      void * dest_buf, lv_coord_t dest_stride, const lv_area_t * dest_area,
                                      void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area);
 
+lv_res_t lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc,
+                                 const lv_area_t * src_area, const void * src);
+
 void lv_gpu_stm32_dma2d_wait_cb(lv_draw_ctx_t * draw_ctx);
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * dst_buf, lv_coord_t dst_stride,
+                                                           const lv_area_t * draw_area, lv_color_t color, lv_opa_t opa);
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                          const lv_area_t * draw_area, const void * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset, lv_opa_t opa,
+                                                          bool isSrcArgb32);
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * dst_buf, lv_coord_t dst_stride,
+                                                            const lv_area_t * draw_area, const lv_opa_t * mask_buf, lv_coord_t mask_stride, const lv_point_t * mask_offset,
+                                                            lv_color_t color, lv_opa_t opa);
+LV_STM32_DMA2D_STATIC lv_res_t _lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw, const lv_draw_img_dsc_t * dsc,
+                                                        const lv_area_t * coords, const void * src);
+LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * dest_buf, lv_coord_t dest_stride,
+                                                            const lv_area_t * draw_area, const lv_color_t * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_await_dma_transfer_finish(lv_disp_drv_t * disp_drv);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t sourceAddress, lv_coord_t offset,
+                                                                lv_coord_t width, lv_coord_t height, uint8_t pixelSize);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t sourceAddress, lv_coord_t offset, lv_coord_t width,
+                                                           lv_coord_t height, uint8_t pixelSize);
+
+LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void);
+LV_STM32_DMA2D_STATIC uint32_t _lv_gpu_stm32_dwt_get_us(void);
 
 /**********************
  *      MACROS

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -19,8 +19,8 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-//#include LV_GPU_DMA2D_CMSIS_INCLUDE
-#include "stm32f7xx_hal.h"
+#include LV_GPU_DMA2D_CMSIS_INCLUDE
+//#include "stm32f7xx_hal.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.h
@@ -10,14 +10,17 @@
 extern "C" {
 #endif
 
-/*********************
- *      INCLUDES
- *********************/
 #include "../../misc/lv_color.h"
 #include "../../hal/lv_hal_disp.h"
 #include "../sw/lv_draw_sw.h"
 
 #if LV_USE_GPU_STM32_DMA2D
+
+/*********************
+ *      INCLUDES
+ *********************/
+//#include LV_GPU_DMA2D_CMSIS_INCLUDE
+#include "stm32f7xx_hal.h"
 
 /*********************
  *      DEFINES
@@ -32,6 +35,15 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+LV_STM32_DMA2D_STATIC enum bitmap_color_code {
+    ARGB8888 = DMA2D_INPUT_ARGB8888,
+    RGB888 = DMA2D_INPUT_RGB888,
+    RGB565 = DMA2D_INPUT_RGB565,
+    ARGB1555 = DMA2D_INPUT_ARGB1555,
+    ARGB4444 = DMA2D_INPUT_ARGB4444,
+};
+typedef enum bitmap_color_code bitmap_color_code_t;
+
 typedef lv_draw_sw_ctx_t lv_draw_stm32_dma2d_ctx_t;
 struct _lv_disp_drv_t;
 
@@ -62,20 +74,18 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * ds
                                                            const lv_area_t * draw_area, lv_color_t color, lv_opa_t opa);
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * dest_buf, lv_coord_t dest_stride,
                                                           const lv_area_t * draw_area, const void * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset, lv_opa_t opa,
-                                                          bool isSrcArgb32);
+                                                          bitmap_color_code_t src_color_code, bool ignore_src_alpha);
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * dst_buf, lv_coord_t dst_stride,
                                                             const lv_area_t * draw_area, const lv_opa_t * mask_buf, lv_coord_t mask_stride, const lv_point_t * mask_offset,
                                                             lv_color_t color, lv_opa_t opa);
-LV_STM32_DMA2D_STATIC lv_res_t _lv_draw_stm32_dma2d_img(lv_draw_ctx_t * draw, const lv_draw_img_dsc_t * dsc,
-                                                        const lv_area_t * coords, const void * src);
 LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * dest_buf, lv_coord_t dest_stride,
                                                             const lv_area_t * draw_area, const lv_color_t * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_await_dma_transfer_finish(lv_disp_drv_t * disp_drv);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void);
-LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t sourceAddress, lv_coord_t offset,
-                                                                lv_coord_t width, lv_coord_t height, uint8_t pixelSize);
-LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t sourceAddress, lv_coord_t offset, lv_coord_t width,
-                                                           lv_coord_t height, uint8_t pixelSize);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address, lv_coord_t offset,
+                                                                lv_coord_t width, lv_coord_t height, uint8_t pixel_size);
+LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
+                                                           lv_coord_t height, uint8_t pixel_size);
 
 LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void);


### PR DESCRIPTION
This PR is a major rework of the current LVGL STM32 DMA2D support. It adds more hardware acceleration, especially for bitmap-blended solid colors used (e.g.) to draw anti-aliased fonts. In 32-bit color mode all four types of rectangles are painted with dma2d. In 16-bit color three types are dma2d painted, including the type which is the most performance critical.
The feature has been fairly tested using LVGL demos with both 32 and 16 bit colors, but it should still be considered experimental.
Resolves #3714, see [this](https://github.com/lvgl/lvgl/issues/3714#issuecomment-1365187036) post for a summary.