### PR TITLE
chore: use lv_xxx_t where possible

### DIFF
--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -18,8 +18,14 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+
 #include "../misc/lv_ll.h"
 #include "../misc/lv_types.h"
+
+/*Group is used by lv_obj, thus delcare it firstly*/
+struct _lv_group_t;
+typedef struct _lv_group_t lv_group_t;
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -52,19 +58,16 @@ typedef uint8_t lv_key_t;
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-struct _lv_group_t;
-
-typedef void (*lv_group_focus_cb_t)(struct _lv_group_t *);
-typedef void (*lv_group_edge_cb_t)(struct _lv_group_t *, bool);
+typedef void (*lv_group_focus_cb_t)(lv_group_t *);
+typedef void (*lv_group_edge_cb_t)(lv_group_t *, bool);
 
 /**
  * Groups can be used to logically hold objects so that they can be individually focused.
  * They are NOT for laying out objects on a screen (try layouts for that).
  */
-typedef struct _lv_group_t {
+struct _lv_group_t {
     lv_ll_t obj_ll;        /**< Linked list to store the objects in the group*/
-    struct _lv_obj_t ** obj_focus; /**< The object in focus*/
+    lv_obj_t ** obj_focus; /**< The object in focus*/
 
     lv_group_focus_cb_t focus_cb;              /**< A function to call when a new object is focused (optional)*/
     lv_group_edge_cb_t  edge_cb;               /**< A function to call when an edge is reached, no more focus
@@ -79,7 +82,7 @@ typedef struct _lv_group_t {
                                    deletion.*/
     uint8_t wrap : 1;           /**< 1: Focus next/prev can wrap at end of list. 0: Focus next/prev stops at end
                                    of list.*/
-} lv_group_t;
+};
 
 
 typedef enum {
@@ -126,20 +129,20 @@ lv_group_t * lv_group_get_default(void);
  * @param group     pointer to a group
  * @param obj       pointer to an object to add
  */
-void lv_group_add_obj(lv_group_t * group, struct _lv_obj_t * obj);
+void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj);
 
 /**
  * Swap 2 object in a group. The object must be in the same group
  * @param obj1  pointer to an object
  * @param obj2  pointer to an other object
  */
