### PR TITLE
feat(mem): add memalign API

### DIFF
--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -56,6 +56,7 @@
 #define LV_STDIO_INCLUDE  <stdio.h>
 #define LV_STRING_INCLUDE <string.h>
 #define LV_MALLOC       lv_malloc_builtin
+#define LV_MEMALIGN     lv_memalign_builtin
 #define LV_REALLOC      lv_realloc_builtin
 #define LV_FREE         lv_free_builtin
 #define LV_MEMSET       lv_memset_builtin

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -63,6 +63,7 @@
 #define LV_STDIO_INCLUDE  <stdint.h>
 #define LV_STRING_INCLUDE <stdint.h>
 #define LV_MALLOC       lv_malloc_builtin
+#define LV_MEMALIGN     lv_memalign_builtin
 #define LV_REALLOC      lv_realloc_builtin
 #define LV_FREE         lv_free_builtin
 #define LV_MEMSET       lv_memset_builtin

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -203,6 +203,13 @@
         #define LV_MALLOC       lv_malloc_builtin
     #endif
 #endif
+#ifndef LV_MEMALIGN
+    #ifdef CONFIG_LV_MEMALIGN
+        #define LV_MEMALIGN CONFIG_LV_MEMALIGN
+    #else
+        #define LV_MEMALIGN     lv_memalign_builtin
+    #endif
+#endif
 #ifndef LV_REALLOC
     #ifdef CONFIG_LV_REALLOC
         #define LV_REALLOC CONFIG_LV_REALLOC

--- a/src/misc/lv_malloc_builtin.c
+++ b/src/misc/lv_malloc_builtin.c
@@ -164,6 +164,13 @@ void * lv_malloc_builtin(size_t size)
     return lv_tlsf_malloc(tlsf, size);
 }
 
