### PR TITLE
feat(math): add cubic-bezier function

### DIFF
--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -25,12 +25,16 @@
  *      TYPEDEFS
  **********************/
 
+#define _path_cubic_bezier(a, x1, x2, y1, y2) lv_anim_path_cubic_bezier(a, (x1) * 1024, (y1) * 1024, (x2) * 1024, (y2) * 1024)
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 static void anim_timer(lv_timer_t * param);
 static void anim_mark_list_change(void);
 static void anim_ready_handler(lv_anim_t * a);
+static int32_t lv_anim_path_cubic_bezier(const lv_anim_t * a, int32_t x1,
+                                         int32_t y1, int32_t x2, int32_t y2);
 
 /**********************
  *  STATIC VARIABLES
@@ -221,58 +225,22 @@ int32_t lv_anim_path_linear(const lv_anim_t * a)
 
 int32_t lv_anim_path_ease_in(const lv_anim_t * a)
 {
-    /*Calculate the current step*/
-    uint32_t t = lv_map(a->act_time, 0, a->time, 0, LV_BEZIER_VAL_MAX);
-    int32_t step = lv_bezier3(t, 0, 50, 100, LV_BEZIER_VAL_MAX);
-
-    int32_t new_value;
-    new_value = step * (a->end_value - a->start_value);
-    new_value = new_value >> LV_BEZIER_VAL_SHIFT;
-    new_value += a->start_value;
-
-    return new_value;
+    return _path_cubic_bezier(a, 0.42, 0.0, 1.0, 1.0);
 }
 
 int32_t lv_anim_path_ease_out(const lv_anim_t * a)
 {
-    /*Calculate the current step*/
-    uint32_t t = lv_map(a->act_time, 0, a->time, 0, LV_BEZIER_VAL_MAX);
-    int32_t step = lv_bezier3(t, 0, 900, 950, LV_BEZIER_VAL_MAX);
-
-    int32_t new_value;
-    new_value = step * (a->end_value - a->start_value);
-    new_value = new_value >> LV_BEZIER_VAL_SHIFT;
-    new_value += a->start_value;
-
-    return new_value;
+    return _path_cubic_bezier(a, 0.0, 0.0, 0.58, 1.0);
 }
 
 int32_t lv_anim_path_ease_in_out(const lv_anim_t * a)
 {
-    /*Calculate the current step*/
-    uint32_t t = lv_map(a->act_time, 0, a->time, 0, LV_BEZIER_VAL_MAX);
-    int32_t step = lv_bezier3(t, 0, 50, 952, LV_BEZIER_VAL_MAX);
-
-    int32_t new_value;
-    new_value = step * (a->end_value - a->start_value);
-    new_value = new_value >> LV_BEZIER_VAL_SHIFT;
-    new_value += a->start_value;
-
-    return new_value;
+    return _path_cubic_bezier(a, 0.42, 0.0, 0.58, 1.0);
 }
 
 int32_t lv_anim_path_overshoot(const lv_anim_t * a)
 {
-    /*Calculate the current step*/
-    uint32_t t = lv_map(a->act_time, 0, a->time, 0, LV_BEZIER_VAL_MAX);
-    int32_t step = lv_bezier3(t, 0, 1000, 1300, LV_BEZIER_VAL_MAX);
-
-    int32_t new_value;
-    new_value = step * (a->end_value - a->start_value);
-    new_value = new_value >> LV_BEZIER_VAL_SHIFT;
-    new_value += a->start_value;
-
-    return new_value;
+    return lv_anim_path_cubic_bezier(a, 341, 0, 683, 1300);
 }
 
 int32_t lv_anim_path_bounce(const lv_anim_t * a)
@@ -462,4 +430,18 @@ static void anim_mark_list_change(void)
         lv_timer_pause(_lv_anim_tmr);
     else
         lv_timer_resume(_lv_anim_tmr);
+}
+
+static int32_t lv_anim_path_cubic_bezier(const lv_anim_t * a, int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+    /*Calculate the current step*/
+    uint32_t t = lv_map(a->act_time, 0, a->time, 0, LV_BEZIER_VAL_MAX);
+    int32_t step = lv_cubic_bezier(t, x1, y1, x2, y2);
+
+    int32_t new_value;
+    new_value = step * (a->end_value - a->start_value);
+    new_value = new_value >> LV_BEZIER_VAL_SHIFT;
+    new_value += a->start_value;
+
+    return new_value;
 }

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -16,6 +16,13 @@
  *      TYPEDEFS
  **********************/
 
