### PR TITLE
Add sdl resource free feature

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -158,6 +158,8 @@ void lv_disp_remove(lv_disp_t * disp)
     bool was_default = false;
     if(disp == lv_disp_get_default()) was_default = true;
 
+    lv_disp_send_event(disp, LV_EVENT_DELETE, NULL);
+
     /*Detach the input devices*/
     lv_indev_t * indev;
     indev = lv_indev_get_next(NULL);

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -39,7 +39,7 @@ static void window_update(lv_disp_t * disp);
 static void clean_up(lv_disp_t * disp);
 static void texture_resize(lv_disp_t * disp);
 static void sdl_event_handler(lv_timer_t * t);
-static void release_disp_cb(lv_event_t *e);
+static void release_disp_cb(lv_event_t * e);
 
 /***********************
  *   GLOBAL PROTOTYPES
@@ -346,7 +346,8 @@ static int tick_thread(void * ptr)
 }
 #endif
 
-static void release_disp_cb(lv_event_t *e){
+static void release_disp_cb(lv_event_t * e)
+{
     lv_disp_t * disp = (lv_disp_t *) lv_event_get_user_data(e);
     clean_up(disp);
 }

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -39,6 +39,7 @@ static void window_update(lv_disp_t * disp);
 static void clean_up(lv_disp_t * disp);
 static void texture_resize(lv_disp_t * disp);
 static void sdl_event_handler(lv_timer_t * t);
+static void release_disp_cb(lv_event_t *e);
 
 /***********************
  *   GLOBAL PROTOTYPES
@@ -89,6 +90,7 @@ lv_disp_t * lv_sdl_window_create(lv_coord_t hor_res, lv_coord_t ver_res)
         lv_free(dsc);
         return NULL;
     }
+    lv_disp_add_event(disp, release_disp_cb, LV_EVENT_DELETE, disp);
     lv_disp_set_driver_data(disp, dsc);
     window_create(disp);
 
@@ -139,6 +141,15 @@ void lv_sdl_window_set_title(lv_disp_t * disp, const char * title)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
     SDL_SetWindowTitle(dsc->window, title);
+}
+
+void lv_sdl_quit()
+{
+    if(inited) {
+        SDL_Quit();
+        lv_timer_del(event_handler_timer);
+        inited = false;
+    }
 }
 
 /**********************
@@ -334,5 +345,10 @@ static int tick_thread(void * ptr)
     return 0;
 }
 #endif
+
+static void release_disp_cb(lv_event_t *e){
+    lv_disp_t * disp = (lv_disp_t *) lv_event_get_user_data(e);
+    clean_up(disp);
+}
 
 #endif /*LV_USE_SDL*/

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -247,7 +247,6 @@ static void clean_up(lv_disp_t * disp)
     SDL_DestroyWindow(dsc->window);
 
     lv_free(dsc);
-    lv_disp_remove(disp);
 }
 
 static void window_create(lv_disp_t * disp)

--- a/src/dev/sdl/lv_sdl_window.h
+++ b/src/dev/sdl/lv_sdl_window.h
@@ -41,6 +41,8 @@ lv_disp_t * _lv_sdl_get_disp_from_win_id(uint32_t win_id);
 
 void lv_sdl_window_set_title(lv_disp_t * disp, const char * title);
 
+void lv_sdl_quit();
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

Following #4267 to add this feature to let user release `disp` at any time they send `LV_EVENT_DELETE`.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
