### PR TITLE
feat(object_tree): make lv_obj_get_index return error value if the object has no parent

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -336,7 +336,7 @@ uint32_t lv_obj_get_index(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_obj_t * parent = lv_obj_get_parent(obj);
-    if(parent == NULL) return 0;
+    if(parent == NULL) return 0xFFFFFFFF;
 
     uint32_t i = 0;
     for(i = 0; i < lv_obj_get_child_cnt(parent); i++) {

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -151,7 +151,8 @@ uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
  * Get the index of a child.
  * @param obj       pointer to an object
  * @return          the child index of the object.
- *                  E.g. 0: the oldest (firstly created child)
+ *                  E.g. 0: the oldest (firstly created child).
+ *                  (0xFFFFFFFF if child could not be found or no parent exists)
  */
 uint32_t lv_obj_get_index(const struct _lv_obj_t * obj);
 


### PR DESCRIPTION
### Description of the feature or fix

If lv_obj_get_index is called by passing an object that has no parent, it returns 0. This indicates that the object's non-existing parent has a child which is the passed object. I find this very confusing and have changed it to return the error value 0xFFFFFFFF which is also used if the passed object is not among the parent's children.

I haven't yet checked where this function is used, but I think we need to do something. If this code change is raising other issues, we might just improve the documentation of lv_obj_get_index  in the header by saying that ONLY "an object with a parent" or "an object that is a child for sure" may be passed.

Currently the documentation says "Get the index of a child" which implies that only children will work but I think it should be more striking.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- ~~Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.~~
- ~~Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.~~
- ~~If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).~~
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
