### PR TITLE
Specify color format value in enum

### DIFF
--- a/src/draw/lv_img_buf.h
+++ b/src/draw/lv_img_buf.h
@@ -61,13 +61,11 @@ typedef struct {
 } lv_img_header_t;
 #else
 typedef struct {
-
     uint32_t cf : 5;          /*Color format: See `lv_color_format_t`*/
     uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
                                  non-printable character*/
 
-    uint32_t reserved : 1; /*Reserved to be used later*/
-    uint32_t chroma_keyed : 2; /*Reserved to be used later*/
+    uint32_t reserved : 2; /*Reserved to be used later*/
 
     uint32_t w : 11; /*Width of the image map*/
     uint32_t h : 11; /*Height of the image map*/

--- a/src/draw/lv_img_decoder.c
+++ b/src/draw/lv_img_decoder.c
@@ -352,7 +352,7 @@ lv_res_t lv_img_decoder_built_in_open(lv_img_decoder_t * decoder, lv_img_decoder
     if(dsc->src_type == LV_IMG_SRC_VARIABLE) {
         lv_img_dsc_t * img_dsc = (lv_img_dsc_t *)dsc->src;
         lv_color_format_t cf = img_dsc->header.cf;
-        if(cf >= LV_COLOR_FORMAT_I1 && cf <= LV_COLOR_FORMAT_I8) {
+        if(LV_COLOR_FORMAT_IS_INDEXED(cf)) {
             switch(cf) {
                 case LV_COLOR_FORMAT_I1:
                     dsc->palette_size = 2;
@@ -404,7 +404,7 @@ void lv_img_decoder_built_in_close(lv_img_decoder_t * decoder, lv_img_decoder_ds
     LV_UNUSED(decoder); /*Unused*/
     lv_img_dsc_t * img_dsc = (lv_img_dsc_t *)dsc->src;
     lv_color_format_t cf = img_dsc->header.cf;
-    if(cf >= LV_COLOR_FORMAT_I1 && cf <= LV_COLOR_FORMAT_I8) {
+    if(LV_COLOR_FORMAT_IS_INDEXED(cf)) {
         lv_free((void *)dsc->img_data);
     }
 }

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -57,7 +57,6 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_img_dsc_t * draw
     img_dsc.header.h = lv_area_get_height(&layer_to_draw->buf_area);
     img_dsc.header.cf = layer_to_draw->color_format;
     img_dsc.header.always_zero = 0;
-    img_dsc.header.chroma_keyed = 0;
     img_dsc.data = layer_to_draw->buf;
 
     lv_draw_img_dsc_t new_draw_dsc;

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -99,46 +99,59 @@ typedef struct {
 typedef uint8_t lv_opa_t;
 //! @endcond
 
+enum _lv_color_format_t {
+    LV_COLOR_FORMAT_UNKNOWN           = 0,
 
-typedef enum {
-    LV_COLOR_FORMAT_UNKNOWN,
+    LV_COLOR_FORMAT_RAW               = 0x01,
+    LV_COLOR_FORMAT_RAW_ALPHA         = 0x02,
 
     /*<=1 byte (+alpha) formats*/
-    LV_COLOR_FORMAT_L8,
-    LV_COLOR_FORMAT_A8,
-    LV_COLOR_FORMAT_I1,
-    LV_COLOR_FORMAT_I2,
-    LV_COLOR_FORMAT_I4,
-    LV_COLOR_FORMAT_I8,
+    LV_COLOR_FORMAT_L8                = 0x06,
+    LV_COLOR_FORMAT_I1                = 0x07,
+    LV_COLOR_FORMAT_I2                = 0x08,
+    LV_COLOR_FORMAT_I4                = 0x09,
+    LV_COLOR_FORMAT_I8                = 0x0A,
+    LV_COLOR_FORMAT_A8                = 0x0E,
 
     /*2 byte (+alpha) formats*/
-    LV_COLOR_FORMAT_RGB565,
-    LV_COLOR_FORMAT_RGB565A8,       /**< Color array followed by Alpha array*/
+    LV_COLOR_FORMAT_RGB565            = 0x12,
+    LV_COLOR_FORMAT_RGB565A8          = 0x14    /**< Color array followed by Alpha array*/,
 
     /*3 byte (+alpha) formats*/
-    LV_COLOR_FORMAT_RGB888,
-    LV_COLOR_FORMAT_ARGB8888,
-    LV_COLOR_FORMAT_XRGB8888,
+    LV_COLOR_FORMAT_RGB888            = 0x0F,
+    LV_COLOR_FORMAT_ARGB8888          = 0x10,
+    LV_COLOR_FORMAT_XRGB8888          = 0x11,
+
+    /*Miscellaneous formats*/
+    LV_COLOR_FORMAT_NATIVE_REVERSED   = 0x1A,
+
+    /*Formats not supported by software renderer but kept here so GPU can use it*/
+    LV_COLOR_FORMAT_A1                = 0x0B,
+    LV_COLOR_FORMAT_A2                = 0x0C,
+    LV_COLOR_FORMAT_A4                = 0x0D,
 
     /*Color formats in which LVGL can render*/
 #if LV_COLOR_DEPTH == 8
-    LV_COLOR_FORMAT_NATIVE = LV_COLOR_FORMAT_L8,
+    LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_L8,
 #elif LV_COLOR_DEPTH == 16
-    LV_COLOR_FORMAT_NATIVE =  LV_COLOR_FORMAT_RGB565,
+    LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_RGB565,
     LV_COLOR_FORMAT_NATIVE_WITH_ALPHA = LV_COLOR_FORMAT_RGB565A8,
 #elif LV_COLOR_DEPTH == 24
-    LV_COLOR_FORMAT_NATIVE = LV_COLOR_FORMAT_RGB888,
+    LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_RGB888,
     LV_COLOR_FORMAT_NATIVE_WITH_ALPHA = LV_COLOR_FORMAT_ARGB8888,
 #elif LV_COLOR_DEPTH == 32
-    LV_COLOR_FORMAT_NATIVE = LV_COLOR_FORMAT_XRGB8888,
+    LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_XRGB8888,
     LV_COLOR_FORMAT_NATIVE_WITH_ALPHA = LV_COLOR_FORMAT_ARGB8888,
 #endif
-    /*Miscellaneous formats*/
-    LV_COLOR_FORMAT_NATIVE_REVERSED = 0x1A,
+};
 
-    LV_COLOR_FORMAT_RAW,
-    LV_COLOR_FORMAT_RAW_ALPHA,
-} lv_color_format_t;
+#ifdef DOXYGEN
+typedef _lv_color_format_t lv_color_format_t;
+#else
+typedef uint8_t lv_color_format_t;
+#endif /*DOXYGEN*/
+
+#define LV_COLOR_FORMAT_IS_INDEXED(cf) ((cf) >= LV_COLOR_FORMAT_I1 && (cf) <= LV_COLOR_FORMAT_I8)
 
 
 /**********************

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -83,7 +83,7 @@ void lv_canvas_set_px(lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_color_t col
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
-    if(canvas->dsc.header.cf >= LV_COLOR_FORMAT_I1 && canvas->dsc.header.cf <= LV_COLOR_FORMAT_I8) {
+    if(LV_COLOR_FORMAT_IS_INDEXED(canvas->dsc.header.cf)) {
         uint32_t stride = (canvas->dsc.header.w + 7) >> 3;
         uint8_t * buf = (uint8_t *)canvas->dsc.data;
         buf += 8;


### PR DESCRIPTION
### Specify color format value in enum

Color format's value is used for binary image file generation. It's important to keep it consistent. 
- Use enum makes it hard to track its real value and tends to change easily. 
- `enum` size is platform dependent, but color format is supposed to be 8bit exact.  

~This PR changes it to macro,~ makes the CF value compatible with v8's definition, so the bin file generated and the tool can still work in V9, at least for now.

I have changed the macro back to enum but specify enum value to make micropython binding pass.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
