### PR TITLE
feat(keyboard): add functions for adding/removing default event

### DIFF
--- a/src/widgets/keyboard/lv_keyboard.c
+++ b/src/widgets/keyboard/lv_keyboard.c
@@ -309,6 +309,40 @@ bool lv_btnmatrix_get_popovers(const lv_obj_t * obj)
  *====================*/
 
 /**
+ * Add the default keyboard event if it wasn't added previously.
+ * @param obj pointer to a keyboard object
+ */
+void lv_keyboard_add_default_event(lv_obj_t * obj)
+{
+    lv_keyboard_t * keyboard = (lv_keyboard_t *)obj;
+    if(keyboard->def_event_dsc) {
+        return;
+    }
+    lv_obj_add_event(obj, lv_keyboard_def_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
+    keyboard->def_event_dsc = lv_obj_get_event_dsc(obj, lv_obj_get_event_count(obj) - 1);
+}
+
+/**
+ * Remove the default keyboard event if it was added previously.
+ * @param obj pointer to a keyboard object
+ */
+void lv_keyboard_remove_default_event(lv_obj_t * obj)
+{
+    lv_keyboard_t * keyboard = (lv_keyboard_t *)obj;
+    if(!keyboard->def_event_dsc) {
+        return;
+    }
+    uint32_t num_events = lv_obj_get_event_count(obj);
+    for(uint32_t i = 0; i < num_events; ++i) {
+        if(lv_obj_get_event_dsc(obj, i) == keyboard->def_event_dsc) {
+            lv_obj_remove_event(obj, i);
+            break;
+        }
+    }
+    keyboard->def_event_dsc = NULL;
+}
+
+/**
  * Default keyboard event to add characters to the Text area and change the map.
  * If a custom `event_cb` is added to the keyboard this function can be called from it to handle the
  * button clicks
@@ -429,14 +463,15 @@ static void lv_keyboard_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
     lv_keyboard_t * keyboard = (lv_keyboard_t *)obj;
-    keyboard->ta         = NULL;
-    keyboard->mode       = LV_KEYBOARD_MODE_TEXT_LOWER;
-    keyboard->popovers   = 0;
+    keyboard->ta            = NULL;
+    keyboard->mode          = LV_KEYBOARD_MODE_TEXT_LOWER;
+    keyboard->popovers      = 0;
+    keyboard->def_event_dsc = NULL;
 
     lv_obj_align(obj, LV_ALIGN_BOTTOM_MID, 0, 0);
-    lv_obj_add_event(obj, lv_keyboard_def_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
     lv_obj_set_style_base_dir(obj, LV_BASE_DIR_LTR, 0);
 
+    lv_keyboard_add_default_event(obj);
     lv_keyboard_update_map(obj);
 }
 

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -57,6 +57,7 @@ typedef struct {
     lv_obj_t * ta;              /*Pointer to the assigned text area*/
     lv_keyboard_mode_t mode;    /*Key map type*/
     uint8_t popovers : 1;       /*Show button titles in popovers on press*/
+    lv_event_dsc_t * def_event_dsc; /*Descriptor for the default event or NULL if it was removed*/
 } lv_keyboard_t;
 
 extern const lv_obj_class_t lv_keyboard_class;
@@ -167,6 +168,18 @@ static inline const char * lv_keyboard_get_btn_text(const lv_obj_t * obj, uint16
 /*=====================
  * Other functions
  *====================*/
+
+/**
+ * Add the default keyboard event if it wasn't added previously.
+ * @param obj pointer to a keyboard object
+ */
+void lv_keyboard_add_default_event(lv_obj_t * obj);
+
+/**
+ * Remove the default keyboard event if it was added previously.
+ * @param obj pointer to a keyboard object
+ */
+void lv_keyboard_remove_default_event(lv_obj_t * obj);
 
 /**
  * Default keyboard event to add characters to the Text area and change the map.


### PR DESCRIPTION
### Description of the feature or fix

This adds function for safely adding and removing the default event on keyboard widgets.

Fixes: #4112

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