+#define NEWTON_ITERATIONS       8
+#define CUBIC_PRECISION_BITS    20 /* 10 or 20 bits recommended, int64_t calculation is used for 20bit precision */
+
+#if CUBIC_PRECISION_BITS < 10 || CUBIC_PRECISION_BITS > 20
+    #error "cubic precision bits should be in range of [10, 20] for 32bit/64bit calculations."
+#endif
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -94,6 +101,212 @@ uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t 
     uint32_t v4 = (t3 * u3) >> 10;
 
     return v1 + v2 + v3 + v4;
+}
+
+static float do_cubic_bezier_f(float t, float a, float b, float c)
+{
+    /*a*t^3 + b*t^2 + c*t*/
+    return ((a * t + b) * t + c) * t;
+}
+
+/**
+ * cubic-bezier Reference:
+ *
+ * https://github.com/gre/bezier-easing
+ * https://opensource.apple.com/source/WebCore/WebCore-955.66/platform/graphics/UnitBezier.h
+ *
+ * Copyright (c) 2014 Gaëtan Renaudeau
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
+ * @param x time in range of [0..1]
+ * @param x1 x of control point 1 in range of [0..1]
+ * @param y1 y of control point 1 in range of [0..1]
+ * @param x2 x of control point 2 in range of [0..1]
+ * @param y2 y of control point 2 in range of [0..1]
+ * @return the value calculated
+ */
+float lv_cubic_bezier_f(float x, float x1, float y1, float x2, float y2)
+{
+    float ax, bx, cx, ay, by, cy;
+    float tl, tr, t;  /*t in cubic-bezier function, used for bisection */
+    float xs;  /*x sampled on curve */
+    float d; /*slope value at specified t*/
+
+    if(x == 0 || x == 1) return x;
+
+    cx = 3.f * x1;
+    bx = 3.f * (x2 - x1) - cx;
+    ax = 1.f - cx - bx;
+
+    cy = 3.f * y1;
+    by = 3.f * (y2 - y1) - cy;
+    ay = 1.f - cy - by;
+
+    /*Try Newton's method firstly */
+    t = x; /*Make a guess*/
+    for(int i = 0; i < NEWTON_ITERATIONS; i++) {
+        xs = do_cubic_bezier_f(t, ax, bx, cx);
+        xs -= x;
+        if(LV_ABS(xs) < 1e-6f) goto found;
+
+        d = (3.f * ax * t + 2.f * bx) * t + cx;
+        if(LV_ABS(d) < 1e-6f) break;
+        t -= xs / d;
+    }
+
+    /*Fallback to bisection method for reliability*/
+    tl = 0.f, tr = 1.f, t = x;
+
+    if(t < tl) {
+        t = tl;
+        goto found;
+    }
+
+    if(t > tr) {
+        t = tr;
+        goto found;
+    }
+
+    while(tl < tr) {
+        xs = do_cubic_bezier_f(t, ax, bx, cx);
+        if(LV_ABS(xs - x) < 1e-6f) goto found;
+        x > xs ? (tl = t) : (tr = t);
+        t = (tr - tl) * .5f + tl;
+    }
+
+found:
+    return do_cubic_bezier_f(t, ay, by, cy);
+}
+
+static int32_t do_cubic_bezier(int32_t t, int32_t a, int32_t b, int32_t c)
+{
+    /*a * t^3 + b * t^2 + c * t*/
+#if CUBIC_PRECISION_BITS > 10
+    int64_t ret;
+#else
+    int32_t ret;
+#endif
+
+    ret = a;
+    ret = (ret * t) >> CUBIC_PRECISION_BITS;
+    ret = ((ret + b) * t) >> CUBIC_PRECISION_BITS;
+    ret = ((ret + c) * t) >> CUBIC_PRECISION_BITS;
+    return ret;
+}
+
+/**
+ * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
+ * @param x time in range of [0..1024]
+ * @param x1 x of control point 1 in range of [0..1024]
+ * @param y1 y of control point 1 in range of [0..1024]
+ * @param x2 x of control point 2 in range of [0..1024]
+ * @param y2 y of control point 2 in range of [0..1024]
+ * @return the value calculated
+ */
+int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+    int32_t ax, bx, cx, ay, by, cy;
+    int32_t tl, tr, t;  /*t in cubic-bezier function, used for bisection */
+    int32_t xs;  /*x sampled on curve */
+#if CUBIC_PRECISION_BITS > 10
+    int64_t d; /*slope value at specified t*/
+#else
+    int32_t d;
+#endif
+
+    if(x == 0 || x == 1024) return x;
+
+    /* input is always 10bit precision */
+
+#if CUBIC_PRECISION_BITS != 10
+    x <<= CUBIC_PRECISION_BITS - 10;
+    x1 <<= CUBIC_PRECISION_BITS - 10;
+    x2 <<= CUBIC_PRECISION_BITS - 10;
+    y1 <<= CUBIC_PRECISION_BITS - 10;
+    y2 <<= CUBIC_PRECISION_BITS - 10;
+#endif
+
+    cx = 3 * x1;
+    bx = 3 * (x2 - x1) - cx;
+    ax = (1L << CUBIC_PRECISION_BITS) - cx - bx;
+
+    cy = 3 * y1;
+    by = 3 * (y2 - y1) - cy;
+    ay = (1L << CUBIC_PRECISION_BITS)  - cy - by;
+
+    /*Try Newton's method firstly */
+    t = x; /*Make a guess*/
+    for(int i = 0; i < NEWTON_ITERATIONS; i++) {
+        /*Check if x on curve at t matches input x*/
+        xs = do_cubic_bezier(t, ax, bx, cx) - x;
+        if(LV_ABS(xs) <= 1) goto found;
+
+        /* get slop at t, d = 3 * ax * t^2 + 2 * bx + t + cx */
+        d = ax; /* use 64bit operation if needed. */
+        d = (3 * d * t) >> CUBIC_PRECISION_BITS;
+        d = ((d + 2 * bx) * t) >> CUBIC_PRECISION_BITS;
+        d += cx;
+
+        if(LV_ABS(d) <= 1) break;
+
+        d = ((int64_t)xs * (1L << CUBIC_PRECISION_BITS)) / d;
+        if(d == 0) break;  /*Reached precision limits*/
+        t -= d;
+    }
+
+    /*Fallback to bisection method for reliability*/
+    tl = 0, tr = 1L << CUBIC_PRECISION_BITS, t = x;
+
+    if(t < tl) {
+        t = tl;
+        goto found;
+    }
+
+    if(t > tr) {
+        t = tr;
+        goto found;
+    }
+
+    while(tl < tr) {
+        xs = do_cubic_bezier(t, ax, bx, cx);
+        if(LV_ABS(xs - x) <= 1) goto found;
+        x > xs ? (tl = t) : (tr = t);
+        t = (tr - tl) / 2 + tl;
+        if(t == tl) break;
+    }
+
+    /*Failed to find suitable t for given x, return a value anyway.*/
+found:
+    /*Return y at t*/
+#if CUBIC_PRECISION_BITS != 10
+    return do_cubic_bezier(t, ay, by, cy) >> (CUBIC_PRECISION_BITS - 10);
+#else
+    return do_cubic_bezier(t, ay, by, cy);
+#endif
 }
 
 /**

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -79,31 +79,6 @@ LV_ATTRIBUTE_FAST_MEM int32_t lv_trigo_sin(int16_t angle)
 }
 
 /**
- * Calculate a value of a Cubic Bezier function.
- * @param t time in range of [0..LV_BEZIER_VAL_MAX]
- * @param u0 start values in range of [0..LV_BEZIER_VAL_MAX]
- * @param u1 control value 1 values in range of [0..LV_BEZIER_VAL_MAX]
- * @param u2 control value 2 in range of [0..LV_BEZIER_VAL_MAX]
- * @param u3 end values in range of [0..LV_BEZIER_VAL_MAX]
- * @return the value calculated from the given parameters in range of [0..LV_BEZIER_VAL_MAX]
- */
-uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3)
-{
-    uint32_t t_rem  = 1024 - t;
-    uint32_t t_rem2 = (t_rem * t_rem) >> 10;
-    uint32_t t_rem3 = (t_rem2 * t_rem) >> 10;
-    uint32_t t2     = (t * t) >> 10;
-    uint32_t t3     = (t2 * t) >> 10;
-
-    uint32_t v1 = (t_rem3 * u0) >> 10;
-    uint32_t v2 = (3 * t_rem2 * t * u1) >> 20;
-    uint32_t v3 = (3 * t_rem * t2 * u2) >> 20;
-    uint32_t v4 = (t3 * u3) >> 10;
-
-    return v1 + v2 + v3 + v4;
-}
-
-/**
  * cubic-bezier Reference:
  *
  * https://github.com/gre/bezier-easing
@@ -152,11 +127,11 @@ static int32_t do_cubic_bezier(int32_t t, int32_t a, int32_t b, int32_t c)
 
 /**
  * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
- * @param x time in range of [0..1024]
- * @param x1 x of control point 1 in range of [0..1024]
- * @param y1 y of control point 1 in range of [0..1024]
- * @param x2 x of control point 2 in range of [0..1024]
- * @param y2 y of control point 2 in range of [0..1024]
+ * @param x time in range of [0..LV_BEZIER_VAL_MAX]
+ * @param x1 x of control point 1 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param y1 y of control point 1 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param x2 x of control point 2 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param y2 y of control point 2 in range of [0..LV_BEZIER_VAL_MAX]
  * @return the value calculated
  */
 int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y2)
