### PR TITLE
fix(chart,ticks): change line chart widget ticks

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1576,7 +1576,16 @@ static void draw_x_ticks(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, lv_chart_axis
     }
 
     p1.y = y_ofs;
-    uint32_t total_tick_num = (t->major_cnt - 1) * t->minor_cnt;
+    uint32_t total_tick_num;
+    if ((chart->type == LV_CHART_TYPE_LINE) && (((t->major_cnt - 1) * t->minor_cnt) == chart->point_cnt))
+    {
+        total_tick_num = chart->point_cnt - 1;
+    }
+    else
+    {
+        total_tick_num = (t->major_cnt - 1) * t->minor_cnt;
+    }
+    if (!total_tick_num) return; /* Ensure total_tick_num does not equal zero */
     for(i = 0; i <= total_tick_num; i++) { /*one extra loop - it may not exist in the list, empty label*/
         bool major = false;
         if(i % t->minor_cnt == 0) major = true;


### PR DESCRIPTION
### Description of the feature or fix

Change for tick marks of the chart widget to be equal to that of data points present for LV_CHART_TYPE_LINE. For reference see  [post](https://forum.lvgl.io/t/line-graph-x-axis-tick-labels/10821).

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
