### PR TITLE
removes non ascii characters

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -48,7 +48,7 @@ Changelog
 Performance
 ~~~~~~~~~~~
 
--  perf(gpu): improve NXP’s PXP and VGLite accelerators
+-  perf(gpu): improve NXP's PXP and VGLite accelerators
    ```3952`` <https://github.com/lvgl/lvgl/pull/3952>`__
 -  perf(dam2d): rework stm32 dma2d
    ```3904`` <https://github.com/lvgl/lvgl/pull/3904>`__
@@ -90,7 +90,7 @@ Others
 -  chore(cmsis-pack): update cmsis-pack for v8.3.5
    ```3972`` <https://github.com/lvgl/lvgl/pull/3972>`__
 
--  chore: add an option to “LV_TICK_CUSTOM”
+-  chore: add an option to "LV_TICK_CUSTOM"
    ```3879`` <https://github.com/lvgl/lvgl/pull/3879>`__
 
 -  bump version numbers to v8.3.5-dev
@@ -126,7 +126,7 @@ Fixes
 -  fix(style): add the missing support for pct pivot in tranasform style
    properties
    ```c8e584f`` <https://github.com/lvgl/lvgl/commit/c8e584f879a1e1427e7a8f5ff496af39f17df41d>`__
--  fix(flex): be sure obj->w_layout and h_layout can’t be set at the
+-  fix(flex): be sure obj->w_layout and h_layout can't be set at the
    same time
    ```c4c4007`` <https://github.com/lvgl/lvgl/commit/c4c400716e80a279e7b3d43b8992915fe94441eb>`__
 -  fix(chart): fix very dense bar charts
@@ -291,9 +291,9 @@ Overview
    nested objects are blended as one layer to avoid color bleeding. See
    more
    `here <https://docs.lvgl.io/master/overview/style.html#opacity-blend-modes-and-transformations>`__.
