### PR TITLE
fix(code128): type conversion warning

### DIFF
--- a/src/libs/barcode/code128.c
+++ b/src/libs/barcode/code128.c
@@ -241,6 +241,8 @@ static signed char code128_switch_code(char from_mode, char to_mode)
                     return 101;
             }
             break;
+        default:
+            break;
     }
 
     CODE128_ASSERT(0); // Invalid mode switch
@@ -250,32 +252,32 @@ static signed char code128_switch_code(char from_mode, char to_mode)
 static signed char code128a_ascii_to_code(signed char value)
 {
     if(value >= ' ' && value <= '_')
-        return value - ' ';
+        return (signed char)(value - ' ');
     else if(value >= 0 && value < ' ')
-        return value + 64;
-    else if(value == CODE128_FNC1)
+        return (signed char)(value + 64);
+    else if(value == (signed char)CODE128_FNC1)
         return 102;
-    else if(value == CODE128_FNC2)
+    else if(value == (signed char)CODE128_FNC2)
         return 97;
-    else if(value == CODE128_FNC3)
+    else if(value == (signed char)CODE128_FNC3)
         return 96;
-    else if(value == CODE128_FNC4)
+    else if(value == (signed char)CODE128_FNC4)
         return 101;
     else
         return -1;
 }
 
-static signed char code128b_ascii_to_code(char value)
+static signed char code128b_ascii_to_code(signed char value)
 {
-    if(value >= 32)  // value <= 127 is implied
-        return value - 32;
-    else if(value == CODE128_FNC1)
+    if(value >= ' ')  // value <= 127 is implied
+        return (signed char)(value - ' ');
+    else if(value == (signed char)CODE128_FNC1)
         return 102;
-    else if(value == CODE128_FNC2)
+    else if(value == (signed char)CODE128_FNC2)
         return 97;
-    else if(value == CODE128_FNC3)
+    else if(value == (signed char)CODE128_FNC3)
         return 96;
-    else if(value == CODE128_FNC4)
+    else if(value == (signed char)CODE128_FNC4)
         return 100;
     else
         return -1;


### PR DESCRIPTION
### Description of the feature or fix

When I open `LV_USE_BARCODE` and try to run testcase, this error occurs.

```shell
lvgl/src/libs/barcode/code128.c: In function ‘code128a_ascii_to_code’: lvgl/src/libs/barcode/code128.c:256:19: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  256 |     else if(value == CODE128_FNC1)
      |                   ^~
lvgl/src/libs/barcode/code128.c:258:19: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  258 |     else if(value == CODE128_FNC2)
      |                   ^~
lvgl/src/libs/barcode/code128.c:260:19: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  260 |     else if(value == CODE128_FNC3)
      |                   ^~
lvgl/src/libs/barcode/code128.c:262:19: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  262 |     else if(value == CODE128_FNC4)
```



### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
