### PR TITLE
Refresh test code. ***DO NOT MERGE***

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -346,6 +346,21 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
         return;
     }
 
+    /*Do nothing if there is no active screen*/
+    if(disp_refr->act_scr == NULL) {
+        disp_refr->inv_p = 0;
+        LV_LOG_WARN("there is no active screen");
+        return;
+    }
+
+    if (
+        (disp_refr->act_scr->scr_layout_inv == 0) &&
+        (disp_refr->inv_p == 0) &&
+        ((disp_refr->prev_scr == NULL) || (disp_refr->prev_scr->scr_layout_inv))
+    ) {
+        return;
+    }
+
     lv_disp_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
 
     /*Refresh the screen's layout if required*/
@@ -356,15 +371,7 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     lv_obj_update_layout(disp_refr->top_layer);
     lv_obj_update_layout(disp_refr->sys_layer);
 
-    /*Do nothing if there is no active screen*/
-    if(disp_refr->act_scr == NULL) {
-        disp_refr->inv_p = 0;
-        LV_LOG_WARN("there is no active screen");
-        goto refr_finish;
-    }
-
     lv_refr_join_area();
-
     refr_invalid_areas();
 
     if(disp_refr->inv_p == 0) goto refr_finish;
@@ -372,30 +379,6 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     /*If refresh happened ...*/
     /*Call monitor cb if present*/
     lv_disp_send_event(disp_refr, LV_EVENT_RENDER_READY, NULL);
-
-    if(!lv_disp_is_double_buffered(disp_refr) || disp_refr->render_mode != LV_DISP_RENDER_MODE_DIRECT) goto refr_clean_up;
-
-    /*With double buffered direct mode synchronize the rendered areas to the other buffer*/
-    /*We need to wait for ready here to not mess up the active screen*/
-    while(disp_refr->flushing);
-
-    /*The buffers are already swapped.
-     *So the active buffer is the off screen buffer where LVGL will render*/
-    void * buf_off_screen = disp_refr->draw_buf_act;
-    void * buf_on_screen = disp_refr->draw_buf_act == disp_refr->draw_buf_1
-                           ? disp_refr->draw_buf_2
-                           : disp_refr->draw_buf_1;
-
-    lv_coord_t stride = lv_disp_get_hor_res(disp_refr);
-    uint32_t i;
-    for(i = 0; i < disp_refr->inv_p; i++) {
-        if(disp_refr->inv_area_joined[i]) continue;
-        disp_refr->layer_head->buffer_copy(
-            disp_refr->layer_head,
-            buf_off_screen, stride, &disp_refr->inv_areas[i],
-            buf_on_screen, stride, &disp_refr->inv_areas[i]
-        );
-    }
 
 refr_clean_up:
     lv_memzero(disp_refr->inv_areas, sizeof(disp_refr->inv_areas));
@@ -901,16 +884,35 @@ static void draw_buf_flush(lv_disp_t * disp)
      * and driver is ready to receive the new buffer.
      * If we need to wait here it means that the content of one buffer is being sent to display
      * and other buffer already contains the new rendered image. */
-    if(lv_disp_is_double_buffered(disp)) {
-        while(disp->flushing);
-    }
-
-    disp->flushing = 1;
 
     if(disp->last_area && disp->last_part) disp->flushing_last = 1;
     else disp->flushing_last = 0;
 
     bool flushing_last = disp->flushing_last;
