### PR TITLE
fix(cmsis-pack): catchup update for v9.0.0-dev

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,7 +36,11 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-     <release date="2023-03-03" version="8.3.6" url="https://github.com/lvgl/lvgl/raw/release/v8.3/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
+     <release date="2023-05-03" version="8.3.7" url="https://github.com/GorgonMeducer/lvgl/raw/a8195160fcb18b522b4a16c230455d48d99a0368/env_support/cmsis-pack/LVGL.lvgl.8.3.7.pack">
+      - LVGL 8.3.7 release
+      - Various fixes
+    </release>
+     <release date="2023-03-03" version="8.3.6" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
       - LVGL 8.3.6 release
       - Various fixes
     </release>
@@ -45,7 +49,7 @@
       - New Driver Architecture
       - Other fixes
      </release>
-     <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/release/v8.3/env_support/cmsis-pack/LVGL.lvgl.8.3.5.pack">
+     <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
       - LVGL 8.3.5 release
       - Use LVGL version as the cmsis-pack version
       - Fix GPU support for NXP PXP and NXP VGLite
@@ -404,6 +408,7 @@
                 <file category="sourceC"            name="src/others/snapshot/lv_snapshot.c" />
                 <file category="sourceC"            name="src/others/imgfont/lv_imgfont.c" />
                 <file category="sourceC"            name="src/others/gridnav/lv_gridnav.c" />
+                <file category="sourceC"            name="src/others/sysmon/lv_sysmon.c" />
 
                 <!-- src/misc-->
                 <file category="sourceC"            name="src/misc/lv_style_gen.c" />
@@ -430,6 +435,7 @@
                 <file category="sourceC"            name="src/misc/lv_color.c" />
                 <file category="sourceC"            name="src/misc/lv_printf.c" />
                 <file category="sourceC"            name="src/misc/lv_event.c" />
+                <file category="sourceC"            name="src/misc/lv_profiler_builtin.c" />
 
                 <!-- src/widgets -->
                 <file category="sourceC"            name="src/widgets/spinner/lv_spinner.c" />
@@ -867,11 +873,10 @@
             </component>
 
             <component Cgroup="lvgl" Csub="File Explorer"  condition="LVGL-Essential">
-              <description>Add Pinyin input method</description>
+              <description>Add a file explorer</description>
               <files>
                 <!-- src/others/file_explorer -->
                 <file category="sourceC"    name="src/others/file_explorer/lv_file_explorer.c" />
-                <file category="header"     name="src/others/file_explorer/lv_file_explorer.h" />
               </files>
 
               <RTE_Components_h>
@@ -883,11 +888,10 @@
             </component>
 
             <component Cgroup="lvgl" Csub="Tiny TTF"  condition="LVGL-Essential">
-              <description>Add tiny ttf support</description>
+              <description>Add the Tiny TTF support</description>
               <files>
                 <!-- src/libs/tiny_ttf -->
                 <file category="sourceC"    name="src/libs/tiny_ttf/lv_tiny_ttf.c" />
-                <file category="header"     name="src/libs/tiny_ttf/lv_tiny_ttf.h" />
                 <!-- src/libs/fsdrv -->
                 <file category="sourceC"    name="src/libs/fsdrv/lv_fs_cbfs.c" />
               </files>

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -4,6 +4,6 @@
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
   <timestamp>2023-03-03T12:22:00</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.6"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.7"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -42,6 +42,7 @@ remove the misleading guide above this code segment.
 4. Update `LV_STDIO_INCLUDE` and `LV_STRING_INCLUDE`
 
    ```c
+   #define LV_STDLIB_INCLUDE <stdlib.h>
    #define LV_STDIO_INCLUDE  <stdio.h>
    #define LV_STRING_INCLUDE <string.h>
    ```
@@ -61,7 +62,7 @@ remove the misleading guide above this code segment.
    - LV_USE_IME_PINYIN
    - LV_USE_FILE_EXPLORER
 
-6. Update `LV_LOG_PRINTF` to `1`
+6. Update `LV_LOG_PRINTF` to `1` and `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER`
 
 7. Update `LV_DEMO_BENCHMARK_RGB565A8` to `1`
 
@@ -121,6 +122,9 @@ Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
     #if LV_TICK_CUSTOM
         #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
         #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+        /*If using lvgl as ESP32 component*/
+        // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
+        // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
     #endif   /*LV_TICK_CUSTOM*/
 #endif       /*__PERF_COUNTER__*/
 ```

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -3,6 +3,24 @@
  *
  */
 
+/*
+ * Copyright (C) 2010-2023 Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*********************
  *      INCLUDES
  *********************/
@@ -97,6 +115,8 @@
     arm_2dp_rgb565_tile_transform_with_src_mask_and_opacity_prepare
 #define arm_2d_tile_transform_with_opacity_prepare                              \
     arm_2dp_rgb565_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_only_with_opacity_prepare                         \
+    arm_2dp_rgb565_tile_transform_only_with_opacity_prepare
 #define arm_2d_tile_transform_prepare                                           \
     arm_2dp_rgb565_tile_transform_prepare
 
@@ -134,6 +154,8 @@
     arm_2dp_cccn888_tile_transform_with_src_mask_and_opacity_prepare
 #define arm_2d_tile_transform_with_opacity_prepare                              \
     arm_2dp_cccn888_tile_transform_with_opacity_prepare
+#define arm_2d_tile_transform_only_with_opacity_prepare                         \
+    arm_2dp_cccn888_tile_transform_only_with_opacity_prepare
 #define arm_2d_tile_transform_prepare                                           \
     arm_2dp_cccn888_tile_transform_prepare
 
@@ -1093,6 +1115,24 @@ static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                     );
                     is_accelerated = true;
                 }
+    #if ARM_2D_VERISON >= 10103
+                else if (LV_COLOR_FORMAT_NATIVE == cf) {
+                    __ARM_2D_PREPARE_TRANS_AND_TARGET_REGION(
+                        arm_2d_tile_transform_only_with_opacity_prepare,
+                        &source_tile,
+                        source_center,
+                        ARM_2D_ANGLE((draw_dsc->angle / 10.0f)),
+                        draw_dsc->zoom / 256.0f,
+                        blend_dsc.opa);
+
+                    arm_2d_tile_transform(
+                        &target_tile,
+                        &target_region,
+                        NULL
+                    );
+                    is_accelerated = true;
+                }
+    #endif
                 else if(LV_COLOR_FORMAT_RGB565A8 == cf) {
                     static arm_2d_tile_t mask_tile;
                     mask_tile = source_tile;


### PR DESCRIPTION
### Description of the feature or fix
- catchup update for v9.0.0-dev
- fix pdsc url issue
- update GPU Arm-2D

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
