### PR TITLE
meter: Return early on malloc failure

### DIFF
--- a/src/widgets/meter/lv_meter.c
+++ b/src/widgets/meter/lv_meter.c
@@ -109,6 +109,10 @@ lv_meter_indicator_t * lv_meter_add_needle_line(lv_obj_t * obj, uint16_t width,
     lv_meter_t * meter = (lv_meter_t *)obj;
     lv_meter_indicator_t * indic = _lv_ll_ins_head(&meter->indicator_ll);
     LV_ASSERT_MALLOC(indic);
+    if(NULL == indic) {
+        return NULL;
+    }
+
     lv_memzero(indic, sizeof(lv_meter_indicator_t));
     indic->opa = LV_OPA_COVER;
 
@@ -128,6 +132,10 @@ lv_meter_indicator_t * lv_meter_add_needle_img(lv_obj_t * obj, const void * src,
     lv_meter_t * meter = (lv_meter_t *)obj;
     lv_meter_indicator_t * indic = _lv_ll_ins_head(&meter->indicator_ll);
     LV_ASSERT_MALLOC(indic);
+    if(NULL == indic) {
+        return NULL;
+    }
+
     lv_memzero(indic, sizeof(lv_meter_indicator_t));
     indic->opa = LV_OPA_COVER;
 
@@ -147,6 +155,10 @@ lv_meter_indicator_t * lv_meter_add_arc(lv_obj_t * obj, uint16_t width, lv_color
     lv_meter_t * meter = (lv_meter_t *)obj;
     lv_meter_indicator_t * indic = _lv_ll_ins_head(&meter->indicator_ll);
     LV_ASSERT_MALLOC(indic);
+    if(NULL == indic) {
+        return NULL;
+    }
+
     lv_memzero(indic, sizeof(lv_meter_indicator_t));
     indic->opa = LV_OPA_COVER;
 
@@ -166,6 +178,10 @@ lv_meter_indicator_t * lv_meter_add_scale_lines(lv_obj_t * obj, lv_color_t color
     lv_meter_t * meter = (lv_meter_t *)obj;
     lv_meter_indicator_t * indic = _lv_ll_ins_head(&meter->indicator_ll);
     LV_ASSERT_MALLOC(indic);
+    if(NULL == indic) {
+        return NULL;
+    }
+
     lv_memzero(indic, sizeof(lv_meter_indicator_t));
     indic->opa = LV_OPA_COVER;
 

--- a/src/widgets/meter/lv_meter.h
+++ b/src/widgets/meter/lv_meter.h
@@ -163,7 +163,7 @@ void lv_meter_set_scale_range(lv_obj_t * obj, int32_t min, int32_t max, uint32_t
  * @param width         width of the line
  * @param color         color of the line
  * @param r_mod         the radius modifier (added to the scale's radius) to get the lines length
- * @return              the new indicator
+ * @return              the new indicator or NULL on allocation failure.
  */
 lv_meter_indicator_t * lv_meter_add_needle_line(lv_obj_t * obj, uint16_t width,
                                                 lv_color_t color, int16_t r_mod);
@@ -174,7 +174,7 @@ lv_meter_indicator_t * lv_meter_add_needle_line(lv_obj_t * obj, uint16_t width,
  * @param src           the image source of the indicator. path or pointer to ::lv_img_dsc_t
  * @param pivot_x       the X pivot point of the needle
  * @param pivot_y       the Y pivot point of the needle
- * @return              the new indicator
+ * @return              the new indicator or NULL on allocation failure.
  * @note                the needle image should point to the right, like -O----->
  */
 lv_meter_indicator_t * lv_meter_add_needle_img(lv_obj_t * obj, const void * src,
@@ -186,7 +186,7 @@ lv_meter_indicator_t * lv_meter_add_needle_img(lv_obj_t * obj, const void * src,
  * @param width         width of the arc
  * @param color         color of the arc
  * @param r_mod         the radius modifier (added to the scale's radius) to get the outer radius of the arc
- * @return              the new indicator
+ * @return              the new indicator or NULL on allocation failure.
  */
 lv_meter_indicator_t * lv_meter_add_arc(lv_obj_t * obj, uint16_t width, lv_color_t color,
                                         int16_t r_mod);
@@ -199,7 +199,7 @@ lv_meter_indicator_t * lv_meter_add_arc(lv_obj_t * obj, uint16_t width, lv_color
  * @param color_end     the end color
  * @param local         tell how to map start and end color. true: the indicator's start and end_value; false: the scale's min max value
  * @param width_mod     add this the affected tick's width
- * @return              the new indicator
+ * @return              the new indicator or NULL on allocation failure.
  */
 lv_meter_indicator_t * lv_meter_add_scale_lines(lv_obj_t * obj, lv_color_t color_start,
                                                 lv_color_t color_end, bool local, int16_t width_mod);


### PR DESCRIPTION
### Description of the feature or fix

Return early when malloc fails

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
