### PR TITLE
fix(flush,tick): use atomics instead of volatile for synchronization

### DIFF
--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -23,6 +23,11 @@ extern "C" {
 #include "../misc/lv_area.h"
 #include "../misc/lv_ll.h"
 #include "../misc/lv_timer.h"
+#include "../misc/lv_types.h"
+
+#if LV_USE_ATOMICS == 1
+#include <stdatomic.h>
+#endif
 
 /*********************
  *      DEFINES
@@ -47,6 +52,11 @@ struct _lv_disp_t;
 struct _lv_disp_drv_t;
 struct _lv_theme_t;
 
+#if LV_USE_ATOMICS == 1
+#define FLUSHING_TYPE atomic_int
+#else
+#define FLUSHING_TYPE volatile int
+#endif
 /**
  * Structure for holding display buffer information.
  */
@@ -57,13 +67,13 @@ typedef struct _lv_disp_draw_buf_t {
     /*Internal, used by the library*/
     void * buf_act;
     uint32_t size; /*In pixel count*/
-    /*1: flushing is in progress. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
-    volatile int flushing;
-    /*1: It was the last chunk to flush. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
-    volatile int flushing_last;
-    volatile uint32_t last_area         : 1; /*1: the last area is being rendered*/
-    volatile uint32_t last_part         : 1; /*1: the last part of the current area is being rendered*/
+    FLUSHING_TYPE flushing;
+    /*It was the last chunk to flush. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
+    FLUSHING_TYPE flushing_last;
+    uint32_t last_area         : 1; /*1: the last area is being rendered*/
+    uint32_t last_part         : 1; /*1: the last part of the current area is being rendered*/
 } lv_disp_draw_buf_t;
+#undef FLUSHING_TYPE
 
 typedef enum {
     LV_DISP_ROT_NONE = 0,

--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -7,6 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_hal_tick.h"
+#include "../misc/lv_types.h"
 #include <stddef.h>
 
 #if LV_TICK_CUSTOM == 1
@@ -29,8 +30,13 @@
  *  STATIC VARIABLES
  **********************/
 #if !LV_TICK_CUSTOM
-    static uint32_t sys_time = 0;
-    static volatile uint8_t tick_irq_flag;
+    #if LV_USE_ATOMICS == 1
+        static _Atomic(uint32_t) sys_time = 0;
+        static _Atomic(uint8_t) tick_irq_flag;
+    #else
+        static uint32_t sys_time = 0;
+        static volatile uint8_t tick_irq_flag;
+    #endif
 #endif
 
 /**********************

--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_hal_tick.h"
 #include "../misc/lv_types.h"
+#include <stdatomic.h>
 #include <stddef.h>
 
 #if LV_TICK_CUSTOM == 1
@@ -32,10 +33,10 @@
 #if !LV_TICK_CUSTOM
     #if LV_USE_ATOMICS == 1
         static _Atomic(uint32_t) sys_time = 0;
-        static _Atomic(uint8_t) tick_irq_flag;
+        static atomic_int tick_irq_flag;
     #else
-        static uint32_t sys_time = 0;
-        static volatile uint8_t tick_irq_flag;
+        static volatile uint32_t sys_time = 0;
+        static volatile int tick_irq_flag;
     #endif
 #endif
 

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -32,6 +32,15 @@ extern "C" {
 
 #endif
 
+/*Use atomics instead of volatile variables for state which is potentially shared between threads, as long as
+ *the compiler supports it.*/
+#if (defined(__cplusplus) && __cplusplus >= 201103L)\
+    || (__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__))
+#define LV_USE_ATOMICS 1
+#else
+#define LV_USE_ATOMICS 0
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

As of the documentation[^1] `lv_tick_inc()` and `lv_disp_flush_ready()` should be thread-safe.

These functions alter global LVGL state to transfer information to the LVGL thread. Because of mis-optimizations these variables where previously already declared as `volatile`.

`volatile` however **is not enough**[^2] to ensure thread-safety and can still lead to subtle mis-optimizations.

To ensure correct synchronization, leverage the builtin, portable atomic implementation C11 provides.

To be backwards compatible, an opt in option `LV_USE_ATOMICS` was introduced, which is also only active, when the compiler supports it.

The atomics types replacing the volatile types are drop-in replacements with the same memory layout (e.g. `volatile int` => `atomic_int`).

Builtin increment and decrement and compound assignments on atomics are `memory_order_seq_cst`, so do provide even stricter ordering guarantees than volatile, while also being truly thread-safe for every CPU architecture supported by the compiler. [^3] This also reduces changes in the lines of code, because no `atomic_fetch_...` function is needed [^4]

This patch also removes volatile declarations of some bit-fields, because these fields are not shared between threads, used for the `lv_disp_flush_ready()` function. I assume these fields to be declared as volatile for historical reasons.

[^1]: https://docs.lvgl.io/8.3/porting/os.html?highlight=lv_tick_in#interrupts
[^2]: https://stackoverflow.com/questions/4557979/when-to-use-volatile-with-multi-threading/4558031#4558031
[^3]: https://en.cppreference.com/w/c/language/atomic
[^4]: https://en.cppreference.com/w/cpp/header/stdatomic.h

### Checkpoints

<details><summary>checkpoints</summary>

- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] ~~Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.~~
- [x] ~~Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.~~
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
  
  </details>
