### PR TITLE
add config set label default text (4372)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -778,6 +778,10 @@ menu "LVGL configuration"
             bool "Store extra some info in labels (12 bytes) to speed up drawing of very long texts."
             depends on LV_USE_LABEL
             default y
+        config LV_LABEL_DEFAULT_TEXT
+            string "Set default text for label"
+            depends on LV_USE_LABEL
+            default "Text"
         config LV_USE_LINE
             bool "Line."
             default y if !LV_CONF_MINIMAL

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -491,6 +491,7 @@
 #if LV_USE_LABEL
     #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
     #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+    #define LV_LABEL_DEFAULT_TEXT "Text" /*Set default text for label*/
 #endif
 
 #define LV_USE_LINE       1

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1497,6 +1497,13 @@
             #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
         #endif
     #endif
+    #ifndef LV_LABEL_DEFAULT_TEXT
+        #ifdef CONFIG_LV_LABEL_DEFAULT_TEXT
+            #define LV_LABEL_DEFAULT_TEXT CONFIG_LV_LABEL_DEFAULT_TEXT
+        #else
+            #define LV_LABEL_DEFAULT_TEXT "Text" /*Set default text for label*/
+        #endif
+    #endif
 #endif
 
 #ifndef LV_USE_LINE

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -715,7 +715,7 @@ static void lv_label_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICKABLE);
     lv_label_set_long_mode(obj, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(obj, "Text");
+    lv_label_set_text(obj, LV_LABEL_DEFAULT_TEXT);
 
 
     LV_TRACE_OBJ_CREATE("finished");


### PR DESCRIPTION
### Description of the feature or fix

add config set label default text

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
