### PR TITLE
fix(gc) Initialize GC if needed

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -120,6 +120,11 @@ void lv_init(void)
 
     LV_LOG_INFO("begin");
 
+    /*First initialize Garbage Collection if needed*/
+#ifdef LV_GC_INIT
+    LV_GC_INIT();
+#endif
+
     /*Initialize the misc modules*/
 #if LV_USE_BUILTIN_MALLOC
     lv_mem_init_builtin();


### PR DESCRIPTION
As part of the alignment of lv_micropython to Micropython v1.20.0, we need a way to initialize gc.  
We use that initialization code for registering LVGL root pointers with Micropython's gc, even when the LVGL bindings are external Micropython module.

The new macro `LV_GC_INIT` will be defined under lv_bindings_micropython in `lv_conf.h`  
It's important that `LV_GC_INIT` is called first thing in lv_init, before any root pointer is referenced.


Related: 
- https://github.com/lvgl/lv_binding_micropython/issues/272
- https://github.com/lvgl/lv_binding_micropython/pull/242