### PR TITLE
fix: fix lv_chart_get_point_pos_by_id for line type chart

### DIFF
--- a/examples/widgets/chart/lv_example_chart_6.c
+++ b/examples/widgets/chart/lv_example_chart_6.c
@@ -23,7 +23,7 @@ static void event_cb(lv_event_t * e)
         if(dsc->p1 == NULL || dsc->p2 == NULL || dsc->p1->y != dsc->p2->y || last_id < 0) return;
 
         lv_coord_t * data_array = lv_chart_get_y_array(chart, ser);
-        lv_coord_t v = data_array[last_id];
+        lv_coord_t v = data_array[(last_id + lv_chart_get_x_start_point(chart, ser)) % lv_chart_get_point_count(chart)];
         char buf[16];
         lv_snprintf(buf, sizeof(buf), "%d", v);
 

--- a/src/extra/widgets/chart/lv_chart.h
+++ b/src/extra/widgets/chart/lv_chart.h
@@ -78,6 +78,7 @@ typedef struct {
     uint8_t y_ext_buf_assigned : 1;
     uint8_t x_axis_sec : 1;
     uint8_t y_axis_sec : 1;
+    uint8_t rewind : 1;
 } lv_chart_series_t;
 
 typedef struct {


### PR DESCRIPTION
in the case that points drew are less than point_cnt, function lv_chart_get_point_pos_by_id return wrong position