### PR TITLE
Replace std string functions with builtin version

### DIFF
--- a/src/misc/lv_memcpy_builtin.c
+++ b/src/misc/lv_memcpy_builtin.c
@@ -150,12 +150,13 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset_builtin(void * dst, uint8_t v, size_t len)
     }
 }
 
+/* See https://en.cppreference.com/w/c/string/byte/strlen for reference */
 size_t lv_strlen_builtin(const char * str)
 {
     size_t i = 0;
     while(str[i]) i++;
 
-    return i + 1;
+    return i;
 }
 
 char * lv_strncpy_builtin(char * dst, const char * src, size_t dest_size)

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -75,7 +75,7 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
         len = _lv_txt_ap_calc_bytes_cnt(txt);
 #else
-        len = strlen(txt);
+        len = lv_strlen(txt);
 #endif
 
         if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len + 1);
@@ -87,7 +87,7 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
         _lv_txt_ap_proc(txt, cb->txt);
 #else
-        strcpy(cb->txt, txt);
+        lv_strcpy(cb->txt, txt);
 #endif
 
         cb->static_txt = 0;

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -87,7 +87,7 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
         _lv_txt_ap_proc(txt, cb->txt);
 #else
-        lv_strcpy(cb->txt, txt);
+        lv_strncpy(cb->txt, txt, len);
 #endif
 
         cb->static_txt = 0;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -130,7 +130,7 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
 
     /*Allocate space for the new text*/
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    size_t len = strlen(options) + 1;
+    size_t len = lv_strlen(options) + 1;
 #else
     size_t len = _lv_txt_ap_calc_bytes_cnt(options) + 1;
 #endif
@@ -197,7 +197,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     /*Convert static options to dynamic*/
     if(dropdown->static_txt != 0) {
         char * static_options = dropdown->options;
-        size_t len = strlen(static_options) + 1;
+        size_t len = lv_strlen(static_options) + 1;
 
         dropdown->options = lv_malloc(len);
         LV_ASSERT_MALLOC(dropdown->options);
@@ -208,9 +208,9 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     }
 
     /*Allocate space for the new option*/
-    size_t old_len = (dropdown->options == NULL) ? 0 : strlen(dropdown->options);
+    size_t old_len = (dropdown->options == NULL) ? 0 : lv_strlen(dropdown->options);
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    size_t ins_len = strlen(option) + 1;
+    size_t ins_len = lv_strlen(option) + 1;
 #else
     size_t ins_len = _lv_txt_ap_calc_bytes_cnt(option) + 1;
 #endif
@@ -375,7 +375,7 @@ void lv_dropdown_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf
     size_t txt_len;
 
     if(dropdown->options)  {
-        txt_len     = strlen(dropdown->options);
+        txt_len     = lv_strlen(dropdown->options);
     }
     else {
         buf[0] = '\0';
@@ -408,7 +408,7 @@ int32_t lv_dropdown_get_option_index(lv_obj_t * obj, const char * option)
     while(start[0] != '\0') {
         for(char_i = 0; (start[char_i] != '\n') && (start[char_i] != '\0'); char_i++);
 
-        if(memcmp(start, option, LV_MIN(strlen(option), char_i)) == 0) return opt_i;
+        if(memcmp(start, option, LV_MIN(lv_strlen(option), char_i)) == 0) return opt_i;
         start = &start[char_i];
         if(start[0] == '\n') start++;
         opt_i++;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -146,7 +146,7 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
     if(dropdown->options == NULL) return;
 
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    strcpy(dropdown->options, options);
+    lv_strncpy(dropdown->options, options, len);
 #else
     _lv_txt_ap_proc(options, dropdown->options);
 #endif
@@ -203,7 +203,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;
 
-        strcpy(dropdown->options, static_options);
+        lv_strncpy(dropdown->options, static_options, len);
         dropdown->static_txt = 0;
     }
 
@@ -243,7 +243,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     LV_ASSERT_MALLOC(ins_buf);
     if(ins_buf == NULL) return;
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    strcpy(ins_buf, option);
+    lv_strncpy(ins_buf, option, new_len + 1);
 #else
     _lv_txt_ap_proc(option, ins_buf);
 #endif

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1281,7 +1281,8 @@ static void copy_text_to_label(lv_label_t * label, const char * text)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(text, label->text);
 #else
-    (void) strcpy(label->text, text);
+    size_t len = lv_strlen(text);
+    (void) lv_strncpy(label->text, text, len);
 #endif
 }
 

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -611,8 +611,8 @@ void lv_label_ins_text(lv_obj_t * obj, uint32_t pos, const char * txt)
     lv_obj_invalidate(obj);
 
     /*Allocate space for the new text*/
