### PR TITLE
refact(user_data): remove LV_USE_USER_DATA configuration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -441,10 +441,6 @@ menu "LVGL configuration"
 				bool "Enable float in built-in (v)snprintf functions"
 				depends on !LV_SPRINTF_CUSTOM
 
-			config LV_USE_USER_DATA
-				bool "Add a 'user_data' to drivers and objects."
-				default y
-
 			config LV_ENABLE_GC
 				bool "Enable garbage collector"
 

--- a/demos/flex_layout/lv_demo_flex_layout_ctrl_pad.c
+++ b/demos/flex_layout/lv_demo_flex_layout_ctrl_pad.c
@@ -9,7 +9,7 @@
 
 #include "lv_demo_flex_layout_main.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/flex_layout/lv_demo_flex_layout_flex_loader.c
+++ b/demos/flex_layout/lv_demo_flex_layout_flex_loader.c
@@ -9,7 +9,7 @@
 
 #include "lv_demo_flex_layout_main.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/flex_layout/lv_demo_flex_layout_main.c
+++ b/demos/flex_layout/lv_demo_flex_layout_main.c
@@ -10,7 +10,7 @@
 #include "lv_demo_flex_layout_main.h"
 #include "lv_demo_flex_layout.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/flex_layout/lv_demo_flex_layout_view.c
+++ b/demos/flex_layout/lv_demo_flex_layout_view.c
@@ -9,7 +9,7 @@
 
 #include "lv_demo_flex_layout_main.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/flex_layout/lv_demo_flex_layout_view_child_node.c
+++ b/demos/flex_layout/lv_demo_flex_layout_view_child_node.c
@@ -9,7 +9,7 @@
 
 #include "lv_demo_flex_layout_main.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/flex_layout/lv_demo_flex_layout_view_ctrl_pad.c
+++ b/demos/flex_layout/lv_demo_flex_layout_view_ctrl_pad.c
@@ -9,7 +9,7 @@
 
 #include "lv_demo_flex_layout_main.h"
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 
 /*********************
  *      DEFINES

--- a/demos/lv_demos.h
+++ b/demos/lv_demos.h
@@ -35,7 +35,7 @@ extern "C" {
 #include "widgets/lv_demo_widgets.h"
 #endif
 
-#if LV_USE_DEMO_FLEX_LAYOUT && LV_USE_USER_DATA
+#if LV_USE_DEMO_FLEX_LAYOUT
 #include "flex_layout/lv_demo_flex_layout.h"
 #endif
 

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -279,8 +279,6 @@
  *Only used if software rotation is enabled in the display driver.*/
 #define LV_DISP_ROT_MAX_BUF (10*1024)
 
-#define LV_USE_USER_DATA 1
-
 /*Garbage Collector settings
  *Used if lvgl is bound to higher level language and the memory is managed by that language*/
 #define LV_ENABLE_GC 0

--- a/examples/widgets/menu/lv_example_menu_3.c
+++ b/examples/widgets/menu/lv_example_menu_3.c
@@ -1,5 +1,5 @@
 #include "../../lv_examples.h"
-#if LV_USE_MENU && LV_USE_USER_DATA && LV_BUILD_EXAMPLES
+#if LV_USE_MENU && LV_BUILD_EXAMPLES
 
 void lv_example_menu_3(void)
 {

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -297,8 +297,6 @@
  *Only used if software rotation is enabled in the display driver.*/
 #define LV_DISP_ROT_MAX_BUF (10*1024)
 
-#define LV_USE_USER_DATA 1
-
 /*Garbage Collector settings
  *Used if lvgl is bound to higher level language and the memory is managed by that language*/
 #define LV_ENABLE_GC 0

--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -863,13 +863,7 @@ void lv_disp_set_user_data(lv_disp_t * disp, void * user_data)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) return;
-
-#if LV_USE_USER_DATA
     disp->user_data = user_data;
-#else
-    LV_UNUSED(user_data);
-    LV_LOG_WARN("LV_USE_USER_DATA is not enabled");
-#endif
 }
 
 void lv_disp_set_driver_data(lv_disp_t * disp, void * driver_data)
@@ -884,13 +878,7 @@ void * lv_disp_get_user_data(lv_disp_t * disp)
 {
     if(!disp) disp = lv_disp_get_default();
     if(!disp) return NULL;
-
-#if LV_USE_USER_DATA
     return disp->user_data;
-#else
-    LV_LOG_WARN("LV_USE_USER_DATA is no enabled");
-    return NULL;
-#endif
 }
 
 void * lv_disp_get_driver_data(lv_disp_t * disp)

