### PR TITLE
feat(meter): Add linear meter widget

### DIFF
--- a/docs/widgets/extra/meter.md
+++ b/docs/widgets/extra/meter.md
@@ -11,6 +11,26 @@ The Meter widget can visualize data in very flexible ways. In can show arcs, nee
 
 ## Usage
 
+### Meter mode
+
+Meter widget can have a linear (vertical/horizontal) or round mode.
+By default, the mode is round, but changing is simple: `lv_meter_set_indicator_mode(meter, LV_METER_INDICATOR_MODE_LINEAR)`.
+If the mode is `LV_METER_INDICATOR_MODE_LINEAR`, the widget's orientation depends on it's size:
+if width >= height - horizontal, otherwise - vertical.
+
+Linear mode has additional options:
+- `lv_obj_set_style_base_dir(meter, LV_BASE_DIR_RTL, 0)` - for changing scale direction. By default horizontal meter has scale direction from
+  left to right, vertical meter - from up to down.
+- `lv_meter_set_needle_side(scale, toggle_side)` - for toggle labels with needle. By default horizontal meter has labels under
+  the scale and needle below the scale, vertical meter has labels on the left and needle on the right.
+
+According to the styles widget has borders and custom background. It can be disabled for showing only widget
+itself, useful for linear meter:
+```c
+lv_obj_set_style_bg_opa(meter, LV_OPA_TRANSP, 0);
+lv_obj_set_style_border_width(meter, 0, 0);
+```
+
 ### Add a scale
 
 First a *Scale* needs to be added to the Meter with `lv_meter_scale_t * scale = lv_meter_add_scale(meter)`.

--- a/examples/widgets/lv_example_widgets.h
+++ b/examples/widgets/lv_example_widgets.h
@@ -101,6 +101,7 @@ void lv_example_meter_1(void);
 void lv_example_meter_2(void);
 void lv_example_meter_3(void);
 void lv_example_meter_4(void);
+void lv_example_meter_5(void);
 
 void lv_example_msgbox_1(void);
 

--- a/examples/widgets/meter/index.rst
+++ b/examples/widgets/meter/index.rst
@@ -26,3 +26,9 @@ Pie chart
 .. lv_example:: widgets/meter/lv_example_meter_4
   :language: c
 
