### PR TITLE
fix(scripts): in lv_conf_internal preserve newline value for updated …

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -17,7 +17,7 @@ if sys.version_info < (3,6,0):
   exit(1)
 
 fin = open(LV_CONF_TEMPLATE)
-fout = open(LV_CONF_INTERNAL, "w")
+fout = open(LV_CONF_INTERNAL, "w", newline='')
 
 fout.write(
 '''/**


### PR DESCRIPTION
### Description of the feature or fix

1. file type changed from `scripts/lv_conf_internal_gen.py: Python script, ASCII text executable` to `scripts/lv_conf_internal_gen.py: Python script, ASCII text executable, with CRLF line terminators`
2. Preserve the file type for the generated lv_conf_internal.h file