-    size_t old_len = strlen(label->text);
-    size_t ins_len = strlen(txt);
+    size_t old_len = lv_strlen(label->text);
+    size_t ins_len = lv_strlen(txt);
     size_t new_len = ins_len + old_len;
     label->text        = lv_realloc(label->text, new_len + 1);
     LV_ASSERT_MALLOC(label->text);
@@ -1126,7 +1126,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
             uint32_t letter_id = lv_label_get_letter_on(obj, &p);
 
             /*Be sure there is space for the dots*/
-            size_t txt_len = strlen(label->text);
+            size_t txt_len = lv_strlen(label->text);
             uint32_t byte_id     = _lv_txt_encoded_get_byte_id(label->text, letter_id);
             while(byte_id + LV_LABEL_DOT_NUM > txt_len) {
                 _lv_txt_encoded_prev(label->text, &byte_id);
@@ -1270,7 +1270,7 @@ static size_t get_text_length(const char * text)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     len = _lv_txt_ap_calc_bytes_cnt(text);
 #else
-    len = strlen(text) + 1;
+    len = lv_strlen(text) + 1;
 #endif
 
     return len;

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -392,7 +392,7 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
     }
 
     if(title) {
-        page->title        = lv_malloc(strlen(title) + 1);
+        page->title        = lv_malloc(lv_strlen(title) + 1);
         page->static_title = false;
 
         LV_ASSERT_MALLOC(page->title);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -392,14 +392,15 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
     }
 
     if(title) {
-        page->title        = lv_malloc(lv_strlen(title) + 1);
+        size_t len = lv_strlen(title) + 1
+                     page->title        = lv_malloc(len);
         page->static_title = false;
 
         LV_ASSERT_MALLOC(page->title);
         if(page->title == NULL) {
             return;
         }
-        strcpy(page->title, title);
+        lv_strncpy(page->title, title, len);
     }
     else {
         page->title        = NULL;

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -392,8 +392,8 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
     }
 
     if(title) {
-        size_t len = lv_strlen(title) + 1
-                     page->title        = lv_malloc(len);
+        size_t len = lv_strlen(title) + 1;
+        page->title        = lv_malloc(len);
         page->static_title = false;
 
         LV_ASSERT_MALLOC(page->title);

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -87,7 +87,7 @@ lv_obj_t * lv_msgbox_create(lv_obj_t * parent, const char * title, const char * 
 
     lv_obj_set_flex_flow(obj, LV_FLEX_FLOW_ROW_WRAP);
 
-    bool has_title = title && strlen(title) > 0;
+    bool has_title = title && lv_strlen(title) > 0;
 
     /*When a close button is required, we need the empty label as spacer to push the button to the right*/
     if(add_close_btn || has_title) {
@@ -112,7 +112,7 @@ lv_obj_t * lv_msgbox_create(lv_obj_t * parent, const char * title, const char * 
 
     mbox->content = lv_obj_class_create_obj(&lv_msgbox_content_class, obj);
 
-    bool has_txt = txt && strlen(txt) > 0;
+    bool has_txt = txt && lv_strlen(txt) > 0;
     if(has_txt) {
         mbox->text = lv_label_create(mbox->content);
         lv_label_set_text(mbox->text, txt);

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -126,7 +126,7 @@ void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_
         if(!(roller->inf_page_cnt & 1)) roller->inf_page_cnt++;   /*Make it odd*/
         LV_LOG_INFO("Using %" LV_PRIu32 " pages to make the roller look infinite", roller->inf_page_cnt);
 
-        size_t opt_len = strlen(options) + 1; /*+1 to add '\n' after option lists*/
+        size_t opt_len = lv_strlen(options) + 1; /*+1 to add '\n' after option lists*/
         char * opt_extra = lv_malloc(opt_len * roller->inf_page_cnt);
         uint8_t i;
         for(i = 0; i < roller->inf_page_cnt; i++) {
@@ -243,7 +243,7 @@ void lv_roller_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf_s
     uint32_t i;
     uint16_t line        = 0;
     const char * opt_txt = lv_label_get_text(label);
-    size_t txt_len     = strlen(opt_txt);
+    size_t txt_len     = lv_strlen(opt_txt);
 
     for(i = 0; i < txt_len && line != roller->sel_opt_id; i++) {
         if(opt_txt[i] == '\n') line++;

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -130,7 +130,7 @@ void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_
         char * opt_extra = lv_malloc(opt_len * roller->inf_page_cnt);
         uint8_t i;
         for(i = 0; i < roller->inf_page_cnt; i++) {
-            strcpy(&opt_extra[opt_len * i], options);
+            lv_strncpy(&opt_extra[opt_len * i], options, opt_len);
             opt_extra[opt_len * (i + 1) - 1] = '\n';
         }
         opt_extra[opt_len * roller->inf_page_cnt - 1] = '\0';

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -151,11 +151,11 @@ void lv_span_set_text(lv_span_t * span, const char * text)
     }
 
     if(span->txt == NULL || span->static_flag == 1) {
-        span->txt = lv_malloc(strlen(text) + 1);
+        span->txt = lv_malloc(lv_strlen(text) + 1);
         LV_ASSERT_MALLOC(span->txt);
     }
     else {
-        span->txt = lv_realloc(span->txt, strlen(text) + 1);
+        span->txt = lv_realloc(span->txt, lv_strlen(text) + 1);
         LV_ASSERT_MALLOC(span->txt);
     }
 
@@ -903,7 +903,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
             }
             if(txt_pos.y + max_line_h + next_line_h - line_space > coords.y2 + 1) { /* for overflow if is end line. */
                 if(last_snippet->txt[last_snippet->bytes] != '\0') {
-                    last_snippet->bytes = strlen(last_snippet->txt);
+                    last_snippet->bytes = lv_strlen(last_snippet->txt);
                     last_snippet->txt_w = lv_txt_get_width(last_snippet->txt, last_snippet->bytes, last_snippet->font,
                                                            last_snippet->letter_space, txt_flag);
                 }

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -150,19 +150,21 @@ void lv_span_set_text(lv_span_t * span, const char * text)
         return;
     }
 
+    size_t text_alloc_len = lv_strlen(text) + 1;
+
     if(span->txt == NULL || span->static_flag == 1) {
-        span->txt = lv_malloc(lv_strlen(text) + 1);
+        span->txt = lv_malloc(text_alloc_len);
         LV_ASSERT_MALLOC(span->txt);
     }
     else {
-        span->txt = lv_realloc(span->txt, lv_strlen(text) + 1);
+        span->txt = lv_realloc(span->txt, text_alloc_len);
         LV_ASSERT_MALLOC(span->txt);
     }
 
     if(span->txt == NULL) return;
 
     span->static_flag = 0;
-    strcpy(span->txt, text);
+    lv_strncpy(span->txt, text, text_alloc_len);
 
     refresh_self_size(span->spangroup);
 }

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -401,7 +401,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
          * Set `step` accordingly*/
         else {
             const char * txt = lv_textarea_get_text(obj);
-            const size_t txt_len = strlen(txt);
+            const size_t txt_len = lv_strlen(txt);
 
             /* Check cursor position */
             /* Cursor is in '.' digit */
@@ -484,7 +484,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
 
     /*Add leading zeros*/
     int32_t i;
-    const int digits_len = (int)strlen(digits);
+    const int digits_len = (int) lv_strlen(digits);
 
     const int leading_zeros_cnt = spinbox->digit_count - digits_len;
     if(leading_zeros_cnt) {

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -971,7 +971,8 @@ static void copy_cell_txt(char * dst, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(txt, &dst[1]);
 #else
-    strcpy(&dst[1], txt);
+    size_t len = lv_strlen(txt);
+    lv_strncpy(&dst[1], txt, len);
 #endif
 }
 

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -959,7 +959,7 @@ static size_t get_cell_txt_len(const char * txt)
 #else
     /* cell_data layout: [ctrl][txt][trailing '\0' terminator]
      * +2 because of the trailing '\0' and the ctrl */
-    retval = strlen(txt) + 2;
+    retval = lv_strlen(txt) + 2;
 #endif
 
     return retval;

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -84,7 +84,7 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
     if(tabview->tab_pos & LV_DIR_VER) {
         new_map = lv_malloc((tab_id + 1) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1));
-        new_map[tab_id - 1] = lv_malloc(strlen(name) + 1);
+        new_map[tab_id - 1] = lv_malloc(lv_strlen(name) + 1);
         strcpy((char *)new_map[tab_id - 1], name);
         new_map[tab_id] = (char *)"";
     }
@@ -93,13 +93,13 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         new_map = lv_malloc((tab_id * 2) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1) * 2);
         if(tabview->tab_cnt == 0) {
-            new_map[0] = lv_malloc(strlen(name) + 1);
+            new_map[0] = lv_malloc(lv_strlen(name) + 1);
             strcpy((char *)new_map[0], name);
             new_map[1] = (char *)"";
         }
         else {
             new_map[tab_id * 2 - 3] = (char *)"\n";
-            new_map[tab_id * 2 - 2] = lv_malloc(strlen(name) + 1);
+            new_map[tab_id * 2 - 2] = lv_malloc(lv_strlen(name) + 1);
             new_map[tab_id * 2 - 1] = (char *)"";
             strcpy((char *)new_map[(tab_id * 2) - 2], name);
         }
@@ -130,7 +130,7 @@ void lv_tabview_rename_tab(lv_obj_t * obj, uint32_t id, const char * new_name)
     if(tabview->tab_pos & LV_DIR_HOR) id *= 2;
 
     lv_free(tabview->map[id]);
-    tabview->map[id] = lv_malloc(strlen(new_name) + 1);
+    tabview->map[id] = lv_malloc(lv_strlen(new_name) + 1);
     strcpy(tabview->map[id], new_name);
     lv_obj_invalidate(obj);
 }

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -84,8 +84,9 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
     if(tabview->tab_pos & LV_DIR_VER) {
         new_map = lv_malloc((tab_id + 1) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1));
-        new_map[tab_id - 1] = lv_malloc(lv_strlen(name) + 1);
-        strcpy((char *)new_map[tab_id - 1], name);
+        size_t len = lv_strlen(name) + 1;
+        new_map[tab_id - 1] = lv_malloc(len);
+        lv_strncpy((char *)new_map[tab_id - 1], name, len);
         new_map[tab_id] = (char *)"";
     }
     /*left or right dir*/
@@ -93,15 +94,17 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         new_map = lv_malloc((tab_id * 2) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1) * 2);
         if(tabview->tab_cnt == 0) {
-            new_map[0] = lv_malloc(lv_strlen(name) + 1);
-            strcpy((char *)new_map[0], name);
+            size_t len = lv_strlen(name) + 1;
+            new_map[0] = lv_malloc(len);
+            lv_strncpy((char *)new_map[0], name, len);
             new_map[1] = (char *)"";
         }
         else {
+            size_t len = lv_strlen(name) + 1;
             new_map[tab_id * 2 - 3] = (char *)"\n";
-            new_map[tab_id * 2 - 2] = lv_malloc(lv_strlen(name) + 1);
+            new_map[tab_id * 2 - 2] = lv_malloc(len);
             new_map[tab_id * 2 - 1] = (char *)"";
-            strcpy((char *)new_map[(tab_id * 2) - 2], name);
+            lv_strncpy((char *)new_map[(tab_id * 2) - 2], name, len);
         }
     }
     tabview->map = new_map;