+
+    if(lv_disp_is_double_buffered(disp)) {
+        while(disp->flushing);
+        /*If there are 2 buffers swap them. With direct mode swap only on the last area*/
+
+        void * buf_on_screen = disp_refr->draw_buf_act;
+        void * buf_off_screen = disp_refr->draw_buf_act == disp_refr->draw_buf_1 ? disp_refr->draw_buf_2 : disp_refr->draw_buf_1;
+
+        lv_coord_t stride = lv_disp_get_hor_res(disp_refr);
+        uint32_t i;
+        for(i = 0; i < disp_refr->inv_p; i++) {
+            if(disp_refr->inv_area_joined[i]) continue;
+            disp_refr->layer_head->buffer_copy(
+                disp_refr->layer_head,
+                buf_off_screen, stride, &disp_refr->inv_areas[i],
+                buf_on_screen, stride, &disp_refr->inv_areas[i]
+            );
+        }
+        if(disp->render_mode != LV_DISP_RENDER_MODE_DIRECT || flushing_last) {
+            disp->draw_buf_act = disp_refr->draw_buf_act == disp_refr->draw_buf_1 ? disp_refr->draw_buf_2 : disp_refr->draw_buf_1;
+        }
+    }
+
+    disp->flushing = 1;
 
     if(disp->flush_cb) {
         /*Rotate the buffer to the display's native orientation if necessary*/
@@ -920,15 +922,6 @@ static void draw_buf_flush(lv_disp_t * disp)
         }
         else {
             call_flush_cb(disp, &disp->refreshed_area, layer->buf);
-        }
-    }
-    /*If there are 2 buffers swap them. With direct mode swap only on the last area*/
-    if(lv_disp_is_double_buffered(disp) && (disp->render_mode != LV_DISP_RENDER_MODE_DIRECT || flushing_last)) {
-        if(disp->draw_buf_act == disp->draw_buf_1) {
-            disp->draw_buf_act = disp->draw_buf_2;
-        }
-        else {
-            disp->draw_buf_act = disp->draw_buf_1;
         }
     }
 }

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -132,20 +132,15 @@ static int32_t lv_draw_sw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * laye
         }
     }
 
-#if LV_USE_OS
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_sw_unit->base_unit.target_layer = layer;
     draw_sw_unit->base_unit.clip_area = &t->clip_area;
     draw_sw_unit->task_act = t;
 
+#if LV_USE_OS
     /*Let the render thread work*/
     lv_thread_sync_signal(&draw_sw_unit->sync);
 #else
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_sw_unit->base_unit.target_layer = layer;
-    draw_sw_unit->base_unit.clip_area = &t->clip_area;
-    draw_sw_unit->task_act = t;
-
     execute_drawing(draw_sw_unit);
 
     draw_sw_unit->task_act->state = LV_DRAW_TASK_STATE_READY;

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -133,11 +133,8 @@ static void perf_monitor_disp_event_cb(lv_event_t * e)
             info->refr_start = lv_tick_get();
             break;
         case LV_EVENT_REFR_FINISH:
-            uint32_t elapsed_time = lv_tick_elaps(info->refr_start);
-            if (elapsed_time > 0) {
-                info->refr_elaps_sum += elapsed_time;
-                info->refr_cnt++;
-            }
+            info->refr_elaps_sum += lv_tick_elaps(info->refr_start);
+            info->refr_cnt++;
             break;
         case LV_EVENT_RENDER_START:
             info->render_start = lv_tick_get();
@@ -185,6 +182,14 @@ static void perf_monitor_event_cb(lv_event_t * e)
            refr_avg_time, render_real_avg_time, flush_avg_time,
            cpu);
 #else
+
+    /* **************************************************
+     * This causes the displayed FPS to persist if the FPS drops down to a zero.
+     * It makes it a little bit easier to see insteaad of flipping to a
+     * zero right away. If the FPS is >0 the new FPS will be displayed
+     * and the mechanics below will get reset.
+     * **************************************************/
+
     if (fps == 0) {
         info->delay_zero_update_cnt += 1;
         if (info->delay_zero_update_cnt == 10) {
@@ -197,6 +202,8 @@ static void perf_monitor_event_cb(lv_event_t * e)
         info->delay_zero_update_cnt = 0;
         info->last_fps = (uint16_t) fps;
     }
+
+    //  ***************************************************
 
     lv_label_set_text_fmt(
         sysmon,


### PR DESCRIPTION
I changed the organization of the code so double buffering will actually work. I also made some changes to the performance monitor so a true FPS fill be given, it will not count frames when there is no work to be done.

I have only tested this on my desktop PC with the default refresh timer set to 1 millisecond Test version and also baaseline version has the changed made to the performance monitor so they would not count frames where no work has been done. This gives a true indication of what kind of difference there would be performance wise between the original refresh setup and the one I modified. Using a slider and having it change value every 1 millisecond using a frame buffer that is the size of the display (480 x 320 x 32) the code change I made gave a boost of 20% which is a pretty large increase.

I would like someone to test it in a read world setup on an MCU using DMA memory and double buffering. I believe there is going to be an even larger increase in performance when this is done. The default refresh timer value for this test should be decreased to 1 millisecond to ensure the timer value is not limiting the speed in which an update is able to occur and the slider value should only be changed once a millisecond.

DO NOT MERGE this PR, it is only to be used as a proof of concept.
