### PR TITLE
fix: update Kconfig and lv_conf_kconfig.h

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -21,6 +21,8 @@ menu "LVGL configuration"
 
 			config LV_COLOR_DEPTH_32
 				bool "32: ARGB8888"
+			config LV_COLOR_DEPTH_24
+				bool "24: RGB888"
 			config LV_COLOR_DEPTH_16
 				bool "16: RGB565"
 			config LV_COLOR_DEPTH_8
@@ -34,6 +36,7 @@ menu "LVGL configuration"
 			default 1 if LV_COLOR_DEPTH_1
 			default 8 if LV_COLOR_DEPTH_8
 			default 16 if LV_COLOR_DEPTH_16
+			default 24 if LV_COLOR_DEPTH_24
 			default 32 if LV_COLOR_DEPTH_32
 
 		config LV_COLOR_MIX_ROUND_OFS
@@ -57,28 +60,65 @@ menu "LVGL configuration"
 	endmenu
 
 	menu "Memory settings"
-		config LV_MEM_CUSTOM
-			bool "If true use custom malloc/free, otherwise use the built-in `lv_malloc()` and `lv_free()`"
+		choice
+			prompt "Malloc functions source"
+			default LV_USE_BUILTIN_MALLOC
+
+		config LV_USE_BUILTIN_MALLOC
+			bool "LVGL's built in implementation"
+
+		config LV_USE_CLIB_MALLOC
+			bool "Standard C functions malloc/realloc/free"
+
+		config LV_USE_CUSTOM_MALLOC
+			bool "Implement the functions externally"
+
+		endchoice # "Malloc functions"
+
+		choice
+			prompt "String functions source"
+			default LV_USE_BUILTIN_STRING
+
+		config LV_USE_BUILTIN_STRING
+			bool "LVGL's built in implementation"
+
+		config LV_USE_CLIB_STRING
+			bool "Standard C functions memcpy/memset/strlen/strcpy"
+
+		config LV_USE_CUSTOM_STRING
+			bool "Implement the functions externally"
+
+		endchoice # "String functions"
+
+		choice
+			prompt "Sprintf functions source"
+			default LV_USE_BUILTIN_SPRINTF
+
+		config LV_USE_BUILTIN_SPRINTF
+			bool "LVGL's built in implementation"
+
+		config LV_USE_CLIB_SPRINTF
+			bool "Standard C functions vsnprintf"
+
+		config LV_USE_CUSTOM_SPRINTF
+			bool "Implement the functions externally"
+
+		endchoice # "Sprintf functions"
 
 		config LV_MEM_SIZE_KILOBYTES
 			int "Size of the memory used by `lv_malloc()` in kilobytes (>= 2kB)"
 			default 32
-			depends on !LV_MEM_CUSTOM
+			depends on LV_USE_BUILTIN_MALLOC
 
 		config LV_MEM_POOL_EXPAND_SIZE_KILOBYTES
 			int "Size of the memory expand for `lv_malloc()` in kilobytes"
 			default 0
-			depends on !LV_MEM_CUSTOM
+			depends on LV_USE_BUILTIN_MALLOC
 
-		config LV_MEM_ADDR
+		config LV_MEM_ADR
 			hex "Address for the memory pool instead of allocating it as a normal array"
 			default 0x0
-			depends on !LV_MEM_CUSTOM
-
-		config LV_MEM_CUSTOM_INCLUDE
-			string "Header to include for the custom memory function"
-			default "stdlib.h"
-			depends on LV_MEM_CUSTOM
+			depends on LV_USE_BUILTIN_MALLOC
 
 		config LV_MEM_BUF_MAX_NUM
 			int "Number of the memory buffer"
@@ -88,8 +128,6 @@ menu "LVGL configuration"
 				internal processing mechanisms.  You will see an error log message if
 				there wasn't enough buffers.
 
-		config LV_MEMCPY_MEMSET_STD
-			bool "Use the standard memcpy and memset instead of LVGL's own functions"
 	endmenu
 
 	menu "HAL Settings"
@@ -112,25 +150,32 @@ menu "LVGL configuration"
 	menu "Feature configuration"
 
 		menu "Drawing"
-			config LV_DRAW_COMPLEX
+			config LV_USE_DRAW_SW
+				bool "Enable software rendering"
+				default y
+			help
+				Required to draw anything on the screen.
+
+			config LV_DRAW_SW_COMPLEX
 				bool "Enable complex draw engine"
 				default y
