### PR TITLE
Fix SDL window size not changing on some platforms

### DIFF
--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -252,6 +252,9 @@ static void window_create(lv_disp_t * disp)
     dsc->renderer = SDL_CreateRenderer(dsc->window, -1, SDL_RENDERER_SOFTWARE);
     texture_resize(disp);
     lv_memset(dsc->fb, 0xff, hor_res * ver_res * sizeof(lv_color_t));
+    /*Some platforms (e.g. Emscripten) seem to require setting the size again */
+    SDL_SetWindowSize(dsc->window, hor_res * dsc->zoom, ver_res * dsc->zoom);
+    texture_resize(disp);
 }
 
 static void window_update(lv_disp_t * disp)


### PR DESCRIPTION
### Description of the feature or fix

We had an issue with not being able to change the display size on the Micropython JS port anymore in v9: https://github.com/lvgl/lv_binding_micropython/issues/264#issuecomment-1513794078

For some reason Emscripten doesn't seem to accept the first window size and requires setting it again.

This fix was suggested by @kdschlosser and appears to fix the issue.
