### PR TITLE
fix(demo_flex_layout): fix warning

### DIFF
--- a/demos/flex_layout/lv_demo_flex_layout_view.c
+++ b/demos/flex_layout/lv_demo_flex_layout_view.c
@@ -101,7 +101,7 @@ void view_create(lv_obj_t * par, view_t * ui)
     ui->ctrl_pad.btn.add = btn_create(obj, "Add", lv_palette_main(LV_PALETTE_BLUE_GREY));
     ui->ctrl_pad.btn.remove = btn_create(obj, "Remove", lv_palette_main(LV_PALETTE_RED));
 
-    lv_event_send(ui->root, LV_EVENT_CLICKED, NULL); /*Make it active by default*/
+    lv_obj_send_event(ui->root, LV_EVENT_CLICKED, NULL); /*Make it active by default*/
 
     /* fade effect */
     lv_obj_fade_in(ui->root, 600, 0);


### PR DESCRIPTION
### Description of the feature or fix

Fix warnings from API changes
https://github.com/lvgl/lvgl/pull/3755#issuecomment-1467881261

```bash
demos/flex_layout/lv_demo_flex_layout_view.c(104,19): warning: incompatible pointer types passing 'lv_obj_t *' (aka 'struct _lv_obj_t *') to  parameter of type 'lv_event_list_t *' [-Wincompatible-pointer-types]
    lv_event_send(ui->root, LV_EVENT_CLICKED, NULL); /*Make it active by default*/
                  ^~~~~~~~
src/core/misc/lv_event.h(143,42): note: passing argument to parameter 'list' here lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool prerpocess);
                                         ^
demos/flex_layout/lv_demo_flex_layout_view.c(104,29): error: incompatible integer to pointer conversion passing 'int' to parameter of type 'lv_event_t *' (aka 'struct _lv_event_t *') [-Wint-conversion]
    lv_event_send(ui->root, LV_EVENT_CLICKED, NULL); /*Make it active by default*/
                            ^~~~~~~~~~~~~~~~
src/core/misc/lv_event.h(143,61): note: passing argument to parameter 'e' here lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool prerpocess);
                                                            ^
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
