### PR TITLE
fix(cmsis-pack): update cmsis-pack scripts

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,6 +36,11 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
+     <release date="2023-02-26" version="9.0.0-dev" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.9.0.0-dev.pack">
+      - LVGL 9.0.0-dev
+      - New Driver Architecture
+      - Other fixes
+     </release>
      <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/release/v8.3/env_support/cmsis-pack/LVGL.lvgl.8.3.5.pack">
       - LVGL 8.3.5 release
       - Use LVGL version as the cmsis-pack version
@@ -43,7 +48,7 @@
       - Rework stm32 DMA2D support
       - Various fixes
     </release>
-    <release date="2023-01-15" version="1.1.0-alpha" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.1.1.0-alpha.pack">
+    <release date="2023-01-15" version="1.1.0-alpha" url="https://github.com/lvgl/lvgl/raw/4e3f341b882e0453d3da5cce6bb1b6357e52e3e7/env_support/cmsis-pack/LVGL.lvgl.1.1.0-alpha.pack">
       - LVGL 9.0.0-dev
       - Monthly update for January
     </release>
@@ -316,7 +321,7 @@
                 <file category="sourceC"            name="src/core/lv_indev.c" />
                 <file category="sourceC"            name="src/core/lv_disp.c" />
                 <file category="sourceC"            name="src/core/lv_obj_scroll.c" />
-                <file category="sourceC"            name="src/core/lv_event.c" />
+                <file category="sourceC"            name="src/core/lv_obj_event.c" />
                 <file category="sourceC"            name="src/core/lv_obj_draw.c" />
                 <file category="sourceC"            name="src/core/lv_group.c" />
                 <file category="sourceC"            name="src/core/lv_obj_style.c" />
@@ -384,8 +389,6 @@
                 <file category="sourceC"            name="src/font/lv_font_unscii_16.c" />
 
                 <!-- src/hal -->
-                <file category="sourceC"            name="src/hal/lv_hal_disp.c" />
-                <file category="sourceC"            name="src/hal/lv_hal_indev.c" />
                 <file category="sourceC"            name="src/hal/lv_hal_tick.c" />
 
                 <!-- src/others -->
@@ -422,6 +425,7 @@
                 <file category="sourceC"            name="src/misc/lv_style.c" />
                 <file category="sourceC"            name="src/misc/lv_color.c" />
                 <file category="sourceC"            name="src/misc/lv_printf.c" />
+                <file category="sourceC"            name="src/misc/lv_event.c" />
 
                 <!-- src/widgets -->
                 <file category="sourceC"            name="src/widgets/spinner/lv_spinner.c" />
@@ -482,11 +486,18 @@
                 <file category="sourceC"            name="src/themes/default/lv_theme_default.c" />
 
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.1.7" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.2.0" />
                 <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
-
+                
+                <!-- code template -->
+                <file category="header"       name="examples/porting/lv_port_disp_template.h" attr="template" select="Display port template" version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_disp_template.c" attr="template" select="Display port template" version="2.0.0"/>
+                <file category="header"       name="examples/porting/lv_port_indev_template.h" attr="template" select="Input devices port template" version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_indev_template.c" attr="template" select="Input devices port template" version="2.0.0"/>
+                <file category="header"       name="examples/porting/lv_port_fs_template.h" attr="template" select="File system port template" version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_fs_template.c" attr="template" select="File system port template" version="2.0.0"/>
               </files>
 
               <Pre_Include_Global_h>
@@ -564,7 +575,7 @@
             <component Cgroup="lvgl" Csub="GPU NXP-PXP"  condition="LVGL-GPU-NXP-PXP">
               <description>An hardware acceleration from NXP-PXP</description>
               <files>
-                <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp.c" />
                 <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_blend.c" />
                 <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp.c" />
                 <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp_osa.c" />
@@ -581,11 +592,13 @@
             <component Cgroup="lvgl" Csub="GPU NXP-VGLite"  condition="LVGL-GPU-NXP-VGLite">
               <description>An hardware acceleration from NXP-VGLite</description>
               <files>
-                <file category="sourceC"      name="src/draw/nxp/lv_gpu_nxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_line.c" />
                 <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_arc.c" />
                 <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_blend.c" />
                 <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_rect.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_gpu_nxp_vglite.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_buf.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_utils.c" />
               </files>
 
               <RTE_Components_h>
@@ -776,7 +789,7 @@
               </RTE_Components_h>
 
             </component>
-
+      
             <component Cgroup="lvgl" Csub="Libs QRCode"  condition="LVGL-Essential">
               <description>Add QRCode support</description>
               <files>
@@ -890,7 +903,7 @@
                 <file category="sourceC"    name="demos/benchmark/lv_demo_benchmark.c" />
                 <file category="header"     name="demos/benchmark/lv_demo_benchmark.h" />
 
-                <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_alpha16.c" />
+                <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_alpha256.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_argb.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_chroma_keyed.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_indexed16.c" />

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -151,6 +151,7 @@ Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
     - \#define LV_USE_BMP 0
     - \#define LV_USE_SJPG 0
     - \#define LV_USE_GIF 0
