### PR TITLE
fix(dropdown): lv_dropdown_get_option_index shouldn't match strings of different lengths

### DIFF
--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -404,11 +404,13 @@ int32_t lv_dropdown_get_option_index(lv_obj_t * obj, const char * option)
     uint32_t char_i = 0;
     uint32_t opt_i = 0;
     const char * start = opts;
+    const size_t option_len = lv_strlen(option); /*avoid recomputing this multiple times in the loop*/
 
     while(start[0] != '\0') {
         for(char_i = 0; (start[char_i] != '\n') && (start[char_i] != '\0'); char_i++);
 
-        if(memcmp(start, option, LV_MIN(lv_strlen(option), char_i)) == 0) return opt_i;
+        if(option_len == char_i &&
+           memcmp(start, option, option_len) == 0) return opt_i; /*cannot match exactly unless they are the same length*/
         start = &start[char_i];
         if(start[0] == '\n') start++;
         opt_i++;

--- a/tests/src/test_cases/test_dropdown.c
+++ b/tests/src/test_cases/test_dropdown.c
@@ -441,5 +441,17 @@ void test_dropdown_should_list_on_top(void)
     TEST_ASSERT_EQUAL_INT(2, lv_obj_get_index(list));
 }
 
+/* See #4191 */
+void test_dropdown_get_options_should_check_lengths(void)
+{
+    lv_obj_t * dd = lv_dropdown_create(lv_scr_act());
+    lv_dropdown_set_options(dd, "abc\nab");
+    TEST_ASSERT_EQUAL_INT(1, lv_dropdown_get_option_index(dd, "ab"));
+
+    lv_dropdown_set_options(dd, "Option 1\nOption 2\nOption 3\nOption");
+    TEST_ASSERT_EQUAL_INT(3, lv_dropdown_get_option_index(dd, "Option"));
+    TEST_ASSERT_EQUAL_INT(-1, lv_dropdown_get_option_index(dd, "Option "));
+}
+
 
 #endif


### PR DESCRIPTION
### Description of the feature or fix

The `lv_dropdown_get_option_index` function returns the index of the first item that matches the given string.
Previously, it matched based on the first n chars, where n is the shorter of the lengths of the strings being compard.
As a result, "abc" would match "ab" because the first 2 chars do match. However this is not expected behaviour.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
