### PR TITLE
fix(profiler): fixed inability to disable and add new measurement points

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1010,7 +1010,7 @@ menu "LVGL configuration"
 			default n
 
 		config LV_USE_PROFILER
-			bool "Run-time performance profiler."
+			bool "Runtime performance profiler."
 		config LV_PROFILER_INCLUDE
 			string "Header to include for the profiler"
 			depends on LV_USE_PROFILER

--- a/docs/porting/profiler.rst
+++ b/docs/porting/profiler.rst
@@ -14,9 +14,9 @@ Porting
 
 To enable profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and configure the following options:
 
-- :c:macro:`LV_PROFILER_INCLUDE`: Provides a header file for the performance measurement function.
-- :c:macro:`LV_PROFILER_BEGIN`: Performance measurement start point function.
-- :c:macro:`LV_PROFILER_END`: Performance measurement end point function.
+- :c:macro:`LV_PROFILER_INCLUDE`: Provides a header file for the profiler function.
+- :c:macro:`LV_PROFILER_BEGIN`: Profiler start point function.
+- :c:macro:`LV_PROFILER_END`: Profiler end point function.
 
 Example
 *******
@@ -30,7 +30,7 @@ Configure ``lv_conf.h``:
    #define LV_USE_PROFILER 1
    #define LV_PROFILER_INCLUDE "lvgl/src/hal/lv_hal_tick.h"
    #define LV_PROFILER_BEGIN   uint32_t profiler_start = lv_tick_get()
-   #define LV_PROFILER_END     LV_LOG_USER("cost %" LV_PRIu32 "ms", lv_tick_elaps(profiler_start))
+   #define LV_PROFILER_END     LV_LOG_USER("cost %dms", (int)lv_tick_elaps(profiler_start))
 
 
 Users can add the measured functions themselves:

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -700,11 +700,18 @@
 /*1: Enable system monitor component*/
 #define LV_USE_SYSMON 0
 
-/*1: Enable the run-time performance profiler*/
+/*1: Enable the runtime performance profiler*/
 #define LV_USE_PROFILER 0
-#define LV_PROFILER_INCLUDE <stdint.h>
-#define LV_PROFILER_BEGIN
-#define LV_PROFILER_END
+#if LV_USE_PROFILER
+    /*Header to include for the profiler*/
+    #define LV_PROFILER_INCLUDE <stdint.h>
+
+    /*Profiler start point function*/
+    #define LV_PROFILER_BEGIN
+
+    /*Profiler end point function*/
+    #define LV_PROFILER_END
+#endif
 
 /*1: Enable Monkey test*/
 #define LV_USE_MONKEY 0

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -19,6 +19,7 @@
 #include "../misc/lv_timer.h"
 #include "../misc/lv_math.h"
 #include "../misc/lv_gc.h"
+#include "../misc/lv_profiler.h"
 
 /*********************
  *      DEFINES
@@ -135,6 +136,7 @@ lv_indev_t * lv_indev_get_next(lv_indev_t * indev)
 
 void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
+    LV_PROFILER_BEGIN;
     lv_memzero(data, sizeof(lv_indev_data_t));
 
     /* For touchpad sometimes users don't set the last pressed coordinate on release.
@@ -159,6 +161,7 @@ void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
     else {
         LV_LOG_WARN("indev_read_cb is not registered");
     }
+    LV_PROFILER_END;
 }
 
 void lv_indev_read_timer_cb(lv_timer_t * timer)
@@ -177,6 +180,9 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
 
     if(indev_act->disabled ||
        indev_act->disp->prev_scr != NULL) return; /*Input disabled or screen animation active*/
+
+    LV_PROFILER_BEGIN;
+
     bool continue_reading;
     do {
         /*Read the data*/
@@ -218,6 +224,7 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     indev_obj_act = NULL;
 
     INDEV_TRACE("finished");
+    LV_PROFILER_END;
 }
 
 void lv_indev_enable(lv_indev_t * indev, bool en)

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -1074,6 +1074,7 @@ static void draw_buf_flush(lv_disp_t * disp)
 
 static void call_flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t * color_p)
 {
+    LV_PROFILER_BEGIN;
     REFR_TRACE("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer",
                (int)area->x1, (int)area->y1, (int)area->x2, (int)area->y2,
                (void *)color_p);
@@ -1088,4 +1089,5 @@ static void call_flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t *
     if(disp->draw_ctx->buffer_convert) disp->draw_ctx->buffer_convert(disp->draw_ctx);
 
     disp->flush_cb(disp, &offset_area, color_p);
+    LV_PROFILER_END;
 }

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2346,7 +2346,7 @@
     #endif
 #endif
 
-/*1: Enable the run-time performance profiler*/
+/*1: Enable the runtime performance profiler*/
 #ifndef LV_USE_PROFILER
     #ifdef CONFIG_LV_USE_PROFILER
         #define LV_USE_PROFILER CONFIG_LV_USE_PROFILER
@@ -2354,25 +2354,32 @@
         #define LV_USE_PROFILER 0
     #endif
 #endif
-#ifndef LV_PROFILER_INCLUDE
-    #ifdef CONFIG_LV_PROFILER_INCLUDE
-        #define LV_PROFILER_INCLUDE CONFIG_LV_PROFILER_INCLUDE
-    #else
-        #define LV_PROFILER_INCLUDE <stdint.h>
+#if LV_USE_PROFILER
+    /*Header to include for the profiler*/
+    #ifndef LV_PROFILER_INCLUDE
+        #ifdef CONFIG_LV_PROFILER_INCLUDE
+            #define LV_PROFILER_INCLUDE CONFIG_LV_PROFILER_INCLUDE
+        #else
+            #define LV_PROFILER_INCLUDE <stdint.h>
+        #endif
     #endif
-#endif
-#ifndef LV_PROFILER_BEGIN
-    #ifdef CONFIG_LV_PROFILER_BEGIN
-        #define LV_PROFILER_BEGIN CONFIG_LV_PROFILER_BEGIN
-    #else
-        #define LV_PROFILER_BEGIN
+
+    /*Profiler start point function*/
+    #ifndef LV_PROFILER_BEGIN
+        #ifdef CONFIG_LV_PROFILER_BEGIN
+            #define LV_PROFILER_BEGIN CONFIG_LV_PROFILER_BEGIN
+        #else
+            #define LV_PROFILER_BEGIN
+        #endif
     #endif
-#endif
-#ifndef LV_PROFILER_END
-    #ifdef CONFIG_LV_PROFILER_END
-        #define LV_PROFILER_END CONFIG_LV_PROFILER_END
-    #else
-        #define LV_PROFILER_END
+
+    /*Profiler end point function*/
+    #ifndef LV_PROFILER_END
+        #ifdef CONFIG_LV_PROFILER_END
+            #define LV_PROFILER_END CONFIG_LV_PROFILER_END
+        #else
+            #define LV_PROFILER_END
+        #endif
     #endif
 #endif
 

--- a/src/misc/lv_profiler.h
+++ b/src/misc/lv_profiler.h
@@ -36,6 +36,11 @@ extern "C" {
  *      MACROS
  **********************/
 
+#else
+
+#define LV_PROFILER_BEGIN
+#define LV_PROFILER_END
+
 #endif /*LV_USE_PROFILER*/
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description of the feature or fix

1. Updated document description.
2. Add LV_USE_PROFILER judgment in lv_conf to ensure that LV_PROFILER_BEGIN/END is invalid when disabled.
3. Add call_flush_cb measurement in lv_refr.
4. Add read point measurement in lv_indev.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
