### PR TITLE
doc(timer): use precise delay description in Timer Handler

### DIFF
--- a/docs/porting/os.rst
+++ b/docs/porting/os.rst
@@ -29,10 +29,11 @@ Here is some pseudocode to illustrate the concept:
    void lvgl_thread(void)
    {
        while(1) {
+           uint32_t time_till_next;
            mutex_lock(&lvgl_mutex);
-           lv_task_handler();
+           time_till_next = lv_task_handler();
            mutex_unlock(&lvgl_mutex);
-           thread_sleep(10); /* sleep for 10 ms */
+           thread_sleep(time_till_next); /* sleep for a while */
        }
    }
 

--- a/docs/porting/timer_handler.rst
+++ b/docs/porting/timer_handler.rst
@@ -11,16 +11,13 @@ periodically in one of the following:
 - timer interrupt periodically (lower priority than :cpp:func:`lv_tick_inc`)
 - an OS task periodically
 
-The timing is not critical but it should be about 5 milliseconds to keep
-the system responsive.
-
 Example:
 
 .. code:: c
 
    while(1) {
-     lv_timer_handler();
-     my_delay_ms(5);
+     uint32_t time_till_next = lv_timer_handler();
+     my_delay_ms(time_till_next);
    }
 
 If you want to use :cpp:func:`lv_timer_handler` in a super-loop, a helper
@@ -30,9 +27,9 @@ the porting:
 .. code:: c
 
    while(1) {
-       ...
-       lv_timer_handler_run_in_period(5); /* run lv_timer_handler() every 5ms */
-       ...
+      ...
+      lv_timer_handler_run_in_period(5); /* run lv_timer_handler() every 5ms */
+      ...
    }
 
 In an OS environment, you can use it together with the **delay** or
@@ -41,8 +38,8 @@ In an OS environment, you can use it together with the **delay** or
 .. code:: c
 
    while (1) {
-       lv_timer_handler_run_in_period(5); /* run lv_timer_handler() every 5ms */
-       my_delay_ms(5);                    /* delay 5ms to avoid unnecessary polling */
+      uint32_t time_till_next = lv_timer_handler(); 
+      os_delay_ms(time_till_next); /* delay to avoid unnecessary polling */
    }
 
 To learn more about timers visit the `Timer </overview/timer>`__


### PR DESCRIPTION
### Description of the feature or fix
`lv_timer_handler` will return an accurate time for the next wake-up from sleep, which can generally improve the time accuracy of `lv_timer` events.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
