### PR TITLE
fix(draw): fix draw sw subpx font build error

### DIFF
--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -450,7 +450,7 @@ static void draw_letter_subpx(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_
     uint8_t font_rgb[3];
 
     lv_color_t color = dsc->color;
-    uint8_t txt_rgb[3] = {color.ch.red, color.ch.green, color.ch.blue};
+    uint8_t txt_rgb[3] = {color.red, color.green, color.blue};
 
     lv_draw_sw_blend_dsc_t blend_dsc;
     lv_memzero(&blend_dsc, sizeof(blend_dsc));
@@ -489,20 +489,20 @@ static void draw_letter_subpx(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_
                 subpx_cnt = 0;
 
                 lv_color_t res_color;
-                uint8_t bg_rgb[3] = {dest_buf_tmp->ch.red, dest_buf_tmp->ch.green, dest_buf_tmp->ch.blue};
+                uint8_t bg_rgb[3] = {dest_buf_tmp->red, dest_buf_tmp->green, dest_buf_tmp->blue};
 
 #if LV_DRAW_SW_FONT_SUBPX_BGR
-                res_color.ch.red = (uint32_t)((uint16_t)txt_rgb[0] * font_rgb[2] + (bg_rgb[0] * (255 - font_rgb[2]))) >> 8;
-                res_color.ch.blue = (uint32_t)((uint16_t)txt_rgb[2] * font_rgb[0] + (bg_rgb[2] * (255 - font_rgb[0]))) >> 8;
+                res_color.red = (uint32_t)((uint16_t)txt_rgb[0] * font_rgb[2] + (bg_rgb[0] * (255 - font_rgb[2]))) >> 8;
+                res_color.blue = (uint32_t)((uint16_t)txt_rgb[2] * font_rgb[0] + (bg_rgb[2] * (255 - font_rgb[0]))) >> 8;
 #else
-                res_color.ch.red = (uint32_t)((uint16_t)txt_rgb[0] * font_rgb[0] + (bg_rgb[0] * (255 - font_rgb[0]))) >> 8;
-                res_color.ch.blue = (uint32_t)((uint16_t)txt_rgb[2] * font_rgb[2] + (bg_rgb[2] * (255 - font_rgb[2]))) >> 8;
+                res_color.red = (uint32_t)((uint16_t)txt_rgb[0] * font_rgb[0] + (bg_rgb[0] * (255 - font_rgb[0]))) >> 8;
+                res_color.blue = (uint32_t)((uint16_t)txt_rgb[2] * font_rgb[2] + (bg_rgb[2] * (255 - font_rgb[2]))) >> 8;
 #endif
 
-                res_color.ch.green = (uint32_t)((uint32_t)txt_rgb[1] * font_rgb[1] + (bg_rgb[1] * (255 - font_rgb[1]))) >> 8;
+                res_color.green = (uint32_t)((uint32_t)txt_rgb[1] * font_rgb[1] + (bg_rgb[1] * (255 - font_rgb[1]))) >> 8;
 
 #if LV_COLOR_DEPTH == 32
-                res_color.ch.alpha = 0xff;
+                res_color.alpha = 0xff;
 #endif
 
                 if(font_rgb[0] == 0 && font_rgb[1] == 0 && font_rgb[2] == 0) mask_buf[mask_p] = LV_OPA_TRANSP;


### PR DESCRIPTION
### Description of the feature or fix

Compile error when `LV_DRAW_SW_FONT_SUBPX=1`

```bash
lvgl/src/draw/sw/lv_draw_sw_letter.c: In function ‘draw_letter_subpx’: lvgl/src/draw/sw/lv_draw_sw_letter.c:453:32: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  453 |     uint8_t txt_rgb[3] = {color.ch.red, color.ch.green, color.ch.blue};
      |                                ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:453:46: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  453 |     uint8_t txt_rgb[3] = {color.ch.red, color.ch.green, color.ch.blue};
      |                                              ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:453:62: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  453 |     uint8_t txt_rgb[3] = {color.ch.red, color.ch.green, color.ch.blue};
      |                                                              ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:492:50: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  492 |                 uint8_t bg_rgb[3] = {dest_buf_tmp->ch.red, dest_buf_tmp->ch.green, dest_buf_tmp->ch.blue};
      |                                                  ^~
lvgl/src/draw/sw/lv_draw_sw_letter.c:492:72: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  492 |                 uint8_t bg_rgb[3] = {dest_buf_tmp->ch.red, dest_buf_tmp->ch.green, dest_buf_tmp->ch.blue};
      |                                                                        ^~
lvgl/src/draw/sw/lv_draw_sw_letter.c:492:96: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  492 |                 uint8_t bg_rgb[3] = {dest_buf_tmp->ch.red, dest_buf_tmp->ch.green, dest_buf_tmp->ch.blue};
      |                                                                                                ^~
lvgl/src/draw/sw/lv_draw_sw_letter.c:498:26: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  498 |                 res_color.ch.red = (uint32_t)((uint16_t)txt_rgb[0] * font_rgb[0] + (bg_rgb[0] * (255 - font_rgb[0]))) >> 8;
      |                          ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:499:26: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  499 |                 res_color.ch.blue = (uint32_t)((uint16_t)txt_rgb[2] * font_rgb[2] + (bg_rgb[2] * (255 - font_rgb[2]))) >> 8;
      |                          ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:502:26: error: ‘lv_color_t’ {aka ‘struct <anonymous>’} has no member named ‘ch’
  502 |                 res_color.ch.green = (uint32_t)((uint32_t)txt_rgb[1] * font_rgb[1] + (bg_rgb[1] * (255 - font_rgb[1]))) >> 8;
      |                          ^
lvgl/src/draw/sw/lv_draw_sw_letter.c:452:16: warning: variable ‘color’ set but not used [-Wunused-but-set-variable]
  452 |     lv_color_t color = dsc->color;
      |                ^~~~~
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
