### PR TITLE
update new feature of list

### DIFF
--- a/src/widgets/list/lv_list.c
+++ b/src/widgets/list/lv_list.c
@@ -114,6 +114,19 @@ const char * lv_list_get_btn_text(lv_obj_t * list, lv_obj_t * btn)
     return "";
 }
 
+void lv_list_set_btn_text(lv_obj_t * list, lv_obj_t * btn,char* text)
+{
+    LV_UNUSED(list);
+    uint32_t i;
+    for(i = 0; i < lv_obj_get_child_cnt(btn); i++) {
+        lv_obj_t * child = lv_obj_get_child(btn, i);
+        if(lv_obj_check_type(child, &lv_label_class)) {
+            lv_label_set_text(child,text);
+            return;
+        }
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/widgets/list/lv_list.c
+++ b/src/widgets/list/lv_list.c
@@ -114,14 +114,14 @@ const char * lv_list_get_btn_text(lv_obj_t * list, lv_obj_t * btn)
     return "";
 }
 
-void lv_list_set_btn_text(lv_obj_t * list, lv_obj_t * btn,char* text)
+static void lv_list_set_btn_text(lv_obj_t * list, lv_obj_t * btn, const char* txt)
 {
     LV_UNUSED(list);
     uint32_t i;
     for(i = 0; i < lv_obj_get_child_cnt(btn); i++) {
         lv_obj_t * child = lv_obj_get_child(btn, i);
         if(lv_obj_check_type(child, &lv_label_class)) {
-            lv_label_set_text(child,text);
+            lv_label_set_text(child,txt);
             return;
         }
     }

--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -64,6 +64,15 @@ lv_obj_t * lv_list_add_btn(lv_obj_t * list, const void * icon, const char * txt)
  */
 const char * lv_list_get_btn_text(lv_obj_t * list, lv_obj_t * btn);
 
+/**
+ * Set text of a given list button
+ * @param list      pointer to a list
+ * @param btn       pointer to the button
+ * @param txt       pointer to the text
+ * @return          Text of btn, if btn doesn't have text "" will be returned
+ */
+static void lv_list_set_btn_text(lv_obj_t * list, lv_obj_t * btn, const char* txt);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
