### PR TITLE
fix(table): fix heap buffer overflow

### DIFF
--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -971,8 +971,8 @@ static void copy_cell_txt(char * dst, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(txt, &dst[1]);
 #else
-    size_t len = lv_strlen(txt);
-    lv_strncpy(&dst[1], txt, len);
+    size_t len = lv_strlen(txt) + 1;
+    lv_memcpy(&dst[1], txt, len);
 #endif
 }
 


### PR DESCRIPTION
### Description of the feature or fix
```bash
=================================================================
==1799106==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000019047 at pc 0x55555598b8fe bp 0x7fffffffcf80 sp 0x7fffffffcf70
READ of size 1 at 0x603000019047 thread T0
    #0 0x55555598b8fd in lv_txt_utf8_next /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:614
    #1 0x555555988b8f in lv_txt_get_next_word /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:194
    #2 0x555555989822 in _lv_txt_get_next_line /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:315
    #3 0x5555559880b2 in lv_txt_get_size /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:108
    #4 0x555555a63037 in get_row_height /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/table/lv_table.c:888
    #5 0x555555a61ec9 in refr_cell_size /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/table/lv_table.c:817
    #6 0x555555a55801 in lv_table_set_cell_value /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/table/lv_table.c:112
    #7 0x555555a88b70 in generate_report /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/benchmark/lv_demo_benchmark.c:1048
    #8 0x555555a85c4d in next_scene_timer_cb /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/benchmark/lv_demo_benchmark.c:879
    #9 0x555555987a0c in lv_timer_exec /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_timer.c:314
    #10 0x555555986a92 in lv_timer_handler /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_timer.c:110
    #11 0x555555842022 in main /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/main.c:141
    #12 0x7ffff63df082 in __libc_start_main ../csu/libc-start.c:308
    #13 0x555555841cad in _start (/home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/build/Simulator+0x2edcad)

0x603000019047 is located 0 bytes to the right of 23-byte region [0x603000019030,0x603000019047)
allocated by thread T0 here:
    #0 0x7ffff7684c3e in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:163
    #1 0x55555597cc39 in lv_realloc /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_mem.c:127
    #2 0x555555a5530f in lv_table_set_cell_value /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/widgets/table/lv_table.c:105
    #3 0x555555a88b70 in generate_report /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/benchmark/lv_demo_benchmark.c:1048
    #4 0x555555a85c4d in next_scene_timer_cb /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/demos/benchmark/lv_demo_benchmark.c:879
    #5 0x555555987a0c in lv_timer_exec /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_timer.c:314
    #6 0x555555986a92 in lv_timer_handler /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_timer.c:110
    #7 0x555555842022 in main /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/main.c:141
    #8 0x7ffff63df082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/vifextech/workpath/LVGL/lv_sim_eclipse_sdl/lvgl/src/misc/lv_txt.c:614 in lv_txt_utf8_next
Shadow bytes around the buggy address:
  0x0c067fffb1b0: fa fa fd fd fd fa fa fa fd fd fd fd fa fa 00 00
  0x0c067fffb1c0: 00 fa fa fa fd fd fd fd fa fa fd fd fd fd fa fa
  0x0c067fffb1d0: fd fd fd fa fa fa 00 00 00 fa fa fa fd fd fd fa
  0x0c067fffb1e0: fa fa 00 00 00 06 fa fa 00 00 02 fa fa fa 00 00
  0x0c067fffb1f0: 00 fa fa fa fd fd fd fd fa fa 00 00 00 fa fa fa
=>0x0c067fffb200: 00 00 00 fa fa fa 00 00[07]fa fa fa fa fa fa fa
  0x0c067fffb210: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffb220: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffb230: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffb240: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffb250: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