+
+Linear meter
+"""""""""""""""""""""""
+
+.. lv_example:: widgets/meter/lv_example_meter_5
+  :language: c

--- a/examples/widgets/meter/lv_example_meter_5.c
+++ b/examples/widgets/meter/lv_example_meter_5.c
@@ -1,0 +1,391 @@
+#include "../../lv_examples.h"
+#if LV_USE_METER && LV_BUILD_EXAMPLES
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+typedef enum {
+    METER_SIMPLE,
+    METER_LINEAR,
+    METER_MULTI_ARCS,
+    METER_MULTI_ARCS_LINEAR,
+    METER_CLOCK,
+    METER_PIE_CHART,
+    METER_PIE_CHART_LINEAR,
+} meter_t;
+
+static struct meter_item {
+    lv_obj_t * obj;
+    lv_anim_t a;
+    lv_point_t coord;
+    uint16_t w;
+    uint16_t h;
+    uint8_t indic_cnt;
+    uint8_t reverse : 1;
+    uint8_t toggle_needle_side: 1;
+    uint8_t hide_borders : 1;
+    uint8_t meter_type: 3;
+    char * name;
+    lv_meter_indicator_t * indic[5];
+} meter_items[] = {
+    /*Horizontal meters*/
+    {
+        .coord.x = 0, .coord.y = 0, .w = 400, .h = 80, .reverse = 0,
+        .hide_borders = 1, .meter_type = METER_LINEAR,
+        .name = "Simple linear horizontal meter, reverse off, no borders"
+    },
+    {
+        .coord.x = 0, .coord.y = 80, .w = 400, .h = 80, .reverse = 1,
+        .hide_borders = 0, .meter_type = METER_LINEAR, .toggle_needle_side = 1,
+        .name = "Simple linear horizontal meter, reverse on, with borders, "
+        "needle side toggled"
+    },
+    {
+        .coord.x = 0, .coord.y = 170, .w = 400, .h = 80, .reverse = 0,
+        .hide_borders = 1, .meter_type = METER_MULTI_ARCS_LINEAR,
+        .name = "Multiple arcs linear horizontal meter, reverse off, no borders"
+    },
+    {
+        .coord.x = 0, .coord.y = 250, .w = 400, .h = 80, .reverse = 0,
+        .hide_borders = 0, .meter_type = METER_PIE_CHART_LINEAR,
+        .name = "Pie chart as linear horizontal meter, reverse off, with borders"
+    },
+    /*Vertical meters*/
+    {
+        .coord.x = 400, .coord.y = 0, .w = 100, .h = 400, .reverse = 0,
+        .hide_borders = 1, .meter_type = METER_LINEAR,
+        .name = "Simple vertical meter, reverse off, no_borders"
+    },
+    {
+        .coord.x = 400 + 100, .coord.y = 0, .w = 100, .h = 400, .reverse = 1,
+        .hide_borders = 1, .meter_type = METER_LINEAR,
+        .name = "Simple vertical meter, reverse on, no borders"
+    },
+    {
+        .coord.x = 400 + 200, .coord.y = 0, .w = 100, .h = 400, .reverse = 1,
+        .hide_borders = 0, .meter_type = METER_MULTI_ARCS_LINEAR,
+        .name = "Multiple arcs vertical meter, reverse on, with borders"
+    },
+    {
+        .coord.x = 400 + 300, .coord.y = 0, .w = 100, .h = 400, .reverse = 1,
+        .hide_borders = 1, .meter_type = METER_LINEAR, .toggle_needle_side = 1,
+        .name = "Simple linear vertical meter, reverse on, no borders, "
+        "needle side toggled"
+    },
+    /*Round meters*/
+    {
+        .coord.x = 0, .coord.y = 360, .w = 200, .h = 200, .reverse = 0,
+        .hide_borders = 0, .meter_type = METER_SIMPLE,
+        .name = "Simple meter, reverse off, with borders"
+    },
+    {
+        .coord.x = 200, .coord.y = 360, .w = 200, .h = 200, .reverse = 0,
+        .hide_borders = 0, .meter_type = METER_MULTI_ARCS,
+        .name = "Multi arcs meter, reverse off, with borders"
+    },
+    {
+        .coord.x = 400, .coord.y = 400, .w = 200, .h = 200, .reverse = 0,
+        .hide_borders = 0, .meter_type = METER_CLOCK,
+        .name = "Clock meter, reverse off, with borders"
+    },
+    {
+        .coord.x = 600, .coord.y = 400, .w = 200, .h = 200, .reverse = 0,
+        .hide_borders = 0, .meter_type = METER_PIE_CHART,
+        .name = "Pie meter, reverse off, with borders"
+    },
+};
+
+static void set_value(void * indic, int32_t v)
+{
+    for(uint8_t i = 0; i < ARRAY_SIZE(meter_items); i++) {
+        for(uint8_t j = 0; j < meter_items[i].indic_cnt; j++) {
+            if(meter_items[i].indic[j] == indic) {
+                lv_meter_set_indicator_value(meter_items[i].obj, indic, v);
+                break;
+            }
+        }
+    }
+}
+
+static void set_value_mult_sc(void * indic, int32_t v)
+{
+    for(uint8_t i = 0; i < ARRAY_SIZE(meter_items); i++) {
+        for(uint8_t j = 0; j < meter_items[i].indic_cnt; j++) {
+            if(meter_items[i].indic[j] == indic) {
+                lv_meter_set_indicator_end_value(meter_items[i].obj, indic, v);
+                break;
+            }
+        }
+    }
+}
+
+static void pie_meter_builder(struct meter_item * meter_in)
+{
+    lv_obj_t * meter =  meter_in->obj;
+
+    /*Remove the background and the circle from the middle*/
+    lv_obj_remove_style(meter, NULL, LV_PART_MAIN);
+    lv_obj_remove_style(meter, NULL, LV_PART_INDICATOR);
+
+    /*After deleting Main style we need to re-apply size and position*/
+    lv_obj_set_size(meter, meter_in->w, meter_in->h);
+    lv_obj_set_pos(meter, meter_in->coord.x, meter_in->coord.y);
+
+    /*Add a scale first with no ticks.*/
+    lv_meter_scale_t * scale = lv_meter_add_scale(meter);
+    lv_meter_set_scale_ticks(meter, scale, 0, 0, 0, lv_color_black());
+    lv_meter_set_scale_range(meter, scale, 0, 100, 360, 0);
+
+    /*Add a three arc indicator*/
+    lv_coord_t indic_w =  meter_in->w / 2;
+    lv_meter_indicator_t * indic1 = lv_meter_add_arc(meter, scale, indic_w,
+                                                     lv_palette_main(LV_PALETTE_ORANGE), 0);
+    lv_meter_set_indicator_start_value(meter, indic1, 0);
+    lv_meter_set_indicator_end_value(meter, indic1, 40);
+
+    lv_meter_indicator_t * indic2 = lv_meter_add_arc(meter, scale, indic_w,
+                                                     lv_palette_main(LV_PALETTE_YELLOW), 0);
+    lv_meter_set_indicator_start_value(meter, indic2, 40);  /*Start from the previous*/
+    lv_meter_set_indicator_end_value(meter, indic2, 80);
+
+    lv_meter_indicator_t * indic3 = lv_meter_add_arc(meter, scale, indic_w,
+                                                     lv_palette_main(LV_PALETTE_DEEP_ORANGE), 0);
+    lv_meter_set_indicator_start_value(meter, indic3, 80);  /*Start from the previous*/
+    lv_meter_set_indicator_end_value(meter, indic3, 100);
+}
+
+static void clock_meter_builder(struct meter_item * meter)
+{
+    /*Create a scale for the minutes*/
+    /*61 ticks in a 360 degrees range (the last and the first line overlaps)*/
+    lv_meter_scale_t * scale_min = lv_meter_add_scale(meter->obj);
+    lv_meter_set_scale_ticks(meter->obj, scale_min, 61, 1, 10, lv_palette_main(LV_PALETTE_GREY));
+    lv_meter_set_scale_range(meter->obj, scale_min, 0, 60, 360, 270);
+
+    /*Create another scale for the hours. It's only visual and contains only major ticks*/
+    lv_meter_scale_t * scale_hour = lv_meter_add_scale(meter->obj);
+    lv_meter_set_scale_ticks(meter->obj, scale_hour, 12, 0, 0, lv_palette_main(LV_PALETTE_GREY));    /*12 ticks*/
+    lv_meter_set_scale_major_ticks(meter->obj, scale_hour, 1, 2, 20, lv_color_black(), 10);    /*Every tick is major*/
+    lv_meter_set_scale_range(meter->obj, scale_hour, 1, 12, 330, 300);       /*[1..12] values in an almost full circle*/
+
+    LV_IMG_DECLARE(img_hand)
+
+    /*Add a the hands from images*/
+    lv_meter_indicator_t * indic_min = lv_meter_add_needle_img(meter->obj, scale_min,
+                                                               &img_hand, 5, 5);
+    lv_meter_indicator_t * indic_hour = lv_meter_add_needle_img(meter->obj, scale_min,
+                                                                &img_hand, 5, 5);
+
+    meter->indic[0] = indic_min;
+    meter->indic[1] = indic_hour;
+    meter->indic_cnt = 2;
+
+    /*Create an animation to set the value*/
+    lv_anim_init(&meter->a);
+    lv_anim_set_exec_cb(&meter->a, set_value);
+    lv_anim_set_values(&meter->a, 0, 60);
+    lv_anim_set_repeat_count(&meter->a, LV_ANIM_REPEAT_INFINITE);
+    lv_anim_set_time(&meter->a, 2000);     /*2 sec for 1 turn of the minute hand (1 hour)*/
+    lv_anim_set_var(&meter->a, indic_min);
+    lv_anim_start(&meter->a);
+
+    lv_anim_set_var(&meter->a, indic_hour);
+    lv_anim_set_time(&meter->a, 24000);    /*24 sec for 1 turn of the hour hand*/
+    lv_anim_set_values(&meter->a, 0, 60);
+    lv_anim_start(&meter->a);
+}
+
+static void multiarcs_meter_builder(struct meter_item * meter)
+{
+    /*Remove the circle from the middle*/
+    lv_obj_remove_style(meter->obj, NULL, LV_PART_INDICATOR);
+
+    /*Add a scale first*/
+    lv_meter_scale_t * scale = lv_meter_add_scale(meter->obj);
+    lv_meter_set_scale_ticks(meter->obj, scale, 11, 2, 10, lv_palette_main(LV_PALETTE_GREY));
+    lv_meter_set_scale_major_ticks(meter->obj, scale, 1, 2, 30, lv_color_hex3(0xeee), 15);
+    lv_meter_set_scale_range(meter->obj, scale, 0, 100, 270, 90);
+
+    if(meter->reverse) {
+        lv_obj_set_style_base_dir(meter->obj, LV_BASE_DIR_RTL, 0);
+    }
+    else {
+        lv_obj_set_style_base_dir(meter->obj, LV_BASE_DIR_LTR, 0);
+    }
+
+    /*Add a three arc indicator*/
+    lv_meter_indicator_t * indic1 = lv_meter_add_arc(meter->obj, scale, 10,
+                                                     lv_palette_main(LV_PALETTE_RED), 0);
+    lv_meter_indicator_t * indic2 = lv_meter_add_arc(meter->obj, scale, 10,
+                                                     lv_palette_main(LV_PALETTE_GREEN), -10);
+    lv_meter_indicator_t * indic3 = lv_meter_add_arc(meter->obj, scale, 10,
+                                                     lv_palette_main(LV_PALETTE_BLUE), -20);
+
+    meter->indic[0] = indic1;
+    meter->indic[1] = indic2;
+    meter->indic[2] = indic3;
+    meter->indic_cnt = 3;
+
+    /*Create an animation to set the value*/
+    lv_anim_init(&meter->a);
+    lv_anim_set_exec_cb(&meter->a, set_value_mult_sc);
+    lv_anim_set_values(&meter->a, 0, 100);
+    lv_anim_set_repeat_delay(&meter->a, 100);
+    lv_anim_set_playback_delay(&meter->a, 100);
+    lv_anim_set_repeat_count(&meter->a, LV_ANIM_REPEAT_INFINITE);
+
+    lv_anim_set_time(&meter->a, 2000);
+    lv_anim_set_playback_time(&meter->a, 500);
+    lv_anim_set_var(&meter->a, indic1);
+    lv_anim_start(&meter->a);
+
+    lv_anim_set_time(&meter->a, 1000);
+    lv_anim_set_playback_time(&meter->a, 1000);
+    lv_anim_set_var(&meter->a, indic2);
+    lv_anim_start(&meter->a);
+
+    lv_anim_set_time(&meter->a, 1000);
+    lv_anim_set_playback_time(&meter->a, 2000);
+    lv_anim_set_var(&meter->a, indic3);
+    lv_anim_start(&meter->a);
+}
+
+static void simple_meter_builder(struct meter_item * meter)
+{
+    /*Add a scale first*/
+    lv_meter_scale_t * scale = lv_meter_add_scale(meter->obj);
+    lv_meter_set_scale_ticks(meter->obj, scale, 41, 2, 10, lv_palette_main(LV_PALETTE_GREY));
+    lv_meter_set_scale_major_ticks(meter->obj, scale, 8, 4, 15, lv_color_black(), 12);
+
+    lv_obj_set_style_text_align(meter->obj, LV_TEXT_ALIGN_CENTER, 0);
+
+    /*Update scale direction: up to down or left to right*/
+    if(meter->reverse) {
+        lv_obj_set_style_base_dir(meter->obj, LV_BASE_DIR_RTL, 0);
+    }
+    else {
+        lv_obj_set_style_base_dir(meter->obj, LV_BASE_DIR_LTR, 0);
+    }
+
+    /*Set needle side: it can be swapped with labels*/
+    lv_meter_set_needle_side(scale, meter->toggle_needle_side);
+
+    lv_meter_indicator_t * indic;
+
+    /*Add a blue arc to the start*/
+    indic = lv_meter_add_arc(meter->obj, scale, 5, lv_palette_main(LV_PALETTE_BLUE), 0);
+    lv_meter_set_indicator_start_value(meter->obj, indic, 0);
+    lv_meter_set_indicator_end_value(meter->obj, indic, 20);
+
+    /*Make the tick lines blue at the start of the scale*/
+    indic = lv_meter_add_scale_lines(meter->obj, scale, lv_palette_main(LV_PALETTE_BLUE),
+                                     lv_palette_main(LV_PALETTE_BLUE),
+                                     false, 0);
+    lv_meter_set_indicator_start_value(meter->obj, indic, 0);
+    lv_meter_set_indicator_end_value(meter->obj, indic, 20);
+
+    /*Add a red arc to the end*/
+    indic = lv_meter_add_arc(meter->obj, scale, 5, lv_palette_main(LV_PALETTE_RED), 0);
+    lv_meter_set_indicator_start_value(meter->obj, indic, 80);
+    lv_meter_set_indicator_end_value(meter->obj, indic, 100);
+
+    /*Make the tick lines red at the end of the scale*/
+    indic = lv_meter_add_scale_lines(meter->obj, scale, lv_palette_main(LV_PALETTE_RED),
+                                     lv_palette_main(LV_PALETTE_RED),
+                                     false,
+                                     0);
+    lv_meter_set_indicator_start_value(meter->obj, indic, 80);
+    lv_meter_set_indicator_end_value(meter->obj, indic, 100);
+
+    /*Add a needle line indicator*/
+    indic = lv_meter_add_needle_line(meter->obj, scale, 4, lv_palette_main(LV_PALETTE_GREY), 0);
+
+    meter->indic[0] = indic;
+    meter->indic_cnt = 1;
+
+    /*Create an animation to set the value*/
+    lv_anim_init(&meter->a);
+    lv_anim_set_exec_cb(&meter->a, set_value);
+    lv_anim_set_var(&meter->a, indic);
+    lv_anim_set_values(&meter->a, 0, 100);
+    lv_anim_set_time(&meter->a, 3000);
+    lv_anim_set_repeat_delay(&meter->a, 100);
+    lv_anim_set_playback_time(&meter->a, 500);
+    lv_anim_set_playback_delay(&meter->a, 100);
+    lv_anim_set_repeat_count(&meter->a, LV_ANIM_REPEAT_INFINITE);
+    lv_anim_start(&meter->a);
+}
+
+static void create_meter(uint8_t index)
+{
+    meter_items[index].obj = lv_meter_create(lv_scr_act());
+    lv_obj_set_pos(meter_items[index].obj, meter_items[index].coord.x,
+                   meter_items[index].coord.y);
+    lv_obj_set_size(meter_items[index].obj, meter_items[index].w, meter_items[index].h);
+
+    /*Remove rectangle around*/
+    if(meter_items[index].hide_borders) {
+        lv_obj_set_style_bg_opa(meter_items[index].obj, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(meter_items[index].obj, 0, 0);
+    }
+
+    /* Switch to linear if need */
+    if(meter_items[index].meter_type == METER_LINEAR ||
+       meter_items[index].meter_type == METER_MULTI_ARCS_LINEAR ||
+       meter_items[index].meter_type == METER_PIE_CHART_LINEAR
+      ) {
+        lv_meter_set_indicator_mode(meter_items[index].obj, LV_METER_INDICATOR_MODE_LINEAR);
+
+        if(meter_items[index].hide_borders == 0) {
+            /* Linear meter(with borders) centered by center of tick. Label height bigger than
+             * needle, so the whole widget looks shifted to one side.
+             * For fix this situation adjust a pad.*/
+            if(meter_items[index].w > meter_items[index].h) {
+                if(meter_items[index].toggle_needle_side == 0) {
+                    lv_obj_set_style_pad_bottom(meter_items[index].obj, 0, 0);
+                }
+            }
+            else {
+                lv_obj_set_style_pad_right(meter_items[index].obj, 0, 0);
+            }
+        }
+    }
+
+    switch(meter_items[index].meter_type) {
+
+        case METER_SIMPLE:
+        case METER_LINEAR:
+            simple_meter_builder(&meter_items[index]);
+            break;
+
+        case METER_MULTI_ARCS:
+        case METER_MULTI_ARCS_LINEAR:
+            multiarcs_meter_builder(&meter_items[index]);
+            break;
+
+        case METER_CLOCK:
+            clock_meter_builder(&meter_items[index]);
+            break;
+
+        case METER_PIE_CHART:
+        case METER_PIE_CHART_LINEAR:
+            pie_meter_builder(&meter_items[index]);
+            break;
+
+        default:
+            LV_LOG_ERROR("Invalid meter type for ' %s '", meter_items[index].name);
+            break;
+    }
+}
+
+/**
+ * Create all type of meters
+ */
+void lv_example_meter_5(void)
+{
+    for(uint8_t i = 0; i < ARRAY_SIZE(meter_items); i++) {
+        create_meter(i);
+        LV_LOG_WARN("%s - Created", meter_items[i].name);
+    }
+}
+
+#endif

--- a/src/extra/widgets/meter/lv_meter.c
+++ b/src/extra/widgets/meter/lv_meter.c
@@ -16,6 +16,9 @@
  *********************/
 #define MY_CLASS &lv_meter_class
 
+/* Triangle side length */
+#define TRIANGLE_NEEDLE_SZ_PX 12
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -31,6 +34,21 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
 static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value);
 static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value);
+static void get_tick_params(lv_meter_t * meter,  lv_meter_scale_t * scale, uint16_t i,
+                            int32_t * value_of_line_out, lv_coord_t * line_width_out,
+                            lv_color_t * line_color_out);
+static void calc_label_coord(lv_meter_indicator_mode_t mode, lv_meter_scale_t * scale,
+                             lv_point_t * p_center, lv_coord_t r_in_major, bool is_hor,
+                             int32_t angle_upscale, lv_point_t label_size,
+                             lv_point_t tick_start, lv_point_t tick_end, lv_area_t * coord_out);
+static void calc_start_and_end(bool major, bool is_hor, uint16_t i, lv_meter_scale_t * scale,
+                               uint32_t max_tick_len, const lv_area_t * scale_area,
+                               lv_point_t * tick_start, lv_point_t * tick_end);
+static void swap_values(lv_coord_t * a, lv_coord_t * b);
+static void get_min_scale(lv_obj_t * obj, lv_meter_scale_t * scale,
+                          int32_t * min_out, int32_t * max_out);
+static bool lv_meter_is_hor(lv_obj_t * obj);
+
 
 /**********************
  *  STATIC VARIABLES
@@ -56,6 +74,11 @@ lv_obj_t * lv_meter_create(lv_obj_t * parent)
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
+
+    /* By default mode is classical round meter */
+    lv_meter_t * meter = (lv_meter_t *)obj;
+    meter->mode = LV_METER_INDICATOR_MODE_ROUND;
+
     return obj;
 }
 
@@ -130,7 +153,12 @@ lv_meter_indicator_t * lv_meter_add_needle_line(lv_obj_t * obj, lv_meter_scale_t
     indic->scale = scale;
     indic->opa = LV_OPA_COVER;
 
-    indic->type = LV_METER_INDICATOR_TYPE_NEEDLE_LINE;
+    if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+        indic->type = LV_METER_INDICATOR_TYPE_NEEDLE_LINE;
+    }
+    else {
+        indic->type = LV_METER_INDICATOR_TYPE_NEEDLE_TRIANGLE;
+    }
     indic->type_data.needle_line.width = width;
     indic->type_data.needle_line.color = color;
     indic->type_data.needle_line.r_mod = r_mod;
@@ -215,7 +243,9 @@ void lv_meter_set_indicator_value(lv_obj_t * obj, lv_meter_indicator_t * indic, 
         inv_arc(obj, indic, old_start, value);
         inv_arc(obj, indic, old_end, value);
     }
-    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG || indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
+    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG ||
+            indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE ||
+            indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_TRIANGLE) {
         inv_line(obj, indic, old_start);
         inv_line(obj, indic, old_end);
         inv_line(obj, indic, value);
@@ -233,7 +263,8 @@ void lv_meter_set_indicator_start_value(lv_obj_t * obj, lv_meter_indicator_t * i
     if(indic->type == LV_METER_INDICATOR_TYPE_ARC) {
         inv_arc(obj, indic, old_value, value);
     }
-    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG || indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
+    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG ||
+            indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
         inv_line(obj, indic, old_value);
         inv_line(obj, indic, value);
     }
@@ -250,7 +281,8 @@ void lv_meter_set_indicator_end_value(lv_obj_t * obj, lv_meter_indicator_t * ind
     if(indic->type == LV_METER_INDICATOR_TYPE_ARC) {
         inv_arc(obj, indic, old_value, value);
     }
-    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG || indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
+    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG ||
+            indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
         inv_line(obj, indic, old_value);
         inv_line(obj, indic, value);
     }
@@ -259,9 +291,42 @@ void lv_meter_set_indicator_end_value(lv_obj_t * obj, lv_meter_indicator_t * ind
     }
 }
 
+/*=====================
+ * Set indicator options
+ *====================*/
+
+void lv_meter_set_indicator_mode(lv_obj_t * obj, lv_meter_indicator_mode_t mode)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_meter_t * meter = (lv_meter_t *)obj;
+    meter->mode = mode;
+
+    /* Adjust default style for the Linear mode meter */
+    if(mode == LV_METER_INDICATOR_MODE_ROUND) {
+        lv_obj_set_style_radius(obj, LV_RADIUS_CIRCLE, 0);
+    }
+    else {
+        lv_obj_set_style_radius(obj, 40, 0);
+    }
+}
+
+void lv_meter_set_needle_side(lv_meter_scale_t * scale, bool toggle_side)
+{
+    if(scale) {
+        scale->toggle_needle_side = toggle_side;
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+static bool lv_meter_is_hor(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    return lv_obj_get_width(obj) >= lv_obj_get_height(obj) ? true : false;
+}
 
 static void lv_meter_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
@@ -286,6 +351,28 @@ static void lv_meter_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
 }
 
+static void swap_values(lv_coord_t * a, lv_coord_t * b)
+{
+    *a ^= *b;
+    *b ^= *a;
+    *a ^= *b;
+}
+
+static void get_min_scale(lv_obj_t * obj, lv_meter_scale_t * scale,
+                          int32_t * min_out, int32_t * max_out)
+{
+    lv_base_dir_t base_dir = lv_obj_get_style_base_dir(obj, LV_PART_MAIN);
+
+    if(base_dir == LV_BASE_DIR_RTL) {
+        *min_out = scale->max;
+        *max_out = scale->min;
+    }
+    else if(base_dir == LV_BASE_DIR_LTR) {
+        *min_out = scale->min;
+        *max_out = scale->max;
+    }
+}
+
 static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e)
 {
     LV_UNUSED(class_p);
@@ -295,87 +382,281 @@ static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target(e);
+    lv_meter_t * meter = (lv_meter_t *)obj;
+
     if(code == LV_EVENT_DRAW_MAIN) {
         lv_draw_ctx_t * draw_ctx = lv_event_get_draw_ctx(e);
         lv_area_t scale_area;
         lv_obj_get_content_coords(obj, &scale_area);
 
+        /* For linear meter arcs is like head and tail of scale */
         draw_arcs(obj, draw_ctx, &scale_area);
         draw_ticks_and_labels(obj, draw_ctx, &scale_area);
         draw_needles(obj, draw_ctx, &scale_area);
 
-        lv_coord_t r_edge = lv_area_get_width(&scale_area) / 2;
-        lv_point_t scale_center;
-        scale_center.x = scale_area.x1 + r_edge;
-        scale_center.y = scale_area.y1 + r_edge;
+        /* By default draw the center point */
+        if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+            lv_coord_t r_edge = lv_area_get_width(&scale_area) / 2;
+            lv_point_t scale_center;
+            scale_center.x = scale_area.x1 + r_edge;
+            scale_center.y = scale_area.y1 + r_edge;
 
-        lv_draw_rect_dsc_t mid_dsc;
-        lv_draw_rect_dsc_init(&mid_dsc);
-        lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
-        lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
-        lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
-        lv_area_t nm_cord;
-        nm_cord.x1 = scale_center.x - w;
-        nm_cord.y1 = scale_center.y - h;
-        nm_cord.x2 = scale_center.x + w;
-        nm_cord.y2 = scale_center.y + h;
-        lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
+            lv_draw_rect_dsc_t mid_dsc;
+            lv_draw_rect_dsc_init(&mid_dsc);
+            lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
+            lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
+            lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
+            lv_area_t nm_cord;
+            nm_cord.x1 = scale_center.x - w;
+            nm_cord.y1 = scale_center.y - h;
+            nm_cord.x2 = scale_center.x + w;
+            nm_cord.y2 = scale_center.y + h;
+            lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
+        }
     }
 }
 
 static void draw_arcs(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area)
 {
     lv_meter_t * meter = (lv_meter_t *)obj;
-
-    lv_draw_arc_dsc_t arc_dsc;
-    lv_draw_arc_dsc_init(&arc_dsc);
-    arc_dsc.rounded = lv_obj_get_style_arc_rounded(obj, LV_PART_ITEMS);
-
-    lv_coord_t r_out = lv_area_get_width(scale_area) / 2 ;
-    lv_point_t scale_center;
-    scale_center.x = scale_area->x1 + r_out;
-    scale_center.y = scale_area->y1 + r_out;
-
-    lv_opa_t opa_main = lv_obj_get_style_opa(obj, LV_PART_MAIN);
     lv_meter_indicator_t * indic;
+    lv_meter_scale_t * scale;
+    lv_opa_t opa_main = lv_obj_get_style_opa(obj, LV_PART_MAIN);
 
-    lv_obj_draw_part_dsc_t part_draw_dsc;
-    lv_obj_draw_dsc_init(&part_draw_dsc, draw_ctx);
-    part_draw_dsc.arc_dsc = &arc_dsc;
-    part_draw_dsc.part = LV_PART_INDICATOR;
-    part_draw_dsc.class_p = MY_CLASS;
-    part_draw_dsc.type = LV_METER_DRAW_PART_ARC;
+    /* Classical round gauge */
+    if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+        lv_draw_arc_dsc_t arc_dsc;
+        lv_draw_arc_dsc_init(&arc_dsc);
+        arc_dsc.rounded = lv_obj_get_style_arc_rounded(obj, LV_PART_ITEMS);
+
+        lv_coord_t r_out = lv_area_get_width(scale_area) / 2 ;
+        lv_point_t scale_center;
+        scale_center.x = scale_area->x1 + r_out;
+        scale_center.y = scale_area->y1 + r_out;
+
+        lv_obj_draw_part_dsc_t part_draw_dsc;
+        lv_obj_draw_dsc_init(&part_draw_dsc, draw_ctx);
+        part_draw_dsc.arc_dsc = &arc_dsc;
+        part_draw_dsc.part = LV_PART_INDICATOR;
+        part_draw_dsc.class_p = MY_CLASS;
+        part_draw_dsc.type = LV_METER_DRAW_PART_ARC;
+
+        _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
+            if(indic->type != LV_METER_INDICATOR_TYPE_ARC) continue;
+
+            arc_dsc.color = indic->type_data.arc.color;
+            arc_dsc.width = indic->type_data.arc.width;
+            arc_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
+
+            scale = indic->scale;
+
+            int32_t start_angle = lv_map(indic->start_value, scale->min, scale->max,
+                                         scale->rotation,
+                                         scale->rotation + scale->angle_range);
+            int32_t end_angle = lv_map(indic->end_value, scale->min, scale->max,
+                                       scale->rotation,
+                                       scale->rotation + scale->angle_range);
+
+            part_draw_dsc.radius = r_out + indic->type_data.arc.r_mod;
+            part_draw_dsc.sub_part_ptr = indic;
+            part_draw_dsc.p1 = &scale_center;
+
+            lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
+            lv_draw_arc(draw_ctx, &arc_dsc, &scale_center, part_draw_dsc.radius,
+                        start_angle, end_angle);
+            lv_event_send(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
+        }
+        /* Linear gauge */
+    }
+    else {
+        bool is_hor = lv_meter_is_hor(obj);
+        lv_point_t line_start;
+        lv_point_t line_end;
+        int32_t scale_min;
+        int32_t scale_max;
+        uint32_t scale_len = 0;
+        uint32_t max_tick_len;
+
+        lv_draw_line_dsc_t line_dsc;
+        lv_draw_line_dsc_init(&line_dsc);
+        lv_obj_init_draw_line_dsc(obj, LV_PART_TICKS, &line_dsc);
+        line_dsc.raw_end = 1;
+
+
+        _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
+            if(indic->type != LV_METER_INDICATOR_TYPE_ARC) continue;
+
+            scale = indic->scale;
+            line_dsc.color = indic->type_data.arc.color;
+            line_dsc.width = indic->type_data.arc.width;
+            line_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
+
+            max_tick_len = scale->tick_major_nth ? scale->tick_major_length :
+                           scale->tick_length;
+
+            get_min_scale(obj, scale, &scale_min, &scale_max);
+
+            if(is_hor) {
+                scale_len = lv_area_get_width(scale_area);
+                line_start.y = scale_area->y1 + (lv_area_get_height(scale_area) - max_tick_len) / 2 -
+                               indic->type_data.arc.r_mod + line_dsc.width / 2;
+                line_end.y = line_start.y;
+                line_start.x = scale_area->x1 + lv_map(indic->start_value, scale_min,
+                                                       scale_max, 0, scale_len);
+                line_end.x = scale_area->x1 +  lv_map(indic->end_value, scale_min,
+                                                      scale_max, 0, scale_len);
+                if(scale->tick_major_width) {
+                    line_start.x -= scale->tick_major_width / 2;
+                    line_end.x += scale->tick_major_width / 2;
+                }
+            }
+            else {
+                scale_len = lv_area_get_height(scale_area);
+                line_start.x = scale_area->x1 + (lv_area_get_width(scale_area) - max_tick_len) / 2 -
+                               indic->type_data.arc.r_mod + line_dsc.width / 2;
+                line_end.x = line_start.x;
+                line_start.y = scale_area->y1 + lv_map(indic->start_value, scale_min,
+                                                       scale_max, 0, scale_len);
+                line_end.y = scale_area->y1 + lv_map(indic->end_value, scale_min, scale_max, 0,
+                                                     scale_len);
+
+                if(scale->tick_major_width) {
+                    line_start.y -= scale->tick_major_width / 2;
+                    line_end.y += scale->tick_major_width / 2;
+                }
+            }
+            lv_draw_line(draw_ctx, &line_dsc, &line_start, &line_end);
+        }
+    }
+}
+
+static void calc_start_and_end(bool major, bool is_hor, uint16_t i,
+                               lv_meter_scale_t * scale, uint32_t max_tick_len,
+                               const lv_area_t * scale_area,
+                               lv_point_t * tick_start, lv_point_t * tick_end)
+{
+    if(is_hor) {
+        tick_start->x = scale_area->x1 +
+                        lv_area_get_width(scale_area) * i / (scale->tick_cnt - 1);
+        tick_end->x =  tick_start->x;
+        tick_start->y = scale_area->y1 +
+                        (lv_area_get_height(scale_area) - max_tick_len) / 2;
+
+        if(major) {
+            tick_end->y = tick_start->y + max_tick_len;
+        }
+        else {
+            tick_end->y = tick_start->y + scale->tick_length;
+        }
+    }
+    else {
+        tick_start->x = scale_area->x1 +
+                        (lv_area_get_width(scale_area) - max_tick_len) / 2;
+        tick_start->y = scale_area->y1 +
+                        lv_area_get_height(scale_area) * i / (scale->tick_cnt - 1);
+        tick_end->y = tick_start->y;
+
+        if(major) {
+            tick_end->x = tick_start->x + max_tick_len;
+        }
+        else {
+            tick_end->x = tick_start->x + scale->tick_length;
+        }
+    }
+}
+
+static void calc_label_coord(lv_meter_indicator_mode_t mode, lv_meter_scale_t * scale,
+                             lv_point_t * p_center, lv_coord_t r_in_major, bool is_hor,
+                             int32_t angle_upscale, lv_point_t label_size,
+                             lv_point_t tick_start, lv_point_t tick_end,
+                             lv_area_t * coord_out)
+{
+    lv_point_t p;
+
+    if(mode == LV_METER_INDICATOR_MODE_ROUND) {
+        uint32_t r_text = r_in_major - scale->label_gap;
+        p.x = p_center->x + r_text;
+        p.y = p_center->y;
+        lv_point_transform(&p, angle_upscale, 256, p_center);
+    }
+    else {
+        if(is_hor) {
+            p.x = tick_start.x;
+            /*Toggle labels side if need*/
+            if(scale->toggle_needle_side) {
+                p.y = tick_end.y + scale->label_gap;
+            }
+            else {
+                p.y = tick_start.y - scale->label_gap;
+            }
+        }
+        else {
+            p.y = tick_start.y;
+            /*Toggle labels side if need*/
+            if(scale->toggle_needle_side) {
+                p.x = tick_end.x + scale->label_gap;
+            }
+            else {
+                p.x = tick_start.x - scale->label_gap;
+            }
+        }
+    }
+
+    coord_out->x1 = p.x - label_size.x / 2;
+    coord_out->y1 = p.y - label_size.y / 2;
+    coord_out->x2 = coord_out->x1 + label_size.x;
+    coord_out->y2 = coord_out->y1 + label_size.y;
+}
+
+static void get_tick_params(lv_meter_t * meter,  lv_meter_scale_t * scale, uint16_t i,
+                            int32_t * value_of_line_out, lv_coord_t * line_width_out,
+                            lv_color_t * line_color_out)
+{
+    lv_meter_indicator_t * indic;
+    int32_t scale_min;
+    int32_t scale_max;
+
+    get_min_scale((lv_obj_t *)meter, scale, &scale_min, &scale_max);
+
+    int32_t value_of_line = lv_map(i, 0, scale->tick_cnt - 1, scale_min, scale_max);
 
     _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
-        if(indic->type != LV_METER_INDICATOR_TYPE_ARC) continue;
+        if(indic->type != LV_METER_INDICATOR_TYPE_SCALE_LINES) continue;
+        if(value_of_line >= indic->start_value && value_of_line <= indic->end_value) {
+            *line_width_out += indic->type_data.scale_lines.width_mod;
 
-        arc_dsc.color = indic->type_data.arc.color;
-        arc_dsc.width = indic->type_data.arc.width;
-        arc_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
-
-        lv_meter_scale_t * scale = indic->scale;
-
-        int32_t start_angle = lv_map(indic->start_value, scale->min, scale->max, scale->rotation,
-                                     scale->rotation + scale->angle_range);
-        int32_t end_angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation,
-                                   scale->rotation + scale->angle_range);
-
-        part_draw_dsc.radius = r_out + indic->type_data.arc.r_mod;
-        part_draw_dsc.sub_part_ptr = indic;
-        part_draw_dsc.p1 = &scale_center;
-
-        lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
-        lv_draw_arc(draw_ctx, &arc_dsc, &scale_center, part_draw_dsc.radius, start_angle, end_angle);
-        lv_event_send(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
+            if(indic->type_data.scale_lines.color_start.full ==
+               indic->type_data.scale_lines.color_end.full) {
+                *line_color_out = indic->type_data.scale_lines.color_start;
+            }
+            else {
+                lv_opa_t ratio;
+                if(indic->type_data.scale_lines.local_grad) {
+                    ratio = lv_map(value_of_line, indic->start_value,
+                                   indic->end_value, LV_OPA_TRANSP, LV_OPA_COVER);
+                }
+                else {
+                    ratio = lv_map(value_of_line, scale->min, scale->max,
+                                   LV_OPA_TRANSP, LV_OPA_COVER);
+                }
+                *line_color_out = lv_color_mix(indic->type_data.scale_lines.color_end,
+                                               indic->type_data.scale_lines.color_start, ratio);
+            }
+            /*We found the place, don't need to continue*/
+            break;
+        }
     }
+    *value_of_line_out = value_of_line;
 }
 
 static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area)
 {
-    lv_meter_t * meter    = (lv_meter_t *)obj;
-
+    lv_meter_t * meter = (lv_meter_t *)obj;
+    lv_coord_t r_edge = LV_MIN(lv_area_get_width(scale_area) / 2,
+                               lv_area_get_height(scale_area) / 2);
     lv_point_t p_center;
-    lv_coord_t r_edge = LV_MIN(lv_area_get_width(scale_area) / 2, lv_area_get_height(scale_area) / 2);
+    bool is_hor = lv_meter_is_hor(obj);
+
     p_center.x = scale_area->x1 + r_edge;
     p_center.y = scale_area->y1 + r_edge;
 
@@ -388,8 +669,6 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
     lv_draw_label_dsc_init(&label_dsc);
     lv_obj_init_draw_label_dsc(obj, LV_PART_TICKS, &label_dsc);
 
-    lv_meter_scale_t * scale;
-
     lv_draw_mask_radius_param_t inner_minor_mask;
     lv_draw_mask_radius_param_t inner_major_mask;
     lv_draw_mask_radius_param_t outer_mask;
@@ -401,155 +680,167 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
     part_draw_dsc.type = LV_METER_DRAW_PART_TICK;
     part_draw_dsc.line_dsc = &line_dsc;
 
+    lv_meter_scale_t * scale;
+
     _LV_LL_READ_BACK(&meter->scale_ll, scale) {
+
         part_draw_dsc.sub_part_ptr = scale;
-
         lv_coord_t r_out = r_edge;
-        lv_coord_t r_in_minor = r_out - scale->tick_length;
-        lv_coord_t r_in_major = r_out - scale->tick_major_length;
-
+        lv_coord_t r_in_minor = 0;
+        int16_t outer_mask_id = 0;
+        lv_coord_t r_in_major = 0;
         lv_area_t area_inner_minor;
-        area_inner_minor.x1 = p_center.x - r_in_minor;
-        area_inner_minor.y1 = p_center.y - r_in_minor;
-        area_inner_minor.x2 = p_center.x + r_in_minor;
-        area_inner_minor.y2 = p_center.y + r_in_minor;
-        lv_draw_mask_radius_init(&inner_minor_mask, &area_inner_minor, LV_RADIUS_CIRCLE, true);
-
         lv_area_t area_inner_major;
-        area_inner_major.x1 = p_center.x - r_in_major;
-        area_inner_major.y1 = p_center.y - r_in_major;
-        area_inner_major.x2 = p_center.x + r_in_major - 1;
-        area_inner_major.y2 = p_center.y + r_in_major - 1;
-        lv_draw_mask_radius_init(&inner_major_mask, &area_inner_major, LV_RADIUS_CIRCLE, true);
-
         lv_area_t area_outer;
-        area_outer.x1 = p_center.x - r_out;
-        area_outer.y1 = p_center.y - r_out;
-        area_outer.x2 = p_center.x + r_out - 1;
-        area_outer.y2 = p_center.y + r_out - 1;
-        lv_draw_mask_radius_init(&outer_mask, &area_outer, LV_RADIUS_CIRCLE, false);
-        int16_t outer_mask_id = lv_draw_mask_add(&outer_mask, NULL);
+
+        if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+            r_in_minor = r_out - scale->tick_length;
+            r_in_major = r_out - scale->tick_major_length;
+
+            area_inner_minor.x1 = p_center.x - r_in_minor;
+            area_inner_minor.y1 = p_center.y - r_in_minor;
+            area_inner_minor.x2 = p_center.x + r_in_minor;
+            area_inner_minor.y2 = p_center.y + r_in_minor;
+            lv_draw_mask_radius_init(&inner_minor_mask, &area_inner_minor,
+                                     LV_RADIUS_CIRCLE, true);
+
+            area_inner_major.x1 = p_center.x - r_in_major;
+            area_inner_major.y1 = p_center.y - r_in_major;
+            area_inner_major.x2 = p_center.x + r_in_major - 1;
+            area_inner_major.y2 = p_center.y + r_in_major - 1;
+            lv_draw_mask_radius_init(&inner_major_mask, &area_inner_major,
+                                     LV_RADIUS_CIRCLE, true);
+
+            area_outer.x1 = p_center.x - r_out;
+            area_outer.y1 = p_center.y - r_out;
+            area_outer.x2 = p_center.x + r_out - 1;
+            area_outer.y2 = p_center.y + r_out - 1;
+            lv_draw_mask_radius_init(&outer_mask, &area_outer, LV_RADIUS_CIRCLE, false);
+
+            outer_mask_id = lv_draw_mask_add(&outer_mask, NULL);
+        }
 
         int16_t inner_act_mask_id = LV_MASK_ID_INV; /*Will be added later*/
+        uint32_t minor_cnt;
+        uint32_t max_tick_len;
 
-        uint32_t minor_cnt = scale->tick_major_nth ? scale->tick_major_nth - 1 : 0xFFFF;
+        if(scale->tick_major_nth) {
+            minor_cnt = scale->tick_major_nth - 1;
+            max_tick_len = scale->tick_major_length;
+        }
+        else {
+            minor_cnt = 0xFFFF;
+            max_tick_len = scale->tick_length;
+        }
+
+        lv_point_t tick_start;
+        lv_point_t tick_end;
         uint16_t i;
         for(i = 0; i < scale->tick_cnt; i++) {
             minor_cnt++;
             bool major = false;
+
             if(minor_cnt == scale->tick_major_nth) {
                 minor_cnt = 0;
                 major = true;
             }
 
-            int32_t value_of_line = lv_map(i, 0, scale->tick_cnt - 1, scale->min, scale->max);
-            part_draw_dsc.value = value_of_line;
-
-            lv_color_t line_color = major ? scale->tick_major_color : scale->tick_color;
-            lv_color_t line_color_ori = line_color;
-
-            lv_coord_t line_width_ori = major ? scale->tick_major_width : scale->tick_width;
-            lv_coord_t line_width = line_width_ori;
-
-            lv_meter_indicator_t * indic;
-            _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
-                if(indic->type != LV_METER_INDICATOR_TYPE_SCALE_LINES) continue;
-                if(value_of_line >= indic->start_value && value_of_line <= indic->end_value) {
-                    line_width += indic->type_data.scale_lines.width_mod;
-
-                    if(indic->type_data.scale_lines.color_start.full == indic->type_data.scale_lines.color_end.full) {
-                        line_color = indic->type_data.scale_lines.color_start;
-                    }
-                    else {
-                        lv_opa_t ratio;
-                        if(indic->type_data.scale_lines.local_grad) {
-                            ratio = lv_map(value_of_line, indic->start_value, indic->end_value, LV_OPA_TRANSP, LV_OPA_COVER);
-                        }
-                        else {
-                            ratio = lv_map(value_of_line, scale->min, scale->max, LV_OPA_TRANSP, LV_OPA_COVER);
-                        }
-                        line_color = lv_color_mix(indic->type_data.scale_lines.color_end, indic->type_data.scale_lines.color_start, ratio);
-                    }
-                }
+            if(meter->mode == LV_METER_INDICATOR_MODE_LINEAR) {
+                calc_start_and_end(major, is_hor, i, scale, max_tick_len,
+                                   scale_area, &tick_start, &tick_end);
             }
 
-            int32_t angle_upscale = ((i * scale->angle_range) * 10) / (scale->tick_cnt - 1) +  + scale->rotation * 10;
+            line_dsc.color = major ? scale->tick_major_color : scale->tick_color;
+            line_dsc.width = major ? scale->tick_major_width : scale->tick_width;
 
-            line_dsc.color = line_color;
-            line_dsc.width = line_width;
+            int32_t angle_upscale = 0;
+            lv_point_t p_outer = {0};
 
-            /*Draw a little bit longer lines to be sure the mask will clip them correctly
-             *and to get a better precision*/
-            lv_point_t p_outer;
-            p_outer.x = p_center.x + r_out + LV_MAX(LV_DPI_DEF, r_out);
-            p_outer.y = p_center.y;
-            lv_point_transform(&p_outer, angle_upscale, 256, &p_center);
+            get_tick_params(meter, scale, i, &part_draw_dsc.value, &line_dsc.width,
+                            &line_dsc.color);
 
-            part_draw_dsc.p1 = &p_center;
-            part_draw_dsc.p2 = &p_outer;
-            part_draw_dsc.id = i;
-            part_draw_dsc.label_dsc = &label_dsc;
+            if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+                angle_upscale = ((i * scale->angle_range) * 10) / (scale->tick_cnt - 1) +
+                                scale->rotation * 10;
+
+                /*Draw a little bit longer lines to be sure the mask will clip them correctly
+                 *and to get a better precision*/
+                p_outer.x = p_center.x + r_out + LV_MAX(LV_DPI_DEF, r_out);
+                p_outer.y = p_center.y;
+                lv_point_transform(&p_outer, angle_upscale, 256, &p_center);
+
+                part_draw_dsc.p1 = &p_center;
+                part_draw_dsc.p2 = &p_outer;
+                part_draw_dsc.id = i;
+                part_draw_dsc.label_dsc = &label_dsc;
+            }
 
             /*Draw the text*/
             if(major) {
-                lv_draw_mask_remove_id(outer_mask_id);
-                uint32_t r_text = r_in_major - scale->label_gap;
-                lv_point_t p;
-                p.x = p_center.x + r_text;
-                p.y = p_center.y;
-                lv_point_transform(&p, angle_upscale, 256, &p_center);
-
                 lv_draw_label_dsc_t label_dsc_tmp;
                 lv_memcpy(&label_dsc_tmp, &label_dsc, sizeof(label_dsc_tmp));
 
                 part_draw_dsc.label_dsc = &label_dsc_tmp;
                 char buf[16];
 
-                lv_snprintf(buf, sizeof(buf), "%" LV_PRId32, value_of_line);
+                lv_snprintf(buf, sizeof(buf), "%" LV_PRId32, part_draw_dsc.value);
                 part_draw_dsc.text = buf;
 
                 lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
                 lv_point_t label_size;
-                lv_txt_get_size(&label_size, part_draw_dsc.text, label_dsc.font, label_dsc.letter_space, label_dsc.line_space,
+                lv_txt_get_size(&label_size, part_draw_dsc.text, label_dsc.font,
+                                label_dsc.letter_space, label_dsc.line_space,
                                 LV_COORD_MAX, LV_TEXT_FLAG_NONE);
 
                 lv_area_t label_cord;
-                label_cord.x1 = p.x - label_size.x / 2;
-                label_cord.y1 = p.y - label_size.y / 2;
-                label_cord.x2 = label_cord.x1 + label_size.x;
-                label_cord.y2 = label_cord.y1 + label_size.y;
+                calc_label_coord(meter->mode, scale, &p_center, r_in_major, is_hor,
+                                 angle_upscale, label_size, tick_start, tick_end,
+                                 &label_cord);
 
-                lv_draw_label(draw_ctx, part_draw_dsc.label_dsc, &label_cord, part_draw_dsc.text, NULL);
-
-                outer_mask_id = lv_draw_mask_add(&outer_mask, NULL);
+                if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+                    lv_draw_mask_remove_id(outer_mask_id);
+                    lv_draw_label(draw_ctx, part_draw_dsc.label_dsc, &label_cord,
+                                  part_draw_dsc.text, NULL);
+                    outer_mask_id = lv_draw_mask_add(&outer_mask, NULL);
+                }
+                else {
+                    lv_draw_label(draw_ctx, part_draw_dsc.label_dsc, &label_cord,
+                                  part_draw_dsc.text, NULL);
+                }
             }
             else {
                 part_draw_dsc.label_dsc = NULL;
                 part_draw_dsc.text = NULL;
-                lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
             }
 
-            inner_act_mask_id = lv_draw_mask_add(major ? &inner_major_mask : &inner_minor_mask, NULL);
-            lv_draw_line(draw_ctx, &line_dsc, &p_outer, &p_center);
-            lv_draw_mask_remove_id(inner_act_mask_id);
+            lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
+
+            if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+                inner_act_mask_id = lv_draw_mask_add(major ? &inner_major_mask :
+                                                     &inner_minor_mask, NULL);
+                lv_draw_line(draw_ctx, &line_dsc, &p_outer, &p_center);
+                lv_draw_mask_remove_id(inner_act_mask_id);
+            }
+            else {
+                lv_draw_line(draw_ctx, &line_dsc, &tick_start, &tick_end);
+            }
+
             lv_event_send(obj, LV_EVENT_DRAW_MAIN_END, &part_draw_dsc);
-
-            line_dsc.color = line_color_ori;
-            line_dsc.width = line_width_ori;
-
         }
-        lv_draw_mask_free_param(&inner_minor_mask);
-        lv_draw_mask_free_param(&inner_major_mask);
-        lv_draw_mask_free_param(&outer_mask);
-        lv_draw_mask_remove_id(outer_mask_id);
+        if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+            lv_draw_mask_free_param(&inner_minor_mask);
+            lv_draw_mask_free_param(&inner_major_mask);
+            lv_draw_mask_free_param(&outer_mask);
+            lv_draw_mask_remove_id(outer_mask_id);
+        }
     }
 }
-
 
 static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area)
 {
     lv_meter_t * meter = (lv_meter_t *)obj;
+    bool is_hor = lv_meter_is_hor(obj);
 
     lv_coord_t r_edge = lv_area_get_width(scale_area) / 2;
     lv_point_t scale_center;
@@ -571,32 +862,120 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
     part_draw_dsc.p1 = &scale_center;
 
     lv_meter_indicator_t * indic;
+
     _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
         lv_meter_scale_t * scale = indic->scale;
         part_draw_dsc.sub_part_ptr = indic;
 
-        if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
-            int32_t angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
-            lv_coord_t r_out = r_edge + scale->r_mod + indic->type_data.needle_line.r_mod;
-            lv_point_t p_end;
-            p_end.y = (lv_trigo_sin(angle) * (r_out)) / LV_TRIGO_SIN_MAX + scale_center.y;
-            p_end.x = (lv_trigo_cos(angle) * (r_out)) / LV_TRIGO_SIN_MAX + scale_center.x;
+        if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE ||
+           indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_TRIANGLE) {
+
             line_dsc.color = indic->type_data.needle_line.color;
             line_dsc.width = indic->type_data.needle_line.width;
             line_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
-
             part_draw_dsc.id = LV_METER_DRAW_PART_NEEDLE_LINE;
             part_draw_dsc.line_dsc = &line_dsc;
-            part_draw_dsc.p2 = &p_end;
 
-            lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
-            lv_draw_line(draw_ctx, &line_dsc, &scale_center, &p_end);
-            lv_event_send(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
+            if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+                lv_point_t p_end;
+                int32_t angle;
+                lv_coord_t r_out;
+                angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation,
+                               scale->rotation + scale->angle_range);
+                r_out = r_edge + scale->r_mod + indic->type_data.needle_line.r_mod;
+                p_end.y = (lv_trigo_sin(angle) * (r_out)) / LV_TRIGO_SIN_MAX + scale_center.y;
+                p_end.x = (lv_trigo_cos(angle) * (r_out)) / LV_TRIGO_SIN_MAX + scale_center.x;
+                part_draw_dsc.p2 = &p_end;
+
+                lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
+                lv_draw_line(draw_ctx, &line_dsc, &scale_center, &p_end);
+                lv_event_send(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
+
+            }
+            else {
+                uint32_t max_tick_len;
+                lv_point_t tick_center;
+                lv_point_t tick_end;
+                int32_t scale_min;
+                int32_t scale_max;
+
+                get_min_scale(obj, scale, &scale_min, &scale_max);
+
+                part_draw_dsc.p1 = &tick_center;
+                part_draw_dsc.p2 = &tick_end;
+                max_tick_len = scale->tick_major_length > scale->tick_length ?
+                               scale->tick_major_length : scale->tick_length;
+
+                lv_point_t points[3] = {0};
+
+                if(is_hor) {
+                    tick_center.y = scale_area->y1 + lv_area_get_height(scale_area) / 2 -
+                                    indic->type_data.needle_line.r_mod;
+                    tick_end.y = tick_center.y + max_tick_len / 2;
+                    tick_center.x = scale_area->x1 + lv_map(indic->end_value,
+                                                            scale_min, scale_max, 0,
+                                                            lv_area_get_width(scale_area));
+                    tick_end.x = tick_center.x;
+
+                    if(scale->toggle_needle_side) {
+                        points[0].x = tick_center.x;
+                        points[0].y = tick_end.y - max_tick_len;
+                        points[1].x = points[0].x - TRIANGLE_NEEDLE_SZ_PX / 2;
+                        points[1].y = points[0].y - TRIANGLE_NEEDLE_SZ_PX;
+                        points[2].x = points[1].x + TRIANGLE_NEEDLE_SZ_PX;
+                        points[2].y = points[1].y;
+                    }
+                    else {
+                        points[0].x = tick_end.x;
+                        points[0].y = tick_end.y;
+                        points[1].x = points[0].x  - TRIANGLE_NEEDLE_SZ_PX / 2;
+                        points[1].y = points[0].y + TRIANGLE_NEEDLE_SZ_PX;
+                        points[2].x = points[1].x + TRIANGLE_NEEDLE_SZ_PX;
+                        points[2].y = points[1].y;
+                    }
+                }
+                else {
+                    tick_center.x = scale_area->x1 + lv_area_get_width(scale_area) / 2 -
+                                    indic->type_data.needle_line.r_mod;
+                    tick_end.x = tick_center.x + max_tick_len / 2;
+                    tick_center.y = scale_area->y1 + lv_map(indic->end_value, scale_min,
+                                                            scale_max, 0,
+                                                            lv_area_get_height(scale_area));
+                    tick_end.y = tick_center.y;
+
+                    /*Triangle on the left side*/
+                    if(scale->toggle_needle_side) {
+                        points[0].x = tick_end.x - max_tick_len;
+                        points[0].y = tick_end.y;
+                        points[1].x = points[0].x - TRIANGLE_NEEDLE_SZ_PX;
+                        points[1].y = points[0].y - TRIANGLE_NEEDLE_SZ_PX / 2;
+                        points[2].x = points[1].x;
+                        points[2].y = points[1].y + TRIANGLE_NEEDLE_SZ_PX;
+                        /*Triangle on the right side*/
+                    }
+                    else {
+                        points[0].x = tick_end.x;
+                        points[0].y = tick_end.y;
+                        points[1].x = tick_end.x + TRIANGLE_NEEDLE_SZ_PX;
+                        points[1].y = tick_end.y + TRIANGLE_NEEDLE_SZ_PX / 2;
+                        points[2].x =  points[1].x;
+                        points[2].y = points[1].y - TRIANGLE_NEEDLE_SZ_PX;
+                    }
+                }
+
+                lv_draw_rect_dsc_t triag_dsc;
+                lv_draw_rect_dsc_init(&triag_dsc);
+                triag_dsc.bg_color = indic->type_data.needle_line.color;
+                triag_dsc.bg_img_opa = LV_OPA_COVER;
+
+                lv_draw_triangle(draw_ctx, &triag_dsc, points);
+            }
         }
         else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG) {
             if(indic->type_data.needle_img.src == NULL) continue;
 
-            int32_t angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
+            int32_t angle = lv_map(indic->end_value, scale->min, scale->max,
+                                   scale->rotation, scale->rotation + scale->angle_range);
             lv_img_header_t info;
             lv_img_decoder_get_info(indic->type_data.needle_img.src, &info);
             lv_area_t a;
@@ -624,26 +1003,82 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
 
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value)
 {
-    bool rounded = lv_obj_get_style_arc_rounded(obj, LV_PART_ITEMS);
-
+    lv_area_t a;
     lv_area_t scale_area;
+    lv_meter_t * meter = (lv_meter_t *)obj;
+
     lv_obj_get_content_coords(obj, &scale_area);
 
-    lv_coord_t r_out = lv_area_get_width(&scale_area) / 2;
-    lv_point_t scale_center;
-    scale_center.x = scale_area.x1 + r_out;
-    scale_center.y = scale_area.y1 + r_out;
+    /* Classical round gauge */
+    if(meter->mode == LV_METER_INDICATOR_MODE_ROUND) {
+        bool rounded = lv_obj_get_style_arc_rounded(obj, LV_PART_ITEMS);
+        lv_coord_t r_out = lv_area_get_width(&scale_area) / 2;
+        lv_point_t scale_center;
 
-    r_out += indic->type_data.arc.r_mod;
+        scale_center.x = scale_area.x1 + r_out;
+        scale_center.y = scale_area.y1 + r_out;
 
-    lv_meter_scale_t * scale = indic->scale;
+        r_out += indic->type_data.arc.r_mod;
 
-    int32_t start_angle = lv_map(old_value, scale->min, scale->max, scale->rotation, scale->angle_range + scale->rotation);
-    int32_t end_angle = lv_map(new_value, scale->min, scale->max, scale->rotation, scale->angle_range + scale->rotation);
+        lv_meter_scale_t * scale = indic->scale;
 
-    lv_area_t a;
-    lv_draw_arc_get_area(scale_center.x, scale_center.y, r_out, LV_MIN(start_angle, end_angle), LV_MAX(start_angle,
-                                                                                                       end_angle), indic->type_data.arc.width, rounded, &a);
+        int32_t start_angle = lv_map(old_value, scale->min, scale->max,
+                                     scale->rotation, scale->angle_range + scale->rotation);
+        int32_t end_angle = lv_map(new_value, scale->min, scale->max,
+                                   scale->rotation, scale->angle_range + scale->rotation);
+
+        lv_draw_arc_get_area(scale_center.x, scale_center.y, r_out,
+                             LV_MIN(start_angle, end_angle), LV_MAX(start_angle,
+                                                                    end_angle), indic->type_data.arc.width, rounded, &a);
+    }
+    else {
+        int32_t scale_min;
+        int32_t scale_max;
+        uint32_t scale_len = 0;
+        uint32_t max_tick_len;
+
+        max_tick_len = indic->scale->tick_major_nth ? indic->scale->tick_major_length :
+                       indic->scale->tick_length;
+
+        get_min_scale(obj, indic->scale, &scale_min, &scale_max);
+
+        if(lv_meter_is_hor(obj)) {
+            scale_len = lv_area_get_width(&scale_area);
+            a.y1 = scale_area.y1 + (lv_area_get_height(&scale_area) - max_tick_len) / 2 -
+                   indic->type_data.arc.r_mod + indic->type_data.arc.width / 2;
+            a.y2 = a.y1;
+            a.x1 = scale_area.x1 + lv_map(old_value, scale_min, scale_max, 0,
+                                          scale_len);
+            a.x2 = scale_area.x1 +  lv_map(new_value, scale_min, scale_max, 0,
+                                           scale_len);
+
+            a.y1 -= indic->type_data.arc.width / 2;
+            a.y2 += indic->type_data.arc.width / 2;
+
+            /*Swap coord for reverse direction*/
+            if(a.x1 > a.x2) {
+                swap_values(&a.x1, &a.x2);
+            }
+        }
+        else {
+            scale_len = lv_area_get_height(&scale_area);
+            a.x1 = scale_area.x1 + (lv_area_get_width(&scale_area) - max_tick_len) / 2 -
+                   indic->type_data.arc.r_mod + indic->type_data.arc.width / 2;
+            a.x2 = a.x1;
+            a.y1 = scale_area.y1 + lv_map(old_value, scale_min, scale_max, 0,
+                                          scale_len);
+            a.y2 = scale_area.y1 + lv_map(new_value, scale_min, scale_max, 0,
+                                          scale_len);
+
+            a.x1 -= indic->type_data.arc.width / 2;
+            a.x2 += indic->type_data.arc.width / 2;
+
+            /*Swap coord for reverse direction*/
+            if(a.y1 > a.y2) {
+                swap_values(&a.y1, &a.y2);
+            }
+        }
+    }
     lv_obj_invalidate_area(obj, &a);
 }
 
@@ -661,7 +1096,8 @@ static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value
     lv_meter_scale_t * scale = indic->scale;
 
     if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_LINE) {
-        int32_t angle = lv_map(value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
+        int32_t angle = lv_map(value, scale->min, scale->max, scale->rotation,
+                               scale->rotation + scale->angle_range);
         r_out += scale->r_mod + indic->type_data.needle_line.r_mod;
         lv_point_t p_end;
         p_end.y = (lv_trigo_sin(angle) * (r_out)) / LV_TRIGO_SIN_MAX + scale_center.y;
@@ -675,8 +1111,67 @@ static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value
 
         lv_obj_invalidate_area(obj, &a);
     }
+    else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_TRIANGLE) {
+        lv_area_t a;
+        uint32_t max_tick_len;
+        lv_point_t tick_center;
+        lv_point_t tick_end;
+        int32_t scale_min;
+        int32_t scale_max;
+
+        get_min_scale(obj, scale, &scale_min, &scale_max);
+
+        max_tick_len = scale->tick_major_length > scale->tick_length ?
+                       scale->tick_major_length : scale->tick_length;
+
+        if(lv_meter_is_hor(obj)) {
+            tick_center.y = scale_area.y1 + lv_area_get_height(&scale_area) / 2 -
+                            indic->type_data.needle_line.r_mod;
+            tick_end.y = tick_center.y + max_tick_len / 2;
+            tick_center.x = scale_area.x1 + lv_map(value, scale_min, scale_max, 0,
+                                                   lv_area_get_width(&scale_area));
+            tick_end.x = tick_center.x;
+
+            if(scale->toggle_needle_side) {
+                a.x1 = tick_center.x - TRIANGLE_NEEDLE_SZ_PX;
+                a.x2 = tick_center.x + TRIANGLE_NEEDLE_SZ_PX;
+                a.y1 = tick_end.y - max_tick_len - TRIANGLE_NEEDLE_SZ_PX;
+                a.y2 = a.y1 + TRIANGLE_NEEDLE_SZ_PX;
+            }
+            else {
+                a.x1 = tick_end.x - TRIANGLE_NEEDLE_SZ_PX;
+                a.x2 = tick_end.x + TRIANGLE_NEEDLE_SZ_PX;
+                a.y1 = tick_end.y;
+                a.y2 = tick_end.y + TRIANGLE_NEEDLE_SZ_PX;
+            }
+        }
+        else {
+            tick_center.x = scale_area.x1 + lv_area_get_width(&scale_area) / 2 -
+                            indic->type_data.needle_line.r_mod;
+            tick_end.x = tick_center.x + max_tick_len / 2;
+            tick_center.y = scale_area.y1 + lv_map(value, scale_min, scale_max, 0,
+                                                   lv_area_get_height(&scale_area));
+            tick_end.y = tick_center.y;
+
+            if(scale->toggle_needle_side) {
+                a.x1 = tick_end.x - max_tick_len - TRIANGLE_NEEDLE_SZ_PX;
+                a.x2 = tick_center.x;
+                a.y1 = tick_center.y - TRIANGLE_NEEDLE_SZ_PX;
+                a.y2 = tick_center.y + TRIANGLE_NEEDLE_SZ_PX;
+            }
+            else {
+                a.x1 = tick_end.x;
+                a.x2 = tick_end.x + TRIANGLE_NEEDLE_SZ_PX;
+                a.y1 = tick_end.y - TRIANGLE_NEEDLE_SZ_PX;
+                a.y2 = tick_end.y + TRIANGLE_NEEDLE_SZ_PX;
+            }
+        }
+
+        lv_obj_invalidate_area(obj, &a);
+    }
     else if(indic->type == LV_METER_INDICATOR_TYPE_NEEDLE_IMG) {
-        int32_t angle = lv_map(value, scale->min, scale->max, scale->rotation, scale->rotation + scale->angle_range);
+        int32_t angle = lv_map(value, scale->min, scale->max, scale->rotation,
+                               scale->rotation + scale->angle_range);
         lv_img_header_t info;
         lv_img_decoder_get_info(indic->type_data.needle_img.src, &info);
 
@@ -686,7 +1181,8 @@ static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value
         scale_center.x -= indic->type_data.needle_img.pivot.x;
         scale_center.y -= indic->type_data.needle_img.pivot.y;
         lv_area_t a;
-        _lv_img_buf_get_transformed_area(&a, info.w, info.h, angle, LV_IMG_ZOOM_NONE, &indic->type_data.needle_img.pivot);
+        _lv_img_buf_get_transformed_area(&a, info.w, info.h, angle, LV_IMG_ZOOM_NONE,
+                                         &indic->type_data.needle_img.pivot);
         a.x1 += scale_center.x - 2;
         a.y1 += scale_center.y - 2;
         a.x2 += scale_center.x + 2;

--- a/src/extra/widgets/meter/lv_meter.h
+++ b/src/extra/widgets/meter/lv_meter.h
@@ -47,17 +47,26 @@ typedef struct {
     int32_t min;
     int32_t max;
     int16_t r_mod;
+
     uint16_t angle_range;
     int16_t rotation;
+    uint8_t toggle_needle_side;
 } lv_meter_scale_t;
 
 enum {
     LV_METER_INDICATOR_TYPE_NEEDLE_IMG,
     LV_METER_INDICATOR_TYPE_NEEDLE_LINE,
     LV_METER_INDICATOR_TYPE_SCALE_LINES,
+    LV_METER_INDICATOR_TYPE_NEEDLE_TRIANGLE,
     LV_METER_INDICATOR_TYPE_ARC,
 };
 typedef uint8_t lv_meter_indicator_type_t;
+
+enum {
+    LV_METER_INDICATOR_MODE_ROUND,
+    LV_METER_INDICATOR_MODE_LINEAR,
+};
+typedef uint8_t lv_meter_indicator_mode_t;
 
 typedef struct {
     lv_meter_scale_t * scale;
@@ -95,6 +104,7 @@ typedef struct {
     lv_obj_t obj;
     lv_ll_t scale_ll;
     lv_ll_t indicator_ll;
+    lv_meter_indicator_mode_t mode;
 } lv_meter_t;
 
 extern const lv_obj_class_t lv_meter_class;
@@ -253,6 +263,30 @@ void lv_meter_set_indicator_start_value(lv_obj_t * obj, lv_meter_indicator_t * i
  * @param value         the new value
  */
 void lv_meter_set_indicator_end_value(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value);
+
+
+/*=====================
+ * Set indicator options
+ *====================*/
+
+
+/**
+ * Set indicator mode. By default for is 'LV_METER_INDICATOR_MODE_ROUND'
+ * For the classical 'LV_METER_INDICATOR_MODE_ROUND' meter
+ * height and width of the 'obj' must be the same!
+ * @param obj           pointer to a meter object
+ * @param mode          type of meter mode
+ */
+void lv_meter_set_indicator_mode(lv_obj_t * obj, lv_meter_indicator_mode_t mode);
+
+/**
+ * Swap labels with needle. Usable for vertical meter.
+ * By default needle is under the scale and labels is above the scale(horizontal meter)
+ * For the vertical meter: needle is on the right and labels is on the left
+ * @param scale         scale
+ * @param toggle_side   If true - the labels will be swapped with the needle once.
+ */
+void lv_meter_set_needle_side(lv_meter_scale_t * scale, bool toggle_side);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Based on the current meter expand them for supporting vertical and horizontal linear meter. The algorithms and api for the old meter is still the same for the backward compatibility. For using another form of meter just change the form(by default form is round):

` lv_meter_set_indicator_form(obj, LV_METER_INDICATOR_FORM_LINEAR);`

Also you can set the direction of scale(by default: left to rigth and up to down):

` lv_obj_set_style_base_dir(meter, LV_BASE_DIR_RTL, 0);`

And swap the labels with needle, if needed:

` lv_meter_set_needle_side(scale, toggle_side);`

If widget width >= height the result form is horizontal otherwise it is a vertical. All current meters can be linear, EXCEPT the clock meter, because you know, it's a clock :)

issue #10986

https://user-images.githubusercontent.com/11601575/222968104-c5c01036-e73a-429c-bd17-dbc212b966a4.mp4


### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
