### PR TITLE
fix(benchmark): skip tests when compressed fonts are disabled

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -87,9 +87,11 @@ LV_IMG_DECLARE(img_benchmark_cogwheel_chroma_keyed);
 LV_IMG_DECLARE(img_benchmark_cogwheel_indexed16);
 LV_IMG_DECLARE(img_benchmark_cogwheel_alpha16);
 
-LV_FONT_DECLARE(lv_font_benchmark_montserrat_12_compr_az);
-LV_FONT_DECLARE(lv_font_benchmark_montserrat_16_compr_az);
-LV_FONT_DECLARE(lv_font_benchmark_montserrat_28_compr_az);
+#if LV_USE_FONT_COMPRESSED
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_12_compr_az);
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_16_compr_az);
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_28_compr_az);
+#endif
 
 static void benchmark_init(void);
 static void show_scene_report(void);
@@ -446,13 +448,13 @@ static void txt_large_cb(void)
 
 }
 
+#if LV_USE_FONT_COMPRESSED
 static void txt_small_compr_cb(void)
 {
     lv_style_reset(&style_common);
     lv_style_set_text_font(&style_common, &lv_font_benchmark_montserrat_12_compr_az);
     lv_style_set_text_opa(&style_common, scene_with_opa ? LV_OPA_50 : LV_OPA_COVER);
     txt_create(&style_common);
-
 }
 
 static void txt_medium_compr_cb(void)
@@ -461,7 +463,6 @@ static void txt_medium_compr_cb(void)
     lv_style_set_text_font(&style_common, &lv_font_benchmark_montserrat_16_compr_az);
     lv_style_set_text_opa(&style_common, scene_with_opa ? LV_OPA_50 : LV_OPA_COVER);
     txt_create(&style_common);
-
 }
 
 static void txt_large_compr_cb(void)
@@ -470,9 +471,8 @@ static void txt_large_compr_cb(void)
     lv_style_set_text_font(&style_common, &lv_font_benchmark_montserrat_28_compr_az);
     lv_style_set_text_opa(&style_common, scene_with_opa ? LV_OPA_50 : LV_OPA_COVER);
     txt_create(&style_common);
-
 }
-
+#endif
 
 static void line_cb(void)
 {
@@ -480,7 +480,6 @@ static void line_cb(void)
     lv_style_set_line_width(&style_common, LINE_WIDTH);
     lv_style_set_line_opa(&style_common, scene_with_opa ? LV_OPA_50 : LV_OPA_COVER);
     line_create(&style_common);
-
 }
 
 static void arc_think_cb(void)
@@ -622,9 +621,11 @@ static scene_dsc_t scenes[] = {
     {.name = "Text medium",                  .weight = 30, .create_cb = txt_medium_cb},
     {.name = "Text large",                   .weight = 20, .create_cb = txt_large_cb},
 
+#if LV_USE_FONT_COMPRESSED
     {.name = "Text small compressed",        .weight = 3, .create_cb = txt_small_compr_cb},
     {.name = "Text medium compressed",       .weight = 5, .create_cb = txt_medium_compr_cb},
     {.name = "Text large compressed",        .weight = 10, .create_cb = txt_large_compr_cb},
+#endif
 
     {.name = "Line",                         .weight = 10, .create_cb = line_cb},
 


### PR DESCRIPTION
### Description of the feature or fix

Automatically skip tests when compressed fonts are disabled, avoiding interference with test results.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