-void lv_group_swap_obj(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
+void lv_group_swap_obj(lv_obj_t * obj1, lv_obj_t * obj2);
 
 /**
  * Remove an object from its group
  * @param obj       pointer to an object to remove
  */
-void lv_group_remove_obj(struct _lv_obj_t * obj);
+void lv_group_remove_obj(lv_obj_t * obj);
 
 /**
  * Remove all objects from a group
@@ -151,7 +154,7 @@ void lv_group_remove_all_objs(lv_group_t * group);
  * Focus on an object (defocus the current)
  * @param obj       pointer to an object to focus on
  */
-void lv_group_focus_obj(struct _lv_obj_t * obj);
+void lv_group_focus_obj(lv_obj_t * obj);
 
 /**
  * Focus the next object in a group (defocus the current)
@@ -222,7 +225,7 @@ void lv_group_set_wrap(lv_group_t * group, bool en);
  * @param group         pointer to a group
  * @return              pointer to the focused object
  */
-struct _lv_obj_t * lv_group_get_focused(const lv_group_t * group);
+lv_obj_t * lv_group_get_focused(const lv_group_t * group);
 
 /**
  * Get the focus callback function of a group

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -23,6 +23,18 @@ extern "C" {
 #include "../misc/lv_color.h"
 #include "../misc/lv_assert.h"
 
+/*lv_obj_t is needed for below headers, declare it firstly*/
+struct _lv_obj_t;
+typedef struct _lv_obj_t lv_obj_t;
+
+#include "lv_obj_scroll.h"
+#include "lv_obj_tree.h"
+#include "lv_obj_pos.h"
+#include "lv_obj_draw.h"
+#include "lv_obj_class.h"
+#include "lv_obj_event.h"
+#include "lv_group.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -31,7 +43,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
 
 /**
  * Possible states of a widget.
@@ -134,15 +145,8 @@ typedef _lv_obj_flag_t lv_obj_flag_t;
 typedef uint32_t lv_obj_flag_t;
 #endif /*DOXYGEN*/
 
-
-#include "lv_obj_tree.h"
-#include "lv_obj_pos.h"
-#include "lv_obj_scroll.h"
+/*It needs lv_part_t and lv_obj_flag_t defined above.*/
 #include "lv_obj_style.h"
-#include "lv_obj_draw.h"
-#include "lv_obj_class.h"
-#include "lv_obj_event.h"
-#include "lv_group.h"
 
 /**
  * Make the base object's class publicly available.
@@ -154,7 +158,7 @@ extern const lv_obj_class_t lv_obj_class;
  * They are allocated automatically if any elements is set.
  */
 typedef struct {
-    struct _lv_obj_t ** children;       /**< Store the pointer of the children in an array.*/
+    lv_obj_t ** children;       /**< Store the pointer of the children in an array.*/
     uint32_t child_cnt;                 /**< Number of children*/
     lv_group_t * group_p;
     lv_event_list_t event_list;
@@ -171,9 +175,9 @@ typedef struct {
     uint8_t layer_type : 2;    /**< Cache the layer type here. Element of @lv_intermediate_layer_type_t */
 } _lv_obj_spec_attr_t;
 
-typedef struct _lv_obj_t {
+struct _lv_obj_t {
     const lv_obj_class_t * class_p;
-    struct _lv_obj_t * parent;
+    lv_obj_t * parent;
     _lv_obj_spec_attr_t * spec_attr;
     _lv_obj_style_t * styles;
     void * user_data;
@@ -186,7 +190,7 @@ typedef struct _lv_obj_t {
     uint16_t style_cnt  : 6;
     uint16_t h_layout   : 1;
     uint16_t w_layout   : 1;
-} lv_obj_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -16,6 +16,8 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include "../misc/lv_area.h"
+#include "../misc/lv_event.h"
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -26,9 +28,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
 struct _lv_obj_class_t;
-struct _lv_event_t;
+typedef struct _lv_obj_class_t lv_obj_class_t;
 
 typedef enum {
     LV_OBJ_CLASS_EDITABLE_INHERIT,      /**< Check the base class. Must have 0 value to let zero initialized class inherit*/
@@ -47,17 +48,17 @@ typedef enum {
     LV_OBJ_CLASS_THEME_INHERITABLE_TRUE,
 } lv_obj_class_theme_inheritable_t;
 
-typedef void (*lv_obj_class_event_cb_t)(struct _lv_obj_class_t * class_p, struct _lv_event_t * e);
+typedef void (*lv_obj_class_event_cb_t)(lv_obj_class_t * class_p, lv_event_t * e);
 /**
  * Describe the common methods of every object.
  * Similar to a C++ class.
  */
-typedef struct _lv_obj_class_t {
-    const struct _lv_obj_class_t * base_class;
-    void (*constructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
-    void (*destructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
-    void (*event_cb)(const struct _lv_obj_class_t * class_p,
-                     struct _lv_event_t * e);  /**< Widget type specific event function*/
+struct _lv_obj_class_t {
+    const lv_obj_class_t * base_class;
+    void (*constructor_cb)(const lv_obj_class_t * class_p, lv_obj_t * obj);
+    void (*destructor_cb)(const lv_obj_class_t * class_p, lv_obj_t * obj);
+    void (*event_cb)(const lv_obj_class_t * class_p,
+                     lv_event_t * e);  /**< Widget type specific event function*/
     void * user_data;
     lv_coord_t width_def;
     lv_coord_t height_def;
@@ -65,7 +66,7 @@ typedef struct _lv_obj_class_t {
     uint32_t group_def : 2;            /**< Value from ::lv_obj_class_group_def_t*/
     uint32_t instance_size : 16;
     uint32_t theme_inheritable : 1;    /**< Value from ::lv_obj_class_theme_inheritable_t*/
-} lv_obj_class_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -77,15 +78,15 @@ typedef struct _lv_obj_class_t {
  * @param parent    pointer to an object where the new object should be created
  * @return          pointer to the created object
  */
-struct _lv_obj_t * lv_obj_class_create_obj(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * parent);
+lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * parent);
 
-void lv_obj_class_init_obj(struct _lv_obj_t * obj);
+void lv_obj_class_init_obj(lv_obj_t * obj);
 
-void _lv_obj_destruct(struct _lv_obj_t * obj);
+void _lv_obj_destruct(lv_obj_t * obj);
 
-bool lv_obj_is_editable(struct _lv_obj_t * obj);
+bool lv_obj_is_editable(lv_obj_t * obj);
 
-bool lv_obj_is_group_def(struct _lv_obj_t * obj);
+bool lv_obj_is_group_def(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_draw.h
+++ b/src/core/lv_obj_draw.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../draw/lv_draw.h"
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -22,9 +23,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_obj_class_t;
 
 typedef enum {
     LV_LAYER_TYPE_NONE,
@@ -46,7 +44,7 @@ typedef enum {
  * @note Only the relevant fields will be set.
  *       E.g. if `border width == 0` the other border properties won't be evaluated.
  */
-void lv_obj_init_draw_rect_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t * draw_dsc);
+void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t * draw_dsc);
 
 /**
  * Initialize a label draw descriptor from an object's styles in its current state
@@ -56,7 +54,7 @@ void lv_obj_init_draw_rect_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_re
  *                  If the `opa` field is set to or the property is equal to `LV_OPA_TRANSP` the rest won't be initialized.
  *                  Should be initialized with `lv_draw_label_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_label_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_label_dsc_t * draw_dsc);
+void lv_obj_init_draw_label_dsc(lv_obj_t * obj, uint32_t part, lv_draw_label_dsc_t * draw_dsc);
 
 /**
  * Initialize an image draw descriptor from an object's styles in its current state
@@ -65,7 +63,7 @@ void lv_obj_init_draw_label_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_l
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_image_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_img_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_img_dsc_t * draw_dsc);
+void lv_obj_init_draw_img_dsc(lv_obj_t * obj, uint32_t part, lv_draw_img_dsc_t * draw_dsc);
 
 
 /**
@@ -75,7 +73,7 @@ void lv_obj_init_draw_img_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_img
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_line_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_line_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_line_dsc_t * draw_dsc);
+void lv_obj_init_draw_line_dsc(lv_obj_t * obj, uint32_t part, lv_draw_line_dsc_t * draw_dsc);
 
 /**
  * Initialize an arc draw descriptor from an object's styles in its current state
@@ -84,7 +82,7 @@ void lv_obj_init_draw_line_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_li
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_arc_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_arc_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_arc_dsc_t * draw_dsc);
+void lv_obj_init_draw_arc_dsc(lv_obj_t * obj, uint32_t part, lv_draw_arc_dsc_t * draw_dsc);
 
 /**
  * Get the required extra size (around the object's part) to draw shadow, outline, value etc.
@@ -92,24 +90,24 @@ void lv_obj_init_draw_arc_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_arc
  * @param part      part of the object
  * @return          the extra size required around the object
  */
-lv_coord_t lv_obj_calculate_ext_draw_size(struct _lv_obj_t * obj, uint32_t part);
+lv_coord_t lv_obj_calculate_ext_draw_size(lv_obj_t * obj, uint32_t part);
 
 /**
  * Send a 'LV_EVENT_REFR_EXT_DRAW_SIZE' Call the ancestor's event handler to the object to refresh the value of the extended draw size.
  * The result will be saved in `obj`.
  * @param obj       pointer to an object
  */
-void lv_obj_refresh_ext_draw_size(struct _lv_obj_t * obj);
+void lv_obj_refresh_ext_draw_size(lv_obj_t * obj);
 
 /**
  * Get the extended draw area of an object.
  * @param obj       pointer to an object
  * @return          the size extended draw area around the real coordinates
  */
-lv_coord_t _lv_obj_get_ext_draw_size(const struct _lv_obj_t * obj);
+lv_coord_t _lv_obj_get_ext_draw_size(const lv_obj_t * obj);
 
 
-lv_layer_type_t _lv_obj_get_layer_type(const struct _lv_obj_t * obj);
+lv_layer_type_t _lv_obj_get_layer_type(const lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -14,8 +14,11 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdbool.h>
+#include "lv_obj.h"
+#include "lv_obj_class.h"
 #include "../misc/lv_event.h"
 #include "../indev/lv_indev.h"
+#include "../draw/lv_draw.h"
 
 /*********************
  *      DEFINES
@@ -24,9 +27,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_obj_class_t;
 
 /**
  * Used as the event parameter of ::LV_EVENT_HIT_TEST to check if an `point` can click the object or not.
@@ -69,7 +69,7 @@ typedef struct {
  * @param param         arbitrary data depending on the widget type and the event. (Usually `NULL`)
  * @return LV_RES_OK: `obj` was not deleted in the event; LV_RES_INV: `obj` was deleted in the event_code
  */
-lv_res_t lv_obj_send_event(struct _lv_obj_t * obj, lv_event_code_t event_code, void * param);
+lv_res_t lv_obj_send_event(lv_obj_t * obj, lv_event_code_t event_code, void * param);
 
 /**
  * Used by the widgets internally to call the ancestor widget types's event handler
@@ -77,7 +77,7 @@ lv_res_t lv_obj_send_event(struct _lv_obj_t * obj, lv_event_code_t event_code, v
  * @param e         pointer to the event descriptor
  * @return          LV_RES_OK: the target object was not deleted in the event; LV_RES_INV: it was deleted in the event_code
  */
-lv_res_t lv_obj_event_base(const struct _lv_obj_class_t * class_p, lv_event_t * e);
+lv_res_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e);
 
 /**
  * Get the current target of the event. It's the object which event handler being called.
@@ -85,14 +85,14 @@ lv_res_t lv_obj_event_base(const struct _lv_obj_class_t * class_p, lv_event_t * 
  * @param e     pointer to the event descriptor
  * @return      the target of the event_code
  */
-struct _lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e);
+lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e);
 
 /**
  * Get the object originally targeted by the event. It's the same even if the event is bubbled.
  * @param e     pointer to the event descriptor
  * @return      pointer to the original target of the event_code
  */
-struct _lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
+lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
 
 /**
  * Add an event handler function for an object.
@@ -103,14 +103,14 @@ struct _lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
  * @param event_cb  the new event function
  * @param           user_data custom data data will be available in `event_cb`
  */
-void lv_obj_add_event(struct _lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter,
+void lv_obj_add_event(lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter,
                       void * user_data);
 
-uint32_t lv_obj_get_event_count(struct _lv_obj_t * obj);
+uint32_t lv_obj_get_event_count(lv_obj_t * obj);
 
-lv_event_dsc_t * lv_obj_get_event_dsc(struct _lv_obj_t * obj, uint32_t index);
+lv_event_dsc_t * lv_obj_get_event_dsc(lv_obj_t * obj, uint32_t index);
 
-bool lv_obj_remove_event(struct _lv_obj_t * obj, uint32_t index);
+bool lv_obj_remove_event(lv_obj_t * obj, uint32_t index);
 
 /**
  * Get the input device passed as parameter to indev related events.

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../misc/lv_area.h"
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -22,9 +23,8 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-struct _lv_obj_t;
 
-typedef void (*lv_layout_update_cb_t)(struct _lv_obj_t *, void * user_data);
+typedef void (*lv_layout_update_cb_t)(lv_obj_t *, void * user_data);
 typedef struct {
     lv_layout_update_cb_t cb;
     void * user_data;
@@ -44,7 +44,7 @@ typedef struct {
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_pos(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
+void lv_obj_set_pos(lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
 
 /**
  * Set the x coordinate of an object
@@ -55,7 +55,7 @@ void lv_obj_set_pos(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_x(struct _lv_obj_t * obj, lv_coord_t x);
+void lv_obj_set_x(lv_obj_t * obj, lv_coord_t x);
 
 /**
  * Set the y coordinate of an object
@@ -66,7 +66,7 @@ void lv_obj_set_x(struct _lv_obj_t * obj, lv_coord_t x);
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_y(struct _lv_obj_t * obj, lv_coord_t y);
+void lv_obj_set_y(lv_obj_t * obj, lv_coord_t y);
 
 /**
  * Set the size of an object.
@@ -79,14 +79,14 @@ void lv_obj_set_y(struct _lv_obj_t * obj, lv_coord_t y);
  *                  LV_SIZE_PCT(x)     to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_size(struct _lv_obj_t * obj, lv_coord_t w, lv_coord_t h);
+void lv_obj_set_size(lv_obj_t * obj, lv_coord_t w, lv_coord_t h);
 
 /**
  * Recalculate the size of the object
  * @param obj       pointer to an object
  * @return          true: the size has been changed
  */
-bool lv_obj_refr_size(struct _lv_obj_t * obj);
+bool lv_obj_refr_size(lv_obj_t * obj);
 
 /**
  * Set the width of an object
@@ -98,7 +98,7 @@ bool lv_obj_refr_size(struct _lv_obj_t * obj);
  *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_width(struct _lv_obj_t * obj, lv_coord_t w);
+void lv_obj_set_width(lv_obj_t * obj, lv_coord_t w);
 
 /**
  * Set the height of an object
@@ -110,47 +110,47 @@ void lv_obj_set_width(struct _lv_obj_t * obj, lv_coord_t w);
  *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_height(struct _lv_obj_t * obj, lv_coord_t h);
+void lv_obj_set_height(lv_obj_t * obj, lv_coord_t h);
 
 /**
  * Set the width reduced by the left and right padding and the border width.
  * @param obj       pointer to an object
  * @param w         the width without paddings in pixels
  */
-void lv_obj_set_content_width(struct _lv_obj_t * obj, lv_coord_t w);
+void lv_obj_set_content_width(lv_obj_t * obj, lv_coord_t w);
 
 /**
  * Set the height reduced by the top and bottom padding and the border width.
  * @param obj       pointer to an object
  * @param h         the height without paddings in pixels
  */
-void lv_obj_set_content_height(struct _lv_obj_t * obj, lv_coord_t h);
+void lv_obj_set_content_height(lv_obj_t * obj, lv_coord_t h);
 
 /**
  * Set a layout for an object
  * @param obj       pointer to an object
  * @param layout    pointer to a layout descriptor to set
  */
-void lv_obj_set_layout(struct _lv_obj_t * obj, uint32_t layout);
+void lv_obj_set_layout(lv_obj_t * obj, uint32_t layout);
 
 /**
  * Test whether the and object is positioned by a layout or not
  * @param obj       pointer to an object to test
  * @return true:    positioned by a layout; false: not positioned by a layout
  */
-bool lv_obj_is_layout_positioned(const struct _lv_obj_t * obj);
+bool lv_obj_is_layout_positioned(const lv_obj_t * obj);
 
 /**
  * Mark the object for layout update.
  * @param obj      pointer to an object whose children needs to be updated
  */
-void lv_obj_mark_layout_as_dirty(struct _lv_obj_t * obj);
+void lv_obj_mark_layout_as_dirty(lv_obj_t * obj);
 
 /**
  * Update the layout of an object.
  * @param obj      pointer to an object whose children needs to be updated
  */
-void lv_obj_update_layout(const struct _lv_obj_t * obj);
+void lv_obj_update_layout(const lv_obj_t * obj);
 
 /**
  * Register a new layout
@@ -165,7 +165,7 @@ uint32_t lv_layout_register(lv_layout_update_cb_t cb, void * user_data);
  * @param obj       pointer to an object to align
  * @param align     type of alignment (see 'lv_align_t' enum) `LV_ALIGN_OUT_...` can't be used.
  */
-void lv_obj_set_align(struct _lv_obj_t * obj, lv_align_t align);
+void lv_obj_set_align(lv_obj_t * obj, lv_align_t align);
 
 /**
  * Change the alignment of an object and set new coordinates.
@@ -177,7 +177,7 @@ void lv_obj_set_align(struct _lv_obj_t * obj, lv_align_t align);
  * @param x_ofs     x coordinate offset after alignment
  * @param y_ofs     y coordinate offset after alignment
  */
-void lv_obj_align(struct _lv_obj_t * obj, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs);
+void lv_obj_align(lv_obj_t * obj, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs);
 
 /**
  * Align an object to an other object.
@@ -188,7 +188,7 @@ void lv_obj_align(struct _lv_obj_t * obj, lv_align_t align, lv_coord_t x_ofs, lv
  * @param y_ofs     y coordinate offset after alignment
  * @note            if the position or size of `base` changes `obj` needs to be aligned manually again
  */
-void lv_obj_align_to(struct _lv_obj_t * obj, const struct _lv_obj_t * base, lv_align_t align, lv_coord_t x_ofs,
+void lv_obj_align_to(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align, lv_coord_t x_ofs,
                      lv_coord_t y_ofs);
 
 /**
@@ -196,7 +196,7 @@ void lv_obj_align_to(struct _lv_obj_t * obj, const struct _lv_obj_t * base, lv_a
  * @param obj       pointer to an object to align
  * @note            if the parent size changes `obj` needs to be aligned manually again
  */
-static inline void lv_obj_center(struct _lv_obj_t * obj)
+static inline void lv_obj_center(lv_obj_t * obj)
 {
     lv_obj_align(obj, LV_ALIGN_CENTER, 0, 0);
 }
@@ -207,7 +207,7 @@ static inline void lv_obj_center(struct _lv_obj_t * obj)
  * @param obj       pointer to an object
  * @param coords    pointer to an area to store the coordinates
  */
-void lv_obj_get_coords(const struct _lv_obj_t * obj, lv_area_t * coords);
+void lv_obj_get_coords(const lv_obj_t * obj, lv_area_t * coords);
 
 /**
  * Get the x coordinate of object.
@@ -219,7 +219,7 @@ void lv_obj_get_coords(const struct _lv_obj_t * obj, lv_area_t * coords);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-lv_coord_t lv_obj_get_x(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_x(const lv_obj_t * obj);
 
 /**
  * Get the x2 coordinate of object.
@@ -231,7 +231,7 @@ lv_coord_t lv_obj_get_x(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-lv_coord_t lv_obj_get_x2(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_x2(const lv_obj_t * obj);
 
 /**
  * Get the y coordinate of object.
@@ -243,7 +243,7 @@ lv_coord_t lv_obj_get_x2(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-lv_coord_t lv_obj_get_y(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_y(const lv_obj_t * obj);
 
 /**
  * Get the y2 coordinate of object.
@@ -255,21 +255,21 @@ lv_coord_t lv_obj_get_y(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-lv_coord_t lv_obj_get_y2(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_y2(const lv_obj_t * obj);
 
 /**
  * Get the actually set x coordinate of object, i.e. the offset form the set alignment
  * @param obj       pointer to an object
  * @return          the set x coordinate
  */
-lv_coord_t lv_obj_get_x_aligned(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_x_aligned(const lv_obj_t * obj);
 
 /**
  * Get the actually set y coordinate of object, i.e. the offset form the set alignment
  * @param obj       pointer to an object
  * @return          the set y coordinate
  */
-lv_coord_t lv_obj_get_y_aligned(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_y_aligned(const lv_obj_t * obj);
 
 /**
  * Get the width of an object
@@ -278,7 +278,7 @@ lv_coord_t lv_obj_get_y_aligned(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the width in pixels
  */
-lv_coord_t lv_obj_get_width(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_width(const lv_obj_t * obj);
 
 /**
  * Get the height of an object
@@ -287,7 +287,7 @@ lv_coord_t lv_obj_get_width(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the height in pixels
  */
-lv_coord_t lv_obj_get_height(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_height(const lv_obj_t * obj);
 
 /**
  * Get the width reduced by the left and right padding and the border width.
@@ -296,7 +296,7 @@ lv_coord_t lv_obj_get_height(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the width which still fits into its parent without causing overflow (making the parent scrollable)
  */
-lv_coord_t lv_obj_get_content_width(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_content_width(const lv_obj_t * obj);
 
 /**
  * Get the height reduced by the top and bottom padding and the border width.
@@ -305,7 +305,7 @@ lv_coord_t lv_obj_get_content_width(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the height which still fits into the parent without causing overflow (making the parent scrollable)
  */
-lv_coord_t lv_obj_get_content_height(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_content_height(const lv_obj_t * obj);
 
 /**
  * Get the area reduced by the paddings and the border width.
@@ -314,7 +314,7 @@ lv_coord_t lv_obj_get_content_height(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @param area      the area which still fits into the parent without causing overflow (making the parent scrollable)
  */
-void lv_obj_get_content_coords(const struct _lv_obj_t * obj, lv_area_t * area);
+void lv_obj_get_content_coords(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Get the width occupied by the "parts" of the widget. E.g. the width of all columns of a table.
@@ -323,7 +323,7 @@ void lv_obj_get_content_coords(const struct _lv_obj_t * obj, lv_area_t * area);
  * @note            This size independent from the real size of the widget.
  *                  It just tells how large the internal ("virtual") content is.
  */
-lv_coord_t lv_obj_get_self_width(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_self_width(const lv_obj_t * obj);
 
 /**
  * Get the height occupied by the "parts" of the widget. E.g. the height of all rows of a table.
@@ -332,21 +332,21 @@ lv_coord_t lv_obj_get_self_width(const struct _lv_obj_t * obj);
  * @note            This size independent from the real size of the widget.
  *                  It just tells how large the internal ("virtual") content is.
  */
-lv_coord_t lv_obj_get_self_height(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_self_height(const lv_obj_t * obj);
 
 /**
  * Handle if the size of the internal ("virtual") content of an object has changed.
  * @param obj       pointer to an object
  * @return          false: nothing happened; true: refresh happened
  */
-bool lv_obj_refresh_self_size(struct _lv_obj_t * obj);
+bool lv_obj_refresh_self_size(lv_obj_t * obj);
 
-void lv_obj_refr_pos(struct _lv_obj_t * obj);
+void lv_obj_refr_pos(lv_obj_t * obj);
 
-void lv_obj_move_to(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
+void lv_obj_move_to(lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
 
 
-void lv_obj_move_children_by(struct _lv_obj_t * obj, lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating);
+void lv_obj_move_children_by(lv_obj_t * obj, lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating);
 
 /**
  * Transform a point using the angle and zoom style properties of an object
@@ -355,7 +355,7 @@ void lv_obj_move_children_by(struct _lv_obj_t * obj, lv_coord_t x_diff, lv_coord
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
+void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
 
 /**
  * Transform an area using the angle and zoom style properties of an object
@@ -364,7 +364,7 @@ void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, bool r
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_get_transformed_area(const struct _lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
+void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
 
 /**
  * Mark an area of an object as invalid.
@@ -372,13 +372,13 @@ void lv_obj_get_transformed_area(const struct _lv_obj_t * obj, lv_area_t * area,
  * @param obj       pointer to an object
  * @param           area the area to redraw
  */
-void lv_obj_invalidate_area(const struct _lv_obj_t * obj, const lv_area_t * area);
+void lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area);
 
 /**
  * Mark the object as invalid to redrawn its area
  * @param obj       pointer to an object
  */
-void lv_obj_invalidate(const struct _lv_obj_t * obj);
+void lv_obj_invalidate(const lv_obj_t * obj);
 
 /**
  * Tell whether an area of an object is visible (even partially) now or not
@@ -386,21 +386,21 @@ void lv_obj_invalidate(const struct _lv_obj_t * obj);
  * @param area      the are to check. The visible part of the area will be written back here.
  * @return true     visible; false not visible (hidden, out of parent, on other screen, etc)
  */
-bool lv_obj_area_is_visible(const struct _lv_obj_t * obj, lv_area_t * area);
+bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Tell whether an object is visible (even partially) now or not
  * @param obj       pointer to an object
  * @return      true: visible; false not visible (hidden, out of parent, on other screen, etc)
  */
-bool lv_obj_is_visible(const struct _lv_obj_t * obj);
+bool lv_obj_is_visible(const lv_obj_t * obj);
 
 /**
  * Set the size of an extended clickable area
  * @param obj       pointer to an object
  * @param size      extended clickable area in all 4 directions [px]
  */
-void lv_obj_set_ext_click_area(struct _lv_obj_t * obj, lv_coord_t size);
+void lv_obj_set_ext_click_area(lv_obj_t * obj, lv_coord_t size);
 
 /**
  * Get the an area where to object can be clicked.
@@ -408,7 +408,7 @@ void lv_obj_set_ext_click_area(struct _lv_obj_t * obj, lv_coord_t size);
  * @param obj       pointer to an object
  * @param area      store the result area here
  */
-void lv_obj_get_click_area(const struct _lv_obj_t * obj, lv_area_t * area);
+void lv_obj_get_click_area(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Hit-test an object given a particular point in screen space.
@@ -416,7 +416,7 @@ void lv_obj_get_click_area(const struct _lv_obj_t * obj, lv_area_t * area);
  * @param point     screen-space point (absolute coordinate)
  * @return          true: if the object is considered under the point
  */
-bool lv_obj_hit_test(struct _lv_obj_t * obj, const lv_point_t * point);
+bool lv_obj_hit_test(lv_obj_t * obj, const lv_point_t * point);
 
 /**
  * Clamp a width between min and max width. If the min/max width is in percentage value use the ref_width

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -6,8 +6,8 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_obj_scroll.h"
 #include "lv_obj.h"
+#include "lv_obj_scroll.h"
 #include "../indev/lv_indev.h"
 #include "../indev/lv_indev_scroll.h"
 #include "../disp/lv_disp.h"

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -26,7 +26,6 @@ extern "C" {
  **********************/
 
 /*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 /** Scrollbar modes: shows when should the scrollbars be visible*/
 enum _lv_scrollbar_mode_t {
@@ -69,28 +68,28 @@ typedef uint8_t lv_scroll_snap_t;
  * @param obj       pointer to an object
  * @param mode      LV_SCROLL_MODE_ON/OFF/AUTO/ACTIVE
  */
-void lv_obj_set_scrollbar_mode(struct _lv_obj_t * obj, lv_scrollbar_mode_t mode);
+void lv_obj_set_scrollbar_mode(lv_obj_t * obj, lv_scrollbar_mode_t mode);
 
 /**
  * Set the object in which directions can be scrolled
  * @param obj       pointer to an object
  * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
  */
-void lv_obj_set_scroll_dir(struct _lv_obj_t * obj, lv_dir_t dir);
+void lv_obj_set_scroll_dir(lv_obj_t * obj, lv_dir_t dir);
 
 /**
  * Set where to snap the children when scrolling ends horizontally
  * @param obj       pointer to an object
  * @param align     the snap align to set from `lv_scroll_snap_t`
  */
-void lv_obj_set_scroll_snap_x(struct _lv_obj_t * obj, lv_scroll_snap_t align);
+void lv_obj_set_scroll_snap_x(lv_obj_t * obj, lv_scroll_snap_t align);
 
 /**
  * Set where to snap the children when scrolling ends vertically
  * @param obj       pointer to an object
  * @param align     the snap align to set from `lv_scroll_snap_t`
  */
-void lv_obj_set_scroll_snap_y(struct _lv_obj_t * obj, lv_scroll_snap_t align);
+void lv_obj_set_scroll_snap_y(lv_obj_t * obj, lv_scroll_snap_t align);
 
 /*=====================
  * Getter functions
@@ -101,28 +100,28 @@ void lv_obj_set_scroll_snap_y(struct _lv_obj_t * obj, lv_scroll_snap_t align);
  * @param obj       pointer to an object
  * @return          the current scroll mode from `lv_scrollbar_mode_t`
  */
-lv_scrollbar_mode_t lv_obj_get_scrollbar_mode(const struct _lv_obj_t * obj);
+lv_scrollbar_mode_t lv_obj_get_scrollbar_mode(const lv_obj_t * obj);
 
 /**
  * Get the object in which directions can be scrolled
  * @param obj       pointer to an object
  * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
  */
-lv_dir_t lv_obj_get_scroll_dir(const struct _lv_obj_t * obj);
+lv_dir_t lv_obj_get_scroll_dir(const lv_obj_t * obj);
 
 /**
  * Get where to snap the children when scrolling ends horizontally
  * @param obj       pointer to an object
  * @return          the current snap align from `lv_scroll_snap_t`
  */
-lv_scroll_snap_t lv_obj_get_scroll_snap_x(const struct _lv_obj_t * obj);
+lv_scroll_snap_t lv_obj_get_scroll_snap_x(const lv_obj_t * obj);
 
 /**
  * Get where to snap the children when scrolling ends vertically
  * @param  obj      pointer to an object
  * @return          the current snap align from `lv_scroll_snap_t`
  */
-lv_scroll_snap_t lv_obj_get_scroll_snap_y(const struct _lv_obj_t * obj);
+lv_scroll_snap_t lv_obj_get_scroll_snap_y(const lv_obj_t * obj);
 
 /**
  * Get current X scroll position.
@@ -132,7 +131,7 @@ lv_scroll_snap_t lv_obj_get_scroll_snap_y(const struct _lv_obj_t * obj);
  *                  If scrolled return > 0
  *                  If scrolled in (elastic scroll) return < 0
  */
-lv_coord_t lv_obj_get_scroll_x(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_x(const lv_obj_t * obj);
 
 /**
  * Get current Y scroll position.
@@ -142,7 +141,7 @@ lv_coord_t lv_obj_get_scroll_x(const struct _lv_obj_t * obj);
  *                  If scrolled return > 0
  *                  If scrolled inside return < 0
  */
-lv_coord_t lv_obj_get_scroll_y(const struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_y(const lv_obj_t * obj);
 
 /**
  * Return the height of the area above the object.
@@ -151,7 +150,7 @@ lv_coord_t lv_obj_get_scroll_y(const struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area above the object in pixels
  */
-lv_coord_t lv_obj_get_scroll_top(struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_top(lv_obj_t * obj);
 
 /**
  * Return the height of the area below the object.
@@ -160,7 +159,7 @@ lv_coord_t lv_obj_get_scroll_top(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area below the object in pixels
  */
-lv_coord_t lv_obj_get_scroll_bottom(struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_bottom(lv_obj_t * obj);
 
 /**
  * Return the width of the area on the left the object.
@@ -169,7 +168,7 @@ lv_coord_t lv_obj_get_scroll_bottom(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area on the left the object in pixels
  */
-lv_coord_t lv_obj_get_scroll_left(struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_left(lv_obj_t * obj);
 
 /**
  * Return the width of the area on the right the object.
@@ -178,7 +177,7 @@ lv_coord_t lv_obj_get_scroll_left(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area on the right the object in pixels
  */
-lv_coord_t lv_obj_get_scroll_right(struct _lv_obj_t * obj);
+lv_coord_t lv_obj_get_scroll_right(lv_obj_t * obj);
 
 /**
  * Get the X and Y coordinates where the scrolling will end for this object if a scrolling animation is in progress.
@@ -186,7 +185,7 @@ lv_coord_t lv_obj_get_scroll_right(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @param end       pointer to store the result
  */
-void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end);
+void lv_obj_get_scroll_end(lv_obj_t  * obj, lv_point_t * end);
 
 /*=====================
  * Other functions
@@ -201,7 +200,7 @@ void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end);
  * @note            > 0 value means scroll right/bottom (show the more content on the right/bottom)
  * @note            e.g. dy = -20 means scroll down 20 px
  */
-void lv_obj_scroll_by(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_by(lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll by a given amount of pixels.
@@ -212,7 +211,7 @@ void lv_obj_scroll_by(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_ani
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  * @note            e.g. dy = -20 means scroll down 20 px
  */
-void lv_obj_scroll_by_bounded(struct _lv_obj_t * obj, lv_coord_t dx, lv_coord_t dy, lv_anim_enable_t anim_en);
+void lv_obj_scroll_by_bounded(lv_obj_t * obj, lv_coord_t dx, lv_coord_t dy, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given coordinate on an object.
@@ -222,7 +221,7 @@ void lv_obj_scroll_by_bounded(struct _lv_obj_t * obj, lv_coord_t dx, lv_coord_t 
  * @param y         pixels to scroll vertically
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to(lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given X coordinate on an object.
@@ -231,7 +230,7 @@ void lv_obj_scroll_to(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y, lv_ani
  * @param x         pixels to scroll horizontally
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_x(struct _lv_obj_t * obj, lv_coord_t x, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_x(lv_obj_t * obj, lv_coord_t x, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given Y coordinate on an object
@@ -240,14 +239,14 @@ void lv_obj_scroll_to_x(struct _lv_obj_t * obj, lv_coord_t x, lv_anim_enable_t a
  * @param y         pixels to scroll vertically
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_y(struct _lv_obj_t * obj, lv_coord_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_y(lv_obj_t * obj, lv_coord_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to an object until it becomes visible on its parent
  * @param obj       pointer to an object to scroll into view
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_view(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_view(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to an object until it becomes visible on its parent.
@@ -256,7 +255,7 @@ void lv_obj_scroll_to_view(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
  * @param obj       pointer to an object to scroll into view
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_view_recursive(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_view_recursive(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 
 /**
@@ -268,21 +267,21 @@ void lv_obj_scroll_to_view_recursive(struct _lv_obj_t * obj, lv_anim_enable_t an
  * @return          `LV_RES_INV`: to object was deleted in `LV_EVENT_SCROLL`;
  *                  `LV_RES_OK`: if the object is still valid
  */
-lv_res_t _lv_obj_scroll_by_raw(struct _lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
+lv_res_t _lv_obj_scroll_by_raw(lv_obj_t * obj, lv_coord_t x, lv_coord_t y);
 
 /**
  * Tell whether an object is being scrolled or not at this moment
  * @param obj   pointer to an object
  * @return      true: `obj` is being scrolled
  */
-bool lv_obj_is_scrolling(const struct _lv_obj_t * obj);
+bool lv_obj_is_scrolling(const lv_obj_t * obj);
 
 /**
  * Check the children of `obj` and scroll `obj` to fulfill the scroll_snap settings
  * @param obj       an object whose children needs to checked and snapped
  * @param anim_en   LV_ANIM_ON/OFF
  */
-void lv_obj_update_snap(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_update_snap(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**
  * Get the area of the scrollbars
@@ -290,20 +289,20 @@ void lv_obj_update_snap(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
  * @param hor   pointer to store the area of the horizontal scrollbar
  * @param ver   pointer to store the area of the vertical  scrollbar
  */
-void lv_obj_get_scrollbar_area(struct _lv_obj_t * obj, lv_area_t * hor, lv_area_t * ver);
+void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor, lv_area_t * ver);
 
 /**
  * Invalidate the area of the scrollbars
  * @param obj       pointer to an object
  */
-void lv_obj_scrollbar_invalidate(struct _lv_obj_t * obj);
+void lv_obj_scrollbar_invalidate(lv_obj_t * obj);
 
 /**
  * Checked if the content is scrolled "in" and adjusts it to a normal position.
  * @param obj       pointer to an object
  * @param anim_en   LV_ANIM_ON/OFF
  */
-void lv_obj_readjust_scroll(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_readjust_scroll(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <stdbool.h>
 #include "../misc/lv_bidi.h"
 #include "../misc/lv_style.h"
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -25,8 +26,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-/*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 #ifndef LV_OBJ_H
 /// @cond
@@ -83,7 +82,7 @@ void _lv_obj_style_init(void);
  * @example         lv_obj_add_style(btn, &style_btn, 0); //Default button style
  * @example         lv_obj_add_style(btn, &btn_red, LV_STATE_PRESSED); //Overwrite only some colors to red when pressed
  */
-void lv_obj_add_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
+void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
  * Replaces a style of an object, preserving the order of the style stack (local styles and transitions are ignored).
@@ -94,7 +93,7 @@ void lv_obj_add_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style
  * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_ANY | LV_STATE_ANY); //Replace a specific style
  * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_MAIN | LV_STATE_PRESSED); //Replace a specific style assigned to the main part when it is pressed
  */
-bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
+bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
                           lv_style_selector_t selector);
 
 /**
@@ -106,13 +105,13 @@ bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, 
  * @example lv_obj_remove_style(obj, NULL, LV_PART_MAIN | LV_STATE_ANY); //Remove all styles from the main part
  * @example lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY); //Remove all styles
  */
-void lv_obj_remove_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
+void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
  * Remove all styles from an object
  * @param obj       pointer to an object
  */
-void lv_obj_remove_style_all(struct _lv_obj_t * obj);
+void lv_obj_remove_style_all(lv_obj_t * obj);
 
 /**
  * Notify all object if a style is modified
@@ -129,7 +128,7 @@ void lv_obj_report_style_change(lv_style_t * style);
  *                  It is used to optimize what needs to be refreshed.
  *                  `LV_STYLE_PROP_INV` to perform only a style cache update
  */
-void lv_obj_refresh_style(struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
  * Enable or disable automatic style refreshing when a new style is added/removed to/from an object
@@ -148,7 +147,7 @@ void lv_obj_enable_style_refresh(bool en);
  * @return          the value of the property.
  *                  Should be read from the correct field of the `lv_style_value_t` according to the type of the property.
  */
-lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
  * Set local style property on an object's part and state.
@@ -157,13 +156,13 @@ lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t p
  * @param value     value of the property. The correct element should be set according to the type of the property
  * @param selector  OR-ed value of parts and state for which the style should be set
  */
-void lv_obj_set_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t value,
+void lv_obj_set_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t value,
                                  lv_style_selector_t selector);
 
-void lv_obj_set_local_style_prop_meta(struct _lv_obj_t * obj, lv_style_prop_t prop, uint16_t meta,
+void lv_obj_set_local_style_prop_meta(lv_obj_t * obj, lv_style_prop_t prop, uint16_t meta,
                                       lv_style_selector_t selector);
 
-lv_style_res_t lv_obj_get_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t * value,
+lv_style_res_t lv_obj_get_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t * value,
                                            lv_style_selector_t selector);
 
 /**
@@ -173,12 +172,12 @@ lv_style_res_t lv_obj_get_local_style_prop(struct _lv_obj_t * obj, lv_style_prop
  * @param selector  OR-ed value of parts and state for which the style should be removed
  * @return true     the property was found and removed; false: the property was not found
  */
-bool lv_obj_remove_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_selector_t selector);
+bool lv_obj_remove_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_selector_t selector);
 
 /**
  * Used internally for color filtering
  */
-lv_style_value_t _lv_obj_style_apply_color_filter(const struct _lv_obj_t * obj, uint32_t part, lv_style_value_t v);
+lv_style_value_t _lv_obj_style_apply_color_filter(const lv_obj_t * obj, uint32_t part, lv_style_value_t v);
 
 /**
  * Used internally to create a style transition
@@ -188,7 +187,7 @@ lv_style_value_t _lv_obj_style_apply_color_filter(const struct _lv_obj_t * obj, 
  * @param new_state
  * @param tr
  */
-void _lv_obj_style_create_transition(struct _lv_obj_t * obj, lv_part_t part, lv_state_t prev_state,
+void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t prev_state,
                                      lv_state_t new_state, const _lv_obj_style_transition_dsc_t * tr);
 
 /**
@@ -198,7 +197,7 @@ void _lv_obj_style_create_transition(struct _lv_obj_t * obj, lv_part_t part, lv_
  * @param state2
  * @return
  */
-_lv_style_state_cmp_t _lv_obj_style_state_compare(struct _lv_obj_t * obj, lv_state_t state1, lv_state_t state2);
+_lv_style_state_cmp_t _lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2);
 
 /**
  * Fade in an an object and all its children.
@@ -206,7 +205,7 @@ _lv_style_state_cmp_t _lv_obj_style_state_compare(struct _lv_obj_t * obj, lv_sta
  * @param time      time of fade
  * @param delay     delay to start the animation
  */
-void lv_obj_fade_in(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
+void lv_obj_fade_in(lv_obj_t * obj, uint32_t time, uint32_t delay);
 
 /**
  * Fade out an an object and all its children.
@@ -214,7 +213,7 @@ void lv_obj_fade_in(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
  * @param time      time of fade
  * @param delay     delay to start the animation
  */
-void lv_obj_fade_out(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
+void lv_obj_fade_out(lv_obj_t * obj, uint32_t time, uint32_t delay);
 
 lv_state_t lv_obj_style_get_selector_state(lv_style_selector_t selector);
 
@@ -222,7 +221,7 @@ lv_part_t lv_obj_style_get_selector_part(lv_style_selector_t selector);
 
 #include "lv_obj_style_gen.h"
 
-static inline void lv_obj_set_style_pad_all(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_all(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_left(obj, value, selector);
     lv_obj_set_style_pad_right(obj, value, selector);
@@ -230,19 +229,19 @@ static inline void lv_obj_set_style_pad_all(struct _lv_obj_t * obj, lv_coord_t v
     lv_obj_set_style_pad_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_hor(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_hor(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_left(obj, value, selector);
     lv_obj_set_style_pad_right(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_ver(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_ver(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_top(obj, value, selector);
     lv_obj_set_style_pad_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_all(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_all(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_left(obj, value, selector);
     lv_obj_set_style_margin_right(obj, value, selector);
@@ -250,32 +249,32 @@ static inline void lv_obj_set_style_margin_all(struct _lv_obj_t * obj, lv_coord_
     lv_obj_set_style_margin_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_hor(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_hor(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_left(obj, value, selector);
     lv_obj_set_style_margin_right(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_ver(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_ver(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_top(obj, value, selector);
     lv_obj_set_style_margin_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_gap(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_gap(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_row(obj, value, selector);
     lv_obj_set_style_pad_column(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_size(struct _lv_obj_t * obj, lv_coord_t width, lv_coord_t height,
+static inline void lv_obj_set_style_size(lv_obj_t * obj, lv_coord_t width, lv_coord_t height,
                                          lv_style_selector_t selector)
 {
     lv_obj_set_style_width(obj, width, selector);
     lv_obj_set_style_height(obj, height, selector);
 }
 
-static inline lv_coord_t lv_obj_get_style_space_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_space_left(const lv_obj_t * obj, uint32_t part)
 {
     lv_coord_t padding = lv_obj_get_style_pad_left(obj, part);
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -283,7 +282,7 @@ static inline lv_coord_t lv_obj_get_style_space_left(const struct _lv_obj_t * ob
     return (border_side & LV_BORDER_SIDE_LEFT) ? padding + border_width : padding;
 }
 
-static inline lv_coord_t lv_obj_get_style_space_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_space_right(const lv_obj_t * obj, uint32_t part)
 {
     lv_coord_t padding = lv_obj_get_style_pad_right(obj, part);
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -291,7 +290,7 @@ static inline lv_coord_t lv_obj_get_style_space_right(const struct _lv_obj_t * o
     return (border_side & LV_BORDER_SIDE_RIGHT) ? padding + border_width : padding;
 }
 
-static inline lv_coord_t lv_obj_get_style_space_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_space_top(const lv_obj_t * obj, uint32_t part)
 {
     lv_coord_t padding = lv_obj_get_style_pad_top(obj, part);
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -299,7 +298,7 @@ static inline lv_coord_t lv_obj_get_style_space_top(const struct _lv_obj_t * obj
     return (border_side & LV_BORDER_SIDE_TOP) ? padding + border_width : padding;
 }
 
-static inline lv_coord_t lv_obj_get_style_space_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_space_bottom(const lv_obj_t * obj, uint32_t part)
 {
     lv_coord_t padding = lv_obj_get_style_pad_bottom(obj, part);
     lv_coord_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -307,9 +306,9 @@ static inline lv_coord_t lv_obj_get_style_space_bottom(const struct _lv_obj_t * 
     return (border_side & LV_BORDER_SIDE_BOTTOM) ? padding + border_width : padding;
 }
 
-lv_text_align_t lv_obj_calculate_style_text_align(const struct _lv_obj_t * obj, lv_part_t part, const char * txt);
+lv_text_align_t lv_obj_calculate_style_text_align(const lv_obj_t * obj, lv_part_t part, const char * txt);
 
-static inline lv_coord_t lv_obj_get_style_transform_zoom_safe(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_zoom_safe(const lv_obj_t * obj, uint32_t part)
 {
     int16_t zoom = lv_obj_get_style_transform_zoom(obj, part);
     return zoom != 0 ? zoom : 1;

--- a/src/core/lv_obj_style_gen.c
+++ b/src/core/lv_obj_style_gen.c
@@ -1,6 +1,6 @@
 #include "lv_obj.h"
 
-void lv_obj_set_style_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -8,7 +8,7 @@ void lv_obj_set_style_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_min_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_min_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -16,7 +16,7 @@ void lv_obj_set_style_min_width(struct _lv_obj_t * obj, lv_coord_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_MIN_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_max_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_max_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -24,7 +24,7 @@ void lv_obj_set_style_max_width(struct _lv_obj_t * obj, lv_coord_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_MAX_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -32,7 +32,7 @@ void lv_obj_set_style_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_min_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_min_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -40,7 +40,7 @@ void lv_obj_set_style_min_height(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_MIN_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_max_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_max_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -48,7 +48,7 @@ void lv_obj_set_style_max_height(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_MAX_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -56,7 +56,7 @@ void lv_obj_set_style_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selec
     lv_obj_set_local_style_prop(obj, LV_STYLE_X, v, selector);
 }
 
-void lv_obj_set_style_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -64,7 +64,7 @@ void lv_obj_set_style_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selec
     lv_obj_set_local_style_prop(obj, LV_STYLE_Y, v, selector);
 }
 
-void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -72,7 +72,7 @@ void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -80,7 +80,7 @@ void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, lv_coord_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -88,7 +88,7 @@ void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, lv_coord_t value,
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_translate_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -96,7 +96,7 @@ void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, lv_coord_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSLATE_X, v, selector);
 }
 
-void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_translate_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -104,7 +104,7 @@ void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, lv_coord_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSLATE_Y, v, selector);
 }
 
-void lv_obj_set_style_transform_zoom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_zoom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -112,7 +112,7 @@ void lv_obj_set_style_transform_zoom(struct _lv_obj_t * obj, lv_coord_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_ZOOM, v, selector);
 }
 
-void lv_obj_set_style_transform_angle(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_angle(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -120,7 +120,7 @@ void lv_obj_set_style_transform_angle(struct _lv_obj_t * obj, lv_coord_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_ANGLE, v, selector);
 }
 
-void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -128,7 +128,7 @@ void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, lv_coord_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_PIVOT_X, v, selector);
 }
 
-void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -136,7 +136,7 @@ void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, lv_coord_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_PIVOT_Y, v, selector);
 }
 
-void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_top(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -144,7 +144,7 @@ void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_TOP, v, selector);
 }
 
-void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_bottom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -152,7 +152,7 @@ void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_BOTTOM, v, selector);
 }
 
-void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_left(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -160,7 +160,7 @@ void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, lv_coord_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_LEFT, v, selector);
 }
 
-void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_right(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -168,7 +168,7 @@ void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, lv_coord_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_RIGHT, v, selector);
 }
 
-void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_row(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -176,7 +176,7 @@ void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, lv_coord_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_ROW, v, selector);
 }
 
-void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_column(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -184,7 +184,7 @@ void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_COLUMN, v, selector);
 }
 
-void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_top(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -192,7 +192,7 @@ void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_TOP, v, selector);
 }
 
-void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_bottom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -200,7 +200,7 @@ void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_BOTTOM, v, selector);
 }
 
-void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_left(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -208,7 +208,7 @@ void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, lv_coord_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_LEFT, v, selector);
 }
 
-void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_right(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -216,7 +216,7 @@ void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_RIGHT, v, selector);
 }
 
-void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -224,7 +224,7 @@ void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_COLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -232,7 +232,7 @@ void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -240,7 +240,7 @@ void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_COLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -248,7 +248,7 @@ void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_DIR, v, selector);
 }
 
-void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -256,7 +256,7 @@ void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_MAIN_STOP, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -264,7 +264,7 @@ void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_STOP, v, selector);
 }
 
-void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -272,7 +272,7 @@ void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * valu
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD, v, selector);
 }
 
-void lv_obj_set_style_bg_dither_mode(struct _lv_obj_t * obj, lv_dither_mode_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_dither_mode(lv_obj_t * obj, lv_dither_mode_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -280,7 +280,7 @@ void lv_obj_set_style_bg_dither_mode(struct _lv_obj_t * obj, lv_dither_mode_t va
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_DITHER_MODE, v, selector);
 }
 
-void lv_obj_set_style_bg_img_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_img_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -288,7 +288,7 @@ void lv_obj_set_style_bg_img_src(struct _lv_obj_t * obj, const void * value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMG_SRC, v, selector);
 }
 
-void lv_obj_set_style_bg_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_img_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -296,7 +296,7 @@ void lv_obj_set_style_bg_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMG_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_img_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_img_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -304,7 +304,7 @@ void lv_obj_set_style_bg_img_recolor(struct _lv_obj_t * obj, lv_color_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMG_RECOLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_img_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -312,7 +312,7 @@ void lv_obj_set_style_bg_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value,
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMG_RECOLOR_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_img_tiled(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_img_tiled(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -320,7 +320,7 @@ void lv_obj_set_style_bg_img_tiled(struct _lv_obj_t * obj, bool value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMG_TILED, v, selector);
 }
 
-void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -328,7 +328,7 @@ void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_COLOR, v, selector);
 }
 
-void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -336,7 +336,7 @@ void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_OPA, v, selector);
 }
 
-void lv_obj_set_style_border_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -344,7 +344,7 @@ void lv_obj_set_style_border_width(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -352,7 +352,7 @@ void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_SIDE, v, selector);
 }
 
-void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -360,7 +360,7 @@ void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_POST, v, selector);
 }
 
-void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -368,7 +368,7 @@ void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, lv_coord_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -376,7 +376,7 @@ void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_COLOR, v, selector);
 }
 
-void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -384,7 +384,7 @@ void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_OPA, v, selector);
 }
 
-void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_pad(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -392,7 +392,7 @@ void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, lv_coord_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_PAD, v, selector);
 }
 
-void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -400,7 +400,7 @@ void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_shadow_ofs_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_ofs_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -408,7 +408,7 @@ void lv_obj_set_style_shadow_ofs_x(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OFS_X, v, selector);
 }
 
-void lv_obj_set_style_shadow_ofs_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_ofs_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -416,7 +416,7 @@ void lv_obj_set_style_shadow_ofs_y(struct _lv_obj_t * obj, lv_coord_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OFS_Y, v, selector);
 }
 
-void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_spread(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -424,7 +424,7 @@ void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, lv_coord_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_SPREAD, v, selector);
 }
 
-void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -432,7 +432,7 @@ void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_COLOR, v, selector);
 }
 
-void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -440,7 +440,7 @@ void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OPA, v, selector);
 }
 
-void lv_obj_set_style_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_img_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -448,7 +448,7 @@ void lv_obj_set_style_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMG_OPA, v, selector);
 }
 
-void lv_obj_set_style_img_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_img_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -456,7 +456,7 @@ void lv_obj_set_style_img_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMG_RECOLOR, v, selector);
 }
 
-void lv_obj_set_style_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_img_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -464,7 +464,7 @@ void lv_obj_set_style_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMG_RECOLOR_OPA, v, selector);
 }
 
-void lv_obj_set_style_line_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -472,7 +472,7 @@ void lv_obj_set_style_line_width(struct _lv_obj_t * obj, lv_coord_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_dash_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -480,7 +480,7 @@ void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, lv_coord_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_DASH_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -488,7 +488,7 @@ void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, lv_coord_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_DASH_GAP, v, selector);
 }
 
-void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -496,7 +496,7 @@ void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_ROUNDED, v, selector);
 }
 
-void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -504,7 +504,7 @@ void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_COLOR, v, selector);
 }
 
-void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -512,7 +512,7 @@ void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_OPA, v, selector);
 }
 
-void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -520,7 +520,7 @@ void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, lv_coord_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -528,7 +528,7 @@ void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_ROUNDED, v, selector);
 }
 
-void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -536,7 +536,7 @@ void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_COLOR, v, selector);
 }
 
-void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -544,7 +544,7 @@ void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_OPA, v, selector);
 }
 
-void lv_obj_set_style_arc_img_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_img_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -552,7 +552,7 @@ void lv_obj_set_style_arc_img_src(struct _lv_obj_t * obj, const void * value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_IMG_SRC, v, selector);
 }
 
-void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -560,7 +560,7 @@ void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_COLOR, v, selector);
 }
 
-void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -568,7 +568,7 @@ void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_OPA, v, selector);
 }
 
-void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -576,7 +576,7 @@ void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value,
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_FONT, v, selector);
 }
 
-void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_letter_space(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -584,7 +584,7 @@ void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, lv_coord_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_LETTER_SPACE, v, selector);
 }
 
-void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_line_space(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -592,7 +592,7 @@ void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, lv_coord_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_LINE_SPACE, v, selector);
 }
 
-void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -600,7 +600,7 @@ void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_DECOR, v, selector);
 }
 
