### PR TITLE
fix(meter): fix mid draw, fix(switch): fix get object area interface

### DIFF
--- a/src/widgets/meter/lv_meter.c
+++ b/src/widgets/meter/lv_meter.c
@@ -30,7 +30,6 @@ static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void draw_arcs(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
-static void draw_mid(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value);
 static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value);
 
@@ -307,7 +306,23 @@ static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e)
         draw_arcs(obj, draw_ctx, &scale_area);
         draw_ticks_and_labels(obj, draw_ctx, &scale_area);
         draw_needles(obj, draw_ctx, &scale_area);
-        draw_mid(obj, draw_ctx, &scale_area);
+
+        lv_coord_t r_edge = lv_area_get_width(scale_area) / 2;
+        lv_point_t scale_center;
+        scale_center.x = scale_area->x1 + r_edge;
+        scale_center.y = scale_area->y1 + r_edge;
+
+        lv_draw_rect_dsc_t mid_dsc;
+        lv_draw_rect_dsc_init(&mid_dsc);
+        lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
+        lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
+        lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
+        lv_area_t nm_cord;
+        nm_cord.x1 = scale_center.x - w;
+        nm_cord.y1 = scale_center.y - h;
+        nm_cord.x2 = scale_center.x + w;
+        nm_cord.y2 = scale_center.y + h;
+        lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
     }
 }
 
@@ -604,26 +619,6 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
             lv_obj_send_event(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
         }
     }
-}
-
-static void draw_mid(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area)
-{
-    lv_coord_t r_edge = lv_area_get_width(scale_area) / 2;
-    lv_point_t scale_center;
-    scale_center.x = scale_area->x1 + r_edge;
-    scale_center.y = scale_area->y1 + r_edge;
-
-    lv_draw_rect_dsc_t mid_dsc;
-    lv_draw_rect_dsc_init(&mid_dsc);
-    lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
-    lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
-    lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
-    lv_area_t nm_cord;
-    nm_cord.x1 = scale_center.x - w;
-    nm_cord.y1 = scale_center.y - h;
-    nm_cord.x2 = scale_center.x + w;
-    nm_cord.y2 = scale_center.y + h;
-    lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
 }
 
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value)

--- a/src/widgets/meter/lv_meter.c
+++ b/src/widgets/meter/lv_meter.c
@@ -30,6 +30,7 @@ static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void draw_arcs(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
+static void draw_mid(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area);
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value);
 static void inv_line(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t value);
 
@@ -306,23 +307,7 @@ static void lv_meter_event(const lv_obj_class_t * class_p, lv_event_t * e)
         draw_arcs(obj, draw_ctx, &scale_area);
         draw_ticks_and_labels(obj, draw_ctx, &scale_area);
         draw_needles(obj, draw_ctx, &scale_area);
-
-        lv_coord_t r_edge = lv_area_get_width(&scale_area) / 2;
-        lv_point_t scale_center;
-        scale_center.x = scale_area.x1 + r_edge;
-        scale_center.y = scale_area.y1 + r_edge;
-
-        lv_draw_rect_dsc_t mid_dsc;
-        lv_draw_rect_dsc_init(&mid_dsc);
-        lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
-        lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
-        lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
-        lv_area_t nm_cord;
-        nm_cord.x1 = scale_center.x - w;
-        nm_cord.y1 = scale_center.y - h;
-        nm_cord.x2 = scale_center.x + w;
-        nm_cord.y2 = scale_center.y + h;
-        lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
+        draw_mid(obj, draw_ctx, &scale_area);
     }
 }
 
@@ -619,6 +604,26 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
             lv_obj_send_event(obj, LV_EVENT_DRAW_PART_END, &part_draw_dsc);
         }
     }
+}
+
+static void draw_mid(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t * scale_area)
+{
+    lv_coord_t r_edge = lv_area_get_width(scale_area) / 2;
+    lv_point_t scale_center;
+    scale_center.x = scale_area->x1 + r_edge;
+    scale_center.y = scale_area->y1 + r_edge;
+
+    lv_draw_rect_dsc_t mid_dsc;
+    lv_draw_rect_dsc_init(&mid_dsc);
+    lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &mid_dsc);
+    lv_coord_t w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
+    lv_coord_t h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
+    lv_area_t nm_cord;
+    nm_cord.x1 = scale_center.x - w;
+    nm_cord.y1 = scale_center.y - h;
+    nm_cord.x2 = scale_center.x + w;
+    nm_cord.y2 = scale_center.y + h;
+    lv_draw_rect(draw_ctx, &mid_dsc, &nm_cord);
 }
 
 static void inv_arc(lv_obj_t * obj, lv_meter_indicator_t * indic, int32_t old_value, int32_t new_value)

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -150,12 +150,6 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_ctx_t * draw_ctx = lv_event_get_draw_ctx(e);
 
-    /*Calculate the indicator area*/
-    lv_coord_t bg_left = lv_obj_get_style_pad_left(obj,     LV_PART_MAIN);
-    lv_coord_t bg_right = lv_obj_get_style_pad_right(obj,   LV_PART_MAIN);
-    lv_coord_t bg_top = lv_obj_get_style_pad_top(obj,       LV_PART_MAIN);
-    lv_coord_t bg_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
-
     /*Draw the indicator*/
     /*Respect the background's padding*/
     lv_area_t indic_area;

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -151,8 +151,8 @@ static void draw_main(lv_event_t * e)
     lv_draw_ctx_t * draw_ctx = lv_event_get_draw_ctx(e);
 
     /*Draw the indicator*/
-    /*Respect the background's padding*/
     lv_area_t indic_area;
+    /*Exclude background's padding*/
     lv_obj_get_content_coords(obj, &indic_area);
 
     lv_draw_rect_dsc_t draw_indic_dsc;
@@ -180,11 +180,9 @@ static void draw_main(lv_event_t * e)
     }
 
     lv_area_t knob_area;
-    knob_area.x1 = obj->coords.x1 + anim_value_x;
+    lv_area_copy(&knob_area, &obj->coords);
+    knob_area.x1 += anim_value_x;
     knob_area.x2 = knob_area.x1 + (knob_size > 0 ? knob_size - 1 : 0);
-
-    knob_area.y1 = obj->coords.y1;
-    knob_area.y2 = obj->coords.y2;
 
     lv_coord_t knob_left = lv_obj_get_style_pad_left(obj, LV_PART_KNOB);
     lv_coord_t knob_right = lv_obj_get_style_pad_right(obj, LV_PART_KNOB);

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -159,11 +159,7 @@ static void draw_main(lv_event_t * e)
     /*Draw the indicator*/
     /*Respect the background's padding*/
     lv_area_t indic_area;
-    lv_area_copy(&indic_area, &obj->coords);
-    indic_area.x1 += bg_left;
-    indic_area.x2 -= bg_right;
-    indic_area.y1 += bg_top;
-    indic_area.y2 -= bg_bottom;
+    lv_obj_get_content_coords(obj, &indic_area);
 
     lv_draw_rect_dsc_t draw_indic_dsc;
     lv_draw_rect_dsc_init(&draw_indic_dsc);


### PR DESCRIPTION
- Modularize the `meter` drawing `mid` section
- The plot `switch` indicator area using a uniform coordinate acquisition interface `lv_obj_get_content_coords`