### PR TITLE
fix(img): possible divide by 0 exception (lvgl#3988)

### DIFF
--- a/src/lv_widgets/lv_img.c
+++ b/src/lv_widgets/lv_img.c
@@ -261,8 +261,6 @@ void lv_img_set_offset_x(lv_obj_t * img, lv_coord_t x)
 
     lv_img_ext_t * ext = lv_obj_get_ext_attr(img);
 
-    x = x % ext->w;
-
     ext->offset.x = x;
     lv_obj_invalidate(img);
 }
@@ -278,8 +276,6 @@ void lv_img_set_offset_y(lv_obj_t * img, lv_coord_t y)
     LV_ASSERT_OBJ(img, LV_OBJX_NAME);
 
     lv_img_ext_t * ext = lv_obj_get_ext_attr(img);
-
-    y = y % ext->h;
 
     ext->offset.y = y;
     lv_obj_invalidate(img);
@@ -683,8 +679,10 @@ static lv_design_res_t lv_img_design(lv_obj_t * img, const lv_area_t * clip_area
             lv_area_t zoomed_coords;
             lv_obj_get_coords(img, &zoomed_coords);
 
-            zoomed_coords.x1 += (int32_t)((int32_t)ext->offset.x * zoom_final) >> 8;
-            zoomed_coords.y1 += (int32_t)((int32_t)ext->offset.y * zoom_final) >> 8;
+            int32_t offset_x = (int32_t)ext->offset.x % ext->w;
+            int32_t offset_y = (int32_t)ext->offset.y % ext->w;
+            zoomed_coords.x1 += (int32_t)(offset_x * zoom_final) >> 8;
+            zoomed_coords.y1 += (int32_t)(offset_y * zoom_final) >> 8;
             zoomed_coords.x2 = zoomed_coords.x1 + ((int32_t)((int32_t)(obj_w - 1) * zoom_final) >> 8);
             zoomed_coords.y2 = zoomed_coords.y1 + ((int32_t)((int32_t)(obj_h - 1) * zoom_final) >> 8);
 

--- a/src/lv_widgets/lv_img.c
+++ b/src/lv_widgets/lv_img.c
@@ -680,7 +680,7 @@ static lv_design_res_t lv_img_design(lv_obj_t * img, const lv_area_t * clip_area
             lv_obj_get_coords(img, &zoomed_coords);
 
             int32_t offset_x = (int32_t)ext->offset.x % ext->w;
-            int32_t offset_y = (int32_t)ext->offset.y % ext->w;
+            int32_t offset_y = (int32_t)ext->offset.y % ext->h;
             zoomed_coords.x1 += (int32_t)(offset_x * zoom_final) >> 8;
             zoomed_coords.y1 += (int32_t)(offset_y * zoom_final) >> 8;
             zoomed_coords.x2 = zoomed_coords.x1 + ((int32_t)((int32_t)(obj_w - 1) * zoom_final) >> 8);


### PR DESCRIPTION
### Description of the feature or fix

Fix divide by 0 exception in the image widget when all of the following are true:
- The image src failed to load (e.g. file does not exist on disk, is corrupted or invalid, ...)    and
- its img->w or img->h are still zero    and
- you try to use lv_image_set_offset_x or lv_image_set_offset_y on the image object

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