@@ -130,8 +133,9 @@ void lv_tabview_rename_tab(lv_obj_t * obj, uint32_t id, const char * new_name)
     if(tabview->tab_pos & LV_DIR_HOR) id *= 2;
 
     lv_free(tabview->map[id]);
-    tabview->map[id] = lv_malloc(lv_strlen(new_name) + 1);
-    strcpy(tabview->map[id], new_name);
+    size_t len = lv_strlen(new_name) + 1;
+    tabview->map[id] = lv_malloc(len);
+    lv_strncpy(tabview->map[id], new_name, len);
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -300,10 +300,11 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
     }
 
     if(ta->pwd_mode) {
-        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, lv_strlen(txt) + 1);
+        size_t len = lv_strlen(txt) + 1;
+        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, len);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
-        strcpy(ta->pwd_tmp, txt);
+        lv_strncpy(ta->pwd_tmp, txt, len);
 
         /*Auto hide characters*/
         auto_hide_characters(obj);
@@ -334,7 +335,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
             return;
         }
 
-        strcpy(ta->placeholder_txt, txt);
+        lv_strncpy(ta->placeholder_txt, txt, txt_len + 1);
         ta->placeholder_txt[txt_len] = '\0';
     }
 
@@ -418,7 +419,7 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
 
-        strcpy(ta->pwd_tmp, txt);
+        lv_strncpy(ta->pwd_tmp, txt, len + 1);
 
         pwd_char_hider(obj);
 