@@ -170,16 +145,16 @@ int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y
     int32_t d;
 #endif
 
-    if(x == 0 || x == 1024) return x;
+    if(x == 0 || x == LV_BEZIER_VAL_MAX) return x;
 
-    /* input is always 10bit precision */
+    /* input is always LV_BEZIER_VAL_SHIFT bit precision */
 
-#if CUBIC_PRECISION_BITS != 10
-    x <<= CUBIC_PRECISION_BITS - 10;
-    x1 <<= CUBIC_PRECISION_BITS - 10;
-    x2 <<= CUBIC_PRECISION_BITS - 10;
-    y1 <<= CUBIC_PRECISION_BITS - 10;
-    y2 <<= CUBIC_PRECISION_BITS - 10;
+#if CUBIC_PRECISION_BITS != LV_BEZIER_VAL_SHIFT
+    x <<= CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT;
+    x1 <<= CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT;
+    x2 <<= CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT;
+    y1 <<= CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT;
+    y2 <<= CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT;
 #endif
 
     cx = 3 * x1;
@@ -234,8 +209,8 @@ int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y
     /*Failed to find suitable t for given x, return a value anyway.*/
 found:
     /*Return y at t*/
-#if CUBIC_PRECISION_BITS != 10
-    return do_cubic_bezier(t, ay, by, cy) >> (CUBIC_PRECISION_BITS - 10);
+#if CUBIC_PRECISION_BITS != LV_BEZIER_VAL_SHIFT
+    return do_cubic_bezier(t, ay, by, cy) >> (CUBIC_PRECISION_BITS - LV_BEZIER_VAL_SHIFT);
 #else
     return do_cubic_bezier(t, ay, by, cy);
 #endif

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -76,17 +76,6 @@ uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t 
 int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y2);
 
 /**
- * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
- * @param x time in range of [0..1]
- * @param x1 x of control point 1 in range of [0..1]
- * @param y1 y of control point 1 in range of [0..1]
- * @param x2 x of control point 2 in range of [0..1]
- * @param y2 y of control point 2 in range of [0..1]
- * @return the value calculated
- */
-float lv_cubic_bezier_f(float x, float x1, float y1, float x2, float y2);
-
-/**
  * Calculate the atan2 of a vector.
  * @param x
  * @param y

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -22,8 +22,19 @@ extern "C" {
 #define LV_TRIGO_SIN_MAX 32767
 #define LV_TRIGO_SHIFT 15 /**<  >> LV_TRIGO_SHIFT to normalize*/
 
