### PR TITLE
feat(lv_math): add align_up/down function

### DIFF
--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -388,6 +388,16 @@ uint32_t lv_rand(uint32_t min, uint32_t max)
     return (a % (max - min + 1)) + min;
 }
 
+int32_t lv_align_up(int32_t x, int32_t align)
+{
+    return (x + (align - 1)) & ~(align - 1);
+}
+
+int32_t lv_align_down(int32_t x, int32_t align)
+{
+    return x - (x & (align - 1));
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -133,6 +133,22 @@ int32_t lv_map(int32_t x, int32_t min_in, int32_t max_in, int32_t min_out, int32
  */
 uint32_t lv_rand(uint32_t min, uint32_t max);
 
+/**
+ * Get a aligned up value to the given alignment
+ * @param x
+ * @param align the alignment (e.g. 4: x will be divisible with 4) (MUST be power of 2)
+ * @return
+ */
+int32_t lv_align_up(int32_t x, int32_t align);
+
+/**
+ * Get a aligned down value to the given alignment
+ * @param x
+ * @param align the alignment (e.g. 4: x will be divisible with 4) (MUST be power of 2)
+ * @return
+ */
+int32_t lv_align_down(int32_t x, int32_t align);
+
 /**********************
  *      MACROS
  **********************/

--- a/tests/src/test_cases/test_math.c
+++ b/tests/src/test_cases/test_math.c
@@ -136,4 +136,30 @@ void test_math_cubic_bezier_result_should_be_precise(void)
     }
 }
 
+void test_math_align_up_down(void)
+{
+    int32_t values[] = { 0, 1, 3, 6, 23, 54, 55, 345, 5342, 662, 456, 234, 123, 12, 44, 55, 66, 77, 88, 99, 100, 101, 102, 103, 104, 105, 106, 107 };
+    int32_t values_align_up_4[] = { 0, 4, 4, 8, 24, 56, 56, 348, 5344, 664, 456, 236, 124, 12, 44, 56, 68, 80, 88, 100, 100, 104, 104, 104, 104, 108, 108, 108 };
+    int32_t values_align_up_8[] = { 0, 8, 8, 8, 24, 56, 56, 352, 5344, 664, 456, 240, 128, 16, 48, 56, 72, 80, 88, 104, 104, 104, 104, 104, 104, 112, 112, 112 };
+    int32_t values_align_up_16[] = { 0, 16, 16, 16, 32, 64, 64, 352, 5344, 672, 464, 240, 128, 16, 48, 64, 80, 80, 96, 112, 112, 112, 112, 112, 112, 112, 112, 112 };
+    int32_t values_align_up_64[] = { 0, 64, 64, 64, 64, 64, 64, 384, 5376, 704, 512, 256, 128, 64, 64, 64, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
+
+    int32_t values_align_down_4[] = { 0, 0, 0, 4, 20, 52, 52, 344, 5340, 660, 456, 232, 120, 12, 44, 52, 64, 76, 88, 96, 100, 100, 100, 100, 104, 104, 104, 104 };
+    int32_t values_align_down_8[] = { 0, 0, 0, 0, 16, 48, 48, 344, 5336, 656, 456, 232, 120, 8, 40, 48, 64, 72, 88, 96, 96, 96, 96, 96, 104, 104, 104, 104 };
+    int32_t values_align_down_16[] = { 0, 0, 0, 0, 16, 48, 48, 336, 5328, 656, 448, 224, 112, 0, 32, 48, 64, 64, 80, 96, 96, 96, 96, 96, 96, 96, 96, 96 };
+    int32_t values_align_down_64[] = { 0, 0, 0, 0, 0, 0, 0, 320, 5312, 640, 448, 192, 64, 0, 0, 0, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64 };
+
+    for(uint32_t i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        TEST_ASSERT_EQUAL_INT32(values_align_up_4[i], lv_align_up(values[i], 4));
+        TEST_ASSERT_EQUAL_INT32(values_align_up_8[i], lv_align_up(values[i], 8));
+        TEST_ASSERT_EQUAL_INT32(values_align_up_16[i], lv_align_up(values[i], 16));
+        TEST_ASSERT_EQUAL_INT32(values_align_up_64[i], lv_align_up(values[i], 64));
+
+        TEST_ASSERT_EQUAL_INT32(values_align_down_4[i], lv_align_down(values[i], 4));
+        TEST_ASSERT_EQUAL_INT32(values_align_down_8[i], lv_align_down(values[i], 8));
+        TEST_ASSERT_EQUAL_INT32(values_align_down_16[i], lv_align_down(values[i], 16));
+        TEST_ASSERT_EQUAL_INT32(values_align_down_64[i], lv_align_down(values[i], 64));
+    }
+}
+
 #endif


### PR DESCRIPTION
### Description of the feature or fix

add `lv_align_up` `lv_align_down` for aligning to numbers power of 2

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
