### PR TITLE
feat(style): add function to replace styles while preserving the style stack

### DIFF
--- a/docs/overview/style.md
+++ b/docs/overview/style.md
@@ -203,6 +203,19 @@ lv_obj_add_style(btn, &style_btn, 0);      				  /*Default button style*/
 lv_obj_add_style(btn, &btn_red, LV_STATE_PRESSED);  /*Overwrite only some colors to red when pressed*/
 ```
 
+### Replace styles
+To replace a specific style of an object use `lv_obj_replace_style(obj, old_style, new_style, selector)`. This function
+will only replace `old_style` with `new_style` if the `selector` matches the `selector` used in `lv_obj_add_style`.
+Both styles, i.e. `old_style` and `new_style`, must not be `NULL` (for adding and removing separate functions exist).
+If the combination of `old_style` and `selector` exists multiple times in `obj`'s styles, all occurrences will be
+replaced. The return value of the function indicates whether at least one successful replacement took place.
+
+Using `lv_obj_replace_style`:
+```c
+lv_obj_add_style(btn, &style_btn, 0);                      /*Add a button style*/
+lv_obj_replace_style(btn, &style_btn, &new_style_btn, 0);  /*Replace the button style with a different one*/
+```
+
 ### Remove styles
 To remove all styles from an object use `lv_obj_remove_style_all(obj)`.
 

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -107,6 +107,51 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     lv_obj_refresh_style(obj, selector, LV_STYLE_PROP_ANY);
 }
 
+bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
+                          lv_style_selector_t selector)
+{
+    lv_state_t state = lv_obj_style_get_selector_state(selector);
+    lv_part_t part = lv_obj_style_get_selector_part(selector);
+
+    /*All objects must exist*/
+    if(!obj || !old_style || !new_style || (old_style == new_style)) {
+        return false;
+    }
+
+    /*Similar to lv_obj_add_style, delete transition*/
+    trans_del(obj, selector, LV_STYLE_PROP_ANY, NULL);
+
+    bool replaced = false;
+    uint32_t i;
+    for(i = 0; i < obj->style_cnt; i++) {
+        lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
+
+        /*Skip local styles and transitions*/
+        if(obj->styles[i].is_local || obj->styles[i].is_trans) {
+            continue;
+        }
+
+        /*Skip non-matching styles*/
+        if((state != LV_STATE_ANY && state_act != state) ||
+           (part != LV_PART_ANY && part_act != part) ||
+           (old_style != obj->styles[i].style)) {
+            continue;
+        }
+
+        lv_memzero(&obj->styles[i], sizeof(_lv_obj_style_t));
+        obj->styles[i].style = new_style;
+        obj->styles[i].selector = selector;
+
+        replaced = true;
+        /*Don't break and continue replacing other occurrences*/
+    }
+    if(replaced) {
+        lv_obj_refresh_style(obj, part, LV_STYLE_PROP_ANY);
+    }
+    return replaced;
+}
+
 void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
     lv_state_t state = lv_obj_style_get_selector_state(selector);

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -78,6 +78,18 @@ void _lv_obj_style_init(void);
 void lv_obj_add_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
+ * Replaces a style of an object, preserving the order of the style stack (local styles and transitions are ignored).
+ * @param obj           pointer to an object
+ * @param old_style     pointer to a style to replace.
+ * @param new_style     pointer to a style to replace the old style with.
+ * @param selector      OR-ed values of states and a part to replace only styles with matching selectors. LV_STATE_ANY and LV_PART_ANY can be used
+ * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_ANY | LV_STATE_ANY); //Replace a specific style
+ * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_MAIN | LV_STATE_PRESSED); //Replace a specific style assigned to the main part when it is pressed
+ */
+bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
+                          lv_style_selector_t selector);
+
+/**
  * Add a style to an object.
  * @param obj       pointer to an object
  * @param style     pointer to a style to remove. Can be NULL to check only the selector

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -122,4 +122,32 @@ void test_const_style(void)
     TEST_ASSERT_EQUAL(50, lv_obj_get_style_height(obj, LV_PART_MAIN));
 }
 
+void test_style_replacement(void)
+{
+    /*Define styles*/
+    lv_style_t style_red;
+    lv_style_t style_blue;
+
+    lv_style_init(&style_red);
+    lv_style_set_bg_color(&style_red, lv_color_hex(0xff0000));
+
+    lv_style_init(&style_blue);
+    lv_style_set_bg_color(&style_blue, lv_color_hex(0x0000ff));
+
+    /*Create object with style*/
+    lv_obj_t * obj = lv_obj_create(lv_scr_act());
+    lv_obj_add_style(obj, &style_red, LV_PART_MAIN);
+    TEST_ASSERT_EQUAL(lv_color_hex(0xff0000).full, lv_obj_get_style_bg_color(obj, LV_PART_MAIN).full);
+
+    /*Replace style successfully*/
+    bool replaced = lv_obj_replace_style(obj, &style_red, &style_blue, LV_PART_MAIN);
+    TEST_ASSERT_EQUAL(true, replaced);
+    TEST_ASSERT_EQUAL(lv_color_hex(0x0000ff).full, lv_obj_get_style_bg_color(obj, LV_PART_MAIN).full);
+
+    /*Failed replacement (already replaced)*/
+    replaced = lv_obj_replace_style(obj, &style_red, &style_blue, LV_PART_MAIN);
+    TEST_ASSERT_EQUAL(false, replaced);
+    TEST_ASSERT_EQUAL(lv_color_hex(0x0000ff).full, lv_obj_get_style_bg_color(obj, LV_PART_MAIN).full);
+}
+
 #endif


### PR DESCRIPTION
Hi,

during development I came up with a little problem and I wonder whether my approach to solve it might be suitable for upstream lvgl. What's your opinion on such a function?

Best regards,
sparkles

Hints for reviewers:
If most of it is OK, I would like to ask you to have a look at the use of the transition deletion in the new function. I am a bit unsure whether that is necessary or whether it is placed at the right spot.

### Description of the feature or fix

Currently, it is only possible to add styles or remove styles in lvgl. This pull request introduces a function that allows replacing styles kept in the style array of lv objects, while preserving the order of styles.

A reason to allow such replacements over the use of removing one style and adding another is the preservation of the style stack order. While removing and adding would make the replacement style the most dominant one, it can be beneficial (for abstraction purposes) to prevent this. Imagine the following:
	- We create a new widget that has two possible sets of styles
	- These styles shall be selected internally (perhaps based on an event or timing behavior)
	- However, we want a developer to further enrich our widget by adding further styles (no matter whether local or not)
	- In case the developer adds a non-local style (e.g. a huge styling change stored in flash) it becomes impossible to replace our two sets of styles WITHOUT disturbing the additional styles set by the developer


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- n/a ~~Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.~~
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- n/a ~~If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).~~
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.