### PR TITLE
Release/acceleration updates since lvgl 8.3.5

### DIFF
--- a/docs/get-started/platforms/nxp.md
+++ b/docs/get-started/platforms/nxp.md
@@ -23,6 +23,7 @@ Supported draw callbacks are available in "src/draw/nxp/pxp/lv_draw_pxp.c":
     pxp_draw_ctx->base_draw.draw_img_decoded = lv_draw_pxp_img_decoded;
     pxp_draw_ctx->blend = lv_draw_pxp_blend;
     pxp_draw_ctx->base_draw.wait_for_finish = lv_draw_pxp_wait_for_finish;
+    pxp_draw_ctx->base_draw.buffer_copy = lv_draw_pxp_buffer_copy;
 ```
 
 #### Features supported:
@@ -35,6 +36,7 @@ Supported draw callbacks are available in "src/draw/nxp/pxp/lv_draw_pxp.c":
   - Color keying
   - Recoloring (color tint)
   - Image Rotation (90, 180, 270 degree)
+  - Buffer copy
   - RTOS integration layer
   - Default FreeRTOS and bare metal code provided
 
@@ -114,6 +116,7 @@ Supported draw callbacks are available in "src/draw/nxp/vglite/lv_draw_vglite.c"
     vglite_draw_ctx->base_draw.draw_img_decoded = lv_draw_vglite_img_decoded;
     vglite_draw_ctx->blend = lv_draw_vglite_blend;
     vglite_draw_ctx->base_draw.wait_for_finish = lv_draw_vglite_wait_for_finish;
+    vglite_draw_ctx->base_draw.buffer_copy = lv_draw_vglite_buffer_copy;
 ```
 
 #### Features supported:
@@ -129,6 +132,7 @@ Supported draw callbacks are available in "src/draw/nxp/vglite/lv_draw_vglite.c"
   - Draw rectangle border/outline with optional rounded corners
   - Draw arc with optional rounded ending
   - Draw line or dashed line with optional rounded ending
+  - Buffer copy
 
 #### Known limitations:
   - Source image alignment:

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -192,21 +192,19 @@ static void lv_draw_pxp_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-    lv_area_t blend_area;
-    bool has_transform = dsc->angle != 0 || dsc->zoom != LV_IMG_ZOOM_NONE;
+    bool has_scale = (dsc->zoom != LV_IMG_ZOOM_NONE);
+    bool has_rotation = (dsc->angle != 0);
+    bool unsup_rotation = false;
 