--  **inherit and initial style properties** Besides setting “normal
-   values” for style properties now you can set them to ``inherit``
-   (inherit the parent’s value) and ``initial`` (set the system
+-  **inherit and initial style properties** Besides setting "normal
+   values" for style properties now you can set them to ``inherit``
+   (inherit the parent's value) and ``initial`` (set the system
    default). See more
    `here <https://docs.lvgl.io/master/overview/style.html#forced-value-inheritance-default-value>`__
 -  **NXP-PXP and VGLITE GPU support** The support for NXP GPUs are added
@@ -301,8 +301,8 @@ Overview
 -  **Color font support** You can use emojis and images in texts with
    this great new features. See more
    `here <https://docs.lvgl.io/master/others/imgfont.html>`__.
--  **ARM2D GPU support** Get support for Arm’s Microcontroller 2D
-   Graphics Acceleration, e.g. Helium based acceleration, DMA-350 based
+-  **ARM2D GPU support** Get support for Arm's Microcontroller 2D
+   Graphics Acceleration, e.g. Helium based acceleration, DMA-350 based
    acceleration etc.
 -  **PubSub messaging** A publisher-subscriber based messaging system is
    added to make communication between components easier. See more
@@ -310,8 +310,8 @@ Overview
 -  **Pinyin IME** Add support for Pinyin IME Chinese input. See more
    `here <https://docs.lvgl.io/master/others/ime_pinyin.html>`__.
 -  **render_start_cb** A new callback is added to ``lv_disp_drv_t`` to
-   indicate when the rendering starts. It’s useful to make
-   synchronization, e.g. wait for a TE signal.
+   indicate when the rendering starts. It's useful to make
+   synchronization, e.g. wait for a TE signal.
 
 .. _new-features-1:
 
@@ -328,7 +328,7 @@ New Features
    ```3439`` <https://github.com/lvgl/lvgl/pull/3439>`__
 -  feat(ime_pinyin): add API to use Pinyin IME(Chinese input)
    ```3408`` <https://github.com/lvgl/lvgl/pull/3408>`__
--  feat(style) add ‘inherit’ and ‘initial’ CSS properties
+-  feat(style) add 'inherit' and 'initial' CSS properties
    ```3390`` <https://github.com/lvgl/lvgl/pull/3390>`__
 -  feat(porting): add flushing control to the template
    ```3384`` <https://github.com/lvgl/lvgl/pull/3384>`__
@@ -427,7 +427,7 @@ New Features
 -  feat(indev): send LV_EVENT_PRESS_LOST on release with
    wait_until_release
    ```cc18518`` <https://github.com/lvgl/lvgl/commit/cc18518e96df63c2a02ee9d423cb7bc23382e5a7>`__
--  feat(style) add ‘inherit’ and ‘initial’ CSS properties (#3390)
+-  feat(style) add 'inherit' and 'initial' CSS properties (#3390)
    ```9a48de0`` <https://github.com/lvgl/lvgl/commit/9a48de0f8b19ec02a44aaf6b330066eed7d0a105>`__
 -  feat(draw): improve acceleration for LV_IMG_CF_ALPHA_8BIT (#3337)
    ```8d3c41d`` <https://github.com/lvgl/lvgl/commit/8d3c41d5170dad0455fea3d95b2765db70d3c7c2>`__
@@ -523,7 +523,7 @@ Fixes
    ```3264`` <https://github.com/lvgl/lvgl/pull/3264>`__
 -  fix(menu): use LV_ASSERT_MALLOC check for new_node
    ```3263`` <https://github.com/lvgl/lvgl/pull/3263>`__
--  fix(canvas):image cache may expire after set canvas’s buff
+-  fix(canvas):image cache may expire after set canvas's buff
    ```3267`` <https://github.com/lvgl/lvgl/pull/3267>`__
 -  fix(obj_style): prevent access to class null pointer
    ```3252`` <https://github.com/lvgl/lvgl/pull/3252>`__
@@ -594,7 +594,7 @@ Fixes
    ```3193`` <https://github.com/lvgl/lvgl/pull/3193>`__
 -  fix(Kconfig): move LV_USE_IMGFONT to others menu
    ```3176`` <https://github.com/lvgl/lvgl/pull/3176>`__
--  fix(draw): src_buf_tmp will be NULL when LV_DRAW_COMPLEX is ‘0’
+-  fix(draw): src_buf_tmp will be NULL when LV_DRAW_COMPLEX is '0'
    ```3163`` <https://github.com/lvgl/lvgl/pull/3163>`__
 -  fix(span): align the baselines
    ```3164`` <https://github.com/lvgl/lvgl/pull/3164>`__
@@ -642,7 +642,7 @@ Fixes
    ```9ac8ce6`` <https://github.com/lvgl/lvgl/commit/9ac8ce69f67234563d4254e29e1903a638bb8f4e>`__
 -  fix(draw): revert handling of style_opa on not MAIN parts
    ```51a7a61`` <https://github.com/lvgl/lvgl/commit/51a7a61df365685a7cd04b0512ba3844dcfa7209>`__
--  fix(draw): clip the bg img to the rectangle’s area in lv_draw_sw_rect
+-  fix(draw): clip the bg img to the rectangle's area in lv_draw_sw_rect
    ```77d726e`` <https://github.com/lvgl/lvgl/commit/77d726efb2467ff86691dee487f97aac79ea45c2>`__
 -  fix(obj): fix LV_OBJ_FLAG_OVERFLOW_VISIBLE
    ```c742f2c`` <https://github.com/lvgl/lvgl/commit/c742f2c8888ad0102cebe91b4069b376068baa81>`__
@@ -666,7 +666,7 @@ Fixes
    ```7153e3f`` <https://github.com/lvgl/lvgl/commit/7153e3f8b7b660474b8907954c80e21eb2f0bd21>`__
 -  fix(refr): fix memory write out of bounds issue
    ```13c99fc`` <https://github.com/lvgl/lvgl/commit/13c99fc4b66d3e8d0ffcd6fda21d3b5a40b0771c>`__
--  fix(gif): fix rare issue when drawing the gif’s background
+-  fix(gif): fix rare issue when drawing the gif's background
    ```b1e2c06`` <https://github.com/lvgl/lvgl/commit/b1e2c0665829aa489f444169ce80fcd7cdf487bb>`__
 -  fix(chart): fix misaligned horizontal tick lines on bar charts
    ```4572a0c`` <https://github.com/lvgl/lvgl/commit/4572a0c6c92b126e229ce9aada551d71b4f4296b>`__
@@ -674,7 +674,7 @@ Fixes
    ```7cf5709`` <https://github.com/lvgl/lvgl/commit/7cf5709b0669ab64e437a796c50f6bdb97b9d0d5>`__
 -  revert(group): 72cb683c799f65cd4fbae22dafc3a35c123bb66b
    ```b7b22c1`` <https://github.com/lvgl/lvgl/commit/b7b22c190c6d9e11a841289708f55be0be86830f>`__
--  fix(keyboard): don’t show popovers on map change
+-  fix(keyboard): don't show popovers on map change
    ```ac202e7`` <https://github.com/lvgl/lvgl/commit/ac202e7b96510b9b12beb8a1eee3dfd65bc56a3d>`__
 -  fix(refr): consider masks with LV_OBJ_FLAG_OVERFLOW_VISIBLE
    ```a7f9dfa`` <https://github.com/lvgl/lvgl/commit/a7f9dfa8c3e4fd56cc2db5c3f3926b9391d3661f>`__
@@ -865,7 +865,7 @@ CI and tests
    ```b83c5aa`` <https://github.com/lvgl/lvgl/commit/b83c5aa9bc4a278a6758f76e77ac9c403e483948>`__
 -  ci remove formatting comment
    ```d345f76`` <https://github.com/lvgl/lvgl/commit/d345f76d02a23d94550b1b60be90585f6f5276b7>`__
--  ci don’t run workflows twice on PRs
+-  ci don't run workflows twice on PRs
    ```fcc1152`` <https://github.com/lvgl/lvgl/commit/fcc1152f9c14494f128f26a6b47b00864a70c741>`__
 -  ci bump test timeout to 30 seconds [skip ci]
    ```85e3e23`` <https://github.com/lvgl/lvgl/commit/85e3e2387845bd29c9f85b406623e41d36b66808>`__
@@ -891,10 +891,10 @@ Overview
 Among many fixes and minor updates these are the most important features
 in v8.2.0: - Abstract render layer to make it easier to attach external
 draw engines - Add ``LV_FLAD_OVERFLOW_VISIBLE``. If enabled the children
-of an object won’t be clipped to the boundary of the object - Add ffmpeg
+of an object won't be clipped to the boundary of the object - Add ffmpeg
 decoder support to play videos and open a wide variety of image formats
 - Add font fallback support - Add gradient dithering support - Add
-“monkey test” - Add cmsis-pack support - Add Grid navigation
+"monkey test" - Add cmsis-pack support - Add Grid navigation
 (``lv_gridnav``)
 
 The GPU support for NXP microcontrollers is still not updated to the new
@@ -1053,7 +1053,7 @@ Fixes
    ```2996`` <https://github.com/littlevgl/lvgl/pull/2996>`__
 -  fix(refr): crash if full_refresh = 1
    ```2999`` <https://github.com/littlevgl/lvgl/pull/2999>`__
--  fix(Kconfig): adapt to lvgl’s built-in demos
+-  fix(Kconfig): adapt to lvgl's built-in demos
    ```2989`` <https://github.com/littlevgl/lvgl/pull/2989>`__
 -  fix(Makefile): compilation errors
    ```2944`` <https://github.com/littlevgl/lvgl/pull/2944>`__
@@ -1061,7 +1061,7 @@ Fixes
    ```2971`` <https://github.com/littlevgl/lvgl/pull/2971>`__
 -  fix(group): in lv_group_del() remove group from indev (lvgl#2963)
    ```2964`` <https://github.com/littlevgl/lvgl/pull/2964>`__
--  fix(obj): old parent’s scroll is not updated in lv_obj_set_parent()
+-  fix(obj): old parent's scroll is not updated in lv_obj_set_parent()
    ```2965`` <https://github.com/littlevgl/lvgl/pull/2965>`__
 -  fix(fatfs) add missing cast
    ```2969`` <https://github.com/littlevgl/lvgl/pull/2969>`__
@@ -1147,7 +1147,7 @@ Fixes
    ```2813`` <https://github.com/littlevgl/lvgl/pull/2813>`__
 -  fix(obj): in obj event use the current target instead of target
    ```2785`` <https://github.com/littlevgl/lvgl/pull/2785>`__
--  fix(draw_label): radius Mask doesn’t work in Specific condition
+-  fix(draw_label): radius Mask doesn't work in Specific condition
    ```2784`` <https://github.com/littlevgl/lvgl/pull/2784>`__
 -  fix(draw_mask): will crash if get_width/height < 0
    ```2793`` <https://github.com/littlevgl/lvgl/pull/2793>`__
@@ -1209,7 +1209,7 @@ Fixes
    ```71c739c`` <https://github.com/littlevgl/lvgl/commit/71c739cc2dbcebf16e8adc805dda182011e725da>`__
 -  chore(docs): fix lv_list_add_text
    ```a5fbf22`` <https://github.com/littlevgl/lvgl/commit/a5fbf22d415a52cb2641c6dfda6937a10e4952cc>`__
--  fix(png) check png magic number to be sure it’s a png image
+-  fix(png) check png magic number to be sure it's a png image
    ```1092550`` <https://github.com/littlevgl/lvgl/commit/1092550775c464f9ae8c406786fe02115776d5c6>`__
 -  fix(btnmatrix): fix crash if an empty btnmatrix is pressed
    ```2392f58`` <https://github.com/littlevgl/lvgl/commit/2392f585bb9317153f6fb648d2a660cbdc3e276f>`__
@@ -1288,7 +1288,7 @@ Docs
    ```2719862`` <https://github.com/littlevgl/lvgl/commit/2719862fc3065b5d72c74c3f5f0923c3f6cc82c6>`__
 -  docs(style): describe const styles
    ```28ffae8`` <https://github.com/littlevgl/lvgl/commit/28ffae8c931ff01a4e5d426a2e496053e840c094>`__
--  docs(faq): add “LVGL doesn’t start, nothing is drawn on the display”
+-  docs(faq): add "LVGL doesn't start, nothing is drawn on the display"
    section
    ```0388d92`` <https://github.com/littlevgl/lvgl/commit/0388d9218a36debf6c989eb999ae68478d8f6b02>`__
 -  docs add demos
@@ -1646,7 +1646,7 @@ Performance
 -  perf(draw) reimplement rectangle drawing algorithms
    ```5b3d3dc`` <https://github.com/lvgl/lvgl/commit/5b3d3dc8b35bdd16e5dea00ffc40b7a20471079d>`__
 
--  perf(draw) ignore masks if they don’t affect the current draw area
+-  perf(draw) ignore masks if they don't affect the current draw area
    ```a842791`` <https://github.com/lvgl/lvgl/commit/a8427915c747dfe562f7f7e80adb6d1be5b2eeae>`__
 
 -  perf(refresh) optimize where to wait for lv_disp_flush_ready with 2
@@ -1661,10 +1661,10 @@ Performance
 Fixes
 ~~~~~
 
--  fix(bidi): add weak characters to the previous strong character’s run
+-  fix(bidi): add weak characters to the previous strong character's run
    ```2777`` <https://github.com/lvgl/lvgl/pull/2777>`__
 
--  fix(draw_img): radius mask doesn’t work in specific condition
+-  fix(draw_img): radius mask doesn't work in specific condition
    ```2786`` <https://github.com/lvgl/lvgl/pull/2786>`__
 
 -  fix(border_post): ignore bg_img_opa draw when draw border_post
@@ -1688,7 +1688,7 @@ Fixes
 -  fix(draw_img): fix typos in API comments
    ```2773`` <https://github.com/lvgl/lvgl/pull/2773>`__
 
--  fix(draw_img):radius Mask doesn’t work in Specific condition
+-  fix(draw_img):radius Mask doesn't work in Specific condition
    ```2775`` <https://github.com/lvgl/lvgl/pull/2775>`__
 
 -  fix(proto) Remove redundant prototype declarations
@@ -1818,7 +1818,7 @@ Fixes
 -  fix(meter) make lv_meter_indicator_type_t of type uint8_t
    ```2632`` <https://github.com/lvgl/lvgl/pull/2632>`__
 
--  fix(span):crash if span->txt = “”
+-  fix(span):crash if span->txt = ""
    ```2616`` <https://github.com/lvgl/lvgl/pull/2616>`__
 
 -  fix(disp) set default theme also for non-default displays
@@ -1842,7 +1842,7 @@ Fixes
 -  fix(span) opa bug
    ```2584`` <https://github.com/lvgl/lvgl/pull/2584>`__
 
--  fix(snapshot) snapshot is affected by parent’s style because of wrong
+-  fix(snapshot) snapshot is affected by parent's style because of wrong
    coords ```2579`` <https://github.com/lvgl/lvgl/pull/2579>`__
 
 -  fix(label):make draw area contain ext_draw_size
@@ -1892,7 +1892,7 @@ Fixes
    ```2501`` <https://github.com/lvgl/lvgl/pull/2501>`__
 
 -  fix(event) be sure to move all elements in copy
-   “lv_obj_remove_event_cb”
+   "lv_obj_remove_event_cb"
    ```2492`` <https://github.com/lvgl/lvgl/pull/2492>`__
 
 -  fix(draw) use correct pointer in lv_draw_mask assertion
@@ -1901,7 +1901,7 @@ Fixes
 -  feat(mem) LV_MEM_POOL_ALLOC
    ```2458`` <https://github.com/lvgl/lvgl/pull/2458>`__
 
--  fix(cmake) require ‘main’ for Micropython
+-  fix(cmake) require 'main' for Micropython
    ```2444`` <https://github.com/lvgl/lvgl/pull/2444>`__
 
 -  fix(docs) add static keyword to driver declaration
@@ -2278,7 +2278,7 @@ Fixes
 -  fix shadowed variable
    ```df60018`` <https://github.com/lvgl/lvgl/commit/df600183f211bde0ff34add973a7a401a1da9af1>`__
 
--  fix(chart) be sure the chart doesn’t remain scrolled out on zoom out
+-  fix(chart) be sure the chart doesn't remain scrolled out on zoom out
    ```ad5b1bd`` <https://github.com/lvgl/lvgl/commit/ad5b1bdc00a4a44e775a280f8b686353ef4f2a38>`__
 
 -  fix(docs) commit to meta repo as lvgl-bot instead of actual commit
@@ -2356,7 +2356,7 @@ Fixes
 -  fix(msgbox) prevent the buttons being wider than the msgbox
    ```73e036b`` <https://github.com/lvgl/lvgl/commit/73e036bba748e8677f219f573cba5f82c4158a17>`__
 
--  fix(chart) don’t draw series lines with < 1 points
+-  fix(chart) don't draw series lines with < 1 points
    ```655f42b`` <https://github.com/lvgl/lvgl/commit/655f42b852669f27ab8bfde84bf70cf0b7ea027d>`__
 
 -  fix(tests) remove src/test_runners when cleaning
@@ -2368,7 +2368,7 @@ Fixes
 -  fix(colorwheel) disable LV_OBJ_FLAG_SCROLL_CHAIN by default
    ```48d1c29`` <https://github.com/lvgl/lvgl/commit/48d1c292a3c19380d5669baf911954cc1b083d43>`__
 
--  fix(obj) do not set the child’s position in lv_obj_set_parent
+-  fix(obj) do not set the child's position in lv_obj_set_parent
    ```d89a5fb`` <https://github.com/lvgl/lvgl/commit/d89a5fbbd2af33cf759c120e6a14b334099c4c98>`__
 
 -  feat: add LV_USE_MEM_PERF/MONITOR_POS
@@ -2434,7 +2434,7 @@ Fixes
 -  fix(obj) swap objects in the group too in lv_obj_swap()
    ```52c7558`` <https://github.com/lvgl/lvgl/commit/52c7558ab46a7024e05499edb483f115b13086f0>`__
 
--  fix(theme) use opacity on button’s shadow in the default theme
+-  fix(theme) use opacity on button's shadow in the default theme
    ```c5342e9`` <https://github.com/lvgl/lvgl/commit/c5342e9324c492c70b65f8c228d44b7a290cf110>`__
 
 -  fix(win) enable clip_corner and border_post by default
@@ -2479,7 +2479,7 @@ Fixes
 -  fix(tabview) send LV_EVENT_VALUE_CHANGED only once
    ```933d282`` <https://github.com/lvgl/lvgl/commit/933d2829aca8bc269c0b481f2a535274626374bc>`__
 
--  fix(obj style) fix children reposition if the parent’s padding
+-  fix(obj style) fix children reposition if the parent's padding
    changes.
    ```57cf661`` <https://github.com/lvgl/lvgl/commit/57cf6610a9ec2e6458035abfdaa5554f4296c89c>`__
 
@@ -2559,7 +2559,7 @@ Examples
 -  fix(example_roller_3) mask free param bug
    ```2553`` <https://github.com/lvgl/lvgl/pull/2553>`__
 
--  fix(examples) don’t compile assets unless needed
+-  fix(examples) don't compile assets unless needed
    ```2523`` <https://github.com/lvgl/lvgl/pull/2523>`__
 
 -  fix(example) scroll example sqort types
@@ -2577,7 +2577,7 @@ Examples
 -  fix(examples) remove symlinks
    ```2406`` <https://github.com/lvgl/lvgl/pull/2406>`__
 
--  fix(examples) import ‘u’-prefixed versions of modules
+-  fix(examples) import 'u'-prefixed versions of modules
    ```2365`` <https://github.com/lvgl/lvgl/pull/2365>`__
 
 -  fix(examples) remove cast in MP scripts
@@ -2734,7 +2734,7 @@ Docs
 -  docs(README) update links, examples, and add services menu
    ```3471bd1`` <https://github.com/lvgl/lvgl/commit/3471bd1c698ee58f6632415559dcc34e9d2ee3c0>`__
 
--  docs(color) update colors’ docs
+-  docs(color) update colors' docs
    ```9056b5e`` <https://github.com/lvgl/lvgl/commit/9056b5ee1bfea6796307bdf983a4a00ea47fe9f0>`__
 
 -  docs update lv_fs.h, layer and align.png to v8
@@ -2992,7 +2992,7 @@ Others
 -  build: fix lib name in CMakeLists
    ```2641`` <https://github.com/lvgl/lvgl/pull/2641>`__
 
--  build: remove use of ‘project’ keyword in CMakeLists
+-  build: remove use of 'project' keyword in CMakeLists
    ```2640`` <https://github.com/lvgl/lvgl/pull/2640>`__
 
 -  build add install rule to CMakeList.txt
@@ -3025,7 +3025,7 @@ Others
 -  added lv_obj_move_up() and lv_obj_move_down()
    ```2467`` <https://github.com/lvgl/lvgl/pull/2467>`__
 
--  Fix buf name error for “lv_port_disp_template.c” and optimize the
+-  Fix buf name error for "lv_port_disp_template.c" and optimize the
    arduino example ```2475`` <https://github.com/lvgl/lvgl/pull/2475>`__
 
 -  Fix two examples in the docs with new v8 api
@@ -3085,7 +3085,7 @@ Others
 -  Update ROADMAP.md
    ```a38fcf2`` <https://github.com/lvgl/lvgl/commit/a38fcf2c7aa5fd156d3f2b6965ec4f81d7ff5503>`__
 
--  Revert “feat(conf) add better check for Kconfig default”
+-  Revert "feat(conf) add better check for Kconfig default"
    ```a5793c7`` <https://github.com/lvgl/lvgl/commit/a5793c70a9a60340a5f1c5d33ba1d118af0a76e2>`__
 
 -  remove temporary test file
@@ -3152,7 +3152,7 @@ Others
 -  Update index.rst
    ```9ce2c77`` <https://github.com/lvgl/lvgl/commit/9ce2c7702d15d74f64b7d4bf6273cba442b48c09>`__
 
--  chore(docs) minor formatting on example’s GitHub link
+-  chore(docs) minor formatting on example's GitHub link
    ```75209e8`` <https://github.com/lvgl/lvgl/commit/75209e893e89b6aa9d6a231af4661ce6a6dd6161>`__
 
 -  chore(lv_conf_template) fix spelling mistake
@@ -3164,13 +3164,13 @@ Others
 -  chore(stale) disable on forks
    ```93c1303`` <https://github.com/lvgl/lvgl/commit/93c1303ee7989d25216262e1d0ea244b59b975f6>`__
 
--  Revert “fix(tests) remove src/test_runners when cleaning”
+-  Revert "fix(tests) remove src/test_runners when cleaning"
    ```ae15a1b`` <https://github.com/lvgl/lvgl/commit/ae15a1bbfe122115e5c8ac1f707929673843ad37>`__
 
 -  style fix usage of clang-format directives
    ```2122583`` <https://github.com/lvgl/lvgl/commit/2122583ec23d82422e1e3d6f2b5a20745fa5dd6d>`__
 
--  Revert “fix(indev) focus on objects on release instead of press”
+-  Revert "fix(indev) focus on objects on release instead of press"
    ```f61b2ca`` <https://github.com/lvgl/lvgl/commit/f61b2ca45502472cde8ac0983b73dbf153de2b20>`__
 
 v8.0.2 (16.07.2021)
@@ -3180,7 +3180,7 @@ v8.0.2 (16.07.2021)
 -  fix(tabview) send LV_EVENT_VALUE_CHANGED only once
 -  fix(imgbtn) use the correct src in LV_EVENT_GET_SELF_SIZE
 -  fix(color) remove extraneous cast for 8-bit color
--  fix(obj style) fix children reposition if the parent’s padding
+-  fix(obj style) fix children reposition if the parent's padding
    changes.
 -  fix(color) remove extraneous \_LV_COLOR_MAKE_TYPE_HELPER (#2372)
 -  fix(spinner) should not be clickable (#2373)
@@ -3248,12 +3248,12 @@ v8.0.1 (14.06.2021)
 -  fix(msgbox) handle NULL btn map parameter 769c4a30
 -  fix(group) allow refocusing objects 1520208b
 -  docs(overview) spelling fixes d2efb8c6
--  Merge branch ‘master’ of https://github.com/lvgl/lvgl 45960838
+-  Merge branch 'master' of https://github.com/lvgl/lvgl 45960838
 -  feat(timer) check if lv_tick_inc is called aa6641a6
 -  feat(docs) add view on GitHub link a716ac6e
 -  fix(theme) fix the switch style in the default theme 0c0dc8ea
 -  docs fix typo 8ab80645
--  Merge branch ‘master’ of https://github.com/lvgl/lvgl e796448f
+-  Merge branch 'master' of https://github.com/lvgl/lvgl e796448f
 -  feat(event) pass the scroll animation to LV_EVENT_SCROLL_BEGIN
    ca54ecfe
 -  fix(tabview) fix with left and right tabs 17c57449
@@ -3269,8 +3269,8 @@ v8.0.1 (14.06.2021)
 -  docs(color) minor fix ac8f4534
 -  fix(example) revert test code 77e2c1ff
 -  fix(draw) with additive blending with 32-bit color depth 786db2af
--  docs(color) update colors’ docs 9056b5ee
--  Merge branch ‘master’ of https://github.com/lvgl/lvgl a711a1dd
+-  docs(color) update colors' docs 9056b5ee
+-  Merge branch 'master' of https://github.com/lvgl/lvgl a711a1dd
 -  perf(refresh) optimize where to wait for lv_disp_flush_ready with 2
    buffers d0172f14
 -  docs(lv_obj_style) update add_style and remove_style function headers
@@ -3278,7 +3278,7 @@ v8.0.1 (14.06.2021)
 -  fix memory leak of spangroup (#2285) 33e0926a
 -  fix make lv_img_cache.h public because cache invalidation is public
    38ebcd81
--  Merge branch ‘master’ of https://github.com/lvgl/lvgl 2b292495
+-  Merge branch 'master' of https://github.com/lvgl/lvgl 2b292495
 -  fix(btnmatrix) fix focus event handling 3b58ef14
 -  Merge pull request #2280 from lvgl/dependabot/pip/docs/urllib3-1.26.5
    a2f45b26
@@ -3293,7 +3293,7 @@ v8.0 brings many new features like simplified and more powerful
 scrolling, new layouts inspired by CSS Flexbox and Grid, simplified and
 improved widgets, more powerful events, hookable drawing, and more.
 
-v8 is a major change and therefore it’s not backward compatible with v7.
+v8 is a major change and therefore it's not backward compatible with v7.
 
 Directory structure
 ~~~~~~~~~~~~~~~~~~~
@@ -3321,7 +3321,7 @@ Widget changes
 New scrolling
 ~~~~~~~~~~~~~
 
--  Support “elastic” scrolling when scrolled in
+-  Support "elastic" scrolling when scrolled in
 -  Support scroll chaining among any objects types (not only
    ``lv_pages``\ s)
 -  Remove ``lv_drag``. Similar effect can be achieved by setting the
@@ -3374,8 +3374,8 @@ Other changes
 -  Use a more generic inheritance
 -  The built-in themes are reworked
 -  ``lv_obj_align`` now saved the alignment and realigns the object
-   automatically but can’t be used to align to other than the parent
--  ``lv_obj_align_to`` can align to an object but doesn’t save the
+   automatically but can't be used to align to other than the parent
+-  ``lv_obj_align_to`` can align to an object but doesn't save the
    alignment
 -  ``lv_pct(x)`` can be used to set the size and position in percentage
 -  There are many other changes in widgets that are not detailed here.
@@ -3394,7 +3394,7 @@ Migrating from v7 to v8
 
 -  First and foremost, create a new ``lv_conf.h`` based on
    ``lv_conf_template.h``.
--  To try the new version it’s recommended to use a simulator project
+-  To try the new version it's recommended to use a simulator project
    and see the examples.
 -  When migrating your project to v8
 
@@ -3406,7 +3406,7 @@ Migrating from v7 to v8
    -  See the changes in
       `Colors <https://docs.lvgl.io/8.0/overview/color.html>`__
    -  The other parts are mainly minor renames and refactoring. See the
-      functions’ documentation for descriptions.
+      functions' documentation for descriptions.
 
 v7.11.0 (16.03.2021)
 --------------------
@@ -3418,7 +3418,7 @@ New features
 
 -  Add better screen orientation management with software rotation
    support
--  Decide text animation’s direction based on base_dir (when using
+-  Decide text animation's direction based on base_dir (when using
    LV_USE_BIDI)
 
 Bugfixes
@@ -3437,7 +3437,7 @@ Bugfixes
 
 -  fix(draw) overlap outline with background to prevent aliasing
    artifacts
--  fix(indev) clear the indev’s ``act_obj`` in ``lv_indev_reset``
+-  fix(indev) clear the indev's ``act_obj`` in ``lv_indev_reset``
 -  fix(text) fix out of bounds read in ``_lv_txt_get_width``
 -  fix(list) scroll list when button is focused using LV_KEY_NEXT/PREV
 -  fix(text) improve Arabic contextual analysis by adding hyphen
@@ -3476,7 +3476,7 @@ Bugfixes
 -  fix(dropdown) fix selecting options after the last one
 -  fix(msgbox) use the animation time provided
 -  fix(gpu_nxp_pxp) fix incorrect define name
--  fix(indev) don’t leave edit mode if there is only one object in the
+-  fix(indev) don't leave edit mode if there is only one object in the
    group
 -  fix(draw_rect) fix draw pattern stack-use-after-scope error
 
@@ -3540,7 +3540,7 @@ Bugfixes
 ~~~~~~~~
 
 -  fix(btnmatrix) handle arabic texts in button matrices
--  fix(indev) disabled object shouldn’t absorb clicks but let the parent
+-  fix(indev) disabled object shouldn't absorb clicks but let the parent
    to be clicked
 -  fix(arabic) support processing again already processed texts with
    \_lv_txt_ap_proc
@@ -3585,7 +3585,7 @@ v7.7.1 (03.11.2020)
 Bugfixes
 ~~~~~~~~
 
--  Respect btnmatrix’s ``one_check`` in ``lv_btnmatrix_set_btn_ctrl``
+-  Respect btnmatrix's ``one_check`` in ``lv_btnmatrix_set_btn_ctrl``
 -  Gauge: make the needle images to use the styles from
    ``LV_GAUGE_PART_PART``
 -  Group: fix in ``lv_group_remove_obj`` to handle deleting hidden
@@ -3717,7 +3717,7 @@ Bugfixes
 ~~~~~~~~
 
 -  Fix color bleeding on border drawing
--  Fix using ‘LV_SCROLLBAR_UNHIDE’ after ‘LV_SCROLLBAR_ON’
+-  Fix using 'LV_SCROLLBAR_UNHIDE' after 'LV_SCROLLBAR_ON'
 -  Fix cropping of last column/row if an image is zoomed
 -  Fix zooming and rotating mosaic images
 -  Fix deleting tabview with LEFT/RIGHT tab position
@@ -3736,7 +3736,7 @@ Bugfixes
 -  Fix drawing value string twice
 -  Rename ``lv_chart_clear_serie`` to ``lv_chart_clear_series`` and
    ``lv_obj_align_origo`` to ``lv_obj_align_mid``
--  Add linemeter’s mirror feature again
+-  Add linemeter's mirror feature again
 -  Fix text decor (underline strikethrough) with older versions of font
    converter
 -  Fix setting local style property multiple times
@@ -3745,7 +3745,7 @@ Bugfixes
 -  Fix crash if ``lv_table_set_col_cnt`` is called before
    ``lv_table_set_row_cnt`` for the first time
 -  Fix overflow in large image transformations
--  Limit extra button click area of button matrix’s buttons. With large
+-  Limit extra button click area of button matrix's buttons. With large
    paddings it was counter-intuitive. (Gaps are mapped to button when
    clicked).
 -  Fix ``lv_btnmatrix_set_one_check`` not forcing exactly one button to
@@ -3764,7 +3764,7 @@ New features
 -  Add ``lv_task_get_next``
 -  Add ``lv_event_send_refresh``, ``lv_event_send_refresh_recursive`` to
    easily send ``LV_EVENT_REFRESH`` to object
--  Add ``lv_tabview_set_tab_name()`` function - used to change a tab’s
+-  Add ``lv_tabview_set_tab_name()`` function - used to change a tab's
    name
 -  Add ``LV_THEME_MATERIAL_FLAG_NO_TRANSITION`` and
    ``LV_THEME_MATERIAL_FLAG_NO_FOCUS`` flags
@@ -3783,7 +3783,7 @@ Bugfixes
 -  Prevent duplicated sending of ``LV_EVENT_INSERT`` from text area
 -  Tidy outer edges of cpicker widget.
 -  Remove duplicated lines from ``lv_tabview_add_tab``
--  btnmatrix: handle combined states of buttons (e.g. checked +
+-  btnmatrix: handle combined states of buttons (e.g. checked +
    disabled)
 -  textarea: fix typo in lv_textarea_set_scrollbar_mode
 -  gauge: fix image needle drawing
@@ -3813,7 +3813,7 @@ New features
 -  Add ``lv_chart_get_point_id()`` function - Get an individual point
    value in the chart series directly based on index
 -  Add ``ext_buf_assigned`` bit field to ``lv_chart_series_t`` structure
-   - it’s true if external buffer is assigned to series
+   - it's true if external buffer is assigned to series
 -  Add ``lv_chart_set_series_axis()`` to assign series to primary or
    secondary axis
 -  Add ``lv_chart_set_y_range()`` to allow setting range of secondary
@@ -3836,7 +3836,7 @@ Bugfixes
 -  ``tileview`` fix navigation when not screen sized
 -  Use 14px font by default to for better compatibility with smaller
    displays
--  ``linemeter`` fix conversation of current value to “level”
+-  ``linemeter`` fix conversation of current value to "level"
 -  Fix drawing on right border
 -  Set the cursor image non-clickable by default
 -  Improve mono theme when used with keyboard or encoder
@@ -3871,7 +3871,7 @@ Bugfixes
 -  ``lv_img`` fix invalidation area when angle or zoom changes
 -  Update the style handling to support Big endian MCUs
 -  Change some methods to support big endian hardware.
--  remove use of c++ keyword ‘new’ in parameter of function
+-  remove use of c++ keyword 'new' in parameter of function
    lv_theme_set_base().
 -  Add LV_BIG_ENDIAN_SYSTEM flag to lv_conf.h in order to fix displaying
    images on big endian systems.
@@ -3959,7 +3959,7 @@ is created to manage LVGL and offer services.
 New drawing system
 ~~~~~~~~~~~~~~~~~~
 
-Complete rework of LVGL’s draw engine to use “masks” for more advanced
+Complete rework of LVGL's draw engine to use "masks" for more advanced
 and higher quality graphical effects. A possible use-case of this system
 is to remove the overflowing content from the rounded edges. It also
 allows drawing perfectly anti-aliased circles, lines, and arcs.
@@ -3970,12 +3970,12 @@ are drawn by using 2 rectangle masks: one mask removes the inner part
 and another the outer part.
 
 The API in this regard remained the same but some new functions were
-added: - ``lv_img_set_zoom``: set image object’s zoom factor -
-``lv_img_set_angle``: set image object’s angle without using canvas -
+added: - ``lv_img_set_zoom``: set image object's zoom factor -
+``lv_img_set_angle``: set image object's angle without using canvas -
 ``lv_img_set_pivot``: set the pivot point of rotation
 
 The new drawing engine brought new drawing features too. They are
-highlighted in the “style” section.
+highlighted in the "style" section.
 
 New style system
 ~~~~~~~~~~~~~~~~
@@ -3998,7 +3998,7 @@ been changed.
 -  *pattern*: display and image in the middle of the background or
    repeat it
 -  *value* display a text which is stored in the style. It can be used
-   e.g. as a light-weighted text on buttons too.
+   e.g. as a light-weighted text on buttons too.
 -  *margin*: similar to *padding* but used to keep space outside the
    object
 
@@ -4012,7 +4012,7 @@ To better utilize GPUs, from this version GPU usage can be integrated
 into LVGL. In ``lv_conf.h`` any supported GPUs can be enabled with a
 single configuration option.
 
-Right now, only ST’s DMA2D (Chrom-ART) is integrated. More will in the
+Right now, only ST's DMA2D (Chrom-ART) is integrated. More will in the
 upcoming releases.
 
 Renames
@@ -4035,7 +4035,7 @@ Reworked and improved object
    visible background/border/shadow etc it will be drawn. Padding really
    makes the object larger (not just virtually as before)
 -  ``arc``: can draw background too.
--  ``btn``: doesn’t store styles for each state because it’s done
+-  ``btn``: doesn't store styles for each state because it's done
    naturally in the new style system.
 -  ``calendar``: highlight the pressed datum. The used styles are
    changed: use ``LV_CALENDAR_PART_DATE`` normal for normal dates,
@@ -4073,12 +4073,12 @@ Others
    `Montserrat <https://fonts.google.com/specimen/Montserrat>`__ and add
    built-in fonts from 12 px to 48 px for every 2nd size.
 -  Add example CJK and Arabic/Persian/Hebrew built-in font
--  Add ° and “bullet” to the built-in fonts
+-  Add ° and "bullet" to the built-in fonts
 -  Add Arabic/Persian script support: change the character according to
    its position in the text.
 -  Add ``playback_time`` to animations.
--  Add ``repeat_count`` to animations instead of the current “repeat
-   forever”.
+-  Add ``repeat_count`` to animations instead of the current "repeat
+   forever".
 -  Replace ``LV_LAYOUT_PRETTY`` with ``LV_LAYOUT_PRETTY_TOP/MID/BOTTOM``
 
 Demos

--- a/docs/CODE_OF_CONDUCT.rst.back
+++ b/docs/CODE_OF_CONDUCT.rst.back
@@ -30,7 +30,7 @@ Examples of unacceptable behavior by participants include:
 -  Trolling, insulting/derogatory comments, and personal or political
    attacks
 -  Public or private harassment
--  Publishing others’ private information, such as a physical or
+-  Publishing others' private information, such as a physical or
    electronic address, without explicit permission
 -  Other conduct which could reasonably be considered inappropriate in a
    professional setting
@@ -73,7 +73,7 @@ separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in
 good faith may face temporary or permanent repercussions as determined
-by other members of the project’s leadership.
+by other members of the project's leadership.
 
 Attribution
 -----------

--- a/docs/CODING_STYLE.rst
+++ b/docs/CODING_STYLE.rst
@@ -10,7 +10,7 @@ and `misc/lv_templ.h <https://github.com/lvgl/lvgl/blob/master/src/misc/lv_templ
 Naming conventions
 ------------------
 
--  Words are separated by ’\_’
+-  Words are separated by '\_'
 -  In variable and function names use only lower case letters
    (e.g. *height_tmp*)
 -  In enums and defines use only upper case letters
@@ -77,7 +77,7 @@ doing.
 You should write **why** have you done this:
 ``x++; /*Because of closing '\0' of the string*/``
 
-Short “code summaries” of a few lines are accepted. E.g.
+Short "code summaries" of a few lines are accepted. E.g.
 ``/*Calculate the new coordinates*/``
 
 In comments use \` \` when referring to a variable. E.g.
@@ -160,7 +160,7 @@ If you want to skip any particular hook you can do so with:
 Testing hooks
 -------------
 
-It’s no necessary to do a commit to test the hooks, you can test hooks
+It's no necessary to do a commit to test the hooks, you can test hooks
 by adding the files into the staging area and run:
 
 .. code:: console

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -6,7 +6,7 @@ Contributing
 Introduction
 ------------
 
-Join LVGL’s community and leave your footprint in the library!
+Join LVGL's community and leave your footprint in the library!
 
 There are a lot of ways to contribute to LVGL even if you are new to the
 library or even new to programming.
@@ -15,7 +15,7 @@ It might be scary to make the first step but you have nothing to be
 afraid of. A friendly and helpful community is waiting for you. Get to
 know like-minded people and make something great together.
 
-So let’s find which contribution option fits you the best and help you
+So let's find which contribution option fits you the best and help you
 join the development of LVGL!
 
 Before getting started here are some guidelines to make contribution smoother:
@@ -33,7 +33,7 @@ Before getting started here are some guidelines to make contribution smoother:
 - Speak about one thing in one issue or topic. It makes your post easier to find later for
   someone with the same question.
 - Give feedback and close the issue or mark the topic as solved if your question is answered.
-- For non-trivial fixes and features, it’s better to open an issue first to discuss the
+- For non-trivial fixes and features, it's better to open an issue first to discuss the
   details instead of sending a pull request directly.
 - Please read and follow the Coding style guide.
 
@@ -42,8 +42,8 @@ Pull request
 
 Merging new code into the lvgl, documentation, blog, examples, and other
 repositories happen via *Pull requests* (PR for short). A PR is a
-notification like “Hey, I made some updates to your project. Here are
-the changes, you can add them if you want.” To do this you need a copy
+notification like "Hey, I made some updates to your project. Here are
+the changes, you can add them if you want." To do this you need a copy
 (called fork) of the original project under your account, make some
 changes there, and notify the original repository about your updates.
 You can see what it looks like on GitHub for LVGL here:
@@ -70,13 +70,13 @@ The instructions describe the main ``lvgl`` repository but it works the
 same way for the other repositories.
 
 1. Fork the `lvgl repository <https://github.com/lvgl/lvgl>`__. To do this click the
-   “Fork” button in the top right corner. It will “copy” the ``lvgl``
+   "Fork" button in the top right corner. It will "copy" the ``lvgl``
    repository to your GitHub account (``https://github.com/<YOUR_NAME>?tab=repositories``)
 2. Clone your forked repository.
 3. Add your changes. You can create a *feature branch* from *master* for the updates: ``git checkout -b the-new-feature``
 4. Commit and push your changes to the forked ``lvgl`` repository.
 5. Create a PR on GitHub from the page of your ``lvgl`` repository (``https://github.com/<YOUR_NAME>/lvgl``) by
-   clicking the *“New pull request”* button. Don’t forget to select the branch where you added your changes.
+   clicking the *"New pull request"* button. Don't forget to select the branch where you added your changes.
 6. Set the base branch. It means where you want to merge your update. In the ``lvgl`` repo both the fixes
    and new features go to ``master`` branch.
 7. Describe what is in the update. An example code is welcome if applicable.
@@ -111,13 +111,13 @@ Possible ``<type>``\ s:
 - ``chore`` any minor formatting or style changes that would make the changelog noisy
 
 ``<scope>`` is the module, file, or sub-system that is affected by the
-commit. It’s usually one word and can be chosen freely. For example
+commit. It's usually one word and can be chosen freely. For example
 ``img``, ``layout``, ``txt``, ``anim``. The scope can be omitted.
 
 ``<subject>`` contains a short description of the change:
 
-- use the imperative, present tense: “change” not “changed” nor “changes”
-- don’t capitalize the first letter
+- use the imperative, present tense: "change" not "changed" nor "changes"
+- don't capitalize the first letter
 - no dot (.) at the end
 - max 90 characters
 
@@ -126,7 +126,7 @@ change.
 
 ``<footer>`` shall contain
 
-- the words “BREAKING CHANGE” if the changes break the API
+- the words "BREAKING CHANGE" if the changes break the API
 - reference to the GitHub issue or Pull Request if applicable.
 
 Some examples:
@@ -149,7 +149,7 @@ Overview
 ~~~~~~~~
 
 To ensure all licensing criteria are met for every repository of the
-LVGL project, we apply a process called DCO (Developer’s Certificate of
+LVGL project, we apply a process called DCO (Developer's Certificate of
 Origin).
 
 The text of DCO can be read here: https://developercertificate.org/.
@@ -199,7 +199,7 @@ Use MIT licensed code
 As LVGL is MIT licensed, other MIT licensed code can be integrated
 without issues. The MIT license requires a copyright notice be added to
 the derived work. Any derivative work based on MIT licensed code must
-copy the original work’s license file or text.
+copy the original work's license file or text.
 
 Use GPL licensed code
 ^^^^^^^^^^^^^^^^^^^^^
@@ -210,8 +210,8 @@ can not accept GPL licensed code.
 Ways to contribute
 ------------------
 
-Even if you’re just getting started with LVGL there are plenty of ways
-to get your feet wet. Most of these options don’t even require knowing a
+Even if you're just getting started with LVGL there are plenty of ways
+to get your feet wet. Most of these options don't even require knowing a
 single line of LVGL code.
 
 Below we have collected some opportunities about the ways you can
@@ -242,11 +242,11 @@ Have you already started using LVGL in a
 `Simulator </get-started/platforms/pc-simulator>`__, a development
 board, or on your custom hardware? Was it easy or were there some
 obstacles? Are you happy with the result? Showing your project to others
-is a win-win situation because it increases your and LVGL’s reputation
+is a win-win situation because it increases your and LVGL's reputation
 at the same time.
 
 You can post about your project on Twitter, Facebook, LinkedIn, create a
-YouTube video, and so on. Only one thing: On social media don’t forget
+YouTube video, and so on. Only one thing: On social media don't forget
 to add a link to ``https://lvgl.io`` or ``https://github.com/lvgl`` and
 use the hashtag ``#lvgl``. Thank you! :)
 
@@ -255,7 +255,7 @@ projects <https://forum.lvgl.io/c/my-projects/10>`__ category of the
 Forum.
 
 The `LVGL Blog <https://blog.lvgl.io>`__ welcomes posts from anyone.
-It’s a good place to talk about a project you created with LVGL, write a
+It's a good place to talk about a project you created with LVGL, write a
 tutorial, or share some nice tricks. The latest blog posts are shown on
 the `homepage of LVGL <https://lvgl.io>`__ to make your work more
 visible.
@@ -268,7 +268,7 @@ add your post.
 Any of these help to spread the word and familiarize new developers with
 LVGL.
 
-If you don’t want to speak about your project publicly, feel free to use
+If you don't want to speak about your project publicly, feel free to use
 `Contact form <https://lvgl.io/#contact>`__ on lvgl.io to private
 message to us.
 
@@ -278,7 +278,7 @@ Write examples
 As you learn LVGL you will probably play with the features of widgets.
 Why not publish your experiments?
 
-Each widgets’ documentation contains examples. For instance, here are
+Each widgets' documentation contains examples. For instance, here are
 the examples of the `Drop-down list </widgets/dropdown#examples>`__
 widget. The examples are directly loaded from the
 `lvgl/examples <https://github.com/lvgl/lvgl/tree/master/examples>`__
@@ -292,7 +292,7 @@ conventions:
 - Make the example as short and simple as possible.
 - Add comments to explain what the example does.
 - Use 320x240 resolution.
-- Update ``index.rst`` in the example’s folder with your new example. To see how other examples are added, look in the
+- Update ``index.rst`` in the example's folder with your new example. To see how other examples are added, look in the
   `lvgl/examples/widgets <https://github.com/lvgl/lvgl/tree/master/examples/widgets>`__
   folder.
 
@@ -327,7 +327,7 @@ Send fixes
 The beauty of open-source software is you can easily dig in to it to
 understand how it works. You can also fix or adjust it as you wish.
 
-If you found and fixed a bug don’t hesitate to send a `Pull
+If you found and fixed a bug don't hesitate to send a `Pull
 request <#pull-request>`__ with the fix.
 
 In your Pull request please also add a line to
@@ -337,7 +337,7 @@ Join the conversations in the Forum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It feels great to know you are not alone if something is not working.
-It’s even better to help others when they struggle with something.
+It's even better to help others when they struggle with something.
 
 While you were learning LVGL you might have had questions and used the
 Forum to get answers. As a result, you probably have more knowledge
@@ -346,7 +346,7 @@ about how LVGL works.
 One of the best ways to give back is to use the Forum and answer the
 questions of newcomers - like you were once.
 
-Just read the titles and if you are familiar with the topic don’t
+Just read the titles and if you are familiar with the topic don't
 hesitate to share your thoughts and suggestions.
 
 Participating in the discussions is one of the best ways to become part
@@ -402,8 +402,8 @@ maintainer
 If you are interested, just send a message (e.g. from the Forum) to the
 current maintainers of the repository. They will check if the
 prerequisites are met. Note that meeting the prerequisites is not a
-guarantee of acceptance, i.e. if the conditions are met you won’t
-automatically become a maintainer. It’s up to the current maintainers to
+guarantee of acceptance, i.e. if the conditions are met you won't
+automatically become a maintainer. It's up to the current maintainers to
 make the decision.
 
 Move your project repository under LVGL organization

--- a/docs/README_pt_BR.rst.back
+++ b/docs/README_pt_BR.rst.back
@@ -172,10 +172,10 @@ ou corrigir um problema rotulado como
 pessoa receberá um pagamento por esse trabalho. Estimamos o tempo
 necessário, a complexidade e a importância da questão e definimos um
 preço de acordo. Para entrar, apenas comente sobre um problema
-patrocinado dizendo “Olá, gostaria de lidar com isso. É assim que estou
-planejando corrigi-lo/implementá-lo…”. Um trabalho é considerado pronto
+patrocinado dizendo "Olá, gostaria de lidar com isso. É assim que estou
+planejando corrigi-lo/implementá-lo…". Um trabalho é considerado pronto
 quando é aprovado e mesclado por um mantenedor. Depois disso, você pode
-enviar uma “despesa” (expense) pela plataforma
+enviar uma "despesa" (expense) pela plataforma
 `opencollective.com <https://opencollective.com/lvgl>`__ e então
 receberá o pagamento em alguns dias.
 
@@ -241,19 +241,19 @@ Código C
 
 .. code:: c
 
-   lv_obj_t * btn = lv_btn_create(lv_scr_act());                   /* Adiciona o botão a tela atual */
-   lv_obj_center(btn);                                             /* Define a posição do botão */
-   lv_obj_set_size(btn, 100, 50);                                  /* Define o tamanho do botão */
+   lv_obj_t * btn = lv_btn_create(lv_scr_act());                   /* Adiciona o botão a tela atual */
+   lv_obj_center(btn);                                             /* Define a posição do botão */
+   lv_obj_set_size(btn, 100, 50);                                  /* Define o tamanho do botão */
    lv_obj_add_event(btn, btn_event_cb, LV_EVENT_CLICKED, NULL); /* Atribui um retorno de chamada (callback) ao botão */
 
-   lv_obj_t * label = lv_label_create(btn);                        /* Adiciona um rótulo (label) */
-   lv_label_set_text(label, "Botão");                              /* Define um texto para o rótulo (label) */
-   lv_obj_center(label);                                           /* Alinha o texto no centro do botão */
+   lv_obj_t * label = lv_label_create(btn);                        /* Adiciona um rótulo (label) */
+   lv_label_set_text(label, "Botão");                              /* Define um texto para o rótulo (label) */
+   lv_obj_center(label);                                           /* Alinha o texto no centro do botão */
    ...
 
    void btn_event_cb(lv_event_t * e)
    {
-     printf("Clicado\n");
+     printf("Clicado\n");
    }
 
 .. raw:: html
@@ -277,7 +277,7 @@ Código MicroPython \| Simulador online
 .. code:: python
 
    def btn_event_cb(e):
-     print("Clicado")
+     print("Clicado")
 
    # Cria um botão e um rótulo (label)
    btn = lv.btn(lv.scr_act())

--- a/docs/get-started/bindings/javascript.rst
+++ b/docs/get-started/bindings/javascript.rst
@@ -5,7 +5,7 @@ JavaScript
 With `lv_binding_js <https://github.com/lvgl/lv_binding_js>`__ you can
 write lvgl with JavaScript.
 
-It uses React’s virtual DOM concept to manipulate lvgl UI components,
+It uses React's virtual DOM concept to manipulate lvgl UI components,
 providing a familiar React-like experience to users.
 
 **Code**

--- a/docs/get-started/bindings/micropython.rst
+++ b/docs/get-started/bindings/micropython.rst
@@ -110,7 +110,7 @@ Many `LVGL examples <https://docs.lvgl.io/master/examples.html>`__ are available
 PC Simulator
 ~~~~~~~~~~~~
 
-Micropython is ported to many platforms. One notable port is “unix”, which allows you to build and run Micropython
+Micropython is ported to many platforms. One notable port is "unix", which allows you to build and run Micropython
 (+LVGL) on a Linux machine. (On a Windows machine you might need Virtual Box or WSL or MinGW or Cygwin etc.)
 
 `Click here to know more information about building and running the unix port <https://github.com/lvgl/lv_micropython>`__
@@ -190,7 +190,7 @@ follow some coding conventions:
 - ``struct`` APIs should follow the widgets' conventions. That is to receive a pointer to the ``struct`` as the
   first argument, and the prefix of the ``struct`` name should be used as the prefix of the
   function name too (e.g. :cpp:expr:`lv_disp_set_default(lv_disp_t * disp)`)
-- Functions and ``struct``\ s which are not part of the public API must begin with underscore in order to mark them as “private”.
+- Functions and ``struct``\ s which are not part of the public API must begin with underscore in order to mark them as "private".
 - Argument must be named in H files too.
 - Do not ``malloc`` into a static or global variables. Instead declare the variable in :c:macro:`LV_ITERATE_ROOTS`
   list in ``lv_gc.h`` and mark the variable with :cpp:expr:`GC_ROOT(variable)` when it's used. **See** :ref:`memory_management`

--- a/docs/get-started/bindings/pikascript.rst
+++ b/docs/get-started/bindings/pikascript.rst
@@ -8,7 +8,7 @@ What is PikaScript ?
 interpreter designed specifically for microcontrollers, and it supports
 a subset of the common Python3 syntax.
 
-It’s lighter, requiring only 32k of code space and 4k of RAM, which
+It's lighter, requiring only 32k of code space and 4k of RAM, which
 means it can run on stm32f103c8 (blue-pill) or even stm32g030c8, on the
 other hand, you can leave valuable space for more material or larger
 buffer areas.
@@ -18,9 +18,9 @@ all, does not depend on OS or file system, has good support for popular
 IDEs for Windows platforms like Keil, IAR, RT-Thread-Studio, and of
 course, supports linux-gcc development platforms.
 
-It’s smarter, with a unique C module mechanism that allows you to
+It's smarter, with a unique C module mechanism that allows you to
 generate bindings automatically by simply writing the API for the C
-module in Python, and you don’t need to deal with the headache of
+module in Python, and you don't need to deal with the headache of
 writing any macros or global tables manually. On the other hand, all C
 modules have sophisticated smart hints, even hinting at the types of
 your arguments .
@@ -152,7 +152,7 @@ interface file)
        def set_bg_angles(self, start: int, end: int): ...
        def set_angles(self, start: int, end: int): ...
 
-Then PikaScript’s pre-compiler can automatically bind the following C
+Then PikaScript's pre-compiler can automatically bind the following C
 functions, simply by naming the functions in the module_class_method
 format, without any additional work, and all binding and registration is
 done automatically.

--- a/docs/get-started/os/nuttx.rst
+++ b/docs/get-started/os/nuttx.rst
@@ -66,7 +66,7 @@ NuttX + LVGL could be used for
 -  Fast prototyping GUI for MVP (Minimum Viable Product) presentation.
 -  visualize sensor data directly and easily on the board without using
    a computer.
--  Final products with a GUI without a touchscreen (i.e. 3D Printer
+-  Final products with a GUI without a touchscreen (i.e. 3D Printer
    Interface using Rotary Encoder to Input data).
 -  Final products with a touchscreen (and all sorts of bells and
    whistles).
@@ -78,21 +78,21 @@ How to get started with NuttX and LVGL?
 
 There are many boards in the `NuttX
 mainline <https://github.com/apache/incubator-nuttx>`__ with support for
-LVGL. Let’s use the
+LVGL. Let's use the
 `STM32F429IDISCOVERY <https://www.st.com/en/evaluation-tools/32f429idiscovery.html>`__
 as an example because it is a very popular board.
 
 First you need to install the pre-requisites on your system
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let’s use the `Windows Subsystem for
+Let's use the `Windows Subsystem for
 Linux <https://acassis.wordpress.com/2018/01/10/how-to-build-nuttx-on-windows-10/>`__
 
 .. code:: shell
 
    $ sudo apt-get install automake bison build-essential flex gcc-arm-none-eabi gperf git libncurses5-dev libtool libusb-dev libusb-1.0.0-dev pkg-config kconfig-frontends openocd
 
-Now let’s create a workspace to save our files
+Now let's create a workspace to save our files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: shell
@@ -131,7 +131,7 @@ Flashing the firmware in the board using OpenOCD:
 
    $ sudo openocd -f interface/stlink-v2.cfg -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase nuttx.bin 0x08000000"
 
-Reset the board and using the ‘NSH>’ terminal start the LVGL demo:
+Reset the board and using the 'NSH>' terminal start the LVGL demo:
 
 .. code:: shell
 

--- a/docs/get-started/os/rt-thread.rst
+++ b/docs/get-started/os/rt-thread.rst
@@ -14,7 +14,7 @@ Flash and 1.2 KB RAM memory resources can be tailored with easy-to-use
 tools. For resource-rich IoT devices, RT-Thread can use the **online
 software package** management tool, together with system configuration
 tools, to achieve intuitive and rapid modular cutting, seamlessly import
-rich software packages; thus, achieving complex functions like Android’s
+rich software packages; thus, achieving complex functions like Android's
 graphical interface and touch sliding effects, smart voice interaction
 effects, and so on.
 

--- a/docs/get-started/platforms/cmake.rst
+++ b/docs/get-started/platforms/cmake.rst
@@ -9,7 +9,7 @@ with preconfigured targets for:
 - `MicroPython <https://docs.micropython.org/en/v1.15/develop/cmodules.html>`__
 - `Zephyr <https://docs.zephyrproject.org/latest/guides/zephyr_cmake_package.html>`__
 
-On top of the preconfigured targets you can also use “plain” CMake to
+On top of the preconfigured targets you can also use "plain" CMake to
 integrate LVGL into any custom C/C++ project.
 
 
@@ -75,7 +75,7 @@ Include paths options
    ============ ==============
    ON (default) OFF
    ============ ==============
-   “lvgl.h”     “../../lvgl.h”
+   "lvgl.h"     "../../lvgl.h"
    ============ ==============
 
 -  :c:macro:`LV_CONF_INCLUDE_SIMPLE`: which specifies whether to ``#include "lv_conf.h"`` and ``"lv_drv_conf.h"`` absolut or relative
@@ -83,8 +83,8 @@ Include paths options
    =============== =====================
    ON (default)    OFF
    =============== =====================
-   “lv_conf.h”     “../../lv_conf.h”
-   “lv_drv_conf.h” “../../lv_drv_conf.h”
+   "lv_conf.h"     "../../lv_conf.h"
+   "lv_drv_conf.h" "../../lv_drv_conf.h"
    =============== =====================
 
 ..

--- a/docs/get-started/platforms/espressif.rst
+++ b/docs/get-started/platforms/espressif.rst
@@ -10,7 +10,7 @@ More information about ESP-IDF build system can be found `here <https://docs.esp
 LVGL demo project for ESP32
 ---------------------------
 
-We’ve created `lv_port_esp32 <https://github.com/lvgl/lv_port_esp32>`__,
+We've created `lv_port_esp32 <https://github.com/lvgl/lv_port_esp32>`__,
 a project using ESP-IDF and LVGL to show one of the demos from
 `demos <https://github.com/lvgl/lvgl/demos>`__. You can configure the
 project to use one of the many supported display controllers and targets
@@ -44,7 +44,7 @@ git repository you can include LVGL as a git submodule:
 
    git submodule add https://github.com/lvgl/lvgl.git components/lvgl
 
-The above command will clone LVGL’s main repository into the
+The above command will clone LVGL's main repository into the
 ``components/lvgl`` directory. LVGL includes a ``CMakeLists.txt`` file
 that sets some configuration options so you can use LVGL right away.
 
@@ -73,8 +73,8 @@ When you are ready to configure LVGL, launch the configuration menu with
 Using lvgl_esp32_drivers in ESP-IDF project
 -------------------------------------------
 
-You can also add ``lvgl_esp32_drivers`` as a “component”. This component
-should be located inside a directory named “components” in your project
+You can also add ``lvgl_esp32_drivers`` as a "component". This component
+should be located inside a directory named "components" in your project
 root directory.
 
 When your project is a git repository you can include

--- a/docs/get-started/platforms/pc-simulator.rst
+++ b/docs/get-started/platforms/pc-simulator.rst
@@ -57,9 +57,9 @@ Eclipse is a Java-based tool so be sure **Java Runtime Environment** is installe
 
 On Debian-based distros (e.g. Ubuntu): ``sudo apt-get install default-jre``
 
-:note: If you are using other distros, then please install a ‘Java
+:note: If you are using other distros, then please install a 'Java
        Runtime Environment' suitable to your distro. Note: If you are using
-       macOS and get a “Failed to create the Java Virtual Machine” error,
+       macOS and get a "Failed to create the Java Virtual Machine" error,
        uninstall any other Java JDK installs and install Java JDK 8u. This
        should fix the problem.
 
@@ -142,7 +142,7 @@ Compile and Run
 Now you are ready to run LVGL on your PC. Click on the Hammer Icon on
 the top menu bar to Build the project. If you have done everything
 right, then you will not get any errors. Note that on some systems
-additional steps might be required to “see” SDL 2 from Eclipse but in
+additional steps might be required to "see" SDL 2 from Eclipse but in
 most cases the configuration in the downloaded project is enough.
 
 After a successful build, click on the Play button on the top menu bar

--- a/docs/get-started/platforms/tasmota-berry.rst
+++ b/docs/get-started/platforms/tasmota-berry.rst
@@ -34,7 +34,7 @@ Berry has the following advantages:
 - Lightweight: A well-optimized interpreter with very little resources. Ideal for use in microprocessors.
 - Fast: optimized one-pass bytecode compiler and register-based virtual machine.
 - Powerful: supports imperative programming, object-oriented programming, functional programming.
-- Flexible: Berry is a dynamic type script, and it’s intended for embedding in applications.
+- Flexible: Berry is a dynamic type script, and it's intended for embedding in applications.
   It can provide good dynamic scalability for the host system.
 - Simple: simple and natural syntax, support garbage collection, and easy to use FFI (foreign function interface).
 - RAM saving: With compile-time object construction, most of the constant objects are stored
@@ -63,7 +63,7 @@ Tasmota + Berry + LVGL could be used for:
 - Fast prototyping GUI.
 - Shortening the cycle of changing and fine-tuning the GUI.
 - Modelling the GUI in a more abstract way by defining reusable composite objects, taking
-  advantage of Berry’s language features such as Inheritance, Closures, Exception Handling…
+  advantage of Berry's language features such as Inheritance, Closures, Exception Handling…
 - Make LVGL accessible to a larger audience. No need to know C to create a nice GUI on an embedded system.
 
 A higher level interface compatible with
@@ -75,9 +75,9 @@ is also under development.
 So what does it look like?
 --------------------------
 
-TL;DR: Similar to MicroPython, it’s very much like the C API, but Object-Oriented for LVGL components.
+TL;DR: Similar to MicroPython, it's very much like the C API, but Object-Oriented for LVGL components.
 
-Let’s dive right into an example!
+Let's dive right into an example!
 
 A simple example
 ~~~~~~~~~~~~~~~~

--- a/docs/get-started/quick-overview.rst
+++ b/docs/get-started/quick-overview.rst
@@ -12,7 +12,7 @@ after that.
 Get started in a simulator
 --------------------------
 
-Instead of porting LVGL to embedded hardware straight away, it’s highly
+Instead of porting LVGL to embedded hardware straight away, it's highly
 recommended to get started in a simulator first.
 
 LVGL is ported to many IDEs to be sure you will find your favorite one.
@@ -30,7 +30,7 @@ If you would rather try LVGL on your own project follow these steps:
 -  Copy the ``lvgl`` folder into your project.
 -  Copy ``lvgl/lv_conf_template.h`` as ``lv_conf.h`` next to the
    ``lvgl`` folder, change the first ``#if 0`` to ``1`` to enable the
-   file’s content and set the :c:macro:`LV_COLOR_DEPTH` defines.
+   file's content and set the :c:macro:`LV_COLOR_DEPTH` defines.
 -  Include ``lvgl/lvgl.h`` in files where you need to use LVGL related functions.
 -  Call :cpp:expr:`lv_tick_inc(x)` every ``x`` milliseconds in a Timer or Task
    (``x`` should be between 1 and 10). It is required for the internal
@@ -121,10 +121,10 @@ label is created on a button, the button is the parent of label.
 The child object moves with the parent and if the parent is deleted the
 children will be deleted too.
 
-Children can be visible only within their parent’s bounding area. In
+Children can be visible only within their parent's bounding area. In
 other words, the parts of the children outside the parent are clipped.
 
-A Screen is the “root” parent. You can have any number of screens.
+A Screen is the "root" parent. You can have any number of screens.
 
 To get the current screen call :cpp:func:`lv_scr_act`, and to load a screen
 use :cpp:expr:`lv_scr_load(scr1)`.
@@ -208,7 +208,7 @@ and :cpp:enumerator:`LV_PART_KNOB`.
 By using parts you can apply different styles to sub-elements of a
 widget. (See below)
 
-Read the widgets’ documentation to learn which parts each uses.
+Read the widgets' documentation to learn which parts each uses.
 
 States
 ~~~~~~
@@ -262,8 +262,8 @@ configure the style. For example:
 
 See the full list of properties here :ref:`style_properties`.
 
-Styles are assigned using the ORed combination of an object’s part and
-state. For example to use this style on the slider’s indicator when the
+Styles are assigned using the ORed combination of an object's part and
+state. For example to use this style on the slider's indicator when the
 slider is pressed:
 
 .. code:: c
@@ -304,7 +304,7 @@ property is not defined in the default state.
 
 Some properties (typically the text-related ones) can be inherited. This
 means if a property is not set in an object it will be searched for in
-its parents too. For example, you can set the font once in the screen’s
+its parents too. For example, you can set the font once in the screen's
 style and all text on that screen will inherit it by default.
 
 Local style properties also can be added to objects. This creates a

--- a/docs/layouts/flex.rst
+++ b/docs/layouts/flex.rst
@@ -59,12 +59,12 @@ To manage the placement of the children use
 :c:expr:`lv_obj_set_flex_align(obj,  main_place, cross_place, track_cross_place)`
 
 -  ``main_place`` determines how to distribute the items in their track
-   on the main axis. E.g. flush the items to the right on :c:enumerator:`LV_FLEX_FLOW_ROW_WRAP`. (It’s called
+   on the main axis. E.g. flush the items to the right on :c:enumerator:`LV_FLEX_FLOW_ROW_WRAP`. (It's called
    ``justify-content`` in CSS)
 -  ``cross_place`` determines how to distribute the items in their track
    on the cross axis. E.g. if the items have different height place them
-   to the bottom of the track. (It’s called ``align-items`` in CSS)
--  ``track_cross_place`` determines how to distribute the tracks (It’s
+   to the bottom of the track. (It's called ``align-items`` in CSS)
+-  ``track_cross_place`` determines how to distribute the tracks (It's
    called ``align-content`` in CSS)
 
 The possible values are:
@@ -77,7 +77,7 @@ The possible values are:
   equal. Does not apply to ``track_cross_place``.
 - :c:enumerator:`LV_FLEX_ALIGN_SPACE_AROUND`: items are evenly
   distributed in the track with equal space around them. Note that
-  visually the spaces aren’t equal, since all the items have equal space
+  visually the spaces aren't equal, since all the items have equal space
   on both sides. The first item will have one unit of space against the
   container edge, but two units of space between the next item because
   that next item has its own spacing that applies. Not applies to
@@ -123,7 +123,7 @@ following properties can be set on the flex container style:
 
 -  ``pad_column`` Sets the padding between the columns.
 
-These can for example be used if you don’t want any padding between your
+These can for example be used if you don't want any padding between your
 objects: :c:expr:`lv_style_set_pad_column(&row_container_style,0)`
 
 Other features

--- a/docs/layouts/grid.rst
+++ b/docs/layouts/grid.rst
@@ -9,7 +9,7 @@ The Grid layout is a subset of `CSS Flexbox <https://css-tricks.com/snippets/css
 
 It can arrange items into a 2D "table" that has rows or columns
 (tracks). The item can span through multiple columns or rows. The
-track’s size can be set in pixel, to the largest item
+track's size can be set in pixel, to the largest item
 (:c:macro:`LV_GRID_CONTENT`) or in "Free unit" (FR) to distribute the free
 space proportionally.
 
@@ -22,7 +22,7 @@ Terms
 *****
 
 -  tracks: the rows or columns
--  free unit (FR): if set on track’s size is set in ``FR`` it will grow
+-  free unit (FR): if set on track's size is set in ``FR`` it will grow
    to fill the remaining space on the parent.
 -  gap: the space between the rows and columns or the items on a track
 
@@ -88,7 +88,7 @@ If there are some empty space the track can be aligned several ways:
   between any two items (and the space to the edges) is equal. Not applies to ``track_cross_place``.
 - :c:enumerator:`LV_GRID_ALIGN_SPACE_AROUND`: items are
   evenly distributed in the track with equal space around them. Note that
-  visually the spaces aren’t equal, since all the items have equal space
+  visually the spaces aren't equal, since all the items have equal space
   on both sides. The first item will have one unit of space against the
   container edge, but two units of space between the next item because
   that next item has its own spacing that applies. Not applies to ``track_cross_place``.
@@ -96,7 +96,7 @@ If there are some empty space the track can be aligned several ways:
   evenly distributed in the track: first item is on the start line, last
   item on the end line. Not applies to ``track_cross_place``.
 
-To set the track’s alignment use
+To set the track's alignment use
 :c:expr:`lv_obj_set_grid_align(obj, column_align, row_align)`.
 
 Style interface

--- a/docs/libs/ffmpeg.rst
+++ b/docs/libs/ffmpeg.rst
@@ -25,7 +25,7 @@ Enable :c:macro:`LV_USE_FFMPEG` in ``lv_conf.h``.
 
 See the examples below.
 
-Note that, the FFmpeg extension doesn’t use LVGL’s file system. You can
+Note that, the FFmpeg extension doesn't use LVGL's file system. You can
 simply pass the path to the image or video as usual on your operating
 system or platform.
 

--- a/docs/libs/png.rst
+++ b/docs/libs/png.rst
@@ -16,7 +16,7 @@ enable one in ``lv_conf.h`` with ``LV_USE_FS_...``
 The whole PNG image is decoded so during decoding RAM equals to
 ``image width x image height x 4`` bytes are required.
 
-As it might take significant time to decode PNG images LVGL’s :ref:`image-caching` feature can be useful.
+As it might take significant time to decode PNG images LVGL's :ref:`image-caching` feature can be useful.
 
 Example
 -------

--- a/docs/libs/rlottie.rst
+++ b/docs/libs/rlottie.rst
@@ -56,7 +56,7 @@ To create a Lottie animation from file use:
      lv_obj_t * lottie = lv_rlottie_create_from_file(parent, width, height, "path/to/lottie.json");
 
 Note that, Rlottie uses the standard STDIO C file API, so you can use
-the path “normally” and no LVGL specific driver letter is required.
+the path "normally" and no LVGL specific driver letter is required.
 
 Use Rlottie from raw string data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -206,7 +206,7 @@ An example CMakeLists file has been provided at
 ``/env_support/esp/rlottie/CMakeLists.txt``
 
 Copy this CMakeLists file to
-``‘your-project-directory'/components/rlottie/``
+``'your-project-directory'/components/rlottie/``
 
 In addition to the component CMakeLists file, you'll also need to tell
 your project level CMakeLists in your IDF project to require rlottie:

--- a/docs/libs/sjpg.rst
+++ b/docs/libs/sjpg.rst
@@ -12,9 +12,9 @@ Overview
 -  Supports both normal JPG and the custom SJPG formats.
 -  Decoding normal JPG consumes RAM with the size fo the whole
    uncompressed image (recommended only for devices with more RAM)
--  SJPG is a custom format based on “normal” JPG and specially made for
+-  SJPG is a custom format based on "normal" JPG and specially made for
    LVGL.
--  SJPG is ‘split-jpeg’ which is a bundle of small jpeg fragments with
+-  SJPG is 'split-jpeg' which is a bundle of small jpeg fragments with
    an sjpg header.
 -  SJPG size will be almost comparable to the jpg file or might be a
    slightly larger.
@@ -25,7 +25,7 @@ Overview
    (can be modified)
 -  Currently only 16 bit image format is supported (TODO)
 -  Only the required partion of the JPG and SJPG images are decoded,
-   therefore they can’t be zoomed or rotated.
+   therefore they can't be zoomed or rotated.
 
 Usage
 -----

--- a/docs/others/file_explorer.rst
+++ b/docs/others/file_explorer.rst
@@ -5,7 +5,7 @@ File Explorer
 ``lv_file_explorer`` provides an API to browse the contents of the file
 system. ``lv_file_explorer`` only provides the file browsing function,
 but does not provide the actual file operation function. In other words,
-you can’t click a picture file to open and view the picture like a PC.
+you can't click a picture file to open and view the picture like a PC.
 ``lv_file_explorer`` will tell you the full path and name of the
 currently clicked file. The file operation function needs to be
 implemented by the user.

--- a/docs/others/fragment.rst
+++ b/docs/others/fragment.rst
@@ -5,12 +5,12 @@ Fragment
 Fragment is a concept copied from
 `Android <https://developer.android.com/guide/fragments>`__.
 
-It represents a reusable portion of your app’s UI. A fragment defines
+It represents a reusable portion of your app's UI. A fragment defines
 and manages its own layout, has its own lifecycle, and can handle its
-own events. Like Android’s Fragment that must be hosted by an activity
+own events. Like Android's Fragment that must be hosted by an activity
 or another fragment, Fragment in LVGL needs to be hosted by an object,
-or another fragment. The fragment’s view hierarchy becomes part of, or
-attaches to, the host’s view hierarchy.
+or another fragment. The fragment's view hierarchy becomes part of, or
+attaches to, the host's view hierarchy.
 
 Such concept also has some similarities to `UiViewController on
 iOS <https://developer.apple.com/documentation/uikit/uiviewcontroller>`__.

--- a/docs/others/gridnav.rst
+++ b/docs/others/gridnav.rst
@@ -9,7 +9,7 @@ If the children are arranged into a grid-like layout then the up, down,
 left and right arrows move focus to the nearest sibling in the
 respective direction.
 
-It doesn’t matter how the children are positioned, as only the current x
+It doesn't matter how the children are positioned, as only the current x
 and y coordinates are considered. This means that gridnav works with
 manually positioned children, as well as `Flex </layouts/flex>`__ and
 `Grid </layouts/grid>`__ layouts.

--- a/docs/others/ime_pinyin.rst
+++ b/docs/others/ime_pinyin.rst
@@ -53,7 +53,7 @@ input method plug-in, then use
 :c:expr:`lv_ime_pinyin_set_keyboard(pinyin_ime, kb)` to add the ``keyboard``
 you created to the Pinyin input method plug-in. You can use
 :c:expr:`lv_ime_pinyin_set_dict(pinyin_ime, your_dict)` to use a custom
-dictionary (if you don’t want to use the built-in dictionary at first,
+dictionary (if you don't want to use the built-in dictionary at first,
 you can disable :c:macro:`LV_IME_PINYIN_USE_DEFAULT_DICT` in ``lv_conf.h``,
 which can save a lot of memory space).
 
@@ -110,7 +110,7 @@ the keyboard and dictionary at any time.
 Custom dictionary
 -----------------
 
-If you don’t want to use the built-in Pinyin dictionary, you can use the
+If you don't want to use the built-in Pinyin dictionary, you can use the
 custom dictionary. Or if you think that the built-in phonetic dictionary
 consumes a lot of memory, you can also use a custom dictionary.
 
@@ -260,7 +260,7 @@ The lv_ime_pinyin have the following modes:
 -  :c:enumerator:`LV_IME_PINYIN_MODE_K9`: Pinyin 9 key input mode
 -  :c:enumerator:`LV_IME_PINYIN_MODE_K9_NUMBER`: Numeric keypad mode
 
-The ``TEXT`` modes’ layout contains buttons to change mode.
+The ``TEXT`` modes' layout contains buttons to change mode.
 
 To set the mode manually, use
 :c:expr:`lv_ime_pinyin_set_mode(pinyin_ime, mode)` . The default mode is

--- a/docs/others/msg.rst
+++ b/docs/others/msg.rst
@@ -26,7 +26,7 @@ no payload but :c:enumerator:`MSG_USER_NAME_CHANGED` can have a :c:expr:`const c
 payload containing the user name, and :c:enumerator:`MSG_USER_AVATAR_CHANGED` a
 :c:expr:`const void *` image source with the new avatar image.
 
-To be more precise the message ID’s type is declared like this:
+To be more precise the message ID's type is declared like this:
 
 .. code:: c
 
@@ -43,7 +43,7 @@ Subscribe to a message
 :c:expr:`lv_msg_subscribe(msg_id, callback, user_data)` can be used to
 subscribe to message.
 
-Don’t forget that ``msg_id`` can be a constant or a variable address
+Don't forget that ``msg_id`` can be a constant or a variable address
 too:
 
 .. code:: c
@@ -74,7 +74,7 @@ From :c:struct:`lv_msg_t` the followings can be used to get some data:
 Subscribe with an lv_obj
 ------------------------
 
-It’s quite typical that an LVGL widget is interested in some messages.
+It's quite typical that an LVGL widget is interested in some messages.
 To make it simpler :c:expr:`lv_msg_subsribe_obj(msg_id, obj, user_data)` can
 be used. If a new message is published with ``msg_id`` an
 :c:enumerator:`LV_EVENT_MSG_RECEIVED` event will be sent to the object.
@@ -95,7 +95,7 @@ For example:
        lv_label_set_text(label, lv_msg_get_payload(m));
    }
 
-Here ``msg_id`` also can be a variable’s address:
+Here ``msg_id`` also can be a variable's address:
 
 .. code:: c
 
@@ -128,19 +128,19 @@ Messages can be sent with :c:expr:`lv_msg_send(msg_id, payload)`. E.g.
 
 If have subscribed to a variable with
 :c:expr:`lv_msg_subscribe((lv_msg_id_t)&v, callback, NULL)` and changed the
-variable’s value the subscribers can be notified like this:
+variable's value the subscribers can be notified like this:
 
 .. code:: c
 
    v = 10;
    lv_msg_update_value(&v); //Notify all the subscribers of `(lv_msg_id_t)&v`
 
-It’s handy way of creating API for the UI too. If the UI provides some
+It's handy way of creating API for the UI too. If the UI provides some
 global variables (e.g. ``int current_tempereature``) and anyone can
 read and write this variable. After writing they can notify all the
 elements who are interested in that value. E.g. an ``lv_label`` can
 subscribe to :c:expr:`(lv_msg_id_t)&current_tempereature` and update its text
-when it’s notified about the new temperature.
+when it's notified about the new temperature.
 
 Example
 -------

--- a/docs/others/snapshot.rst
+++ b/docs/others/snapshot.rst
@@ -45,13 +45,13 @@ Use Existing Buffer
 
 If the snapshot needs update now and then, or simply caller provides memory, use API
 ``lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * dsc, void * buf, uint32_t buff_size)``
-for this case. It’s caller’s responsibility to alloc/free the memory.
+for this case. It's caller's responsibility to alloc/free the memory.
 
 If snapshot is generated successfully, the image descriptor is updated
 and image data will be stored to provided ``buf``.
 
 Note that snapshot may fail if provided buffer is not enough, which may
-happen when object size changes. It’s recommended to use API
+happen when object size changes. It's recommended to use API
 :c:func:`lv_snapshot_buf_size_needed` to check the needed buffer size in byte
 firstly and resize the buffer accordingly.
 

--- a/docs/overview/anim.rst
+++ b/docs/overview/anim.rst
@@ -132,7 +132,7 @@ Timeline
 A timeline is a collection of multiple animations which makes it easy to
 create complex composite animations.
 
-Firstly, create an animation element but don’t call :cpp:func:`lv_anim_start`.
+Firstly, create an animation element but don't call :cpp:func:`lv_anim_start`.
 
 Secondly, create an animation timeline object by calling
 :cpp:func:`lv_anim_timeline_create`.

--- a/docs/overview/disp.rst
+++ b/docs/overview/disp.rst
@@ -29,7 +29,7 @@ Why would you want multi-display support? Here are some examples:
 Using only one display
 ----------------------
 
-Using more displays can be useful but in most cases it’s not required.
+Using more displays can be useful but in most cases it's not required.
 Therefore, the whole concept of multi-display handling is completely
 hidden if you register only one display. By default, the last created
 (and only) display is used.
@@ -44,7 +44,7 @@ user activity on the default display. (See below in `Inactivity <#Inactivity>`__
 Mirror display
 --------------
 
-To mirror the image of a display to another display, you don’t need to
+To mirror the image of a display to another display, you don't need to
 use multi-display support. Just transfer the buffer received in
 ``flush_cb`` to the other display too.
 
@@ -53,8 +53,8 @@ Split image
 
 You can create a larger virtual display from an array of smaller ones.
 You can create it as below: 1. Set the resolution of the displays to the
-large display’s resolution. 2. In ``flush_cb``, truncate and modify the
-``area`` parameter for each display. 3. Send the buffer’s content to
+large display's resolution. 2. In ``flush_cb``, truncate and modify the
+``area`` parameter for each display. 3. Send the buffer's content to
 each real display with the truncated area.
 
 Screens
@@ -71,10 +71,10 @@ Be sure not to confuse displays and screens:
    with it, but not vice versa.
 
 Screens can be considered the highest level containers which have no
-parent. A screen’s size is always equal to its display and their origin
-is (0;0). Therefore, a screen’s coordinates can’t be changed,
+parent. A screen's size is always equal to its display and their origin
+is (0;0). Therefore, a screen's coordinates can't be changed,
 i.e. :cpp:expr:`lv_obj_set_pos()`, :cpp:expr:`lv_obj_set_size()` or similar functions
-can’t be used on screens.
+can't be used on screens.
 
 A screen can be created from any object type but the two most typical
 types are `Base object </widgets/obj>`__ and `Image </widgets/img>`__
@@ -99,7 +99,7 @@ Transparent screens
 
 Usually, the opacity of the screen is :cpp:enumerator:`LV_OPA_COVER` to provide a
 solid background for its children. If this is not the case (opacity <
-100%) the display’s ``bottom_layer`` be visible. If the bottom layer’s
+100%) the display's ``bottom_layer`` be visible. If the bottom layer's
 opacity is also not :cpp:enumerator:`LV_OPA_COVER` LVGL has no solid background to
 draw.
 
@@ -107,17 +107,17 @@ This configuration (transparent screen and display) could be used to
 create for example OSD menus where a video is played on a lower layer,
 and a menu is overlaid on an upper layer.
 
-To properly render the screen the display’s color format needs to be set
+To properly render the screen the display's color format needs to be set
 to one with alpha channel.
 
 In summary, to enable transparent screens and displays for OSD menu-like
 UIs:
 
-- Set the screen’s ``bg_opa`` to transparent:
+- Set the screen's ``bg_opa`` to transparent:
   :cpp:expr:`lv_obj_set_style_bg_opa(lv_scr_act(), LV_OPA_TRANSP, 0)`
-- Set the bottom layer’s ``bg_opa`` to transparent:
+- Set the bottom layer's ``bg_opa`` to transparent:
   :cpp:expr:`lv_obj_set_style_bg_opa(lv_scr_act(), LV_OPA_TRANSP, 0)`
-- Set the screen’s bg_opa to 0:
+- Set the screen's bg_opa to 0:
   :cpp:expr:`lv_obj_set_style_bg_opa(lv_layer_bottom(), LV_OPA_TRANSP, 0)`
 - Set a color format with alpha channel. E.g.
   :cpp:expr:`lv_disp_set_color_format(disp, LV_COLOR_FORMAT_NATIVE_ALPHA)`
@@ -128,11 +128,11 @@ Features of displays
 Inactivity
 ----------
 
-A user’s inactivity time is measured on each display. Every use of an
+A user's inactivity time is measured on each display. Every use of an
 `Input device </overview/indev>`__ (if `associated with the display </porting/indev#other-features>`__) counts as an activity. To
 get time elapsed since the last activity, use
 :cpp:expr:`lv_disp_get_inactive_time(disp)`. If ``NULL`` is passed, the lowest
-inactivity time among all displays will be returned (**NULL isn’t just
+inactivity time among all displays will be returned (**NULL isn't just
 the default display**).
 
 You can manually trigger an activity using
@@ -152,7 +152,7 @@ adjusted with :cpp:expr:`lv_obj_set_style_bg_color(obj, color)`;
 The display background image is a path to a file or a pointer to an
 :cpp:struct:`lv_img_dsc_t` variable (converted image data) to be used as
 wallpaper. It can be set with :cpp:expr:`lv_obj_set_style_bg_img_src(obj, &my_img)`;
-If a background image is configured the background won’t be filled with
+If a background image is configured the background won't be filled with
 ``bg_color``.
 
 The opacity of the background color or image can be adjusted with

--- a/docs/overview/draw.rst
+++ b/docs/overview/draw.rst
@@ -4,7 +4,7 @@
 Drawing
 =======
 
-With LVGL, you don’t need to draw anything manually. Just create objects
+With LVGL, you don't need to draw anything manually. Just create objects
 (like buttons, labels, arc, etc.), move and change them, and LVGL will
 refresh and redraw what is required.
 
@@ -16,7 +16,7 @@ The basic concept is to not draw directly onto the display but rather to
 first draw on an internal draw buffer. When a drawing (rendering) is
 ready that buffer is copied to the display.
 
-The draw buffer can be smaller than a display’s size. LVGL will simply
+The draw buffer can be smaller than a display's size. LVGL will simply
 render in "tiles" that fit into the given draw buffer.
 
 This approach has two main advantages compared to directly drawing to
@@ -25,7 +25,7 @@ the display:
 1. It avoids flickering while the layers of the UI are
    drawn. For example, if LVGL drew directly onto the display, when drawing
    a *background + button + text*, each "stage" would be visible for a short time.
-2. It’s faster to modify a buffer in internal RAM and
+2. It's faster to modify a buffer in internal RAM and
    finally write one pixel only once than reading/writing the display
    directly on each pixel access. (e.g. via a display controller with SPI interface).
 
@@ -33,7 +33,7 @@ Note that this concept is different from "traditional" double buffering
 where there are two display sized frame buffers: one holds the current
 image to show on the display, and rendering happens to the other
 (inactive) frame buffer, and they are swapped when the rendering is
-finished. The main difference is that with LVGL you don’t have to store
+finished. The main difference is that with LVGL you don't have to store
 two frame buffers (which usually requires external RAM) but only smaller
 draw buffer(s) that can easily fit into internal RAM.
 
@@ -48,28 +48,28 @@ LVGL refreshes the screen in the following steps:
 in the UI which requires redrawing. For example, a button is pressed, a
 chart is changed, an animation happened, etc.
 
-2. LVGL saves the changed object’s old and new area into a buffer, called an *Invalid area
+2. LVGL saves the changed object's old and new area into a buffer, called an *Invalid area
    buffer*. For optimization, in some cases, objects are not added to the buffer:
 
   - Hidden objects are not added.
   - Objects completely out of their parent are not added.
-  - Areas partially out of the parent are cropped to the parent’s area.
+  - Areas partially out of the parent are cropped to the parent's area.
   - Objects on other screens are not added.
 
 3. In every :c:macro:`LV_DEF_REFR_PERIOD` (set in ``lv_hal_disp.h``) the
    following happens:
 
   - LVGL checks the invalid areas and joins those that are adjacent or intersecting.
-  - Takes the first joined area, if it’s smaller than the *draw buffer*, then simply renders the area’s content
-    into the *draw buffer*. If the area doesn’t fit into the buffer, draw as many lines as possible to the *draw buffer*.
+  - Takes the first joined area, if it's smaller than the *draw buffer*, then simply renders the area's content
+    into the *draw buffer*. If the area doesn't fit into the buffer, draw as many lines as possible to the *draw buffer*.
   - When the area is rendered, call ``flush_cb`` from the display driver to refresh the display.
   - If the area was larger than the buffer, render the remaining parts too.
   - Repeat the same with remaining joined areas.
 
 When an area is redrawn the library searches the top-most object which
 covers that area and starts drawing from that object. For example, if a
-button’s label has changed, the library will see that it’s enough to
-draw the button under the text and it’s not necessary to redraw the
+button's label has changed, the library will see that it's enough to
+draw the button under the text and it's not necessary to redraw the
 display under the rest of the button too.
 
 The difference between buffering modes regarding the drawing mechanism
@@ -83,23 +83,23 @@ is the following:
 Masking
 *******
 
-*Masking* is the basic concept of LVGL’s draw engine. To use LVGL it’s
+*Masking* is the basic concept of LVGL's draw engine. To use LVGL it's
 not required to know about the mechanisms described here but you might
 find interesting to know how drawing works under hood. Knowing about
 masking comes in handy if you want to customize drawing.
 
-To learn about masking let’s see the steps of drawing first. LVGL
+To learn about masking let's see the steps of drawing first. LVGL
 performs the following steps to render any shape, image or text. It can
 be considered as a drawing pipeline.
 
 1. **Prepare the draw descriptors** Create a draw descriptor from an
-   object’s styles (e.g. :cpp:struct:`lv_draw_rect_dsc_t`). This gives us the
+   object's styles (e.g. :cpp:struct:`lv_draw_rect_dsc_t`). This gives us the
    parameters for drawing, for example colors, widths, opacity, fonts,
    radius, etc.
 2. **Call the draw function** Call the draw function with the draw
    descriptor and some other parameters (e.g. :cpp:func:`lv_draw_rect`). It
    will render the primitive shape to the current draw buffer.
-3. **Create masks** If the shape is very simple and doesn’t require
+3. **Create masks** If the shape is very simple and doesn't require
    masks, go to #5. Otherwise, create the required masks in the draw
    function. (e.g. a rounded rectangle mask)
 4. **Calculate all the added mask** It composites opacity values into a
@@ -119,7 +119,7 @@ applied real-time:
   of it. Essentially, every (skew) line is bounded with four line masks
   forming a rectangle.
 - :cpp:enumerator:`LV_DRAW_MASK_TYPE_RADIUS`: Removes the inner or
-  outer corners of a rectangle with a radiused transition. It’s also used
+  outer corners of a rectangle with a radiused transition. It's also used
   to create circles by setting the radius to large value
   (:c:macro:`LV_RADIUS_CIRCLE`)
 - :cpp:enumerator:`LV_DRAW_MASK_TYPE_ANGLE`: Removes a circular
@@ -130,7 +130,7 @@ applied real-time:
 
 Masks are used to create almost every basic primitive: 
 
-- **letters**: Create a mask from the letter and draw a rectangle with the letter’s color using the mask. 
+- **letters**: Create a mask from the letter and draw a rectangle with the letter's color using the mask.
 - **line**: Created from four "line masks" to mask out the left, right, top and bottom part of the line to get a perfectly perpendicular perimeter. 
 - **rounded rectangle**: A mask is created real-time to add a radius to the corners. 
 - **clip corner**: To clip overflowing content (usually children) on rounded corners, a rounded rectangle mask is also applied. 
@@ -141,7 +141,7 @@ Masks are used to create almost every basic primitive:
 Using masks
 -----------
 
-Every mask type has a related parameter structure to describe the mask’s
+Every mask type has a related parameter structure to describe the mask's
 data. The following parameter types exist:
 
 - :cpp:type:`lv_draw_mask_line_param_t`
@@ -179,7 +179,7 @@ can be added manually.
 
 A good use case for this is the `Button matrix </widgets/btnmatrix>`__
 widget. By default, its buttons can be styled in different states, but
-you can’t style the buttons one by one. However, an event is sent for
+you can't style the buttons one by one. However, an event is sent for
 every button and you can, for example, tell LVGL to use different colors
 on a specific button or to manually draw an image on some buttons.
 
@@ -208,7 +208,7 @@ LV_EVENT_DRAW_MAIN
 ^^^^^^^^^^^^^^^^^^
 
 The actual drawing of an object happens in this event. E.g. a rectangle
-for a button is drawn here. First, the widgets’ internal events are
+for a button is drawn here. First, the widgets' internal events are
 called to perform drawing and after that you can draw anything on top of
 them. For example you can add a custom text or an image.
 
@@ -216,7 +216,7 @@ LV_EVENT_DRAW_MAIN_END
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Called when the main drawing is finished. You can draw anything here as
-well and it’s also a good place to remove any masks created in
+well and it's also a good place to remove any masks created in
 :cpp:enumerator:`LV_EVENT_DRAW_MAIN_BEGIN`.
 
 Post drawing
@@ -250,15 +250,15 @@ Called when post drawing has finished. If masks were not removed in
 Part drawing
 ------------
 
-When LVGL draws a part of an object (e.g. a slider’s indicator, a
-table’s cell or a button matrix’s button) it sends events before and
+When LVGL draws a part of an object (e.g. a slider's indicator, a
+table's cell or a button matrix's button) it sends events before and
 after drawing that part with some context of the drawing. This allows
 changing the parts on a very low level with masks, extra drawing, or
 changing the parameters that LVGL is planning to use for drawing.
 
 In these events an :cpp:struct:`lv_obj_draw_part_dsc_t` structure is used to describe
 the context of the drawing. Not all fields are set for every part and
-widget. To see which fields are set for a widget refer to the widget’s
+widget. To see which fields are set for a widget refer to the widget's
 documentation.
 
 :cpp:struct:`lv_obj_draw_part_dsc_t` has the following fields:
@@ -327,33 +327,33 @@ these results:
 Here are some reasons why an object would be unable to fully cover an
 area:
 
-- It’s simply not fully in area
+- It's simply not fully in area
 - It has a radius
-- It doesn’t have 100% background opacity
-- It’s an ARGB or chroma keyed image
+- It doesn't have 100% background opacity
+- It's an ARGB or chroma keyed image
 - It does not have normal blending mode. In this case LVGL needs to know the
   colors under the object to apply blending properly
-- It’s a text, etc
+- It's a text, etc
 
 In short if for any reason the area below an object is visible than the
-object doesn’t cover that area.
+object doesn't cover that area.
 
-Before sending this event LVGL checks if at least the widget’s
+Before sending this event LVGL checks if at least the widget's
 coordinates fully cover the area or not. If not the event is not called.
 
 You need to check only the drawing you have added. The existing
 properties known by a widget are handled in its internal events. E.g. if
 a widget has > 0 radius it might not cover an area, but you need to
-handle ``radius`` only if you will modify it and the widget won’t know
+handle ``radius`` only if you will modify it and the widget won't know
 about it.
 
 LV_EVENT_REFR_EXT_DRAW_SIZE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you need to draw outside a widget, LVGL needs to know about it to
-provide extra space for drawing. Let’s say you create an event which
+provide extra space for drawing. Let's say you create an event which
 writes the current value of a slider above its knob. In this case LVGL
-needs to know that the slider’s draw area should be larger with the size
+needs to know that the slider's draw area should be larger with the size
 required for the text.
 
 You can simply set the required draw area with

--- a/docs/overview/layer.rst
+++ b/docs/overview/layer.rst
@@ -73,7 +73,7 @@ acts as a modal.
    lv_obj_add_flag(lv_layer_top(), LV_OBJ_FLAG_CLICKABLE);
 
 The ``layer_sys`` is also used for similar purposes in LVGL. For
-example, it places the mouse cursor above all layers to be sure it’s
+example, it places the mouse cursor above all layers to be sure it's
 always visible.
 
 API

--- a/docs/overview/renderers/arm2d.rst
+++ b/docs/overview/renderers/arm2d.rst
@@ -17,7 +17,7 @@ In general, you can set the macro :c:macro:`LV_USE_GPU_ARM2D` to ``1`` in
 
 If you are using
 `CMSIS-Pack <https://github.com/lvgl/lvgl/tree/master/env_support/cmsis-pack>`__
-to deploy the LVGL. You don’t have to define the macro
+to deploy the LVGL. You don't have to define the macro
 :c:macro:`LV_USE_GPU_ARM2D` manually, instead, please select the component
 ``GPU Arm-2D`` in the **RTE** dialog. This step will define the macro for us.
 

--- a/docs/overview/style-props.rst
+++ b/docs/overview/style-props.rst
@@ -13,7 +13,7 @@ width
 
 Sets the width of object. Pixel, percentage and :c:macro:`LV_SIZE_CONTENT`
 values can be used. Percentage values are relative to the width of the
-parent’s content area.
+parent's content area.
 
 .. raw:: html
 
@@ -67,7 +67,7 @@ min_width
 ~~~~~~~~~
 
 Sets a minimal width. Pixel and percentage values can be used.
-Percentage values are relative to the width of the parent’s content
+Percentage values are relative to the width of the parent's content
 area.
 
 .. raw:: html
@@ -122,7 +122,7 @@ max_width
 ~~~~~~~~~
 
 Sets a maximal width. Pixel and percentage values can be used.
-Percentage values are relative to the width of the parent’s content
+Percentage values are relative to the width of the parent's content
 area.
 
 .. raw:: html
@@ -177,7 +177,7 @@ height
 ~~~~~~
 
 Sets the height of object. Pixel, percentage and :c:macro:`LV_SIZE_CONTENT` can
-be used. Percentage values are relative to the height of the parent’s
+be used. Percentage values are relative to the height of the parent's
 content area.
 
 .. raw:: html
@@ -232,7 +232,7 @@ min_height
 ~~~~~~~~~~
 
 Sets a minimal height. Pixel and percentage values can be used.
-Percentage values are relative to the width of the parent’s content
+Percentage values are relative to the width of the parent's content
 area.
 
 .. raw:: html
@@ -287,7 +287,7 @@ max_height
 ~~~~~~~~~~
 
 Sets a maximal height. Pixel and percentage values can be used.
-Percentage values are relative to the height of the parent’s content
+Percentage values are relative to the height of the parent's content
 area.
 
 .. raw:: html
@@ -343,7 +343,7 @@ x
 
 Set the X coordinate of the object considering the set ``align``. Pixel
 and percentage values can be used. Percentage values are relative to the
-width of the parent’s content area.
+width of the parent's content area.
 
 .. raw:: html
 
@@ -398,7 +398,7 @@ y
 
 Set the Y coordinate of the object considering the set ``align``. Pixel
 and percentage values can be used. Percentage values are relative to the
-height of the parent’s content area.
+height of the parent's content area.
 
 .. raw:: html
 
@@ -523,7 +523,7 @@ transform_width
 
 Make the object wider on both sides with this value. Pixel and
 percentage (with :cpp:expr:`lv_pct(x)`) values can be used. Percentage values
-are relative to the object’s width.
+are relative to the object's width.
 
 .. raw:: html
 
@@ -578,7 +578,7 @@ transform_height
 
 Make the object higher on both sides with this value. Pixel and
 percentage (with :cpp:expr:`lv_pct(x)`) values can be used. Percentage values
-are relative to the object’s height.
+are relative to the object's height.
 
 .. raw:: html
 
@@ -633,7 +633,7 @@ translate_x
 
 Move the object with this value in X direction. Applied after layouts,
 aligns and other positioning. Pixel and percentage (with :cpp:expr:`lv_pct(x)`)
-values can be used. Percentage values are relative to the object’s
+values can be used. Percentage values are relative to the object's
 width.
 
 .. raw:: html
@@ -689,7 +689,7 @@ translate_y
 
 Move the object with this value in Y direction. Applied after layouts,
 aligns and other positioning. Pixel and percentage (with :cpp:expr:`lv_pct(x)`)
-values can be used. Percentage values are relative to the object’s
+values can be used. Percentage values are relative to the object's
 height.
 
 .. raw:: html
@@ -851,8 +851,8 @@ Ext. draw Yes
 transform_pivot_x
 ~~~~~~~~~~~~~~~~~
 
-Set the pivot point’s X coordinate for transformations. Relative to the
-object’s top left corner’
+Set the pivot point's X coordinate for transformations. Relative to the
+object's top left corner'
 
 .. raw:: html
 
@@ -905,8 +905,8 @@ Ext. draw No
 transform_pivot_y
 ~~~~~~~~~~~~~~~~~
 
-Set the pivot point’s Y coordinate for transformations. Relative to the
-object’s top left corner’
+Set the pivot point's Y coordinate for transformations. Relative to the
+object's top left corner'
 
 .. raw:: html
 
@@ -959,7 +959,7 @@ Ext. draw No
 Padding
 -------
 
-Properties to describe spacing between the parent’s sides and the
+Properties to describe spacing between the parent's sides and the
 children and among the children. Very similar to the padding properties
 in HTML.
 
@@ -1791,7 +1791,7 @@ Ext. draw No
 bg_grad_stop
 ~~~~~~~~~~~~
 
-Set the point from which the background’s gradient color should start. 0
+Set the point from which the background's gradient color should start. 0
 means to top/left side, 255 the bottom/right side, 128 the center, and
 so on
 
@@ -2517,7 +2517,7 @@ Ext. draw No
 Outline
 -------
 
-Properties to describe the outline. It’s like a border but drawn outside
+Properties to describe the outline. It's like a border but drawn outside
 of the rectangles.
 
 outline_width
@@ -3780,7 +3780,7 @@ Ext. draw No
 arc_img_src
 ~~~~~~~~~~~
 
-Set an image from which the arc will be masked out. It’s useful to
+Set an image from which the arc will be masked out. It's useful to
 display complex effects on the arcs. Can be a pointer to
 :cpp:struct:`lv_img_dsc_t` or a path to a file
 
@@ -4168,7 +4168,7 @@ Ext. draw No
 text_align
 ~~~~~~~~~~
 
-Set how to align the lines of the text. Note that it doesn’t align the
+Set how to align the lines of the text. Note that it doesn't align the
 object itself, only the lines inside the object. The possible values are:
 
 - :cpp:enumerator:`LV_TEXT_ALIGN_LEFT`
@@ -4504,10 +4504,10 @@ Ext. draw No
 anim
 ~~~~
 
-The animation template for the object’s animation. Should be a pointer
+The animation template for the object's animation. Should be a pointer
 to :cpp:type:`lv_anim_t`. The animation parameters are widget specific,
 e.g. animation time could be the E.g. blink time of the cursor on the
-text area or scroll time of a roller. See the widgets’ documentation to
+text area or scroll time of a roller. See the widgets' documentation to
 learn more.
 
 .. raw:: html
@@ -4563,7 +4563,7 @@ anim_time
 
 The animation time in milliseconds. Its meaning is widget specific. E.g.
 blink time of the cursor on the text area or scroll time of a roller.
-See the widgets’ documentation to learn more.
+See the widgets' documentation to learn more.
 
 .. raw:: html
 
@@ -4617,7 +4617,7 @@ anim_speed
 ~~~~~~~~~~
 
 The animation speed in pixel/sec. Its meaning is widget specific. E.g.
-scroll speed of label. See the widgets’ documentation to learn more.
+scroll speed of label. See the widgets' documentation to learn more.
 
 .. raw:: html
 

--- a/docs/overview/style.rst
+++ b/docs/overview/style.rst
@@ -7,24 +7,24 @@ Styles
 *Styles* are used to set the appearance of objects. Styles in lvgl are
 heavily inspired by CSS. The concept in a nutshell is as follows: - A
 style is an :cpp:type:`lv_style_t` variable which can hold properties like
-border width, text color and so on. It’s similar to a ``class`` in CSS.
+border width, text color and so on. It's similar to a ``class`` in CSS.
 
 - Styles can be assigned to objects to change their appearance. Upon
   assignment, the target part (*pseudo-element* in CSS) and target state
   (*pseudo class*) can be specified. For example one can add
-  ``style_blue`` to the knob of a slider when it’s in pressed state.
+  ``style_blue`` to the knob of a slider when it's in pressed state.
 - The same style can be used by any number of objects.
 - Styles can be cascaded which means multiple styles may be assigned to an object and
   each style can have different properties. Therefore, not all properties
   have to be specified in a style. LVGL will search for a property until a
-  style defines it or use a default if it’s not specified by any of the
+  style defines it or use a default if it's not specified by any of the
   styles. For example ``style_btn`` can result in a default gray button
   and ``style_btn_red`` can add only a ``background-color=red`` to
   overwrite the background color.
 - The most recently added style has higher precedence. This means if a property
   is specified in two styles the newest style in the object will be used.
-- Some properties (e.g. text color) can be inherited from a parent(s) if it’s not specified in an object.
-- Objects can also have local styles with higher precedence than “normal” styles.
+- Some properties (e.g. text color) can be inherited from a parent(s) if it's not specified in an object.
+- Objects can also have local styles with higher precedence than "normal" styles.
 - Unlike CSS (where pseudo-classes describe different states, e.g. ``:focus``),
   in LVGL a property is assigned to a given state.
 - Transitions can be applied when the object changes state.
@@ -53,51 +53,51 @@ pressed at the same time. This is represented as :cpp:expr:`LV_STATE_FOCUSED | L
 
 A style can be added to any state or state combination. For example,
 setting a different background color for the default and pressed states.
-If a property is not defined in a state the best matching state’s
+If a property is not defined in a state the best matching state's
 property will be used. Typically this means the property with
 :cpp:enumerator:`LV_STATE_DEFAULT` is used.˛ If the property is not set even for the
 default state the default value will be used. (See later)
 
-But what does the “best matching state’s property” really mean? States
+But what does the "best matching state's property" really mean? States
 have a precedence which is shown by their value (see in the above list).
-A higher value means higher precedence. To determine which state’s
-property to use let’s take an example. Imagine the background color is
+A higher value means higher precedence. To determine which state's
+property to use let's take an example. Imagine the background color is
 defined like this:
 
 - :cpp:enumerator:`LV_STATE_DEFAULT`: white
 - :cpp:enumerator:`LV_STATE_PRESSED`: gray
 - :cpp:enumerator:`LV_STATE_FOCUSED`: red
 
-1. Initially the object is in the default state, so it’s a simple case:
-   the property is perfectly defined in the object’s current state as
+1. Initially the object is in the default state, so it's a simple case:
+   the property is perfectly defined in the object's current state as
    white.
 2. When the object is pressed there are 2 related properties: default
    with white (default is related to every state) and pressed with gray.
    The pressed state has 0x0020 precedence which is higher than the
-   default state’s 0x0000 precedence, so gray color will be used.
+   default state's 0x0000 precedence, so gray color will be used.
 3. When the object is focused the same thing happens as in pressed state
    and red color will be used. (Focused state has higher precedence than
    default state).
 4. When the object is focused and pressed both gray and red would work,
    but the pressed state has higher precedence than focused so gray
    color will be used.
-5. It’s possible to set e.g. rose color for :cpp:expr:`LV_STATE_PRESSED | LV_STATE_FOCUSED`.
+5. It's possible to set e.g. rose color for :cpp:expr:`LV_STATE_PRESSED | LV_STATE_FOCUSED`.
    In this case, this combined state has 0x0020 + 0x0002 = 0x0022 precedence, which is higher than
-   the pressed state’s precedence so rose color would be used.
+   the pressed state's precedence so rose color would be used.
 6. When the object is in the checked state there is no property to set
    the background color for this state. So for lack of a better option,
-   the object remains white from the default state’s property.
+   the object remains white from the default state's property.
 
 Some practical notes:
 
-- The precedence (value) of states is quite intuitive, and it’s something the
+- The precedence (value) of states is quite intuitive, and it's something the
   user would expect naturally. E.g. if an object is focused the user will still
-  want to see if it’s pressed, therefore the pressed state has a higher
+  want to see if it's pressed, therefore the pressed state has a higher
   precedence. If the focused state had a higher precedence it would overwrite
   the pressed color.
 - If you want to set a property for all states (e.g. red background color)
-  just set it for the default state. If the object can’t find a property
-  for its current state it will fall back to the default state’s property.
+  just set it for the default state. If the object can't find a property
+  for its current state it will fall back to the default state's property.
 - Use ORed states to describe the properties for complex cases. (E.g.
   pressed + checked + focused)
 - It might be a good idea to use different
@@ -110,7 +110,7 @@ Some practical notes:
 Cascading styles
 ****************
 
-It’s not required to set all the properties in one style. It’s possible
+It's not required to set all the properties in one style. It's possible
 to add more styles to an object and have the latter added style modify
 or extend appearance. For example, create a general gray button style
 and create a new one for red buttons where only the new background color
@@ -122,13 +122,13 @@ This is much like in CSS when used classes are listed like
 Styles added later have precedence over ones set earlier. So in the
 gray/red button example above, the normal button style should be added
 first and the red style second. However, the precedence of the states
-are still taken into account. So let’s examine the following case:
+are still taken into account. So let's examine the following case:
 
 - the basic button style defines dark-gray color for the default state and
   light-gray color for the pressed state
 - the red button style defines the background color as red only in the default state
 
-In this case, when the button is released (it’s in default state) it
+In this case, when the button is released (it's in default state) it
 will be red because a perfect match is found in the most recently added
 style (red). When the button is pressed the light-gray color is a better
 match because it describes the current state perfectly, so the button
@@ -138,9 +138,9 @@ Inheritance
 ***********
 
 Some properties (typically those related to text) can be inherited from
-the parent object’s styles. Inheritance is applied only if the given
-property is not set in the object’s styles (even in default state). In
-this case, if the property is inheritable, the property’s value will be
+the parent object's styles. Inheritance is applied only if the given
+property is not set in the object's styles (even in default state). In
+this case, if the property is inheritable, the property's value will be
 searched in the parents until an object specifies a value for the
 property. The parents will use their own state to determine the value.
 So if a button is pressed, and the text color comes from here, the
@@ -149,9 +149,9 @@ pressed text color will be used.
 Forced value inheritance/default value
 **************************************
 
-Sometimes you may want to force a child object to use the parent’s value
+Sometimes you may want to force a child object to use the parent's value
 for a given style property. To do this you can use one of the following
-(depending on what type of style you’re using):
+(depending on what type of style you're using):
 
 .. code:: c
 
@@ -184,7 +184,7 @@ The following predefined parts exist in LVGL:
 - :cpp:enumerator:`LV_PART_SELECTED`: Indicate the currently selected option or section
 - :cpp:enumerator:`LV_PART_ITEMS`: Used if the widget has multiple similar elements (e.g. table cells)
 - :cpp:enumerator:`LV_PART_TICKS`: Ticks on scales e.g. for a chart or meter
-- :cpp:enumerator:`LV_PART_CURSOR`: Mark a specific place e.g. text area’s or chart’s cursor
+- :cpp:enumerator:`LV_PART_CURSOR`: Mark a specific place e.g. text area's or chart's cursor
 - :cpp:enumerator:`LV_PART_CUSTOM_FIRST`: Custom part identifiers can be added starting from here.
 
 For example a `Slider </widgets/slider.html>`__ has three parts:
@@ -229,7 +229,7 @@ To remove a property use:
 
    lv_style_remove_prop(&style, LV_STYLE_BG_COLOR);
 
-To get a property’s value from a style:
+To get a property's value from a style:
 
 .. code:: c
 
@@ -302,7 +302,7 @@ function will only replace ``old_style`` with ``new_style`` if the
 ``selector`` matches the ``selector`` used in ``lv_obj_add_style``. Both
 styles, i.e. ``old_style`` and ``new_style``, must not be ``NULL`` (for
 adding and removing separate functions exist). If the combination of
-``old_style`` and ``selector`` exists multiple times in ``obj``\ ’s
+``old_style`` and ``selector`` exists multiple times in ``obj``\ 's
 styles, all occurrences will be replaced. The return value of the
 function indicates whether at least one successful replacement took
 place.
@@ -344,14 +344,14 @@ notified. There are 3 options to do this:
    when needed, call :cpp:expr:`lv_obj_report_style_change(&style)`. If ``style``
    is ``NULL`` all objects will be notified about a style change.
 
-Get a property’s value on an object
+Get a property's value on an object
 -----------------------------------
 
 To get a final value of property
 
 - considering cascading, inheritance, local styles and transitions (see below)
 - property get functions like this can be used: ``lv_obj_get_style_<property_name>(obj, <part>)``.
-  These functions use the object’s current state and if no better candidate exists they return a default value.
+  These functions use the object's current state and if no better candidate exists they return a default value.
   For example:
 
 .. code:: c
@@ -361,11 +361,11 @@ To get a final value of property
 Local styles
 ************
 
-In addition to “normal” styles, objects can also store local styles.
+In addition to "normal" styles, objects can also store local styles.
 This concept is similar to inline styles in CSS
 (e.g. ``<div style="color:red">``) with some modification.
 
-Local styles are like normal styles, but they can’t be shared among
+Local styles are like normal styles, but they can't be shared among
 other objects. If used, local styles are allocated automatically, and
 freed when the object is deleted. They are useful to add local
 customization to an object.
@@ -391,9 +391,9 @@ For the full list of style properties click
 Typical background properties
 -----------------------------
 
-In the documentation of the widgets you will see sentences like “The
-widget uses the typical background properties”. These “typical
-background properties” are the ones related to:
+In the documentation of the widgets you will see sentences like "The
+widget uses the typical background properties". These "typical
+background properties" are the ones related to:
 
 - Background
 - Border
@@ -406,13 +406,13 @@ background properties” are the ones related to:
 Transitions
 ***********
 
-By default, when an object changes state (e.g. it’s pressed) the new
+By default, when an object changes state (e.g. it's pressed) the new
 properties from the new state are set immediately. However, with
-transitions it’s possible to play an animation on state change. For
+transitions it's possible to play an animation on state change. For
 example, on pressing a button its background color can be animated to
 the pressed color over 300 ms.
 
-The parameters of the transitions are stored in the styles. It’s
+The parameters of the transitions are stored in the styles. It's
 possible to set
 
 - the time of the transition
@@ -456,18 +456,18 @@ transformation properties.
 These properties have this effect only on the ``MAIN`` part of the
 widget.
 
-The created snapshot is called “intermediate layer” or simply “layer”.
+The created snapshot is called "intermediate layer" or simply "layer".
 If only ``opa`` and/or ``blend_mode`` is set to a non-default value LVGL
 can build the layer from smaller chunks. The size of these chunks can be
 configured by the following properties in ``lv_conf.h``:
 
 - :cpp:enumerator:`LV_LAYER_SIMPLE_BUF_SIZE`: [bytes] the optimal target buffer size. LVGL will try to allocate this size of memory.
-- :cpp:enumerator:`LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE`: [bytes] used if :cpp:enumerator:`LV_LAYER_SIMPLE_BUF_SIZE` couldn’t be allocated.
+- :cpp:enumerator:`LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE`: [bytes] used if :cpp:enumerator:`LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
 
 If transformation properties were also used the layer can not be
 rendered in chunks, but one larger memory needs to be allocated. The
 required memory depends on the angle, zoom and pivot parameters, and the
-size of the area to redraw, but it’s never larger than the size of the
+size of the area to redraw, but it's never larger than the size of the
 widget (including the extra draw size used for shadow, outline, etc).
 
 If the widget can fully cover the area to redraw, LVGL creates an RGB
@@ -499,7 +499,7 @@ To set a theme for a display, two steps are required:
 2. Assign the initialized theme to a display.
 
 Theme initialization functions can have different prototypes. This
-example shows how to set the “default” theme:
+example shows how to set the "default" theme:
 
 .. code:: c
 
@@ -518,8 +518,8 @@ Extending themes
 ----------------
 
 Built-in themes can be extended. If a custom theme is created, a parent
-theme can be selected. The parent theme’s styles will be added before
-the custom theme’s styles. Any number of themes can be chained this way.
+theme can be selected. The parent theme's styles will be added before
+the custom theme's styles. Any number of themes can be chained this way.
 E.g. default theme -> custom theme -> dark theme.
 
 :cpp:expr:`lv_theme_set_parent(new_theme, base_theme)` extends the

--- a/docs/overview/timer.rst
+++ b/docs/overview/timer.rst
@@ -66,29 +66,29 @@ Repeat count
 
 You can make a timer repeat only a given number of times with
 :cpp:expr:`lv_timer_set_repeat_count(timer, count)`. The timer will
-automatically be deleted after it’s called the defined number of times.
+automatically be deleted after it's called the defined number of times.
 Set the count to ``-1`` to repeat indefinitely.
 
 Measure idle time
 *****************
 
 You can get the idle percentage time of :cpp:func:`lv_timer_handler` with
-:cpp:func:`lv_timer_get_idle`. Note that, it doesn’t measure the idle time of
+:cpp:func:`lv_timer_get_idle`. Note that, it doesn't measure the idle time of
 the overall system, only :cpp:func:`lv_timer_handler`. It can be misleading if
 you use an operating system and call :cpp:func:`lv_timer_handler` in a timer, as
-it won’t actually measure the time the OS spends in an idle thread.
+it won't actually measure the time the OS spends in an idle thread.
 
 Asynchronous calls
 ******************
 
-In some cases, you can’t perform an action immediately. For example, you
-can’t delete an object because something else is still using it, or you
-don’t want to block the execution now. For these cases,
+In some cases, you can't perform an action immediately. For example, you
+can't delete an object because something else is still using it, or you
+don't want to block the execution now. For these cases,
 :cpp:expr:`lv_async_call(my_function, data_p)` can be used to call
 ``my_function`` on the next invocation of :cpp:func:`lv_timer_handler`.
-``data_p`` will be passed to the function when it’s called. Note that
+``data_p`` will be passed to the function when it's called. Note that
 only the data pointer is saved, so you need to ensure that the variable
-will be “alive” while the function is called. It can be *static*, global
+will be "alive" while the function is called. It can be *static*, global
 or dynamically allocated data. If you want to cancel an asynchronous
 call, call :cpp:expr:`lv_async_call_cancel(my_function, data_p)`, which will
 clear all asynchronous calls matching ``my_function`` and ``data_p``.
@@ -114,7 +114,7 @@ For example:
 
    /*The screen is still valid so you can do other things with it*/
 
-If you just want to delete an object and don’t need to clean anything up
+If you just want to delete an object and don't need to clean anything up
 in ``my_screen_cleanup`` you could just use :cpp:func:`lv_obj_del_async` which
 will delete the object on the next call to :cpp:func:`lv_timer_handler`.
 

--- a/docs/porting/disp.rst
+++ b/docs/porting/disp.rst
@@ -11,7 +11,7 @@ a multiple displays and a different driver for each (see below),
 Basic setup
 ***********
 
-Draw buffer(s) are simple array(s) that LVGL uses to render the screen’s
+Draw buffer(s) are simple array(s) that LVGL uses to render the screen's
 content. Once rendering is ready the content of the draw buffer is sent
 to the display using the ``flush_cb`` function.
 
@@ -75,7 +75,7 @@ The draw buffers can be set with
    -  :cpp:enumerator:`LV_DISP_RENDER_MODE_FULL` The buffer can smaller or screen
       sized but LVGL will always redraw the whole screen even is only 1
       pixel has been changed. If two screen sized draw buffers are
-      provided, LVGL’s display handling works like “traditional” double
+      provided, LVGL's display handling works like "traditional" double
       buffering. This means the ``flush_cb`` callback only has to update
       the address of the framebuffer (``color_p`` parameter).
 
@@ -112,7 +112,7 @@ Resolution
 To set the resolution of the display after creation use
 :cpp:expr:`lv_disp_set_res(disp, hor_res, ver_res)`
 
-It’s not mandatory to use the whole display for LVGL, however in some
+It's not mandatory to use the whole display for LVGL, however in some
 cases the physical resolution is important. For example the touchpad
 still sees the whole resolution and the values needs to be converted to
 the active LVGL display area. So the physical resoltution and the offset
@@ -124,13 +124,13 @@ Rotation
 --------
 
 LVGL supports rotation of the display in 90 degree increments. You can
-select whether you’d like software rotation or hardware rotation.
+select whether you'd like software rotation or hardware rotation.
 
 The orientation of the display can be changed with
 ``lv_disp_set_rotation(disp, LV_DISP_ROTATION_0/90/180/270, true/false)``.
 LVGL will swap the horizontal and vertical resolutions internally
 according to the set degree. IF the last paramter is ``true`` LVGL will
-rotate the rendered image. If it’s ``false`` the display driver should
+rotate the rendered image. If it's ``false`` the display driver should
 rotate the rendered image.
 
 Color format
@@ -173,7 +173,7 @@ native color format to the desired, therfore rendering in non-native
 formats has a negative effect on peroformance. Learn more about
 ``draw_ctx`` `here </porting/gpu>`__.
 
-It’s very important that draw buffer(s) should be large enough for both
+It's very important that draw buffer(s) should be large enough for both
 the native format and the target color format. For example if
 ``LV_COLOR_DEPTH == 16`` and :cpp:enumerator:`LV_COLOR_FORMAT_XRGB8888` is selected
 LVGL will choosoe the larger to figure out how many pixel can be

--- a/docs/porting/draw.rst
+++ b/docs/porting/draw.rst
@@ -24,7 +24,7 @@ Fields
 - ``void (*draw_rect)()`` Draw a rectangle with shadow, gradient, border, etc.
 - ``void (*draw_arc)()`` Draw an arc
 - ``void (*draw_img_decoded)()`` Draw an (A)RGB image that is already decoded by LVGL.
-- ``lv_res_t (*draw_img)()`` Draw an image before decoding it (it bypasses LVGL’s internal image decoders)
+- ``lv_res_t (*draw_img)()`` Draw an image before decoding it (it bypasses LVGL's internal image decoders)
 - ``void (*draw_letter)()`` Draw a letter
 - ``void (*draw_line)()`` Draw a line - ``void (*draw_polygon)()`` Draw a polygon
 - ``void (*draw_bg)()`` Replace the buffer with a rect without decoration like radius or borders.
@@ -35,9 +35,9 @@ Fields
 
 All ``draw_*`` callbacks receive a pointer to the current ``draw_ctx``
 as their first parameter. Among the other parameters there is a
-descriptor that tells what to draw, e.g. for ``draw_rect`` it’s called
+descriptor that tells what to draw, e.g. for ``draw_rect`` it's called
 :cpp:struct:`lv_draw_rect_dsc_t`,
-for :cpp:func:`lv_draw_line` it’s called :cpp:struct:`lv_draw_line_dsc_t`,
+for :cpp:func:`lv_draw_line` it's called :cpp:struct:`lv_draw_line_dsc_t`,
 etc.
 
 To correctly render according to a ``draw_dsc`` you need to be familiar
@@ -67,7 +67,7 @@ calling :cpp:func:`lv_disp_drv_register`. It makes it possible to use your own
 Software renderer
 *****************
 
-LVGL’s built in software renderer extends the basic :cpp:type:`lv_draw_ctx_t`
+LVGL's built in software renderer extends the basic :cpp:type:`lv_draw_ctx_t`
 structure and sets the draw callbacks. It looks like this:
 
 .. code:: c
@@ -92,7 +92,7 @@ Blend callback
 --------------
 
 As you saw above the software renderer adds the ``blend`` callback
-field. It’s a special callback related to how the software renderer
+field. It's a special callback related to how the software renderer
 works. All draw operations end up in the ``blend`` callback which can
 either fill an area or copy an image to an area by considering an optional mask.
 
@@ -100,7 +100,7 @@ The :cpp:struct:`lv_draw_sw_blend_dsc_t` parameter describes what and how to
 blend. It has the following fields:
 
 - ``const lv_area_t * blend_area`` The area with absolute coordinates to draw
-  on ``draw_ctx->buf``. If ``src_buf`` is set, it’s the coordinates of the image to blend.
+  on ``draw_ctx->buf``. If ``src_buf`` is set, it's the coordinates of the image to blend.
 - ``const lv_color_t * src_buf`` Pointer to an image to blend. If set,
   ``color`` is ignored. If not set fill ``blend_area`` with ``color``
 - ``lv_color_t color`` Fill color. Used only if ``src_buf == NULL``
@@ -116,7 +116,7 @@ Extend the software renderer
 New blend callback
 ------------------
 
-Let’s take a practical example: you would like to use your MCUs GPU for
+Let's take a practical example: you would like to use your MCUs GPU for
 color fill operations only.
 
 As all draw callbacks call ``blend`` callback to fill an area in the end
@@ -244,7 +244,7 @@ Fully custom draw engine
 ************************
 
 For example if your MCU/MPU supports a powerful vector graphics engine
-you might use only that instead of LVGL’s SW renderer. In this case, you
+you might use only that instead of LVGL's SW renderer. In this case, you
 need to base the renderer on the basic :cpp:type:`lv_draw_ctx_t` (instead of
 :cpp:struct:`lv_draw_sw_ctx_t`) and extend/initialize it as you wish.
 

--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -154,7 +154,7 @@ specified in ``indev_drv.long_press_repeat_time``.
 Button
 ------
 
-*Buttons* mean external “hardware” buttons next to the screen which are
+*Buttons* mean external "hardware" buttons next to the screen which are
 assigned to specific coordinates of the screen. If a button is pressed
 it will simulate the pressing on the assigned coordinate. (Similarly to a touchpad)
 

--- a/docs/porting/log.rst
+++ b/docs/porting/log.rst
@@ -15,7 +15,7 @@ To enable logging, set :c:macro:`LV_USE_LOG` in ``lv_conf.h`` and set
 
 - :c:macro:`LV_LOG_LEVEL_TRACE`: A lot of logs to give detailed information
 - :c:macro:`LV_LOG_LEVEL_INFO`: Log important events
-- :c:macro:`LV_LOG_LEVEL_WARN`: Log if something unwanted happened but didn’t cause a problem
+- :c:macro:`LV_LOG_LEVEL_WARN`: Log if something unwanted happened but didn't cause a problem
 - :c:macro:`LV_LOG_LEVEL_ERROR`: Only critical issues, where the system may fail
 - :c:macro:`LV_LOG_LEVEL_USER`: Only user messages
 - :c:macro:`LV_LOG_LEVEL_NONE`: Do not log anything
@@ -36,8 +36,8 @@ If your system supports ``printf``, you just need to enable
 Custom log function
 -------------------
 
-If you can’t use ``printf`` or want to use a custom function to log, you
-can register a “logger” callback with :cpp:func:`lv_log_register_print_cb`.
+If you can't use ``printf`` or want to use a custom function to log, you
+can register a "logger" callback with :cpp:func:`lv_log_register_print_cb`.
 
 For example:
 

--- a/docs/porting/os.rst
+++ b/docs/porting/os.rst
@@ -6,7 +6,7 @@ Operating system and interrupts
 
 LVGL is **not thread-safe** by default.
 
-However, in the following conditions it’s valid to call LVGL related
+However, in the following conditions it's valid to call LVGL related
 functions: - In *events*. Learn more in :ref:`events`. -
 In *lv_timer*. Learn more in `Timers </overview/timer>`__.
 
@@ -60,6 +60,6 @@ Try to avoid calling LVGL functions from interrupt handlers (except
 this you have to disable the interrupt which uses LVGL functions while
 :cpp:func:`lv_timer_handler` is running.
 
-It’s a better approach to simply set a flag or some value in the
+It's a better approach to simply set a flag or some value in the
 interrupt, and periodically check it in an LVGL timer (which is run by
 :cpp:func:`lv_timer_handler`).

--- a/docs/porting/project.rst
+++ b/docs/porting/project.rst
@@ -61,7 +61,7 @@ Configuration file
 ------------------
 
 There is a configuration header file for LVGL called **lv_conf.h**. You
-modify this header to set the library’s basic behavior, disable unused
+modify this header to set the library's basic behavior, disable unused
 modules and features, adjust the size of memory buffers in compile-time,
 etc.
 
@@ -77,7 +77,7 @@ content. So the layout of the files should look like this:
    |-other files and folders
 
 Comments in the config file explain the meaning of the options. Be sure
-to set at least :c:macro:`LV_COLOR_DEPTH` according to your display’s color
+to set at least :c:macro:`LV_COLOR_DEPTH` according to your display's color
 depth. Note that, the examples and demos explicitly need to be enabled
 in ``lv_conf.h``.
 

--- a/docs/widgets/animimg.rst
+++ b/docs/widgets/animimg.rst
@@ -4,7 +4,7 @@ Animation Image (lv_animimg)
 Overview
 ********
 
-The animation image is similar to the normal ‘Image’ object. The only
+The animation image is similar to the normal 'Image' object. The only
 difference is that instead of one source image, you set an array of
 multiple source images.
 

--- a/docs/widgets/arc.rst
+++ b/docs/widgets/arc.rst
@@ -11,14 +11,14 @@ Parts and Styles
 ****************
 
 -  :cpp:enumerator:`LV_PART_MAIN` Draws a background using the typical background
-   style properties and an arc using the arc style properties. The arc’s
+   style properties and an arc using the arc style properties. The arc's
    size and position will respect the *padding* style properties.
 -  :cpp:enumerator:`LV_PART_INDICATOR` Draws another arc using the *arc* style
    properties. Its padding values are interpreted relative to the
    background arc.
 -  :cpp:enumerator:`LV_PART_KNOB` Draws a handle on the end of the indicator using all
    background properties and padding values. With zero padding the knob
-   size is the same as the indicator’s width. Larger padding makes it
+   size is the same as the indicator's width. Larger padding makes it
    larger, smaller padding makes it smaller.
 
 Usage
@@ -32,13 +32,13 @@ value is interpreted in a range (minimum and maximum values) which can
 be modified with :cpp:expr:`lv_arc_set_range(arc, min, max)`. The default range
 is 0..100.
 
-The indicator arc is drawn on the main part’s arc. This if the value is
-set to maximum the indicator arc will cover the entire “background” arc.
+The indicator arc is drawn on the main part's arc. This if the value is
+set to maximum the indicator arc will cover the entire "background" arc.
 To set the start and end angle of the background arc use the
 :cpp:expr:`lv_arc_set_bg_angles(arc, start_angle, end_angle)` functions or
 ``lv_arc_set_bg_start/end_angle(arc, angle)``.
 
-Zero degrees is at the middle right (3 o’clock) of the object and the
+Zero degrees is at the middle right (3 o'clock) of the object and the
 degrees are increasing in clockwise direction. The angles should be in
 the [0;360] range.
 
@@ -81,10 +81,10 @@ relative to the end of the arc The knob offset can be set by
 Setting the indicator manually
 ------------------------------
 
-It’s also possible to set the angles of the indicator arc directly with
+It's also possible to set the angles of the indicator arc directly with
 :cpp:expr:`lv_arc_set_angles(arc, start_angle, end_angle)` function or
 ``lv_arc_set_start/end_angle(arc, start_angle)``. In this case the set
-“value” and “mode” are ignored.
+"value" and "mode" are ignored.
 
 In other words, the angle and value settings are independent. You should
 exclusively use one or the other. Mixing the two might result in
@@ -110,14 +110,14 @@ Place another object to the knob
 --------------------------------
 
 Another object can be positioned according to the current position of
-the arc in order to follow the arc’s current value (angle). To do this
+the arc in order to follow the arc's current value (angle). To do this
 use :cpp:expr:`lv_arc_align_obj_to_angle(arc, obj_to_align, radius_offset)`.
 
 Similarly
 :cpp:expr:`lv_arc_rotate_obj_to_angle(arc, obj_to_rotate, radius_offset)` can be
 used to rotate the object to the current value of the arc.
 
-It’s a typical use case to call these functions in the ``VALUE_CHANGED``
+It's a typical use case to call these functions in the ``VALUE_CHANGED``
 event of the arc.
 
 Events

--- a/docs/widgets/btnmatrix.rst
+++ b/docs/widgets/btnmatrix.rst
@@ -27,7 +27,7 @@ Parts and Styles
 Usage
 *****
 
-Button’s text
+Button's text
 -------------
 
 There is a text on each button. To specify them a descriptor string
@@ -38,7 +38,7 @@ that the last element has to be either ``NULL`` or an empty string
 (``""``)!
 
 Use ``"\n"`` in the map to insert a **line break**. E.g.
-``{"btn1", "btn2", "\n", "btn3", ""}``. Each line’s buttons have their
+``{"btn1", "btn2", "\n", "btn3", ""}``. Each line's buttons have their
 width calculated automatically. So in the example the first row will
 have 2 buttons each with 50% width and a second row with 1 button having
 100% width.
@@ -46,10 +46,10 @@ have 2 buttons each with 50% width and a second row with 1 button having
 Control buttons
 ---------------
 
-The buttons’ width can be set relative to the other button in the same
+The buttons' width can be set relative to the other button in the same
 row with :cpp:expr:`lv_btnmatrix_set_btn_width(btnm, btn_id, width)` E.g. in a
 line with two buttons: *btnA, width = 1* and *btnB, width = 2*, *btnA*
-will have 33 % width and *btnB* will have 66 % width. It’s similar to
+will have 33 % width and *btnB* will have 66 % width. It's similar to
 how the
 ```flex-grow`` <https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow>`__
 property works in CSS. The width must be in the [1..15] range and the
@@ -71,7 +71,7 @@ following parameters:
 
 By default, all flags are disabled.
 
-To set or clear a button’s control attribute, use
+To set or clear a button's control attribute, use
 ``lv_btnmatrix_set_btn_ctrl(btnm, btn_id, LV_BTNM_CTRL_...)`` and
 ``lv_btnmatrix_clear_btn_ctrl(btnm, btn_id, LV_BTNMATRIX_CTRL_...)``
 respectively. More ``LV_BTNM_CTRL_...`` values can be OR-ed
@@ -90,7 +90,7 @@ The number of elements should be equal to the number of buttons
 One check
 ---------
 
-The “One check” feature can be enabled with
+The "One check" feature can be enabled with
 :cpp:expr:`lv_btnmatrix_set_one_checked(btnm, true)` to allow only one button to
 be checked at a time.
 
@@ -130,11 +130,11 @@ Keys
 
 Note that long pressing the button matrix with an encoder can mean to
 enter/leave edit mode and simply long pressing a button to make it
-repeat as well. To avoid this contradiction it’s suggested to add
+repeat as well. To avoid this contradiction it's suggested to add
 :cpp:expr:`lv_btnmatrix_set_btn_ctrl_all(btnm, LV_BTNMATRIX_CTRL_CLICK_TRIG | LV_BTNMATRIX_CTRL_NO_REPEAT)`
 to the button matrix if used with encoder. This way, the pressed button
 repeat feature is disabled and on leaving edit mode the selected button
-won’t be activated.
+won't be activated.
 
 Learn more about :ref:`indev_keys`.
 

--- a/docs/widgets/calendar.rst
+++ b/docs/widgets/calendar.rst
@@ -12,8 +12,8 @@ The Calendar is added to the default group (if it is set). Calendar is
 an editable object which allow selecting and clicking the dates with
 encoder navigation too.
 
-To make the Calendar flexible, by default it doesn’t show the current
-year or month. Instead, there are optional “headers” that can be
+To make the Calendar flexible, by default it doesn't show the current
+year or month. Instead, there are optional "headers" that can be
 attached to the calendar.
 
 Parts and Styles
@@ -28,7 +28,7 @@ object under the hood to arrange the days into a matrix.
 
   - day names have no border, no background and drawn with a gray color
   - days of the previous and next month have :cpp:enumerator:`LV_BTNMATRIX_CTRL_DISABLED` flag
-  - today has a thicker border with the theme’s primary color - highlighted days have some opacity with the theme’s primary color.
+  - today has a thicker border with the theme's primary color - highlighted days have some opacity with the theme's primary color.
 
 Usage
 *****
@@ -55,7 +55,7 @@ Highlighted days
 The list of highlighted dates should be stored in a
 :cpp:struct:`lv_calendar_date_t` array loaded by
 :cpp:expr:`lv_calendar_set_highlighted_dates(calendar, highlighted_dates, date_num)`.
-Only the array’s pointer will be saved so the array should be a static
+Only the array's pointer will be saved so the array should be a static
 or global variable.
 
 Name of the days

--- a/docs/widgets/canvas.rst
+++ b/docs/widgets/canvas.rst
@@ -6,7 +6,7 @@ Overview
 
 A Canvas inherits from `Image </widgets/img>`__ where the user can draw
 anything. Rectangles, texts, images, lines, arcs can be drawn here using
-lvgl’s drawing engine. Additionally “effects” can be applied, such as
+lvgl's drawing engine. Additionally "effects" can be applied, such as
 rotation, zoom and blur.
 
 Parts and Styles
@@ -45,18 +45,18 @@ sets pixels with *index=3* to red.
 Drawing
 -------
 
-To set a pixel’s color on the canvas, use
+To set a pixel's color on the canvas, use
 :cpp:expr:`lv_canvas_set_px_color(canvas, x, y, LV_COLOR_RED)`. With
 ``LV_IMG_CF_INDEXED_...`` the index of the color needs to be passed as
 color. E.g. ``lv_color_t c; c.full = 3;``
 
-To set a pixel’s opacity with :cpp:enumerator:`LV_IMG_CF_TRUE_COLOR_ALPHA` or
+To set a pixel's opacity with :cpp:enumerator:`LV_IMG_CF_TRUE_COLOR_ALPHA` or
 ``LV_IMG_CF_ALPHA_...`` format on the canvas, use
 :cpp:expr:`lv_canvas_set_px_opa(canvas, x, y, opa)`.
 
 :cpp:expr:`lv_canvas_fill_bg(canvas, LV_COLOR_BLUE, LV_OPA_50)` fills the whole
 canvas to blue with 50% opacity. Note that if the current color format
-doesn’t support colors (e.g. :cpp:enumerator:`LV_IMG_CF_ALPHA_2BIT`) the color will be
+doesn't support colors (e.g. :cpp:enumerator:`LV_IMG_CF_ALPHA_2BIT`) the color will be
 ignored. Similarly, if opacity is not supported
 (e.g. :cpp:enumerator:`LV_IMG_CF_TRUE_COLOR`) it will be ignored.
 
@@ -78,7 +78,7 @@ which should be first initialized with one of
 ``lv_draw_rect/label/img/line/arc_dsc_init()`` and then modified with
 the desired colors and other values.
 
-The draw function can draw to any color format. For example, it’s
+The draw function can draw to any color format. For example, it's
 possible to draw a text to an :cpp:enumerator:`LV_IMG_VF_ALPHA_8BIT` canvas and use
 the result image as a `draw mask </overview/drawing>`__ later.
 
@@ -99,7 +99,7 @@ following parameters:
 - ``pivot_y`` pivot Y of rotation. Relative to the source canvas. Set to ``source height / 2`` to rotate around the center
 - ``antialias`` true: apply anti-aliasing during the transformation. Looks better but slower.
 
-Note that a canvas can’t be rotated on itself. You need a source and
+Note that a canvas can't be rotated on itself. You need a source and
 destination canvas or image.
 
 Blur

--- a/docs/widgets/chart.rst
+++ b/docs/widgets/chart.rst
@@ -20,7 +20,7 @@ Parts and Styles
    charts ``pad_column`` sets the space between the columns of the
    adjacent indices.
 -  :cpp:enumerator:`LV_PART_SCROLLBAR` The scrollbar used if the chart is zoomed. See
-   the `Base object </widgets/obj>`__\ ’s documentation for details.
+   the `Base object </widgets/obj>`__\ 's documentation for details.
 -  :cpp:enumerator:`LV_PART_ITEMS` Refers to the line or bar series.
 
    -  Line chart: The *line* properties are used by the lines.
@@ -49,7 +49,7 @@ The following data display types exist:
 - :cpp:enumerator:`LV_CHART_TYPE_NONE`:  Do not display any data. Can be used to hide the series.
 - :cpp:enumerator:`LV_CHART_TYPE_LINE`:  Draw lines between the data points and/or points (rectangles or circles) on the data points.
 - :cpp:enumerator:`LV_CHART_TYPE_BAR`: Draw bars.
-- :cpp:enumerator:`LV_CHART_TYPE_SCATTER`: X/Y chart drawing point’s and lines between the points. .
+- :cpp:enumerator:`LV_CHART_TYPE_SCATTER`: X/Y chart drawing point's and lines between the points. .
 
 You can specify the display type with
 :cpp:expr:`lv_chart_set_type(chart, LV_CHART_TYPE_...)`.
@@ -67,13 +67,13 @@ an array for the data points. ``axis`` can have the following values:
 - :cpp:enumerator:`LV_CHART_AXIS_PRIMARY_X` Bottom axis
 - :cpp:enumerator:`LV_CHART_AXIS_SECONDARY_X` Top axis
 
-``axis`` tells which axis’s range should be used te scale the values.
+``axis`` tells which axis's range should be used te scale the values.
 
 :cpp:expr:`lv_chart_set_ext_y_array(chart, ser, value_array)` makes the chart
 use an external array for the given series. ``value_array`` should look
 like this: ``lv_coord_t * value_array[num_points]``. The array size
 needs to be large enough to hold all the points of that series. The
-array’s pointer will be saved in the chart so it needs to be global,
+array's pointer will be saved in the chart so it needs to be global,
 static or dynamically allocated. Note: you should call
 :cpp:expr:`lv_chart_refresh(chart)` after the external data source has been
 updated to update the chart.
@@ -130,7 +130,7 @@ Handling large number of points
 
 On line charts, if the number of points is greater than the pixels
 horizontally, the Chart will draw only vertical lines to make the
-drawing of large amount of data effective. If there are, let’s say, 10
+drawing of large amount of data effective. If there are, let's say, 10
 points to a pixel, LVGL searches the smallest and the largest value and
 draws a vertical lines between them to ensure no peaks are missed.
 
@@ -152,7 +152,7 @@ The number of horizontal and vertical division lines can be modified by
 :cpp:expr:`lv_chart_set_div_line_count(chart, hdiv_num, vdiv_num)`. The default
 settings are 3 horizontal and 5 vertical division lines. If there is a
 visible border on a side and no padding on that side, the division line
-would be drawn on top of the border and therefore it won’t be drawn.
+would be drawn on top of the border and therefore it won't be drawn.
 
 Override default start point for series
 ---------------------------------------
@@ -200,11 +200,11 @@ the cursor. ``pos`` is a pointer to an :cpp:struct:`lv_point_t` variable. E.g.
 will remain in the same place.
 
 :cpp:expr:`lv_chart_get_point_pos_by_id(chart, series, id, &point_out)` gets the
-coordinate of a given point. It’s useful to place the cursor at a given
+coordinate of a given point. It's useful to place the cursor at a given
 point.
 
 :cpp:expr:`lv_chart_set_cursor_point(chart, cursor, series, point_id)` sticks
-the cursor at a point. If the point’s position changes (new value or
+the cursor at a point. If the point's position changes (new value or
 scrolling) the cursor will move with the point.
 
 Events

--- a/docs/widgets/checkbox.rst
+++ b/docs/widgets/checkbox.rst
@@ -4,7 +4,7 @@ Checkbox (lv_checkbox)
 Overview
 ********
 
-The Checkbox object is created from a “tick box” and a label. When the
+The Checkbox object is created from a "tick box" and a label. When the
 Checkbox is clicked the tick box is toggled.
 
 Parts and Styles
@@ -13,9 +13,9 @@ Parts and Styles
 -  :cpp:enumerator:`LV_PART_MAIN` The is the background of the Checkbox and it uses
    the text and all the typical background style properties.
    ``pad_column`` adjusts the spacing between the tickbox and the label
--  :cpp:enumerator:`LV_PART_INDICATOR` The “tick box” is a square that uses all the
+-  :cpp:enumerator:`LV_PART_INDICATOR` The "tick box" is a square that uses all the
    typical background style properties. By default, its size is equal to
-   the height of the main part’s font. Padding properties make the tick
+   the height of the main part's font. Padding properties make the tick
    box larger in the respective directions.
 
 The Checkbox is added to the default group (if it is set).
@@ -31,7 +31,7 @@ The text can be modified with the
 dynamically allocated.
 
 To set a static text, use :cpp:expr:`lv_checkbox_set_static_text(cb, txt)`. This
-way, only a pointer to ``txt`` will be stored. The text then shouldn’t
+way, only a pointer to ``txt`` will be stored. The text then shouldn't
 be deallocated while the checkbox exists.
 
 Check, uncheck, disable
@@ -69,7 +69,7 @@ Learn more about :ref:`events`.
 Keys
 ****
 
-The following *Keys* are processed by the ‘Buttons’: -
+The following *Keys* are processed by the 'Buttons': -
 ``LV_KEY_RIGHT/UP`` Go to toggled state if toggling is enabled -
 ``LV_KEY_LEFT/DOWN`` Go to non-toggled state if toggling is enabled -
 :cpp:enumerator:`LV_KEY_ENTER` Clicks the checkbox and toggles it

--- a/docs/widgets/colorwheel.rst
+++ b/docs/widgets/colorwheel.rst
@@ -27,7 +27,7 @@ Create a color wheel
 --------------------
 
 :cpp:expr:`lv_colorwheel_create(parent, knob_recolor)` creates a new color
-wheel. With ``knob_recolor=true`` the knob’s background color will be
+wheel. With ``knob_recolor=true`` the knob's background color will be
 set to the current color.
 
 Set color
@@ -57,9 +57,9 @@ Learn more about :ref:`events`.
 Keys
 ****
 
--  :cpp:enumerator:`LV_KEY_UP`, :cpp:enumerator:`LV_KEY_RIGHT` Increment the current parameter’s
+-  :cpp:enumerator:`LV_KEY_UP`, :cpp:enumerator:`LV_KEY_RIGHT` Increment the current parameter's
    value by 1
--  :cpp:enumerator:`LV_KEY_DOWN`, :cpp:enumerator:`LV_KEY_LEFT` Decrement the current parameter’s
+-  :cpp:enumerator:`LV_KEY_DOWN`, :cpp:enumerator:`LV_KEY_LEFT` Decrement the current parameter's
    value by 1
 -  :cpp:enumerator:`LV_KEY_ENTER` A long press will show the next mode. Double click
    to reset the current parameter.

--- a/docs/widgets/dropdown.rst
+++ b/docs/widgets/dropdown.rst
@@ -18,7 +18,7 @@ with encoder navigation too.
 Parts and Styles
 ****************
 
-The Dropdown widget is built from the elements: “button” and “list”
+The Dropdown widget is built from the elements: "button" and "list"
 (both not related to the button and list widgets)
 
 Button
@@ -29,7 +29,7 @@ Button
 -  :cpp:enumerator:`LV_PART_INDICATOR` Typically an arrow symbol that can be an image
    or a text (:cpp:enumerator:`LV_SYMBOL`).
 
-The button goes to :cpp:enumerator:`LV_STATE_CHECKED` when it’s opened.
+The button goes to :cpp:enumerator:`LV_STATE_CHECKED` when it's opened.
 
 List
 ----
@@ -74,7 +74,7 @@ inserts a new option to ``pos`` index.
 To save memory the options can set from a static(constant) string too
 with :cpp:expr:`lv_dropdown_set_static_options(dropdown, options)`. In this case
 the options string should be alive while the drop-down list exists and
-:cpp:func:`lv_dropdown_add_option` can’t be used
+:cpp:func:`lv_dropdown_add_option` can't be used
 
 You can select an option manually with
 :cpp:expr:`lv_dropdown_set_selected(dropdown, id)`, where ``id`` is the index of

--- a/docs/widgets/img.rst
+++ b/docs/widgets/img.rst
@@ -38,7 +38,7 @@ To make the variable visible in the C file, you need to declare it with
 
 To use external files, you also need to convert the image files using
 the online converter tool but now you should select the binary output
-format. You also need to use LVGL’s file system module and register a
+format. You also need to use LVGL's file system module and register a
 driver with some functions for the basic file operation. Go to the
 `File system </overview/file-system>`__ to learn more. To set an image sourced
 from a file, use :cpp:expr:`lv_img_set_src(img, "S:folder1/my_img.bin")`.
@@ -46,7 +46,7 @@ from a file, use :cpp:expr:`lv_img_set_src(img, "S:folder1/my_img.bin")`.
 You can also set a symbol similarly to `Labels </widgets/label>`__. In
 this case, the image will be rendered as text according to the *font*
 specified in the style. It enables to use of light-weight monochrome
-“letters” instead of real images. You can set symbol like
+"letters" instead of real images. You can set symbol like
 :cpp:expr:`lv_img_set_src(img1, LV_SYMBOL_OK)`.
 
 Label as an image
@@ -67,7 +67,7 @@ handling methods:
 -  **Chroma-keying** - Pixels with :c:macro:`LV_COLOR_CHROMA_KEY` (*lv_conf.h*)
    color will be transparent.
 -  **Alpha byte** - An alpha byte is added to every pixel that contains
-   the pixel’s opacity
+   the pixel's opacity
 
 Palette and Alpha index
 -----------------------
@@ -98,13 +98,13 @@ Auto-size
 ---------
 
 If the width or height of the image object is set to :c:macro:`LV_SIZE_CONTENT`
-the object’s size will be set according to the size of the image source
+the object's size will be set according to the size of the image source
 in the respective direction.
 
 Mosaic
 ------
 
-If the object’s size is greater than the image size in any directions,
+If the object's size is greater than the image size in any directions,
 then the image will be repeated like a mosaic. This allows creation a
 large image from only a very narrow source. For example, you can have a
 *300 x 5* image with a special gradient and set it as a wallpaper using
@@ -117,7 +117,7 @@ With :cpp:expr:`lv_img_set_offset_x(img, x_ofs)` and
 :cpp:expr:`lv_img_set_offset_y(img, y_ofs)`, you can add some offset to the
 displayed image. Useful if the object size is smaller than the image
 source size. Using the offset parameter a `Texture atlas <https://en.wikipedia.org/wiki/Texture_atlas>`__
-or a “running image” effect can be created by `Animating </overview/animation>`__ the x or y offset.
+or a "running image" effect can be created by `Animating </overview/animation>`__ the x or y offset.
 
 Transformations
 ***************
@@ -149,7 +149,7 @@ In other words transformations work only on true color images stored as
 C array, or if a custom `Image decoder </overview/images#image-edecoder>`__
 returns the whole image.
 
-Note that the real coordinates of image objects won’t change during
+Note that the real coordinates of image objects won't change during
 transformation. That is ``lv_obj_get_width/height/x/y()`` will return
 the original, non-zoomed coordinates.
 
@@ -158,7 +158,7 @@ transformation properties coming from styles. (See
 `here </overview/style#opacity-and-transformations>`__). The main
 differences are that pure image widget transformation
 
-- doesn’t transform the children of the image widget
+- doesn't transform the children of the image widget
 - image is transformed directly without creating an intermediate layer (buffer) to snapshot the widget
 
 Size mode
@@ -166,14 +166,14 @@ Size mode
 
 By default, when the image is zoomed or rotated the real coordinates of
 the image object are not changed. The larger content simply overflows
-the object’s boundaries. It also means the layouts are not affected the
+the object's boundaries. It also means the layouts are not affected the
 by the transformations.
 
 If you need the object size to be updated to the transformed size set
 :cpp:expr:`lv_img_set_size_mode(img, LV_IMG_SIZE_MODE_REAL)`. (The previous mode
 is the default and called :cpp:enumerator:`LV_IMG_SIZE_MODE_VIRTUAL`). In this case if
 the width/height of the object is set to :c:macro:`LV_SIZE_CONTENT` the
-object’s size will be set to the zoomed and rotated size. If an explicit
+object's size will be set to the zoomed and rotated size. If an explicit
 size is set then the overflowing content will be cropped.
 
 Rounded image

--- a/docs/widgets/imgbtn.rst
+++ b/docs/widgets/imgbtn.rst
@@ -4,7 +4,7 @@ Image button (lv_imgbtn)
 Overview
 ********
 
-The Image button is very similar to the simple ‘Button’ object. The only
+The Image button is very similar to the simple 'Button' object. The only
 difference is that it displays user-defined images in each state instead
 of drawing a rectangle.
 
@@ -28,7 +28,7 @@ To set the image in a state, use the
 :cpp:expr:`lv_imgbtn_set_src(imgbtn, LV_IMGBTN_STATE_..., src_left, src_center, src_right)`.
 
 The image sources work the same as described in the `Image object </widgets/img>`__
-except that “Symbols” are not supported by the Image button. Any of the sources can ``NULL``.
+except that "Symbols" are not supported by the Image button. Any of the sources can ``NULL``.
 
 The possible states are:
 

--- a/docs/widgets/keyboard.rst
+++ b/docs/widgets/keyboard.rst
@@ -30,7 +30,7 @@ The Keyboards have the following modes:
 - :cpp:enumerator:`LV_KEYBOARD_MODE_NUMBER` Display numbers, +/- sign, and decimal dot
 - :cpp:enumerator:`LV_KEYBOARD_MODE_USER_1` through :cpp:enumerator:`LV_KEYBOARD_MODE_USER_4` User-defined modes.
 
-The ``TEXT`` modes’ layout contains buttons to change mode.
+The ``TEXT`` modes' layout contains buttons to change mode.
 
 To set the mode manually, use :cpp:expr:`lv_keyboard_set_mode(kb, mode)`. The
 default mode is :cpp:enumerator:`LV_KEYBOARD_MODE_TEXT_UPPER`.
@@ -57,7 +57,7 @@ boundaries. To account for this, reserve extra free space on top of the
 keyboard or ensure that the keyboard is added *after* any widgets
 adjacent to its top boundary so that the popovers can draw over those.
 
-The popovers currently are merely a visual effect and don’t allow
+The popovers currently are merely a visual effect and don't allow
 selecting additional characters such as accents yet.
 
 New Keymap
@@ -77,9 +77,9 @@ with the original map:
 - :c:macro:`LV_SYMBOL_LEFT` Move the cursor left.
 - :c:macro:`LV_SYMBOL_RIGHT` Move the cursor right.
 - :c:macro:`LV_SYMBOL_NEW_LINE` New line.
-- *“ABC”* Load the uppercase map.
-- *“abc”* Load the lower case map.
-- *“1#”* Load the lower case map.
+- *"ABC"* Load the uppercase map.
+- *"abc"* Load the lower case map.
+- *"1#"* Load the lower case map.
 
 Events
 ******

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -13,7 +13,7 @@ Parts and Styles
    text properties. The padding values can be used to add space between
    the text and the background.
 -  :cpp:enumerator:`LV_PART_SCROLLBAR` The scrollbar that is shown when the text is
-   larger than the widget’s size.
+   larger than the widget's size.
 -  :cpp:enumerator:`LV_PART_SELECTED` Tells the style of the `selected
    text <#text-selection>`__. Only ``text_color`` and ``bg_color`` style
    properties can be used.
@@ -27,7 +27,7 @@ Set text
 You can set the text on a label at runtime with
 :cpp:expr:`lv_label_set_text(label, "New text")`. This will allocate a buffer
 dynamically, and the provided string will be copied into that buffer.
-Therefore, you don’t need to keep the text you pass to
+Therefore, you don't need to keep the text you pass to
 :cpp:func:`lv_label_set_text` in scope after that function returns.
 
 With :cpp:expr:`lv_label_set_text_fmt(label, "Value: %d", 15)` printf formatting
@@ -36,7 +36,7 @@ can be used to set the text.
 Labels are able to show text from a static character buffer. To do so,
 use :cpp:expr:`lv_label_set_text_static(label, "Text")`. In this case, the text
 is not stored in the dynamic memory and the given buffer is used
-directly instead. This means that the array can’t be a local variable
+directly instead. This means that the array can't be a local variable
 which goes out of scope when the function exits. Constant strings are
 safe to use with :cpp:func:`lv_label_set_text_static` (except when used with
 :cpp:enumerator:`LV_LABEL_LONG_DOT`, as it modifies the buffer in-place), as they are
@@ -56,16 +56,16 @@ By default, the width and height of the label is set to
 :c:macro:`LV_SIZE_CONTENT`. Therefore, the size of the label is automatically
 expanded to the text size. Otherwise, if the width or height are
 explicitly set (using e.g.\ :cpp:func:`lv_obj_set_width` or a layout), the lines
-wider than the label’s width can be manipulated according to several
+wider than the label's width can be manipulated according to several
 long mode policies. Similarly, the policies can be applied if the height
 of the text is greater than the height of the label.
 
-- :cpp:enumerator:`LV_LABEL_LONG_WRAP` Wrap too long lines. If the height is :c:macro:`LV_SIZE_CONTENT` the label’s
+- :cpp:enumerator:`LV_LABEL_LONG_WRAP` Wrap too long lines. If the height is :c:macro:`LV_SIZE_CONTENT` the label's
   height will be expanded, otherwise the text will be clipped. (Default)
 - :cpp:enumerator:`LV_LABEL_LONG_DOT` Replaces the last 3 characters from bottom right corner of the label with dots (``.``)
-- :cpp:enumerator:`LV_LABEL_LONG_SCROLL` If the text is wider than the label scroll it horizontally back and forth. If it’s
+- :cpp:enumerator:`LV_LABEL_LONG_SCROLL` If the text is wider than the label scroll it horizontally back and forth. If it's
   higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
-- :cpp:enumerator:`LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continuously. If it’s
+- :cpp:enumerator:`LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continuously. If it's
   higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
 - :cpp:enumerator:`LV_LABEL_LONG_CLIP` Simply clip the parts of the text outside the label.
 
@@ -90,7 +90,7 @@ Text selection
 --------------
 
 If enabled by :c:macro:`LV_LABEL_TEXT_SELECTION` part of the text can be
-selected. It’s similar to when you use your mouse on a PC to select a
+selected. It's similar to when you use your mouse on a PC to select a
 text. The whole mechanism (click and select the text as you drag your
 finger/mouse) is implemented in `Text area </widgets/textarea>`__ and
 the Label widget only allows manual text selection with

--- a/docs/widgets/line.rst
+++ b/docs/widgets/line.rst
@@ -24,15 +24,15 @@ the object by the :cpp:expr:`lv_line_set_points(lines, point_array, point_cnt)`
 function.
 
 Their coordinates can either be specified as raw pixel coordinates
-(e.g. ``{5, 10}``), or as a percentage of the line’s bounding box using
-:cpp:expr:`lv_pct(x)`. In the latter case, the line’s width/height may need to
+(e.g. ``{5, 10}``), or as a percentage of the line's bounding box using
+:cpp:expr:`lv_pct(x)`. In the latter case, the line's width/height may need to
 be set explicitly using ``lv_obj_set_width/height``, as percentage
 values do not automatically expand the bounding box.
 
 Auto-size
 ---------
 
-By default, the Line’s width and height are set to :c:macro:`LV_SIZE_CONTENT`.
+By default, the Line's width and height are set to :c:macro:`LV_SIZE_CONTENT`.
 This means it will automatically set its size to fit all the points. If
 the size is set explicitly, parts on the line may not be visible.
 

--- a/docs/widgets/list.rst
+++ b/docs/widgets/list.rst
@@ -15,7 +15,7 @@ Parts and Styles
 - :cpp:enumerator:`LV_PART_MAIN` The main part of the list that uses all the typical background properties
 - :cpp:enumerator:`LV_PART_SCROLLBAR` The scrollbar. See the `Base objects </widgets/obj>`__ documentation for details.
 
-**Buttons and Texts** See the `Button </widgets/btn>`__\ ’s and `Label </widgets/label>`__\ ’s documentation.
+**Buttons and Texts** See the `Button </widgets/btn>`__\ 's and `Label </widgets/label>`__\ 's documentation.
 
 Usage
 *****
@@ -28,7 +28,7 @@ Buttons
 - that can be an image or symbol
 - and a text.
 
-The text starts to scroll horizontally if it’s too long.
+The text starts to scroll horizontally if it's too long.
 
 Texts
 -----

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -56,7 +56,7 @@ Needle line
 
 ``indic = lv_meter_add_needle_line(meter, line_width, line_color, r_mod)``
 adds a needle line to a Scale. By default, the length of the line is the
-same as the scale’s radius but ``r_mod`` changes the length.
+same as the scale's radius but ``r_mod`` changes the length.
 
 :cpp:expr:`lv_meter_set_indicator_value(meter, indic, value)` sets the value of
 the indicator.
@@ -78,7 +78,7 @@ Arc
 
 ``indic = lv_meter_add_arc(meter, arc_width, arc_color, r_mod)`` adds
 and arc indicator. . By default, the radius of the arc is the same as
-the scale’s radius but ``r_mod`` changes the radius.
+the scale's radius but ``r_mod`` changes the radius.
 
 :cpp:expr:`lv_meter_set_indicator_start_value(meter, indic, value)` and
 :cpp:expr:`lv_meter_set_indicator_end_value(meter, inidicator, value)` sets the
@@ -89,11 +89,11 @@ Scale lines (ticks)
 
 ``indic = lv_meter_add_scale_lines(meter, color_start, color_end, local, width_mod)``
 adds an indicator that modifies the ticks lines. If ``local`` is
-``true`` the ticks’ color will be faded from ``color_start`` to
-``color_end`` in the indicator’s start and end value range. If ``local``
+``true`` the ticks' color will be faded from ``color_start`` to
+``color_end`` in the indicator's start and end value range. If ``local``
 is ``false`` ``color_start`` and ``color_end`` will be mapped to the
-start and end value of the scale and only a “slice” of that color
-gradient will be visible in the indicator’s start and end value range.
+start and end value of the scale and only a "slice" of that color
+gradient will be visible in the indicator's start and end value range.
 ``width_mod`` modifies the width of the tick lines.
 
 :cpp:expr:`lv_meter_set_indicator_start_value(meter, inidicator, value)` and

--- a/docs/widgets/msgbox.rst
+++ b/docs/widgets/msgbox.rst
@@ -18,7 +18,7 @@ Parts and Styles
 ****************
 
 The message box is built from other widgets, so you can check these
-widgets’ documentation for details.
+widgets' documentation for details.
 
 - Background: `lv_obj </widgets/obj>`__
 - Close button: `lv_btn </widgets/btn>`__
@@ -36,9 +36,9 @@ creates a message box.
 
 If ``parent`` is ``NULL`` the message box will be modal. ``title`` and
 ``txt`` are strings for the title and the text. ``btn_txts[]`` is an
-array with the buttons’ text. E.g.
+array with the buttons' text. E.g.
 ``const char * btn_txts[] = {"Ok", "Cancel", NULL}``. ``add_close_btn``
-can be ``true`` or ``false`` to add/don’t add a close button.
+can be ``true`` or ``false`` to add/don't add a close button.
 
 Get the parts
 -------------

--- a/docs/widgets/obj.rst
+++ b/docs/widgets/obj.rst
@@ -4,7 +4,7 @@ Base object (lv_obj)
 Overview
 ********
 
-The ‘Base Object’ implements the basic properties of widgets on a
+The 'Base Object' implements the basic properties of widgets on a
 screen, such as:
 
 - coordinates
@@ -19,7 +19,7 @@ objects in LVGL are inherited.
 The functions and functionalities of the Base object can be used with
 other widgets too. For example :cpp:expr:`lv_obj_set_width(slider, 100)`
 
-The Base object can be directly used as a simple widget: it’s nothing
+The Base object can be directly used as a simple widget: it's nothing
 more than a rectangle. In HTML terms, think of it as a ``<div>``.
 
 Coordinates
@@ -118,11 +118,11 @@ When you have created a screen like
 :cpp:expr:`lv_scr_load(screen)`. The :cpp:func:`lv_scr_act` function gives you a
 pointer to the active screen.
 
-If you have multiple displays, it’s important to know that the screen
+If you have multiple displays, it's important to know that the screen
 functions operate on the most recently created display or the one
 explicitly selected with :cpp:func:`lv_disp_set_default`.
 
-To get an object’s screen use the :cpp:expr:`lv_obj_get_screen(obj)` function.
+To get an object's screen use the :cpp:expr:`lv_obj_get_screen(obj)` function.
 
 Events
 ------
@@ -156,13 +156,13 @@ Flags
 There are some attributes which can be enabled/disabled by
 ``lv_obj_add/clear_flag(obj, LV_OBJ_FLAG_...)``:
 
--  :cpp:enumerator:`LV_OBJ_FLAG_HIDDEN` Make the object hidden. (Like it wasn’t there at all)
+-  :cpp:enumerator:`LV_OBJ_FLAG_HIDDEN` Make the object hidden. (Like it wasn't there at all)
 -  :cpp:enumerator:`LV_OBJ_FLAG_CLICKABLE` Make the object clickable by input devices
 -  :cpp:enumerator:`LV_OBJ_FLAG_CLICK_FOCUSABLE` Add focused state to the object when clicked
 -  :cpp:enumerator:`LV_OBJ_FLAG_CHECKABLE` Toggle checked state when the object is clicked
 -  :cpp:enumerator:`LV_OBJ_FLAG_SCROLLABLE` Make the object scrollable
 -  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_ELASTIC` Allow scrolling inside but with slower speed
--  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_MOMENTUM` Make the object scroll further when “thrown”
+-  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_MOMENTUM` Make the object scroll further when "thrown"
 -  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_ONE` Allow scrolling only one snappable children
 -  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_CHAIN_HOR` Allow propagating the horizontal scroll to a parent
 -  :cpp:enumerator:`LV_OBJ_FLAG_SCROLL_CHAIN_VER` Allow propagating the vertical scroll to a parent
@@ -176,7 +176,7 @@ There are some attributes which can be enabled/disabled by
 -  :cpp:enumerator:`LV_OBJ_FLAG_ADV_HITTEST` Allow performing more accurate hit (click) test. E.g. accounting for rounded corners
 -  :cpp:enumerator:`LV_OBJ_FLAG_IGNORE_LAYOUT` Make the object positionable by the layouts
 -  :cpp:enumerator:`LV_OBJ_FLAG_FLOATING` Do not scroll the object when the parent scrolls and ignore layout
--  :cpp:enumerator:`LV_OBJ_FLAG_OVERFLOW_VISIBLE` Do not clip the children’s content to the parent’s boundary
+-  :cpp:enumerator:`LV_OBJ_FLAG_OVERFLOW_VISIBLE` Do not clip the children's content to the parent's boundary
 -  :cpp:enumerator:`LV_OBJ_FLAG_LAYOUT_1` Custom flag, free to use by layouts
 -  :cpp:enumerator:`LV_OBJ_FLAG_LAYOUT_2` Custom flag, free to use by layouts
 -  :cpp:enumerator:`LV_OBJ_FLAG_WIDGET_1` Custom flag, free to use by widget

--- a/docs/widgets/roller.rst
+++ b/docs/widgets/roller.rst
@@ -12,7 +12,7 @@ Parts and Styles
 -  :cpp:enumerator:`LV_PART_MAIN` The background of the roller uses all the typical
    background properties and text style properties.
    ``style_text_line_space`` adjusts the space between the options. When
-   the Roller is scrolled and doesn’t stop exactly on an option it will
+   the Roller is scrolled and doesn't stop exactly on an option it will
    scroll to the nearest valid option automatically in ``anim_time``
    milliseconds as specified in the style.
 -  :cpp:enumerator:`LV_PART_SELECTED` The selected option in the middle. Besides the

--- a/docs/widgets/slider.rst
+++ b/docs/widgets/slider.rst
@@ -32,7 +32,7 @@ Value and range
 ---------------
 
 To set an initial value use :cpp:expr:`lv_slider_set_value(slider, new_value, LV_ANIM_ON/OFF)`. The
-animation time is set by the styles’ ``anim_time`` property.
+animation time is set by the styles' ``anim_time`` property.
 
 To specify the range (min, max values), :cpp:expr:`lv_slider_set_range(slider, min , max)` can be used.
 
@@ -60,7 +60,7 @@ desirable to set the slider to react on dragging the knob only. This
 feature is enabled by adding the :cpp:enumerator:`LV_OBJ_FLAG_ADV_HITTEST`:
 :cpp:expr:`lv_obj_add_flag(slider, LV_OBJ_FLAG_ADV_HITTEST)`.
 
-The extended click area (set by :cpp:expr:`lv_obj_set_ext_click_area(slider, value)`) increases to knob’s click area.
+The extended click area (set by :cpp:expr:`lv_obj_set_ext_click_area(slider, value)`) increases to knob's click area.
 
 Events
 ******
@@ -93,8 +93,8 @@ Learn more about :ref:`events`.
 Keys
 ****
 
--  ``LV_KEY_UP/RIGHT`` Increment the slider’s value by 1
--  ``LV_KEY_DOWN/LEFT`` Decrement the slider’s value by 1
+-  ``LV_KEY_UP/RIGHT`` Increment the slider's value by 1
+-  ``LV_KEY_DOWN/LEFT`` Decrement the slider's value by 1
 
 Learn more about :ref:`indev_keys`.
 

--- a/docs/widgets/span.rst
+++ b/docs/widgets/span.rst
@@ -33,7 +33,7 @@ Retrieving a span child
 -----------------------
 
 Spangroups store their children differently from normal objects, so
-normal functions for getting children won’t work.
+normal functions for getting children won't work.
 
 :cpp:expr:`lv_spangroup_get_child(spangroup, id)` will return a pointer to the
 child span at index ``id``. In addition, ``id`` can be negative to index

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -30,7 +30,7 @@ value is changed by :cpp:func:`lv_spinbox_set_value`, by
 increment/decrement. Only multiples of ten can be set, and not for example 3.
 
 :cpp:expr:`lv_spinbox_set_cursor_pos(spinbox, 1)` sets the cursor to a specific
-digit to change on increment/decrement. For example position ‘0’ sets the cursor to the least significant digit.
+digit to change on increment/decrement. For example position '0' sets the cursor to the least significant digit.
 
 If an encoder is used as input device, the selected digit is shifted to
 the right by default whenever the encoder button is clicked. To change this behaviour to shifting

--- a/docs/widgets/table.rst
+++ b/docs/widgets/table.rst
@@ -66,12 +66,12 @@ To merge more adjacent cells call this function for each cell.
 Scroll
 ------
 
-If the label’s width or height is set to :c:macro:`LV_SIZE_CONTENT` that size
+If the label's width or height is set to :c:macro:`LV_SIZE_CONTENT` that size
 will be used to show the whole table in the respective direction. E.g.
 :cpp:expr:`lv_obj_set_size(table, LV_SIZE_CONTENT, LV_SIZE_CONTENT)`
 automatically sets the table size to show all the columns and rows.
 
-If the width or height is set to a smaller number than the “intrinsic”
+If the width or height is set to a smaller number than the "intrinsic"
 size then the table becomes scrollable.
 
 Events

--- a/docs/widgets/tabview.rst
+++ b/docs/widgets/tabview.rst
@@ -41,7 +41,7 @@ Add tabs
 
 New tabs can be added with :cpp:expr:`lv_tabview_add_tab(tabview, "Tab name")`.
 This will return a pointer to an `lv_obj </widgets/obj>`__ object where
-the tab’s content can be created.
+the tab's content can be created.
 
 Rename tabs
 -----------

--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -25,11 +25,11 @@ Parts and Styles
    ``bg_color`` style properties can be used. ``bg_color`` should be set
    directly on the label of the text area.
 -  :cpp:enumerator:`LV_PART_CURSOR` Marks the position where the characters are
-   inserted. The cursor’s area is always the bounding box of the current
+   inserted. The cursor's area is always the bounding box of the current
    character. A block cursor can be created by adding a background color
-   and background opacity to :cpp:enumerator:`LV_PART_CURSOR`\ ’s style. The create
+   and background opacity to :cpp:enumerator:`LV_PART_CURSOR`\ 's style. The create
    line cursor leave the cursor transparent and set a left border. The
-   ``anim_time`` style property sets the cursor’s blink time.
+   ``anim_time`` style property sets the cursor's blink time.
 -  :cpp:enumerator:`LV_PART_TEXTAREA_PLACEHOLDER` Unique to Text Area, allows styling
    the placeholder text.
 
@@ -39,7 +39,7 @@ Usage
 Add text
 --------
 
-You can insert text or characters to the current cursor’s position with:
+You can insert text or characters to the current cursor's position with:
 
 -  :cpp:expr:`lv_textarea_add_char(textarea, 'c')`
 -  :cpp:expr:`lv_textarea_add_text(textarea, "insert this text")`
@@ -69,8 +69,8 @@ Move the cursor
 
 The cursor position can be modified directly like
 :cpp:expr:`lv_textarea_set_cursor_pos(textarea, 10)`. The ``0`` position means
-“before the first characters”, :cpp:enumerator:`LV_TA_CURSOR_LAST` means “after the
-last character”
+"before the first characters", :cpp:enumerator:`LV_TA_CURSOR_LAST` means "after the
+last character"
 
 You can step the cursor with
 
@@ -135,7 +135,7 @@ scrolling and drawing might be slow. However, by enabling
 :c:macro:`LV_LABEL_LONG_TXT_HINT` in ``lv_conf.h`` the performance can be
 hugely improved. This will save some additional information about the
 label to speed up its drawing. Using :c:macro:`LV_LABEL_LONG_TXT_HINT` the
-scrolling and drawing will as fast as with “normal” short texts.
+scrolling and drawing will as fast as with "normal" short texts.
 
 Select text
 -----------

--- a/docs/widgets/win.rst
+++ b/docs/widgets/win.rst
@@ -34,7 +34,7 @@ Title and buttons
 Any number of texts (but typically only one) can be added to the header
 with :cpp:expr:`lv_win_add_title(win, "The title")`.
 
-Control buttons can be added to the window’s header with
+Control buttons can be added to the window's header with
 :cpp:expr:`lv_win_add_btn(win, icon, btn_width)`. ``icon`` can be any image
 source, and ``btn_width`` is the width of the button.
 


### PR DESCRIPTION
### Description of the feature or fix

removes non ascii characters from the documentation. Not all non ascii characters just things like the non ascii double quotes and single quotes and also the "NBSP" or non ascii space
