### PR TITLE
feat(color): added option to overwrite lv_color_mix

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -72,6 +72,11 @@
 #define LV_STRLEN       lv_strlen_builtin
 #define LV_STRNCPY      lv_strncpy_builtin
 
+#define LV_COLOR_EXTERN_INCLUDE <stdint.h>
+#define LV_COLOR_MIX      lv_color_mix
+#define LV_COLOR_PREMULT      lv_color_premult
+#define LV_COLOR_MIX_PREMULT      lv_color_mix_premult
+
 /*====================
    HAL SETTINGS
  *====================*/

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -9,6 +9,7 @@
 #include "lv_obj.h"
 #include "lv_disp.h"
 #include "../misc/lv_gc.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -815,7 +816,7 @@ static void trans_anim_cb(void * _tr, int32_t v)
             case LV_STYLE_IMG_RECOLOR:
                 if(v <= 0) value_final.color = tr->start_value.color;
                 else if(v >= 255) value_final.color = tr->end_value.color;
-                else value_final.color = lv_color_mix(tr->end_value.color, tr->start_value.color, v);
+                else value_final.color = LV_COLOR_MIX(tr->end_value.color, tr->start_value.color, v);
                 break;
 
             default:

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.c
@@ -35,6 +35,7 @@
 
 #if LV_USE_GPU_NXP_PXP
 #include "lvgl_support.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -478,7 +479,7 @@ static void lv_pxp_blit_cf(lv_color_t * dest_buf, const lv_area_t * dest_area, l
 
         if(has_recolor) {
             /* New color key after recoloring */
-            lv_color_t colorKey =  lv_color_mix(dsc->recolor, LV_COLOR_CHROMA_KEY, dsc->recolor_opa);
+            lv_color_t colorKey =  LV_COLOR_MIX(dsc->recolor, LV_COLOR_CHROMA_KEY, dsc->recolor_opa);
 
             LV_COLOR_SET_R(colorKeyLow, colorKey.ch.red != 0 ? colorKey.ch.red - 1 : 0);
             LV_COLOR_SET_G(colorKeyLow, colorKey.ch.green != 0 ? colorKey.ch.green - 1 : 0);

--- a/src/draw/sdl/lv_draw_sdl_img.c
+++ b/src/draw/sdl/lv_draw_sdl_img.c
@@ -23,6 +23,7 @@
 #include "lv_draw_sdl_composite.h"
 #include "lv_draw_sdl_rect.h"
 #include "lv_draw_sdl_layer.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -366,7 +367,7 @@ static void apply_recolor_opa(SDL_Texture * texture, const lv_draw_img_dsc_t * d
 {
     if(draw_dsc->recolor_opa > LV_OPA_TRANSP) {
         /* Draw with mixed recolor */
-        lv_color_t recolor = lv_color_mix(draw_dsc->recolor, lv_color_white(), draw_dsc->recolor_opa);
+        lv_color_t recolor = LV_COLOR_MIX(draw_dsc->recolor, lv_color_white(), draw_dsc->recolor_opa);
         SDL_SetTextureColorMod(texture, recolor.ch.red, recolor.ch.green, recolor.ch.blue);
     }
     else {

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -12,6 +12,7 @@
 #include "../../misc/lv_math.h"
 #include "../../hal/lv_hal_disp.h"
 #include "../../core/lv_refr.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -59,14 +60,14 @@ static inline lv_color_t color_blend_true_color_multiply(lv_color_t fg, lv_color
  **********************/
 #define FILL_NORMAL_MASK_PX(color)                                                          \
     if(*mask == LV_OPA_COVER) *dest_buf = color;                                 \
-    else *dest_buf = lv_color_mix(color, *dest_buf, *mask);            \
+    else *dest_buf = LV_COLOR_MIX(color, *dest_buf, *mask);            \
     mask++;                                                         \
     dest_buf++;
 
 #define MAP_NORMAL_MASK_PX(x)                                                          \
     if(*mask_tmp_x) {          \
         if(*mask_tmp_x == LV_OPA_COVER) dest_buf[x] = src_buf[x];                                 \
-        else dest_buf[x] = lv_color_mix(src_buf[x], dest_buf[x], *mask_tmp_x);            \
+        else dest_buf[x] = LV_COLOR_MIX(src_buf[x], dest_buf[x], *mask_tmp_x);            \
     }                                                                                               \
     mask_tmp_x++;
 
@@ -187,7 +188,7 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_ar
         /*Has opacity*/
         else {
             lv_color_t last_dest_color = lv_color_black();
-            lv_color_t last_res_color = lv_color_mix(color, last_dest_color, opa);
+            lv_color_t last_res_color = LV_COLOR_MIX(color, last_dest_color, opa);
 
 #if LV_COLOR_MIX_ROUND_OFS == 0 && LV_COLOR_DEPTH == 16
             /*lv_color_mix work with an optimized algorithm with 16 bit color depth.
@@ -198,14 +199,14 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_ar
 #endif
 
             uint16_t color_premult[3];
-            lv_color_premult(color, opa, color_premult);
+            LV_COLOR_PREMULT(color, opa, color_premult);
             lv_opa_t opa_inv = 255 - opa;
 
             for(y = 0; y < h; y++) {
                 for(x = 0; x < w; x++) {
                     if(last_dest_color.full != dest_buf[x].full) {
                         last_dest_color = dest_buf[x];
-                        last_res_color = lv_color_mix_premult(color_premult, dest_buf[x], opa_inv);
+                        last_res_color = LV_COLOR_MIX_PREMULT(color_premult, dest_buf[x], opa_inv);
                     }
                     dest_buf[x] = last_res_color;
                 }
@@ -286,7 +287,7 @@ LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_ar
                                                              (uint32_t)((uint32_t)(*mask) * opa) >> 8;
                         if(*mask != last_mask || last_dest_color.full != dest_buf[x].full) {
                             if(opa_tmp == LV_OPA_COVER) last_res_color = color;
-                            else last_res_color = lv_color_mix(color, dest_buf[x], opa_tmp);
+                            else last_res_color = LV_COLOR_MIX(color, dest_buf[x], opa_tmp);
                             last_mask = *mask;
                             last_dest_color.full = dest_buf[x].full;
                         }
@@ -547,7 +548,7 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(lv_color_t * dest_buf, const lv_are
         else {
             for(y = 0; y < h; y++) {
                 for(x = 0; x < w; x++) {
-                    dest_buf[x] = lv_color_mix(src_buf[x], dest_buf[x], opa);
+                    dest_buf[x] = LV_COLOR_MIX(src_buf[x], dest_buf[x], opa);
                 }
                 dest_buf += dest_stride;
                 src_buf += src_stride;
@@ -607,7 +608,7 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(lv_color_t * dest_buf, const lv_are
                 for(x = 0; x < w; x++) {
                     if(mask[x]) {
                         lv_opa_t opa_tmp = mask[x] >= LV_OPA_MAX ? opa : ((opa * mask[x]) >> 8);
-                        dest_buf[x] = lv_color_mix(src_buf[x], dest_buf[x], opa_tmp);
+                        dest_buf[x] = LV_COLOR_MIX(src_buf[x], dest_buf[x], opa_tmp);
                     }
                 }
                 dest_buf += dest_stride;
@@ -870,7 +871,7 @@ static inline lv_color_t color_blend_true_color_additive(lv_color_t fg, lv_color
 
     if(opa == LV_OPA_COVER) return fg;
 
-    return lv_color_mix(fg, bg, opa);
+    return LV_COLOR_MIX(fg, bg, opa);
 }
 
 static inline lv_color_t color_blend_true_color_subtractive(lv_color_t fg, lv_color_t bg, lv_opa_t opa)
@@ -889,7 +890,7 @@ static inline lv_color_t color_blend_true_color_subtractive(lv_color_t fg, lv_co
 
     if(opa == LV_OPA_COVER) return fg;
 
-    return lv_color_mix(fg, bg, opa);
+    return LV_COLOR_MIX(fg, bg, opa);
 }
 
 static inline lv_color_t color_blend_true_color_multiply(lv_color_t fg, lv_color_t bg, lv_opa_t opa)
@@ -912,5 +913,5 @@ static inline lv_color_t color_blend_true_color_multiply(lv_color_t fg, lv_color
 
     if(opa == LV_OPA_COVER) return fg;
 
-    return lv_color_mix(fg, bg, opa);
+    return LV_COLOR_MIX(fg, bg, opa);
 }

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -15,6 +15,7 @@
 #include "../../core/lv_refr.h"
 #include "../../misc/lv_mem.h"
 #include "../../misc/lv_math.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -164,11 +165,11 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_c
                 uint16_t premult_v[3];
                 lv_opa_t recolor_opa = draw_dsc->recolor_opa;
                 lv_color_t recolor = draw_dsc->recolor;
-                lv_color_premult(recolor, recolor_opa, premult_v);
+                LV_COLOR_PREMULT(recolor, recolor_opa, premult_v);
                 recolor_opa = 255 - recolor_opa;
                 uint32_t i;
                 for(i = 0; i < buf_size; i++) {
-                    rgb_buf[i] = lv_color_mix_premult(premult_v, rgb_buf[i], recolor_opa);
+                    rgb_buf[i] = LV_COLOR_MIX_PREMULT(premult_v, rgb_buf[i], recolor_opa);
                 }
             }
 #if LV_USE_DRAW_MASKS

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -12,6 +12,7 @@
 #include "../../misc/lv_assert.h"
 #include "../../misc/lv_area.h"
 #include "../../core/lv_refr.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -434,9 +435,9 @@ static void argb_and_rgb_aa(const uint8_t * src, lv_coord_t src_w, lv_coord_t sr
                 cbuf[x] = c_base;
             }
             else {
-                c_ver = lv_color_mix(c_ver, c_base, ys_fract);
-                c_hor = lv_color_mix(c_hor, c_base, xs_fract);
-                cbuf[x] = lv_color_mix(c_hor, c_ver, LV_OPA_50);
+                c_ver = LV_COLOR_MIX(c_ver, c_base, ys_fract);
+                c_hor = LV_COLOR_MIX(c_hor, c_base, xs_fract);
+                cbuf[x] = LV_COLOR_MIX(c_hor, c_ver, LV_OPA_50);
             }
         }
         /*Partially out of the image*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -260,6 +260,35 @@
     #endif
 #endif
 
+#ifndef LV_COLOR_EXTERN_INCLUDE
+    #ifdef CONFIG_LV_COLOR_EXTERN_INCLUDE
+        #define LV_COLOR_EXTERN_INCLUDE CONFIG_LV_COLOR_EXTERN_INCLUDE
+    #else
+        #define LV_COLOR_EXTERN_INCLUDE <stdint.h>
+    #endif
+#endif
+#ifndef LV_COLOR_MIX
+    #ifdef CONFIG_LV_COLOR_MIX
+        #define LV_COLOR_MIX CONFIG_LV_COLOR_MIX
+    #else
+        #define LV_COLOR_MIX      lv_color_mix
+    #endif
+#endif
+#ifndef LV_COLOR_PREMULT
+    #ifdef CONFIG_LV_COLOR_PREMULT
+        #define LV_COLOR_PREMULT CONFIG_LV_COLOR_PREMULT
+    #else
+        #define LV_COLOR_PREMULT      lv_color_premult
+    #endif
+#endif
+#ifndef LV_COLOR_MIX_PREMULT
+    #ifdef CONFIG_LV_COLOR_MIX_PREMULT
+        #define LV_COLOR_MIX_PREMULT CONFIG_LV_COLOR_MIX_PREMULT
+    #else
+        #define LV_COLOR_MIX_PREMULT      lv_color_mix_premult
+    #endif
+#endif
+
 /*====================
    HAL SETTINGS
  *====================*/

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_color.h"
 #include "lv_log.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -125,12 +126,12 @@ LV_ATTRIBUTE_FAST_MEM void lv_color_fill(lv_color_t * buf, lv_color_t color, uin
 
 lv_color_t lv_color_lighten(lv_color_t c, lv_opa_t lvl)
 {
-    return lv_color_mix(lv_color_white(), c, lvl);
+    return LV_COLOR_MIX(lv_color_white(), c, lvl);
 }
 
 lv_color_t lv_color_darken(lv_color_t c, lv_opa_t lvl)
 {
-    return lv_color_mix(lv_color_black(), c, lvl);
+    return LV_COLOR_MIX(lv_color_black(), c, lvl);
 }
 
 lv_color_t lv_color_change_lightness(lv_color_t c, lv_opa_t lvl)

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -552,7 +552,7 @@ LV_ATTRIBUTE_FAST_MEM static inline void lv_color_mix_with_alpha(lv_color_t bg_c
     }
     /*Opaque background: use simple mix*/
     else if(bg_opa >= LV_OPA_MAX) {
-        *res_color = lv_color_mix(fg_color, bg_color, fg_opa);
+        *res_color = LV_COLOR_MIX(fg_color, bg_color, fg_opa);
         *res_opa = LV_OPA_COVER;
     }
     /*Both colors have alpha. Expensive calculation need to be applied*/
@@ -576,7 +576,7 @@ LV_ATTRIBUTE_FAST_MEM static inline void lv_color_mix_with_alpha(lv_color_t bg_c
             res_opa_saved = 255 - ((uint16_t)((uint16_t)(255 - fg_opa) * (255 - bg_opa)) >> 8);
             LV_ASSERT(res_opa_saved != 0);
             lv_opa_t ratio = (uint16_t)((uint16_t)fg_opa * 255) / res_opa_saved;
-            res_color_saved = lv_color_mix(fg_color, bg_color, ratio);
+            res_color_saved = LV_COLOR_MIX(fg_color, bg_color, ratio);
 
         }
 

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -12,6 +12,7 @@
 
 #include "lv_theme_default.h"
 #include "../../misc/lv_gc.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -198,8 +199,8 @@ static lv_color_t dark_color_filter_cb(const lv_color_filter_dsc_t * f, lv_color
 static lv_color_t grey_filter_cb(const lv_color_filter_dsc_t * f, lv_color_t color, lv_opa_t opa)
 {
     LV_UNUSED(f);
-    if(theme.flags & MODE_DARK) return lv_color_mix(lv_palette_darken(LV_PALETTE_GREY, 2), color, opa);
-    else return lv_color_mix(lv_palette_lighten(LV_PALETTE_GREY, 2), color, opa);
+    if(theme.flags & MODE_DARK) return LV_COLOR_MIX(lv_palette_darken(LV_PALETTE_GREY, 2), color, opa);
+    else return LV_COLOR_MIX(lv_palette_lighten(LV_PALETTE_GREY, 2), color, opa);
 }
 
 static void style_init(void)

--- a/src/widgets/led/lv_led.c
+++ b/src/widgets/led/lv_led.c
@@ -11,6 +11,7 @@
 
 #include "../../misc/lv_assert.h"
 #include "../../themes/lv_themes.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -179,22 +180,22 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &rect_dsc);
 
         /*Use the original colors brightness to modify color->led*/
-        rect_dsc.bg_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.bg_color));
-        rect_dsc.bg_grad.stops[0].color = lv_color_mix(led->color, lv_color_black(),
+        rect_dsc.bg_color = LV_COLOR_MIX(led->color, lv_color_black(), lv_color_brightness(rect_dsc.bg_color));
+        rect_dsc.bg_grad.stops[0].color = LV_COLOR_MIX(led->color, lv_color_black(),
                                                        lv_color_brightness(rect_dsc.bg_grad.stops[0].color));
-        rect_dsc.bg_grad.stops[1].color = lv_color_mix(led->color, lv_color_black(),
+        rect_dsc.bg_grad.stops[1].color = LV_COLOR_MIX(led->color, lv_color_black(),
                                                        lv_color_brightness(rect_dsc.bg_grad.stops[1].color));
-        rect_dsc.shadow_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.shadow_color));
-        rect_dsc.border_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.border_color));
-        rect_dsc.outline_color = lv_color_mix(led->color, lv_color_black(), lv_color_brightness(rect_dsc.outline_color));
+        rect_dsc.shadow_color = LV_COLOR_MIX(led->color, lv_color_black(), lv_color_brightness(rect_dsc.shadow_color));
+        rect_dsc.border_color = LV_COLOR_MIX(led->color, lv_color_black(), lv_color_brightness(rect_dsc.border_color));
+        rect_dsc.outline_color = LV_COLOR_MIX(led->color, lv_color_black(), lv_color_brightness(rect_dsc.outline_color));
 
         /*Mix. the color with black proportionally with brightness*/
