### PR TITLE
feat(mem): add lv_strcpy_builtin

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -50,7 +50,7 @@
     #endif
 #endif  /*LV_USE_BUILTIN_MALLOC*/
 
-/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin*/
+/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin, lv_strcpy_builtin*/
 #define LV_USE_BUILTIN_MEMCPY 1
 
 /*Enable and configure the built-in (v)snprintf */
@@ -71,6 +71,7 @@
 #define LV_VSNPRINTF    lv_vsnprintf_builtin
 #define LV_STRLEN       lv_strlen_builtin
 #define LV_STRNCPY      lv_strncpy_builtin
+#define LV_STRCPY       lv_strcpy_builtin
 
 #define LV_COLOR_EXTERN_INCLUDE <stdint.h>
 #define LV_COLOR_MIX      lv_color_mix

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -140,7 +140,7 @@
     #endif
 #endif  /*LV_USE_BUILTIN_MALLOC*/
 
-/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin*/
+/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin, lv_strcpy_builtin*/
 #ifndef LV_USE_BUILTIN_MEMCPY
     #ifdef _LV_KCONFIG_PRESENT
         #ifdef CONFIG_LV_USE_BUILTIN_MEMCPY
@@ -257,6 +257,13 @@
         #define LV_STRNCPY CONFIG_LV_STRNCPY
     #else
         #define LV_STRNCPY      lv_strncpy_builtin
+    #endif
+#endif
+#ifndef LV_STRCPY
+    #ifdef CONFIG_LV_STRCPY
+        #define LV_STRCPY CONFIG_LV_STRCPY
+    #else
+        #define LV_STRCPY       lv_strcpy_builtin
     #endif
 #endif
 

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -154,6 +154,11 @@ char * lv_strncpy(char * dst, const char * src, size_t dest_size)
     return LV_STRNCPY(dst, src, dest_size);
 }
 
+char * lv_strcpy(char * dst, const char * src)
+{
+    return LV_STRCPY(dst, src);
+}
+
 lv_res_t lv_mem_test(void)
 {
     if(zero_mem != ZERO_MEM_SENTINEL) {

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -88,6 +88,8 @@ size_t lv_strlen(const char * str);
 
 char * lv_strncpy(char * dst, const char * src, size_t dest_size);
 
+char * lv_strcpy(char * dst, const char * src);
+
 /**
  *
  * @return

--- a/src/misc/lv_memcpy_builtin.c
+++ b/src/misc/lv_memcpy_builtin.c
@@ -169,6 +169,13 @@ char * lv_strncpy_builtin(char * dst, const char * src, size_t dest_size)
     return dst;
 }
 
+char * lv_strcpy_builtin(char * dst, const char * src)
+{
+    char * tmp = dst;
+    while((*dst++ = *src++) != '\0');
+    return tmp;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/lv_memcpy_builtin.h
+++ b/src/misc/lv_memcpy_builtin.h
@@ -48,6 +48,8 @@ size_t lv_strlen_builtin(const char * str);
 
 char * lv_strncpy_builtin(char * dst, const char * src, size_t dest_size);
 
+char * lv_strcpy_builtin(char * dst, const char * src);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

Add built-in `strcpy` implementation.
Related discussion: https://github.com/lvgl/lvgl/pull/4131

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
