### PR TITLE
feat(misc): add performance profiler hook

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1009,6 +1009,13 @@ menu "LVGL configuration"
 			bool "Enable Monkey test"
 			default n
 
+		config LV_USE_PROFILER
+			bool "Run-time performance profiler."
+		config LV_PROFILER_INCLUDE
+			string "Header to include for the profiler"
+			depends on LV_USE_PROFILER
+			default "profiler.h"
+
 		config LV_USE_GRIDNAV
 			bool "Enable grid navigation"
 			default n

--- a/docs/porting/index.rst
+++ b/docs/porting/index.rst
@@ -16,4 +16,5 @@ Porting
     sleep
     os
     log
+    profiler
     draw

--- a/docs/porting/profiler.rst
+++ b/docs/porting/profiler.rst
@@ -1,0 +1,42 @@
+.. _profiler:
+
+========
+Profiler
+========
+
+As the complexity of the application increases, performance issues 
+such as low FPS and frequent cache misses causing lag may arise. 
+LVGL has internally set up some hooks for performance measurement 
+to help developers analyze and locate performance issues.
+
+Porting
+*******
+
+To enable profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and configure the following options:
+
+- :c:macro:`LV_PROFILER_INCLUDE`: Provides a header file for the performance measurement function.
+- :c:macro:`LV_PROFILER_BEGIN`: Performance measurement start point function.
+- :c:macro:`LV_PROFILER_END`: Performance measurement end point function.
+
+Example
+*******
+
+The following is an example of output performance measurements using LVGL logging systems:
+
+Configure ``lv_conf.h``:
+
+.. code:: c
+
+   #define LV_USE_PROFILER 1
+   #define LV_PROFILER_INCLUDE "lvgl/src/hal/lv_hal_tick.h"
+   #define LV_PROFILER_BEGIN   uint32_t profiler_start = lv_tick_get()
+   #define LV_PROFILER_END     LV_LOG_USER("cost %" LV_PRIu32 "ms", lv_tick_elaps(profiler_start))
+
+
+Users can add the measured functions themselves:
+
+.. code:: c
+
+   LV_PROFILER_BEGIN;
+   my_func();
+   LV_PROFILER_END;

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -700,6 +700,12 @@
 /*1: Enable system monitor component*/
 #define LV_USE_SYSMON 0
 
+/*1: Enable custom trace system*/
+#define LV_USE_TRACE 0
+#if LV_USE_TRACE
+#define LV_TRACE_INCLUDE <stdint.h>
+#endif
+
 /*1: Enable Monkey test*/
 #define LV_USE_MONKEY 0
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -700,11 +700,11 @@
 /*1: Enable system monitor component*/
 #define LV_USE_SYSMON 0
 
-/*1: Enable custom trace system*/
-#define LV_USE_TRACE 0
-#if LV_USE_TRACE
-#define LV_TRACE_INCLUDE <stdint.h>
-#endif
+/*1: Enable the run-time performance profiler*/
+#define LV_USE_PROFILER 0
+#define LV_PROFILER_INCLUDE <stdint.h>
+#define LV_PROFILER_BEGIN
+#define LV_PROFILER_END
 
 /*1: Enable Monkey test*/
 #define LV_USE_MONKEY 0

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -14,9 +14,9 @@
 #include "../misc/lv_timer.h"
 #include "../misc/lv_math.h"
 #include "../misc/lv_gc.h"
+#include "../misc/lv_profiler.h"
 #include "../draw/lv_draw.h"
 #include "../font/lv_font_fmt_txt.h"
-#include "../others/trace/lv_trace.h"
 
 /*********************
  *      DEFINES
@@ -232,7 +232,7 @@ lv_disp_t * _lv_refr_get_disp_refreshing(void)
  */
 void _lv_disp_refr_timer(lv_timer_t * tmr)
 {
-    LV_TRACE_BEGIN;
+    LV_PROFILER_BEGIN;
     REFR_TRACE("begin");
 
     uint32_t start = lv_tick_get();
@@ -343,7 +343,7 @@ refr_finish:
     lv_disp_send_event(disp_refr, LV_EVENT_REFR_FINISH, NULL);
 
     REFR_TRACE("finished");
-    LV_TRACE_END;
+    LV_PROFILER_END;
 }
 
 /**********************
@@ -393,6 +393,7 @@ static void lv_refr_join_area(void)
 static void refr_invalid_areas(void)
 {
     if(disp_refr->inv_p == 0) return;
+    LV_PROFILER_BEGIN;
 
     /*Find the last area which will be drawn*/
     int32_t i;
@@ -422,6 +423,7 @@ static void refr_invalid_areas(void)
     }
 
     disp_refr->rendering_in_progress = false;
