### PR TITLE
bug: Update lv_sdl_window.c to fix SDL2 type error

### DIFF
--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -284,16 +284,16 @@ static void texture_resize(lv_disp_t * disp)
     if(dsc->texture) SDL_DestroyTexture(dsc->texture);
 
 #if LV_COLOR_DEPTH == 32
-    SDL_PixelFormatEnum px_format = SDL_PIXELFORMAT_ARGB8888;
+    SDL_PixelFormat px_format = {.format = SDL_PIXELFORMAT_ARGB8888};
 #elif LV_COLOR_DEPTH == 24
-    SDL_PixelFormatEnum px_format = SDL_PIXELFORMAT_BGR24;
+    SDL_PixelFormat px_format = {.format = SDL_PIXELFORMAT_BGR24};
 #elif LV_COLOR_DEPTH == 16
-    SDL_PixelFormatEnum px_format = SDL_PIXELFORMAT_RGB565;
+    SDL_PixelFormat px_format = {.format = SDL_PIXELFORMAT_RGB565};
 #else
 #error("Unsupported color format")
 #endif
 
-    dsc->texture = SDL_CreateTexture(dsc->renderer, px_format,
+    dsc->texture = SDL_CreateTexture(dsc->renderer, px_format.format,
                                      SDL_TEXTUREACCESS_STATIC, hor_res, ver_res);
     SDL_SetTextureBlendMode(dsc->texture, SDL_BLENDMODE_BLEND);
 }


### PR DESCRIPTION
Change SDL_PixelFormatEnum to use SDL_PixelFormat type instead

### Description of the feature or fix

When trying to compile with libsdl2-dev (2.0.8) that gets installed with docker
compilation failed as:
```
make -j3 
Makefile:4: Using Make to build this project is deprecated, please switch to CMake
CC //lvgl/src/core/lv_obj_class.c
//lvgl/src/dev/sdl/lv_sdl_window.c: In function 'window_create':
//lvgl/src/dev/sdl/lv_sdl_window.c:232:5: warning: "SDL_FULLSCREEN" is not defined, evaluates to 0 [-Wundef]
 #if SDL_FULLSCREEN
     ^~~~~~~~~~~~~~
//lvgl/src/dev/sdl/lv_sdl_window.c: In function 'texture_resize':
//lvgl/src/dev/sdl/lv_sdl_window.c:278:5: error: unknown type name 'SDL_PixelFormatEnum'; did you mean 'SDL_PixelFormat'?
     SDL_PixelFormatEnum px_format = SDL_PIXELFORMAT_RGB565;
     ^~~~~~~~~~~~~~~~~~~
     SDL_PixelFormat
Makefile:44: recipe for target '//lvgl/src/dev/sdl/lv_sdl_window.o' failed
make: *** [//lvgl/src/dev/sdl/lv_sdl_window.o] Error 1
make: *** Waiting for unfinished jobs....
```

Changed unknown SDL_PixelFormatEnum type to SDL_PixelFormat type. 
Compilation is ow succesful and running https://github.com/lvgl/lv_port_pc_eclipse/ displays demo widget