### PR TITLE
Revert "fix(flush,tick): use atomics instead of volatile for synchronization (#3965)"

### DIFF
--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -23,11 +23,6 @@ extern "C" {
 #include "../misc/lv_area.h"
 #include "../misc/lv_ll.h"
 #include "../misc/lv_timer.h"
-#include "../misc/lv_types.h"
-
-#if LV_USE_ATOMICS == 1
-#include <stdatomic.h>
-#endif
 
 /*********************
  *      DEFINES
@@ -52,11 +47,6 @@ struct _lv_disp_t;
 struct _lv_disp_drv_t;
 struct _lv_theme_t;
 
-#if LV_USE_ATOMICS == 1
-#define FLUSHING_TYPE atomic_int
-#else
-#define FLUSHING_TYPE volatile int
-#endif
 /**
  * Structure for holding display buffer information.
  */
@@ -67,13 +57,13 @@ typedef struct _lv_disp_draw_buf_t {
     /*Internal, used by the library*/
     void * buf_act;
     uint32_t size; /*In pixel count*/
-    FLUSHING_TYPE flushing;
-    /*It was the last chunk to flush. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
-    FLUSHING_TYPE flushing_last;
-    uint32_t last_area         : 1; /*1: the last area is being rendered*/
-    uint32_t last_part         : 1; /*1: the last part of the current area is being rendered*/
+    /*1: flushing is in progress. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
+    volatile int flushing;
+    /*1: It was the last chunk to flush. (It can't be a bit field because when it's cleared from IRQ Read-Modify-Write issue might occur)*/
+    volatile int flushing_last;
+    volatile uint32_t last_area         : 1; /*1: the last area is being rendered*/
+    volatile uint32_t last_part         : 1; /*1: the last part of the current area is being rendered*/
 } lv_disp_draw_buf_t;
-#undef FLUSHING_TYPE
 
 typedef enum {
     LV_DISP_ROT_NONE = 0,

--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -7,8 +7,6 @@
  *      INCLUDES
  *********************/
 #include "lv_hal_tick.h"
-#include "../misc/lv_types.h"
-#include <stdatomic.h>
 #include <stddef.h>
 
 #if LV_TICK_CUSTOM == 1
@@ -31,13 +29,8 @@
  *  STATIC VARIABLES
  **********************/
 #if !LV_TICK_CUSTOM
-    #if LV_USE_ATOMICS == 1
-        static _Atomic(uint32_t) sys_time = 0;
-        static atomic_int tick_irq_flag;
-    #else
-        static volatile uint32_t sys_time = 0;
-        static volatile int tick_irq_flag;
-    #endif
+    static uint32_t sys_time = 0;
+    static volatile uint8_t tick_irq_flag;
 #endif
 
 /**********************

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -32,15 +32,6 @@ extern "C" {
 
 #endif
 
-/*Use atomics instead of volatile variables for state which is potentially shared between threads, as long as
- *the compiler supports it.*/
-#if (defined(__cplusplus) && __cplusplus >= 201103L)\
-    || (__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__))
-#define LV_USE_ATOMICS 1
-#else
-#define LV_USE_ATOMICS 0
-#endif
-
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

This reverts commit fc659cdecc0378dd19dd3f8cf03d4ba5156e589c.

I feel the current approach results in more problems than improvements. The reasoning is explained in  https://github.com/lvgl/lvgl/issues/3994#issuecomment-1434162987

Fixes #3994 
As an alternative to #3995 


<details><summary>checkpoints</summary>

### Checkpoints

- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ x Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.

<details>