+    LV_PROFILER_END;
 }
 
 /**

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -16,6 +16,7 @@
 #include "../misc/lv_gc.h"
 #include "../draw/lv_draw.h"
 #include "../font/lv_font_fmt_txt.h"
+#include "../others/trace/lv_trace.h"
 
 /*********************
  *      DEFINES
@@ -231,6 +232,7 @@ lv_disp_t * _lv_refr_get_disp_refreshing(void)
  */
 void _lv_disp_refr_timer(lv_timer_t * tmr)
 {
+    LV_TRACE_BEGIN;
     REFR_TRACE("begin");
 
     uint32_t start = lv_tick_get();
@@ -341,6 +343,7 @@ refr_finish:
     lv_disp_send_event(disp_refr, LV_EVENT_REFR_FINISH, NULL);
 
     REFR_TRACE("finished");
+    LV_TRACE_END;
 }
 
 /**********************

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -44,7 +44,9 @@ void lv_draw_init(void)
 
 void lv_draw_wait_for_finish(lv_draw_ctx_t * draw_ctx)
 {
+    LV_PROFILER_BEGIN;
     if(draw_ctx->wait_for_finish) draw_ctx->wait_for_finish(draw_ctx);
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -17,6 +17,7 @@ extern "C" {
 
 #include "../misc/lv_style.h"
 #include "../misc/lv_txt.h"
+#include "../misc/lv_profiler.h"
 #include "lv_img_decoder.h"
 #include "lv_img_cache.h"
 

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -48,10 +48,12 @@ void lv_draw_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const 
     if(dsc->width == 0) return;
     if(start_angle == end_angle) return;
 
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_arc(draw_ctx, dsc, center, radius, start_angle, end_angle);
 
     //    const lv_draw_backend_t * backend = lv_draw_backend_get();
     //    backend->draw_arc(center_x, center_y, radius, start_angle, end_angle, clip_area, dsc);
+    LV_PROFILER_END;
 }
 
 void lv_draw_arc_get_area(lv_coord_t x, lv_coord_t y, uint16_t radius,  uint16_t start_angle, uint16_t end_angle,

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -69,6 +69,7 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
 
     if(dsc->opa <= LV_OPA_MIN) return;
 
+    LV_PROFILER_BEGIN;
     lv_res_t res;
     if(draw_ctx->draw_img) {
         res = draw_ctx->draw_img(draw_ctx, dsc, coords, src);
@@ -76,6 +77,7 @@ void lv_draw_img(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc, const 
     else {
         res = decode_and_draw(draw_ctx, dsc, coords, src);
     }
+    LV_PROFILER_END;
 
     if(res == LV_RES_INV) {
         LV_LOG_WARN("Image draw error");
@@ -121,8 +123,9 @@ void lv_draw_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc
                          const uint8_t * map_p, const lv_draw_img_sup_t * sup, lv_color_format_t color_format)
 {
     if(draw_ctx->draw_img_decoded == NULL) return;
-
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_img_decoded(draw_ctx, dsc, coords, map_p, sup, color_format);
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -364,7 +364,9 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw
 void lv_draw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
                     uint32_t letter)
 {
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_letter(draw_ctx, dsc, pos_p, letter);
+    LV_PROFILER_END;
 }
 
 

--- a/src/draw/lv_draw_layer.c
+++ b/src/draw/lv_draw_layer.c
@@ -45,6 +45,7 @@ lv_draw_layer_ctx_t * lv_draw_layer_create(lv_draw_ctx_t * draw_ctx, const lv_ar
         LV_LOG_WARN("Couldn't allocate a new layer context");
         return NULL;
     }
+    LV_PROFILER_BEGIN;
 
     lv_memzero(layer_ctx, draw_ctx->layer_instance_size);
 
@@ -55,27 +56,33 @@ lv_draw_layer_ctx_t * lv_draw_layer_create(lv_draw_ctx_t * draw_ctx, const lv_ar
     layer_ctx->area_full = *layer_area;
 
     lv_draw_layer_ctx_t * init_layer_ctx =  draw_ctx->layer_init(draw_ctx, layer_ctx, flags);
+
     if(NULL == init_layer_ctx) {
         lv_free(layer_ctx);
     }
+    LV_PROFILER_END;
     return init_layer_ctx;
 }
 
 void lv_draw_layer_adjust(struct _lv_draw_ctx_t * draw_ctx, struct _lv_draw_layer_ctx_t * layer_ctx,
                           lv_draw_layer_flags_t flags)
 {
+    LV_PROFILER_BEGIN;
     if(draw_ctx->layer_adjust) draw_ctx->layer_adjust(draw_ctx, layer_ctx, flags);
+    LV_PROFILER_END;
 }
 
 void lv_draw_layer_blend(struct _lv_draw_ctx_t * draw_ctx, struct _lv_draw_layer_ctx_t * layer_ctx,
                          lv_draw_img_dsc_t * draw_dsc)
 {
+    LV_PROFILER_BEGIN;
     if(draw_ctx->layer_blend) draw_ctx->layer_blend(draw_ctx, layer_ctx, draw_dsc);
+    LV_PROFILER_END;
 }
 
 void lv_draw_layer_destroy(lv_draw_ctx_t * draw_ctx, lv_draw_layer_ctx_t * layer_ctx)
 {
-
+    LV_PROFILER_BEGIN;
     lv_draw_wait_for_finish(draw_ctx);
     draw_ctx->buf = layer_ctx->original.buf;
     draw_ctx->buf_area = layer_ctx->original.buf_area;
@@ -84,6 +91,7 @@ void lv_draw_layer_destroy(lv_draw_ctx_t * draw_ctx, lv_draw_layer_ctx_t * layer
 
     if(draw_ctx->layer_destroy) draw_ctx->layer_destroy(draw_ctx, layer_ctx);
     lv_free(layer_ctx);
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -48,7 +48,9 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const 
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
 
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_line(draw_ctx, dsc, point1, point2);
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -63,8 +63,9 @@ void lv_draw_rect(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, cons
 {
     if(lv_area_get_height(coords) < 1 || lv_area_get_width(coords) < 1) return;
 
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_rect(draw_ctx, dsc, coords);
-
+    LV_PROFILER_END;
     LV_ASSERT_MEM_INTEGRITY();
 }
 

--- a/src/draw/lv_draw_transform.c
+++ b/src/draw/lv_draw_transform.c
@@ -46,7 +46,9 @@ void lv_draw_transform(lv_draw_ctx_t * draw_ctx, const lv_area_t * dest_area, co
         return;
     }
 
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_transform(draw_ctx, dest_area, src_buf, src_w, src_h, src_stride, draw_dsc, sup, cf, cbuf, abuf);
+    LV_PROFILER_END;
 }
 
 

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -38,13 +38,16 @@
 void lv_draw_polygon(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_point_t points[],
                      uint16_t point_cnt)
 {
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_polygon(draw_ctx, draw_dsc, points, point_cnt);
+    LV_PROFILER_END;
 }
 
 void lv_draw_triangle(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc, const lv_point_t points[])
 {
-
+    LV_PROFILER_BEGIN;
     draw_ctx->draw_polygon(draw_ctx, draw_dsc, points, 3);
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2346,22 +2346,34 @@
     #endif
 #endif
 
-/*1: Enable custom trace system*/
-#ifndef LV_USE_TRACE
-    #ifdef CONFIG_LV_USE_TRACE
-        #define LV_USE_TRACE CONFIG_LV_USE_TRACE
+/*1: Enable the run-time performance profiler*/
+#ifndef LV_USE_PROFILER
+    #ifdef CONFIG_LV_USE_PROFILER
+        #define LV_USE_PROFILER CONFIG_LV_USE_PROFILER
     #else
