### PR TITLE
fix(event): fix typo prerpocess -> preprocess

### DIFF
--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -61,7 +61,7 @@ void _lv_event_pop(lv_event_t * e)
     event_head = e->prev;
 }
 
-lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool prerpocess)
+lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preprocess)
 {
     if(list == NULL) return LV_RES_OK;
 
@@ -69,7 +69,7 @@ lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool prerpocess)
     for(i = 0; i < list->cnt; i++) {
         if(list->dsc[i].cb == NULL) continue;
         bool is_preprocessed = (list->dsc[i].filter & LV_EVENT_PREPROCESS) != 0;
-        if(is_preprocessed != prerpocess) continue;
+        if(is_preprocessed != preprocess) continue;
         lv_event_code_t filter = list->dsc[i].filter & ~LV_EVENT_PREPROCESS;
         if(filter == LV_EVENT_ALL || filter == e->code) {
             e->user_data = list->dsc[i].user_data;

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -140,8 +140,7 @@ void _lv_event_push(lv_event_t * e);
 
 void _lv_event_pop(lv_event_t * e);
 
-lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool prerpocess);
-
+lv_res_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preprocess);
 
 void lv_event_add(lv_event_list_t * list, lv_event_cb_t cb, lv_event_code_t filter, void * user_data);
 


### PR DESCRIPTION
### Description of the feature or fix

https://github.com/lvgl/lvgl/pull/3755#issuecomment-1467881261

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
