### PR TITLE
fix(fbdev): Automatically set DPI based on device info

### DIFF
--- a/src/dev/disp/fb/lv_linux_fbdev.c
+++ b/src/dev/disp/fb/lv_linux_fbdev.c
@@ -78,6 +78,10 @@ static void flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t * colo
     #define FBIOBLANK FBIO_BLANK
 #endif /* LV_LINUX_FBDEV_BSD */
 
+#ifndef DIV_ROUND_UP
+    #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+#endif
+
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
@@ -184,13 +188,18 @@ void lv_linux_fbdev_set_file(lv_disp_t * disp, const char * file)
 
     lv_coord_t hor_res = dsc->vinfo.xres;
     lv_coord_t ver_res = dsc->vinfo.yres;
+    lv_coord_t width = dsc->vinfo.width;
+
     uint32_t draw_buf_size = hor_res * ver_res / 4; /*1/4 screen sized buffer has the same performance */
     lv_color_t * draw_buf = malloc(draw_buf_size * sizeof(lv_color_t));
     lv_disp_set_draw_buffers(disp, draw_buf, NULL, draw_buf_size, LV_DISP_RENDER_MODE_PARTIAL);
     lv_disp_set_res(disp, hor_res, ver_res);
 
-    LV_LOG_INFO("Resolution is set to %dx%d", hor_res, ver_res);
+    if(width) {
+        lv_disp_set_dpi(disp, DIV_ROUND_UP(hor_res * 254, width * 10));
+    }
 
+    LV_LOG_INFO("Resolution is set to %dx%d at %ddpi", hor_res, ver_res, lv_disp_get_dpi(disp));
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

The old fbdev driver had a [function](https://github.com/lvgl/lv_drivers/blob/master/display/fbdev.c#L280) to query the framebuffer resolution and DPI and relied on the caller to apply them on the display as needed.

The new fbdev driver applies the resolution automatically in `lv_linux_fbdev_set_file` but it doesn't set the DPI.

This change also applies the DPI as computed from the framebuffer info.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
