### PR TITLE
chore: fix build error on macOS

### DIFF
--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -116,6 +116,13 @@ typedef int32_t (*lv_anim_get_value_cb_t)(struct _lv_anim_t *);
 /** Callback used when the animation is deleted*/
 typedef void (*lv_anim_deleted_cb_t)(struct _lv_anim_t *);
 
+typedef struct _lv_anim_bezier3_para_t {
+    int16_t x1;
+    int16_t y1;
+    int16_t x2;
+    int16_t y2;
+} lv_anim_bezier3_para_t; /**< Parameter used when path is custom_bezier*/
+
 /** Describes an animation*/
 typedef struct _lv_anim_t {
     void * var;                          /**<Variable to animate*/
@@ -136,12 +143,7 @@ typedef struct _lv_anim_t {
     uint32_t repeat_delay;       /**< Wait before repeat*/
     uint16_t repeat_cnt;         /**< Repeat count for the animation*/
     union _lv_anim_path_para_t {
-        struct _lv_anim_bezier3_para_t {
-            int16_t x1;
-            int16_t y1;
-            int16_t x2;
-            int16_t y2;
-        } bezier3; /**< Parameter used when path is custom_bezier*/
+        lv_anim_bezier3_para_t bezier3; /**< Parameter used when path is custom_bezier*/
     } parameter;
 
     uint8_t early_apply  : 1;    /**< 1: Apply start value immediately even is there is `delay`*/


### PR DESCRIPTION
### Description of the feature or fix

```bash
In file included from lvgl/src/misc/lv_anim_timeline.h:16:
lvgl/src/misc/lv_anim.h:367:38: error: cannot initialize a variable of type 'struct _lv_anim_bezier3_para_t *' (aka '_lv_anim_bezier3_para_t *') with an rvalue of type 'struct _lv_anim_bezier3_para_t *' (aka '_lv_anim_t::_lv_anim_path_para_t::_lv_anim_bezier3_para_t *')
    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
                                     ^      ~~~~~~~~~~~~~~~~~~~~~
lvgl/src/misc/lv_anim.h:369:9: error: member access into incomplete type 'struct _lv_anim_bezier3_para_t'
    para->x1 = x1;
        ^
lvgl/src/misc/lv_anim.h:367:12: note: forward declaration of '_lv_anim_bezier3_para_t'
    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
           ^
lvgl/src/misc/lv_anim.h:370:9: error: member access into incomplete type 'struct _lv_anim_bezier3_para_t'
    para->x2 = x2;
        ^
lvgl/src/misc/lv_anim.h:367:12: note: forward declaration of '_lv_anim_bezier3_para_t'
    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
           ^
lvgl/src/misc/lv_anim.h:371:9: error: member access into incomplete type 'struct _lv_anim_bezier3_para_t'
    para->y1 = y1;
        ^
lvgl/src/misc/lv_anim.h:367:12: note: forward declaration of '_lv_anim_bezier3_para_t'
    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
           ^
lvgl/src/misc/lv_anim.h:372:9: error: member access into incomplete type 'struct _lv_anim_bezier3_para_t'
    para->y2 = y2;
        ^
lvgl/src/misc/lv_anim.h:367:12: note: forward declaration of '_lv_anim_bezier3_para_t'
    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
           ^
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
