### PR TITLE
chart: Add initial tests

### DIFF
--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -271,7 +271,7 @@ void lv_chart_refresh(lv_obj_t * obj);
  * @param obj       pointer to a chart object
  * @param color     color of the data series
  * @param axis      the y axis to which the series should be attached (::LV_CHART_AXIS_PRIMARY_Y or ::LV_CHART_AXIS_SECONDARY_Y)
- * @return          pointer to the allocated data series
+ * @return          pointer to the allocated data series or NULL on failure
  */
 lv_chart_series_t * lv_chart_add_series(lv_obj_t * obj, lv_color_t color, lv_chart_axis_t axis);
 

--- a/tests/src/test_cases/test_chart.c
+++ b/tests/src/test_cases/test_chart.c
@@ -1,0 +1,119 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+static lv_obj_t * active_screen = NULL;
+static lv_obj_t * chart = NULL;
+
+static lv_color_t red_color;
+
+void setUp(void)
+{
+    active_screen = lv_scr_act();
+    chart = lv_chart_create(active_screen);
+
+    red_color = lv_palette_main(LV_PALETTE_RED);
+}
+
+void tearDown(void)
+{
+    /* Is there a way to destroy a chart without having to call remove_series for each of it series? */
+}
+
+/* NOTE: Default chart type is LV_CHART_TYPE_LINE */
+void test_chart_add_series(void)
+{
+    lv_chart_series_t * red_series;
+
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(red_series, "Red series not added to chart");
+    TEST_ASSERT_NULL_MESSAGE(red_series->x_points, "X points in non scatter chart should not point to anything");
+
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_set_point_count_increments(void)
+{
+    lv_chart_series_t * red_series;
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+
+    uint16_t points_in_serie = lv_chart_get_point_count(chart);
+    uint16_t new_point_count = points_in_serie * 2;
+    lv_chart_set_point_count(chart, new_point_count);
+
+    TEST_ASSERT_EQUAL_MESSAGE(new_point_count, lv_chart_get_point_count(chart),
+                              "Actual points in chart are less than expected");
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_set_point_count_decrements(void)
+{
+    lv_chart_series_t * red_series;
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+    uint16_t points_in_serie = lv_chart_get_point_count(chart);
+    uint16_t new_point_count = points_in_serie / 2;
+
+    lv_chart_set_point_count(chart, new_point_count);
+
+    TEST_ASSERT_EQUAL_MESSAGE(new_point_count, lv_chart_get_point_count(chart),
+                              "Actual points in chart are more than expected");
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_set_point_count_as_same(void)
+{
+    lv_chart_series_t * red_series;
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+    uint16_t points_in_serie = lv_chart_get_point_count(chart);
+    uint16_t new_point_count = points_in_serie;
+
+    lv_chart_set_point_count(chart, new_point_count);
+
+    TEST_ASSERT_EQUAL_MESSAGE(new_point_count, lv_chart_get_point_count(chart),
+                              "Actual points is not equal to original point count");
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_set_new_point_count_as_zero(void)
+{
+    lv_chart_series_t * red_series;
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+
+    lv_chart_set_point_count(chart, 0u);
+
+    TEST_ASSERT_EQUAL_MESSAGE(1u, lv_chart_get_point_count(chart), "Actual points in chart are more than 1");
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_point_is_added_at_the_end_of_a_serie(void)
+{
+    lv_chart_series_t * red_series;
+    red_series = lv_chart_add_series(chart, red_color, LV_CHART_AXIS_SECONDARY_Y);
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(red_series, "Red series not added to chart");
+    TEST_ASSERT_NULL_MESSAGE(red_series->x_points, "X points in non scatter chart should not point to anything");
+
+    lv_chart_remove_series(chart, red_series);
+}
+
+void test_chart_one_point_when_setting_point_count_to_zero(void)
+{
+    lv_chart_set_point_count(chart, 0u);
+    TEST_ASSERT_EQUAL(1u, lv_chart_get_point_count(chart));
+}
+
+void test_chart_set_zoom_y_to_none_when_factor_is_less_than_256(void)
+{
+    lv_chart_set_zoom_y(chart, 128);
+    TEST_ASSERT_EQUAL(LV_ZOOM_NONE, lv_chart_get_zoom_y(chart));
+}
+
+void test_chart_set_zoom_x_to_none_when_factor_is_less_than_256(void)
+{
+    lv_chart_set_zoom_x(chart, 128);
+    TEST_ASSERT_EQUAL(LV_ZOOM_NONE, lv_chart_get_zoom_x(chart));
+}
+
+#endif


### PR DESCRIPTION
### Description of the feature or fix

Initial tests for `lv_chart` I had laying around

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