-void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -608,7 +608,7 @@ void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_radius(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
+void lv_obj_set_style_radius(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -616,7 +616,7 @@ void lv_obj_set_style_radius(struct _lv_obj_t * obj, lv_coord_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_RADIUS, v, selector);
 }
 
-void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -624,7 +624,7 @@ void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_CLIP_CORNER, v, selector);
 }
 
-void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -632,7 +632,7 @@ void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selec
     lv_obj_set_local_style_prop(obj, LV_STYLE_OPA, v, selector);
 }
 
-void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_filter_dsc_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -640,7 +640,7 @@ void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_fi
     lv_obj_set_local_style_prop(obj, LV_STYLE_COLOR_FILTER_DSC, v, selector);
 }
 
-void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -648,7 +648,7 @@ void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_COLOR_FILTER_OPA, v, selector);
 }
 
-void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -656,7 +656,7 @@ void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ANIM, v, selector);
 }
 
-void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_anim_time(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -664,7 +664,7 @@ void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_ANIM_TIME, v, selector);
 }
 
-void lv_obj_set_style_anim_speed(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_anim_speed(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -672,7 +672,7 @@ void lv_obj_set_style_anim_speed(struct _lv_obj_t * obj, uint32_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_ANIM_SPEED, v, selector);
 }
 
-void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transition_dsc_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -680,7 +680,7 @@ void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transiti
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSITION, v, selector);
 }
 