-        #define LV_USE_TRACE 0
+        #define LV_USE_PROFILER 0
     #endif
 #endif
-#if LV_USE_TRACE
-#ifndef LV_TRACE_INCLUDE
-    #ifdef CONFIG_LV_TRACE_INCLUDE
-        #define LV_TRACE_INCLUDE CONFIG_LV_TRACE_INCLUDE
+#ifndef LV_PROFILER_INCLUDE
+    #ifdef CONFIG_LV_PROFILER_INCLUDE
+        #define LV_PROFILER_INCLUDE CONFIG_LV_PROFILER_INCLUDE
     #else
-        #define LV_TRACE_INCLUDE <stdint.h>
+        #define LV_PROFILER_INCLUDE <stdint.h>
     #endif
 #endif
+#ifndef LV_PROFILER_BEGIN
+    #ifdef CONFIG_LV_PROFILER_BEGIN
+        #define LV_PROFILER_BEGIN CONFIG_LV_PROFILER_BEGIN
+    #else
+        #define LV_PROFILER_BEGIN
+    #endif
+#endif
+#ifndef LV_PROFILER_END
+    #ifdef CONFIG_LV_PROFILER_END
+        #define LV_PROFILER_END CONFIG_LV_PROFILER_END
+    #else
+        #define LV_PROFILER_END
+    #endif
 #endif
 
 /*1: Enable Monkey test*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2346,6 +2346,24 @@
     #endif
 #endif
 
+/*1: Enable custom trace system*/
+#ifndef LV_USE_TRACE
+    #ifdef CONFIG_LV_USE_TRACE
+        #define LV_USE_TRACE CONFIG_LV_USE_TRACE
+    #else
+        #define LV_USE_TRACE 0
+    #endif
+#endif
+#if LV_USE_TRACE
+#ifndef LV_TRACE_INCLUDE
+    #ifdef CONFIG_LV_TRACE_INCLUDE
+        #define LV_TRACE_INCLUDE CONFIG_LV_TRACE_INCLUDE
+    #else
+        #define LV_TRACE_INCLUDE <stdint.h>
+    #endif
+#endif
+#endif
+
 /*1: Enable Monkey test*/
 #ifndef LV_USE_MONKEY
     #ifdef CONFIG_LV_USE_MONKEY

