### PR TITLE
chore: change `anlge` and `zoom` to `lv_coord`

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -1137,8 +1137,8 @@ static void layout_update_core(lv_obj_t * obj)
 
 static void transform_point(const lv_obj_t * obj, lv_point_t * p, bool inv)
 {
-    int16_t angle = lv_obj_get_style_transform_angle(obj, 0);
-    int16_t zoom = lv_obj_get_style_transform_zoom_safe(obj, 0);
+    lv_coord_t angle = lv_obj_get_style_transform_angle(obj, 0);
+    lv_coord_t zoom = lv_obj_get_style_transform_zoom_safe(obj, 0);
 
     if(angle == 0 && zoom == LV_ZOOM_NONE) return;
 

--- a/src/draw/lv_draw_img.h
+++ b/src/draw/lv_draw_img.h
@@ -38,9 +38,8 @@ typedef struct {
 } lv_draw_img_sup_t;
 
 typedef struct {
-
-    int16_t angle;
-    uint16_t zoom;
+    lv_coord_t angle;
+    lv_coord_t zoom;
     lv_point_t pivot;
 
     lv_color_t chroma_key_color;

--- a/src/draw/lv_img_buf.c
+++ b/src/draw/lv_img_buf.c
@@ -58,7 +58,7 @@ void lv_img_buf_free(lv_img_dsc_t * dsc)
     }
 }
 
-void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, int16_t angle, uint16_t zoom,
+void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, lv_coord_t angle, uint16_t zoom,
                                       const lv_point_t * pivot)
 {
 #if LV_USE_DRAW_MASKS

--- a/src/draw/lv_img_buf.h
+++ b/src/draw/lv_img_buf.h
@@ -113,7 +113,7 @@ void lv_img_buf_free(lv_img_dsc_t * dsc);
  * @param zoom zoom, (256 no zoom)
  * @param pivot x,y pivot coordinates of rotation
  */
-void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, int16_t angle, uint16_t zoom,
+void _lv_img_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, lv_coord_t angle, uint16_t zoom,
                                       const lv_point_t * pivot);
 
 /**********************

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -191,7 +191,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_c
             /*Blend*/
             lv_draw_sw_blend(draw_ctx, &blend_dsc);
 
-            /*Go the the next lines*/
+            /*Go to the next lines*/
             blend_area.y1 = blend_area.y2 + 1;
             blend_area.y2 = blend_area.y1 + buf_h - 1;
             if(blend_area.y2 > y_last) blend_area.y2 = y_last;

--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -327,7 +327,7 @@ lv_coord_t lv_img_get_offset_y(lv_obj_t * obj)
     return img->offset.y;
 }
 
-uint16_t lv_img_get_angle(lv_obj_t * obj)
+lv_coord_t lv_img_get_angle(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -345,7 +345,7 @@ void lv_img_get_pivot(lv_obj_t * obj, lv_point_t * pivot)
     *pivot = img->pivot;
 }
 
-uint16_t lv_img_get_zoom(lv_obj_t * obj)
+lv_coord_t lv_img_get_zoom(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -386,13 +386,13 @@ static void lv_img_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     img->cf        = LV_COLOR_FORMAT_UNKNOWN;
     img->w         = lv_obj_get_width(obj);
     img->h         = lv_obj_get_height(obj);
-    img->angle = 0;
-    img->zoom = LV_ZOOM_NONE;
+    img->angle     = 0;
+    img->zoom      = LV_ZOOM_NONE;
     img->antialias = LV_COLOR_DEPTH > 8 ? 1 : 0;
     img->offset.x  = 0;
     img->offset.y  = 0;
-    img->pivot.x = 0;
-    img->pivot.y = 0;
+    img->pivot.x   = 0;
+    img->pivot.y   = 0;
     img->obj_size_mode = LV_IMG_SIZE_MODE_VIRTUAL;
 
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICKABLE);

--- a/src/widgets/img/lv_img.h
+++ b/src/widgets/img/lv_img.h
@@ -43,9 +43,9 @@ typedef struct {
     lv_point_t offset;
     lv_coord_t w;          /*Width of the image (Handled by the library)*/
     lv_coord_t h;          /*Height of the image (Handled by the library)*/
-    uint16_t angle;    /*rotation angle of the image*/
+    lv_coord_t angle;    /*rotation angle of the image*/
     lv_point_t pivot;     /*rotation center of the image*/
-    uint16_t zoom;         /*256 means no zoom, 512 double size, 128 half size*/
+    lv_coord_t zoom;         /*256 means no zoom, 512 double size, 128 half size*/
     uint8_t src_type : 2;  /*See: lv_img_src_t*/
     uint8_t cf : 5;        /*Color format from `lv_color_format_t`*/
     uint8_t antialias : 1; /*Apply anti-aliasing in transformations (rotate, zoom)*/
@@ -192,7 +192,7 @@ lv_coord_t lv_img_get_offset_y(lv_obj_t * obj);
  * @param obj       pointer to an image object
  * @return      rotation angle in 0.1 degrees (0..3600)
  */
-uint16_t lv_img_get_angle(lv_obj_t * obj);
+lv_coord_t lv_img_get_angle(lv_obj_t * obj);
 
 /**
  * Get the pivot (rotation center) of the image.
@@ -206,7 +206,7 @@ void lv_img_get_pivot(lv_obj_t * obj, lv_point_t * pivot);
  * @param obj       pointer to an image object
  * @return          zoom factor (256: no zoom)
  */
-uint16_t lv_img_get_zoom(lv_obj_t * obj);
+lv_coord_t lv_img_get_zoom(lv_obj_t * obj);
 
 /**
  * Get whether the transformations (rotate, zoom) are anti-aliased or not


### PR DESCRIPTION
### Description of the feature or fix

My IDE always gives me this type's conversion warnings

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
