### PR TITLE
Feat/freertos task notify

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -71,7 +71,6 @@ void lv_draw_sw_init(void)
         draw_sw_unit->idx = i;
 
 #if LV_USE_OS
-        lv_thread_sync_init(&draw_sw_unit->sync);
         lv_thread_init(&draw_sw_unit->thread, LV_THREAD_PRIO_HIGH, render_thread_cb, 8 * 1024, draw_sw_unit);
 #endif
     }
@@ -276,6 +275,8 @@ static void lv_draw_sw_buffer_clear(lv_layer_t * layer, const lv_area_t * a)
 static void render_thread_cb(void * ptr)
 {
     lv_draw_sw_unit_t * u = ptr;
+
+    lv_thread_sync_init(&u->sync);
 
     while(1) {
         while(u->task_act == NULL) {

--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -62,7 +62,7 @@ lv_res_t lv_thread_init(lv_thread_t * pxThread, lv_thread_prio_t xSchedPriority,
                         void * xAttr)
 {
     pxThread->xTaskArg = xAttr;
-    pxThread->pvStartRoutine = (void * (*)(void *))pvStartRoutine;
+    pxThread->pvStartRoutine = pvStartRoutine;
 
     BaseType_t xTaskCreateStatus = xTaskCreate(
                                        prvRunThread,
@@ -290,7 +290,7 @@ static void prvRunThread(void * pxArg)
     lv_thread_t * pxThread = (lv_thread_t *)pxArg;
 
     /* Run the thread routine. */
-    pxThread->xReturn = pxThread->pvStartRoutine((void *)pxThread->xTaskArg);
+    pxThread->pvStartRoutine((void *)pxThread->xTaskArg);
 
     vTaskDelete(NULL);
 }

--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -252,7 +252,7 @@ lv_res_t lv_thread_sync_signal(lv_thread_sync_t * pxCond)
                0,
                ulLocalWaitingThreads)) {
             /* Unblock all. */
-            for(int i = 0; i < ulLocalWaitingThreads; i++) {
+            for(uint32_t i = 0; i < ulLocalWaitingThreads; i++) {
                 xSemaphoreGive(pxCond->xCondWaitSemaphore);
             }
 

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -29,6 +29,14 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/*
+ * Unblocking an RTOS task with a direct notification is 45% faster and uses less RAM
+ * than unblocking a task using an intermediary object such as a binary semaphore.
+ *
+ * RTOS task notifications can only be used when there is only one task that can be the recipient of the event.
+ */
+#define USE_FREERTOS_TASK_NOTIFY 1
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -45,12 +53,16 @@ typedef struct {
 } lv_mutex_t;
 
 typedef struct {
+#if USE_FREERTOS_TASK_NOTIFY
+    TaskHandle_t xTaskToNotify;
+#else
     BaseType_t
     xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
     SemaphoreHandle_t xCondWaitSemaphore; /**< Threads block on this semaphore in lv_thread_sync_wait. */
     uint32_t ulWaitingThreads;            /**< The number of threads currently waiting on this condition variable. */
     SemaphoreHandle_t xSyncMutex;         /**< Threads take this mutex before accessing the condition variable. */
     BaseType_t xSyncSignal;               /**< Set to pdTRUE if the thread is signaled, pdFALSE otherwise. */
+#endif
 } lv_thread_sync_t;
 
 /**********************

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -46,7 +46,7 @@ typedef struct {
 
 typedef struct {
     BaseType_t
-    xIsInitialized;            /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
+    xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
     SemaphoreHandle_t xCondWaitSemaphore; /**< Threads block on this semaphore in lv_thread_sync_wait. */
     uint32_t ulWaitingThreads;            /**< The number of threads currently waiting on this condition variable. */
     SemaphoreHandle_t xSyncMutex;         /**< Threads take this mutex before accessing the condition variable. */

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -34,10 +34,9 @@ extern "C" {
  **********************/
 
 typedef struct {
-    void * (*pvStartRoutine)(void *);     /**< Application thread function. */
+    void (*pvStartRoutine)(void *);       /**< Application thread function. */
     void * xTaskArg;                      /**< Arguments for application thread function. */
     TaskHandle_t xTaskHandle;             /**< FreeRTOS task handle. */
-    void * xReturn;                       /**< Return value of pvStartRoutine. */
 } lv_thread_t;
 
 typedef struct {


### PR DESCRIPTION
### Description of the feature or fix

Freertos updates.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