--- a/src/misc/lv_profiler.h
+++ b/src/misc/lv_profiler.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_trace.h
+ * @file lv_profiler.h
  *
  */
 
-#ifndef LV_TRACE_H
-#define LV_TRACE_H
+#ifndef LV_PROFILER_H
+#define LV_PROFILER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,25 +14,15 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_conf_internal.h"
+#include "../lv_conf_internal.h"
 
-#if LV_USE_TRACE
+#if LV_USE_PROFILER
 
-#include LV_TRACE_INCLUDE
+#include LV_PROFILER_INCLUDE
 
 /*********************
  *      DEFINES
  *********************/
-
-#ifndef LV_TRACE_BEGIN
-#warning "LV_TRACE_BEGIN is not defined"
-#define LV_TRACE_BEGIN
-#endif
-
-#ifndef LV_TRACE_END
-#warning "LV_TRACE_END is not defined"
-#define LV_TRACE_END
-#endif
 
 /**********************
  *      TYPEDEFS
@@ -46,15 +36,10 @@ extern "C" {
  *      MACROS
  **********************/
 
-#else
-
-#define LV_TRACE_BEGIN
-#define LV_TRACE_END
-
-#endif /*LV_USE_TRACE*/
+#endif /*LV_USE_PROFILER*/
 
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif
 
-#endif /*LV_TRACE_H*/
+#endif /*LV_PROFILER_H*/

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -12,6 +12,7 @@
 #include "lv_ll.h"
 #include "lv_gc.h"
 #include "lv_printf.h"
+#include "lv_profiler.h"
 
 /*********************
  *      DEFINES
@@ -82,6 +83,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
         return 1;
     }
 
+    LV_PROFILER_BEGIN;
     static uint32_t idle_period_start = 0;
     static uint32_t busy_time         = 0;
 
@@ -143,6 +145,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
     already_running = false; /*Release the mutex*/
 
     TIMER_TRACE("finished (%" LV_PRIu32 " ms until the next timer call)", time_till_next);
+    LV_PROFILER_END;
     return time_till_next;
 }
 

--- a/src/others/trace/lv_trace.h
+++ b/src/others/trace/lv_trace.h
@@ -1,0 +1,60 @@
+/**
+ * @file lv_trace.h
+ *
+ */
+
+#ifndef LV_TRACE_H
+#define LV_TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_TRACE
+
+#include LV_TRACE_INCLUDE
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#ifndef LV_TRACE_BEGIN
+#warning "LV_TRACE_BEGIN is not defined"
+#define LV_TRACE_BEGIN
+#endif
+
+#ifndef LV_TRACE_END
+#warning "LV_TRACE_END is not defined"
+#define LV_TRACE_END
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#else
+
+#define LV_TRACE_BEGIN
+#define LV_TRACE_END
+
+#endif /*LV_USE_TRACE*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_TRACE_H*/


### PR DESCRIPTION
### Description of the feature or fix

**This PR is for discussion purposes, not merge.**

Performance measurement becomes difficult as the complexity of the application increases.
Many systems provide many trace methods to help users find performance problems:
NuttX: [sched note](https://github.com/apache/nuttx/blob/master/include/nuttx/sched_note.h)

In this PR, we can implement sched node access to facilitate performance measurement:
`#define LV_USE_TRACE 1`
`#define LV_TRACE_INCLUDE <nuttx/sched_note.h>`
```makefile
-DLV_TRACE_BEGIN=sched_note_begin(NOTE_TAG_ALWAYS)
-DLV_TRACE_END=sched_note_end(NOTE_TAG_ALWAYS)
````

We can preset many hook functions in LVGL's drawing functions. After processing the trace information, we can generate the following chart for performance analysis:
![image](https://user-images.githubusercontent.com/26767803/236624741-301617b1-ca44-40f9-80b3-505eff74647d.png)

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