@@ -458,7 +459,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
             return;
         }
 
-        strcpy(ta->pwd_bullet, bullet);
+        lv_strncpy(ta->pwd_bullet, bullet, txt_len + 1);
         ta->pwd_bullet[txt_len] = '\0';
     }
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -141,7 +141,7 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
 
     if(ta->pwd_mode) {
         /*+2: the new char + \0*/
-        size_t realloc_size = strlen(ta->pwd_tmp) + strlen(letter_buf) + 1;
+        size_t realloc_size = lv_strlen(ta->pwd_tmp) + lv_strlen(letter_buf) + 1;
         ta->pwd_tmp = lv_realloc(ta->pwd_tmp, realloc_size);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
@@ -191,7 +191,7 @@ void lv_textarea_add_text(lv_obj_t * obj, const char * txt)
     lv_textarea_clear_selection(obj);
 
     if(ta->pwd_mode) {
-        size_t realloc_size = strlen(ta->pwd_tmp) + strlen(txt) + 1;
+        size_t realloc_size = lv_strlen(ta->pwd_tmp) + lv_strlen(txt) + 1;
         ta->pwd_tmp = lv_realloc(ta->pwd_tmp, realloc_size);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
@@ -240,7 +240,7 @@ void lv_textarea_del_char(lv_obj_t * obj)
     if(ta->pwd_mode) {
         _lv_txt_cut(ta->pwd_tmp, ta->cursor.pos - 1, 1);
 
-        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, strlen(ta->pwd_tmp) + 1);
+        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, lv_strlen(ta->pwd_tmp) + 1);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
     }
