### PR TITLE
feat(timer): implementation of adaptive call timer handler cycle method

### DIFF
--- a/docs/porting/timer_handler.rst
+++ b/docs/porting/timer_handler.rst
@@ -35,6 +35,16 @@ the porting:
        ...
    }
 
+Or use the sleep time automatically calculated by LVGL:
+
+.. code:: c
+
+   while(1) {
+     ...
+     lv_timer_periodic_handler();
+     ...
+   }
+
 In an OS environment, you can use it together with the **delay** or
 **sleep** provided by OS to release CPU whenever possible:
 

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -38,7 +38,7 @@ static bool lv_timer_run = false;
 static uint8_t idle_last = 0;
 static bool timer_deleted;
 static bool timer_created;
-static uint32_t timer_time_untill_next;
+static uint32_t timer_time_until_next;
 
 /**********************
  *      MACROS
@@ -123,13 +123,13 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
         }
     } while(LV_GC_ROOT(_lv_timer_act));
 
-    uint32_t time_untill_next = LV_NO_TIMER_READY;
+    uint32_t time_until_next = LV_NO_TIMER_READY;
     next = _lv_ll_get_head(&LV_GC_ROOT(_lv_timer_ll));
     while(next) {
         if(!next->paused) {
             uint32_t delay = lv_timer_time_remaining(next);
-            if(delay < time_untill_next)
-                time_untill_next = delay;
+            if(delay < time_until_next)
+                time_until_next = delay;
         }
 
         next = _lv_ll_get_next(&LV_GC_ROOT(_lv_timer_ll), next); /*Find the next timer*/
@@ -144,19 +144,19 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
         idle_period_start = lv_tick_get();
     }
 
-    timer_time_untill_next = time_untill_next;
+    timer_time_until_next = time_until_next;
     already_running = false; /*Release the mutex*/
 
-    TIMER_TRACE("finished (%" LV_PRIu32 " ms until the next timer call)", time_untill_next);
+    TIMER_TRACE("finished (%" LV_PRIu32 " ms until the next timer call)", time_until_next);
     LV_PROFILER_END;
-    return time_untill_next;
+    return time_until_next;
 }
 
 LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void)
 {
     static uint32_t last_tick = 0;
 
-    if(lv_tick_elaps(last_tick) >= timer_time_untill_next) {
+    if(lv_tick_elaps(last_tick) >= timer_time_until_next) {
         lv_timer_handler();
         last_tick = lv_tick_get();
     }
@@ -303,9 +303,9 @@ uint8_t lv_timer_get_idle(void)
  * Get idle period start tick
  * @return the lv_timer idle period start tick
  */
-uint32_t lv_timer_get_time_untill_next(void)
+uint32_t lv_timer_get_time_until_next(void)
 {
-    return timer_time_untill_next;
+    return timer_time_until_next;
 }
 
 /**
@@ -385,7 +385,7 @@ static uint32_t lv_timer_time_remaining(lv_timer_t * timer)
 static void lv_timer_handler_resume(void)
 {
     /*If there is a timer which is ready to run then resume the timer loop*/
-    if(timer_time_untill_next == LV_NO_TIMER_READY) {
-        timer_time_untill_next = 0;
+    if(timer_time_until_next == LV_NO_TIMER_READY) {
+        timer_time_until_next = 0;
     }
 }

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -157,6 +157,7 @@ LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void)
     static uint32_t last_tick = 0;
 
     if(lv_tick_elaps(last_tick) >= timer_time_until_next) {
+        TIMER_TRACE("calling lv_timer_handler()");
         lv_timer_handler();
         last_tick = lv_tick_get();
     }
@@ -385,7 +386,5 @@ static uint32_t lv_timer_time_remaining(lv_timer_t * timer)
 static void lv_timer_handler_resume(void)
 {
     /*If there is a timer which is ready to run then resume the timer loop*/
-    if(timer_time_until_next == LV_NO_TIMER_READY) {
-        timer_time_until_next = 0;
-    }
+    timer_time_until_next = 0;
 }

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -91,16 +91,7 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period
  * Call it in the super-loop of main() or threads. It will automatically call lv_timer_handler() at the right time.
  * This function is used to simplify the porting.
  */
-static inline LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void)
-{
-    static uint32_t last_tick = 0;
-    static uint32_t time_till_next = 0;
-
-    if(lv_tick_elaps(last_tick) >= time_till_next) {
-        time_till_next = lv_timer_handler();
-        last_tick = lv_tick_get();
-    }
-}
+LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void);
 
 /**
  * Create an "empty" timer. It needs to be initialized with at least

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -70,21 +70,18 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
 //! @endcond
 
 /**
- * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
- * with a given period in ms. You can use it with sleep or delay in OS environment.
+ * Call it in the super-loop of main() or threads. It will automatically call lv_timer_handler() at the right time.
  * This function is used to simplify the porting.
- * @param ms the period for running lv_timer_handler()
  */
-static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period(uint32_t ms)
+static inline LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void)
 {
     static uint32_t last_tick = 0;
-    uint32_t curr_tick = lv_tick_get();
+    static uint32_t time_till_next = 0;
 
-    if((curr_tick - last_tick) >= (ms)) {
-        last_tick = curr_tick;
-        return lv_timer_handler();
+    if(lv_tick_elaps(last_tick) >= time_till_next) {
+        time_till_next = lv_timer_handler();
+        last_tick = lv_tick_get();
     }
-    return 1;
 }
 
 /**

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -70,6 +70,24 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
 //! @endcond
 
 /**
+ * Call it in the super-loop of main() or threads. It will run lv_timer_handler()
+ * with a given period in ms. You can use it with sleep or delay in OS environment.
+ * This function is used to simplify the porting.
+ * @param ms the period for running lv_timer_handler()
+ */
+static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period(uint32_t ms)
+{
+    static uint32_t last_tick = 0;
+    uint32_t curr_tick = lv_tick_get();
+
+    if((curr_tick - last_tick) >= (ms)) {
+        last_tick = curr_tick;
+        return lv_timer_handler();
+    }
+    return 1;
+}
+
+/**
  * Call it in the super-loop of main() or threads. It will automatically call lv_timer_handler() at the right time.
  * This function is used to simplify the porting.
  */

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -175,7 +175,7 @@ uint8_t lv_timer_get_idle(void);
  * Get the time remaining until the next timer will run
  * @return the time remaining in ms
  */
-uint32_t lv_timer_get_time_untill_next(void);
+uint32_t lv_timer_get_time_until_next(void);
 
 /**
  * Iterate through the timers

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -172,6 +172,12 @@ void lv_timer_enable(bool en);
 uint8_t lv_timer_get_idle(void);
 
 /**
+ * Get the time remaining until the next timer will run
+ * @return the time remaining in ms
+ */
+uint32_t lv_timer_get_time_untill_next(void);
+
+/**
  * Iterate through the timers
  * @param timer NULL to start iteration or the previous return value to get the next timer
  * @return the next timer or NULL if there is no more timer


### PR DESCRIPTION
### Description of the feature or fix
The return value of `lv_timer_handler` can be used to automatically calculate the next start time, instead of using a user-specified time. This can reduce rendering and interaction delays.
I suggest renaming it to `lv_timer_periodic_handler`.

What do you think? @GorgonMeducer 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
