### PR TITLE
chore: fix warning build on macOS

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -9,7 +9,6 @@
 #include "lv_disp.h"
 #include "../misc/lv_math.h"
 #include "../core/lv_refr.h"
-#include "../core/lv_disp.h"
 #include "../core/lv_disp_private.h"
 #include "../misc/lv_gc.h"
 

--- a/src/core/lv_disp_private.h
+++ b/src/core/lv_disp_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 #include "lv_obj.h"
 #include "../draw/lv_draw.h"
-
+#include "lv_disp.h"
 /*********************
  *      DEFINES
  *********************/
@@ -28,8 +28,6 @@ extern "C" {
  **********************/
 
 struct _lv_disp_t;
-
-typedef void (*lv_disp_flush_cb_t)(struct _lv_disp_t * disp, const lv_area_t * area, lv_color_t * px_map);
 
 struct _lv_disp_t {
 

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -6,7 +6,6 @@
 /*********************
  *      INCLUDES
  ********************/
-#include "lv_indev.h"
 #include "lv_indev_private.h"
 #include "lv_disp.h"
 #include "lv_disp_private.h"

--- a/src/core/lv_indev_private.h
+++ b/src/core/lv_indev_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-
+#include "lv_indev.h"
 /*********************
  *      DEFINES
  *********************/
@@ -23,8 +23,6 @@ extern "C" {
  **********************/
 
 struct _lv_indev_t;
-
-typedef void (*lv_indev_read_cb_t)(struct _lv_indev_t * indev, lv_indev_data_t * data);
 
 struct _lv_indev_t {
     /**< Input device type*/


### PR DESCRIPTION
### Description of the feature or fix

```cpp
Building C object build_lvgl/CMakeFiles/lvgl_demos.dir/demos/widgets/assets/img_clothes.c.o
In file included from lvgl/demos/widgets/assets/img_clothes.c:1:
In file included from lvgl/demos/widgets/assets/../../../lvgl.h:117:
In file included from lvgl/src/lvgl_private.h:16:
lvgl/src/misc/../core/lv_disp_private.h:32:16: warning: redefinition of typedef 'lv_disp_flush_cb_t' is a C11 feature [-Wtypedef-redefinition]
typedef void (*lv_disp_flush_cb_t)(struct _lv_disp_t * disp, const lv_area_t * area, lv_color_t * px_map);
               ^
lvgl/src/core/../core/lv_disp.h:88:16: note: previous definition is here
typedef void (*lv_disp_flush_cb_t)(struct _lv_disp_t * disp, const lv_area_t * area, lv_color_t * px_map);
               ^
In file included from lvgl/demos/widgets/assets/img_clothes.c:1:
In file included from lvgl/demos/widgets/assets/../../../lvgl.h:117:
In file included from lvgl/src/lvgl_private.h:17:
lvgl/src/misc/../core/lv_indev_private.h:27:16: warning: redefinition of typedef 'lv_indev_read_cb_t' is a C11 feature [-Wtypedef-redefinition]
typedef void (*lv_indev_read_cb_t)(struct _lv_indev_t * indev, lv_indev_data_t * data);
               ^
lvgl/src/core/lv_indev.h:60:16: note: previous definition is here
typedef void (*lv_indev_read_cb_t)(struct _lv_indev_t * indev, lv_indev_data_t * data);
               ^
2 warnings generated.
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