+				depends on LV_USE_DRAW_SW
 				help
 					Required to draw shadow, gradient, rounded corners, circles, arc, skew lines,
 					image transformations or any masks.
 
-			config LV_SHADOW_CACHE_SIZE
+			config LV_DRAW_SW_SHADOW_CACHE_SIZE
 				int "Allow buffering some shadow calculation"
-				depends on LV_DRAW_COMPLEX
+				depends on LV_DRAW_SW_COMPLEX
 				default 0
 				help
-					LV_SHADOW_CACHE_SIZE is the max shadow size to buffer, where
+					LV_DRAW_SW_SHADOW_CACHE_SIZE is the max shadow size to buffer, where
 					shadow size is `shadow_width + radius`.
-					Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost.
+					Caching has LV_DRAW_SW_SHADOW_CACHE_SIZE^2 RAM cost.
 
-			config LV_CIRCLE_CACHE_SIZE
+			config LV_DRAW_SW_CIRCLE_CACHE_SIZE
 				int "Set number of maximally cached circle data"
-				depends on LV_DRAW_COMPLEX
+				depends on LV_DRAW_SW_COMPLEX
 				default 4
 				help
 					The circumference of 1/4 circle are saved for anti-aliasing
@@ -138,9 +183,10 @@ menu "LVGL configuration"
 					radiuses are saved).
 					Set to 0 to disable caching.
 
-			config LV_LAYER_SIMPLE_BUF_SIZE
+			config LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
 				int "Optimal size to buffer the widget with opacity"
 				default 24576
+				depends on LV_USE_DRAW_SW
 				help
 					"Simple layers" are used when a widget has `style_opa < 255`
 					to buffer the widget into a layer and blend it as an image
@@ -150,6 +196,7 @@ menu "LVGL configuration"
 			config LV_IMG_CACHE_DEF_SIZE
 				int "Default image cache size. 0 to disable caching."
 				default 0
+				depends on LV_USE_DRAW_SW
 				help
 					If only the built-in image formats are used there is no real advantage of caching.
 					(I.e. no new image decoder is added).
@@ -161,6 +208,7 @@ menu "LVGL configuration"
 			config LV_GRADIENT_MAX_STOPS
 				int "Number of stops allowed per gradient."
 				default 2
+				depends on LV_USE_DRAW_SW
 				help
 					Increase this to allow more stops.
 					This adds (sizeof(lv_color_t) + 1) bytes per additional stop
@@ -168,6 +216,7 @@ menu "LVGL configuration"
 			config LV_GRAD_CACHE_DEF_SIZE
 				int "Default gradient buffer size."
 				default 0
+				depends on LV_USE_DRAW_SW
 				help
 					When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
 					LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
@@ -176,6 +225,7 @@ menu "LVGL configuration"
 
 			config LV_DITHER_GRADIENT
 				bool "Allow dithering the gradients"
+				depends on LV_USE_DRAW_SW
 				help
 					Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
 					LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
@@ -191,6 +241,7 @@ menu "LVGL configuration"
 			config LV_DISP_ROT_MAX_BUF
 				int "Maximum buffer size to allocate for rotation"
 				default 10240
+				depends on LV_USE_DRAW_SW
 				help
 					Only used if software rotation is enabled in the display driver.
 		endmenu
@@ -338,7 +389,7 @@ menu "LVGL configuration"
 				bool "Enable/Disable LV_LOG_TRACE in anim module"
 				default y
 				depends on LV_USE_LOG
-			
+
 			config LV_LOG_TRACE_MSG
 				bool "Enable/Disable LV_LOG_TRACE in msg module"
 				default y
@@ -436,17 +487,13 @@ menu "LVGL configuration"
 			config LV_USE_REFR_DEBUG
 				bool "Draw random colored rectangles over the redrawn areas."
 
-			config LV_SPRINTF_CUSTOM
-				bool "Change the built-in (v)snprintf functions"
-
-			config LV_SPRINTF_INCLUDE
-				string "Header to include for the custom sprintf function"
-				depends on LV_SPRINTF_CUSTOM
-				default "stdio.h"
+			config LV_USE_BUILTIN_SNPRINTF
+				bool "Use the built-in (v)snprintf functions"
+				default y
 
 			config LV_SPRINTF_USE_FLOAT
 				bool "Enable float in built-in (v)snprintf functions"
-				depends on !LV_SPRINTF_CUSTOM
+				depends on LV_USE_BUILTIN_SNPRINTF
 
 			config LV_ENABLE_GC
 				bool "Enable garbage collector"