-    if(has_transform)
+    lv_area_t blend_area;
+    if(has_rotation)
         lv_area_copy(&blend_area, &rel_coords);
     else if(!_lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
         return; /*Fully clipped, nothing to do*/
 
+    bool has_mask = lv_draw_mask_is_any(&blend_area);
     lv_coord_t src_width = lv_area_get_width(coords);
     lv_coord_t src_height = lv_area_get_height(coords);
-
-    bool has_mask = lv_draw_mask_is_any(&blend_area);
-    bool has_scale = (dsc->zoom != LV_IMG_ZOOM_NONE);
-    bool has_rotation = (dsc->angle != 0);
-    bool unsup_rotation = false;
 
     if(has_rotation) {
         /*

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -184,13 +184,21 @@ static void lv_draw_pxp_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_
         return;
     }
 
-    lv_area_t blend_area;
-    /*Let's get the blend area which is the intersection of the area to draw and the clip area.*/
-    if(!_lv_area_intersect(&blend_area, coords, draw_ctx->clip_area))
-        return; /*Fully clipped, nothing to do*/
+    lv_area_t rel_coords;
+    lv_area_copy(&rel_coords, coords);
+    lv_area_move(&rel_coords, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-    /*Make the blend area relative to the buffer*/
-    lv_area_move(&blend_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
+    lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
+
+    lv_area_t blend_area;
+    bool has_transform = dsc->angle != 0 || dsc->zoom != LV_IMG_ZOOM_NONE;
+
+    if(has_transform)
+        lv_area_copy(&blend_area, &rel_coords);
+    else if(!_lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
+        return; /*Fully clipped, nothing to do*/
 
     lv_coord_t src_width = lv_area_get_width(coords);
     lv_coord_t src_height = lv_area_get_height(coords);

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.c
@@ -100,7 +100,7 @@ static void lv_pxp_blit_opa(lv_color_t * dest_buf, const lv_area_t * dest_area, 
  * @param[in] dsc Image descriptor
  * @param[in] cf Color format
  */
-static void lv_pxp_blit_cover(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+static void lv_pxp_blit_cover(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
                               const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                               const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf);
 
@@ -286,7 +286,7 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_
     lv_gpu_nxp_pxp_run();
 }
 
-void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
                                    const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                    const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf)
 {
@@ -316,22 +316,25 @@ static void lv_pxp_blit_opa(lv_color_t * dest_buf, const lv_area_t * dest_area, 
                             const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                             const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf)
 {
-    lv_coord_t temp_area_w = lv_area_get_width(dest_area);
-    lv_coord_t temp_area_h = lv_area_get_height(dest_area);
-    const lv_area_t temp_area = {
-        .x1 = 0,
-        .y1 = 0,
-        .x2 = temp_area_w - 1,
-        .y2 = temp_area_h - 1
-    };
+    lv_area_t temp_area;
+    lv_area_copy(&temp_area, dest_area);
+    lv_coord_t temp_stride = dest_stride;
+    lv_coord_t temp_w = lv_area_get_width(&temp_area);
+    lv_coord_t temp_h = lv_area_get_height(&temp_area);
 
     /*Step 1: Transform with full opacity to temporary buffer*/
-    lv_pxp_blit_cover((lv_color_t *)temp_buf, &temp_area, temp_area_w, src_buf, src_area, src_stride, dsc, cf);
+    lv_pxp_blit_cover((lv_color_t *)temp_buf, &temp_area, temp_stride, src_buf, src_area, src_stride, dsc, cf);
+
+    /*Switch width and height if angle requires it*/
+    if(dsc->angle == 900 || dsc->angle == 2700) {
+        temp_area.x2 = temp_area.x1 + temp_h - 1;
+        temp_area.y2 = temp_area.y1 + temp_w - 1;
+    }
 
     /*Step 2: Blit temporary result with required opacity to output*/
-    lv_pxp_blit_cf(dest_buf, dest_area, dest_stride, (lv_color_t *)temp_buf, &temp_area, temp_area_w, dsc, cf);
+    lv_pxp_blit_cf(dest_buf, &temp_area, dest_stride, (lv_color_t *)temp_buf, &temp_area, temp_stride, dsc, cf);
 }
-static void lv_pxp_blit_cover(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+static void lv_pxp_blit_cover(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
                               const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                               const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf)
 {
@@ -344,8 +347,8 @@ static void lv_pxp_blit_cover(lv_color_t * dest_buf, const lv_area_t * dest_area
     bool has_rotation = (dsc->angle != 0);
 
     lv_point_t pivot = dsc->pivot;
-    lv_coord_t piv_offset_x = 0;
-    lv_coord_t piv_offset_y = 0;
+    lv_coord_t piv_offset_x;
+    lv_coord_t piv_offset_y;
 
     lv_gpu_nxp_pxp_reset();
 
@@ -359,26 +362,27 @@ static void lv_pxp_blit_cover(lv_color_t * dest_buf, const lv_area_t * dest_area
                 piv_offset_y = 0;
                 break;
             case 900:
-                pxp_angle = kPXP_Rotate90;
-                piv_offset_x = pivot.x + pivot.y - src_h;
+                piv_offset_x = pivot.x + pivot.y - dest_h;
                 piv_offset_y = pivot.y - pivot.x;
+                pxp_angle = kPXP_Rotate90;
                 break;
             case 1800:
+                piv_offset_x = 2 * pivot.x - dest_w;
+                piv_offset_y = 2 * pivot.y - dest_h;
                 pxp_angle = kPXP_Rotate180;
-                piv_offset_x = 2 * pivot.x - src_w;
-                piv_offset_y = 2 * pivot.y - src_h;
                 break;
             case 2700:
-                pxp_angle = kPXP_Rotate270;
                 piv_offset_x = pivot.x - pivot.y;
-                piv_offset_y = pivot.x + pivot.y - src_w;
+                piv_offset_y = pivot.x + pivot.y - dest_w;
+                pxp_angle = kPXP_Rotate270;
                 break;
             default:
-                pxp_angle = kPXP_Rotate0;
                 piv_offset_x = 0;
                 piv_offset_y = 0;
+                pxp_angle = kPXP_Rotate0;
         }
         PXP_SetRotateConfig(LV_GPU_NXP_PXP_ID, kPXP_RotateOutputBuffer, pxp_angle, kPXP_FlipDisable);
+        lv_area_move(dest_area, piv_offset_x, piv_offset_y);
     }
 
     /*AS buffer - source image*/
@@ -400,7 +404,7 @@ static void lv_pxp_blit_cover(lv_color_t * dest_buf, const lv_area_t * dest_area
     pxp_output_buffer_config_t outputBufferConfig = {
         .pixelFormat = (pxp_output_pixel_format_t)PXP_OUT_PIXEL_FORMAT,
         .interlacedMode = kPXP_OutputProgressive,
-        .buffer0Addr = (uint32_t)(dest_buf + dest_stride * (dest_area->y1 + piv_offset_y) + (dest_area->x1 + piv_offset_x)),
+        .buffer0Addr = (uint32_t)(dest_buf + dest_stride * dest_area->y1 + dest_area->x1),
         .buffer1Addr = (uint32_t)0U,
         .pitchBytes = dest_stride * sizeof(lv_color_t),
         .width = dest_w,

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.c
@@ -40,8 +40,6 @@
  *      DEFINES
  *********************/
 
-#define PXP_TEMP_BUF_SIZE LCD_WIDTH * LCD_HEIGHT * LCD_FB_BYTE_PER_PIXEL
-
 #if LV_COLOR_16_SWAP
     #error Color swap not implemented. Disable LV_COLOR_16_SWAP feature.
 #endif
@@ -50,10 +48,12 @@
     #define PXP_OUT_PIXEL_FORMAT kPXP_OutputPixelFormatRGB565
     #define PXP_AS_PIXEL_FORMAT kPXP_AsPixelFormatRGB565
     #define PXP_PS_PIXEL_FORMAT kPXP_PsPixelFormatRGB565
+    #define PXP_TEMP_BUF_SIZE LCD_WIDTH * LCD_HEIGHT * 2U
 #elif LV_COLOR_DEPTH == 32
     #define PXP_OUT_PIXEL_FORMAT kPXP_OutputPixelFormatARGB8888
     #define PXP_AS_PIXEL_FORMAT kPXP_AsPixelFormatARGB8888
     #define PXP_PS_PIXEL_FORMAT kPXP_PsPixelFormatRGB888
+    #define PXP_TEMP_BUF_SIZE LCD_WIDTH * LCD_HEIGHT * 4U
 #elif
     #error Only 16bit and 32bit color depth are supported. Set LV_COLOR_DEPTH to 16 or 32.
 #endif

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.c
@@ -52,7 +52,12 @@
 #elif LV_COLOR_DEPTH == 32
     #define PXP_OUT_PIXEL_FORMAT kPXP_OutputPixelFormatARGB8888
     #define PXP_AS_PIXEL_FORMAT kPXP_AsPixelFormatARGB8888
-    #define PXP_PS_PIXEL_FORMAT kPXP_PsPixelFormatRGB888
+    #if (!(defined(FSL_FEATURE_PXP_HAS_NO_EXTEND_PIXEL_FORMAT) && FSL_FEATURE_PXP_HAS_NO_EXTEND_PIXEL_FORMAT)) && \
+        (!(defined(FSL_FEATURE_PXP_V3) && FSL_FEATURE_PXP_V3))
+        #define PXP_PS_PIXEL_FORMAT kPXP_PsPixelFormatARGB8888
+    #else
+        #define PXP_PS_PIXEL_FORMAT kPXP_PsPixelFormatRGB888
+    #endif
     #define PXP_TEMP_BUF_SIZE LCD_WIDTH * LCD_HEIGHT * 4U
 #elif
     #error Only 16bit and 32bit color depth are supported. Set LV_COLOR_DEPTH to 16 or 32.

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.c
@@ -308,6 +308,33 @@ void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area,
     lv_pxp_blit_cf(dest_buf, dest_area, dest_stride, src_buf, src_area, src_stride, dsc, cf);
 }
 
+void lv_gpu_nxp_pxp_buffer_copy(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride)
+{
+    lv_coord_t src_width = lv_area_get_width(src_area);
+    lv_coord_t src_height = lv_area_get_height(src_area);
+
+    lv_gpu_nxp_pxp_reset();
+
+    const pxp_pic_copy_config_t picCopyConfig = {
+        .srcPicBaseAddr = (uint32_t)src_buf,
+        .srcPitchBytes = src_stride * sizeof(lv_color_t),
+        .srcOffsetX = src_area->x1,
+        .srcOffsetY = src_area->y1,
+        .destPicBaseAddr = (uint32_t)dest_buf,
+        .destPitchBytes = dest_stride * sizeof(lv_color_t),
+        .destOffsetX = dest_area->x1,
+        .destOffsetY = dest_area->y1,
+        .width = src_width,
+        .height = src_height,
+        .pixelFormat = PXP_AS_PIXEL_FORMAT
+    };
+
+    PXP_StartPictureCopy(LV_GPU_NXP_PXP_ID, &picCopyConfig);
+
+    lv_gpu_nxp_pxp_wait();
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.h
@@ -103,6 +103,20 @@ void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area,
                                    const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                    const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf);
 
+/**
+ * BLock Image Transfer - copy rectangular image from src_buf to dst_buf, no transformation or blending.
+ *
+ *
+ * @param[in/out] dest_buf Destination buffer
+ * @param[in] dest_area Area with relative coordinates of destination buffer
+ * @param[in] dest_stride Stride of destination buffer in pixels
+ * @param[in] src_buf Source buffer
+ * @param[in] src_area Area with relative coordinates of source buffer
+ * @param[in] src_stride Stride of source buffer in pixels
+ */
+void lv_gpu_nxp_pxp_buffer_copy(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/nxp/pxp/lv_draw_pxp_blend.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp_blend.h
@@ -99,7 +99,7 @@ void lv_gpu_nxp_pxp_blit(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_
  * @param[in] dsc Image descriptor
  * @param[in] cf Color format
  */
-void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+void lv_gpu_nxp_pxp_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
                                    const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                    const lv_draw_img_dsc_t * dsc, lv_img_cf_t cf);
 

--- a/src/draw/nxp/pxp/lv_gpu_nxp_pxp.h
+++ b/src/draw/nxp/pxp/lv_gpu_nxp_pxp.h
@@ -149,7 +149,7 @@ void lv_gpu_nxp_pxp_wait(void);
 #if LV_GPU_NXP_PXP_LOG_TRACES
 #define PXP_LOG_TRACE(fmt, ...)               \
     do {                                      \
-        LV_LOG_ERROR(fmt, ##__VA_ARGS__);     \
+        LV_LOG(fmt, ##__VA_ARGS__);     \
     } while (0)
 #else
 #define PXP_LOG_TRACE(fmt, ...)               \

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -518,10 +518,15 @@ static void lv_draw_vglite_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-    done = (lv_gpu_nxp_vglite_draw_arc(&rel_center, (int32_t)radius, (int32_t)start_angle, (int32_t)end_angle,
-                                       &rel_clip_area, dsc) == LV_RES_OK);
-    if(!done)
-        VG_LITE_LOG_TRACE("VG-Lite draw arc failed. Fallback.");
+    bool mask_any = lv_draw_mask_is_any(&rel_clip_area);
+
+    if(!mask_any) {
+        done = (lv_gpu_nxp_vglite_draw_arc(&rel_center, (int32_t)radius, (int32_t)start_angle, (int32_t)end_angle,
+                                           &rel_clip_area, dsc) == LV_RES_OK);
+        if(!done)
+            VG_LITE_LOG_TRACE("VG-Lite draw arc failed. Fallback.");
+    }
+
 #endif/*LV_DRAW_COMPLEX*/
 
     if(!done)

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -316,9 +316,9 @@ static void lv_draw_vglite_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc
     lv_point_t rel_point2 = { point2->x - draw_ctx->buf_area->x1, point2->y - draw_ctx->buf_area->y1 };
 
     bool done = false;
-    bool mask_any = lv_draw_mask_is_any(&rel_clip_area);
+    bool has_mask = lv_draw_mask_is_any(&rel_clip_area);
 
-    if(!mask_any) {
+    if(!has_mask) {
         done = (lv_gpu_nxp_vglite_draw_line(&rel_point1, &rel_point2, &rel_clip_area, dsc) == LV_RES_OK);
         if(!done)
             VG_LITE_LOG_TRACE("VG-Lite draw line failed. Fallback.");
@@ -399,7 +399,7 @@ static lv_res_t lv_draw_vglite_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_d
     if(!_lv_area_intersect(&clipped_coords, &rel_coords, &rel_clip_area))
         return LV_RES_OK; /*Fully clipped, nothing to do*/
 
-    bool mask_any = lv_draw_mask_is_any(&rel_coords);
+    bool has_mask = lv_draw_mask_is_any(&rel_coords);
     lv_grad_dir_t grad_dir = dsc->bg_grad.dir;
     lv_color_t bg_color = (grad_dir == (lv_grad_dir_t)LV_GRAD_DIR_NONE) ?
                           dsc->bg_color : dsc->bg_grad.stops[0].color;
@@ -412,7 +412,7 @@ static lv_res_t lv_draw_vglite_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_d
      *
      * Complex case: gradient or radius but no mask.
      */
-    if(!mask_any && ((dsc->radius != 0) || (grad_dir != (lv_grad_dir_t)LV_GRAD_DIR_NONE))) {
+    if(!has_mask && ((dsc->radius != 0) || (grad_dir != (lv_grad_dir_t)LV_GRAD_DIR_NONE))) {
         lv_res_t res = lv_gpu_nxp_vglite_draw_bg(&rel_coords, &rel_clip_area, dsc);
         if(res != LV_RES_OK)
             VG_LITE_LOG_TRACE("VG-Lite draw bg failed. Fallback.");
@@ -518,9 +518,9 @@ static void lv_draw_vglite_arc(lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-    bool mask_any = lv_draw_mask_is_any(&rel_clip_area);
+    bool has_mask = lv_draw_mask_is_any(&rel_clip_area);
 
-    if(!mask_any) {
+    if(!has_mask) {
         done = (lv_gpu_nxp_vglite_draw_arc(&rel_center, (int32_t)radius, (int32_t)start_angle, (int32_t)end_angle,
                                            &rel_clip_area, dsc) == LV_RES_OK);
         if(!done)

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -306,7 +306,8 @@ static void lv_draw_vglite_line(lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc
     rel_clip_area.y1 = LV_MIN(point1->y, point2->y) - dsc->width / 2;
     rel_clip_area.y2 = LV_MAX(point1->y, point2->y) + dsc->width / 2;
 
-    if(!_lv_area_intersect(&rel_clip_area, &rel_clip_area, draw_ctx->clip_area))
+    lv_area_t clipped_coords;
+    if(!_lv_area_intersect(&clipped_coords, &rel_clip_area, draw_ctx->clip_area))
         return; /*Fully clipped, nothing to do*/
 
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
@@ -394,7 +395,8 @@ static lv_res_t lv_draw_vglite_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_d
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
-    if(!_lv_area_intersect(&rel_coords, &rel_coords, &rel_clip_area))
+    lv_area_t clipped_coords;
+    if(!_lv_area_intersect(&clipped_coords, &rel_coords, &rel_clip_area))
         return LV_RES_OK; /*Fully clipped, nothing to do*/
 
     bool mask_any = lv_draw_mask_is_any(&rel_coords);
@@ -448,6 +450,10 @@ static lv_res_t lv_draw_vglite_border(lv_draw_ctx_t * draw_ctx, const lv_draw_re
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
 
+    lv_area_t clipped_coords;
+    if(!_lv_area_intersect(&clipped_coords, &rel_coords, &rel_clip_area))
+        return LV_RES_OK; /*Fully clipped, nothing to do*/
+
     lv_res_t res = lv_gpu_nxp_vglite_draw_border_generic(&rel_coords, &rel_clip_area, dsc, true);
     if(res != LV_RES_OK)
         VG_LITE_LOG_TRACE("VG-Lite draw border failed. Fallback.");
@@ -476,6 +482,10 @@ static lv_res_t lv_draw_vglite_outline(lv_draw_ctx_t * draw_ctx, const lv_draw_r
     lv_area_t rel_clip_area;
     lv_area_copy(&rel_clip_area, draw_ctx->clip_area);
     lv_area_move(&rel_clip_area, -draw_ctx->buf_area->x1, -draw_ctx->buf_area->y1);
+
+    lv_area_t clipped_coords;
+    if(!_lv_area_intersect(&clipped_coords, &rel_coords, &rel_clip_area))
+        return LV_RES_OK; /*Fully clipped, nothing to do*/
 
     lv_res_t res = lv_gpu_nxp_vglite_draw_border_generic(&rel_coords, &rel_clip_area, dsc, false);
     if(res != LV_RES_OK)

--- a/src/draw/nxp/vglite/lv_draw_vglite_arc.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_arc.c
@@ -216,12 +216,16 @@ lv_res_t lv_gpu_nxp_vglite_draw_arc(const lv_point_t * center, int32_t radius, i
     vg_lite_matrix_t matrix;
     vg_lite_identity(&matrix);
 
+    lv_vglite_set_scissor(clip_area);
+
     /*** Draw arc ***/
     err = vg_lite_draw(vgbuf, &path, VG_LITE_FILL_NON_ZERO, &matrix, VG_LITE_BLEND_SRC_OVER, vgcol);
     VG_LITE_ERR_RETURN_INV(err, "Draw arc failed.");
 
     if(lv_vglite_run() != LV_RES_OK)
         VG_LITE_RETURN_INV("Run failed.");
+
+    lv_vglite_disable_scissor();
 
     err = vg_lite_clear_path(&path);
     VG_LITE_ERR_RETURN_INV(err, "Clear path failed.");

--- a/src/draw/nxp/vglite/lv_draw_vglite_blend.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_blend.c
@@ -35,6 +35,7 @@
 
 #if LV_USE_GPU_NXP_VG_LITE
 #include "lv_vglite_buf.h"
+#include "lv_vglite_utils.h"
 
 /*********************
  *      DEFINES
@@ -95,18 +96,6 @@ static inline void lv_vglite_set_translation_matrix(const lv_area_t * dest_area)
  * @param[in] dsc Image descriptor
  */
 static inline void lv_vglite_set_transformation_matrix(const lv_area_t * dest_area, const lv_draw_img_dsc_t * dsc);
-
-/**
- * Enable scissor and set the clipping box.
- *
- * @param[in] clip_area Clip area with relative coordinates of destination buffer
- */
-static inline void lv_vglite_set_scissor(const lv_area_t * clip_area);
-
-/**
- * Disable scissor.
- */
-static inline void lv_vglite_disable_scissor(void);
 
 #if VG_LITE_BLIT_SPLIT_ENABLED
 /**
@@ -555,19 +544,6 @@ static inline void lv_vglite_set_transformation_matrix(const lv_area_t * dest_ar
         vg_lite_scale(scale, scale, &vgmatrix);
     }
     vg_lite_translate(0.0f - dsc->pivot.x, 0.0f - dsc->pivot.y, &vgmatrix);
-}
-
-static inline void lv_vglite_set_scissor(const lv_area_t * clip_area)
-{
-    vg_lite_enable_scissor();
-    vg_lite_set_scissor((int32_t)clip_area->x1, (int32_t)clip_area->y1,
-                        (int32_t)lv_area_get_width(clip_area),
-                        (int32_t)lv_area_get_height(clip_area));
-}
-
-static inline void lv_vglite_disable_scissor(void)
-{
-    vg_lite_disable_scissor();
 }
 
 #if VG_LITE_BLIT_SPLIT_ENABLED

--- a/src/draw/nxp/vglite/lv_draw_vglite_blend.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite_blend.h
@@ -136,7 +136,24 @@ lv_res_t lv_gpu_nxp_vglite_blit(const lv_area_t * dest_area,
 lv_res_t lv_gpu_nxp_vglite_blit_transform(const lv_area_t * dest_area, const lv_area_t * clip_area,
                                           const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                           const lv_draw_img_dsc_t * dsc);
+
 #endif /*VG_LITE_BLIT_SPLIT_ENABLED*/
+
+/**
+ * BLock Image Transfer - simple copy of rectangular image from source to destination.
+ *
+ * @param[in] dest_buf Destination buffer
+ * @param[in] dest_area Area with relative coordinates of destination buffer
+ * @param[in] dest_stride Stride of destination buffer in pixels
+ * @param[in] src_buf Source buffer
+ * @param[in] src_area Source area with relative coordinates of source buffer
+ * @param[in] src_stride Stride of source buffer in pixels
+ *
+ * @retval LV_RES_OK Transfer complete
+ * @retval LV_RES_INV Error occurred (\see LV_GPU_NXP_VG_LITE_LOG_ERRORS)
+ */
+lv_res_t lv_gpu_nxp_vglite_buffer_copy(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                       const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride);
 
 /**********************
  *      MACROS

--- a/src/draw/nxp/vglite/lv_draw_vglite_blend.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite_blend.h
@@ -47,6 +47,21 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * Enable BLIT quality degradation workaround for RT595,
+ * recommended for screen's dimension > 352 pixels.
+ */
+#define RT595_BLIT_WRKRND_ENABLED 1
+
+/* Internal compound symbol */
+#if (defined(CPU_MIMXRT595SFFOB) || defined(CPU_MIMXRT595SFFOB_cm33) || \
+    defined(CPU_MIMXRT595SFFOC) || defined(CPU_MIMXRT595SFFOC_cm33)) && \
+    RT595_BLIT_WRKRND_ENABLED
+#define VG_LITE_BLIT_SPLIT_ENABLED 1
+#else
+#define VG_LITE_BLIT_SPLIT_ENABLED 0
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -67,6 +82,7 @@ extern "C" {
  */
 lv_res_t lv_gpu_nxp_vglite_fill(const lv_area_t * dest_area, lv_color_t color, lv_opa_t opa);
 
+#if VG_LITE_BLIT_SPLIT_ENABLED
 /**
  * BLock Image Transfer - copy rectangular image from src_buf to dst_buf with effects.
  * By default, image is copied directly, with optional opacity.
@@ -82,17 +98,32 @@ lv_res_t lv_gpu_nxp_vglite_fill(const lv_area_t * dest_area, lv_color_t color, l
  * @retval LV_RES_OK Transfer complete
  * @retval LV_RES_INV Error occurred (\see LV_GPU_NXP_VG_LITE_LOG_ERRORS)
  */
-lv_res_t lv_gpu_nxp_vglite_blit(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
-                                const lv_color_t * src_buf, lv_area_t * src_area, lv_coord_t src_stride,
+lv_res_t lv_gpu_nxp_vglite_blit_split(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
+                                      const lv_color_t * src_buf, lv_area_t * src_area, lv_coord_t src_stride,
+                                      lv_opa_t opa);
+#else
+/**
+ * BLock Image Transfer - copy rectangular image from src_buf to dst_buf with effects.
+ * By default, image is copied directly, with optional opacity.
+ *
+ * @param[in] dest_stride Stride of destination buffer in pixels
+ * @param[in] src_buf Source buffer
+ * @param[in] src_area Source area with relative coordinates of source buffer
+ * @param[in] src_stride Stride of source buffer in pixels
+ * @param[in] opa Opacity
+ *
+ * @retval LV_RES_OK Transfer complete
+ * @retval LV_RES_INV Error occurred (\see LV_GPU_NXP_VG_LITE_LOG_ERRORS)
+ */
+lv_res_t lv_gpu_nxp_vglite_blit(const lv_area_t * dest_area,
+                                const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                 lv_opa_t opa);
 
 /**
  * BLock Image Transfer - copy rectangular image from src_buf to dst_buf with transformation.
  * By default, image is copied directly, with optional opacity.
  *
- * @param[in/out] dest_buf Destination buffer
  * @param[in] dest_area Area with relative coordinates of destination buffer
- * @param[in] dest_stride Stride of destination buffer in pixels
  * @param[in] clip_area Clip area with relative coordinates of destination buffer
  * @param[in] src_buf Source buffer
  * @param[in] src_area Source area with relative coordinates of source buffer
@@ -102,10 +133,10 @@ lv_res_t lv_gpu_nxp_vglite_blit(lv_color_t * dest_buf, lv_area_t * dest_area, lv
  * @retval LV_RES_OK Transfer complete
  * @retval LV_RES_INV Error occurred (\see LV_GPU_NXP_VG_LITE_LOG_ERRORS)
  */
-lv_res_t lv_gpu_nxp_vglite_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
-                                          lv_area_t * clip_area,
-                                          const lv_color_t * src_buf, lv_area_t * src_area, lv_coord_t src_stride,
+lv_res_t lv_gpu_nxp_vglite_blit_transform(const lv_area_t * dest_area, const lv_area_t * clip_area,
+                                          const lv_color_t * src_buf, const lv_area_t * src_area, lv_coord_t src_stride,
                                           const lv_draw_img_dsc_t * dsc);
+#endif /*VG_LITE_BLIT_SPLIT_ENABLED*/
 
 /**********************
  *      MACROS

--- a/src/draw/nxp/vglite/lv_draw_vglite_blend.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite_blend.h
@@ -93,6 +93,7 @@ lv_res_t lv_gpu_nxp_vglite_blit(lv_color_t * dest_buf, lv_area_t * dest_area, lv
  * @param[in/out] dest_buf Destination buffer
  * @param[in] dest_area Area with relative coordinates of destination buffer
  * @param[in] dest_stride Stride of destination buffer in pixels
+ * @param[in] clip_area Clip area with relative coordinates of destination buffer
  * @param[in] src_buf Source buffer
  * @param[in] src_area Source area with relative coordinates of source buffer
  * @param[in] src_stride Stride of source buffer in pixels
@@ -102,6 +103,7 @@ lv_res_t lv_gpu_nxp_vglite_blit(lv_color_t * dest_buf, lv_area_t * dest_area, lv
  * @retval LV_RES_INV Error occurred (\see LV_GPU_NXP_VG_LITE_LOG_ERRORS)
  */
 lv_res_t lv_gpu_nxp_vglite_blit_transform(lv_color_t * dest_buf, lv_area_t * dest_area, lv_coord_t dest_stride,
+                                          lv_area_t * clip_area,
                                           const lv_color_t * src_buf, lv_area_t * src_area, lv_coord_t src_stride,
                                           const lv_draw_img_dsc_t * dsc);
 

--- a/src/draw/nxp/vglite/lv_draw_vglite_line.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_line.c
@@ -119,11 +119,15 @@ lv_res_t lv_gpu_nxp_vglite_draw_line(const lv_point_t * point1, const lv_point_t
     err = vg_lite_update_stroke(&path);
     VG_LITE_ERR_RETURN_INV(err, "Update stroke failed.");
 
+    lv_vglite_set_scissor(clip_area);
+
     err = vg_lite_draw(vgbuf, &path, VG_LITE_FILL_NON_ZERO, &matrix, vglite_blend_mode, vgcol);
     VG_LITE_ERR_RETURN_INV(err, "Draw line failed.");
 
     if(lv_vglite_run() != LV_RES_OK)
         VG_LITE_RETURN_INV("Run failed.");
+
+    lv_vglite_disable_scissor();
 
     err = vg_lite_clear_path(&path);
     VG_LITE_ERR_RETURN_INV(err, "Clear path failed.");

--- a/src/draw/nxp/vglite/lv_draw_vglite_rect.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_rect.c
@@ -284,6 +284,10 @@ lv_res_t lv_gpu_nxp_vglite_draw_border_generic(const lv_area_t * coords, const l
 
 }
 
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
 static void lv_vglite_create_rect_path_data(int32_t * path_data, uint32_t * path_data_size,
                                             lv_coord_t radius,
                                             const lv_area_t * coords)
@@ -451,9 +455,5 @@ static void lv_vglite_create_rect_path_data(int32_t * path_data, uint32_t * path
     /* Resulting path size */
     *path_data_size = pidx * sizeof(int32_t);
 }
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
 
 #endif /*LV_USE_GPU_NXP_VG_LITE*/

--- a/src/draw/nxp/vglite/lv_draw_vglite_rect.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_rect.c
@@ -166,6 +166,8 @@ lv_res_t lv_gpu_nxp_vglite_draw_bg(const lv_area_t * coords, const lv_area_t * c
     if(lv_vglite_premult_and_swizzle(&vgcol, bg_col32, dsc->bg_opa, color_format) != LV_RES_OK)
         VG_LITE_RETURN_INV("Premultiplication and swizzle failed.");
 
+    lv_vglite_set_scissor(clip_area);
+
     /*** Draw rectangle ***/
     if(dsc->bg_grad.dir == (lv_grad_dir_t)LV_GRAD_DIR_NONE) {
         err = vg_lite_draw(vgbuf, &path, VG_LITE_FILL_EVEN_ODD, &matrix, VG_LITE_BLEND_SRC_OVER, vgcol);
@@ -177,6 +179,8 @@ lv_res_t lv_gpu_nxp_vglite_draw_bg(const lv_area_t * coords, const lv_area_t * c
 
     if(lv_vglite_run() != LV_RES_OK)
         VG_LITE_RETURN_INV("Run failed.");
+
+    lv_vglite_disable_scissor();
 
     err = vg_lite_clear_path(&path);
     VG_LITE_ERR_RETURN_INV(err, "Clear path failed.");
@@ -263,11 +267,15 @@ lv_res_t lv_gpu_nxp_vglite_draw_border_generic(const lv_area_t * coords, const l
     err = vg_lite_update_stroke(&path);
     VG_LITE_ERR_RETURN_INV(err, "Update stroke failed.");
 
+    lv_vglite_set_scissor(clip_area);
+
     err = vg_lite_draw(vgbuf, &path, VG_LITE_FILL_NON_ZERO, &matrix, vglite_blend_mode, vgcol);
     VG_LITE_ERR_RETURN_INV(err, "Draw border failed.");
 
     if(lv_vglite_run() != LV_RES_OK)
         VG_LITE_RETURN_INV("Run failed.");
+
+    lv_vglite_disable_scissor();
 
     err = vg_lite_clear_path(&path);
     VG_LITE_ERR_RETURN_INV(err, "Clear path failed.");

--- a/src/draw/nxp/vglite/lv_vglite_buf.c
+++ b/src/draw/nxp/vglite/lv_vglite_buf.c
@@ -57,8 +57,6 @@
 
 static inline void lv_vglite_set_dest_buf(const lv_color_t * buf, const lv_area_t * area, lv_coord_t stride);
 static inline void lv_vglite_set_buf_ptr(vg_lite_buffer_t * vgbuf, const lv_color_t * buf);
-static inline void lv_vglite_set_buf(vg_lite_buffer_t * vgbuf, const lv_color_t * buf,
-                                     const lv_area_t * area, lv_coord_t stride);
 
 /**********************
  *  STATIC VARIABLES
@@ -106,23 +104,8 @@ void lv_vglite_set_src_buf(const lv_color_t * buf, const lv_area_t * area, lv_co
         lv_vglite_set_buf(&src_vgbuf, buf, area, stride);
 }
 
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static inline void lv_vglite_set_dest_buf(const lv_color_t * buf, const lv_area_t * area, lv_coord_t stride)
-{
-    lv_vglite_set_buf(&dest_vgbuf, buf, area, stride);
-}
-
-static inline void lv_vglite_set_buf_ptr(vg_lite_buffer_t * vgbuf, const lv_color_t * buf)
-{
-    vgbuf->memory = (void *)buf;
-    vgbuf->address = (uint32_t)vgbuf->memory;
-}
-
-static inline void lv_vglite_set_buf(vg_lite_buffer_t * vgbuf, const lv_color_t * buf,
-                                     const lv_area_t * area, lv_coord_t stride)
+void lv_vglite_set_buf(vg_lite_buffer_t * vgbuf, const lv_color_t * buf,
+                       const lv_area_t * area, lv_coord_t stride)
 {
     vgbuf->format = VG_LITE_PX_FMT;
     vgbuf->tiled = VG_LITE_LINEAR;
@@ -138,6 +121,21 @@ static inline void lv_vglite_set_buf(vg_lite_buffer_t * vgbuf, const lv_color_t 
     vgbuf->memory = (void *)buf;
     vgbuf->address = (uint32_t)vgbuf->memory;
     vgbuf->handle = NULL;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static inline void lv_vglite_set_dest_buf(const lv_color_t * buf, const lv_area_t * area, lv_coord_t stride)
+{
+    lv_vglite_set_buf(&dest_vgbuf, buf, area, stride);
+}
+
+static inline void lv_vglite_set_buf_ptr(vg_lite_buffer_t * vgbuf, const lv_color_t * buf)
+{
+    vgbuf->memory = (void *)buf;
+    vgbuf->address = (uint32_t)vgbuf->memory;
 }
 
 #endif /*LV_USE_GPU_NXP_VG_LITE*/

--- a/src/draw/nxp/vglite/lv_vglite_buf.h
+++ b/src/draw/nxp/vglite/lv_vglite_buf.h
@@ -100,6 +100,17 @@ void lv_vglite_set_src_buf_ptr(const lv_color_t * buf);
  */
 void lv_vglite_set_src_buf(const lv_color_t * buf, const lv_area_t * area, lv_coord_t stride);
 
+/**
+ * Set vglite buffer.
+ *
+ * @param[in] vgbuf Address of the VGLite buffer object
+ * @param[in] buf Address of the memory for the VGLite buffer
+ * @param[in] area buffer area (for width and height)
+ * @param[in] stride buffer stride
+ */
+void lv_vglite_set_buf(vg_lite_buffer_t * vgbuf, const lv_color_t * buf,
+                       const lv_area_t * area, lv_coord_t stride);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/nxp/vglite/lv_vglite_utils.h
+++ b/src/draw/nxp/vglite/lv_vglite_utils.h
@@ -72,6 +72,23 @@ extern "C" {
  **********************/
 
 /**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**
+ * Enable scissor and set the clipping box.
+ *
+ * @param[in] clip_area Clip area with relative coordinates of destination buffer
+ */
+static inline void lv_vglite_set_scissor(const lv_area_t * clip_area);
+
+/**
+ * Disable scissor.
+ */
+static inline void lv_vglite_disable_scissor(void);
+
+
+/**********************
  * GLOBAL PROTOTYPES
  **********************/
 
@@ -156,6 +173,23 @@ lv_res_t lv_vglite_run(void);
         return LV_RES_INV;                    \
     }while(0)
 #endif /*LV_GPU_NXP_VG_LITE_LOG_TRACES*/
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static inline void lv_vglite_set_scissor(const lv_area_t * clip_area)
+{
+    vg_lite_enable_scissor();
+    vg_lite_set_scissor((int32_t)clip_area->x1, (int32_t)clip_area->y1,
+                        (int32_t)lv_area_get_width(clip_area),
+                        (int32_t)lv_area_get_height(clip_area));
+}
+
+static inline void lv_vglite_disable_scissor(void)
+{
+    vg_lite_disable_scissor();
+}
 
 #endif /*LV_USE_GPU_NXP_VG_LITE*/
 


### PR DESCRIPTION
### Description of the feature or fix

1.	Add CPU usage to benchmark app
2.	Fix blit with transformation
3.	Add PXP buffer copy
4.	Fix scissoring
5.	Add vglite buffer copy
6.	Bug fixing

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
