### PR TITLE
perf(label): add adaptive redraw text to extend redraw area

### DIFF
--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -76,6 +76,7 @@ typedef struct _lv_font_t {
     lv_coord_t line_height;         /**< The real line height where any text fits*/
     lv_coord_t base_line;           /**< Base line measured from the top of the line_height*/
     uint8_t subpx  : 2;             /**< An element of `lv_font_subpx_t`*/
+    uint8_t ext_draw : 1;           /**< Italic or other non-typical letter needs to expand the drawing area*/
 
     int8_t underline_position;      /**< Distance between the top of the underline and base line (< 0 means below the base line)*/
     int8_t underline_thickness;     /**< Thickness of the underline*/

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -36,7 +36,7 @@
  *      TYPEDEFS
  **********************/
 typedef struct _lv_freetype_font_dsc_t {
-    lv_font_t * font;
+    lv_font_t font;
     char * pathname;
     uint16_t size;
     uint16_t style;
@@ -156,16 +156,13 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16
         return NULL;
     }
 
-    size_t need_size = sizeof(lv_freetype_font_dsc_t) + sizeof(lv_font_t);
-    lv_freetype_font_dsc_t * dsc = lv_malloc(need_size);
+    lv_freetype_font_dsc_t * dsc = lv_malloc(sizeof(lv_freetype_font_dsc_t));
     LV_ASSERT_MALLOC(dsc);
     if(!dsc) {
         LV_LOG_ERROR("malloc failed for lv_freetype_font_dsc");
         return NULL;
     }
-    lv_memzero(dsc, need_size);
-
-    dsc->font = (lv_font_t *)(((uint8_t *)dsc) + sizeof(lv_freetype_font_dsc_t));
+    lv_memzero(dsc, sizeof(lv_freetype_font_dsc_t));
 
     dsc->pathname = lv_malloc(pathname_len + 1);
     LV_ASSERT_MALLOC(dsc->pathname);
@@ -196,13 +193,14 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16
         return NULL;
     }
 
-    lv_font_t * font = dsc->font;
+    lv_font_t * font = &dsc->font;
     font->dsc = dsc;
     font->get_glyph_dsc = freetype_get_glyph_dsc_cb;
     font->get_glyph_bitmap = freetype_get_glyph_bitmap_cb;
     font->subpx = LV_FONT_SUBPX_NONE;
     font->line_height = (face_size->face->size->metrics.height >> 6);
     font->base_line = -(face_size->face->size->metrics.descender >> 6);
+    font->ext_draw = (style & LV_FREETYPE_FONT_STYLE_ITALIC) ? true : false;
 
     FT_Fixed scale = face_size->face->size->metrics.y_scale;
     int8_t thickness = FT_MulFix(scale, face_size->face->underline_thickness) >> 6;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -716,8 +716,10 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
          * To avoid this add some extra draw area.
          * font_h / 4 is an empirical value. */
         const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
-        const lv_coord_t font_h = lv_font_get_line_height(font);
-        lv_event_set_ext_draw_size(e, font_h / 4);
+        if(font->ext_draw) {
+            const lv_coord_t font_h = lv_font_get_line_height(font);
+            lv_event_set_ext_draw_size(e, font_h / 4);
+        }
     }
     else if(code == LV_EVENT_GET_SELF_SIZE) {
         lv_label_t * label = (lv_label_t *)obj;


### PR DESCRIPTION
### Description of the feature or fix

For Italic or other non-typical text, we can add` ext_draw` field in `lv_font_t` to identify whether to expand the redraw area.
For most standard fonts, the extended redraw area is not necessary, and setting `ext_draw` to 0 by default ensures a minimum rendering area to maintain performance.

Before:
![S}ADLNA_MH5KFHDF51A2MTF](https://github.com/lvgl/lvgl/assets/26767803/a35cc4c2-e1cc-429a-a2c3-2f59705efb3c)

After:
![5%D_`QV~6 $M168EZ3~KHBX](https://github.com/lvgl/lvgl/assets/26767803/3a0711ea-b527-4917-a858-7b3a65ce2dc9)


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