-        rect_dsc.bg_color = lv_color_mix(rect_dsc.bg_color, lv_color_black(), led->bright);
-        rect_dsc.bg_grad.stops[0].color   = lv_color_mix(rect_dsc.bg_grad.stops[0].color, lv_color_black(), led->bright);
-        rect_dsc.bg_grad.stops[1].color   = lv_color_mix(rect_dsc.bg_grad.stops[1].color, lv_color_black(), led->bright);
-        rect_dsc.border_color = lv_color_mix(rect_dsc.border_color, lv_color_black(), led->bright);
-        rect_dsc.shadow_color = lv_color_mix(rect_dsc.shadow_color, lv_color_black(), led->bright);
-        rect_dsc.outline_color = lv_color_mix(rect_dsc.outline_color, lv_color_black(), led->bright);
+        rect_dsc.bg_color = LV_COLOR_MIX(rect_dsc.bg_color, lv_color_black(), led->bright);
+        rect_dsc.bg_grad.stops[0].color   = LV_COLOR_MIX(rect_dsc.bg_grad.stops[0].color, lv_color_black(), led->bright);
+        rect_dsc.bg_grad.stops[1].color   = LV_COLOR_MIX(rect_dsc.bg_grad.stops[1].color, lv_color_black(), led->bright);
+        rect_dsc.border_color = LV_COLOR_MIX(rect_dsc.border_color, lv_color_black(), led->bright);
+        rect_dsc.shadow_color = LV_COLOR_MIX(rect_dsc.shadow_color, lv_color_black(), led->bright);
+        rect_dsc.outline_color = LV_COLOR_MIX(rect_dsc.outline_color, lv_color_black(), led->bright);
 
         /*Set the current shadow width according to brightness proportionally between LV_LED_BRIGHT_OFF
          * and LV_LED_BRIGHT_ON*/

--- a/src/widgets/meter/lv_meter.c
+++ b/src/widgets/meter/lv_meter.c
@@ -10,6 +10,7 @@
 #if LV_USE_METER != 0
 
 #include "../../misc/lv_assert.h"
+#include LV_COLOR_EXTERN_INCLUDE
 
 /*********************
  *      DEFINES
@@ -448,7 +449,7 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
                     else {
                         ratio = lv_map(value_of_line, meter->scale.min, meter->scale.max, LV_OPA_TRANSP, LV_OPA_COVER);
                     }
-                    line_color = lv_color_mix(indic->type_data.scale_lines.color_end, indic->type_data.scale_lines.color_start, ratio);
+                    line_color = LV_COLOR_MIX(indic->type_data.scale_lines.color_end, indic->type_data.scale_lines.color_start, ratio);
                 }
             }
         }


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
