### PR TITLE
chore: simplify and flatten code

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -844,7 +844,6 @@ void lv_obj_invalidate(const lv_obj_t * obj)
     obj_coords.y2 += ext_size;
 
     lv_obj_invalidate_area(obj, &obj_coords);
-
 }
 
 bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area)
@@ -911,7 +910,6 @@ bool lv_obj_is_visible(const lv_obj_t * obj)
     obj_coords.y2 += ext_size;
 
     return lv_obj_area_is_visible(obj, &obj_coords);
-
 }
 
 void lv_obj_set_ext_click_area(lv_obj_t * obj, lv_coord_t size)

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -249,14 +249,14 @@ void _lv_inv_area(lv_disp_t * disp, const lv_area_t * area_p)
     }
 
     /*Save the area*/
-    if(disp->inv_p < LV_INV_BUF_SIZE) {
-        lv_area_copy(&disp->inv_areas[disp->inv_p], &com_area);
-    }
-    else {   /*If no place for the area add the screen*/
+    lv_area_t * tmp_area_p = &com_area;
+    if(disp->inv_p >= LV_INV_BUF_SIZE) { /*If no place for the area add the screen*/
         disp->inv_p = 0;
-        lv_area_copy(&disp->inv_areas[disp->inv_p], &scr_area);
+        tmp_area_p = &scr_area;
     }
+    lv_area_copy(&disp->inv_areas[disp->inv_p], tmp_area_p);
     disp->inv_p++;
+
     if(disp->refr_timer) lv_timer_resume(disp->refr_timer);
 }
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -424,39 +424,43 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
 
     refr_invalid_areas();
 
+    if(disp_refr->inv_p == 0) goto refr_cache_clean_up;
+
     /*If refresh happened ...*/
-    if(disp_refr->inv_p != 0) {
-        /*Call monitor cb if present*/
-        lv_disp_send_event(disp_refr, LV_EVENT_RENDER_READY, NULL);
+    /*Call monitor cb if present*/
+    lv_disp_send_event(disp_refr, LV_EVENT_RENDER_READY, NULL);
 
-        /*With double buffered direct mode synchronize the rendered areas to the other buffer*/
-        if(lv_disp_is_double_buffered(disp_refr) && disp_refr->render_mode == LV_DISP_RENDER_MODE_DIRECT) {
-            /*We need to wait for ready here to not mess up the active screen*/
-            while(disp_refr->flushing) {
-                if(disp_refr->wait_cb) disp_refr->wait_cb(disp_refr);
-            }
-            /*The buffers are already swapped.
-             *So the active buffer is the off screen buffer where LVGL will render*/
-            void * buf_off_screen = disp_refr->draw_buf_act;
-            void * buf_on_screen = disp_refr->draw_buf_act == disp_refr->draw_buf_1 ? disp_refr->draw_buf_2 : disp_refr->draw_buf_1;
+    if(!lv_disp_is_double_buffered(disp_refr) || disp_refr->render_mode != LV_DISP_RENDER_MODE_DIRECT) goto refr_clean_up;
 
-            lv_coord_t stride = lv_disp_get_hor_res(disp_refr);
-            uint32_t i;
-            for(i = 0; i < disp_refr->inv_p; i++) {
-                if(disp_refr->inv_area_joined[i]) continue;
-                disp_refr->draw_ctx->buffer_copy(disp_refr->draw_ctx,
-                                                 buf_off_screen, stride, &disp_refr->inv_areas[i],
-                                                 buf_on_screen, stride, &disp_refr->inv_areas[i]);
-            }
-        }
+    /*With double buffered direct mode synchronize the rendered areas to the other buffer*/
+    /*We need to wait for ready here to not mess up the active screen*/
+    while(disp_refr->flushing) {
+        if(disp_refr->wait_cb) disp_refr->wait_cb(disp_refr);
+    }
+    /*The buffers are already swapped.
+     *So the active buffer is the off screen buffer where LVGL will render*/
+    void * buf_off_screen = disp_refr->draw_buf_act;
+    void * buf_on_screen = disp_refr->draw_buf_act == disp_refr->draw_buf_1
+                           ? disp_refr->draw_buf_2
+                           : disp_refr->draw_buf_1;
 
-        /*Clean up*/
-        lv_memzero(disp_refr->inv_areas, sizeof(disp_refr->inv_areas));
-        lv_memzero(disp_refr->inv_area_joined, sizeof(disp_refr->inv_area_joined));
-        disp_refr->inv_p = 0;
-
+    lv_coord_t stride = lv_disp_get_hor_res(disp_refr);
+    uint32_t i;
+    for(i = 0; i < disp_refr->inv_p; i++) {
+        if(disp_refr->inv_area_joined[i]) continue;
+        disp_refr->draw_ctx->buffer_copy(
+            disp_refr->draw_ctx,
+            buf_off_screen, stride, &disp_refr->inv_areas[i],
+            buf_on_screen, stride, &disp_refr->inv_areas[i]
+        );
     }
 
+refr_clean_up:
+    lv_memzero(disp_refr->inv_areas, sizeof(disp_refr->inv_areas));
+    lv_memzero(disp_refr->inv_area_joined, sizeof(disp_refr->inv_area_joined));
+    disp_refr->inv_p = 0;
+
+refr_cache_clean_up:
     _lv_font_clean_up_fmt_txt();
 
 #if LV_USE_DRAW_MASKS


### PR DESCRIPTION
### Description of the feature or fix

simplify and flatten code

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
