### PR TITLE
Any chinese character should be allowed to break line

### DIFF
--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -226,6 +226,12 @@ static uint32_t lv_txt_get_next_word(const char * txt, const lv_font_t * font,
             word_len--;
             break;
         }
+        else if(_lv_txt_is_a_word(letter_next) || _lv_txt_is_a_word(letter)) {
+            /*Found a word for single letter, usually true for CJK*/
+            *word_w_ptr = cur_w;
+            i = i_next;
+            break;
+        }
 
         /*Update the output width*/
         if(word_w_ptr != NULL && break_index == NO_BREAK_FOUND) *word_w_ptr = cur_w;

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -167,8 +167,13 @@ static inline bool _lv_txt_is_break_char(uint32_t letter)
     uint8_t i;
     bool ret = false;
 
-    /* each chinese character can be break */
+    /*Each chinese character can be break*/
     if(letter >= 0x4E00 && letter <= 0x9FA5) {
+        return true;
+    }
+
+    /*Each fullwidth ASCII variants can be break*/
+    if(letter >= 0xFF01 && letter <= 0xFF5E) {
         return true;
     }
 

--- a/src/misc/lv_txt.h
+++ b/src/misc/lv_txt.h
@@ -167,16 +167,6 @@ static inline bool _lv_txt_is_break_char(uint32_t letter)
     uint8_t i;
     bool ret = false;
 
-    /*Each chinese character can be break*/
-    if(letter >= 0x4E00 && letter <= 0x9FA5) {
-        return true;
-    }
-
-    /*Each fullwidth ASCII variants can be break*/
-    if(letter >= 0xFF01 && letter <= 0xFF5E) {
-        return true;
-    }
-
     /*Compare the letter to TXT_BREAK_CHARS*/
     for(i = 0; LV_TXT_BREAK_CHARS[i] != '\0'; i++) {
         if(letter == (uint32_t)LV_TXT_BREAK_CHARS[i]) {
@@ -186,6 +176,35 @@ static inline bool _lv_txt_is_break_char(uint32_t letter)
     }
 
     return ret;
+}
+
+
+/**
+ * Test if char is break char or not (a text can broken here or not)
+ * @param letter a letter
+ * @return false: 'letter' is not break char
+ */
+static inline bool _lv_txt_is_a_word(uint32_t letter)
+{
+    /*Cheap check on invalid letter*/
+    if(letter == 0) return false;
+
+    /*Chinese characters*/
+    if(letter >= 0x4E00 && letter <= 0x9FA5) {
+        return true;
+    }
+
+    /*Fullwidth ASCII variants*/
+    if(letter >= 0xFF01 && letter <= 0xFF5E) {
+        return true;
+    }
+
+    /*CJK symbols and punctuation*/
+    if(letter >= 0x3000 && letter <= 0x303F) {
+        return true;
+    }
+
+    return false;
 }
 
 /***************************************************************


### PR DESCRIPTION
### Chinese punctuation should be allowed to break

1. Add unicode range of fullwidth ascii variants and CKJ symbols.
2. Unlike ` ,.:` etc in English, any Chinese character should be allowed to break line and placed on newline. 


E.g. A simple string `你好，123世界` where label width is set to just enough to include charecter `你好，123` in one line.
It should be displayed as
```
你好，123
世界
```
Instead of current behavior:

```
你好，
123世界
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
