### PR TITLE
chore: fix warnings

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -1236,7 +1236,8 @@ static void draw_buf_flush(lv_disp_t * disp)
 
 static void call_flush_cb(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p)
 {
-    REFR_TRACE("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer", area->x1, area->y1, area->x2, area->y2,
+    REFR_TRACE("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer",
+               (int)area->x1, (int)area->y1, (int)area->x2, (int)area->y2,
                (void *)color_p);
 
     lv_area_t offset_area = {

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -11,6 +11,7 @@
 #include "lv_mem.h"
 #include "lv_ll.h"
 #include "lv_gc.h"
+#include "lv_printf.h"
 
 /*********************
  *      DEFINES
@@ -141,7 +142,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
 
     already_running = false; /*Release the mutex*/
 
-    TIMER_TRACE("finished (%d ms until the next timer call)", time_till_next);
+    TIMER_TRACE("finished (%" LV_PRId32 " ms until the next timer call)", time_till_next);
     return time_till_next;
 }
 

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -124,7 +124,7 @@ void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_
         lv_coord_t normal_h = roller->option_cnt * (lv_font_get_line_height(font) + lv_obj_get_style_text_letter_space(obj, 0));
         roller->inf_page_cnt = LV_CLAMP(3, EXTRA_INF_SIZE / normal_h, 15);
         if(!(roller->inf_page_cnt & 1)) roller->inf_page_cnt++;   /*Make it odd*/
-        LV_LOG_INFO("Using %d pages to make the roller look infinite", roller->inf_page_cnt);
+        LV_LOG_INFO("Using %" LV_PRId32 " pages to make the roller look infinite", roller->inf_page_cnt);
 
         size_t opt_len = strlen(options) + 1; /*+1 to add '\n' after option lists*/
         char * opt_extra = lv_malloc(opt_len * roller->inf_page_cnt);


### PR DESCRIPTION
### Description of the feature or fix

`#define LV_USE_LARGE_COORD 1`
`#define LV_LOG_LEVEL LV_LOG_LEVEL_TRACE`

```bash
lvgl/src/core/lv_refr.c: In function 'call_flush_cb': lvgl/src/core/lv_refr.c:1239:17: warning: format '%d' expects argument of type 'int', but argument 6 has type 'lv_coord_t {aka const long int}' [-Wformat=]
     REFR_TRACE("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer", area->x1, area->y1, area->x2, area->y2,
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~
lvgl/src/core/lv_refr.c:1239:17: warning: format '%d' expects argument of type 'int', but argument 7 has type 'lv_coord_t {aka const long int}' [-Wformat=] lvgl/src/core/lv_refr.c:1239:17: warning: format '%d' expects argument of type 'int', but argument 8 has type 'lv_coord_t {aka const long int}' [-Wformat=] lvgl/src/core/lv_refr.c:1239:17: warning: format '%d' expects argument of type 'int', but argument 9 has type 'lv_coord_t {aka const long int}' [-Wformat=]

lvgl/src/misc/lv_timer.c: In function 'lv_timer_handler': lvgl/src/misc/lv_timer.c:144:90: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
     TIMER_TRACE("finished (%d ms until the next timer call)", time_till_next);
                                                                                          ^

lvgl/src/widgets/roller/lv_roller.c: In function 'lv_roller_set_options': lvgl/src/widgets/roller/lv_roller.c:127:105: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
         LV_LOG_INFO("Using %d pages to make the roller look infinite", roller->inf_page_cnt);
                                                                                                         ^
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
