### PR TITLE
V8.3 Docs (Display Porting): Mention incompatibility between software rotation and `direct_mode` or `full_refresh`

### DIFF
--- a/docs/porting/display.md
+++ b/docs/porting/display.md
@@ -204,6 +204,8 @@ The default rotation of your display when it is initialized can be set using the
 
 Display rotation can also be changed at runtime using the `lv_disp_set_rotation(disp, rot)` API.
 
+Note that when using software rotation, you cannot use neither `direct_mode` nor `full_refresh` in the driver. When using either of these, you will have to rotate the pixels yourself e.g. in the `flush_cb`.
+
 Support for software rotation is a new feature, so there may be some glitches/bugs depending on your configuration. If you encounter a problem please open an issue on [GitHub](https://github.com/lvgl/lvgl/issues).
 
 ### Decoupling the display refresh timer


### PR DESCRIPTION
Although software rotation is not compatible with either of these driver settings, this is not mentioned in the display porting documentation yet. (I only found it mentioned -- for full refresh -- in a lv_refr source comment, and -- for direct mode -- buried in some github issues / forum threads.)

Fixes: #4304

I added a little note aswell, that one should rotate the pixels manually e.g. in the `flush_cb` -- I suspect one will have to also adjust the `lv_disp_drv_t` width/height aswell during runtime? I wonder if that should be mentioned.

(In my personal project, I opted to use LV software rotation instead of implementing the geometric transforms myself...)