### PR TITLE
chore(cmsis-pack): update cmsis-pack for v8.3.8

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -20,7 +20,7 @@
 -->
 
 
-<package schemaVersion="1.4" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+<package schemaVersion="1.4" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd">
   <vendor>LVGL</vendor>
   <name>lvgl</name>
   <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
@@ -36,11 +36,17 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-04-28" version="8.3.7" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.7.pack">
+    <release date="2023-07-04" version="8.3.8" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.8.pack">
+      - LVGL 8.3.8
+      - Add renesas-ra6m3 gpu adaptation
+      - Improve performance and add more features for PXP and VGLite
+      - Minor updates
+    </release>
+    <release date="2023-04-28" version="8.3.7" url="https://github.com/lvgl/lvgl/raw/2b56e04205481daa6575bd5f7ab5df59d11676eb/env_support/cmsis-pack/LVGL.lvgl.8.3.7.pack">
       - LVGL 8.3.7
       - Minor updates
     </release>
-    <release date="2023-04-02" version="8.3.6" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
+    <release date="2023-04-02" version="8.3.6" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
       - LVGL 8.3.6 release
       - Various fixes, See CHANGELOG.md
     </release>
@@ -181,6 +187,7 @@
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
         </condition>
         
         <condition id="LVGL-GPU-STM32-DMA2D">
@@ -192,6 +199,7 @@
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
         </condition>
         
         <condition id="LVGL-GPU-SWM341-DMA2D">
@@ -203,6 +211,7 @@
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
         </condition>
         
         <condition id="LVGL-GPU-NXP-PXP">
@@ -214,6 +223,7 @@
             <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>-->
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
         </condition>
         
         <condition id="LVGL-GPU-NXP-VGLite">
@@ -225,6 +235,7 @@
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
             <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>-->
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
         </condition>
         
         <condition id="LVGL-GPU-GD32-IPA">
@@ -236,6 +247,19 @@
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
             <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
             <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>-->
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>
+        </condition>
+
+        <condition id="LVGL-GPU-RA6M3-G2D">
+            <description>Enable LVGL Arm-2D GPU Support</description>
+            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="LVGL-GPU-RA6M3-G2D"/>-->
         </condition>
 
     </conditions>
@@ -270,7 +294,7 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.7">
+        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.8">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
             <component Cgroup="lvgl" Csub="Essential" >
@@ -525,6 +549,22 @@
 #define LV_USE_GPU_NXP_VG_LITE          1
               </RTE_Components_h>
 
+            </component>
+
+
+            <component Cgroup="lvgl" Csub="GPU RA6M3-G2D"  condition="LVGL-GPU-RA6M3-G2D">
+              <description>An hardware acceleration from Renesas RA6M3-G2D</description>
+              <files>
+                <file category="sourceC"            name="src/draw/renesas/lv_gpu_d2_draw_label.c" />
+                <file category="sourceC"            name="src/draw/renesas/lv_gpu_d2_ra6m3.c" />
+              </files>
+              
+              <RTE_Components_h>
+              
+/*! \brief enable RA6M3-G2D */
+#define LV_USE_GPU_RA6M3_G2D      1
+              </RTE_Components_h>
+              
             </component>
 
             <component Cgroup="lvgl" Csub="Extra Themes"  condition="LVGL-Essential">

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2023-05-03</timestamp>
+  <timestamp>2023-07-04</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.7"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.8"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.7
+ * Configuration file for v8.3.8
  */
 
 /* clang-format off */
@@ -198,6 +198,12 @@
     *0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
     */
     #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#endif
+
+#if LV_USE_GPU_RA6M3_G2D
+    /*include path of target processor
+    e.g. "hal_data.h"*/
+    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
 #endif
 
 /*Use SDL renderer API*/

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "lvgl",
-	"version": "8.3.7",
+	"version": "8.3.8",
 	"keywords": "graphics, gui, embedded, tft, lvgl",
 	"description": "Graphics library to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint. It offers anti-aliasing, opacity, and animations using only one frame buffer.",
 	"repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=lvgl
-version=8.3.7
+version=8.3.8
 author=kisvegabor
 maintainer=kisvegabor,embeddedt,pete-pjb
 sentence=Full-featured Graphics Library for Embedded Systems

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.7
+ * Configuration file for v8.3.8
  */
 
 /*

--- a/lvgl.h
+++ b/lvgl.h
@@ -15,7 +15,7 @@ extern "C" {
  ***************************/
 #define LVGL_VERSION_MAJOR 8
 #define LVGL_VERSION_MINOR 3
-#define LVGL_VERSION_PATCH 7
+#define LVGL_VERSION_PATCH 8
 #define LVGL_VERSION_INFO ""
 
 /*********************


### PR DESCRIPTION
### Description of the feature or fix

Update cmsis-pack for LVGL 8.3.8
      - Add renesas-ra6m3 gpu adaptation
      - Minor updates

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
