### PR TITLE
lv_line: allow LV_PCT for point coordinates

### DIFF
--- a/docs/widgets/line.md
+++ b/docs/widgets/line.md
@@ -11,6 +11,9 @@ The Line object is capable of drawing straight lines between a set of points.
 ### Set points
 The points have to be stored in an `lv_point_t` array and passed to the object by the `lv_line_set_points(lines, point_array, point_cnt)` function.
 
+Their coordinates can either be specified as raw pixel coordinates (e.g. `{5, 10}`), or as a percentage of the line's bounding box using `LV_PCT(x)`. In the latter case, the line's width/height may need to be set explicitly using
+`lv_obj_set_width/height`, as percentage values do not automatically expand the bounding box.
+
 ### Auto-size
 By default, the Line's width and height are set to `LV_SIZE_CONTENT`. This means it will automatically set its size to fit all the points. If the size is set explicitly, parts on the line may not be visible.
 


### PR DESCRIPTION
### Description of the feature or fix

This allows specifying the coordinates of line points using a percentage of the line's overall bounding box.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- Rest: N/A