### PR TITLE
chore: replacement of std string functions with builtin

### DIFF
--- a/src/dev/disp/fb/lv_linux_fbdev.c
+++ b/src/dev/disp/fb/lv_linux_fbdev.c
@@ -103,10 +103,10 @@ lv_disp_t * lv_linux_fbdev_create(void)
 
 void lv_linux_fbdev_set_file(lv_disp_t * disp, const char * file)
 {
-    char * devname = lv_malloc(strlen(file) + 1);
+    char * devname = lv_malloc(lv_strlen(file) + 1);
     LV_ASSERT_MALLOC(devname);
     if(devname == NULL) return;
-    strcpy(devname, file);
+    lv_strcpy(devname, file);
 
     lv_linux_fb_t * dsc = lv_disp_get_driver_data(disp);
     dsc->devname = devname;

--- a/src/dev/sdl/lv_sdl_keyboard.c
+++ b/src/dev/sdl/lv_sdl_keyboard.c
@@ -68,7 +68,7 @@ static void sdl_keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
     lv_sdl_keyboard_t * dev = lv_indev_get_driver_data(indev);
 
-    const size_t len = strlen(dev->buf);
+    const size_t len = lv_strlen(dev->buf);
 
     /*Send a release manually*/
     if(dev->dummy_read) {
@@ -121,7 +121,7 @@ void _lv_sdl_keyboard_handler(SDL_Event * event)
                 const uint32_t ctrl_key = keycode_to_ctrl_key(event->key.keysym.sym);
                 if(ctrl_key == '\0')
                     return;
-                const size_t len = strlen(dsc->buf);
+                const size_t len = lv_strlen(dsc->buf);
                 if(len < KEYBOARD_BUFFER_SIZE - 1) {
                     dsc->buf[len] = ctrl_key;
                     dsc->buf[len + 1] = '\0';
@@ -129,7 +129,7 @@ void _lv_sdl_keyboard_handler(SDL_Event * event)
                 break;
             }
         case SDL_TEXTINPUT: {                   /*Text input*/
-                const size_t len = strlen(dsc->buf) + strlen(event->text.text);
+                const size_t len = lv_strlen(dsc->buf) + lv_strlen(event->text.text);
                 if(len < KEYBOARD_BUFFER_SIZE - 1)
                     strcat(dsc->buf, event->text.text);
             }

--- a/src/draw/lv_img_decoder.c
+++ b/src/draw/lv_img_decoder.c
@@ -111,14 +111,14 @@ lv_res_t lv_img_decoder_open(lv_img_decoder_dsc_t * dsc, const void * src, lv_co
     dsc->frame_id = frame_id;
 
     if(dsc->src_type == LV_IMG_SRC_FILE) {
-        size_t fnlen = strlen(src);
+        size_t fnlen = lv_strlen(src);
         dsc->src = lv_malloc(fnlen + 1);
         LV_ASSERT_MALLOC(dsc->src);
         if(dsc->src == NULL) {
             LV_LOG_WARN("out of memory");
             return LV_RES_INV;
         }
-        strcpy((char *)dsc->src, src);
+        lv_strcpy((char *)dsc->src, src);
     }
     else {
         dsc->src = src;

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -666,7 +666,7 @@ static int ffmpeg_update_next_frame(struct ffmpeg_context_s * ffmpeg_ctx)
 
 struct ffmpeg_context_s * ffmpeg_open_file(const char * path)
 {
-    if(path == NULL || strlen(path) == 0) {
+    if(path == NULL || lv_strlen(path) == 0) {
         LV_LOG_ERROR("file path is empty");
         return NULL;
     }

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -174,7 +174,7 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16
         lv_free(dsc);
         return NULL;
     }
-    strcpy(dsc->pathname, pathname);
+    lv_strcpy(dsc->pathname, pathname);
 
     dsc->size = size;
     dsc->style = style;

--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -257,9 +257,9 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 
         if(fno.fattrib & AM_DIR) {
             fn[0] = '/';
-            strcpy(&fn[1], fno.fname);
+            lv_strcpy(&fn[1], fno.fname);
         }
-        else strcpy(fn, fno.fname);
+        else lv_strcpy(fn, fno.fname);
 
     } while(strcmp(fn, "/.") == 0 || strcmp(fn, "/..") == 0);
 

--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -239,7 +239,7 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
     char buf[256];
     lv_snprintf(buf, sizeof(buf), LV_FS_POSIX_PATH "%s\\*", path);
 
-    strcpy(next_fn, "");
+    lv_strcpy(next_fn, "");
     d = FindFirstFile(buf, &fdata);
     do {
         if(strcmp(fdata.cFileName, ".") == 0 || strcmp(fdata.cFileName, "..") == 0) {
@@ -278,16 +278,16 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
         entry = readdir(dir_p);
         if(entry) {
             if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
-            else strcpy(fn, entry->d_name);
+            else lv_strcpy(fn, entry->d_name);
         }
         else {
-            strcpy(fn, "");
+            lv_strcpy(fn, "");
         }
     } while(strcmp(fn, "/.") == 0 || strcmp(fn, "/..") == 0);
 #else
-    strcpy(fn, next_fn);
+    lv_strcpy(fn, next_fn);
 
-    strcpy(next_fn, "");
+    lv_strcpy(next_fn, "");
     WIN32_FIND_DATA fdata;
 
     if(FindNextFile(dir_p, &fdata) == false) return LV_FS_RES_OK;

--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -240,7 +240,7 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
     char buf[MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_STDIO_PATH "%s\\*", path);
 
-    strcpy(handle->next_fn, "");
+    lv_strcpy(handle->next_fn, "");
     handle->dir_p = FindFirstFileA(buf, &fdata);
     do {
         if(strcmp(fdata.cFileName, ".") == 0 || strcmp(fdata.cFileName, "..") == 0) {
@@ -283,16 +283,16 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
         entry = readdir(handle->dir_p);
         if(entry) {
             if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
-            else strcpy(fn, entry->d_name);
+            else lv_strcpy(fn, entry->d_name);
         }
         else {
-            strcpy(fn, "");
+            lv_strcpy(fn, "");
         }
     } while(strcmp(fn, "/.") == 0 || strcmp(fn, "/..") == 0);
 #else
-    strcpy(fn, handle->next_fn);
+    lv_strcpy(fn, handle->next_fn);
 
-    strcpy(handle->next_fn, "");
+    lv_strcpy(handle->next_fn, "");
     WIN32_FIND_DATAA fdata;
 
     if(FindNextFileA(handle->dir_p, &fdata) == false) return LV_FS_RES_OK;

--- a/src/libs/fsdrv/lv_fs_win32.c
+++ b/src/libs/fsdrv/lv_fs_win32.c
@@ -373,7 +373,7 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
     lv_snprintf(buf, sizeof(buf), "%s\\*", path);
 #endif
 
-    strcpy(handle->next_fn, "");
+    lv_strcpy(handle->next_fn, "");
     handle->dir_p = FindFirstFileA(buf, &fdata);
     do {
         if(is_dots_name(fdata.cFileName)) {
@@ -413,9 +413,9 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
 {
     LV_UNUSED(drv);
     dir_handle_t * handle = (dir_handle_t *)dir_p;
-    strcpy(fn, handle->next_fn);
+    lv_strcpy(fn, handle->next_fn);
     lv_fs_res_t current_error = handle->next_error;
-    strcpy(handle->next_fn, "");
+    lv_strcpy(handle->next_fn, "");
 
     WIN32_FIND_DATAA fdata;
 

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -445,7 +445,7 @@ char * lv_fs_get_letters(char * buf)
 const char * lv_fs_get_ext(const char * fn)
 {
     size_t i;
-    for(i = strlen(fn); i > 0; i--) {
+    for(i = lv_strlen(fn); i > 0; i--) {
         if(fn[i] == '.') {
             return &fn[i + 1];
         }
@@ -459,7 +459,7 @@ const char * lv_fs_get_ext(const char * fn)
 
 char * lv_fs_up(char * path)
 {
-    size_t len = strlen(path);
+    size_t len = lv_strlen(path);
     if(len == 0) return path;
 
     len--; /*Go before the trailing '\0'*/
@@ -485,7 +485,7 @@ char * lv_fs_up(char * path)
 
 const char * lv_fs_get_last(const char * path)
 {
-    size_t len = strlen(path);
+    size_t len = lv_strlen(path);
     if(len == 0) return path;
 
     len--; /*Go before the trailing '\0'*/

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include "lv_printf.h"
+#include "lv_mem.h"
 #include "../hal/lv_hal_tick.h"
 
 #if LV_LOG_PRINTF
@@ -85,7 +86,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 
         /*Use only the file name not the path*/
         size_t p;
-        for(p = strlen(file); p > 0; p--) {
+        for(p = lv_strlen(file); p > 0; p--) {
             if(file[p] == '/' || file[p] == '\\') {
                 p++;    /*Skip the slash*/
                 break;

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -63,15 +63,29 @@ void lv_free(void * data);
 /**
  * Reallocate a memory with a new size. The old content will be kept.
  * @param data_p pointer to an allocated memory.
- * Its content will be copied to the new memory block and freed
+ *               Its content will be copied to the new memory block and freed
  * @param new_size the desired new size in byte
  * @return pointer to the new memory, NULL on failure
  */
 void * lv_realloc(void * data_p, size_t new_size);
 
-
+/**
+ * @brief Copies a block of memory from a source address to a destination address.
+ * @param dst Pointer to the destination array where the content is to be copied.
+ * @param src Pointer to the source of data to be copied.
+ * @param len Number of bytes to copy.
+ * @return Pointer to the destination array.
+ * @note The function does not check for any overlapping of the source and destination memory blocks.
+ */
 void * lv_memcpy(void * dst, const void * src, size_t len);
 
+/**
+ * @brief Fills a block of memory with a specified value.
+ * @param dst Pointer to the destination array to fill with the specified value.
+ * @param v Value to be set. The value is passed as an int, but the function fills
+ *          the block of memory using the unsigned char conversion of this value.
+ * @param len Number of bytes to be set to the value.
+ */
 void lv_memset(void * dst, uint8_t v, size_t len);
 
 /**
@@ -84,15 +98,34 @@ static inline void lv_memzero(void * dst, size_t len)
     lv_memset(dst, 0x00, len);
 }
 
+/**
+ * @brief Computes the length of the string str up to, but not including the terminating null character.
+ * @param str Pointer to the null-terminated byte string to be examined.
+ * @return The length of the string in bytes.
+ */
 size_t lv_strlen(const char * str);
 
+/**
+ * @brief Copies up to dest_size characters from the string pointed to by src to the character array pointed to by dst.
+ * @param dst Pointer to the destination array where the content is to be copied.
+ * @param src Pointer to the source of data to be copied.
+ * @param dest_size Maximum number of characters to be copied to dst, including the null character.
+ * @return A pointer to the destination array, which is dst.
+ */
 char * lv_strncpy(char * dst, const char * src, size_t dest_size);
 
+/**
+ * @brief Copies the string pointed to by src, including the terminating null character,
+ *        to the character array pointed to by dst.
+ * @param dst Pointer to the destination array where the content is to be copied.
+ * @param src Pointer to the source of data to be copied.
+ * @return A pointer to the destination array, which is dst.
+ */
 char * lv_strcpy(char * dst, const char * src);
 
 /**
- *
- * @return
+ * @brief Tests the memory allocation system by allocating and freeing a block of memory.
+ * @return LV_RES_OK if the memory allocation system is working properly, or LV_RES_INV if there is an error.
  */
 lv_res_t lv_mem_test(void);
 

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -420,8 +420,8 @@ void _lv_txt_ins(char * txt_buf, uint32_t pos, const char * ins_txt)
 {
     if(txt_buf == NULL || ins_txt == NULL) return;
 
-    size_t old_len = strlen(txt_buf);
-    size_t ins_len = strlen(ins_txt);
+    size_t old_len = lv_strlen(txt_buf);
+    size_t ins_len = lv_strlen(ins_txt);
     if(ins_len == 0) return;
 
     size_t new_len = ins_len + old_len;
@@ -441,7 +441,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len)
 {
     if(txt == NULL) return;
 
-    size_t old_len = strlen(txt);
+    size_t old_len = lv_strlen(txt);
 
     pos = _lv_txt_encoded_get_byte_id(txt, pos); /*Convert to byte index instead of letter index*/
     len = _lv_txt_encoded_get_byte_id(&txt[pos], len);
@@ -861,7 +861,7 @@ static uint32_t lv_txt_iso8859_1_get_char_id(const char * txt, uint32_t byte_id)
  */
 static uint32_t lv_txt_iso8859_1_get_length(const char * txt)
 {
-    return strlen(txt);
+    return lv_strlen(txt);
 }
 #else
 

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -81,7 +81,7 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
 
     /*If path is unavailable */
-    if((path == NULL) || (strlen(path) <= 0)) return;
+    if((path == NULL) || (lv_strlen(path) <= 0)) return;
 
     char ** dir_str = NULL;
     switch(dir) {
@@ -116,14 +116,14 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
     }
 
     /*Get the size of the text*/
-    size_t len = strlen(path) + 1;
+    size_t len = lv_strlen(path) + 1;
 
     /*Allocate space for the new text*/
     *dir_str = lv_malloc(len);
     LV_ASSERT_MALLOC(*dir_str);
     if(*dir_str == NULL) return;
 
-    strcpy(*dir_str, path);
+    lv_strcpy(*dir_str, path);
 }
 
 #endif
@@ -498,7 +498,7 @@ static void browser_file_event_handler(lv_event_t * e)
         str_fn = str_fn + 5;
         if((strcmp(str_fn, ".") == 0))  return;
 
-        if((strcmp(str_fn, "..") == 0) && (strlen(explorer->current_path) > 3)) {
+        if((strcmp(str_fn, "..") == 0) && (lv_strlen(explorer->current_path) > 3)) {
             strip_ext(explorer->current_path);
             /*Remove the last '/' character*/
             strip_ext(explorer->current_path);
@@ -559,7 +559,7 @@ static void show_dir(lv_obj_t * obj, const char * path)
         }
 
         /*fn is empty, if not more files to read*/
-        if(strlen(fn) == 0) {
+        if(lv_strlen(fn) == 0) {
             LV_LOG_USER("Not more files to read!");
             break;
         }
@@ -605,10 +605,10 @@ static void show_dir(lv_obj_t * obj, const char * path)
     lv_obj_scroll_to_y(explorer->file_table, 0, LV_ANIM_OFF);
 
     lv_memzero(explorer->current_path, sizeof(explorer->current_path));
-    strcpy(explorer->current_path, path);
+    lv_strncpy(explorer->current_path, path, sizeof(explorer->current_path) - 1);
     lv_label_set_text_fmt(explorer->path_label, LV_SYMBOL_EYE_OPEN" %s", path);
 
-    size_t current_path_len = strlen(explorer->current_path);
+    size_t current_path_len = lv_strlen(explorer->current_path);
     if((*((explorer->current_path) + current_path_len) != '/') && (current_path_len < LV_FILE_EXPLORER_PATH_MAX_LEN)) {
         *((explorer->current_path) + current_path_len) = '/';
     }
@@ -618,7 +618,7 @@ static void show_dir(lv_obj_t * obj, const char * path)
 /*Remove the specified suffix*/
 static void strip_ext(char * dir)
 {
-    char * end = dir + strlen(dir);
+    char * end = dir + lv_strlen(dir);
 
     while(end >= dir && *end != '/') {
         --end;
@@ -698,8 +698,8 @@ static bool is_end_with(const char * str1, const char * str2)
     if(str1 == NULL || str2 == NULL)
         return false;
 
-    uint16_t len1 = strlen(str1);
-    uint16_t len2 = strlen(str2);
+    uint16_t len1 = lv_strlen(str1);
+    uint16_t len2 = lv_strlen(str2);
     if((len1 < len2) || (len1 == 0 || len2 == 0))
         return false;
 

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -653,7 +653,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
 #if LV_IME_PINYIN_USE_K9_MODE
         if(pinyin_ime->mode == LV_IME_PINYIN_MODE_K9) {
 
-            uint16_t tmp_btn_str_len = strlen(pinyin_ime->input_char);
+            uint16_t tmp_btn_str_len = lv_strlen(pinyin_ime->input_char);
             if((btn_id >= 16) && (tmp_btn_str_len > 0) && (btn_id < (16 + LV_IME_PINYIN_K9_CAND_TEXT_NUM))) {
                 lv_memzero(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
                 strcat(pinyin_ime->input_char, txt);
@@ -696,7 +696,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
                 }
 #if LV_IME_PINYIN_USE_K9_MODE
                 else if(pinyin_ime->mode == LV_IME_PINYIN_MODE_K9) {
-                    pinyin_ime->k9_input_str_len = strlen(pinyin_ime->input_char) - 1;
+                    pinyin_ime->k9_input_str_len = lv_strlen(pinyin_ime->input_char) - 1;
                     pinyin_k9_get_legal_py(obj, pinyin_ime->k9_input_str, k9_py_map);
                     pinyin_k9_fill_cand(obj);
                     pinyin_input_proc(obj);
@@ -711,7 +711,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
             return;
         }
         else if(strcmp(txt, "123") == 0) {
-            for(uint16_t i = 0; i < strlen(txt); i++)
+            for(uint16_t i = 0; i < lv_strlen(txt); i++)
                 lv_textarea_del_char(ta);
 
             pinyin_ime_clear_data(obj);
@@ -743,8 +743,8 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
         else if((pinyin_ime->mode == LV_IME_PINYIN_MODE_K9) && (txt[0] >= 'a' && txt[0] <= 'z')) {
             for(uint16_t i = 0; i < 8; i++) {
                 if((strcmp(txt, k9_py_map[i]) == 0) || (strcmp(txt, "abc ") == 0)) {
-                    if(strcmp(txt, "abc ") == 0)    pinyin_ime->k9_input_str_len += strlen(k9_py_map[i]) + 1;
-                    else                            pinyin_ime->k9_input_str_len += strlen(k9_py_map[i]);
+                    if(strcmp(txt, "abc ") == 0)    pinyin_ime->k9_input_str_len += lv_strlen(k9_py_map[i]) + 1;
+                    else                            pinyin_ime->k9_input_str_len += lv_strlen(k9_py_map[i]);
                     pinyin_ime->k9_input_str[pinyin_ime->ta_count] = 50 + i;
 
                     break;
@@ -926,7 +926,7 @@ static char * pinyin_search_matching(lv_obj_t * obj, char * py_str, uint16_t * c
     if(*py_str == 'v')     return NULL;
 
     offset = py_str[0] - 'a';
-    len = strlen(py_str);
+    len = lv_strlen(py_str);
 
     cpHZ  = &pinyin_ime->dict[pinyin_ime->py_pos[offset]];
     count = pinyin_ime->py_num[offset];
@@ -941,7 +941,7 @@ static char * pinyin_search_matching(lv_obj_t * obj, char * py_str, uint16_t * c
         // perfect match
         if(len == 1 || index == len) {
             // The Chinese character in UTF-8 encoding format is 3 bytes
-            * cand_num = strlen((const char *)(cpHZ->py_mb)) / 3;
+            * cand_num = lv_strlen((const char *)(cpHZ->py_mb)) / 3;
             return (char *)(cpHZ->py_mb);
         }
         cpHZ++;
@@ -960,8 +960,8 @@ static void pinyin_ime_clear_data(lv_obj_t * obj)
         pinyin_ime->k9_legal_py_count = 0;
         lv_memzero(pinyin_ime->k9_input_str,  LV_IME_PINYIN_K9_MAX_INPUT);
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
     }
 #endif
 
@@ -982,13 +982,13 @@ static void pinyin_k9_init_data(lv_obj_t * obj)
     uint16_t btnm_i = 0;
     for(btnm_i = 19; btnm_i < (LV_IME_PINYIN_K9_CAND_TEXT_NUM + 21); btnm_i++) {
         if(py_str_i == LV_IME_PINYIN_K9_CAND_TEXT_NUM) {
-            strcpy(lv_pinyin_k9_cand_str[py_str_i], LV_SYMBOL_RIGHT"\0");
+            lv_strcpy(lv_pinyin_k9_cand_str[py_str_i], LV_SYMBOL_RIGHT"\0");
         }
         else if(py_str_i == LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1) {
-            strcpy(lv_pinyin_k9_cand_str[py_str_i], "\0");
+            lv_strcpy(lv_pinyin_k9_cand_str[py_str_i], "\0");
         }
         else {
-            strcpy(lv_pinyin_k9_cand_str[py_str_i], " \0");
+            lv_strcpy(lv_pinyin_k9_cand_str[py_str_i], " \0");
         }
 
         lv_btnm_def_pinyin_k9_map[btnm_i] = lv_pinyin_k9_cand_str[py_str_i];
@@ -1009,7 +1009,7 @@ static void pinyin_k9_get_legal_py(lv_obj_t * obj, char * k9_input, const char *
 {
     lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
 
-    uint16_t len = strlen(k9_input);
+    uint16_t len = lv_strlen(k9_input);
 
     if((len == 0) || (len >= LV_IME_PINYIN_K9_MAX_INPUT)) {
         return;
@@ -1032,10 +1032,10 @@ static void pinyin_k9_get_legal_py(lv_obj_t * obj, char * k9_input, const char *
             if(pinyin_k9_is_valid_py(obj, py_comp)) {
                 if((count >= ll_len) || (ll_len == 0)) {
                     ll_index = _lv_ll_ins_tail(&pinyin_ime->k9_legal_py_ll);
-                    strcpy(ll_index->py_str, py_comp);
+                    lv_strcpy(ll_index->py_str, py_comp);
                 }
                 else if((count < ll_len)) {
-                    strcpy(ll_index->py_str, py_comp);
+                    lv_strcpy(ll_index->py_str, py_comp);
                     ll_index = _lv_ll_get_next(&pinyin_ime->k9_legal_py_ll, ll_index);
                 }
                 count++;
@@ -1044,7 +1044,7 @@ static void pinyin_k9_get_legal_py(lv_obj_t * obj, char * k9_input, const char *
         }
         else {
             flag = mark[index];
-            if((size_t)flag < strlen(py9_map[k9_input[index] - '2'])) {
+            if((size_t)flag < lv_strlen(py9_map[k9_input[index] - '2'])) {
                 py_comp[index] = py9_map[k9_input[index] - '2'][flag];
                 mark[index] = mark[index] + 1;
                 index++;
@@ -1078,7 +1078,7 @@ static bool pinyin_k9_is_valid_py(lv_obj_t * obj, char * py_str)
     if(*py_str == 'v')     return false;
 
     offset = py_str[0] - 'a';
-    len = strlen(py_str);
+    len = lv_strlen(py_str);
 
     cpHZ  = &pinyin_ime->dict[pinyin_ime->py_pos[offset]];
     count = pinyin_ime->py_num[offset];
@@ -1112,19 +1112,19 @@ static void pinyin_k9_fill_cand(lv_obj_t * obj)
 
     if(tmp_len != len) {
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
         len = tmp_len;
     }
 
     ll_index = _lv_ll_get_head(&pinyin_ime->k9_legal_py_ll);
-    strcpy(pinyin_ime->input_char, ll_index->py_str);
+    lv_strcpy(pinyin_ime->input_char, ll_index->py_str);
     while(ll_index) {
         if((index >= LV_IME_PINYIN_K9_CAND_TEXT_NUM) || \
            (index >= pinyin_ime->k9_legal_py_count))
             break;
 
-        strcpy(lv_pinyin_k9_cand_str[index], ll_index->py_str);
+        lv_strcpy(lv_pinyin_k9_cand_str[index], ll_index->py_str);
         ll_index = _lv_ll_get_next(&pinyin_ime->k9_legal_py_ll, ll_index); /*Find the next list*/
         index++;
     }
@@ -1134,7 +1134,7 @@ static void pinyin_k9_fill_cand(lv_obj_t * obj)
     for(index = 0; index < pinyin_ime->k9_input_str_len; index++) {
         lv_textarea_del_char(ta);
     }
-    pinyin_ime->k9_input_str_len = strlen(pinyin_ime->input_char);
+    pinyin_ime->k9_input_str_len = lv_strlen(pinyin_ime->input_char);
     lv_textarea_add_text(ta, pinyin_ime->input_char);
 }
 
@@ -1161,8 +1161,8 @@ static void pinyin_k9_cand_page_proc(lv_obj_t * obj, uint16_t dir)
         if((NULL == ll_index) && (dir == 1))   return;
 
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
-        strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
+        lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
 
         // next page
         if(dir == 1) {
@@ -1171,7 +1171,7 @@ static void pinyin_k9_cand_page_proc(lv_obj_t * obj, uint16_t dir)
                 if(count >= (LV_IME_PINYIN_K9_CAND_TEXT_NUM - 1))
                     break;
 
-                strcpy(lv_pinyin_k9_cand_str[count], ll_index->py_str);
+                lv_strcpy(lv_pinyin_k9_cand_str[count], ll_index->py_str);
                 ll_index = _lv_ll_get_next(&pinyin_ime->k9_legal_py_ll, ll_index); /*Find the next list*/
                 count++;
             }
@@ -1185,7 +1185,7 @@ static void pinyin_k9_cand_page_proc(lv_obj_t * obj, uint16_t dir)
             while(ll_index) {
                 if(count < 0)  break;
 
-                strcpy(lv_pinyin_k9_cand_str[count], ll_index->py_str);
+                lv_strcpy(lv_pinyin_k9_cand_str[count], ll_index->py_str);
                 ll_index = _lv_ll_get_prev(&pinyin_ime->k9_legal_py_ll, ll_index); /*Find the previous list*/
                 count--;
             }

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -87,7 +87,7 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
         _lv_txt_ap_proc(txt, cb->txt);
 #else
-        lv_strncpy(cb->txt, txt, len);
+        lv_strcpy(cb->txt, txt);
 #endif
 
         cb->static_txt = 0;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -146,7 +146,7 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
     if(dropdown->options == NULL) return;
 
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    lv_strncpy(dropdown->options, options, len);
+    lv_strcpy(dropdown->options, options);
 #else
     _lv_txt_ap_proc(options, dropdown->options);
 #endif
@@ -203,7 +203,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;
 
-        lv_strncpy(dropdown->options, static_options, len);
+        lv_strcpy(dropdown->options, static_options);
         dropdown->static_txt = 0;
     }
 
@@ -243,7 +243,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     LV_ASSERT_MALLOC(ins_buf);
     if(ins_buf == NULL) return;
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    lv_strncpy(ins_buf, option, new_len + 1);
+    lv_strcpy(ins_buf, option);
 #else
     _lv_txt_ap_proc(option, ins_buf);
 #endif

--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -116,10 +116,10 @@ void lv_img_set_src(lv_obj_t * obj, const void * src)
             if(img->src_type == LV_IMG_SRC_FILE || img->src_type == LV_IMG_SRC_SYMBOL) {
                 old_src = img->src;
             }
-            char * new_str = lv_malloc(strlen(src) + 1);
+            char * new_str = lv_malloc(lv_strlen(src) + 1);
             LV_ASSERT_MALLOC(new_str);
             if(new_str == NULL) return;
-            strcpy(new_str, src);
+            lv_strcpy(new_str, src);
             img->src = new_str;
 
             if(old_src) lv_free((void *)old_src);

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1281,8 +1281,7 @@ static void copy_text_to_label(lv_label_t * label, const char * text)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(text, label->text);
 #else
-    size_t len = lv_strlen(text) + 1;
-    lv_memcpy(label->text, text, len);
+    lv_strcpy(label->text, text);
 #endif
 }
 

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -400,7 +400,7 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
         if(page->title == NULL) {
             return;
         }
-        lv_strncpy(page->title, title, len);
+        lv_strcpy(page->title, title);
     }
     else {
         page->title        = NULL;

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -130,7 +130,7 @@ void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_
         char * opt_extra = lv_malloc(opt_len * roller->inf_page_cnt);
         uint8_t i;
         for(i = 0; i < roller->inf_page_cnt; i++) {
-            lv_strncpy(&opt_extra[opt_len * i], options, opt_len);
+            lv_strcpy(&opt_extra[opt_len * i], options);
             opt_extra[opt_len * (i + 1) - 1] = '\n';
         }
         opt_extra[opt_len * roller->inf_page_cnt - 1] = '\0';

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -164,7 +164,7 @@ void lv_span_set_text(lv_span_t * span, const char * text)
     if(span->txt == NULL) return;
 
     span->static_flag = 0;
-    lv_strncpy(span->txt, text, text_alloc_len);
+    lv_strcpy(span->txt, text);
 
     refresh_self_size(span->spangroup);
 }

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -971,8 +971,7 @@ static void copy_cell_txt(char * dst, const char * txt)
 #if LV_USE_ARABIC_PERSIAN_CHARS
     _lv_txt_ap_proc(txt, &dst[1]);
 #else
-    size_t len = lv_strlen(txt) + 1;
-    lv_memcpy(&dst[1], txt, len);
+    lv_strcpy(&dst[1], txt);
 #endif
 }
 

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -86,7 +86,8 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1));
         size_t len = lv_strlen(name) + 1;
         new_map[tab_id - 1] = lv_malloc(len);
-        lv_strncpy((char *)new_map[tab_id - 1], name, len);
+        LV_ASSERT_MALLOC(new_map[tab_id - 1]);
+        lv_strcpy((char *)new_map[tab_id - 1], name);
         new_map[tab_id] = (char *)"";
     }
     /*left or right dir*/
@@ -96,7 +97,8 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         if(tabview->tab_cnt == 0) {
             size_t len = lv_strlen(name) + 1;
             new_map[0] = lv_malloc(len);
-            lv_strncpy((char *)new_map[0], name, len);
+            LV_ASSERT_MALLOC(new_map[0]);
+            lv_strcpy((char *)new_map[0], name);
             new_map[1] = (char *)"";
         }
         else {
@@ -104,7 +106,7 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
             new_map[tab_id * 2 - 3] = (char *)"\n";
             new_map[tab_id * 2 - 2] = lv_malloc(len);
             new_map[tab_id * 2 - 1] = (char *)"";
-            lv_strncpy((char *)new_map[(tab_id * 2) - 2], name, len);
+            lv_strcpy((char *)new_map[(tab_id * 2) - 2], name);
         }
     }
     tabview->map = new_map;
@@ -135,7 +137,8 @@ void lv_tabview_rename_tab(lv_obj_t * obj, uint32_t id, const char * new_name)
     lv_free(tabview->map[id]);
     size_t len = lv_strlen(new_name) + 1;
     tabview->map[id] = lv_malloc(len);
-    lv_strncpy(tabview->map[id], new_name, len);
+    LV_ASSERT_MALLOC(tabview->map[id]);
+    lv_strcpy(tabview->map[id], new_name);
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -304,7 +304,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
         ta->pwd_tmp = lv_realloc(ta->pwd_tmp, len);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
-        lv_strncpy(ta->pwd_tmp, txt, len);
+        lv_strcpy(ta->pwd_tmp, txt);
 
         /*Auto hide characters*/
         auto_hide_characters(obj);
@@ -335,7 +335,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
             return;
         }
 
-        lv_strncpy(ta->placeholder_txt, txt, txt_len + 1);
+        lv_strcpy(ta->placeholder_txt, txt);
         ta->placeholder_txt[txt_len] = '\0';
     }
 
@@ -419,7 +419,7 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
 
-        lv_strncpy(ta->pwd_tmp, txt, len + 1);
+        lv_strcpy(ta->pwd_tmp, txt);
 
         pwd_char_hider(obj);
 
@@ -459,7 +459,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
             return;
         }
 
-        lv_strncpy(ta->pwd_bullet, bullet, txt_len + 1);
+        lv_strcpy(ta->pwd_bullet, bullet);
         ta->pwd_bullet[txt_len] = '\0';
     }
 


### PR DESCRIPTION
### Description of the feature or fix

Replace all `strcpy` and `strlen` to the built-in implementation.
Related discussion: https://github.com/lvgl/lvgl/pull/4145

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