--- a/src/core/lv_disp_private.h
+++ b/src/core/lv_disp_private.h
@@ -125,9 +125,7 @@ typedef struct _lv_disp_t {
 
     void * driver_data; /**< Custom user data*/
 
-#if LV_USE_USER_DATA
     void * user_data; /**< Custom user data*/
-#endif
 
     lv_event_list_t event_list;
 

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -61,10 +61,7 @@ lv_group_t * lv_group_create(void)
     group->editing        = 0;
     group->refocus_policy = LV_GROUP_REFOCUS_POLICY_PREV;
     group->wrap           = 1;
-
-#if LV_USE_USER_DATA
-    group->user_data = NULL;
-#endif
+    group->user_data      = NULL;
 
     return group;
 }

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -65,9 +65,7 @@ typedef struct _lv_group_t {
                                                     targets are available in this direction (to allow edge feedback
                                                     like a sound or a scroll bounce) */
 
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
 
     uint8_t frozen : 1;         /**< 1: can't focus to new object*/
     uint8_t editing : 1;        /**< 1: Edit mode, 0: Navigate mode*/

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -259,12 +259,7 @@ void lv_indev_set_read_cb(lv_indev_t * indev,  void (*read_cb)(struct _lv_indev_
 void lv_indev_set_user_data(lv_indev_t * indev, void * user_data)
 {
     if(indev == NULL) return;
-#if LV_USE_USER_DATA
     indev->user_data = user_data;
-#else
-    LV_UNUSED(user_data);
-    LV_LOG_WARN("LV_USE_USER_DATA is no enabled");
-#endif
 }
 
 void lv_indev_set_driver_data(lv_indev_t * indev, void * driver_data)
@@ -312,13 +307,7 @@ void lv_indev_set_disp(lv_indev_t * indev, lv_disp_t * disp)
 void * lv_indev_get_user_data(const lv_indev_t * indev)
 {
     if(indev == NULL) return NULL;
-
-#if LV_USE_USER_DATA
     return indev->user_data;
-#else
-    LV_LOG_WARN("LV_USE_USER_DATA is no enabled");
-    return NULL;
-#endif
 }
 
 void * lv_indev_get_driver_data(const lv_indev_t * indev)

--- a/src/core/lv_indev_private.h
+++ b/src/core/lv_indev_private.h
@@ -45,10 +45,7 @@ typedef struct _lv_indev_t {
     uint32_t longpr_rep_timestamp; /**< Long press repeat time stamp*/
 
     void * driver_data;
-
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
 
     /**< Pointer to the assigned display*/
     struct _lv_disp_t * disp;

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -994,9 +994,7 @@ static void lv_obj_set_state(lv_obj_t * obj, lv_state_t new_state)
                 ts[tsi].delay = tr->delay;
                 ts[tsi].path_cb = tr->path_xcb;
                 ts[tsi].prop = tr->props[j];
-#if LV_USE_USER_DATA
                 ts[tsi].user_data = tr->user_data;
-#endif
                 ts[tsi].selector = obj_style->selector;
                 tsi++;
             }

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -175,9 +175,7 @@ typedef struct _lv_obj_t {
     struct _lv_obj_t * parent;
     _lv_obj_spec_attr_t * spec_attr;
     _lv_obj_style_t * styles;
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
     lv_area_t coords;
     lv_obj_flag_t flags;
     lv_state_t state;
@@ -262,12 +260,10 @@ void lv_obj_clear_state(lv_obj_t * obj, lv_state_t state);
  * @param obj   pointer to an object
  * @param user_data   pointer to the new user_data.
  */
-#if LV_USE_USER_DATA
 static inline void lv_obj_set_user_data(lv_obj_t * obj, void * user_data)
 {
     obj->user_data = user_data;
 }
-#endif
 
 /*=======================
  * Getter functions
@@ -316,12 +312,10 @@ lv_group_t * lv_obj_get_group(const lv_obj_t * obj);
  * @param obj   pointer to an object
  * @return      the pointer to the user_data of the object
  */
-#if LV_USE_USER_DATA
 static inline void * lv_obj_get_user_data(lv_obj_t * obj)
 {
     return obj->user_data;
 }
-#endif
 
 /*=======================
  * Other functions

--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -56,11 +56,9 @@ typedef struct _lv_obj_class_t {
     const struct _lv_obj_class_t * base_class;
     void (*constructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
     void (*destructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
-#if LV_USE_USER_DATA
-    void * user_data;
-#endif
     void (*event_cb)(const struct _lv_obj_class_t * class_p,
                      struct _lv_event_t * e);  /**< Widget type specific event function*/
+    void * user_data;
     lv_coord_t width_def;
     lv_coord_t height_def;
     uint32_t editable : 2;             /**< Value from ::lv_obj_class_editable_t*/

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -428,9 +428,7 @@ void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t 
     lv_anim_set_delay(&a, tr_dsc->delay);
     lv_anim_set_path_cb(&a, tr_dsc->path_cb);
     lv_anim_set_early_apply(&a, false);
-#if LV_USE_USER_DATA
-    a.user_data = tr_dsc->user_data;
-#endif
+    lv_anim_set_user_data(&a, tr_dsc->user_data);
     lv_anim_start(&a);
 }
 

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -55,9 +55,7 @@ typedef struct {
     lv_style_selector_t selector;
     lv_style_prop_t prop;
     lv_anim_path_cb_t path_cb;
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
 } _lv_obj_style_transition_dsc_t;
 
 /**********************

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -195,10 +195,7 @@ typedef struct _lv_draw_ctx_t  {
      */
     size_t layer_instance_size;
 
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
-
 } lv_draw_ctx_t;
 
 /**********************

--- a/src/draw/lv_img_decoder.h
+++ b/src/draw/lv_img_decoder.h
@@ -88,10 +88,7 @@ typedef struct _lv_img_decoder_t {
     lv_img_decoder_open_f_t open_cb;
     lv_img_decoder_read_line_f_t read_line_cb;
     lv_img_decoder_close_f_t close_cb;
-
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
 } lv_img_decoder_t;
 
 

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -78,9 +78,7 @@ typedef struct _lv_font_t {
 
     const void * dsc;               /**< Store implementation specific or run_time data or caching here*/
     const struct _lv_font_t * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
-#if LV_USE_USER_DATA
     void * user_data;               /**< Custom user data for font.*/
-#endif
 } lv_font_t;
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -905,18 +905,6 @@
     #endif
 #endif
 
-#ifndef LV_USE_USER_DATA
-    #ifdef _LV_KCONFIG_PRESENT
-        #ifdef CONFIG_LV_USE_USER_DATA
-            #define LV_USE_USER_DATA CONFIG_LV_USE_USER_DATA
-        #else
-            #define LV_USE_USER_DATA 0
-        #endif
-    #else
-        #define LV_USE_USER_DATA 1
-    #endif
-#endif
-
 /*Garbage Collector settings
  *Used if lvgl is bound to higher level language and the memory is managed by that language*/
 #ifndef LV_ENABLE_GC

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -77,9 +77,7 @@ typedef struct _lv_anim_t {
     lv_anim_ready_cb_t ready_cb;         /**< Call it when the animation is ready*/
     lv_anim_deleted_cb_t deleted_cb;     /**< Call it when the animation is deleted*/
     lv_anim_get_value_cb_t get_value_cb; /**< Get the current value in relative mode*/
-#if LV_USE_USER_DATA
-    void * user_data; /**< Custom user data*/
-#endif
+    void * user_data;                    /**< Custom user data*/
     lv_anim_path_cb_t path_cb;         /**< Describe the path (curve) of animations*/
     int32_t start_value;               /**< Start value*/
     int32_t current_value;             /**< Current value*/
@@ -296,12 +294,10 @@ static inline void lv_anim_set_early_apply(lv_anim_t * a, bool en)
  * @param a           pointer to an initialized `lv_anim_t` variable
  * @param user_data   pointer to the new user_data.
  */
-#if LV_USE_USER_DATA
 static inline void lv_anim_set_user_data(lv_anim_t * a, void * user_data)
 {
     a->user_data = user_data;
 }
-#endif
 
 /**
  * Create an animation
@@ -352,12 +348,10 @@ static inline uint16_t lv_anim_get_repeat_count(lv_anim_t * a)
  * @param   a pointer to an initialized `lv_anim_t` variable
  * @return  the pointer to the custom user_data of the animation
  */
-#if LV_USE_USER_DATA
 static inline void * lv_anim_get_user_data(lv_anim_t * a)
 {
     return a->user_data;
 }
-#endif
 
 /**
  * Delete an animation of a variable with a given animator function

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -83,9 +83,7 @@ typedef struct _lv_fs_drv_t {
     lv_fs_res_t (*dir_read_cb)(struct _lv_fs_drv_t * drv, void * rddir_p, char * fn);
     lv_fs_res_t (*dir_close_cb)(struct _lv_fs_drv_t * drv, void * rddir_p);
 
-#if LV_USE_USER_DATA
     void * user_data; /**< Custom file user data*/
-#endif
 } lv_fs_drv_t;
 
 typedef struct {

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -308,11 +308,7 @@ void lv_style_transition_dsc_init(lv_style_transition_dsc_t * tr, const lv_style
     tr->path_xcb = path_cb == NULL ? lv_anim_path_linear : path_cb;
     tr->time = time;
     tr->delay = delay;
-#if LV_USE_USER_DATA
     tr->user_data = user_data;
-#else
-    LV_UNUSED(user_data);
-#endif
 }
 
 lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -304,9 +304,7 @@ typedef uint8_t lv_style_res_t;
  */
 typedef struct {
     const lv_style_prop_t * props; /**< An array with the properties to animate.*/
-#if LV_USE_USER_DATA
     void * user_data;              /**< A custom user data that will be passed to the animation's user_data */
-#endif
     lv_anim_path_cb_t path_xcb;     /**< A path for the animation.*/
     uint32_t time;                 /**< Duration of the transition in [ms]*/
     uint32_t delay;                /**< Delay before the transition in [ms]*/

--- a/src/others/monkey/lv_monkey.c
+++ b/src/others/monkey/lv_monkey.c
@@ -24,9 +24,7 @@ struct _lv_monkey {
     lv_indev_data_t indev_data;
     lv_indev_t * indev;
     lv_timer_t * timer;
-#if LV_USE_USER_DATA
     void * user_data;
-#endif
 };
 
 static const lv_key_t lv_key_map[] = {
@@ -100,8 +98,6 @@ bool lv_monkey_get_enable(lv_monkey_t * monkey)
     return !monkey->timer->paused;
 }
 
-#if LV_USE_USER_DATA
-
 void lv_monkey_set_user_data(lv_monkey_t * monkey, void * user_data)
 {
     LV_ASSERT_NULL(monkey);
@@ -113,8 +109,6 @@ void * lv_monkey_get_user_data(lv_monkey_t * monkey)
     LV_ASSERT_NULL(monkey);
     return monkey->user_data;
 }
-
-#endif
 
 void lv_monkey_del(lv_monkey_t * monkey)
 {

--- a/src/others/monkey/lv_monkey.h
+++ b/src/others/monkey/lv_monkey.h
@@ -81,8 +81,6 @@ void lv_monkey_set_enable(lv_monkey_t * monkey, bool en);
  */
 bool lv_monkey_get_enable(lv_monkey_t * monkey);
 
-#if LV_USE_USER_DATA
-
 /**
  * Set the user_data field of the monkey
  * @param monkey   pointer to a monkey
@@ -96,8 +94,6 @@ void lv_monkey_set_user_data(lv_monkey_t * monkey, void * user_data);
  * @return the pointer to the user_data of the monkey
  */
 void * lv_monkey_get_user_data(lv_monkey_t * monkey);
-
-#endif/*LV_USE_USER_DATA*/
 
 /**
  * Delete monkey

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -13,7 +13,6 @@
 #define LV_USE_ASSERT_MEM_INTEGRITY     1
 #define LV_USE_ASSERT_OBJ               1
 #define LV_USE_ASSERT_STYLE             1
-#define LV_USE_USER_DATA                1
 #define LV_USE_LARGE_COORD      1
 
 #define LV_FONT_MONTSERRAT_8    1

--- a/tests/src/lv_test_conf_minimal.h
+++ b/tests/src/lv_test_conf_minimal.h
@@ -7,7 +7,6 @@
 #define  LV_USE_ASSERT_MEM_INTEGRITY    0
 #define  LV_USE_ASSERT_OBJ              0
 #define  LV_USE_ASSERT_STYLE            0
-#define  LV_USE_USER_DATA               0
 
 #define  LV_USE_BIDI                    0
 #define  LV_USE_ARABIC_PERSIAN_CHARS    0


### PR DESCRIPTION
### Description of the feature or fix

Related discussion: https://github.com/lvgl/lvgl/issues/4051

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
