### PR TITLE
sync(gif):Synchronize with master

### DIFF
--- a/src/extra/libs/gif/gifdec.c
+++ b/src/extra/libs/gif/gifdec.c
@@ -160,6 +160,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
 #endif
     }
     gif->anim_start = f_gif_seek(gif, 0, LV_FS_SEEK_CUR);
+    gif->loop_count = -1;
     goto ok;
 fail:
     f_gif_close(gif_base);
@@ -239,6 +240,7 @@ read_application_ext(gd_GIF *gif)
 {
     char app_id[8];
     char app_auth_code[3];
+    uint16_t loop_count;
 
     /* Discard block size (always 0x0B). */
     f_gif_seek(gif, 1, LV_FS_SEEK_CUR);
@@ -249,7 +251,15 @@ read_application_ext(gd_GIF *gif)
     if (!strncmp(app_id, "NETSCAPE", sizeof(app_id))) {
         /* Discard block size (0x03) and constant byte (0x01). */
         f_gif_seek(gif, 2, LV_FS_SEEK_CUR);
-        gif->loop_count = read_num(gif);
+        loop_count = read_num(gif);
+        if(gif->loop_count < 0) {
+            if(loop_count == 0) {
+                gif->loop_count = 0;
+            }
+            else{
+                gif->loop_count = loop_count + 1;
+            }
+        }
         /* Skip block terminator. */
         f_gif_seek(gif, 1, LV_FS_SEEK_CUR);
     } else if (gif->application) {
@@ -568,9 +578,16 @@ gd_get_frame(gd_GIF *gif)
     dispose(gif);
     f_gif_read(gif, &sep, 1);
     while (sep != ',') {
-        if (sep == ';')
-            return 0;
-        if (sep == '!')
+        if (sep == ';') {
+            f_gif_seek(gif, gif->anim_start, LV_FS_SEEK_SET);
+            if(gif->loop_count == 1 || gif->loop_count < 0) {
+                return 0;
+            }
+            else if(gif->loop_count > 1) {
+                gif->loop_count--;
+            }
+        }
+        else if (sep == '!')
             read_ext(gif);
         else return -1;
         f_gif_read(gif, &sep, 1);
@@ -598,6 +615,7 @@ gd_render_frame(gd_GIF *gif, uint8_t *buffer)
 void
 gd_rewind(gd_GIF *gif)
 {
+    gif->loop_count = -1;
     f_gif_seek(gif, gif->anim_start, LV_FS_SEEK_SET);
 }
 

--- a/src/extra/libs/gif/gifdec.h
+++ b/src/extra/libs/gif/gifdec.h
@@ -29,7 +29,7 @@ typedef struct gd_GIF {
     int32_t anim_start;
     uint16_t width, height;
     uint16_t depth;
-    uint16_t loop_count;
+    int32_t loop_count;
     gd_GCE gce;
     gd_Palette *palette;
     gd_Palette lct, gct;

--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -123,7 +123,7 @@ static void lv_gif_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     LV_UNUSED(class_p);
     lv_gif_t * gifobj = (lv_gif_t *) obj;
     lv_img_cache_invalidate_src(&gifobj->imgdsc);
-    if(gifobj->gif )
+    if(gifobj->gif)
         gd_close_gif(gifobj->gif);
     lv_timer_del(gifobj->timer);
 }

--- a/src/extra/libs/gif/lv_gif.c
+++ b/src/extra/libs/gif/lv_gif.c
@@ -99,6 +99,8 @@ void lv_gif_restart(lv_obj_t * obj)
 {
     lv_gif_t * gifobj = (lv_gif_t *) obj;
     gd_rewind(gifobj->gif);
+    lv_timer_resume(gifobj->timer);
+    lv_timer_reset(gifobj->timer);
 }
 
 /**********************
@@ -111,6 +113,7 @@ static void lv_gif_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
     lv_gif_t * gifobj = (lv_gif_t *) obj;
 
+    gifobj->gif = NULL;
     gifobj->timer = lv_timer_create(next_frame_task_cb, 10, obj);
     lv_timer_pause(gifobj->timer);
 }
@@ -120,7 +123,8 @@ static void lv_gif_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     LV_UNUSED(class_p);
     lv_gif_t * gifobj = (lv_gif_t *) obj;
     lv_img_cache_invalidate_src(&gifobj->imgdsc);
-    gd_close_gif(gifobj->gif);
+    if(gifobj->gif )
+        gd_close_gif(gifobj->gif);
     lv_timer_del(gifobj->timer);
 }
 
@@ -136,14 +140,9 @@ static void next_frame_task_cb(lv_timer_t * t)
     int has_next = gd_get_frame(gifobj->gif);
     if(has_next == 0) {
         /*It was the last repeat*/
-        if(gifobj->gif->loop_count == 1) {
-            lv_res_t res = lv_event_send(obj, LV_EVENT_READY, NULL);
-            if(res != LV_FS_RES_OK) return;
-        }
-        else {
-            if(gifobj->gif->loop_count > 1)  gifobj->gif->loop_count--;
-            gd_rewind(gifobj->gif);
-        }
+        lv_res_t res = lv_event_send(obj, LV_EVENT_READY, NULL);
+        lv_timer_pause(t);
+        if(res != LV_FS_RES_OK) return;
     }
 
     gd_render_frame(gifobj->gif, (uint8_t *)gifobj->imgdsc.data);


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