-#define LV_BEZIER_VAL_MAX 1024 /**< Max time in Bezier functions (not [0..1] to use integers)*/
 #define LV_BEZIER_VAL_SHIFT 10 /**< log2(LV_BEZIER_VAL_MAX): used to normalize up scaled values*/
+#define LV_BEZIER_VAL_MAX (1L << LV_BEZIER_VAL_SHIFT) /**< Max time in Bezier functions (not [0..1] to use integers)*/
+
+/**
+ * Calculate a value of a Cubic Bezier function.
+ * @param t time in range of [0..LV_BEZIER_VAL_MAX]
+ * @param u0 must be 0
+ * @param u1 control value 1 values in range of [0..LV_BEZIER_VAL_MAX]
+ * @param u2 control value 2 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param u3 must be LV_BEZIER_VAL_MAX
+ * @return the value calculated from the given parameters in range of [0..LV_BEZIER_VAL_MAX]
+ */
+#define lv_bezier3(t, u0, u1, u2, u3) lv_cubic_bezier(t, 341, u1, 683, u2)
 
 /**********************
  *      TYPEDEFS
@@ -54,23 +65,12 @@ static inline LV_ATTRIBUTE_FAST_MEM int32_t lv_trigo_cos(int16_t angle)
 //! @endcond
 
 /**
- * Calculate a value of a Cubic Bezier function.
- * @param t time in range of [0..LV_BEZIER_VAL_MAX]
- * @param u0 start values in range of [0..LV_BEZIER_VAL_MAX]
- * @param u1 control value 1 values in range of [0..LV_BEZIER_VAL_MAX]
- * @param u2 control value 2 in range of [0..LV_BEZIER_VAL_MAX]
- * @param u3 end values in range of [0..LV_BEZIER_VAL_MAX]
- * @return the value calculated from the given parameters in range of [0..LV_BEZIER_VAL_MAX]
- */
-uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3);
-
-/**
  * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
- * @param x time in range of [0..1024]
- * @param x1 x of control point 1 in range of [0..1024]
- * @param y1 y of control point 1 in range of [0..1024]
- * @param x2 x of control point 2 in range of [0..1024]
- * @param y2 y of control point 2 in range of [0..1024]
+ * @param x time in range of [0..LV_BEZIER_VAL_MAX]
+ * @param x1 x of control point 1 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param y1 y of control point 1 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param x2 x of control point 2 in range of [0..LV_BEZIER_VAL_MAX]
+ * @param y2 y of control point 2 in range of [0..LV_BEZIER_VAL_MAX]
  * @return the value calculated
  */
 int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y2);

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -65,6 +65,28 @@ static inline LV_ATTRIBUTE_FAST_MEM int32_t lv_trigo_cos(int16_t angle)
 uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3);
 
 /**
+ * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
+ * @param x time in range of [0..1024]
+ * @param x1 x of control point 1 in range of [0..1024]
+ * @param y1 y of control point 1 in range of [0..1024]
+ * @param x2 x of control point 2 in range of [0..1024]
+ * @param y2 y of control point 2 in range of [0..1024]
+ * @return the value calculated
+ */
+int32_t lv_cubic_bezier(int32_t x, int32_t x1, int32_t y1, int32_t x2, int32_t y2);
+
+/**
+ * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
+ * @param x time in range of [0..1]
+ * @param x1 x of control point 1 in range of [0..1]
+ * @param y1 y of control point 1 in range of [0..1]
+ * @param x2 x of control point 2 in range of [0..1]
+ * @param y2 y of control point 2 in range of [0..1]
+ * @return the value calculated
+ */
+float lv_cubic_bezier_f(float x, float x1, float y1, float x2, float y2);
+
+/**
  * Calculate the atan2 of a vector.
  * @param x
  * @param y

--- a/tests/src/test_cases/test_math.c
+++ b/tests/src/test_cases/test_math.c
@@ -1,0 +1,37 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+void test_math_cubic_bezier_result_should_be_precise(void)
+{
+    int32_t x, x1, y1, x2, y2, y;
+    int i = 0;
+    while(i++ < 10000) {
+        x1 = lv_rand(0, 1024);
+        x2 = lv_rand(0, 1024);
+        y1 = lv_rand(0, 1024);
+        y2 = lv_rand(0, 1024);
+        float fx1 = x1 / 1024.f;
+        float fx2 = x2 / 1024.f;
+        float fy1 = y1 / 1024.f;
+        float fy2 = y2 / 1024.f;
+        float fx, fy;
+
+        int j = 0;
+        while(j++ < 100000) {
+            x = lv_rand(0, 1024);
+            y = lv_cubic_bezier(x, x1, y1, x2, y2);
+            fx = x / 1024.f;
+            fy = lv_cubic_bezier_f(fx, fx1, fy1, fx2, fy2);
+#if 1
+            if (LV_ABS(fy * 1024 - y) > 250) {
+                printf("x, x1, y1, x2, y2: %d,%d,%d,%d,%d\n", (int)x, (int)x1, (int)y1, (int)x2, (int)y2);
+            }
+#endif
+            TEST_ASSERT_LESS_OR_EQUAL(250, LV_ABS(fy * 1024 - y));
+        }
+    }
+}
+
+#endif

--- a/tests/src/test_cases/test_math.c
+++ b/tests/src/test_cases/test_math.c
@@ -3,35 +3,113 @@
 
 #include "unity/unity.h"
 
-void test_math_cubic_bezier_result_should_be_precise(void)
-{
-    int32_t x, x1, y1, x2, y2, y;
-    int i = 0;
-    while(i++ < 10000) {
-        x1 = lv_rand(0, 1024);
-        x2 = lv_rand(0, 1024);
-        y1 = lv_rand(0, 1024);
-        y2 = lv_rand(0, 1024);
-        float fx1 = x1 / 1024.f;
-        float fx2 = x2 / 1024.f;
-        float fy1 = y1 / 1024.f;
-        float fy2 = y2 / 1024.f;
-        float fx, fy;
+#define ERROR_THRESHOLD         5 /*5 in 1024, 0.5% max error allowed*/
+#define NEWTON_ITERATIONS       8
 
