### PR TITLE
Tests: malloc/realloc/free stub in unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ add_library(test_common
     STATIC
         src/lv_test_indev.c
         src/lv_test_init.c
+        src/lv_test_malloc.c
         src/test_assets/test_animimg001.c
         src/test_assets/test_animimg002.c
         src/test_assets/test_animimg003.c

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -23,7 +23,7 @@ extern "C" {
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_STDLIB_INCLUDE <stdlib.h>
 #define LV_MALLOC       lv_test_malloc
-#define LV_REALLOC      realloc
+#define LV_REALLOC      lv_test_realloc
 #define LV_FREE         free
 #define LV_MEMSET       memset
 #define LV_MEMCPY       memcpy
@@ -34,7 +34,7 @@ extern "C" {
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_MALLOC       lv_test_malloc
-#define LV_REALLOC      lv_realloc_builtin
+#define LV_REALLOC      lv_test_realloc
 #define LV_FREE         lv_free_builtin
 #define LV_MEMSET       lv_memset_builtin
 #define LV_MEMCPY       lv_memcpy_builtin

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -15,13 +15,14 @@ extern "C" {
 /***********************
  * PLATFORM CONFIGS
  ***********************/
+#include "lv_test_malloc.h"
 
 #ifdef LVGL_CI_USING_SYS_HEAP
 #define LV_USE_BUILTIN_MALLOC   0
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_STDLIB_INCLUDE <stdlib.h>
-#define LV_MALLOC       malloc
+#define LV_MALLOC       lv_malloc_test_wrapper
 #define LV_REALLOC      realloc
 #define LV_FREE         free
 #define LV_MEMSET       memset
@@ -32,7 +33,7 @@ extern "C" {
 #define LV_USE_BUILTIN_MALLOC   1
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
-#define LV_MALLOC       lv_malloc_builtin
+#define LV_MALLOC       lv_malloc_test_wrapper
 #define LV_REALLOC      lv_realloc_builtin
 #define LV_FREE         lv_free_builtin
 #define LV_MEMSET       lv_memset_builtin

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -22,7 +22,7 @@ extern "C" {
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_STDLIB_INCLUDE <stdlib.h>
-#define LV_MALLOC       lv_malloc_test_wrapper
+#define LV_MALLOC       lv_test_malloc
 #define LV_REALLOC      realloc
 #define LV_FREE         free
 #define LV_MEMSET       memset
@@ -33,7 +33,7 @@ extern "C" {
 #define LV_USE_BUILTIN_MALLOC   1
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
-#define LV_MALLOC       lv_malloc_test_wrapper
+#define LV_MALLOC       lv_test_malloc
 #define LV_REALLOC      lv_realloc_builtin
 #define LV_FREE         lv_free_builtin
 #define LV_MEMSET       lv_memset_builtin

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -24,7 +24,7 @@ extern "C" {
 #define LV_STDLIB_INCLUDE <stdlib.h>
 #define LV_MALLOC       lv_test_malloc
 #define LV_REALLOC      lv_test_realloc
-#define LV_FREE         free
+#define LV_FREE         lv_test_free
 #define LV_MEMSET       memset
 #define LV_MEMCPY       memcpy
 #endif
@@ -35,7 +35,7 @@ extern "C" {
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_MALLOC       lv_test_malloc
 #define LV_REALLOC      lv_test_realloc
-#define LV_FREE         lv_free_builtin
+#define LV_FREE         lv_test_free
 #define LV_MEMSET       lv_memset_builtin
 #define LV_MEMCPY       lv_memcpy_builtin
 #endif

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -1,7 +1,7 @@
-
 #if LV_BUILD_TEST
 #include "lv_test_init.h"
 #include "lv_test_indev.h"
+#include "lv_test_malloc.h"
 #include "../../src/misc/lv_malloc_builtin.h"
 #include <sys/time.h>
 #include <stdio.h>
@@ -25,6 +25,7 @@ void lv_test_init(void)
 {
     lv_init();
     hal_init();
+    lv_malloc_test_init();
 }
 
 void lv_test_deinit(void)
@@ -89,7 +90,7 @@ uint32_t custom_tick_get(void)
 
 void lv_test_assert_fail(void)
 {
-    TEST_FAIL();
+    // Handle error on test
 }
 
 #endif

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -25,7 +25,7 @@ void lv_test_init(void)
 {
     lv_init();
     hal_init();
-    lv_malloc_test_init();
+    lv_test_malloc_init();
 }
 
 void lv_test_deinit(void)

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -4,26 +4,29 @@
     #include "../../src/misc/lv_malloc_builtin.h"
 #endif
 
-bool lv_control_lv_malloc;
-void * lv_control_lv_malloc_stub;
+static lv_malloc_stub_cb malloc_stub_cb;
 
-void lv_malloc_test_init(void)
+void lv_test_malloc_init(void)
 {
-    lv_control_lv_malloc = false;
-    lv_control_lv_malloc_stub = NULL;
+    malloc_stub_cb = NULL;
 }
 
-void * lv_malloc_test_wrapper(size_t size)
+void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc)
 {
-    if(lv_control_lv_malloc) {
-        (void) size;
-        return lv_control_lv_malloc_stub;
-    }
-    else {
+    malloc_stub_cb = stub_malloc;
+}
+
+void * lv_test_malloc_normal(size_t size)
+{
 #ifdef LVGL_CI_USING_SYS_HEAP
-        return malloc(size);
+    return malloc(size);
 #else // LVGL_CI_USING_DEF_HEAP and others
-        return lv_malloc_builtin(size);
+    return lv_malloc_builtin(size);
 #endif
-    }
+}
+
+void * lv_test_malloc(size_t s)
+{
+    if(malloc_stub_cb) return malloc_stub_cb(s);
+    else return lv_test_malloc_normal(s);
 }

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -22,8 +22,7 @@ void * lv_malloc_test_wrapper(size_t size)
     else {
 #ifdef LVGL_CI_USING_SYS_HEAP
         return malloc(size);
-#endif
-#ifdef LVGL_CI_USING_DEF_HEAP
+#else // LVGL_CI_USING_DEF_HEAP and others
         return lv_malloc_builtin(size);
 #endif
     }

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -6,11 +6,13 @@
 
 static lv_malloc_stub_cb malloc_stub_cb;
 static lv_realloc_stub_cb realloc_stub_cb;
+static lv_free_stub_cb free_stub_cb;
 
 void lv_test_malloc_init(void)
 {
     malloc_stub_cb = NULL;
     realloc_stub_cb = NULL;
+    free_stub_cb = NULL;
 }
 
 void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc)
@@ -51,4 +53,24 @@ void * lv_test_realloc(void * p, size_t new_size)
 {
     if(realloc_stub_cb) return realloc_stub_cb(p, new_size);
     else return lv_test_realloc_normal(p, new_size);
+}
+
+void lv_test_free_set_cb(lv_free_stub_cb stub_free)
+{
+    free_stub_cb = stub_free;
+}
+
+void lv_test_free_normal(void * p)
+{
+#ifdef LVGL_CI_USING_SYS_HEAP
+    free(p);
+#else // LVGL_CI_USING_DEF_HEAP and others
+    lv_free_builtin(p);
+#endif
+}
+
+void lv_test_free(void * p)
+{
+    if(free_stub_cb) free_stub_cb(p);
+    else lv_test_free_normal(p);
 }

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -1,6 +1,6 @@
 #include "lv_test_malloc.h"
 
-#ifdef LVGL_CI_USING_DEF_HEAP
+#ifndef LVGL_CI_USING_SYS_HEAP
     #include "../../src/misc/lv_malloc_builtin.h"
 #endif
 

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -5,10 +5,12 @@
 #endif
 
 static lv_malloc_stub_cb malloc_stub_cb;
+static lv_realloc_stub_cb realloc_stub_cb;
 
 void lv_test_malloc_init(void)
 {
     malloc_stub_cb = NULL;
+    realloc_stub_cb = NULL;
 }
 
 void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc)
@@ -25,8 +27,28 @@ void * lv_test_malloc_normal(size_t size)
 #endif
 }
 
+void * lv_test_realloc_normal(void * p, size_t new_size)
+{
+#ifdef LVGL_CI_USING_SYS_HEAP
+    return realloc(p, new_size);
+#else // LVGL_CI_USING_DEF_HEAP and others
+    return lv_realloc_builtin(p, new_size);
+#endif
+}
+
 void * lv_test_malloc(size_t s)
 {
     if(malloc_stub_cb) return malloc_stub_cb(s);
     else return lv_test_malloc_normal(s);
+}
+
+void lv_test_realloc_set_cb(lv_realloc_stub_cb stub_realloc)
+{
+    realloc_stub_cb = stub_realloc;
+}
+
+void * lv_test_realloc(void * p, size_t new_size)
+{
+    if(realloc_stub_cb) return realloc_stub_cb(p, new_size);
+    else return lv_test_realloc_normal(p, new_size);
 }

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -1,0 +1,30 @@
+#include "lv_test_malloc.h"
+
+#ifdef LVGL_CI_USING_DEF_HEAP
+    #include "../../src/misc/lv_malloc_builtin.h"
+#endif
+
+bool lv_control_lv_malloc;
+void * lv_control_lv_malloc_stub;
+
+void lv_malloc_test_init(void)
+{
+    lv_control_lv_malloc = false;
+    lv_control_lv_malloc_stub = NULL;
+}
+
+void * lv_malloc_test_wrapper(size_t size)
+{
+    if(lv_control_lv_malloc) {
+        (void) size;
+        return lv_control_lv_malloc_stub;
+    }
+    else {
+#ifdef LVGL_CI_USING_SYS_HEAP
+        return malloc(size);
+#endif
+#ifdef LVGL_CI_USING_DEF_HEAP
+        return lv_malloc_builtin(size);
+#endif
+    }
+}

--- a/tests/src/lv_test_malloc.h
+++ b/tests/src/lv_test_malloc.h
@@ -5,6 +5,7 @@
 
 typedef void * (* lv_malloc_stub_cb)(size_t);
 typedef void * (* lv_realloc_stub_cb)(void * p, size_t new_size);
+typedef void (* lv_free_stub_cb)(void * p);
 
 void lv_test_malloc_init(void);
 void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc);
@@ -12,5 +13,8 @@ void * lv_test_malloc(size_t s);
 
 void lv_test_realloc_set_cb(lv_realloc_stub_cb stub_realloc);
 void * lv_test_realloc(void * p, size_t new_size);
+
+void lv_test_free_set_cb(lv_free_stub_cb stub_free);
+void lv_test_free(void * p);
 
 #endif

--- a/tests/src/lv_test_malloc.h
+++ b/tests/src/lv_test_malloc.h
@@ -1,0 +1,25 @@
+#ifndef LV_TEST_MALLOC
+#define LV_TEST_MALLOC
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern bool lv_control_lv_malloc;
+void * lv_control_lv_malloc_stub;
+
+#define FAKE_MALLOC_RETURN(ret) \
+    do {                                    \
+        lv_control_lv_malloc = true;        \
+        lv_control_lv_malloc_stub = ret;    \
+    } while (0);
+
+#define FAKE_STOP_RETURN    \
+    do {                                    \
+        lv_control_lv_malloc = false;       \
+        lv_control_lv_malloc_stub = NULL;   \
+    } while (0);
+
+void lv_malloc_test_init(void);
+void * lv_malloc_test_wrapper(size_t size);
+
+#endif

--- a/tests/src/lv_test_malloc.h
+++ b/tests/src/lv_test_malloc.h
@@ -4,9 +4,13 @@
 #include <stdlib.h>
 
 typedef void * (* lv_malloc_stub_cb)(size_t);
+typedef void * (* lv_realloc_stub_cb)(void * p, size_t new_size);
 
 void lv_test_malloc_init(void);
 void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc);
 void * lv_test_malloc(size_t s);
+
+void lv_test_realloc_set_cb(lv_realloc_stub_cb stub_realloc);
+void * lv_test_realloc(void * p, size_t new_size);
 
 #endif

--- a/tests/src/lv_test_malloc.h
+++ b/tests/src/lv_test_malloc.h
@@ -2,24 +2,11 @@
 #define LV_TEST_MALLOC
 
 #include <stdlib.h>
-#include <stdbool.h>
 
-extern bool lv_control_lv_malloc;
-void * lv_control_lv_malloc_stub;
+typedef void * (* lv_malloc_stub_cb)(size_t);
 
-#define FAKE_MALLOC_RETURN(ret) \
-    do {                                    \
-        lv_control_lv_malloc = true;        \
-        lv_control_lv_malloc_stub = ret;    \
-    } while (0);
-
-#define FAKE_STOP_RETURN    \
-    do {                                    \
-        lv_control_lv_malloc = false;       \
-        lv_control_lv_malloc_stub = NULL;   \
-    } while (0);
-
-void lv_malloc_test_init(void);
-void * lv_malloc_test_wrapper(size_t size);
+void lv_test_malloc_init(void);
+void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc);
+void * lv_test_malloc(size_t s);
 
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Control `lv_malloc` behaviour (return value) inside unit tests, the stubbed malloc is not enabled by default, so it doesn't break the current behaviour. Naming is not proper, just a dirty implementation

I've tested it with the following test file:

```c
#if LV_BUILD_TEST
#include "../lvgl.h"

#include "lv_test_malloc.h"
#include "unity/unity.h"

static lv_obj_t * active_screen = NULL;
static lv_obj_t * meter;

void setUp(void)
{
    active_screen = lv_scr_act();
    meter = lv_meter_create(active_screen);
}

void tearDown(void)
{
    active_screen = NULL;
    FAKE_STOP_RETURN; // <- Disables malloc stub, this can be done here or at the end of each test FAKE_MALLOC_RETURN was used
}

void test_meter_add_needle_line_returns_null_on_oom(void)
{
    FAKE_MALLOC_RETURN(NULL); // <- Enables malloc stub and sets the return value of malloc

    TEST_ASSERT_NULL(lv_meter_add_needle_line(meter, 1, lv_palette_main(LV_PALETTE_RED), 1));
}

void test_meter_on_successfull_allocation(void)
{
    lv_meter_indicator_t * indicator = lv_meter_add_needle_line(meter, 1, lv_palette_main(LV_PALETTE_RED), 2);
    TEST_ASSERT_NOT_NULL(indicator);

    TEST_ASSERT_EQUAL(LV_METER_INDICATOR_TYPE_NEEDLE_LINE, indicator->type);
    TEST_ASSERT_EQUAL(1, indicator->type_data.needle_line.width);
    TEST_ASSERT_EQUAL(2, indicator->type_data.needle_line.r_mod);
}

#endif
```

And the output:
![imagen](https://user-images.githubusercontent.com/11037705/226723739-f5338cf5-743c-4a3c-8de2-4726bbc2dda2.png)


### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
