### PR TITLE
fix to get button objects from arrow header

### DIFF
--- a/src/widgets/calendar/lv_calendar_header_arrow.c
+++ b/src/widgets/calendar/lv_calendar_header_arrow.c
@@ -69,7 +69,7 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
     LV_UNUSED(class_p);
 
-    lv_calendar_header_arrow_t *calendar_header = (lv_calendar_header_arrow_t *)obj;
+    lv_calendar_header_arrow_t * calendar_header = (lv_calendar_header_arrow_t *)obj;
 
     lv_obj_move_to_index(obj, 0);
 
@@ -83,7 +83,7 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     lv_coord_t btn_size = lv_obj_get_height(calendar_header->prev_btn);
     lv_obj_set_width(calendar_header->prev_btn, btn_size);
 
-    lv_obj_add_event_cb(calendar_header->prev_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event(calendar_header->prev_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
     lv_obj_clear_flag(calendar_header->prev_btn, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
     lv_obj_t * label = lv_label_create(obj);
@@ -95,10 +95,10 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     lv_obj_set_style_bg_img_src(calendar_header->next_btn, LV_SYMBOL_RIGHT, 0);
     lv_obj_set_size(calendar_header->next_btn, btn_size, btn_size);
 
-    lv_obj_add_event_cb(calendar_header->next_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event(calendar_header->next_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
     lv_obj_clear_flag(calendar_header->next_btn, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
-    lv_obj_add_event_cb(obj, value_changed_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_obj_add_event(obj, value_changed_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
     /*Refresh the drop downs*/
     lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
 }

--- a/src/widgets/calendar/lv_calendar_header_arrow.c
+++ b/src/widgets/calendar/lv_calendar_header_arrow.c
@@ -18,6 +18,7 @@
  *      DEFINES
  *********************/
 
+#define MY_CLASS &lv_calendar_header_arrow_class									
 /**********************
  *      TYPEDEFS
  **********************/
@@ -36,7 +37,9 @@ const lv_obj_class_t lv_calendar_header_arrow_class = {
     .base_class = &lv_obj_class,
     .constructor_cb = my_constructor,
     .width_def = LV_PCT(100),
-    .height_def = LV_DPI_DEF / 3
+    .height_def = LV_DPI_DEF / 3,
+    .instance_size = sizeof(lv_calendar_header_arrow_t),
+    .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE																	 
 };
 
 static const char * month_names_def[12] = LV_CALENDAR_DEFAULT_MONTH_NAMES;
@@ -66,36 +69,38 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
     LV_UNUSED(class_p);
 
+    lv_calendar_header_arrow_t *calendar_header = (lv_calendar_header_arrow_t *)obj;
+
     lv_obj_move_to_index(obj, 0);
 
     lv_obj_set_flex_flow(obj, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(obj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
 
-    lv_obj_t * mo_prev = lv_btn_create(obj);
-    lv_obj_set_style_bg_img_src(mo_prev, LV_SYMBOL_LEFT, 0);
-    lv_obj_set_height(mo_prev, lv_pct(100));
-    lv_obj_update_layout(mo_prev);
-    lv_coord_t btn_size = lv_obj_get_height(mo_prev);
-    lv_obj_set_width(mo_prev, btn_size);
+    calendar_header->prev_btn = lv_btn_create(obj);
+    lv_obj_set_style_bg_img_src(calendar_header->prev_btn, LV_SYMBOL_LEFT, 0);
+    lv_obj_set_height(calendar_header->prev_btn, lv_pct(100));
+    lv_obj_update_layout(calendar_header->prev_btn);
+    lv_coord_t btn_size = lv_obj_get_height(calendar_header->prev_btn);
+    lv_obj_set_width(calendar_header->prev_btn, btn_size);
 
-    lv_obj_add_event(mo_prev, month_event_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_clear_flag(mo_prev, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+    lv_obj_add_event_cb(calendar_header->prev_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_clear_flag(calendar_header->prev_btn, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
     lv_obj_t * label = lv_label_create(obj);
     lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_flex_grow(label, 1);
 
-    lv_obj_t * mo_next = lv_btn_create(obj);
-    lv_obj_set_style_bg_img_src(mo_next, LV_SYMBOL_RIGHT, 0);
-    lv_obj_set_size(mo_next, btn_size, btn_size);
+    calendar_header->next_btn = lv_btn_create(obj);
+    lv_obj_set_style_bg_img_src(calendar_header->next_btn, LV_SYMBOL_RIGHT, 0);
+    lv_obj_set_size(calendar_header->next_btn, btn_size, btn_size);
 
-    lv_obj_add_event(mo_next, month_event_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_clear_flag(mo_next, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+    lv_obj_add_event_cb(calendar_header->next_btn, month_event_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_clear_flag(calendar_header->next_btn, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
-    lv_obj_add_event(obj, value_changed_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_obj_add_event_cb(obj, value_changed_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
     /*Refresh the drop downs*/
-    lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_event_send(obj, LV_EVENT_VALUE_CHANGED, NULL);
 }
 
 static void month_event_cb(lv_event_t * e)
@@ -143,6 +148,24 @@ static void value_changed_event_cb(lv_event_t * e)
     const lv_calendar_date_t * cur_date = lv_calendar_get_showed_date(calendar);
     lv_obj_t * label = lv_obj_get_child(header, 1);
     lv_label_set_text_fmt(label, "%d %s", cur_date->year, month_names_def[cur_date->month - 1]);
+}
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+lv_obj_t * lv_calendar_header_arrow_get_prev_btn(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    const lv_calendar_header_arrow_t * header = (lv_calendar_header_arrow_t *)obj;
+    return header->prev_btn;
+}
+
+lv_obj_t * lv_calendar_header_arrow_get_next_btn(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    const lv_calendar_header_arrow_t * header = (lv_calendar_header_arrow_t *)obj;
+    return header->next_btn;
 }
 
 #endif /*LV_USE_CALENDAR_HEADER_ARROW*/

--- a/src/widgets/calendar/lv_calendar_header_arrow.h
+++ b/src/widgets/calendar/lv_calendar_header_arrow.h
@@ -26,8 +26,8 @@ extern "C" {
 
 typedef struct {
     lv_obj_t obj;
-    lv_obj_t *prev_btn;
-    lv_obj_t *next_btn;
+    lv_obj_t * prev_btn;
+    lv_obj_t * next_btn;
 } lv_calendar_header_arrow_t;
 
 extern const lv_obj_class_t lv_calendar_header_arrow_class;

--- a/src/widgets/calendar/lv_calendar_header_arrow.h
+++ b/src/widgets/calendar/lv_calendar_header_arrow.h
@@ -23,6 +23,13 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
+typedef struct {
+    lv_obj_t obj;
+    lv_obj_t *prev_btn;
+    lv_obj_t *next_btn;
+} lv_calendar_header_arrow_t;
+
 extern const lv_obj_class_t lv_calendar_header_arrow_class;
 
 /**********************
@@ -35,6 +42,26 @@ extern const lv_obj_class_t lv_calendar_header_arrow_class;
  * @return          the created header
  */
 lv_obj_t * lv_calendar_header_arrow_create(lv_obj_t * parent);
+
+/*=====================
+ * Getter functions
+ *====================*/
+
+/**
+ * Get the previous button object of the calendar header.
+ * It shows the dates and day names.
+ * @param obj   pointer to a calendar arrow header object
+ * @return      pointer to a button 
+ */
+lv_obj_t * lv_calendar_header_arrow_get_prev_btn(const lv_obj_t * obj);
+
+/**
+ * Get the next button object of the calendar header.
+ * It shows the dates and day names.
+ * @param obj   pointer to a calendar arrow header object
+ * @return      pointer to a button 
+ */
+lv_obj_t * lv_calendar_header_arrow_get_next_btn(const lv_obj_t * obj);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

When trying to change the input group of the calendar component we need to get the btnmatrix component with lv_calendar_get_btnmatrix(). 

This PR adds the equivalent calls for the lv_calendar_header_arrow_t to get the next and previous buttons, which are also needed when trying to change the input group of the calendar.