### PR TITLE
chore: fix warnings

### DIFF
--- a/src/core/lv_disp_private.h
+++ b/src/core/lv_disp_private.h
@@ -26,7 +26,7 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct _lv_disp_t {
+struct _lv_disp_t {
 
     /*---------------------
      * Resolution
@@ -151,7 +151,7 @@ typedef struct _lv_disp_t {
     /** On CHROMA_KEYED images this color will be transparent.
      * `LV_COLOR_CHROMA_KEY` by default. (lv_conf.h) */
     lv_color_t color_chroma_key;
-} lv_disp_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/core/lv_indev_private.h
+++ b/src/core/lv_indev_private.h
@@ -22,7 +22,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef struct _lv_indev_t {
+struct _lv_indev_t {
     /**< Input device type*/
     lv_indev_type_t type;
 
@@ -102,7 +102,7 @@ typedef struct _lv_indev_t {
     struct _lv_group_t * group;    /**< Keypad destination group*/
     const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed
                                       here by the buttons*/
-} lv_indev_t;
+};
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -18,11 +18,6 @@
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct _lv_event_dsc_t {
-    lv_event_cb_t cb;
-    void * user_data;
-    lv_event_code_t filter : 8;
-} lv_event_dsc_t;
 
 /**********************
  *  STATIC PROTOTYPES

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -18,11 +18,11 @@
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct _lv_event_dsc_t {
+struct _lv_event_dsc_t {
     lv_event_cb_t cb;
     void * user_data;
     uint32_t filter;
-} lv_event_dsc_t;
+};
 
 /**********************
  *  STATIC PROTOTYPES


### PR DESCRIPTION
### Description of the feature or fix

fix warnings on macOS with clang

```bash
In file included from lvgl/src/core/lv_obj_event.c:11:
lvgl/src/core/lv_indev_private.h:105:3: warning: redefinition of typedef 'lv_indev_t' is a C11 feature [-Wtypedef-redefinition]
} lv_indev_t;
  ^
lvgl/src/core/lv_indev.h:32:28: note: previous definition is here
typedef struct _lv_indev_t lv_indev_t;
                           ^
lvgl/src/core/lv_obj_event.c:25:3: warning: redefinition of typedef 'lv_event_dsc_t' is a C11 feature [-Wtypedef-redefinition]
} lv_event_dsc_t;
  ^
lvgl/src/core/../misc/lv_event.h:30:32: note: previous definition is here
typedef struct _lv_event_dsc_t lv_event_dsc_t;

In file included from lvgl/examples/libs/gif/img_bulb_gif.c:1:
In file included from lvgl/src/libs/tiny_ttf/../../../lvgl.h:114:
In file included from lvgl/src/lvgl_private.h:16:
lvgl/src/misc/../core/lv_disp_private.h:154:3: warning: redefinition of typedef 'lv_disp_t' is a C11 feature [-Wtypedef-redefinition]
} lv_disp_t;
  ^
lvgl/src/dev/disp/fb/../../../core/lv_disp.h:37:27: note: previous definition is here
typedef struct _lv_disp_t lv_disp_t;
                          ^
In file included from lvgl/examples/libs/gif/img_bulb_gif.c:1:
In file included from lvgl/src/libs/tiny_ttf/../../../lvgl.h:114:
In file included from lvgl/src/lvgl_private.h:17:
lvgl/src/misc/../core/lv_indev_private.h:105:3: warning: redefinition of typedef 'lv_indev_t' is a C11 feature [-Wtypedef-redefinition]
} lv_indev_t;
  ^
lvgl/src/dev/sdl/../../core/lv_indev.h:32:28: note: previous definition is here
typedef struct _lv_indev_t lv_indev_t;
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
