### PR TITLE
changes a couple of things to get the CPython binding working.

### DIFF
--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -227,10 +227,6 @@ const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, uint32_t unic
 bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                    uint32_t unicode_letter_next);
 
-/**
- * Free the allocated memories.
- */
-void _lv_font_clean_up_fmt_txt(void);
 
 /**********************
  *      MACROS

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -19,18 +19,7 @@
  *      TYPEDEFS
  **********************/
 
-/*Data of anim_timeline_dsc*/
-typedef struct {
-    lv_anim_t anim;
-    uint32_t start_time;
-} lv_anim_timeline_dsc_t;
 
-/*Data of anim_timeline*/
-struct _lv_anim_timeline_t {
-    lv_anim_timeline_dsc_t * anim_dsc;  /**< Dynamically allocated anim dsc array*/
-    uint32_t anim_dsc_cnt;              /**< The length of anim dsc array*/
-    bool reverse;                       /**< Reverse playback*/
-};
 
 /**********************
  *  STATIC PROTOTYPES

--- a/src/misc/lv_anim_timeline.h
+++ b/src/misc/lv_anim_timeline.h
@@ -23,7 +23,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
- /*Data of anim_timeline_dsc*/
+/*Data of anim_timeline_dsc*/
 typedef struct {
     lv_anim_t anim;
     uint32_t start_time;

--- a/src/misc/lv_anim_timeline.h
+++ b/src/misc/lv_anim_timeline.h
@@ -23,9 +23,18 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_anim_timeline_t;
+ /*Data of anim_timeline_dsc*/
+typedef struct {
+    lv_anim_t anim;
+    uint32_t start_time;
+} lv_anim_timeline_dsc_t;
 
-typedef struct _lv_anim_timeline_t lv_anim_timeline_t;
+/*Data of anim_timeline*/
+typedef struct {
+    lv_anim_timeline_dsc_t * anim_dsc;  /**< Dynamically allocated anim dsc array*/
+    uint32_t anim_dsc_cnt;              /**< The length of anim dsc array*/
+    bool reverse;                       /**< Reverse playback*/
+} lv_anim_timeline_t;
 
 /**********************
 * GLOBAL PROTOTYPES

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -18,11 +18,6 @@
 /**********************
  *      TYPEDEFS
  **********************/
-struct _lv_event_dsc_t {
-    lv_event_cb_t cb;
-    void * user_data;
-    uint32_t filter;
-};
 
 /**********************
  *  STATIC PROTOTYPES

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -25,9 +25,15 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef void (*lv_event_cb_t)(struct _lv_event_t * e);
 
-struct _lv_event_dsc_t;
-typedef struct _lv_event_dsc_t lv_event_dsc_t;
+
+typedef struct {
+    lv_event_cb_t cb;
+    void * user_data;
+    uint32_t filter;
+} lv_event_dsc_t;
+
 
 /**
  * Type of event being sent to the object.
@@ -131,7 +137,6 @@ typedef struct _lv_event_t {
  * Events are used to notify the user of some action being taken on the object.
  * For details, see ::lv_event_t.
  */
-typedef void (*lv_event_cb_t)(lv_event_t * e);
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -25,6 +25,8 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+struct _lv_event_t;
+
 typedef void (*lv_event_cb_t)(struct _lv_event_t * e);
 
 


### PR DESCRIPTION
These are pretty minor changes. One is removing the declaration for the `_lv_font_clean_up_fmt_txt` function. The function wasn't defined which caused linking problems.

I also moved a couple of structures that were defined in source files and put them into the header files. If this is an issue let me know, I will see if I can manage to work around them not being exposed. I am not sure if ctypes will play nice with me if it is unable to determine the size of the structures. Because ctypes is disconnected so to speak from the structures in C code The only way for me to show their existence is if they can be seen in the header files. That includes the fields in the structures. This is if the structure is used aas a type for aa field in a public structure or as a type in a public function.

They are small changes, I hope it's not a big deal to make them. I managed to code around the rest of the issues I was having before.

The code generation script is too specific to LVGL for my liking, so it will need maintenance due to it having specific parts of it coded specifically to handle LVGL, if those things change it could break. Not a huge deal.
