### PR TITLE
chore(rlottie): Reorganize the usage of static variables

### DIFF
--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -39,10 +39,15 @@ const lv_obj_class_t lv_rlottie_class = {
     .base_class = &lv_img_class
 };
 
-static lv_coord_t create_width;
-static lv_coord_t create_height;
-static const char * rlottie_desc_create;
-static const char * path_create;
+struct _class_init_info {
+    lv_coord_t width;
+    lv_coord_t height;
+    const char * rlottie_desc;
+    const char * path;
+};
+
+// only used in lv_obj_class_create_obj, no affect multiple instances
+static struct _class_init_info create_info;
 
 /**********************
  *      MACROS
@@ -54,27 +59,24 @@ static const char * path_create;
 
 lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, lv_coord_t width, lv_coord_t height, const char * path)
 {
-
-    create_width = width;
-    create_height = height;
-    path_create = path;
-    rlottie_desc_create = NULL;
+    create_info.width = width;
+    create_info.height = height;
+    create_info.path = path;
+    create_info.rlottie_desc = NULL;
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
 
     return obj;
-
 }
 
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, lv_coord_t width, lv_coord_t height, const char * rlottie_desc)
 {
-
-    create_width = width;
-    create_height = height;
-    rlottie_desc_create = rlottie_desc;
-    path_create = NULL;
+    create_info.width = width;
+    create_info.height = height;
+    create_info.rlottie_desc = rlottie_desc;
+    create_info.path = NULL;
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
@@ -109,11 +111,11 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     LV_UNUSED(class_p);
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
 
-    if(rlottie_desc_create) {
-        rlottie->animation = lottie_animation_from_data(rlottie_desc_create, rlottie_desc_create, "");
+    if(create_info.rlottie_desc) {
+        rlottie->animation = lottie_animation_from_data(create_info.rlottie_desc, create_info.rlottie_desc, "");
     }
-    else if(path_create) {
-        rlottie->animation = lottie_animation_from_file(path_create);
+    else if(create_info.path) {
+        rlottie->animation = lottie_animation_from_file(create_info.path);
     }
     if(rlottie->animation == NULL) {
         LV_LOG_WARN("The aniamtion can't be opened");
@@ -124,9 +126,9 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     rlottie->framerate = (size_t)lottie_animation_get_framerate(rlottie->animation);
     rlottie->current_frame = 0;
 
-    rlottie->scanline_width = create_width * LV_ARGB32 / 8;
+    rlottie->scanline_width = create_info.width * LV_ARGB32 / 8;
 
-    size_t allocaled_buf_size = (create_width * create_height * LV_ARGB32 / 8);
+    size_t allocaled_buf_size = (create_info.width * create_info.height * LV_ARGB32 / 8);
     rlottie->allocated_buf = lv_malloc(allocaled_buf_size);
     if(rlottie->allocated_buf != NULL) {
         rlottie->allocated_buffer_size = allocaled_buf_size;
@@ -135,8 +137,8 @@ static void lv_rlottie_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
 
     rlottie->imgdsc.header.always_zero = 0;
     rlottie->imgdsc.header.cf = LV_COLOR_FORMAT_ARGB8888;
-    rlottie->imgdsc.header.h = create_height;
-    rlottie->imgdsc.header.w = create_width;
+    rlottie->imgdsc.header.h = create_info.height;
+    rlottie->imgdsc.header.w = create_info.width;
     rlottie->imgdsc.data = (void *)rlottie->allocated_buf;
     rlottie->imgdsc.data_size = allocaled_buf_size;
 


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
