### PR TITLE
checkbox: Check for mem allocation failure in set_text

### DIFF
--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -68,25 +68,30 @@ lv_obj_t * lv_checkbox_create(lv_obj_t * parent)
 void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 {
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
-#if LV_USE_ARABIC_PERSIAN_CHARS
-    size_t len = _lv_txt_ap_calc_bytes_cnt(txt);
-#else
-    size_t len = strlen(txt);
-#endif
 
-    if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len + 1);
-    else  cb->txt = lv_malloc(len + 1);
-
-    LV_ASSERT_MALLOC(cb->txt);
-    if(NULL == cb->txt) return;
+    if(NULL != txt) {
+        size_t len = 0;
 
 #if LV_USE_ARABIC_PERSIAN_CHARS
-    _lv_txt_ap_proc(txt, cb->txt);
+        len = _lv_txt_ap_calc_bytes_cnt(txt);
 #else
-    strcpy(cb->txt, txt);
+        len = strlen(txt);
 #endif
 
-    cb->static_txt = 0;
+        if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len + 1);
+        else cb->txt = lv_malloc(len + 1);
+
+        LV_ASSERT_MALLOC(cb->txt);
+        if(NULL == cb->txt) return;
+
+#if LV_USE_ARABIC_PERSIAN_CHARS
+        _lv_txt_ap_proc(txt, cb->txt);
+#else
+        strcpy(cb->txt, txt);
+#endif
+
+        cb->static_txt = 0;
+    }
 
     lv_obj_refresh_self_size(obj);
     lv_obj_invalidate(obj);

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -76,6 +76,10 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 
     if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len + 1);
     else  cb->txt = lv_malloc(len + 1);
+
+    LV_ASSERT_MALLOC(cb->txt);
+    if(NULL == cb->txt) return;
+
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(txt, cb->txt);
 #else

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -93,9 +93,12 @@ void test_checkbox_should_allocate_memory_for_static_text(void)
     LV_HEAP_CHECK(TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size));
 }
 
+size_t malloc_calls = 0;
+
 void * malloc_stub(size_t size)
 {
     (void) size;
+    malloc_calls++;
 
     return NULL;
 }
@@ -110,6 +113,20 @@ void test_checkbox_text_should_become_null_when_mem_allocation_fails(void)
     lv_checkbox_set_text(checkbox, message);
 
     TEST_ASSERT_NULL(lv_checkbox_get_text(checkbox));
+
+    lv_test_malloc_set_cb(NULL);
+}
+
+void test_checkbox_no_memory_allocation_when_refreshing_text(void)
+{
+    malloc_calls = 0;
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+    lv_test_malloc_set_cb(malloc_stub);
+
+    lv_checkbox_set_text(checkbox, NULL);
+
+    TEST_ASSERT_EQUAL(0, malloc_calls);
 
     lv_test_malloc_set_cb(NULL);
 }

--- a/tests/src/test_cases/test_checkbox.c
+++ b/tests/src/test_cases/test_checkbox.c
@@ -93,4 +93,25 @@ void test_checkbox_should_allocate_memory_for_static_text(void)
     LV_HEAP_CHECK(TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size));
 }
 
+void * malloc_stub(size_t size)
+{
+    (void) size;
+
+    return NULL;
+}
+
+void test_checkbox_text_should_become_null_when_mem_allocation_fails(void)
+{
+    const char * message = "Hello World!";
+    active_screen = lv_scr_act();
+    checkbox = lv_checkbox_create(active_screen);
+    lv_test_malloc_set_cb(malloc_stub);
+
+    lv_checkbox_set_text(checkbox, message);
+
+    TEST_ASSERT_NULL(lv_checkbox_get_text(checkbox));
+
+    lv_test_malloc_set_cb(NULL);
+}
+
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Handle memory allocation failure in `lv_checkbox_set_text` and add test.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
