### PR TITLE
Add indev - set_feedback_cb() function

### DIFF
--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -170,9 +170,12 @@ The default value of the following parameters can be changed in `lv_indev_t`:
 
 ### Feedback
 
-Besides `read_cb` a `feedback_cb` callback can be also specified in `lv_indev_t`.
-`feedback_cb` is called when any type of event is sent by the input devices (independently of its type). This allows generating feedback for the user, e.g. to play a sound on `LV_EVENT_CLICKED`.
+Besides `read_cb` a `feedback_cb` callback can be also specified.
 
+`feedback_cb` is called when any type of event is sent by the input devices (independently of its type). This allows generating feedback for the user, e.g. to play a sound on `LV_EVENT_CLICKED`.
+```c
+lv_indev_set_feedback_cb(indev, feedback_cb);
+```
 
 ### Associating with a display
 Every input device is associated with a display. By default, a new input device is added to the last display created or explicitly selected (using `lv_disp_set_default()`).

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -256,6 +256,13 @@ void lv_indev_set_read_cb(lv_indev_t * indev,  void (*read_cb)(struct _lv_indev_
     indev->read_cb = read_cb;
 }
 
+void lv_indev_set_feedback_cb(lv_indev_t * indev,  void (*feedback_cb)(struct _lv_indev_t * indev, uint8_t event_code))
+{
+    if(indev == NULL) return;
+
+    indev->feedback_cb = feedback_cb;
+}
+
 void lv_indev_set_user_data(lv_indev_t * indev, void * user_data)
 {
     if(indev == NULL) return;

--- a/src/core/lv_indev.h
+++ b/src/core/lv_indev.h
@@ -114,6 +114,8 @@ void lv_indev_set_type(lv_indev_t * indev, lv_indev_type_t indev_type);
 
 void lv_indev_set_read_cb(lv_indev_t * indev,  void (*read_cb)(struct _lv_indev_t * indev, lv_indev_data_t * data));
 
+void lv_indev_set_feedback_cb(lv_indev_t * indev,  void (*feedback_cb)(struct _lv_indev_t * indev, uint8_t event_code));
+
 void lv_indev_set_user_data(lv_indev_t * indev, void * user_data);
 
 void lv_indev_set_driver_data(lv_indev_t * indev, void * driver_data);


### PR DESCRIPTION
### Description of the feature or fix

Since the display & input driver architecture change the `feedback_cb` field is private (in [lv_indev_private.h](https://github.com/lvgl/lvgl/blob/master/src/core/lv_indev_private.h#L34)), and it's not possible to define a callback function to listen to input device events. 

But this feature (to listen to input device events) is useful for example to have an auto-sleep feature: the callback function stores the time of last input event (for example touch), and a separate auto-sleep thread periodically checks this stored time, and after 10 minutes of inactivity (when there was no user input), the device/display is switched to sleep mode.

Other use case (as documentation mentions) is for example playing a sound for every input event / touch: https://docs.lvgl.io/master/porting/indev.html#feedback


### Checkpoints
- [X] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [X] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [X] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [X] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