+    - \#define LV_USE_BARCODE 0
     - \#define LV_USE_QRCODE 0
     - \#define LV_USE_FREETYPE 0
     - \#define LV_USE_TINY_TTF 0

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -158,7 +158,15 @@ Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
     - \#define LV_USE_RLOTTIE 0
     - \#define LV_USE_FFMPEG 0
 
-9. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
+11. Remove unsupported devices from the `DEVICES` section
+
+    - LV_SE_SDL
+
+    - LV_USE_LINUX_FBDEV
+
+    - LV_USE_TFT_ESPI
+
+12. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
 
 
 

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -160,7 +160,7 @@ Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
 
 11. Remove unsupported devices from the `DEVICES` section
 
-    - LV_SE_SDL
+    - LV_USE_SDL
 
     - LV_USE_LINUX_FBDEV
 

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -65,9 +65,17 @@
 #define LV_STRLEN       lv_strlen_builtin
 #define LV_STRNCPY      lv_strncpy_builtin
 
+#define LV_COLOR_EXTERN_INCLUDE <stdint.h>
+#define LV_COLOR_MIX      lv_color_mix
+#define LV_COLOR_PREMULT      lv_color_premult
+#define LV_COLOR_MIX_PREMULT      lv_color_mix_premult
+
 /*====================
    HAL SETTINGS
  *====================*/
+
+/*Default display refresh, input device read and animation step period.*/
+#define LV_DEF_REFR_PERIOD  33      /*[ms]*/
 
 /*Use a custom tick source that tells the elapsed time in milliseconds.
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
@@ -208,7 +216,7 @@
     *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
     *LV_LOG_LEVEL_USER        Only logs added by the user
     *LV_LOG_LEVEL_NONE        Do not log anything*/
-    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_USER
 
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
@@ -317,7 +325,7 @@
 
 /*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
  * E.g. __attribute__((aligned(4)))*/
-#define LV_ATTRIBUTE_MEM_ALIGN __attribute__((aligned(4)))
+#define LV_ATTRIBUTE_MEM_ALIGN  __attribute__((aligned(4)))
 
 /*Attribute to mark large constant arrays for example font's bitmaps*/
 #define LV_ATTRIBUTE_LARGE_CONST
@@ -605,6 +613,7 @@
     #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
 #endif
 
+/*FreeType library*/
 #if LV_USE_FREETYPE
     /*Memory used by FreeType to cache characters [bytes]*/
     #define LV_FREETYPE_CACHE_SIZE (64 * 1024)
@@ -628,7 +637,6 @@
     /* Enable loading TTF data from files */
     #define LV_TINY_TTF_FILE_SUPPORT 0
 #endif
-
 
 /*FFmpeg library for image decoding and playing videos
  *Supports all major image formats so do not enable other image decoder with it*/
@@ -668,7 +676,6 @@
 
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/
-//#define LV_USE_IME_PINYIN 0
 #if LV_USE_IME_PINYIN
     /*1: Use default thesaurus*/
     /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
@@ -686,7 +693,6 @@
 
 /*1: Enable file explorer*/
 /*Requires: lv_table*/
-//#define LV_USE_FILE_EXPLORER                     0
 #if LV_USE_FILE_EXPLORER
     /*Maximum length of path*/
     #define LV_FILE_EXPLORER_PATH_MAX_LEN        (128)
@@ -694,6 +700,25 @@
     /*Requires: lv_list*/
     #define LV_FILE_EXPLORER_QUICK_ACCESS        1
 #endif
+
+/*==================
+ * DEVICES
+ *==================*/
+
+/*Use SDL to open window on PC and handle mouse and keyboard*/
+#define LV_USE_SDL              0
+#if LV_USE_SDL
+    #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
+#endif
+
+/*Driver for /dev/fb*/
+#define LV_USE_LINUX_FBDEV      0
+#if LV_USE_LINUX_FBDEV
+    #define LV_LINUX_FBDEV_BSD  0
+#endif
+
+/*Interface for TFT_eSPI*/
+#define LV_USE_TFT_ESPI         0
 
 /*==================
 * EXAMPLES
@@ -714,7 +739,7 @@
 /*Benchmark your system*/
 #if LV_USE_DEMO_BENCHMARK
     /*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
-    #define LV_DEMO_BENCHMARK_RGB565A8 0
+    #define LV_DEMO_BENCHMARK_RGB565A8 1
 #endif
 
 /*--END OF LV_CONF_H--*/

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -702,25 +702,6 @@
 #endif
 
 /*==================
- * DEVICES
- *==================*/
-
-/*Use SDL to open window on PC and handle mouse and keyboard*/
-#define LV_USE_SDL              0
-#if LV_USE_SDL
-    #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
-#endif
-
-/*Driver for /dev/fb*/
-#define LV_USE_LINUX_FBDEV      0
-#if LV_USE_LINUX_FBDEV
-    #define LV_LINUX_FBDEV_BSD  0
-#endif
-
-/*Interface for TFT_eSPI*/
-#define LV_USE_TFT_ESPI         0
-
-/*==================
 * EXAMPLES
 *==================*/
 


### PR DESCRIPTION


### Description of the feature or fix

Following API changes

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