@@ -811,9 +858,6 @@ menu "LVGL configuration"
 		config LV_USE_CHART
 			bool "Chart."
 			default y if !LV_CONF_MINIMAL
-		config LV_USE_COLORWHEEL
-			bool "Colorwheel."
-			default y if !LV_CONF_MINIMAL
 		config LV_USE_IMGBTN
 			bool "Imgbtn."
 			default y if !LV_CONF_MINIMAL
@@ -1068,7 +1112,7 @@ menu "LVGL configuration"
 			help
 				Set the maximum number of candidate panels that can be displayed.
 				This needs to be adjusted according to the size of the screen.
-		
+
 		config LV_USE_FILE_EXPLORER
 			bool "Enable file explorer"
 			default n

--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -784,7 +784,6 @@ static void spectrum_draw_event_cb(lv_event_t * e)
         lv_opa_t opa = lv_obj_get_style_opa(obj, LV_PART_MAIN);
         if(opa < LV_OPA_MIN) return;
 
-        lv_point_t poly[4];
         lv_point_t center;
         center.x = obj->coords.x1 + lv_obj_get_width(obj) / 2;
         center.y = obj->coords.y1 + lv_obj_get_height(obj) / 2;

--- a/examples/widgets/chart/lv_example_chart_2.c
+++ b/examples/widgets/chart/lv_example_chart_2.c
@@ -1,6 +1,6 @@
 #include "../../lv_examples.h"
 //TODO should be a chart feature
-#if LV_USE_CHART && LV_USE_DRAW_MASKS && LV_BUILD_EXAMPLES && 0
+#if LV_USE_CHART && LV_DRAW_SW_COMPLEX && LV_BUILD_EXAMPLES && 0
 
 static lv_obj_t * chart1;
 static lv_chart_series_t * ser1;

--- a/examples/widgets/chart/lv_example_chart_8.c
+++ b/examples/widgets/chart/lv_example_chart_8.c
@@ -1,6 +1,6 @@
 #include "../../lv_examples.h"
 //TODO Should be a chart feature
