### PR TITLE
fix(disp): add missing wait_cb

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -410,6 +410,14 @@ void lv_disp_set_flush_cb(lv_disp_t * disp, void (*flush_cb)(struct _lv_disp_t *
     disp->flush_cb = flush_cb;
 }
 
+void lv_disp_set_wait_cb(lv_disp_t * disp, void (*wait_cb)(struct _lv_disp_t * disp))
+{
+    if(disp == NULL) disp = lv_disp_get_default();
+    if(disp == NULL) return;
+
+    disp->wait_cb = wait_cb;
+}
+
 void lv_disp_set_color_format(lv_disp_t * disp, lv_color_format_t color_format)
 {
     if(disp == NULL) disp = lv_disp_get_default();

--- a/src/core/lv_disp.h
+++ b/src/core/lv_disp.h
@@ -243,12 +243,20 @@ void lv_disp_set_draw_buffers(lv_disp_t * disp, void * buf1, void * buf2, uint32
                               lv_disp_render_mode_t render_mode);
 
 /**
- * Set the flush callback whcih will be called to copy the rendered image to the display.
+ * Set the flush callback which will be called to copy the rendered image to the display.
  * @param disp      pointer to a display
  * @param flush_cb  the flush callback (`px_map` contains the rendered image as raw pixel map and it should be copied to `area` on the display)
  */
 void lv_disp_set_flush_cb(lv_disp_t * disp, void (*flush_cb)(struct _lv_disp_t * disp, const lv_area_t * area,
                                                              lv_color_t * px_map));
+
+/**
+ * Set the wait callback which will be called periodically while lvgl waits for operation to be completed.
+ * @param disp     pointer to a display
+ * @param wait_cb  the wait callback
+ */
+void lv_disp_set_wait_cb(lv_disp_t * disp, void (*wait_cb)(struct _lv_disp_t * disp));
+
 /**
  * Set the color format of the display.
  * If set to other than `LV_COLOR_FORMAT_NATIVE` the draw_ctx's `buffer_convert` function will be used

--- a/src/core/lv_disp_private.h
+++ b/src/core/lv_disp_private.h
@@ -146,7 +146,7 @@ struct _lv_disp_t {
     /** OPTIONAL: Called periodically while lvgl waits for operation to be completed.
      * For example flushing or GPU
      * User can execute very simple tasks here or yield the task*/
-    void (*wait_cb)(struct _lv_disp_t * disp_drv);
+    void (*wait_cb)(struct _lv_disp_t * disp);
 
     /** On CHROMA_KEYED images this color will be transparent.
      * `LV_COLOR_CHROMA_KEY` by default. (lv_conf.h) */


### PR DESCRIPTION
### Description of the feature or fix

Added missing wait callback Settings.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
