### PR TITLE
refactor: replace codes with `lv_area_increase`

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -571,10 +571,7 @@ static void lv_obj_draw(lv_event_t * e)
         lv_coord_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
         lv_area_t coords;
         lv_area_copy(&coords, &obj->coords);
-        coords.x1 -= w;
-        coords.x2 += w;
-        coords.y1 -= h;
-        coords.y2 += h;
+        lv_area_increase(&coords, w, h);
 
         if(_lv_area_is_in(info->area, &coords, r) == false) {
             info->res = LV_COVER_RES_NOT_COVER;
@@ -603,10 +600,7 @@ static void lv_obj_draw(lv_event_t * e)
         lv_coord_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
         lv_area_t coords;
         lv_area_copy(&coords, &obj->coords);
-        coords.x1 -= w;
-        coords.x2 += w;
-        coords.y1 -= h;
-        coords.y2 += h;
+        lv_area_increase(&coords, w, h);
 
         lv_obj_draw_part_dsc_t part_dsc;
         lv_obj_draw_dsc_init(&part_dsc, draw_ctx);
@@ -677,10 +671,7 @@ static void lv_obj_draw(lv_event_t * e)
             lv_coord_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
             lv_area_t coords;
             lv_area_copy(&coords, &obj->coords);
-            coords.x1 -= w;
-            coords.x2 += w;
-            coords.y1 -= h;
-            coords.y2 += h;
+            lv_area_increase(&coords, w, h);
 
             lv_obj_draw_part_dsc_t part_dsc;
             lv_obj_draw_dsc_init(&part_dsc, draw_ctx);

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -924,10 +924,7 @@ void lv_obj_get_click_area(const lv_obj_t * obj, lv_area_t * area)
 {
     lv_area_copy(area, &obj->coords);
     if(obj->spec_attr) {
-        area->x1 -= obj->spec_attr->ext_click_pad;
-        area->x2 += obj->spec_attr->ext_click_pad;
-        area->y1 -= obj->spec_attr->ext_click_pad;
-        area->y2 += obj->spec_attr->ext_click_pad;
+        lv_area_increase(area, obj->spec_attr->ext_click_pad, obj->spec_attr->ext_click_pad);
     }
 }
 

--- a/src/draw/sdl/lv_draw_sdl_rect.c
+++ b/src/draw/sdl/lv_draw_sdl_rect.c
@@ -504,11 +504,7 @@ static void draw_outline(lv_draw_sdl_ctx_t * ctx, const lv_area_t * coords, cons
 
     lv_area_t area_outer;
     lv_area_copy(&area_outer, &area_inner);
-
-    area_outer.x1 -= dsc->outline_width;
-    area_outer.x2 += dsc->outline_width;
-    area_outer.y1 -= dsc->outline_width;
-    area_outer.y2 += dsc->outline_width;
+    lv_area_increase(&area_outer, dsc->outline_width, dsc->outline_width);
 
     lv_area_t draw_area;
     if(!_lv_area_intersect(&draw_area, &area_outer, clip)) return;

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -1124,12 +1124,7 @@ static void draw_outline(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * ds
 
     lv_area_t area_outer;
     lv_area_copy(&area_outer, &area_inner);
-
-    area_outer.x1 -= dsc->outline_width;
-    area_outer.x2 += dsc->outline_width;
-    area_outer.y1 -= dsc->outline_width;
-    area_outer.y2 += dsc->outline_width;
-
+    lv_area_increase(&area_outer, dsc->outline_width, dsc->outline_width);
 
     int32_t inner_w = lv_area_get_width(&area_inner);
     int32_t inner_h = lv_area_get_height(&area_inner);

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -257,10 +257,7 @@ static void draw_indic(lv_event_t * e)
 
     lv_coord_t transf_w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
     lv_coord_t transf_h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
-    bar_coords.x1 -= transf_w;
-    bar_coords.x2 += transf_w;
-    bar_coords.y1 -= transf_h;
-    bar_coords.y2 += transf_h;
+    lv_area_increase(&bar_coords, transf_w, transf_h);
     lv_coord_t barw = lv_area_get_width(&bar_coords);
     lv_coord_t barh = lv_area_get_height(&bar_coords);
     int32_t range = bar->max_value - bar->min_value;

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -232,10 +232,7 @@ static void lv_checkbox_draw(lv_event_t * e)
 
     lv_area_t marker_area_transf;
     lv_area_copy(&marker_area_transf, &marker_area);
-    marker_area_transf.x1 -= transf_w;
-    marker_area_transf.x2 += transf_w;
-    marker_area_transf.y1 -= transf_h;
-    marker_area_transf.y2 += transf_h;
+    lv_area_increase(&marker_area_transf, transf_w, transf_h);
 
     lv_obj_draw_part_dsc_t part_draw_dsc;
     lv_obj_draw_dsc_init(&part_draw_dsc, draw_ctx);

--- a/src/widgets/imgbtn/lv_imgbtn.c
+++ b/src/widgets/imgbtn/lv_imgbtn.c
@@ -221,10 +221,7 @@ static void draw_main(lv_event_t * e)
     lv_coord_t th = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
     lv_area_t coords;
     lv_area_copy(&coords, &obj->coords);
-    coords.x1 -= tw;
-    coords.x2 += tw;
-    coords.y1 -= th;
-    coords.y2 += th;
+    lv_area_increase(&coords, tw, th);
 
     lv_draw_img_dsc_t img_dsc;
     lv_draw_img_dsc_init(&img_dsc);


### PR DESCRIPTION
### Description of the feature or fix

replace codes with `lv_area_increase`

like:

```diff
- coords.x1 -= w;
- coords.x2 += w;
- coords.y1 -= h;
- coords.y2 += h;
+ lv_area_increase(&coords, w, h);
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
