### PR TITLE
fix(sysmon): increase FPS sampling rate

### DIFF
--- a/src/core/lv_disp_private.h
+++ b/src/core/lv_disp_private.h
@@ -147,8 +147,6 @@ struct _lv_disp_t {
     /*Miscellaneous data*/
     uint32_t last_activity_time;        /**< Last time when there was activity on this display*/
 
-    uint32_t last_render_start_time;
-
     /** OPTIONAL: Called periodically while lvgl waits for operation to be completed.
      * For example flushing or GPU
      * User can execute very simple tasks here or yield the task*/

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -235,9 +235,6 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     LV_PROFILER_BEGIN;
     REFR_TRACE("begin");
 
-    uint32_t start = lv_tick_get();
-
-
     if(tmr) {
         disp_refr = tmr->user_data;
 #if LV_USE_PERF_MONITOR == 0 && LV_USE_MEM_MONITOR == 0
@@ -268,8 +265,6 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     }
 
     lv_disp_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
-
-    disp_refr->last_render_start_time = start;
 
     /*Refresh the screen's layout if required*/
     lv_obj_update_layout(disp_refr->act_scr);
@@ -1089,6 +1084,9 @@ static void call_flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t *
 
     if(disp->draw_ctx->buffer_convert) disp->draw_ctx->buffer_convert(disp->draw_ctx);
 
+    lv_disp_send_event(disp, LV_EVENT_FLUSH_START, &offset_area);
     disp->flush_cb(disp, &offset_area, color_p);
+    lv_disp_send_event(disp, LV_EVENT_FLUSH_FINISH, &offset_area);
+
     LV_PROFILER_END;
 }

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -99,6 +99,8 @@ typedef enum {
     LV_EVENT_RESOLUTION_CHANGED,
     LV_EVENT_REFR_START,
     LV_EVENT_REFR_FINISH,
+    LV_EVENT_FLUSH_START,
+    LV_EVENT_FLUSH_FINISH,
 
     _LV_EVENT_LAST,               /** Number of default events*/
 

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -22,11 +22,14 @@
  *      TYPEDEFS
  **********************/
 typedef struct {
-    lv_disp_t * disp;
     uint32_t    refr_elaps_sum;
     uint32_t    refr_cnt;
+    uint32_t    render_start_time;
     uint32_t    render_elaps_sum;
     uint32_t    render_cnt;
+    uint32_t    flush_start_time;
+    uint32_t    flush_elaps_sum;
+    uint32_t    flush_cnt;
 } perf_info_t;
 
 /**********************
@@ -115,26 +118,33 @@ static void lv_sysmon_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 #if LV_USE_PERF_MONITOR
 
-static void perf_monitor_refr_start_cb(lv_event_t * e)
+static void perf_monitor_disp_event_cb(lv_event_t * e)
 {
+    lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * sysmon = lv_event_get_user_data(e);
     perf_info_t * info = lv_obj_get_user_data(sysmon);
-    info->refr_elaps_sum += lv_tick_elaps(info->disp->last_render_start_time);
-    info->refr_cnt++;
-}
-
-static void perf_monitor_refr_finish_cb(lv_event_t * e)
-{
-    lv_obj_t * sysmon = lv_event_get_user_data(e);
-    perf_info_t * info = lv_obj_get_user_data(sysmon);
-    info->render_elaps_sum += lv_tick_elaps(info->disp->last_render_start_time);
-}
-
-static void perf_monitor_render_start_cb(lv_event_t * e)
-{
-    lv_obj_t * sysmon = lv_event_get_user_data(e);
-    perf_info_t * info = lv_obj_get_user_data(sysmon);
-    info->render_cnt++;
+    switch(code) {
+        case LV_EVENT_REFR_START:
+            info->refr_elaps_sum += lv_tick_elaps(info->render_start_time);
+            info->refr_cnt++;
+            info->render_start_time = lv_tick_get();
+            break;
+        case LV_EVENT_REFR_FINISH:
+            info->render_elaps_sum += lv_tick_elaps(info->render_start_time);
+            break;
+        case LV_EVENT_RENDER_START:
+            info->render_cnt++;
+            break;
+        case LV_EVENT_FLUSH_START:
+            info->flush_start_time = lv_tick_get();
+            break;
+        case LV_EVENT_FLUSH_FINISH:
+            info->flush_elaps_sum += lv_tick_elaps(info->flush_start_time);
+            info->flush_cnt++;
+            break;
+        default:
+            break;
+    }
 }
 
 static void perf_monitor_event_cb(lv_event_t * e)
@@ -144,7 +154,9 @@ static void perf_monitor_event_cb(lv_event_t * e)
 
     uint32_t cpu = 100 - lv_timer_get_idle();
     uint32_t render_avg_time = info->refr_cnt ? (info->render_elaps_sum / info->refr_cnt) : 0;
+    uint32_t flush_avg_time = info->flush_cnt ? (info->flush_elaps_sum / info->flush_cnt) : 0;
     uint32_t fps = info->refr_elaps_sum ? (1000 * info->refr_cnt / info->refr_elaps_sum) : 0;
+    LV_UNUSED(flush_avg_time);
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     /*Avoid warning*/
@@ -154,10 +166,10 @@ static void perf_monitor_event_cb(lv_event_t * e)
 
     LV_LOG("sysmon: "
            "%" LV_PRIu32" FPS (redraw: %" LV_PRIu32" / refr: %" LV_PRIu32"), "
-           "render %" LV_PRIu32" ms, "
+           "render %" LV_PRIu32"ms (flush %"LV_PRIu32"ms), "
            "CPU %" LV_PRIu32 "%%\n",
            fps, info->render_cnt, info->refr_cnt,
-           render_avg_time,
+           render_avg_time, flush_avg_time,
            cpu);
 #else
     lv_label_set_text_fmt(
@@ -168,25 +180,30 @@ static void perf_monitor_event_cb(lv_event_t * e)
         cpu
     );
 #endif /*LV_USE_PERF_MONITOR_LOG_MODE*/
-    info->refr_elaps_sum = 0;
-    info->refr_cnt = 0;
-    info->render_elaps_sum = 0;
+
     info->render_cnt = 0;
+    info->refr_cnt = 0;
+    info->flush_cnt = 0;
+    info->refr_elaps_sum = 0;
+    info->render_elaps_sum = 0;
+    info->flush_elaps_sum = 0;
 }
 
 static void perf_monitor_init(void)
 {
     static perf_info_t info = { 0 };
-    info.disp = lv_disp_get_default();
+    lv_disp_t * disp = lv_disp_get_default();
 
     lv_obj_t * sysmon = lv_sysmon_create(lv_layer_sys());
     lv_obj_align(sysmon, LV_USE_PERF_MONITOR_POS, 0, 0);
     lv_obj_set_style_text_align(sysmon, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_user_data(sysmon, &info);
     lv_obj_add_event(sysmon, perf_monitor_event_cb, LV_EVENT_REFRESH, NULL);
-    lv_disp_add_event(info.disp, perf_monitor_refr_start_cb, LV_EVENT_REFR_START, sysmon);
-    lv_disp_add_event(info.disp, perf_monitor_refr_finish_cb, LV_EVENT_REFR_FINISH, sysmon);
-    lv_disp_add_event(info.disp, perf_monitor_render_start_cb, LV_EVENT_RENDER_START, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_REFR_START, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_REFR_FINISH, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_RENDER_START, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_FLUSH_START, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_FLUSH_FINISH, sysmon);
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     /*Reduce rendering performance consumption*/

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -127,7 +127,7 @@ static void perf_monitor_disp_event_cb(lv_event_t * e)
     perf_info_t * info = lv_obj_get_user_data(sysmon);
     switch(code) {
         case LV_EVENT_REFR_START:
-            /* skip the first record */
+            /*Skip the first record*/
             if(info->refr_start) {
                 info->refr_interval_sum += lv_tick_elaps(info->refr_start);
             }

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -22,12 +22,14 @@
  *      TYPEDEFS
  **********************/
 typedef struct {
+    uint32_t    refr_start;
+    uint32_t    refr_interval_sum;
     uint32_t    refr_elaps_sum;
     uint32_t    refr_cnt;
-    uint32_t    render_start_time;
+    uint32_t    render_start;
     uint32_t    render_elaps_sum;
     uint32_t    render_cnt;
-    uint32_t    flush_start_time;
+    uint32_t    flush_start;
     uint32_t    flush_elaps_sum;
     uint32_t    flush_cnt;
 } perf_info_t;
@@ -125,21 +127,28 @@ static void perf_monitor_disp_event_cb(lv_event_t * e)
     perf_info_t * info = lv_obj_get_user_data(sysmon);
     switch(code) {
         case LV_EVENT_REFR_START:
-            info->refr_elaps_sum += lv_tick_elaps(info->render_start_time);
-            info->refr_cnt++;
-            info->render_start_time = lv_tick_get();
+            /* skip the first record */
+            if(info->refr_start) {
+                info->refr_interval_sum += lv_tick_elaps(info->refr_start);
+            }
+            info->refr_start = lv_tick_get();
             break;
         case LV_EVENT_REFR_FINISH:
-            info->render_elaps_sum += lv_tick_elaps(info->render_start_time);
+            info->refr_elaps_sum += lv_tick_elaps(info->refr_start);
+            info->refr_cnt++;
             break;
         case LV_EVENT_RENDER_START:
+            info->render_start = lv_tick_get();
+            break;
+        case LV_EVENT_RENDER_READY:
+            info->render_elaps_sum += lv_tick_elaps(info->render_start);
             info->render_cnt++;
             break;
         case LV_EVENT_FLUSH_START:
-            info->flush_start_time = lv_tick_get();
+            info->flush_start = lv_tick_get();
             break;
         case LV_EVENT_FLUSH_FINISH:
-            info->flush_elaps_sum += lv_tick_elaps(info->flush_start_time);
+            info->flush_elaps_sum += lv_tick_elaps(info->flush_start);
             info->flush_cnt++;
             break;
         default:
@@ -152,41 +161,39 @@ static void perf_monitor_event_cb(lv_event_t * e)
     lv_obj_t * sysmon = lv_event_get_current_target_obj(e);
     perf_info_t * info = lv_obj_get_user_data(sysmon);
 
+    uint32_t fps = info->refr_interval_sum ? (1000 * info->refr_cnt / info->refr_interval_sum) : 0;
     uint32_t cpu = 100 - lv_timer_get_idle();
-    uint32_t render_avg_time = info->refr_cnt ? (info->render_elaps_sum / info->refr_cnt) : 0;
+    uint32_t refr_avg_time = info->refr_cnt ? (info->refr_elaps_sum / info->refr_cnt) : 0;
+    uint32_t render_avg_time = info->render_cnt ? (info->render_elaps_sum / info->render_cnt) : 0;
     uint32_t flush_avg_time = info->flush_cnt ? (info->flush_elaps_sum / info->flush_cnt) : 0;
-    uint32_t fps = info->refr_elaps_sum ? (1000 * info->refr_cnt / info->refr_elaps_sum) : 0;
-    LV_UNUSED(flush_avg_time);
+    uint32_t render_real_avg_time = render_avg_time - flush_avg_time;
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     /*Avoid warning*/
     LV_UNUSED(fps);
-    LV_UNUSED(render_avg_time);
     LV_UNUSED(cpu);
+    LV_UNUSED(refr_avg_time);
+    LV_UNUSED(render_real_avg_time);
+    LV_UNUSED(flush_avg_time);
 
     LV_LOG("sysmon: "
-           "%" LV_PRIu32" FPS (redraw: %" LV_PRIu32" / refr: %" LV_PRIu32"), "
-           "render %" LV_PRIu32"ms (flush %"LV_PRIu32"ms), "
+           "%" LV_PRIu32" FPS (refr: %" LV_PRIu32" | redraw: %" LV_PRIu32" | flush: %" LV_PRIu32"), "
+           "refr %" LV_PRIu32"ms (render %" LV_PRIu32 "ms | flush %" LV_PRIu32 "ms), "
            "CPU %" LV_PRIu32 "%%\n",
-           fps, info->render_cnt, info->refr_cnt,
-           render_avg_time, flush_avg_time,
+           fps, info->refr_cnt, info->render_cnt, info->flush_cnt,
+           refr_avg_time, render_real_avg_time, flush_avg_time,
            cpu);
 #else
     lv_label_set_text_fmt(
         sysmon,
-        "%" LV_PRIu32" FPS / %" LV_PRIu32" ms\n%" LV_PRIu32 "%% CPU",
-        fps,
-        render_avg_time,
-        cpu
+        "%" LV_PRIu32" FPS, %" LV_PRIu32 "%% CPU\n"
+        "%" LV_PRIu32" ms (%" LV_PRIu32" | %" LV_PRIu32")",
+        fps, cpu,
+        refr_avg_time, render_real_avg_time, flush_avg_time
     );
 #endif /*LV_USE_PERF_MONITOR_LOG_MODE*/
 
-    info->render_cnt = 0;
-    info->refr_cnt = 0;
-    info->flush_cnt = 0;
-    info->refr_elaps_sum = 0;
-    info->render_elaps_sum = 0;
-    info->flush_elaps_sum = 0;
+    lv_memzero(info, sizeof(perf_info_t));
 }
 
 static void perf_monitor_init(void)
@@ -199,11 +206,7 @@ static void perf_monitor_init(void)
     lv_obj_set_style_text_align(sysmon, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_user_data(sysmon, &info);
     lv_obj_add_event(sysmon, perf_monitor_event_cb, LV_EVENT_REFRESH, NULL);
-    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_REFR_START, sysmon);
-    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_REFR_FINISH, sysmon);
-    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_RENDER_START, sysmon);
-    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_FLUSH_START, sysmon);
-    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_FLUSH_FINISH, sysmon);
+    lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_ALL, sysmon);
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     /*Reduce rendering performance consumption*/
@@ -222,7 +225,7 @@ static void mem_monitor_event_cb(lv_event_t * e)
     uint32_t used_kb = used_size / 1024;
     uint32_t used_kb_tenth = (used_size - (used_kb * 1024)) / 102;
     lv_label_set_text_fmt(sysmon,
-                          "%"LV_PRIu32 ".%"LV_PRIu32 " kB used (%d %%)\n"
+                          "%"LV_PRIu32 ".%"LV_PRIu32 " kB, %d%%\n"
                           "%d%% frag.",
                           used_kb, used_kb_tenth, mon.used_pct,
                           mon.frag_pct);


### PR DESCRIPTION
### Description of the feature or fix

Reduced FPS statistics period from 1000ms to 300ms.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
