### PR TITLE
fix type mismatch in grid

### DIFF
--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -53,7 +53,7 @@ static void calc_free(_lv_grid_calc_t * calc);
 static void calc_cols(lv_obj_t * cont, _lv_grid_calc_t * c);
 static void calc_rows(lv_obj_t * cont, _lv_grid_calc_t * c);
 static void item_repos(lv_obj_t * item, _lv_grid_calc_t * c, item_repos_hint_t * hint);
-static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, uint8_t align, lv_coord_t gap, uint32_t track_num,
+static lv_coord_t grid_align(lv_coord_t cont_size, bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
                              lv_coord_t * size_array, lv_coord_t * pos_array, bool reverse);
 static uint32_t count_tracks(const lv_coord_t * templ);
 
@@ -81,19 +81,19 @@ static inline lv_coord_t get_row_span(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_row_span(obj, 0);
 }
-static inline lv_coord_t get_cell_col_align(lv_obj_t * obj)
+static inline lv_grid_align_t get_cell_col_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_x_align(obj, 0);
 }
-static inline lv_coord_t get_cell_row_align(lv_obj_t * obj)
+static inline lv_grid_align_t get_cell_row_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_y_align(obj, 0);
 }
-static inline uint8_t get_grid_col_align(lv_obj_t * obj)
+static inline lv_grid_align_t get_grid_col_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_column_align(obj, 0);
 }
-static inline uint8_t get_grid_row_align(lv_obj_t * obj)
+static inline lv_grid_align_t get_grid_row_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_row_align(obj, 0);
 }
@@ -252,7 +252,7 @@ void lv_style_set_grid_cell_row_span(lv_style_t * style, lv_coord_t value)
     lv_style_set_prop(style, LV_STYLE_GRID_CELL_ROW_SPAN, v);
 }
 
-void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_coord_t value)
+void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_grid_align_t value)
 {
     lv_style_value_t v = {
         .num = value
@@ -260,7 +260,7 @@ void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_coord_t value)
     lv_style_set_prop(style, LV_STYLE_GRID_CELL_X_ALIGN, v);
 }
 