-void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector)
+void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -688,7 +688,7 @@ void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_BLEND_MODE, v, selector);
 }
 
-void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_selector_t selector)
+void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -696,7 +696,7 @@ void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_LAYOUT, v, selector);
 }
 
-void lv_obj_set_style_base_dir(struct _lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector)
+void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value

--- a/src/core/lv_obj_style_gen.h
+++ b/src/core/lv_obj_style_gen.h
@@ -1,679 +1,681 @@
 #include "../misc/lv_area.h"
 #include "../misc/lv_style.h"
 #include "../core/lv_obj_style.h"
-static inline lv_coord_t lv_obj_get_style_width(const struct _lv_obj_t * obj, uint32_t part)
+#include "lv_obj.h"
+
+static inline lv_coord_t lv_obj_get_style_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_min_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_min_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MIN_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_max_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_max_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MAX_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_HEIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_min_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_min_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MIN_HEIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_max_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_max_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MAX_HEIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_X);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_Y);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_align_t lv_obj_get_style_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_align_t lv_obj_get_style_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ALIGN);
     return (lv_align_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_HEIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_translate_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_translate_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSLATE_X);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_translate_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_translate_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSLATE_Y);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_zoom(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_zoom(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_ZOOM);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_angle(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_angle(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_ANGLE);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_pivot_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_pivot_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_PIVOT_X);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_transform_pivot_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_transform_pivot_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_PIVOT_Y);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_top(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_TOP);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_bottom(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_BOTTOM);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_left(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_LEFT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_right(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_RIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_row(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_row(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_ROW);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_pad_column(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_pad_column(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_COLUMN);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_margin_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_margin_top(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_TOP);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_margin_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_margin_bottom(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_BOTTOM);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_margin_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_margin_left(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_LEFT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_margin_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_margin_right(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_RIGHT);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_BG_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_grad_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_grad_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_grad_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_grad_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_COLOR));
     return v.color;
 }
 
-static inline lv_grad_dir_t lv_obj_get_style_bg_grad_dir(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grad_dir_t lv_obj_get_style_bg_grad_dir(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_DIR);
     return (lv_grad_dir_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_bg_main_stop(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_bg_main_stop(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_MAIN_STOP);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_bg_grad_stop(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_bg_grad_stop(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_STOP);
     return (lv_coord_t)v.num;
 }
 
-static inline const lv_grad_dsc_t * lv_obj_get_style_bg_grad(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_grad_dsc_t * lv_obj_get_style_bg_grad(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD);
     return (const lv_grad_dsc_t *)v.ptr;
 }
 
-static inline lv_dither_mode_t lv_obj_get_style_bg_dither_mode(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_dither_mode_t lv_obj_get_style_bg_dither_mode(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_DITHER_MODE);
     return (lv_dither_mode_t)v.num;
 }
 
-static inline const void * lv_obj_get_style_bg_img_src(const struct _lv_obj_t * obj, uint32_t part)
+static inline const void * lv_obj_get_style_bg_img_src(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_SRC);
     return (const void *)v.ptr;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_img_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_img_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_img_recolor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_img_recolor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_RECOLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_img_recolor_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_img_recolor_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_RECOLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_img_recolor_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_img_recolor_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_RECOLOR_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline bool lv_obj_get_style_bg_img_tiled(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_bg_img_tiled(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMG_TILED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_border_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_border_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_border_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_border_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_border_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_border_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_border_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_border_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_border_side_t lv_obj_get_style_border_side(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_border_side_t lv_obj_get_style_border_side(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_SIDE);
     return (lv_border_side_t)v.num;
 }
 
-static inline bool lv_obj_get_style_border_post(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_border_post(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_POST);
     return (bool)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_outline_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_outline_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_outline_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_outline_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_outline_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_outline_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_outline_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_outline_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_outline_pad(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_outline_pad(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_PAD);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_shadow_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_shadow_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_shadow_ofs_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_shadow_ofs_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OFS_X);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_shadow_ofs_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_shadow_ofs_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OFS_Y);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_shadow_spread(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_shadow_spread(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_SPREAD);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_shadow_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_shadow_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_shadow_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_shadow_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_shadow_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_shadow_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_img_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_img_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMG_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_img_recolor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_img_recolor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMG_RECOLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_img_recolor_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_img_recolor_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_IMG_RECOLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_img_recolor_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_img_recolor_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMG_RECOLOR_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_line_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_line_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_line_dash_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_line_dash_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_DASH_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_line_dash_gap(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_line_dash_gap(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_DASH_GAP);
     return (lv_coord_t)v.num;
 }
 
-static inline bool lv_obj_get_style_line_rounded(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_line_rounded(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_ROUNDED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_line_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_line_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_line_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_line_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_line_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_line_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_arc_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_arc_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_WIDTH);
     return (lv_coord_t)v.num;
 }
 
-static inline bool lv_obj_get_style_arc_rounded(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_arc_rounded(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_ROUNDED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_arc_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_arc_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_arc_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_arc_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_arc_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_arc_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const void * lv_obj_get_style_arc_img_src(const struct _lv_obj_t * obj, uint32_t part)
+static inline const void * lv_obj_get_style_arc_img_src(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_IMG_SRC);
     return (const void *)v.ptr;
 }
 
-static inline lv_color_t lv_obj_get_style_text_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_text_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_text_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_text_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_text_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_text_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_font_t * lv_obj_get_style_text_font(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_font_t * lv_obj_get_style_text_font(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_FONT);
     return (const lv_font_t *)v.ptr;
 }
 
-static inline lv_coord_t lv_obj_get_style_text_letter_space(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_text_letter_space(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_LETTER_SPACE);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_text_line_space(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_text_line_space(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_LINE_SPACE);
     return (lv_coord_t)v.num;
 }
 
-static inline lv_text_decor_t lv_obj_get_style_text_decor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_text_decor_t lv_obj_get_style_text_decor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_DECOR);
     return (lv_text_decor_t)v.num;
 }
 
-static inline lv_text_align_t lv_obj_get_style_text_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_text_align_t lv_obj_get_style_text_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_ALIGN);
     return (lv_text_align_t)v.num;
 }
 
-static inline lv_coord_t lv_obj_get_style_radius(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_coord_t lv_obj_get_style_radius(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_RADIUS);
     return (lv_coord_t)v.num;
 }
 
-static inline bool lv_obj_get_style_clip_corner(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_clip_corner(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_CLIP_CORNER);
     return (bool)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_color_filter_dsc_t * lv_obj_get_style_color_filter_dsc(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_color_filter_dsc_t * lv_obj_get_style_color_filter_dsc(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_COLOR_FILTER_DSC);
     return (const lv_color_filter_dsc_t *)v.ptr;
 }
 
-static inline lv_opa_t lv_obj_get_style_color_filter_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_color_filter_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_COLOR_FILTER_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_anim_t * lv_obj_get_style_anim(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_anim_t * lv_obj_get_style_anim(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ANIM);
     return (const lv_anim_t *)v.ptr;
 }
 
-static inline uint32_t lv_obj_get_style_anim_time(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint32_t lv_obj_get_style_anim_time(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ANIM_TIME);
     return (uint32_t)v.num;
 }
 
-static inline uint32_t lv_obj_get_style_anim_speed(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint32_t lv_obj_get_style_anim_speed(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ANIM_SPEED);
     return (uint32_t)v.num;
 }
 
-static inline const lv_style_transition_dsc_t * lv_obj_get_style_transition(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_style_transition_dsc_t * lv_obj_get_style_transition(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSITION);
     return (const lv_style_transition_dsc_t *)v.ptr;
 }
 
-static inline lv_blend_mode_t lv_obj_get_style_blend_mode(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_blend_mode_t lv_obj_get_style_blend_mode(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BLEND_MODE);
     return (lv_blend_mode_t)v.num;
 }
 
-static inline uint16_t lv_obj_get_style_layout(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint16_t lv_obj_get_style_layout(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LAYOUT);
     return (uint16_t)v.num;
 }
 
-static inline lv_base_dir_t lv_obj_get_style_base_dir(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_base_dir_t lv_obj_get_style_base_dir(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BASE_DIR);
     return (lv_base_dir_t)v.num;
 }
 
-void lv_obj_set_style_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_min_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_max_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_min_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_max_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_zoom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_angle(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_dither_mode(struct _lv_obj_t * obj, lv_dither_mode_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_img_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_img_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_img_tiled(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_ofs_x(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_ofs_y(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_img_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_img_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_img_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_img_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector);
-void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_radius(struct _lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
-void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_filter_dsc_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_anim_speed(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transition_dsc_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector);
-void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
-void lv_obj_set_style_base_dir(struct _lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);
+void lv_obj_set_style_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_min_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_max_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_min_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_max_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_height(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_translate_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_translate_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_zoom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_angle(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_top(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_bottom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_left(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_right(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_row(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_column(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_top(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_bottom(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_left(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_right(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_dither_mode(lv_obj_t * obj, lv_dither_mode_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_img_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_img_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_img_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_img_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_img_tiled(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_pad(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_ofs_x(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_ofs_y(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_spread(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_img_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_img_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_img_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_dash_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_width(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_img_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
+void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_text_letter_space(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_line_space(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_radius(lv_obj_t * obj, lv_coord_t value, lv_style_selector_t selector);
+void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_anim_time(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_anim_speed(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector);
+void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
+void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -1,5 +1,5 @@
 /**
- * @file struct _lv_obj_tree.h
+ * @file lv_obj_tree.h
  *
  */
 
@@ -17,6 +17,7 @@ extern "C" {
 #include <stdbool.h>
 #include "../misc/lv_anim.h"
 #include "../disp/lv_disp.h"
+#include "lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -27,17 +28,13 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-struct _lv_disp_t;
-struct _lv_obj_class_t;
-
 typedef enum {
     LV_OBJ_TREE_WALK_NEXT,
     LV_OBJ_TREE_WALK_SKIP_CHILDREN,
     LV_OBJ_TREE_WALK_END,
 } lv_obj_tree_walk_res_t;
 
-typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(struct _lv_obj_t *, void *);
+typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(lv_obj_t *, void *);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -49,7 +46,7 @@ typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(struct _lv_obj_t *, void
  * Send `LV_EVENT_DELETED` to deleted objects.
  * @param obj       pointer to an object
  */
-void lv_obj_del(struct _lv_obj_t * obj);
+void lv_obj_del(lv_obj_t * obj);
 
 /**
  * Delete all children of an object.
@@ -57,14 +54,14 @@ void lv_obj_del(struct _lv_obj_t * obj);
  * Send `LV_EVENT_DELETED` to deleted objects.
  * @param obj       pointer to an object
  */
-void lv_obj_clean(struct _lv_obj_t * obj);
+void lv_obj_clean(lv_obj_t * obj);
 
 /**
  * Delete an object after some delay
  * @param obj       pointer to an object
  * @param delay_ms  time to wait before delete in milliseconds
  */
-void lv_obj_del_delayed(struct _lv_obj_t * obj, uint32_t delay_ms);
+void lv_obj_del_delayed(lv_obj_t * obj, uint32_t delay_ms);
 
 /**
  * A function to be easily used in animation ready callback to delete an object when the animation is ready
@@ -78,7 +75,7 @@ void lv_obj_del_anim_ready_cb(lv_anim_t * a);
  * @param obj       object to delete
  * @see lv_async_call
  */
-void lv_obj_del_async(struct _lv_obj_t * obj);
+void lv_obj_del_async(lv_obj_t * obj);
 
 /**
  * Move the parent of an object. The relative coordinates will be kept.
@@ -86,7 +83,7 @@ void lv_obj_del_async(struct _lv_obj_t * obj);
  * @param obj       pointer to an object whose parent needs to be changed
  * @param parent pointer to the new parent
  */
-void lv_obj_set_parent(struct _lv_obj_t * obj, struct _lv_obj_t * parent);
+void lv_obj_set_parent(lv_obj_t * obj, lv_obj_t * parent);
 
 /**
  * Swap the positions of two objects.
@@ -94,7 +91,7 @@ void lv_obj_set_parent(struct _lv_obj_t * obj, struct _lv_obj_t * parent);
  * @param obj1  pointer to the first object
  * @param obj2  pointer to the second object
  */
-void lv_obj_swap(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
+void lv_obj_swap(lv_obj_t * obj1, lv_obj_t * obj2);
 
 /**
  * moves the object to the given index in its parent.
@@ -104,28 +101,28 @@ void lv_obj_swap(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
  * @note to move to the background: lv_obj_move_to_index(obj, 0)
  * @note to move forward (up): lv_obj_move_to_index(obj, lv_obj_get_index(obj) - 1)
  */
-void lv_obj_move_to_index(struct _lv_obj_t * obj, int32_t index);
+void lv_obj_move_to_index(lv_obj_t * obj, int32_t index);
 
 /**
  * Get the screen of an object
  * @param obj       pointer to an object
  * @return          pointer to the object's screen
  */
-struct _lv_obj_t * lv_obj_get_screen(const struct _lv_obj_t * obj);
+lv_obj_t * lv_obj_get_screen(const lv_obj_t * obj);
 
 /**
  * Get the display of the object
  * @param obj       pointer to an object
  * @return          pointer to the object's display
  */
-struct _lv_disp_t * lv_obj_get_disp(const struct _lv_obj_t * obj);
+lv_disp_t * lv_obj_get_disp(const lv_obj_t * obj);
 
 /**
  * Get the parent of an object
  * @param obj       pointer to an object
  * @return          the parent of the object. (NULL if `obj` was a screen)
  */
-struct _lv_obj_t * lv_obj_get_parent(const struct _lv_obj_t * obj);
+lv_obj_t * lv_obj_get_parent(const lv_obj_t * obj);
 
 /**
  * Get the child of an object by the child's index.
@@ -138,14 +135,14 @@ struct _lv_obj_t * lv_obj_get_parent(const struct _lv_obj_t * obj);
  *                  -2: the second youngest
  * @return          pointer to the child or NULL if the index was invalid
  */
-struct _lv_obj_t * lv_obj_get_child(const struct _lv_obj_t * obj, int32_t id);
+lv_obj_t * lv_obj_get_child(const lv_obj_t * obj, int32_t id);
 
 /**
  * Get the number of children
  * @param obj       pointer to an object
  * @return          the number of children
  */
-uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
+uint32_t lv_obj_get_child_cnt(const lv_obj_t * obj);
 
 /**
  * Get the index of a child.
@@ -154,7 +151,7 @@ uint32_t lv_obj_get_child_cnt(const struct _lv_obj_t * obj);
  *                  E.g. 0: the oldest (firstly created child).
  *                  (0xFFFFFFFF if child could not be found or no parent exists)
  */
-uint32_t lv_obj_get_index(const struct _lv_obj_t * obj);
+uint32_t lv_obj_get_index(const lv_obj_t * obj);
 
 /**
  * Iterate through all children of any object.
@@ -162,7 +159,7 @@ uint32_t lv_obj_get_index(const struct _lv_obj_t * obj);
  * @param cb            call this callback on the objects
  * @param user_data     pointer to any user related data (will be passed to `cb`)
  */
-void lv_obj_tree_walk(struct _lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void * user_data);
+void lv_obj_tree_walk(lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void * user_data);
 
 /**********************
  *      MACROS

--- a/src/disp/lv_disp.h
+++ b/src/disp/lv_disp.h
@@ -16,7 +16,13 @@ extern "C" {
 #include "../misc/lv_timer.h"
 #include "../misc/lv_event.h"
 #include "../misc/lv_color.h"
+
+struct _lv_disp_t;
+typedef struct _lv_disp_t lv_disp_t;
+
 #include "../draw/lv_draw.h"
+#include "../core/lv_obj.h"
+#include "../themes/lv_theme.h"
 
 /*********************
  *      DEFINES
@@ -29,11 +35,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_theme_t;
-struct _lv_disp_t;
-typedef struct _lv_disp_t lv_disp_t;
 
 typedef enum {
     LV_DISP_ROTATION_0 = 0,
@@ -84,7 +85,7 @@ typedef enum {
 } lv_scr_load_anim_t;
 
 
-typedef void (*lv_disp_flush_cb_t)(struct _lv_disp_t * disp, const lv_area_t * area, uint8_t * px_map);
+typedef void (*lv_disp_flush_cb_t)(lv_disp_t * disp, const lv_area_t * area, uint8_t * px_map);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -315,7 +316,7 @@ bool lv_disp_is_double_buffered(lv_disp_t * disp);
  *                  (NULL to use the default screen)
  * @return          pointer to the active screen object (loaded by 'lv_scr_load()')
  */
-struct _lv_obj_t * lv_disp_get_scr_act(lv_disp_t * disp);
+lv_obj_t * lv_disp_get_scr_act(lv_disp_t * disp);
 
 /**
  * Return with a pointer to the previous screen. Only used during screen transitions.
@@ -323,27 +324,27 @@ struct _lv_obj_t * lv_disp_get_scr_act(lv_disp_t * disp);
  *                  (NULL to use the default screen)
  * @return          pointer to the previous screen object or NULL if not used now
  */
-struct _lv_obj_t * lv_disp_get_scr_prev(lv_disp_t * disp);
+lv_obj_t * lv_disp_get_scr_prev(lv_disp_t * disp);
 
 /**
  * Make a screen active
  * @param scr       pointer to a screen
  */
-void lv_disp_load_scr(struct _lv_obj_t * scr);
+void lv_disp_load_scr(lv_obj_t * scr);
 
 /**
  * Return the top layer. The top layer is the same on all screens and it is above the normal screen layer.
  * @param disp      pointer to display which top layer should be get. (NULL to use the default screen)
  * @return          pointer to the top layer object
  */
-struct _lv_obj_t * lv_disp_get_layer_top(lv_disp_t * disp);
+lv_obj_t * lv_disp_get_layer_top(lv_disp_t * disp);
 
 /**
  * Return the sys. layer. The system layer is the same on all screen and it is above the normal screen and the top layer.
  * @param disp      pointer to display which sys. layer should be retrieved. (NULL to use the default screen)
  * @return          pointer to the sys layer object
  */
-struct _lv_obj_t * lv_disp_get_layer_sys(lv_disp_t * disp);
+lv_obj_t * lv_disp_get_layer_sys(lv_disp_t * disp);
 
 
 /**
@@ -352,7 +353,7 @@ struct _lv_obj_t * lv_disp_get_layer_sys(lv_disp_t * disp);
  * @param disp      pointer to display (NULL to use the default screen)
  * @return          pointer to the bottom layer object
  */
-struct _lv_obj_t * lv_disp_get_layer_bottom(lv_disp_t * disp);
+lv_obj_t * lv_disp_get_layer_bottom(lv_disp_t * disp);
 
 
 /**
@@ -363,14 +364,14 @@ struct _lv_obj_t * lv_disp_get_layer_bottom(lv_disp_t * disp);
  * @param delay     delay before the transition
  * @param auto_del  true: automatically delete the old screen
  */
-void lv_scr_load_anim(struct _lv_obj_t * scr, lv_scr_load_anim_t anim_type, uint32_t time, uint32_t delay,
+void lv_scr_load_anim(lv_obj_t * scr, lv_scr_load_anim_t anim_type, uint32_t time, uint32_t delay,
                       bool auto_del);
 
 /**
  * Get the active screen of the default display
  * @return          pointer to the active screen
  */
-static inline struct _lv_obj_t * lv_scr_act(void)
+static inline lv_obj_t * lv_scr_act(void)
 {
     return lv_disp_get_scr_act(lv_disp_get_default());
 }
@@ -379,7 +380,7 @@ static inline struct _lv_obj_t * lv_scr_act(void)
  * Get the top layer  of the default display
  * @return          pointer to the top layer
  */
-static inline struct _lv_obj_t * lv_layer_top(void)
+static inline lv_obj_t * lv_layer_top(void)
 {
     return lv_disp_get_layer_top(lv_disp_get_default());
 }
@@ -388,7 +389,7 @@ static inline struct _lv_obj_t * lv_layer_top(void)
  * Get the system layer  of the default display
  * @return          pointer to the sys layer
  */
-static inline struct _lv_obj_t * lv_layer_sys(void)
+static inline lv_obj_t * lv_layer_sys(void)
 {
     return lv_disp_get_layer_sys(lv_disp_get_default());
 }
@@ -397,7 +398,7 @@ static inline struct _lv_obj_t * lv_layer_sys(void)
  * Get the bottom layer  of the default display
  * @return          pointer to the bottom layer
  */
-static inline struct _lv_obj_t * lv_layer_bottom(void)
+static inline lv_obj_t * lv_layer_bottom(void)
 {
     return lv_disp_get_layer_bottom(lv_disp_get_default());
 }
@@ -406,7 +407,7 @@ static inline struct _lv_obj_t * lv_layer_bottom(void)
  * Load a screen on the default display
  * @param scr       pointer to a screen
  */
-static inline void lv_scr_load(struct _lv_obj_t * scr)
+static inline void lv_scr_load(lv_obj_t * scr)
 {
     lv_disp_load_scr(scr);
 }
@@ -445,14 +446,14 @@ lv_res_t lv_disp_send_event(lv_disp_t * disp, lv_event_code_t code, void * param
  * @param disp      pointer to a display
  * @param th        pointer to a theme
  */
-void lv_disp_set_theme(lv_disp_t * disp, struct _lv_theme_t * th);
+void lv_disp_set_theme(lv_disp_t * disp, lv_theme_t * th);
 
 /**
  * Get the theme of a display
  * @param disp      pointer to a display
  * @return          the display's theme (can be NULL)
  */
-struct _lv_theme_t * lv_disp_get_theme(lv_disp_t * disp);
+lv_theme_t * lv_disp_get_theme(lv_disp_t * disp);
 
 /**
  * Get elapsed time since last user activity on a display (e.g. click)

--- a/src/disp/lv_disp_private.h
+++ b/src/disp/lv_disp_private.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../core/lv_obj.h"
+#include "../themes/lv_theme.h"
 #include "../draw/lv_draw.h"
 #include "lv_disp.h"
 
@@ -27,8 +28,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_disp_t;
 
 struct _lv_disp_t {
 
@@ -102,21 +101,21 @@ struct _lv_disp_t {
      * Layer
      *--------------------*/
     lv_layer_t * layer_head;
-    lv_layer_t * (*layer_init)(struct _lv_disp_t * disp);
-    void (*layer_deinit)(struct _lv_disp_t * disp, lv_layer_t * layer);
+    lv_layer_t * (*layer_init)(lv_disp_t * disp);
+    void (*layer_deinit)(lv_disp_t * disp, lv_layer_t * layer);
 
     /*---------------------
      * Screens
      *--------------------*/
 
     /** Screens of the display*/
-    struct _lv_obj_t ** screens;    /**< Array of screen objects.*/
-    struct _lv_obj_t * act_scr;     /**< Currently active screen on this display*/
-    struct _lv_obj_t * prev_scr;    /**< Previous screen. Used during screen animations*/
-    struct _lv_obj_t * scr_to_load; /**< The screen prepared to load in lv_scr_load_anim*/
-    struct _lv_obj_t * bottom_layer;    /**< @see lv_disp_get_layer_bottom*/
-    struct _lv_obj_t * top_layer;       /**< @see lv_disp_get_layer_top*/
-    struct _lv_obj_t * sys_layer;       /**< @see lv_disp_get_layer_sys*/
+    lv_obj_t ** screens;    /**< Array of screen objects.*/
+    lv_obj_t * act_scr;     /**< Currently active screen on this display*/
+    lv_obj_t * prev_scr;    /**< Previous screen. Used during screen animations*/
+    lv_obj_t * scr_to_load; /**< The screen prepared to load in lv_scr_load_anim*/
+    lv_obj_t * bottom_layer;    /**< @see lv_disp_get_layer_bottom*/
+    lv_obj_t * top_layer;       /**< @see lv_disp_get_layer_top*/
+    lv_obj_t * sys_layer;       /**< @see lv_disp_get_layer_sys*/
     uint32_t screen_cnt;
     uint8_t draw_prev_over_act  : 1;/** 1: Draw previous screen over active screen*/
     uint8_t del_prev  : 1; /** 1: Automatically delete the previous screen when the screen load animation is ready*/
@@ -135,7 +134,7 @@ struct _lv_disp_t {
     uint32_t rotation  : 2; /**< Element of  @lv_disp_rotation_t*/
 
     /**< The theme assigned to the screen*/
-    struct _lv_theme_t * theme;
+    lv_theme_t * theme;
 
     /** A timer which periodically checks the dirty areas and refreshes them*/
     lv_timer_t * refr_timer;

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -29,8 +29,9 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_draw_img_dsc_t;
 struct _lv_disp_t;
+struct _lv_layer_t;
+typedef struct _lv_layer_t lv_layer_t;
 
 typedef enum {
     LV_DRAW_TASK_TYPE_FILL,
@@ -89,7 +90,7 @@ typedef struct _lv_draw_unit_t {
     /**
      * The target_layer on which drawing should happen
      */
-    struct _lv_layer_t * target_layer;
+    lv_layer_t * target_layer;
 
     const lv_area_t * clip_area;
 
@@ -103,11 +104,11 @@ typedef struct _lv_draw_unit_t {
      *                      -1:     There where no available draw tasks at all.
      *                              Also means to no call the dispatcher of the other draw units as there is no dra task to tkae
      */
-    int32_t (*dispatch)(struct _lv_draw_unit_t * draw_unit, struct _lv_layer_t * layer);
+    int32_t (*dispatch)(struct _lv_draw_unit_t * draw_unit, lv_layer_t * layer);
 } lv_draw_unit_t;
 
 
-typedef struct _lv_layer_t  {
+struct _lv_layer_t  {
     /**
      *  Pointer to a buffer to draw into
      */
@@ -147,7 +148,7 @@ typedef struct _lv_layer_t  {
      *       but can have different x and y position.
      * @note dest_area and src_area must be clipped to the real dimensions of the buffers
      */
-    void (*buffer_copy)(struct _lv_layer_t * target_layer, void * dest_buf, lv_coord_t dest_stride,
+    void (*buffer_copy)(lv_layer_t * target_layer, void * dest_buf, lv_coord_t dest_stride,
                         const lv_area_t * dest_area,
                         void * src_buf, lv_coord_t src_stride, const lv_area_t * src_area);
 
@@ -155,20 +156,20 @@ typedef struct _lv_layer_t  {
      * Convert the content of `target_layer->buf` to `target_layer->color_format`
      * @param target_layer
      */
-    void (*buffer_convert)(struct _lv_layer_t * layer);
+    void (*buffer_convert)(lv_layer_t * layer);
 
-    void (*buffer_clear)(struct _lv_layer_t * target_layer, const lv_area_t * a);
+    void (*buffer_clear)(lv_layer_t * target_layer, const lv_area_t * a);
 
     /**
      * Linked list of draw tasks
      */
     lv_draw_task_t * draw_task_head;
 
-    struct _lv_layer_t * parent;
-    struct _lv_layer_t * next;
+    lv_layer_t * parent;
+    lv_layer_t * next;
     bool all_tasks_added;
     void * user_data;
-} lv_layer_t;
+};
 
 typedef struct {
     struct _lv_obj_t * obj;

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -13,10 +13,15 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+
+struct _lv_indev_t;
+typedef struct _lv_indev_t lv_indev_t;
+
 #include "../core/lv_group.h"
+#include "../core/lv_obj.h"
+#include "../disp/lv_disp.h"
 #include "../misc/lv_area.h"
 #include "../misc/lv_timer.h"
-
 /*********************
  *      DEFINES
  *********************/
@@ -24,12 +29,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-struct _lv_obj_t;
-struct _lv_disp_t;
-struct _lv_group_t;
-struct _lv_indev_t;
-struct _lv_disp_t;
-typedef struct _lv_indev_t lv_indev_t;
 
 /** Possible input device types*/
 typedef enum {
@@ -57,7 +56,7 @@ typedef struct {
     bool continue_reading;  /**< If set to true, the read callback is invoked again*/
 } lv_indev_data_t;
 
-typedef void (*lv_indev_read_cb_t)(struct _lv_indev_t * indev, lv_indev_data_t * data);
+typedef void (*lv_indev_read_cb_t)(lv_indev_t * indev, lv_indev_data_t * data);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -130,9 +129,9 @@ lv_indev_state_t lv_indev_get_state(const lv_indev_t * indev);
 
 lv_group_t * lv_indev_get_group(const lv_indev_t * indev);
 
-struct _lv_disp_t * lv_indev_get_disp(const lv_indev_t * indev);
+lv_disp_t * lv_indev_get_disp(const lv_indev_t * indev);
 
-void lv_indev_set_disp(lv_indev_t * indev, struct _lv_disp_t * disp);
+void lv_indev_set_disp(lv_indev_t * indev, lv_disp_t * disp);
 
 void * lv_indev_get_user_data(const lv_indev_t * indev);
 
@@ -143,7 +142,7 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev);
  * @param indev pointer to an input device to reset or NULL to reset all of them
  * @param obj pointer to an object which triggers the reset.
  */
-void lv_indev_reset(lv_indev_t * indev, struct _lv_obj_t * obj);
+void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj);
 
 /**
  * Reset the long press state of an input device
@@ -156,7 +155,7 @@ void lv_indev_reset_long_press(lv_indev_t * indev);
  * @param indev pointer to an input device
  * @param cur_obj pointer to an object to be used as cursor
  */
-void lv_indev_set_cursor(lv_indev_t * indev, struct _lv_obj_t * cur_obj);
+void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj);
 
 /**
  * Set a destination group for a keypad input device (for LV_INDEV_TYPE_KEYPAD)
@@ -209,7 +208,7 @@ lv_dir_t lv_indev_get_scroll_dir(const lv_indev_t * indev);
  * @param indev pointer to an input device
  * @return pointer to the currently scrolled object or NULL if no scrolling by this indev
  */
-struct _lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev);
+lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev);
 
 /**
  * Get the movement vector of an input device (for LV_INDEV_TYPE_POINTER and
@@ -229,7 +228,7 @@ void lv_indev_wait_release(lv_indev_t * indev);
  * Gets a pointer to the currently active object in the currently processed input device.
  * @return pointer to currently active object or NULL if no active object
  */
-struct _lv_obj_t * lv_indev_get_obj_act(void);
+lv_obj_t * lv_indev_get_obj_act(void);
 
 /**
  * Get a pointer to the indev read timer to
@@ -245,7 +244,7 @@ lv_timer_t * lv_indev_get_read_timer(lv_indev_t * indev);
  * @param point pointer to a point for searching the most top child
  * @return pointer to the found object or NULL if there was no suitable object
  */
-struct _lv_obj_t * lv_indev_search_obj(struct _lv_obj_t * obj, lv_point_t * point);
+lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point);
 
 /**********************
  *      MACROS

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -14,6 +14,9 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "lv_indev.h"
+#include "../core/lv_obj.h"
+#include "../core/lv_group.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -23,6 +26,7 @@ extern "C" {
  **********************/
 
 struct _lv_indev_t;
+typedef struct _lv_indev_t lv_indev_t;
 
 struct _lv_indev_t {
     /**< Input device type*/
@@ -33,7 +37,7 @@ struct _lv_indev_t {
 
     /** Called when an action happened on the input device.
      * The second parameter is the event from `lv_event_t`*/
-    void (*feedback_cb)(struct _lv_indev_t * indev, uint8_t event_code);
+    void (*feedback_cb)(lv_indev_t * indev, uint8_t event_code);
 
     lv_indev_state_t state; /**< Current state of the input device.*/
 
@@ -82,10 +86,10 @@ struct _lv_indev_t {
         lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
         lv_point_t scroll_throw_vect;
         lv_point_t scroll_throw_vect_ori;
-        struct _lv_obj_t * act_obj;      /*The object being pressed*/
-        struct _lv_obj_t * last_obj;     /*The last object which was pressed*/
-        struct _lv_obj_t * scroll_obj;   /*The object being scrolled*/
-        struct _lv_obj_t * last_pressed; /*The lastly pressed object*/
+        lv_obj_t * act_obj;      /*The object being pressed*/
+        lv_obj_t * last_obj;     /*The last object which was pressed*/
+        lv_obj_t * scroll_obj;   /*The object being scrolled*/
+        lv_obj_t * last_pressed; /*The lastly pressed object*/
         lv_area_t scroll_area;
         lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
 
@@ -100,8 +104,8 @@ struct _lv_indev_t {
         uint32_t last_key;
     } keypad;
 
-    struct _lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
-    struct _lv_group_t * group;    /**< Keypad destination group*/
+    lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
+    lv_group_t * group;    /**< Keypad destination group*/
     const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed
                                       here by the buttons*/
 };

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -112,7 +112,7 @@ lv_anim_t * lv_anim_start(const lv_anim_t * a)
     return new_anim;
 }
 
-uint32_t lv_anim_get_playtime(lv_anim_t * a)
+uint32_t lv_anim_get_playtime(const lv_anim_t * a)
 {
     uint32_t playtime = LV_ANIM_PLAYTIME_INFINITE;
 

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -388,7 +388,7 @@ lv_anim_t * lv_anim_start(const lv_anim_t * a);
  * @param a pointer to an initialized `lv_anim_t` variable
  * @return delay before the animation in milliseconds
  */
-static inline uint32_t lv_anim_get_delay(lv_anim_t * a)
+static inline uint32_t lv_anim_get_delay(const lv_anim_t * a)
 {
     return -a->act_time;
 }
@@ -398,14 +398,14 @@ static inline uint32_t lv_anim_get_delay(lv_anim_t * a)
  * @param a pointer to an animation.
  * @return the play time in milliseconds.
  */
-uint32_t lv_anim_get_playtime(lv_anim_t * a);
+uint32_t lv_anim_get_playtime(const lv_anim_t * a);
 
 /**
  * Get the duration of an animation
  * @param a         pointer to an initialized `lv_anim_t` variable
  * @return the duration of the animation in milliseconds
  */
-static inline uint32_t lv_anim_get_time(lv_anim_t * a)
+static inline uint32_t lv_anim_get_time(const lv_anim_t * a)
 {
     return a->time;
 }
@@ -415,7 +415,7 @@ static inline uint32_t lv_anim_get_time(lv_anim_t * a)
  * @param a         pointer to an initialized `lv_anim_t` variable
  * @return the repeat count or `LV_ANIM_REPEAT_INFINITE` for infinite repetition. 0: disabled repetition.
  */
-static inline uint16_t lv_anim_get_repeat_count(lv_anim_t * a)
+static inline uint16_t lv_anim_get_repeat_count(const lv_anim_t * a)
 {
     return a->repeat_cnt;
 }
@@ -425,7 +425,7 @@ static inline uint16_t lv_anim_get_repeat_count(lv_anim_t * a)
  * @param   a pointer to an initialized `lv_anim_t` variable
  * @return  the pointer to the custom user_data of the animation
  */
-static inline void * lv_anim_get_user_data(lv_anim_t * a)
+static inline void * lv_anim_get_user_data(const lv_anim_t * a)
 {
     return a->user_data;
 }

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 #include "lv_math.h"
+#include "lv_timer.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -80,17 +81,17 @@ LV_EXPORT_CONST_INT(LV_ANIM_PLAYTIME_INFINITE);
  *      TYPEDEFS
  **********************/
 
+struct _lv_anim_t;
+typedef struct _lv_anim_t lv_anim_t;
+
 /** Can be used to indicate if animations are enabled or disabled in a case*/
 typedef enum {
     LV_ANIM_OFF,
     LV_ANIM_ON,
 } lv_anim_enable_t;
 
-struct _lv_anim_t;
-struct _lv_timer_t;
-
 /** Get the current value during an animation*/
-typedef int32_t (*lv_anim_path_cb_t)(const struct _lv_anim_t *);
+typedef int32_t (*lv_anim_path_cb_t)(const lv_anim_t *);
 
 /** Generic prototype of "animator" functions.
  * First parameter is the variable to animate.
@@ -102,19 +103,19 @@ typedef void (*lv_anim_exec_xcb_t)(void *, int32_t);
 
 /** Same as `lv_anim_exec_xcb_t` but receives `lv_anim_t *` as the first parameter.
  * It's more consistent but less convenient. Might be used by binding generator functions.*/
-typedef void (*lv_anim_custom_exec_cb_t)(struct _lv_anim_t *, int32_t);
+typedef void (*lv_anim_custom_exec_cb_t)(lv_anim_t *, int32_t);
 
 /** Callback to call when the animation is ready*/
-typedef void (*lv_anim_ready_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_ready_cb_t)(lv_anim_t *);
 
 /** Callback to call when the animation really stars (considering `delay`)*/
-typedef void (*lv_anim_start_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_start_cb_t)(lv_anim_t *);
 
 /** Callback used when the animation values are relative to get the current value*/
-typedef int32_t (*lv_anim_get_value_cb_t)(struct _lv_anim_t *);
+typedef int32_t (*lv_anim_get_value_cb_t)(lv_anim_t *);
 
 /** Callback used when the animation is deleted*/
-typedef void (*lv_anim_deleted_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_deleted_cb_t)(lv_anim_t *);
 
 typedef struct _lv_anim_bezier3_para_t {
     int16_t x1;
@@ -124,7 +125,7 @@ typedef struct _lv_anim_bezier3_para_t {
 } lv_anim_bezier3_para_t; /**< Parameter used when path is custom_bezier*/
 
 /** Describes an animation*/
-typedef struct _lv_anim_t {
+struct _lv_anim_t {
     void * var;                          /**<Variable to animate*/
     lv_anim_exec_xcb_t exec_cb;          /**< Function to execute to animate*/
     lv_anim_start_cb_t start_cb;         /**< Call it when the animation is starts (considering `delay`)*/
@@ -153,7 +154,7 @@ typedef struct _lv_anim_t {
     uint8_t playback_now : 1; /**< Play back is in progress*/
     uint8_t run_round : 1;    /**< Indicates the animation has run in this round*/
     uint8_t start_cb_called : 1;    /**< Indicates that the `start_cb` was already called*/
-} lv_anim_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -366,7 +367,7 @@ static inline void lv_anim_set_user_data(lv_anim_t * a, void * user_data)
  */
 static inline void lv_anim_set_bezier3_param(lv_anim_t * a, int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 {
-    struct _lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
+    lv_anim_bezier3_para_t * para = &a->parameter.bezier3;
 
     para->x1 = x1;
     para->x2 = x2;
@@ -455,7 +456,7 @@ lv_anim_t * lv_anim_get(void * var, lv_anim_exec_xcb_t exec_cb);
  * Get global animation refresher timer.
  * @return pointer to the animation refresher timer.
  */
-struct _lv_timer_t * lv_anim_get_timer(void);
+lv_timer_t * lv_anim_get_timer(void);
 
 /**
  * Delete an animation by getting the animated variable from `a`.

--- a/src/misc/lv_color_op.h
+++ b/src/misc/lv_color_op.h
@@ -27,13 +27,15 @@ extern "C" {
  **********************/
 
 struct _lv_color_filter_dsc_t;
+typedef struct _lv_color_filter_dsc_t lv_color_filter_dsc_t;
 
-typedef lv_color_t (*lv_color_filter_cb_t)(const struct _lv_color_filter_dsc_t *, lv_color_t, lv_opa_t);
 
-typedef struct _lv_color_filter_dsc_t {
+typedef lv_color_t (*lv_color_filter_cb_t)(const lv_color_filter_dsc_t *, lv_color_t, lv_opa_t);
+
+struct _lv_color_filter_dsc_t {
     lv_color_filter_cb_t filter_cb;
     void * user_data;
-} lv_color_filter_dsc_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -26,8 +26,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 struct _lv_event_t;
-
-typedef void (*lv_event_cb_t)(struct _lv_event_t * e);
+typedef struct _lv_event_t lv_event_t;
+typedef void (*lv_event_cb_t)(lv_event_t * e);
 
 
 typedef struct {
@@ -122,17 +122,17 @@ typedef struct {
     uint32_t cnt;
 } lv_event_list_t;
 
-typedef struct _lv_event_t {
+struct _lv_event_t {
     void * current_target;
     void * original_target;
     lv_event_code_t code;
     void * user_data;
     void * param;
-    struct _lv_event_t * prev;
+    lv_event_t * prev;
     uint8_t deleted : 1;
     uint8_t stop_processing : 1;
     uint8_t stop_bubbling : 1;
-} lv_event_t;
+};
 
 /**
  * @brief Event callback.

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -32,23 +32,24 @@ extern "C" {
  **********************/
 
 struct _lv_timer_t;
+typedef struct _lv_timer_t lv_timer_t;
 
 /**
  * Timers execute this type of functions.
  */
-typedef void (*lv_timer_cb_t)(struct _lv_timer_t *);
+typedef void (*lv_timer_cb_t)(lv_timer_t *);
 
 /**
  * Descriptor of a lv_timer
  */
-typedef struct _lv_timer_t {
+struct _lv_timer_t {
     uint32_t period; /**< How often the timer should run*/
     uint32_t last_run; /**< Last time the timer ran*/
     lv_timer_cb_t timer_cb; /**< Timer function*/
     void * user_data; /**< Custom user data*/
     int32_t repeat_count; /**< 1: One time;  -1 : infinity;  n>0: residual times*/
     uint32_t paused : 1;
-} lv_timer_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/themes/lv_theme.h
+++ b/src/themes/lv_theme.h
@@ -14,6 +14,7 @@ extern "C" {
  *    INCLUDES
  *********************/
 #include "../core/lv_obj.h"
+#include "../disp/lv_disp.h"
 
 /*********************
  *    DEFINES
@@ -24,15 +25,14 @@ extern "C" {
  **********************/
 
 struct _lv_theme_t;
-struct _lv_disp_t;
-
-typedef void (*lv_theme_apply_cb_t)(struct _lv_theme_t *, lv_obj_t *);
+typedef struct _lv_theme_t lv_theme_t;
+typedef void (*lv_theme_apply_cb_t)(lv_theme_t *, lv_obj_t *);
 
 typedef struct _lv_theme_t {
     lv_theme_apply_cb_t apply_cb;
-    struct _lv_theme_t * parent;    /**< Apply the current theme's style on top of this theme.*/
+    lv_theme_t * parent;    /**< Apply the current theme's style on top of this theme.*/
     void * user_data;
-    struct _lv_disp_t * disp;
+    lv_disp_t * disp;
     lv_color_t color_primary;
     lv_color_t color_secondary;
     const lv_font_t * font_small;


### PR DESCRIPTION
### Use lv_xxx_t where possible

Continue of #4355

For a module like `lv_obj`, lvgl sepeartes it to several files for different sub-modules like `obj_tree`, `obj_style` etc. `lv_obj_t` is a common type for sub-modules. 

Delcare `lv_obj_t` firstly before including sub-module headers will eliminate most forward declaration of `struct _lv_obj_t`

Same is true for module `lv_disp`.

### The rule:
 - Delecare types provided by this module. E.g. `lv_obj_t`
 - Include other modules below, if they also need this module. E.g. `#include "lv_group.h"

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
