### PR TITLE
feat(refr): add LV_EVENT_REFR_START/FINISH event

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -304,6 +304,8 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
         return;
     }
 
+    lv_disp_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
+
 #if LV_USE_PERF_MONITOR && LV_USE_LABEL
     volatile uint32_t elaps = lv_tick_elaps(disp_refr->last_render_start_time);
 #endif
@@ -409,14 +411,13 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     if(disp_refr->act_scr == NULL) {
         disp_refr->inv_p = 0;
         LV_LOG_WARN("there is no active screen");
-        REFR_TRACE("finished");
-        return;
+        goto refr_finish;
     }
 
     if(disp_refr->render_mode == LV_DISP_RENDER_MODE_DIRECT &&
        disp_refr->draw_ctx->color_format != LV_COLOR_FORMAT_NATIVE) {
         LV_LOG_WARN("In direct_mode only LV_COLOR_FORMAT_NATIVE color format is supported");
-        return;
+        goto refr_finish;
     }
 
     lv_refr_join_area();
@@ -461,6 +462,9 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
 #if LV_USE_DRAW_MASKS
     _lv_draw_mask_cleanup();
 #endif
+
+refr_finish:
+    lv_disp_send_event(disp_refr, LV_EVENT_REFR_FINISH, NULL);
 
     REFR_TRACE("finished");
 }

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -97,6 +97,8 @@ typedef enum {
     LV_EVENT_RENDER_START,
     LV_EVENT_RENDER_READY,
     LV_EVENT_RESOLUTION_CHANGED,
+    LV_EVENT_REFR_START,
+    LV_EVENT_REFR_FINISH,
 
     _LV_EVENT_LAST,               /** Number of default events*/
 


### PR DESCRIPTION
### Description of the feature or fix
Send events before and after screen refresh.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
