### PR TITLE
chore(theme_default): fix warning

### DIFF
--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -1017,7 +1017,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         lv_obj_add_style(obj, &styles->card, 0);
         lv_obj_add_style(obj, &styles->pad_zero, 0);
     }
-#endif
 
 #if LV_USE_CALENDAR_HEADER_ARROW
     else if(lv_obj_check_type(obj, &lv_calendar_header_arrow_class)) {
@@ -1029,6 +1028,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
     else if(lv_obj_check_type(obj, &lv_calendar_header_dropdown_class)) {
         lv_obj_add_style(obj, &styles->calendar_header, 0);
     }
+#endif
 #endif
 
 #if LV_USE_KEYBOARD


### PR DESCRIPTION
### Description of the feature or fix

Fix `LV_USE_THEME_DEFAULT=1` `LV_USE_CALENDAR=0` configuration warning.

```bash
lvgl/src/themes/default/lv_theme_default.c: In function ‘theme_apply’: lvgl/src/themes/default/lv_theme_default.c:1021:5: warning: "LV_USE_CALENDAR_HEADER_ARROW" is not defined, evaluates to 0 [-Wundef]
 1021 | #if LV_USE_CALENDAR_HEADER_ARROW
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/themes/default/lv_theme_default.c:1027:5: warning: "LV_USE_CALENDAR_HEADER_DROPDOWN" is not defined, evaluates to 0 [-Wundef]
 1027 | #if LV_USE_CALENDAR_HEADER_DROPDOWN
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 33%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/canvas/lv_canvas.c.o
[ 33%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/checkbox/lv_checkbox.c.o
[ 33%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/chart/lv_chart.c.o
[ 33%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/dropdown/lv_dropdown.c.o
[ 34%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/colorwheel/lv_colorwheel.c.o
[ 34%] Building C object lvgl/CMakeFiles/lvgl.dir/src/widgets/img/lv_img.c.o
In file included from lvgl/src/widgets/calendar/lv_calendar_header_arrow.c:9:
lvgl/src/widgets/calendar/lv_calendar_header_arrow.h:17:5: warning: "LV_USE_CALENDAR_HEADER_ARROW" is not defined, evaluates to 0 [-Wundef]
   17 | #if LV_USE_CALENDAR_HEADER_ARROW
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/widgets/calendar/lv_calendar_header_arrow.c:10:5: warning: "LV_USE_CALENDAR_HEADER_ARROW" is not defined, evaluates to 0 [-Wundef]
   10 | #if LV_USE_CALENDAR_HEADER_ARROW
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c:9:
lvgl/src/widgets/calendar/lv_calendar_header_dropdown.h:17:5: warning: "LV_USE_CALENDAR_HEADER_DROPDOWN" is not defined, evaluates to 0 [-Wundef]
   17 | #if LV_USE_CALENDAR_HEADER_DROPDOWN
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c:10:5: warning: "LV_USE_CALENDAR_HEADER_DROPDOWN" is not defined, evaluates to 0 [-Wundef]
   10 | #if LV_USE_CALENDAR_HEADER_DROPDOWN
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