@@ -300,7 +300,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
     }
 
     if(ta->pwd_mode) {
-        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, strlen(txt) + 1);
+        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, lv_strlen(txt) + 1);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
         strcpy(ta->pwd_tmp, txt);
@@ -319,7 +319,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
-    size_t txt_len = strlen(txt);
+    size_t txt_len = lv_strlen(txt);
     if((txt_len == 0) && (ta->placeholder_txt)) {
         lv_free(ta->placeholder_txt);
         ta->placeholder_txt = NULL;
@@ -412,7 +412,7 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
     /*Pwd mode is now enabled*/
     if(en) {
         char * txt = lv_label_get_text(ta->label);
-        size_t len = strlen(txt);
+        size_t len = lv_strlen(txt);
 
         ta->pwd_tmp = lv_malloc(len + 1);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
@@ -447,7 +447,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
         ta->pwd_bullet = NULL;
     }
     else {
-        size_t txt_len = strlen(bullet);
+        size_t txt_len = lv_strlen(bullet);
 
         /*Allocate memory for the pwd_bullet text*/
         /*NOTE: Using special realloc behavior, malloc-like when data_p is NULL*/
@@ -997,7 +997,7 @@ static void pwd_char_hider(lv_obj_t * obj)
     if(enc_len == 0) return;
 
     const char * bullet = lv_textarea_get_password_bullet(obj);
-    const size_t bullet_len = strlen(bullet);
+    const size_t bullet_len = lv_strlen(bullet);
     char * txt_tmp = lv_malloc(enc_len * bullet_len + 1);
 
     uint32_t i;


### PR DESCRIPTION
### Description of the feature or fix

Replaces `strlen` and `strcpy` with `lv_strlen` and `lv_strncpy` in `widgets`.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