+void * lv_memalign_builtin(size_t align, size_t size)
+{
+    cur_used += size;
+    max_used = LV_MAX(cur_used, max_used);
+    return lv_tlsf_memalign(tlsf, align, size);
+}
+
 void * lv_realloc_builtin(void * p, size_t new_size)
 {
     return lv_tlsf_realloc(tlsf, p, new_size);

--- a/src/misc/lv_malloc_builtin.h
+++ b/src/misc/lv_malloc_builtin.h
@@ -55,6 +55,7 @@ lv_mem_builtin_pool_t lv_mem_builtin_add_pool(void * mem, size_t bytes);
 void lv_mem_builtin_remove_pool(lv_mem_builtin_pool_t pool);
 
 void * lv_malloc_builtin(size_t size);
+void * lv_memalign_builtin(size_t align, size_t size);
 void * lv_realloc_builtin(void * p, size_t new_size);
 void lv_free_builtin(void * p);
 

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -39,6 +39,9 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+    static void lv_mem_dump_info(void);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -75,11 +78,40 @@ void * lv_malloc(size_t size)
     if(alloc == NULL) {
         LV_LOG_INFO("couldn't allocate memory (%lu bytes)", (unsigned long)size);
 #if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
-        lv_mem_monitor_t mon;
-        lv_mem_monitor(&mon);
-        LV_LOG_INFO("used: %6d (%3d %%), frag: %3d %%, biggest free: %6d",
-                    (int)(mon.total_size - mon.free_size), mon.used_pct, mon.frag_pct,
-                    (int)mon.free_biggest_size);
+        lv_mem_dump_info();
+        return NULL;
+#endif
+    }
+
+#if LV_MEM_ADD_JUNK
+    lv_memset(alloc, 0xaa, size);
+#endif
+
+    MEM_TRACE("allocated at %p", alloc);
+
+    return alloc;
+}
+
+/**
+ * Allocate a block of memory with a specified alignment.
+ * @param align The desired alignment of the memory block.
+ * @param size The size of the memory block to allocate.
+ * @return A pointer to the allocated memory block, or NULL if the allocation failed.
+ */
+void * lv_memalign(size_t align, size_t size)
+{
+    MEM_TRACE("align(%lu) allocating %lu bytes", (unsigned long)align, (unsigned long)size);
+    if(size == 0) {
+        MEM_TRACE("using zero_mem");
+        return &zero_mem;
+    }
+
+    void * alloc = LV_MEMALIGN(align, size);
+
+    if(alloc == NULL) {
+        LV_LOG_INFO("couldn't allocate memory (%lu bytes)", (unsigned long)size);
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+        lv_mem_dump_info();
         return NULL;
 #endif
     }
@@ -185,3 +217,14 @@ void lv_mem_monitor(lv_mem_monitor_t * mon_p)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+static void lv_mem_dump_info(void)
+{
+    lv_mem_monitor_t mon;
+    lv_mem_monitor(&mon);
+    LV_LOG_INFO("used: %6d (%3d %%), frag: %3d %%, biggest free: %6d",
+                (int)(mon.total_size - mon.free_size), mon.used_pct, mon.frag_pct,
+                (int)mon.free_biggest_size);
+}
+#endif

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -55,6 +55,14 @@ typedef struct {
 void * lv_malloc(size_t size);
 
 /**
+ * Allocate a block of memory with a specified alignment.
+ * @param align The desired alignment of the memory block.
+ * @param size The size of the memory block to allocate.
+ * @return A pointer to the allocated memory block, or NULL if the allocation failed.
+ */
+void * lv_memalign(size_t align, size_t size);
+
+/**
  * Free an allocated data
  * @param data pointer to an allocated memory
  */

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -23,6 +23,7 @@ extern "C" {
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_STDLIB_INCLUDE <stdlib.h>
 #define LV_MALLOC       lv_test_malloc
+#define LV_MEMALIGN     lv_test_memalign
 #define LV_REALLOC      lv_test_realloc
 #define LV_FREE         lv_test_free
 #define LV_MEMSET       memset
@@ -34,6 +35,7 @@ extern "C" {
 #define LV_USE_BUILTIN_MEMCPY   1
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_MALLOC       lv_test_malloc
+#define LV_MEMALIGN     lv_test_memalign
 #define LV_REALLOC      lv_test_realloc
 #define LV_FREE         lv_test_free
 #define LV_MEMSET       lv_memset_builtin
@@ -47,6 +49,7 @@ extern "C" {
 #define LV_USE_BUILTIN_SNPRINTF 1
 #define LV_STDLIB_INCLUDE "include/lv_mp_mem_custom_include.h"
 #define LV_MALLOC       m_malloc
+#define LV_MEMALIGN     m_memalign
 #define LV_REALLOC      m_realloc
 #define LV_FREE         m_free
 #define LV_MEMSET       lv_memset_builtin

--- a/tests/src/lv_test_malloc.c
+++ b/tests/src/lv_test_malloc.c
@@ -5,12 +5,14 @@
 #endif
 
 static lv_malloc_stub_cb malloc_stub_cb;
+static lv_memalign_stub_cb memalign_stub_cb;
 static lv_realloc_stub_cb realloc_stub_cb;
 static lv_free_stub_cb free_stub_cb;
 
 void lv_test_malloc_init(void)
 {
     malloc_stub_cb = NULL;
+    memalign_stub_cb = NULL;
     realloc_stub_cb = NULL;
     free_stub_cb = NULL;
 }
@@ -29,6 +31,15 @@ void * lv_test_malloc_normal(size_t size)
 #endif
 }
 
+void * lv_test_memalign_normal(size_t align, size_t size)
+{
+#ifdef LVGL_CI_USING_SYS_HEAP
+    return memalign(align, size);
+#else // LVGL_CI_USING_DEF_HEAP and others
+    return lv_memalign_builtin(align, size);
+#endif
+}
+
 void * lv_test_realloc_normal(void * p, size_t new_size)
 {
 #ifdef LVGL_CI_USING_SYS_HEAP
@@ -42,6 +53,17 @@ void * lv_test_malloc(size_t s)
 {
     if(malloc_stub_cb) return malloc_stub_cb(s);
     else return lv_test_malloc_normal(s);
+}
+
+void lv_test_memalign_set_cb(lv_memalign_stub_cb stub_memalign)
+{
+    memalign_stub_cb = stub_memalign;
+}
+
+void * lv_test_memalign(size_t align, size_t size)
+{
+    if(memalign_stub_cb) return memalign_stub_cb(align, size);
+    else return lv_test_memalign_normal(align, size);
 }
 
 void lv_test_realloc_set_cb(lv_realloc_stub_cb stub_realloc)

--- a/tests/src/lv_test_malloc.h
+++ b/tests/src/lv_test_malloc.h
@@ -4,12 +4,16 @@
 #include <stdlib.h>
 
 typedef void * (* lv_malloc_stub_cb)(size_t);
+typedef void * (* lv_memalign_stub_cb)(size_t align, size_t size);
 typedef void * (* lv_realloc_stub_cb)(void * p, size_t new_size);
 typedef void (* lv_free_stub_cb)(void * p);
 
 void lv_test_malloc_init(void);
 void lv_test_malloc_set_cb(lv_malloc_stub_cb stub_malloc);
 void * lv_test_malloc(size_t s);
+
+void lv_test_memalign_set_cb(lv_memalign_stub_cb stub_memalign);
+void * lv_test_memalign(size_t align, size_t size);
 
 void lv_test_realloc_set_cb(lv_realloc_stub_cb stub_realloc);
 void * lv_test_realloc(void * p, size_t new_size);


### PR DESCRIPTION
### Description of the feature or fix

Supplement `memalign` memory allocation API.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
