### PR TITLE
fix: Explicit casts to avoid -Wdiscarded-qualifiers warnings

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -149,7 +149,7 @@ void lv_init(void)
     lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE);
 #endif
     /*Test if the IDE has UTF-8 encoding*/
-    char * txt = "Á";
+    const char * txt = "Á";
 
     uint8_t * txt_u8 = (uint8_t *)txt;
     if(txt_u8[0] != 0xc3 || txt_u8[1] != 0x81 || txt_u8[2] != 0x00) {

--- a/src/extra/widgets/tabview/lv_tabview.c
+++ b/src/extra/widgets/tabview/lv_tabview.c
@@ -77,15 +77,17 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
 
     lv_obj_t * btns = lv_tabview_get_tab_btns(obj);
 
-    const char ** old_map = (const char **)tabview->map;
+    char * tmp = lv_mem_alloc(strlen(name) + 1);
+    strcpy(tmp, name);
+
+    char ** old_map = tabview->map;
     const char ** new_map;
 
     /*top or bottom dir*/
     if(tabview->tab_pos & LV_DIR_VER) {
         new_map = lv_mem_alloc((tab_id + 1) * sizeof(const char *));
         lv_memcpy_small(new_map, old_map, sizeof(const char *) * (tab_id - 1));
-        new_map[tab_id - 1] = lv_mem_alloc(strlen(name) + 1);
-        strcpy((char *)new_map[tab_id - 1], name);
+        new_map[tab_id - 1] = tmp;
         new_map[tab_id] = "";
     }
     /*left or right dir*/
@@ -93,19 +95,17 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         new_map = lv_mem_alloc((tab_id * 2) * sizeof(const char *));
         lv_memcpy_small(new_map, old_map, sizeof(const char *) * (tab_id - 1) * 2);
         if(tabview->tab_cnt == 0) {
-            new_map[0] = lv_mem_alloc(strlen(name) + 1);
-            strcpy((char *)new_map[0], name);
+            new_map[0] = tmp;
             new_map[1] = "";
         }
         else {
             new_map[tab_id * 2 - 3] = "\n";
-            new_map[tab_id * 2 - 2] = lv_mem_alloc(strlen(name) + 1);
+            new_map[tab_id * 2 - 2] = tmp;
             new_map[tab_id * 2 - 1] = "";
-            strcpy((char *)new_map[(tab_id * 2) - 2], name);
         }
     }
-    tabview->map = new_map;
-    lv_btnmatrix_set_map(btns, (const char **)new_map);
+    tabview->map = (char **) new_map;
+    lv_btnmatrix_set_map(btns, new_map);
     lv_mem_free(old_map);
 
     lv_btnmatrix_set_btn_ctrl_all(btns, LV_BTNMATRIX_CTRL_CHECKABLE | LV_BTNMATRIX_CTRL_CLICK_TRIG |
@@ -225,9 +225,11 @@ static void lv_tabview_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     btnm = lv_btnmatrix_create(obj);
     cont = lv_obj_create(obj);
 
+    const char ** new_map = lv_mem_alloc(sizeof(const char *));
+    new_map[0] = "";
+
     lv_btnmatrix_set_one_checked(btnm, true);
-    tabview->map = lv_mem_alloc(sizeof(const char *));
-    tabview->map[0] = "";
+    tabview->map = (char **) new_map;
     lv_btnmatrix_set_map(btnm, (const char **)tabview->map);
     lv_obj_add_event_cb(btnm, btns_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
     lv_obj_add_flag(btnm, LV_OBJ_FLAG_EVENT_BUBBLE);

--- a/src/extra/widgets/tabview/lv_tabview.h
+++ b/src/extra/widgets/tabview/lv_tabview.h
@@ -27,7 +27,7 @@ extern "C" {
 
 typedef struct {
     lv_obj_t obj;
-    const char ** map;
+    char ** map;
     uint16_t tab_cnt;
     uint16_t tab_cur;
     lv_dir_t tab_pos;

--- a/src/widgets/lv_checkbox.c
+++ b/src/widgets/lv_checkbox.c
@@ -122,7 +122,7 @@ static void lv_checkbox_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
 
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
 
-    cb->txt = "Check box";
+    cb->txt = (char *) "Check box";
     cb->static_txt = 1;
     lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);


### PR DESCRIPTION
### Description of the feature or fix

Explicitly cast `const char *`s to `char *`s where needed in order to prevent `-Wdiscarded-qualifiers` warnings.
