### PR TITLE
chore(cmsis-pack): update cmsis-pack for v8.3.6

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,7 +36,11 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-02-06" version="8.3.5" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.5.pack">
+    <release date="2023-04-02" version="8.3.6" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
+      - LVGL 8.3.6 release
+      - Various fixes, See CHANGELOG.md
+    </release>
+    <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/e7e8cf846dce96f7542e27b5c9655bab680c31a1/env_support/cmsis-pack/LVGL.lvgl.8.3.5.pack">
       - LVGL 8.3.5 release
       - Use LVGL version as the cmsis-pack version
       - Fix GPU support for NXP PXP and NXP VGLite
@@ -262,7 +266,7 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.5">
+        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.6">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
             <component Cgroup="lvgl" Csub="Essential" >
@@ -395,10 +399,18 @@
                 <file category="sourceC"            name="src/widgets/lv_textarea.c" />
 
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.2" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.3" />
                 <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
+                
+                <!-- code template -->
+                <file category="header"       name="examples/porting/lv_port_disp_template.h"   attr="template" select="Display port template"          version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_disp_template.c"   attr="template" select="Display port template"          version="2.0.0"/>
+                <file category="header"       name="examples/porting/lv_port_indev_template.h"  attr="template" select="Input devices port template"    version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_indev_template.c"  attr="template" select="Input devices port template"    version="2.0.0"/>
+                <file category="header"       name="examples/porting/lv_port_fs_template.h"     attr="template" select="File system port template"      version="2.0.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_fs_template.c"     attr="template" select="File system port template"      version="2.0.0"/>
 
               </files>
 

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -4,6 +4,6 @@
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
   <timestamp>2023-02-06T12:22:00</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.5"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.6"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.4
+ * Configuration file for v8.3.6
  */
 
 /* clang-format off */
@@ -181,7 +181,7 @@
 /*Use STM32's DMA2D (aka Chrom Art) GPU*/
 #if LV_USE_GPU_STM32_DMA2D
     /*Must be defined to include path of CMSIS header of target processor
-    e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+    e.g. "stm32f7xx.h" or "stm32f4xx.h"*/
     #define LV_GPU_DMA2D_CMSIS_INCLUDE
 #endif
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "lvgl",
-	"version": "8.3.5-dev",
+	"version": "8.3.6",
 	"keywords": "graphics, gui, embedded, tft, lvgl",
 	"description": "Graphics library to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint. It offers anti-aliasing, opacity, and animations using only one frame buffer.",
 	"repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=lvgl
-version=8.3.5-dev
+version=8.3.6
 author=kisvegabor
 maintainer=kisvegabor,embeddedt,pete-pjb
 sentence=Full-featured Graphics Library for Embedded Systems

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.5-dev
+ * Configuration file for v8.3.6
  */
 
 /*

--- a/lvgl.h
+++ b/lvgl.h
@@ -15,8 +15,8 @@ extern "C" {
  ***************************/
 #define LVGL_VERSION_MAJOR 8
 #define LVGL_VERSION_MINOR 3
-#define LVGL_VERSION_PATCH 5
-#define LVGL_VERSION_INFO "dev"
+#define LVGL_VERSION_PATCH 6
+#define LVGL_VERSION_INFO ""
 
 /*********************
  *      INCLUDES


### PR DESCRIPTION
### Description of the feature or fix

Maintainance Release for v8.3.6

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
