### PR TITLE
fix(sysmon): fix FPS algorithm error

### DIFF
--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -127,10 +127,7 @@ static void perf_monitor_disp_event_cb(lv_event_t * e)
     perf_info_t * info = lv_obj_get_user_data(sysmon);
     switch(code) {
         case LV_EVENT_REFR_START:
-            /*Skip the first record*/
-            if(info->refr_start) {
-                info->refr_interval_sum += lv_tick_elaps(info->refr_start);
-            }
+            info->refr_interval_sum += lv_tick_elaps(info->refr_start);
             info->refr_start = lv_tick_get();
             break;
         case LV_EVENT_REFR_FINISH:
@@ -177,8 +174,8 @@ static void perf_monitor_event_cb(lv_event_t * e)
     LV_UNUSED(flush_avg_time);
 
     LV_LOG("sysmon: "
-           "%" LV_PRIu32" FPS (refr: %" LV_PRIu32" | redraw: %" LV_PRIu32" | flush: %" LV_PRIu32"), "
-           "refr %" LV_PRIu32"ms (render %" LV_PRIu32 "ms | flush %" LV_PRIu32 "ms), "
+           "%" LV_PRIu32 " FPS (refr_cnt: %" LV_PRIu32 " | redraw_cnt: %" LV_PRIu32 " | flush_cnt: %" LV_PRIu32 "), "
+           "refr %" LV_PRIu32 "ms (render %" LV_PRIu32 "ms | flush %" LV_PRIu32 "ms), "
            "CPU %" LV_PRIu32 "%%\n",
            fps, info->refr_cnt, info->render_cnt, info->flush_cnt,
            refr_avg_time, render_real_avg_time, flush_avg_time,
@@ -193,7 +190,14 @@ static void perf_monitor_event_cb(lv_event_t * e)
     );
 #endif /*LV_USE_PERF_MONITOR_LOG_MODE*/
 
+    /*Save the refresh start time of the next period*/
+    uint32_t refr_start = info->refr_start;
+
+    /*Reset the counters*/
     lv_memzero(info, sizeof(perf_info_t));
+
+    /*Restore the refresh start time*/
+    info->refr_start = refr_start;
 }
 
 static void perf_monitor_init(void)


### PR DESCRIPTION
### Description of the feature or fix

The refresh start timestamp should not be cleared, it can continue to be used in the next statistical cycle.

Fix before:
```bash
sysmon: 63 FPS (refr: 18 | redraw: 0 | flush: 0), refr 0ms (render 0ms | flush 0ms), CPU 0%
sysmon: 63 FPS (refr: 18 | redraw: 0 | flush: 0), refr 0ms (render 0ms | flush 0ms), CPU 0%
sysmon: 62 FPS (refr: 18 | redraw: 0 | flush: 0), refr 0ms (render 0ms | flush 0ms), CPU 0%
sysmon: 62 FPS (refr: 18 | redraw: 0 | flush: 0), refr 0ms (render 0ms | flush 0ms), CPU 0%
sysmon: 62 FPS (refr: 18 | redraw: 12 | flush: 12), refr 2ms (render 3ms | flush 1ms), CPU 0%
sysmon: 62 FPS (refr: 18 | redraw: 14 | flush: 14), refr 2ms (render 2ms | flush 1ms), CPU 13%
sysmon: 63 FPS (refr: 18 | redraw: 16 | flush: 16), refr 2ms (render 2ms | flush 1ms), CPU 16%
sysmon: 62 FPS (refr: 17 | redraw: 12 | flush: 12), refr 2ms (render 2ms | flush 1ms), CPU 16%
sysmon: 63 FPS (refr: 18 | redraw: 14 | flush: 14), refr 2ms (render 2ms | flush 1ms), CPU 16%
sysmon: 62 FPS (refr: 18 | redraw: 11 | flush: 11), refr 2ms (render 3ms | flush 1ms), CPU 16%
sysmon: 63 FPS (refr: 18 | redraw: 15 | flush: 15), refr 3ms (render 2ms | flush 1ms), CPU 15%
sysmon: 63 FPS (refr: 18 | redraw: 15 | flush: 15), refr 2ms (render 2ms | flush 1ms), CPU 15%
```

Fix after:
```bash
sysmon: 60 FPS (refr: 18 | redraw: 9 | flush: 9), refr 5ms (render 9ms | flush 1ms), CPU 11%
sysmon: 59 FPS (refr: 18 | redraw: 11 | flush: 11), refr 7ms (render 10ms | flush 1ms), CPU 11%
sysmon: 59 FPS (refr: 18 | redraw: 2 | flush: 2), refr 1ms (render 11ms | flush 1ms), CPU 45%
sysmon: 60 FPS (refr: 18 | redraw: 0 | flush: 0), refr 0ms (render 0ms | flush 0ms), CPU 5%
sysmon: 60 FPS (refr: 18 | redraw: 7 | flush: 7), refr 4ms (render 10ms | flush 1ms), CPU 5%
sysmon: 60 FPS (refr: 18 | redraw: 13 | flush: 13), refr 8ms (render 10ms | flush 1ms), CPU 26%
sysmon: 60 FPS (refr: 18 | redraw: 16 | flush: 16), refr 10ms (render 10ms | flush 1ms), CPU 26%
sysmon: 60 FPS (refr: 19 | redraw: 6 | flush: 6), refr 1ms (render 3ms | flush 0ms), CPU 56%
sysmon: 60 FPS (refr: 18 | redraw: 15 | flush: 15), refr 3ms (render 2ms | flush 1ms), CPU 11%
sysmon: 59 FPS (refr: 18 | redraw: 16 | flush: 16), refr 3ms (render 2ms | flush 1ms), CPU 11%
sysmon: 59 FPS (refr: 17 | redraw: 13 | flush: 13), refr 2ms (render 2ms | flush 1ms), CPU 20%
sysmon: 60 FPS (refr: 19 | redraw: 17 | flush: 17), refr 2ms (render 2ms | flush 1ms), CPU 20%
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