-void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_coord_t value)
+void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_grid_align_t value)
 {
     lv_style_value_t v = {
         .num = value
@@ -334,7 +334,7 @@ void lv_obj_set_style_grid_cell_row_span(lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_ROW_SPAN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = value
@@ -342,7 +342,7 @@ void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_coord_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_X_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = value
@@ -718,7 +718,7 @@ static void item_repos(lv_obj_t * item, _lv_grid_calc_t * c, item_repos_hint_t *
  * @param pos_array write the positions of the tracks here
  * @return the total size of the grid
  */
-static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, uint8_t align, lv_coord_t gap, uint32_t track_num,
+static lv_coord_t grid_align(lv_coord_t cont_size, bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
                              lv_coord_t * size_array, lv_coord_t * pos_array, bool reverse)
 {
     lv_coord_t grid_size = 0;

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -763,7 +763,8 @@ static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, lv_grid_alig
                 gap = (lv_coord_t)(cont_size - grid_size) / (lv_coord_t)(track_num + 1);
                 pos_array[0] = gap;
                 break;
-
+            default:
+                break;
         }
     }
 

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -718,7 +718,7 @@ static void item_repos(lv_obj_t * item, _lv_grid_calc_t * c, item_repos_hint_t *
  * @param pos_array write the positions of the tracks here
  * @return the total size of the grid
  */
-static lv_coord_t grid_align(lv_coord_t cont_size, bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
+static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
                              lv_coord_t * size_array, lv_coord_t * pos_array, bool reverse)
 {
     lv_coord_t grid_size = 0;

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -65,27 +65,27 @@ static inline const lv_coord_t * get_row_dsc(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_row_dsc_array(obj, 0);
 }
-static inline uint8_t get_col_pos(lv_obj_t * obj)
+static inline lv_coord_t get_col_pos(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_column_pos(obj, 0);
 }
-static inline uint8_t get_row_pos(lv_obj_t * obj)
+static inline lv_coord_t get_row_pos(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_row_pos(obj, 0);
 }
-static inline uint8_t get_col_span(lv_obj_t * obj)
+static inline lv_coord_t get_col_span(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_column_span(obj, 0);
 }
-static inline uint8_t get_row_span(lv_obj_t * obj)
+static inline lv_coord_t get_row_span(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_row_span(obj, 0);
 }
-static inline uint8_t get_cell_col_align(lv_obj_t * obj)
+static inline lv_coord_t get_cell_col_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_x_align(obj, 0);
 }
-static inline uint8_t get_cell_row_align(lv_obj_t * obj)
+static inline lv_coord_t get_cell_row_align(lv_obj_t * obj)
 {
     return lv_obj_get_style_grid_cell_y_align(obj, 0);
 }
@@ -172,8 +172,8 @@ void lv_obj_set_grid_align(lv_obj_t * obj, lv_grid_align_t column_align, lv_grid
 
 }
 
-void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t x_align, uint8_t col_pos, uint8_t col_span,
-                          lv_grid_align_t y_align, uint8_t row_pos, uint8_t row_span)
+void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t x_align, lv_coord_t col_pos, lv_coord_t col_span,
+                          lv_grid_align_t y_align, lv_coord_t row_pos, lv_coord_t row_span)
 
 {
     lv_obj_set_style_grid_cell_column_pos(obj, col_pos, 0);

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -53,7 +53,8 @@ static void calc_free(_lv_grid_calc_t * calc);
 static void calc_cols(lv_obj_t * cont, _lv_grid_calc_t * c);
 static void calc_rows(lv_obj_t * cont, _lv_grid_calc_t * c);
 static void item_repos(lv_obj_t * item, _lv_grid_calc_t * c, item_repos_hint_t * hint);
-static lv_coord_t grid_align(lv_coord_t cont_size, bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
+static lv_coord_t grid_align(lv_coord_t cont_size, bool auto_size, lv_grid_align_t align, lv_coord_t gap,
+                             uint32_t track_num,
                              lv_coord_t * size_array, lv_coord_t * pos_array, bool reverse);
 static uint32_t count_tracks(const lv_coord_t * templ);
 
@@ -718,7 +719,8 @@ static void item_repos(lv_obj_t * item, _lv_grid_calc_t * c, item_repos_hint_t *
  * @param pos_array write the positions of the tracks here
  * @return the total size of the grid
  */
-static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, lv_grid_align_t align, lv_coord_t gap, uint32_t track_num,
+static lv_coord_t grid_align(lv_coord_t cont_size,  bool auto_size, lv_grid_align_t align, lv_coord_t gap,
+                             uint32_t track_num,
                              lv_coord_t * size_array, lv_coord_t * pos_array, bool reverse)
 {
     lv_coord_t grid_size = 0;

--- a/src/layouts/grid/lv_grid.h
+++ b/src/layouts/grid/lv_grid.h
@@ -104,8 +104,8 @@ void lv_style_set_grid_cell_column_pos(lv_style_t * style, lv_coord_t value);
 void lv_style_set_grid_cell_column_span(lv_style_t * style, lv_coord_t value);
 void lv_style_set_grid_cell_row_pos(lv_style_t * style, lv_coord_t value);
 void lv_style_set_grid_cell_row_span(lv_style_t * style, lv_coord_t value);
-void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_coord_t value);
-void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_coord_t value);
+void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_grid_align_t value);
+void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_grid_align_t value);
 
 void lv_obj_set_style_grid_row_dsc_array(lv_obj_t * obj, const lv_coord_t value[], lv_style_selector_t selector);
 void lv_obj_set_style_grid_column_dsc_array(lv_obj_t * obj, const lv_coord_t value[], lv_style_selector_t selector);
@@ -115,8 +115,8 @@ void lv_obj_set_style_grid_cell_column_pos(lv_obj_t * obj, lv_coord_t value, lv_
 void lv_obj_set_style_grid_cell_column_span(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
 void lv_obj_set_style_grid_cell_row_pos(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
 void lv_obj_set_style_grid_cell_row_span(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
 
 static inline const lv_coord_t * lv_obj_get_style_grid_row_dsc_array(const lv_obj_t * obj, uint32_t part)
 {
@@ -166,13 +166,13 @@ static inline lv_coord_t lv_obj_get_style_grid_cell_row_span(const lv_obj_t * ob
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_grid_cell_x_align(const lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_cell_x_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_X_ALIGN);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_grid_cell_y_align(const lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_cell_y_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_Y_ALIGN);
     return (lv_coord_t)v.num;

--- a/src/layouts/grid/lv_grid.h
+++ b/src/layouts/grid/lv_grid.h
@@ -85,8 +85,8 @@ void lv_obj_set_grid_align(lv_obj_t * obj, lv_grid_align_t column_align, lv_grid
  * @param row_pos row ID
  * @param row_span number of rows to take (>= 1)
  */
-void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t column_align, uint8_t col_pos, uint8_t col_span,
-                          lv_grid_align_t row_align, uint8_t row_pos, uint8_t row_span);
+void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t column_align, lv_coord_t col_pos, lv_coord_t col_span,
+                          lv_grid_align_t row_align, lv_coord_t row_pos, lv_coord_t row_span);
 
 /**
  * Just a wrapper to `LV_GRID_FR` for bindings.

--- a/src/layouts/grid/lv_grid.h
+++ b/src/layouts/grid/lv_grid.h
@@ -169,13 +169,13 @@ static inline lv_coord_t lv_obj_get_style_grid_cell_row_span(const lv_obj_t * ob
 static inline lv_grid_align_t lv_obj_get_style_grid_cell_x_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_X_ALIGN);
-    return (lv_coord_t)v.num;
+    return (lv_grid_align_t)v.num;
 }
 
 static inline lv_grid_align_t lv_obj_get_style_grid_cell_y_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_Y_ALIGN);
-    return (lv_coord_t)v.num;
+    return (lv_grid_align_t)v.num;
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