-#if LV_USE_CHART && LV_USE_DRAW_MASKS && LV_BUILD_EXAMPLES && 0
+#if LV_USE_CHART && LV_DRAW_SW_COMPLEX && LV_BUILD_EXAMPLES && 0
 
 /*  A struct is used to keep track of the series list because later we need to draw to the series in the reverse order to which they were initialised. */
 typedef struct {

--- a/examples/widgets/chart/lv_example_chart_9.c
+++ b/examples/widgets/chart/lv_example_chart_9.c
@@ -1,5 +1,5 @@
 #include "../../lv_examples.h"
-#if LV_USE_CHART && LV_USE_DRAW_MASKS && LV_BUILD_EXAMPLES
+#if LV_USE_CHART && LV_DRAW_SW_COMPLEX && LV_BUILD_EXAMPLES
 
 
 static void add_data(lv_timer_t * t)

--- a/examples/widgets/label/lv_example_label_4.c
+++ b/examples/widgets/label/lv_example_label_4.c
@@ -1,6 +1,6 @@
 #include "../../lv_examples.h"
 //TODO
-#if LV_USE_LABEL && LV_USE_CANVAS && LV_BUILD_EXAMPLES && LV_USE_DRAW_MASKS && 0
+#if LV_USE_LABEL && LV_USE_CANVAS && LV_BUILD_EXAMPLES && LV_DRAW_SW_COMPLEX && 0
 
 #define MASK_WIDTH 100
 #define MASK_HEIGHT 45

--- a/examples/widgets/roller/lv_example_roller_3.c
+++ b/examples/widgets/roller/lv_example_roller_3.c
@@ -1,6 +1,6 @@
 #include "../../lv_examples.h"
 //TODO
-#if LV_USE_ROLLER && LV_USE_DRAW_MASKS && LV_BUILD_EXAMPLES && 0
+#if LV_USE_ROLLER && LV_DRAW_SW_COMPLEX && LV_BUILD_EXAMPLES && 0
 
 static void mask_event_cb(lv_event_t * e)
 {

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -387,6 +387,9 @@ static void decompress(const uint8_t * in, uint8_t * out, lv_coord_t w, lv_coord
         case 4:
             opa_table = opa4_table;
             break;
+        default:
+            LV_LOG_WARN("%d bpp is not handled", bpp);
+            return;
     }
 
     rle_init(in, bpp);

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -34,6 +34,42 @@ extern "C" {
 #endif
 
 /*******************
+ * LV_USE_STDLIB_MALLOC
+ *******************/
+
+#if defined(CONFIG_LV_USE_BUILTIN_MALLOC)
+#  define CONFIG_LV_USE_STDLIB_MALLOC LV_STDLIB_BUILTIN
+#elif defined(CONFIG_LV_USE_CLIB_MALLOC)
+#  define CONFIG_LV_USE_STDLIB_MALLOC LV_STDLIB_CLIB
+#elif defined (CONFIG_LV_USE_CUSTOM_MALLOC)
+#  define CONFIG_LV_USE_STDLIB_MALLOC LV_STDLIB_CUSTOM
+#endif
+
+/*******************
+ * LV_USE_STDLIB_STRING
+ *******************/
+
+#if defined(CONFIG_LV_USE_BUILTIN_STRING)
+#  define CONFIG_LV_USE_STDLIB_STRING LV_STDLIB_BUILTIN
+#elif defined(CONFIG_LV_USE_CLIB_STRING)
+#  define CONFIG_LV_USE_STDLIB_STRING LV_STDLIB_CLIB
+#elif defined (CONFIG_LV_USE_CUSTOM_STRING)
+#  define CONFIG_LV_USE_STDLIB_STRING LV_STDLIB_CUSTOM
+#endif
+
+/*******************
+ * LV_USE_STDLIB_SPRINTF
+ *******************/
+
+#if defined(CONFIG_LV_USE_BUILTIN_SPRINTF)
+#  define CONFIG_LV_USE_STDLIB_SPRINTF LV_STDLIB_BUILTIN
+#elif defined(CONFIG_LV_USE_CLIB_SPRINTF)
+#  define CONFIG_LV_USE_STDLIB_SPRINTF LV_STDLIB_CLIB
+#elif defined (CONFIG_LV_USE_CUSTOM_SPRINTF)
+#  define CONFIG_LV_USE_STDLIB_SPRINTF LV_STDLIB_CUSTOM
+#endif
+
+/*******************
  * LV_MEM_SIZE
  *******************/
 

--- a/src/themes/basic/lv_theme_basic.c
+++ b/src/themes/basic/lv_theme_basic.c
@@ -34,7 +34,7 @@ typedef struct {
     lv_style_t dark;
     lv_style_t dim;
     lv_style_t scrollbar;
-#if LV_USE_ARC || LV_USE_COLORWHEEL
+#if LV_USE_ARC
     lv_style_t arc_line;
     lv_style_t arc_knob;
 #endif
@@ -113,7 +113,7 @@ static void style_init(void)
     lv_style_set_arc_width(&styles->dim, 2);
     lv_style_set_arc_color(&styles->dim, COLOR_DIM);
 
-#if LV_USE_ARC || LV_USE_COLORWHEEL
+#if LV_USE_ARC
     style_init_reset(&styles->arc_line);
     lv_style_set_arc_width(&styles->arc_line, 6);
     style_init_reset(&styles->arc_knob);

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -122,10 +122,6 @@ typedef struct {
     lv_style_t calendar_btnm_bg, calendar_btnm_day, calendar_header;
 #endif
 
-#if LV_USE_COLORWHEEL
-    lv_style_t colorwheel_main;
-#endif
-
 #if LV_USE_MENU
     lv_style_t menu_bg, menu_cont, menu_sidebar_cont, menu_main_cont, menu_page, menu_header_cont, menu_header_btn,
                menu_section, menu_pressed, menu_separator;
@@ -579,11 +575,6 @@ static void style_init(void)
     lv_style_set_pad_top(&styles->calendar_header, PAD_SMALL);
     lv_style_set_pad_bottom(&styles->calendar_header, PAD_TINY);
     lv_style_set_pad_gap(&styles->calendar_header, PAD_SMALL);
-#endif
-
-#if LV_USE_COLORWHEEL
-    style_init_reset(&styles->colorwheel_main);
-    lv_style_set_arc_width(&styles->colorwheel_main, lv_disp_dpx(theme.disp, 10));
 #endif
 
 #if LV_USE_MSGBOX

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -80,5 +80,3 @@
 #define LV_USE_DEMO_MULTILANG   1
 
 
-#define LV_USE_COLORWHEEL   0
-


### PR DESCRIPTION
### Description of the feature or fix

Fix some build errors found within a Kconfig system.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