-        int j = 0;
-        while(j++ < 100000) {
-            x = lv_rand(0, 1024);
-            y = lv_cubic_bezier(x, x1, y1, x2, y2);
-            fx = x / 1024.f;
-            fy = lv_cubic_bezier_f(fx, fx1, fy1, fx2, fy2);
-#if 1
-            if (LV_ABS(fy * 1024 - y) > 250) {
-                printf("x, x1, y1, x2, y2: %d,%d,%d,%d,%d\n", (int)x, (int)x1, (int)y1, (int)x2, (int)y2);
-            }
-#endif
-            TEST_ASSERT_LESS_OR_EQUAL(250, LV_ABS(fy * 1024 - y));
+static float do_cubic_bezier_f(float t, float a, float b, float c)
+{
+    /*a*t^3 + b*t^2 + c*t*/
+    return ((a * t + b) * t + c) * t;
+}
+
+/**
+ * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
+ * @param x time in range of [0..1]
+ * @param x1 x of control point 1 in range of [0..1]
+ * @param y1 y of control point 1 in range of [0..1]
+ * @param x2 x of control point 2 in range of [0..1]
+ * @param y2 y of control point 2 in range of [0..1]
+ * @return the value calculated
+ */
+static float lv_cubic_bezier_f(float x, float x1, float y1, float x2, float y2)
+{
+    float ax, bx, cx, ay, by, cy;
+    float tl, tr, t;  /*t in cubic-bezier function, used for bisection */
+    float xs;  /*x sampled on curve */
+    float d; /*slope value at specified t*/
+
+    if(x == 0 || x == 1) return x;
+
+    cx = 3.f * x1;
+    bx = 3.f * (x2 - x1) - cx;
+    ax = 1.f - cx - bx;
+
+    cy = 3.f * y1;
+    by = 3.f * (y2 - y1) - cy;
+    ay = 1.f - cy - by;
+
+    /*Try Newton's method firstly */
+    t = x; /*Make a guess*/
+    for(int i = 0; i < NEWTON_ITERATIONS; i++) {
+        xs = do_cubic_bezier_f(t, ax, bx, cx);
+        xs -= x;
+        if(LV_ABS(xs) < 1e-6f) goto found;
+
+        d = (3.f * ax * t + 2.f * bx) * t + cx;
+        if(LV_ABS(d) < 1e-6f) break;
+        t -= xs / d;
+    }
+
+    /*Fallback to bisection method for reliability*/
+    tl = 0.f, tr = 1.f, t = x;
+
+    if(t < tl) {
+        t = tl;
+        goto found;
+    }
+
+    if(t > tr) {
+        t = tr;
+        goto found;
+    }
+
+    while(tl < tr) {
+        xs = do_cubic_bezier_f(t, ax, bx, cx);
+        if(LV_ABS(xs - x) < 1e-6f) goto found;
+        x > xs ? (tl = t) : (tr = t);
+        t = (tr - tl) * .5f + tl;
+    }
+
+found:
+    return do_cubic_bezier_f(t, ay, by, cy);
+}
+
+
+static int test_cubic_bezier_ease_functions(float fx1, float fy1, float fx2, float fy2)
+{
+    int x1, y1, x2, y2, y;
+    float t, t_step, fy;
+
+    t_step = .001f;
+    x1 = fx1 * 1024;
+    y1 = fy1 * 1024;
+    x2 = fx2 * 1024;
+    y2 = fy2 * 1024;
+
+    for(t = 0; t <= 1; t += t_step) {
+        fy = lv_cubic_bezier_f(t, fx1, fy1, fx2, fy2);
+        y = lv_cubic_bezier(t * 1024, x1, y1, x2, y2);
+        if(LV_ABS(fy * 1024 - y) >= ERROR_THRESHOLD) {
+            return 0;
         }
     }
+
+    return 1;
+}
+
+void test_math_cubic_bezier_result_should_be_precise(void)
+{
+    /*ease-in-out function*/
+    TEST_ASSERT_TRUE(test_cubic_bezier_ease_functions(.42, 0, .58, 1));
+
+    /*ease-out function*/
+    TEST_ASSERT_TRUE(test_cubic_bezier_ease_functions(0, 0, .58, 1));
+
+    /*ease-in function*/
+    TEST_ASSERT_TRUE(test_cubic_bezier_ease_functions(.42, 0, 1, 1));
+
+    /*ease function*/
+    TEST_ASSERT_TRUE(test_cubic_bezier_ease_functions(.25, .1, .25, 1));
 }
 
 #endif


### PR DESCRIPTION
### Add basic math support for cubic-bezier

The newly added function is for cubic-bezier function normally used in [css](https://www.cssportal.com/css-cubic-bezier-generator/). 

Discussed here: #4218 
References can be found here:
 - https://opensource.apple.com/source/WebCore/WebCore-955.66/platform/graphics/UnitBezier.h
 - https://github.com/gre/bezier-easing

It has not been integrated with lvgl's animation yet.

This PR firstly needs to discuss whether or not using float calculation instead of fix-point. Below test results on a cortex-m55 MCU shows that float is much faster.

<img width="198" alt="image" src="https://github.com/lvgl/lvgl/assets/25867991/9c3fe4c9-19f8-40b3-a7db-94c5f9d8a460">

Test code:
```c
    int32_t x, x1, y1, x2, y2, y;
    int i = 0;
    while(i++ < 10) {
        x1 = lv_rand(0, 1024);
        x2 = lv_rand(0, 1024);
        y1 = lv_rand(0, 1024);
        y2 = lv_rand(0, 1024);
        double fx1 = x1 / 1024.0;
        double fx2 = x2 / 1024.0;
        double fy1 = y1 / 1024.0;
        double fy2 = y2 / 1024.0;
        double fx, fy;

        int j = 0;
        while(j++ < 10) {
            x = lv_rand(0, 1024);
            uint32_t t_int = lv_tick_get();
            int k = 10000;
            while(k --)
              y = lv_cubic_bezier(x, x1, y1, x2, y2);
            t_int = lv_tick_elaps(t_int);

            fx = x / 1024.0;
            uint32_t t_float = lv_tick_get();
            k = 10000;
            while(k --)
              fy = lv_cubic_bezier_f(fx, fx1, fy1, fx2, fy2);
            t_float = lv_tick_elaps(t_float);

            printf("t_int: %dms, t_float: %dms\n", (int)t_int, (int)t_float);
        }
    }
```



### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
