### PR TITLE
fix(checkbox | label): fix string copy error

### DIFF
--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -70,16 +70,16 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
 
     if(NULL != txt) {
-        size_t len = 0;
+        size_t len;
 
 #if LV_USE_ARABIC_PERSIAN_CHARS
-        len = _lv_txt_ap_calc_bytes_cnt(txt);
+        len = _lv_txt_ap_calc_bytes_cnt(txt) + 1;
 #else
-        len = lv_strlen(txt);
+        len = lv_strlen(txt) + 1;
 #endif
 
-        if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len + 1);
-        else cb->txt = lv_malloc(len + 1);
+        if(!cb->static_txt) cb->txt = lv_realloc(cb->txt, len);
+        else cb->txt = lv_malloc(len);
 
         LV_ASSERT_MALLOC(cb->txt);
         if(NULL == cb->txt) return;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1281,8 +1281,8 @@ static void copy_text_to_label(lv_label_t * label, const char * text)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(text, label->text);
 #else
-    size_t len = lv_strlen(text);
-    (void) lv_strncpy(label->text, text, len);
+    size_t len = lv_strlen(text) + 1;
+    lv_memcpy(label->text, text, len);
 #endif
 }
 


### PR DESCRIPTION
### Description of the feature or fix
fix `lv_demo_widgets` crash:
```bash
[Warn]  (0.000, +0)      lv_init: Memory integrity checks are enabled via LV_USE_ASSERT_MEM_INTEGRITY which makes LVGL much slower     (in lv_obj.c line #189)
[Warn]  (0.000, +0)      lv_init: Object sanity checks are enabled via LV_USE_ASSERT_OBJ which makes LVGL much slower   (in lv_obj.c line #193)
[Warn]  (0.000, +0)      lv_init: Style sanity checks are enabled that uses more RAM    (in lv_obj.c line #197)
[Warn]  (0.428, +428)    lv_demo_widgets: LV_FONT_MONTSERRAT_24 is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.    (in lv_demo_widgets.c line #112)
[Warn]  (0.428, +0)      lv_demo_widgets: LV_FONT_MONTSERRAT_16 is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.    (in lv_demo_widgets.c line #117)
=================================================================
==3675454==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200006b755 at pc 0x55555598941b bp 0x7fffffffd320 sp 0x7fffffffd310
READ of size 1 at 0x60200006b755 thread T0
    #0 0x55555598941a in _lv_txt_get_next_line /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:295
    #1 0x55555598815c in lv_txt_get_size /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:108
    #2 0x555555a1c854 in lv_label_refr_text /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:902
    #3 0x555555a137ca in lv_label_set_text /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:132
    #4 0x555555a1911f in lv_label_constructor /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:681
    #5 0x555555878db6 in lv_obj_construct /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/core/lv_obj_class.c:182
    #6 0x555555878307 in lv_obj_class_init_obj /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/core/lv_obj_class.c:102
    #7 0x555555a12f13 in lv_label_create /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:84
    #8 0x555555a86402 in lv_demo_widgets /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/widgets/lv_demo_widgets.c:178
    #9 0x555555846db4 in main /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/main.c:85
    #10 0x7ffff63df082 in __libc_start_main ../csu/libc-start.c:308
    #11 0x555555846cad in _start (/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/build/Simulator+0x2f2cad)

0x60200006b755 is located 0 bytes to the right of 5-byte region [0x60200006b750,0x60200006b755)
allocated by thread T0 here:
    #0 0x7ffff7684808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x555555981944 in lv_malloc /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_mem.c:73
    #2 0x555555a1359d in lv_label_set_text /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:122
    #3 0x555555a1911f in lv_label_constructor /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:681
    #4 0x555555878db6 in lv_obj_construct /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/core/lv_obj_class.c:182
    #5 0x555555878307 in lv_obj_class_init_obj /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/core/lv_obj_class.c:102
    #6 0x555555a12f13 in lv_label_create /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/label/lv_label.c:84
    #7 0x555555a86402 in lv_demo_widgets /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/widgets/lv_demo_widgets.c:178
    #8 0x555555846db4 in main /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/main.c:85
    #9 0x7ffff63df082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:295 in _lv_txt_get_next_line
Shadow bytes around the buggy address:
  0x0c0480005690: fa fa fd fd fa fa fd fd fa fa fd fd fa fa 00 fa
  0x0c04800056a0: fa fa fd fd fa fa 00 00 fa fa 06 fa fa fa fd fa
  0x0c04800056b0: fa fa 00 fa fa fa 00 00 fa fa 00 fa fa fa 00 fa
  0x0c04800056c0: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fd
  0x0c04800056d0: fa fa 00 00 fa fa 00 fa fa fa 00 00 fa fa fd fa
=>0x0c04800056e0: fa fa 00 00 fa fa 00 00 fa fa[05]fa fa fa fa fa
  0x0c04800056f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480005700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480005710: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480005720: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480005730: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
