### PR TITLE
Fix ESP-IDF pedantic builds (backport v8.3)

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -15,6 +15,7 @@ if(LV_MICROPYTHON)
 else()
   if(CONFIG_LV_BUILD_EXAMPLES)
     file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
+    set_source_files_properties(${EXAMPLE_SOURCES} COMPILE_FLAGS "-Wno-unused-variable -Wno-format")
   endif()
 
   if(CONFIG_LV_USE_DEMO_WIDGETS)
@@ -36,6 +37,7 @@ else()
   if(CONFIG_LV_USE_DEMO_MUSIC)
     file(GLOB_RECURSE DEMO_MUSIC_SOURCES ${LVGL_ROOT_DIR}/demos/music/*.c)
     list(APPEND DEMO_SOURCES ${DEMO_MUSIC_SOURCES})
+    set_source_files_properties(${DEMO_MUSIC_SOURCES} COMPILE_FLAGS "-Wno-format")
   endif()
 
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,2 +1,5 @@
 description: LVGL - Light and Versatile Graphics Library
-url: https://github.com/lvgl/lvgl
+url: https://lvgl.io/
+repository: https://github.com/lvgl/lvgl.git
+documentation: https://docs.lvgl.io/
+issues: https://github.com/lvgl/lvgl/issues


### PR DESCRIPTION
### Description of the feature or fix

1. In many esp-idf projects we run pedantic builds,
where we treat warning as errors and we enable all warnings.
This commit suppress warnings in examples and demo source.

2. Add additional links to IDF component registry

Backport of #4132 

### Checkpoints
_Not really applicable. I removed this section_