### PR TITLE
fix(object_tree): update parents of children after swapping

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -245,7 +245,10 @@ void lv_obj_swap(lv_obj_t * obj1, lv_obj_t * obj2)
     lv_obj_send_event(parent, LV_EVENT_CHILD_DELETED, obj1);
 
     parent->spec_attr->children[index1] = obj2;
+    obj2->parent = parent;
+
     parent2->spec_attr->children[index2] = obj1;
+    obj1->parent = parent2;
 
     lv_obj_send_event(parent, LV_EVENT_CHILD_CHANGED, obj2);
     lv_obj_send_event(parent, LV_EVENT_CHILD_CREATED, obj2);

--- a/tests/src/test_cases/test_obj_tree.c
+++ b/tests/src/test_cases/test_obj_tree.c
@@ -36,4 +36,48 @@ void test_obj_tree_2(void)
     //TEST_ASSERT_EQUAL_SCREENSHOT("scr1.png")
 }
 
+void test_obj_tree_3(void)
+{
+    /* tests lv_obj_swap */
+    lv_obj_t * parent1 = lv_obj_create(lv_scr_act());
+    lv_obj_t * parent2 = lv_obj_create(lv_scr_act());
+    lv_obj_t * child1 = lv_obj_create(parent1);
+    lv_obj_t * child2 = lv_obj_create(parent2);
+
+    /* were the parents set correctly for the children? */
+    lv_obj_t * child1_parent_before = lv_obj_get_parent(child1);
+    lv_obj_t * child2_parent_before = lv_obj_get_parent(child2);
+
+    TEST_ASSERT_EQUAL(child1_parent_before, parent1);
+    TEST_ASSERT_EQUAL(child2_parent_before, parent2);
+
+    /* were the children set correctly for the parents? */
+    TEST_ASSERT_EQUAL(lv_obj_get_child_cnt(parent1), 1);
+    TEST_ASSERT_EQUAL(lv_obj_get_index(child1), 0);
+    TEST_ASSERT_EQUAL(lv_obj_get_child(parent1, 0), child1);
+
+    TEST_ASSERT_EQUAL(lv_obj_get_child_cnt(parent2), 1);
+    TEST_ASSERT_EQUAL(lv_obj_get_index(child2), 0);
+    TEST_ASSERT_EQUAL(lv_obj_get_child(parent2, 0), child2);
+
+    /* swap the children */
+    lv_obj_swap(child1, child2);
+
+    /* test for properly swapped parents */
+    lv_obj_t * child1_parent_after = lv_obj_get_parent(child1);
+    lv_obj_t * child2_parent_after = lv_obj_get_parent(child2);
+
+    TEST_ASSERT_EQUAL(child1_parent_after, parent2);
+    TEST_ASSERT_EQUAL(child2_parent_after, parent1);
+
+    /* test for correctly set children */
+    TEST_ASSERT_EQUAL(lv_obj_get_child_cnt(parent1), 1);
+    TEST_ASSERT_EQUAL(lv_obj_get_index(child2), 0);
+    TEST_ASSERT_EQUAL(lv_obj_get_child(parent1, 0), child2);
+
+    TEST_ASSERT_EQUAL(lv_obj_get_child_cnt(parent2), 1);
+    TEST_ASSERT_EQUAL(lv_obj_get_index(child1), 0);
+    TEST_ASSERT_EQUAL(lv_obj_get_child(parent2, 0), child1);
+}
+
 #endif


### PR DESCRIPTION
### Description of the feature or fix

The lv_obj_swap function does swap the children of two parents but does not update the children's parent pointer.

See this example:
https://sim.lvgl.io/v8.3/micropython/ports/javascript/index.html?script_direct=624dc1d286a5b1257e07a29c0e7a718efa8932be

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- ~~Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed~~
- ~~Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.~~
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- ~~If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).~~
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
