### PR TITLE
fix(attr): refactor LV_ATTRIBUTE_* for function attributes

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -1027,8 +1027,8 @@ static void draw_buf_rotate_180(lv_disp_drv_t * drv, lv_area_t * area, lv_color_
     area->x1 = drv->hor_res - tmp_coord - 1;
 }
 
-static LV_ATTRIBUTE_FAST_MEM void draw_buf_rotate_90(bool invert_i, lv_coord_t area_w, lv_coord_t area_h,
-                                                     lv_color_t * orig_color_p, lv_color_t * rot_buf)
+static void draw_buf_rotate_90(bool invert_i, lv_coord_t area_w, lv_coord_t area_h,
+                               lv_color_t * orig_color_p, lv_color_t * rot_buf) LV_ATTRIBUTE_FAST_MEM
 {
 
     uint32_t invert = (area_w * area_h) - 1;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -1027,8 +1027,8 @@ static void draw_buf_rotate_180(lv_disp_drv_t * drv, lv_area_t * area, lv_color_
     area->x1 = drv->hor_res - tmp_coord - 1;
 }
 
-static void draw_buf_rotate_90(bool invert_i, lv_coord_t area_w, lv_coord_t area_h,
-                               lv_color_t * orig_color_p, lv_color_t * rot_buf) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_buf_rotate_90(bool invert_i, lv_coord_t area_w, lv_coord_t area_h,
+                                                     lv_color_t * orig_color_p, lv_color_t * rot_buf)
 {
 
     uint32_t invert = (area_w * area_h) - 1;

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -418,19 +418,17 @@
  **********************/
 
 #if __ARM_2D_HAS_HW_ACC__
-LV_ATTRIBUTE_FAST_MEM
 static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
                                       const arm_2d_region_t * region,
                                       lv_color_t color,
                                       lv_opa_t opa,
-                                      const arm_2d_tile_t * mask_tile);
+                                      const arm_2d_tile_t * mask_tile) /* LV_ATTRIBUTE_FAST_MEM */;
 
-LV_ATTRIBUTE_FAST_MEM
 static bool lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
                                     const arm_2d_region_t * region,
                                     arm_2d_tile_t * source_tile,
                                     lv_opa_t opa,
-                                    arm_2d_tile_t * mask_tile);
+                                    arm_2d_tile_t * mask_tile) /* LV_ATTRIBUTE_FAST_MEM */;
 #else
 
 static void convert_cb(const lv_area_t * dest_area,
@@ -443,16 +441,14 @@ static void convert_cb(const lv_area_t * dest_area,
                        lv_color_t * cbuf,
                        lv_opa_t * abuf);
 
-LV_ATTRIBUTE_FAST_MEM
 static bool arm_2d_fill_normal(lv_color_t * dest_buf,
                                const lv_area_t * dest_area,
                                lv_coord_t dest_stride,
                                lv_color_t color,
                                lv_opa_t opa,
                                const lv_opa_t * mask,
-                               lv_coord_t mask_stride);
+                               lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
 
-LV_ATTRIBUTE_FAST_MEM
 static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                const lv_area_t * dest_area,
                                lv_coord_t dest_stride,
@@ -460,19 +456,16 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                lv_coord_t src_stride,
                                lv_opa_t opa,
                                const lv_opa_t * mask,
-                               lv_coord_t mask_stride);
+                               lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
 #endif
 
-LV_ATTRIBUTE_FAST_MEM
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
-LV_ATTRIBUTE_FAST_MEM
-static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx);
-LV_ATTRIBUTE_FAST_MEM
+static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
+static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx) /* LV_ATTRIBUTE_FAST_MEM */;
 static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                       const lv_draw_img_dsc_t * draw_dsc,
                                       const lv_area_t * coords,
                                       const uint8_t * src_buf,
-                                      lv_img_cf_t cf);
+                                      lv_img_cf_t cf) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**********************
  *  STATIC VARIABLES
@@ -512,8 +505,7 @@ void lv_draw_arm2d_ctx_deinit(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
 extern void test_flush(lv_color_t * color_p);
 
 #if __ARM_2D_HAS_HW_ACC__
-LV_ATTRIBUTE_FAST_MEM
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -560,12 +552,11 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
 }
 
 
-LV_ATTRIBUTE_FAST_MEM
 static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
                                       const arm_2d_region_t * region,
                                       lv_color_t color,
                                       lv_opa_t opa,
-                                      const arm_2d_tile_t * mask_tile)
+                                      const arm_2d_tile_t * mask_tile) LV_ATTRIBUTE_FAST_MEM
 {
     arm_fsm_rt_t result = (arm_fsm_rt_t)ARM_2D_ERR_NONE;
 
@@ -623,12 +614,11 @@ static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
 
 }
 
-LV_ATTRIBUTE_FAST_MEM
 static bool lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
                                     const arm_2d_region_t * region,
                                     arm_2d_tile_t * source_tile,
                                     lv_opa_t opa,
-                                    arm_2d_tile_t * mask_tile)
+                                    arm_2d_tile_t * mask_tile) LV_ATTRIBUTE_FAST_MEM
 {
     arm_fsm_rt_t result = (arm_fsm_rt_t)ARM_2D_ERR_NONE;
 
@@ -691,8 +681,7 @@ static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx)
 #else
 
 
-LV_ATTRIBUTE_FAST_MEM
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -777,14 +766,13 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
     if(!is_accelerated) lv_draw_sw_blend_basic(draw_ctx, dsc);
 }
 
-LV_ATTRIBUTE_FAST_MEM
 static bool arm_2d_fill_normal(lv_color_t * dest_buf,
                                const lv_area_t * dest_area,
                                lv_coord_t dest_stride,
                                lv_color_t color,
                                lv_opa_t opa,
                                const lv_opa_t * mask,
-                               lv_coord_t mask_stride)
+                               lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
 {
     arm_2d_size_t target_size = {
         .iWidth = lv_area_get_width(dest_area),
@@ -835,7 +823,6 @@ static bool arm_2d_fill_normal(lv_color_t * dest_buf,
 }
 
 
-LV_ATTRIBUTE_FAST_MEM
 static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                const lv_area_t * dest_area,
                                lv_coord_t dest_stride,
@@ -843,7 +830,7 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
                                lv_coord_t src_stride,
                                lv_opa_t opa,
                                const lv_opa_t * mask,
-                               lv_coord_t mask_stride)
+                               lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
 
 {
     int32_t w = lv_area_get_width(dest_area);
@@ -908,12 +895,11 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
     return true;
 }
 
-LV_ATTRIBUTE_FAST_MEM
 static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                       const lv_draw_img_dsc_t * draw_dsc,
                                       const lv_area_t * coords,
                                       const uint8_t * src_buf,
-                                      lv_img_cf_t cf)
+                                      lv_img_cf_t cf) LV_ATTRIBUTE_FAST_MEM
 {
     /*Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -459,7 +459,8 @@ static bool /* LV_ATTRIBUTE_FAST_MEM */ arm_2d_copy_normal(lv_color_t * dest_buf
                                                            lv_coord_t mask_stride);
 #endif
 
-static void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+static void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx,
+                                                            const lv_draw_sw_blend_dsc_t * dsc);
 static void /* LV_ATTRIBUTE_FAST_MEM */ lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx);
 static void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
                                                                   const lv_draw_img_dsc_t * draw_dsc,
@@ -505,7 +506,8 @@ void lv_draw_arm2d_ctx_deinit(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
 extern void test_flush(lv_color_t * color_p);
 
 #if __ARM_2D_HAS_HW_ACC__
-static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx,
+                                                      const lv_draw_sw_blend_dsc_t * dsc)
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -681,7 +683,8 @@ static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx)
 #else
 
 
-static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx,
+                                                      const lv_draw_sw_blend_dsc_t * dsc)
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -418,17 +418,17 @@
  **********************/
 
 #if __ARM_2D_HAS_HW_ACC__
-static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
-                                      const arm_2d_region_t * region,
-                                      lv_color_t color,
-                                      lv_opa_t opa,
-                                      const arm_2d_tile_t * mask_tile) /* LV_ATTRIBUTE_FAST_MEM */;
+static bool /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
+                                                                  const arm_2d_region_t * region,
+                                                                  lv_color_t color,
+                                                                  lv_opa_t opa,
+                                                                  const arm_2d_tile_t * mask_tile);
 
-static bool lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
-                                    const arm_2d_region_t * region,
-                                    arm_2d_tile_t * source_tile,
-                                    lv_opa_t opa,
-                                    arm_2d_tile_t * mask_tile) /* LV_ATTRIBUTE_FAST_MEM */;
+static bool /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
+                                                                const arm_2d_region_t * region,
+                                                                arm_2d_tile_t * source_tile,
+                                                                lv_opa_t opa,
+                                                                arm_2d_tile_t * mask_tile);
 #else
 
 static void convert_cb(const lv_area_t * dest_area,
@@ -441,31 +441,31 @@ static void convert_cb(const lv_area_t * dest_area,
                        lv_color_t * cbuf,
                        lv_opa_t * abuf);
 
-static bool arm_2d_fill_normal(lv_color_t * dest_buf,
-                               const lv_area_t * dest_area,
-                               lv_coord_t dest_stride,
-                               lv_color_t color,
-                               lv_opa_t opa,
-                               const lv_opa_t * mask,
-                               lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
+static bool /* LV_ATTRIBUTE_FAST_MEM */ arm_2d_fill_normal(lv_color_t * dest_buf,
+                                                           const lv_area_t * dest_area,
+                                                           lv_coord_t dest_stride,
+                                                           lv_color_t color,
+                                                           lv_opa_t opa,
+                                                           const lv_opa_t * mask,
+                                                           lv_coord_t mask_stride);
 
-static bool arm_2d_copy_normal(lv_color_t * dest_buf,
-                               const lv_area_t * dest_area,
-                               lv_coord_t dest_stride,
-                               const lv_color_t * src_buf,
-                               lv_coord_t src_stride,
-                               lv_opa_t opa,
-                               const lv_opa_t * mask,
-                               lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
+static bool /* LV_ATTRIBUTE_FAST_MEM */ arm_2d_copy_normal(lv_color_t * dest_buf,
+                                                           const lv_area_t * dest_area,
+                                                           lv_coord_t dest_stride,
+                                                           const lv_color_t * src_buf,
+                                                           lv_coord_t src_stride,
+                                                           lv_opa_t opa,
+                                                           const lv_opa_t * mask,
+                                                           lv_coord_t mask_stride);
 #endif
 
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
-static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx) /* LV_ATTRIBUTE_FAST_MEM */;
-static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
-                                      const lv_draw_img_dsc_t * draw_dsc,
-                                      const lv_area_t * coords,
-                                      const uint8_t * src_buf,
-                                      lv_img_cf_t cf) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+static void /* LV_ATTRIBUTE_FAST_MEM */ lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx);
+static void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
+                                                                  const lv_draw_img_dsc_t * draw_dsc,
+                                                                  const lv_area_t * coords,
+                                                                  const uint8_t * src_buf,
+                                                                  lv_img_cf_t cf);
 
 /**********************
  *  STATIC VARIABLES
@@ -505,7 +505,7 @@ void lv_draw_arm2d_ctx_deinit(lv_disp_drv_t * drv, lv_draw_ctx_t * draw_ctx)
 extern void test_flush(lv_color_t * color_p);
 
 #if __ARM_2D_HAS_HW_ACC__
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -552,11 +552,11 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
 }
 
 
-static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
-                                      const arm_2d_region_t * region,
-                                      lv_color_t color,
-                                      lv_opa_t opa,
-                                      const arm_2d_tile_t * mask_tile) LV_ATTRIBUTE_FAST_MEM
+static bool LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
+                                                            const arm_2d_region_t * region,
+                                                            lv_color_t color,
+                                                            lv_opa_t opa,
+                                                            const arm_2d_tile_t * mask_tile)
 {
     arm_fsm_rt_t result = (arm_fsm_rt_t)ARM_2D_ERR_NONE;
 
@@ -614,11 +614,11 @@ static bool lv_draw_arm2d_fill_colour(const arm_2d_tile_t * target_tile,
 
 }
 
-static bool lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
-                                    const arm_2d_region_t * region,
-                                    arm_2d_tile_t * source_tile,
-                                    lv_opa_t opa,
-                                    arm_2d_tile_t * mask_tile) LV_ATTRIBUTE_FAST_MEM
+static bool LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_tile_copy(const arm_2d_tile_t * target_tile,
+                                                          const arm_2d_region_t * region,
+                                                          arm_2d_tile_t * source_tile,
+                                                          lv_opa_t opa,
+                                                          arm_2d_tile_t * mask_tile)
 {
     arm_fsm_rt_t result = (arm_fsm_rt_t)ARM_2D_ERR_NONE;
 
@@ -681,7 +681,7 @@ static void lv_gpu_arm2d_wait_cb(lv_draw_ctx_t * draw_ctx)
 #else
 
 
-static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
     const lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -766,13 +766,13 @@ static void lv_draw_arm2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend
     if(!is_accelerated) lv_draw_sw_blend_basic(draw_ctx, dsc);
 }
 
-static bool arm_2d_fill_normal(lv_color_t * dest_buf,
-                               const lv_area_t * dest_area,
-                               lv_coord_t dest_stride,
-                               lv_color_t color,
-                               lv_opa_t opa,
-                               const lv_opa_t * mask,
-                               lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
+static bool LV_ATTRIBUTE_FAST_MEM arm_2d_fill_normal(lv_color_t * dest_buf,
+                                                     const lv_area_t * dest_area,
+                                                     lv_coord_t dest_stride,
+                                                     lv_color_t color,
+                                                     lv_opa_t opa,
+                                                     const lv_opa_t * mask,
+                                                     lv_coord_t mask_stride)
 {
     arm_2d_size_t target_size = {
         .iWidth = lv_area_get_width(dest_area),
@@ -823,14 +823,14 @@ static bool arm_2d_fill_normal(lv_color_t * dest_buf,
 }
 
 
-static bool arm_2d_copy_normal(lv_color_t * dest_buf,
-                               const lv_area_t * dest_area,
-                               lv_coord_t dest_stride,
-                               const lv_color_t * src_buf,
-                               lv_coord_t src_stride,
-                               lv_opa_t opa,
-                               const lv_opa_t * mask,
-                               lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
+static bool LV_ATTRIBUTE_FAST_MEM arm_2d_copy_normal(lv_color_t * dest_buf,
+                                                     const lv_area_t * dest_area,
+                                                     lv_coord_t dest_stride,
+                                                     const lv_color_t * src_buf,
+                                                     lv_coord_t src_stride,
+                                                     lv_opa_t opa,
+                                                     const lv_opa_t * mask,
+                                                     lv_coord_t mask_stride)
 
 {
     int32_t w = lv_area_get_width(dest_area);
@@ -895,11 +895,11 @@ static bool arm_2d_copy_normal(lv_color_t * dest_buf,
     return true;
 }
 
-static void lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
-                                      const lv_draw_img_dsc_t * draw_dsc,
-                                      const lv_area_t * coords,
-                                      const uint8_t * src_buf,
-                                      lv_img_cf_t cf) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM lv_draw_arm2d_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
+                                                            const lv_draw_img_dsc_t * draw_dsc,
+                                                            const lv_area_t * coords,
+                                                            const uint8_t * src_buf,
+                                                            lv_img_cf_t cf)
 {
     /*Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -25,8 +25,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                const lv_area_t * coords, const void * src) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_res_t /* LV_ATTRIBUTE_FAST_MEM */ decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                                            const lv_area_t * coords, const void * src);
 
 static void show_error(lv_draw_ctx_t * draw_ctx, const lv_area_t * coords, const char * msg);
 static void draw_cleanup(_lv_img_cache_entry_t * cache);
@@ -236,8 +236,8 @@ void lv_draw_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                const lv_area_t * coords, const void * src) LV_ATTRIBUTE_FAST_MEM
+static lv_res_t LV_ATTRIBUTE_FAST_MEM decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                                      const lv_area_t * coords, const void * src)
 {
     if(draw_dsc->opa <= LV_OPA_MIN) return LV_RES_OK;
 

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -25,8 +25,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-LV_ATTRIBUTE_FAST_MEM static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                      const lv_area_t * coords, const void * src);
+static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                const lv_area_t * coords, const void * src) /* LV_ATTRIBUTE_FAST_MEM */;
 
 static void show_error(lv_draw_ctx_t * draw_ctx, const lv_area_t * coords, const char * msg);
 static void draw_cleanup(_lv_img_cache_entry_t * cache);
@@ -236,8 +236,8 @@ void lv_draw_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc
  *   STATIC FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                      const lv_area_t * coords, const void * src)
+static lv_res_t decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                const lv_area_t * coords, const void * src) LV_ATTRIBUTE_FAST_MEM
 {
     if(draw_dsc->opa <= LV_OPA_MIN) return LV_RES_OK;
 

--- a/src/draw/lv_draw_img.c
+++ b/src/draw/lv_draw_img.c
@@ -25,7 +25,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_res_t /* LV_ATTRIBUTE_FAST_MEM */ decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+static lv_res_t /* LV_ATTRIBUTE_FAST_MEM */ decode_and_draw(lv_draw_ctx_t * draw_ctx,
+                                                            const lv_draw_img_dsc_t * draw_dsc,
                                                             const lv_area_t * coords, const void * src);
 
 static void show_error(lv_draw_ctx_t * draw_ctx, const lv_area_t * coords, const char * msg);
@@ -236,7 +237,8 @@ void lv_draw_img_decoded(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * dsc
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_res_t LV_ATTRIBUTE_FAST_MEM decode_and_draw(lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+static lv_res_t LV_ATTRIBUTE_FAST_MEM decode_and_draw(lv_draw_ctx_t * draw_ctx,
+                                                      const lv_draw_img_dsc_t * draw_dsc,
                                                       const lv_area_t * coords, const void * src)
 {
     if(draw_dsc->opa <= LV_OPA_MIN) return LV_RES_OK;

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -52,7 +52,7 @@ static uint8_t hex_char_to_num(char hex);
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc)
+void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     lv_memset_00(dsc, sizeof(lv_draw_label_dsc_t));
     dsc->opa = LV_OPA_COVER;
@@ -74,8 +74,8 @@ void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc)
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                                         const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint)
+void lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                   const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) LV_ATTRIBUTE_FAST_MEM
 {
     if(dsc->opa <= LV_OPA_MIN) return;
     if(dsc->font == NULL) {

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -52,7 +52,7 @@ static uint8_t hex_char_to_num(char hex);
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc)
 {
     lv_memset_00(dsc, sizeof(lv_draw_label_dsc_t));
     dsc->opa = LV_OPA_COVER;
@@ -74,8 +74,8 @@ void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
  */
-void lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                   const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                         const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
     if(dsc->font == NULL) {

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -68,7 +68,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc);
 
 /**
  * Write a text
@@ -79,8 +79,8 @@ void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM 
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
  */
-void lv_draw_label(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                   const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_label(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                               const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint);
 
 void lv_draw_letter(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
                     uint32_t letter);

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -68,7 +68,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc);
+void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Write a text
@@ -79,8 +79,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label_dsc_init(lv_draw_label_dsc_t * dsc);
  * @param hint pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_label(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                                         const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint);
+void lv_draw_label(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                   const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) /* LV_ATTRIBUTE_FAST_MEM */;
 
 void lv_draw_letter(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p,
                     uint32_t letter);

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -34,7 +34,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
+void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     lv_memset_00(dsc, sizeof(lv_draw_line_dsc_t));
     dsc->width = 1;
@@ -42,8 +42,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
     dsc->color = lv_color_black();
 }
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                        const lv_point_t * point1, const lv_point_t * point2)
+void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                  const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -34,7 +34,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
 {
     lv_memset_00(dsc, sizeof(lv_draw_line_dsc_t));
     dsc->width = 1;
@@ -42,8 +42,8 @@ void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
     dsc->color = lv_color_black();
 }
 
-void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                  const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                        const lv_point_t * point1, const lv_point_t * point2)
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -43,7 +43,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
 
 /**
  * Draw a line
@@ -52,8 +52,8 @@ void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */
  * @param clip the line will be drawn only in this area
  * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
-                  const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
+                                              const lv_point_t * point2);
 
 
 /**********************

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -43,7 +43,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
+void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Draw a line
@@ -53,7 +53,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
  * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
 void lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
-                  const lv_point_t * point2);
+                  const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
 
 
 /**********************

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -52,8 +52,8 @@ void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
  * @param clip the line will be drawn only in this area
  * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc, const lv_point_t * point1,
-                                              const lv_point_t * point2);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                              const lv_point_t * point1, const lv_point_t * point2);
 
 
 /**********************

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -26,31 +26,31 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                  lv_coord_t abs_y, lv_coord_t len,
-                                                                  lv_draw_mask_line_param_t * param);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                    lv_coord_t abs_y, lv_coord_t len,
-                                                                    lv_draw_mask_radius_param_t * param);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                   lv_coord_t abs_y, lv_coord_t len,
-                                                                   lv_draw_mask_angle_param_t * param);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                  lv_coord_t abs_y, lv_coord_t len,
-                                                                  lv_draw_mask_fade_param_t * param);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                 lv_coord_t abs_y, lv_coord_t len,
-                                                                 lv_draw_mask_map_param_t * param);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                     lv_coord_t abs_y, lv_coord_t len,
-                                                                     lv_draw_mask_polygon_param_t * param);
+static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                            lv_coord_t abs_y, lv_coord_t len,
+                                            lv_draw_mask_line_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                              lv_coord_t abs_y, lv_coord_t len,
+                                              lv_draw_mask_radius_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                             lv_coord_t abs_y, lv_coord_t len,
+                                             lv_draw_mask_angle_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                            lv_coord_t abs_y, lv_coord_t len,
+                                            lv_draw_mask_fade_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                           lv_coord_t abs_y, lv_coord_t len,
+                                           lv_draw_mask_map_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                               lv_coord_t abs_y, lv_coord_t len,
+                                               lv_draw_mask_polygon_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                               lv_coord_t len,
-                                                               lv_draw_mask_line_param_t * p);
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                lv_coord_t len,
-                                                                lv_draw_mask_line_param_t * p);
+static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                         lv_coord_t len,
+                                         lv_draw_mask_line_param_t * p) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                          lv_coord_t len,
+                                          lv_draw_mask_line_param_t * p) /* LV_ATTRIBUTE_FAST_MEM */;
 
 static void circ_init(lv_point_t * c, lv_coord_t * tmp, lv_coord_t radius);
 static bool circ_cont(lv_point_t * c);
@@ -58,7 +58,7 @@ static void circ_next(lv_point_t * c, lv_coord_t * tmp);
 static void circ_calc_aa4(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_t radius);
 static lv_opa_t * get_next_line(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_t y, lv_coord_t * len,
                                 lv_coord_t * x_start);
-LV_ATTRIBUTE_FAST_MEM static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new);
+static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**********************
  *  STATIC VARIABLES
@@ -108,8 +108,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id)
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                            lv_coord_t len)
+lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                      lv_coord_t len) LV_ATTRIBUTE_FAST_MEM
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;
@@ -142,8 +142,8 @@ LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf,
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                lv_coord_t len, const int16_t * ids, int16_t ids_count)
+lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                          lv_coord_t len, const int16_t * ids, int16_t ids_count) LV_ATTRIBUTE_FAST_MEM
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;
@@ -243,7 +243,7 @@ void _lv_draw_mask_cleanup(void)
  * Count the currently added masks
  * @return number of active masks
  */
-LV_ATTRIBUTE_FAST_MEM uint8_t lv_draw_mask_get_cnt(void)
+uint8_t lv_draw_mask_get_cnt(void) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t cnt = 0;
     uint8_t i;
@@ -593,9 +593,9 @@ void lv_draw_mask_polygon_init(lv_draw_mask_polygon_param_t * param, const lv_po
  *   STATIC FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                  lv_coord_t abs_y, lv_coord_t len,
-                                                                  lv_draw_mask_line_param_t * p)
+static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                            lv_coord_t abs_y, lv_coord_t len,
+                                            lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     /*Make to points relative to the vertex*/
     abs_y -= p->origo.y;
@@ -653,9 +653,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mas
     return res;
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                               lv_coord_t len,
-                                                               lv_draw_mask_line_param_t * p)
+static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                         lv_coord_t len,
+                                         lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
 
     int32_t y_at_x;
@@ -769,9 +769,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_b
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                lv_coord_t len,
-                                                                lv_draw_mask_line_param_t * p)
+static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                          lv_coord_t len,
+                                          lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t k;
     int32_t x_at_y;
@@ -911,9 +911,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                   lv_coord_t abs_y, lv_coord_t len,
-                                                                   lv_draw_mask_angle_param_t * p)
+static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                             lv_coord_t abs_y, lv_coord_t len,
+                                             lv_draw_mask_angle_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t rel_y = abs_y - p->cfg.vertex_p.y;
     int32_t rel_x = abs_x - p->cfg.vertex_p.x;
@@ -1050,9 +1050,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * ma
 
 
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                    lv_coord_t abs_y, lv_coord_t len,
-                                                                    lv_draw_mask_radius_param_t * p)
+static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                              lv_coord_t abs_y, lv_coord_t len,
+                                              lv_draw_mask_radius_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     bool outer = p->cfg.outer;
     int32_t radius = p->cfg.radius;
@@ -1167,9 +1167,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * m
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                  lv_coord_t abs_y, lv_coord_t len,
-                                                                  lv_draw_mask_fade_param_t * p)
+static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                            lv_coord_t abs_y, lv_coord_t len,
+                                            lv_draw_mask_fade_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     if(abs_y < p->cfg.coords.y1) return LV_DRAW_MASK_RES_FULL_COVER;
     if(abs_y > p->cfg.coords.y2) return LV_DRAW_MASK_RES_FULL_COVER;
@@ -1213,9 +1213,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mas
     }
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                 lv_coord_t abs_y, lv_coord_t len,
-                                                                 lv_draw_mask_map_param_t * p)
+static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                           lv_coord_t abs_y, lv_coord_t len,
+                                           lv_draw_mask_map_param_t * p) LV_ATTRIBUTE_FAST_MEM
 {
     /*Handle out of the mask cases*/
     if(abs_y < p->cfg.coords.y1) return LV_DRAW_MASK_RES_FULL_COVER;
@@ -1247,9 +1247,9 @@ LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-LV_ATTRIBUTE_FAST_MEM static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                                                     lv_coord_t abs_y, lv_coord_t len,
-                                                                     lv_draw_mask_polygon_param_t * param)
+static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                               lv_coord_t abs_y, lv_coord_t len,
+                                               lv_draw_mask_polygon_param_t * param) LV_ATTRIBUTE_FAST_MEM
 {
     uint16_t i;
     struct {
@@ -1518,7 +1518,7 @@ static lv_opa_t * get_next_line(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_
 }
 
 
-LV_ATTRIBUTE_FAST_MEM static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new)
+static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new) LV_ATTRIBUTE_FAST_MEM
 {
     if(mask_new >= LV_OPA_MAX) return mask_act;
     if(mask_new <= LV_OPA_MIN) return 0;

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -45,11 +45,11 @@ static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_polygon(lv_op
                                                                            lv_coord_t abs_y, lv_coord_t len,
                                                                            lv_draw_mask_polygon_param_t * param);
 
-static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                     lv_coord_t len,
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                     lv_coord_t abs_y, lv_coord_t len,
                                                                      lv_draw_mask_line_param_t * p);
-static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                      lv_coord_t len,
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                      lv_coord_t abs_y, lv_coord_t len,
                                                                       lv_draw_mask_line_param_t * p);
 
 static void circ_init(lv_point_t * c, lv_coord_t * tmp, lv_coord_t radius);
@@ -108,8 +108,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id)
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                            lv_coord_t len)
+lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                            lv_coord_t abs_y, lv_coord_t len)
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;
@@ -142,8 +142,9 @@ lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply(lv_opa_t * mask_buf,
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                lv_coord_t len, const int16_t * ids, int16_t ids_count)
+lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                lv_coord_t abs_y, lv_coord_t len,
+                                                                const int16_t * ids, int16_t ids_count)
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -26,31 +26,31 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                            lv_coord_t abs_y, lv_coord_t len,
-                                            lv_draw_mask_line_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                              lv_coord_t abs_y, lv_coord_t len,
-                                              lv_draw_mask_radius_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                             lv_coord_t abs_y, lv_coord_t len,
-                                             lv_draw_mask_angle_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                            lv_coord_t abs_y, lv_coord_t len,
-                                            lv_draw_mask_fade_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                           lv_coord_t abs_y, lv_coord_t len,
-                                           lv_draw_mask_map_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                               lv_coord_t abs_y, lv_coord_t len,
-                                               lv_draw_mask_polygon_param_t * param) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                        lv_coord_t abs_y, lv_coord_t len,
+                                                                        lv_draw_mask_line_param_t * param);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                          lv_coord_t abs_y, lv_coord_t len,
+                                                                          lv_draw_mask_radius_param_t * param);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                         lv_coord_t abs_y, lv_coord_t len,
+                                                                         lv_draw_mask_angle_param_t * param);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                        lv_coord_t abs_y, lv_coord_t len,
+                                                                        lv_draw_mask_fade_param_t * param);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                       lv_coord_t abs_y, lv_coord_t len,
+                                                                       lv_draw_mask_map_param_t * param);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                           lv_coord_t abs_y, lv_coord_t len,
+                                                                           lv_draw_mask_polygon_param_t * param);
 
-static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                         lv_coord_t len,
-                                         lv_draw_mask_line_param_t * p) /* LV_ATTRIBUTE_FAST_MEM */;
-static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                          lv_coord_t len,
-                                          lv_draw_mask_line_param_t * p) /* LV_ATTRIBUTE_FAST_MEM */;
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                     lv_coord_t len,
+                                                                     lv_draw_mask_line_param_t * p);
+static lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                      lv_coord_t len,
+                                                                      lv_draw_mask_line_param_t * p);
 
 static void circ_init(lv_point_t * c, lv_coord_t * tmp, lv_coord_t radius);
 static bool circ_cont(lv_point_t * c);
@@ -58,7 +58,7 @@ static void circ_next(lv_point_t * c, lv_coord_t * tmp);
 static void circ_calc_aa4(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_t radius);
 static lv_opa_t * get_next_line(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_t y, lv_coord_t * len,
                                 lv_coord_t * x_start);
-static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new) /* LV_ATTRIBUTE_FAST_MEM */;
+static inline lv_opa_t /* LV_ATTRIBUTE_FAST_MEM */ mask_mix(lv_opa_t mask_act, lv_opa_t mask_new);
 
 /**********************
  *  STATIC VARIABLES
@@ -108,8 +108,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id)
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                      lv_coord_t len) LV_ATTRIBUTE_FAST_MEM
+lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                            lv_coord_t len)
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;
@@ -142,8 +142,8 @@ lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                          lv_coord_t len, const int16_t * ids, int16_t ids_count) LV_ATTRIBUTE_FAST_MEM
+lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                lv_coord_t len, const int16_t * ids, int16_t ids_count)
 {
     bool changed = false;
     _lv_draw_mask_common_dsc_t * dsc;
@@ -243,7 +243,7 @@ void _lv_draw_mask_cleanup(void)
  * Count the currently added masks
  * @return number of active masks
  */
-uint8_t lv_draw_mask_get_cnt(void) LV_ATTRIBUTE_FAST_MEM
+uint8_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_get_cnt(void)
 {
     uint8_t cnt = 0;
     uint8_t i;
@@ -593,9 +593,9 @@ void lv_draw_mask_polygon_init(lv_draw_mask_polygon_param_t * param, const lv_po
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                            lv_coord_t abs_y, lv_coord_t len,
-                                            lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                  lv_coord_t abs_y, lv_coord_t len,
+                                                                  lv_draw_mask_line_param_t * p)
 {
     /*Make to points relative to the vertex*/
     abs_y -= p->origo.y;
@@ -653,9 +653,9 @@ static lv_draw_mask_res_t lv_draw_mask_line(lv_opa_t * mask_buf, lv_coord_t abs_
     return res;
 }
 
-static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                         lv_coord_t len,
-                                         lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                               lv_coord_t len,
+                                                               lv_draw_mask_line_param_t * p)
 {
 
     int32_t y_at_x;
@@ -769,9 +769,9 @@ static lv_draw_mask_res_t line_mask_flat(lv_opa_t * mask_buf, lv_coord_t abs_x, 
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                          lv_coord_t len,
-                                          lv_draw_mask_line_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                lv_coord_t len,
+                                                                lv_draw_mask_line_param_t * p)
 {
     int32_t k;
     int32_t x_at_y;
@@ -911,9 +911,9 @@ static lv_draw_mask_res_t line_mask_steep(lv_opa_t * mask_buf, lv_coord_t abs_x,
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                             lv_coord_t abs_y, lv_coord_t len,
-                                             lv_draw_mask_angle_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                   lv_coord_t abs_y, lv_coord_t len,
+                                                                   lv_draw_mask_angle_param_t * p)
 {
     int32_t rel_y = abs_y - p->cfg.vertex_p.y;
     int32_t rel_x = abs_x - p->cfg.vertex_p.x;
@@ -1050,9 +1050,9 @@ static lv_draw_mask_res_t lv_draw_mask_angle(lv_opa_t * mask_buf, lv_coord_t abs
 
 
 
-static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                              lv_coord_t abs_y, lv_coord_t len,
-                                              lv_draw_mask_radius_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                    lv_coord_t abs_y, lv_coord_t len,
+                                                                    lv_draw_mask_radius_param_t * p)
 {
     bool outer = p->cfg.outer;
     int32_t radius = p->cfg.radius;
@@ -1167,9 +1167,9 @@ static lv_draw_mask_res_t lv_draw_mask_radius(lv_opa_t * mask_buf, lv_coord_t ab
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                            lv_coord_t abs_y, lv_coord_t len,
-                                            lv_draw_mask_fade_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                  lv_coord_t abs_y, lv_coord_t len,
+                                                                  lv_draw_mask_fade_param_t * p)
 {
     if(abs_y < p->cfg.coords.y1) return LV_DRAW_MASK_RES_FULL_COVER;
     if(abs_y > p->cfg.coords.y2) return LV_DRAW_MASK_RES_FULL_COVER;
@@ -1213,9 +1213,9 @@ static lv_draw_mask_res_t lv_draw_mask_fade(lv_opa_t * mask_buf, lv_coord_t abs_
     }
 }
 
-static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                           lv_coord_t abs_y, lv_coord_t len,
-                                           lv_draw_mask_map_param_t * p) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                 lv_coord_t abs_y, lv_coord_t len,
+                                                                 lv_draw_mask_map_param_t * p)
 {
     /*Handle out of the mask cases*/
     if(abs_y < p->cfg.coords.y1) return LV_DRAW_MASK_RES_FULL_COVER;
@@ -1247,9 +1247,9 @@ static lv_draw_mask_res_t lv_draw_mask_map(lv_opa_t * mask_buf, lv_coord_t abs_x
     return LV_DRAW_MASK_RES_CHANGED;
 }
 
-static lv_draw_mask_res_t lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
-                                               lv_coord_t abs_y, lv_coord_t len,
-                                               lv_draw_mask_polygon_param_t * param) LV_ATTRIBUTE_FAST_MEM
+static lv_draw_mask_res_t LV_ATTRIBUTE_FAST_MEM lv_draw_mask_polygon(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                     lv_coord_t abs_y, lv_coord_t len,
+                                                                     lv_draw_mask_polygon_param_t * param)
 {
     uint16_t i;
     struct {
@@ -1518,7 +1518,7 @@ static lv_opa_t * get_next_line(_lv_draw_mask_radius_circle_dsc_t * c, lv_coord_
 }
 
 
-static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_t mask_new) LV_ATTRIBUTE_FAST_MEM
+static inline lv_opa_t LV_ATTRIBUTE_FAST_MEM mask_mix(lv_opa_t mask_act, lv_opa_t mask_new)
 {
     if(mask_new >= LV_OPA_MAX) return mask_act;
     if(mask_new <= LV_OPA_MIN) return 0;

--- a/src/draw/lv_draw_mask.h
+++ b/src/draw/lv_draw_mask.h
@@ -241,8 +241,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id);
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                      lv_coord_t len) /* LV_ATTRIBUTE_FAST_MEM */;
+lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                  lv_coord_t len);
 
 /**
  * Apply the specified buffers on a line. Used internally by the library's drawing routines.
@@ -257,8 +257,8 @@ lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                          lv_coord_t len, const int16_t * ids, int16_t ids_count) /* LV_ATTRIBUTE_FAST_MEM */;
+lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                                                      lv_coord_t len, const int16_t * ids, int16_t ids_count);
 
 //! @endcond
 
@@ -299,7 +299,7 @@ void _lv_draw_mask_cleanup(void);
  * Count the currently added masks
  * @return number of active masks
  */
-uint8_t lv_draw_mask_get_cnt(void) /* LV_ATTRIBUTE_FAST_MEM */;
+uint8_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_get_cnt(void);
 
 
 /**

--- a/src/draw/lv_draw_mask.h
+++ b/src/draw/lv_draw_mask.h
@@ -241,8 +241,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id);
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                  lv_coord_t len);
+lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                  lv_coord_t abs_y, lv_coord_t len);
 
 /**
  * Apply the specified buffers on a line. Used internally by the library's drawing routines.
@@ -257,8 +257,9 @@ lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply(lv_opa_t * mas
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                      lv_coord_t len, const int16_t * ids, int16_t ids_count);
+lv_draw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x,
+                                                                      lv_coord_t abs_y, lv_coord_t len,
+                                                                      const int16_t * ids, int16_t ids_count);
 
 //! @endcond
 

--- a/src/draw/lv_draw_mask.h
+++ b/src/draw/lv_draw_mask.h
@@ -241,8 +241,8 @@ int16_t lv_draw_mask_add(void * param, void * custom_id);
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                            lv_coord_t len);
+lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                      lv_coord_t len) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Apply the specified buffers on a line. Used internally by the library's drawing routines.
@@ -257,8 +257,8 @@ LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply(lv_opa_t * mask_buf,
  * - `LV_DRAW_MASK_RES_FULL_COVER`: the whole line is fully visible. `mask_buf` is unchanged
  * - `LV_DRAW_MASK_RES_CHANGED`: `mask_buf` has changed, it shows the desired opacity of each pixel in the given line
  */
-LV_ATTRIBUTE_FAST_MEM lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
-                                                                lv_coord_t len, const int16_t * ids, int16_t ids_count);
+lv_draw_mask_res_t lv_draw_mask_apply_ids(lv_opa_t * mask_buf, lv_coord_t abs_x, lv_coord_t abs_y,
+                                          lv_coord_t len, const int16_t * ids, int16_t ids_count) /* LV_ATTRIBUTE_FAST_MEM */;
 
 //! @endcond
 
@@ -299,7 +299,7 @@ void _lv_draw_mask_cleanup(void);
  * Count the currently added masks
  * @return number of active masks
  */
-LV_ATTRIBUTE_FAST_MEM uint8_t lv_draw_mask_get_cnt(void);
+uint8_t lv_draw_mask_get_cnt(void) /* LV_ATTRIBUTE_FAST_MEM */;
 
 
 /**

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -34,7 +34,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc)
 {
     lv_memset_00(dsc, sizeof(lv_draw_rect_dsc_t));
     dsc->bg_color = lv_color_white();

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -34,7 +34,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc)
+void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     lv_memset_00(dsc, sizeof(lv_draw_rect_dsc_t));
     dsc->bg_color = lv_color_white();

--- a/src/draw/lv_draw_rect.h
+++ b/src/draw/lv_draw_rect.h
@@ -74,7 +74,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc);
 
 
 /**

--- a/src/draw/lv_draw_rect.h
+++ b/src/draw/lv_draw_rect.h
@@ -74,7 +74,7 @@ struct _lv_draw_ctx_t;
  * GLOBAL PROTOTYPES
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc);
+void lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
 
 
 /**

--- a/src/draw/renesas/lv_gpu_d2_draw_label.c
+++ b/src/draw/renesas/lv_gpu_d2_draw_label.c
@@ -40,8 +40,8 @@ extern const uint8_t _lv_bpp8_opa_table[256];
  *   STATIC FUNCTIONS
  **********************/
 
-static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                                     const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p)
 {
 
     const uint8_t * bpp_opa_table_p;

--- a/src/draw/renesas/lv_gpu_d2_draw_label.c
+++ b/src/draw/renesas/lv_gpu_d2_draw_label.c
@@ -40,8 +40,8 @@ extern const uint8_t _lv_bpp8_opa_table[256];
  *   STATIC FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                                                     const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p)
+static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) LV_ATTRIBUTE_FAST_MEM
 {
 
     const uint8_t * bpp_opa_table_p;

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -61,11 +61,11 @@ void lv_draw_sw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, con
 void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc, const lv_point_t * pos_p,
                        uint32_t letter);
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                  const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf);
+void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                            const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf) /* LV_ATTRIBUTE_FAST_MEM */;
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                           const lv_point_t * point1, const lv_point_t * point2);
+void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                     const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
 
 void lv_draw_sw_polygon(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc,
                         const lv_point_t * points, uint16_t point_cnt);

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -61,11 +61,11 @@ void lv_draw_sw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, con
 void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc, const lv_point_t * pos_p,
                        uint32_t letter);
 
-void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                            const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                                        const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf);
 
-void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                     const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                 const lv_point_t * point1, const lv_point_t * point2);
 
 void lv_draw_sw_polygon(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * draw_dsc,
                         const lv_point_t * points, uint16_t point_cnt);

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -61,8 +61,10 @@ void lv_draw_sw_bg(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, con
 void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc, const lv_point_t * pos_p,
                        uint32_t letter);
 
-void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                        const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
+                                                        const lv_draw_img_dsc_t * draw_dsc,
+                                                        const lv_area_t * coords, const uint8_t * src_buf,
+                                                        lv_img_cf_t cf);
 
 void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
                                                  const lv_point_t * point1, const lv_point_t * point2);

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -26,13 +26,13 @@
 static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_coord_t dest_stride,
                         lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stide);
 
-LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
-                                              lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                        lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
 
 
 #if LV_COLOR_SCREEN_TRANSP
-LV_ATTRIBUTE_FAST_MEM static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
-                                            lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                      lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
 #if LV_DRAW_COMPLEX
@@ -43,13 +43,13 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_
 static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
                        const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
 
-LV_ATTRIBUTE_FAST_MEM static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                             const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
 
 #if LV_COLOR_SCREEN_TRANSP
-LV_ATTRIBUTE_FAST_MEM static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                           const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                                           const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode);
+static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                     const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                     const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode) /* LV_ATTRIBUTE_FAST_MEM */;
 
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
@@ -101,7 +101,7 @@ void lv_draw_sw_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * d
     ((lv_draw_sw_ctx_t *)draw_ctx)->blend(draw_ctx, dsc);
 }
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+void lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
 {
     lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -237,8 +237,8 @@ static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_
     }
 }
 
-LV_ATTRIBUTE_FAST_MEM static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
-                                              lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                        lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t w = lv_area_get_width(dest_area);
     int32_t h = lv_area_get_height(dest_area);
@@ -442,8 +442,8 @@ static inline void set_px_argb_blend(uint8_t * buf, lv_color_t color, lv_opa_t o
 
 }
 
-LV_ATTRIBUTE_FAST_MEM static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
-                                            lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                      lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;
     int32_t w = lv_area_get_width(dest_area);
@@ -633,8 +633,8 @@ static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_co
     }
 }
 
-LV_ATTRIBUTE_FAST_MEM static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                             const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
 
 {
     int32_t w = lv_area_get_width(dest_area);
@@ -729,9 +729,9 @@ LV_ATTRIBUTE_FAST_MEM static void map_normal(lv_color_t * dest_buf, const lv_are
 
 
 #if LV_COLOR_SCREEN_TRANSP
-LV_ATTRIBUTE_FAST_MEM static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                           const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                                           const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode)
+static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                     const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                     const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode) LV_ATTRIBUTE_FAST_MEM
 
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -26,13 +26,13 @@
 static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_coord_t dest_stride,
                         lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stide);
 
-static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                        lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                                    lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
 
 
 #if LV_COLOR_SCREEN_TRANSP
-static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                      lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                                  lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
 #if LV_DRAW_COMPLEX
@@ -43,13 +43,13 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_
 static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
                        const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
 
-static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                                   const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
 
 #if LV_COLOR_SCREEN_TRANSP
-static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                     const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                     const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                                 const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                                                 const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode);
 
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
@@ -101,7 +101,7 @@ void lv_draw_sw_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * d
     ((lv_draw_sw_ctx_t *)draw_ctx)->blend(draw_ctx, dsc);
 }
 
-void lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
 {
     lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -237,8 +237,8 @@ static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_
     }
 }
 
-static void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                        lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
+static LV_ATTRIBUTE_FAST_MEM void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                              lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
 {
     int32_t w = lv_area_get_width(dest_area);
     int32_t h = lv_area_get_height(dest_area);
@@ -442,8 +442,8 @@ static inline void set_px_argb_blend(uint8_t * buf, lv_color_t color, lv_opa_t o
 
 }
 
-static void fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                      lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                            lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;
     int32_t w = lv_area_get_width(dest_area);
@@ -633,8 +633,8 @@ static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_co
     }
 }
 
-static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                             const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
 
 {
     int32_t w = lv_area_get_width(dest_area);
@@ -729,9 +729,9 @@ static void map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_co
 
 
 #if LV_COLOR_SCREEN_TRANSP
-static void map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                     const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                     const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
+                                           const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                                           const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode)
 
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;

--- a/src/draw/sw/lv_draw_sw_blend.c
+++ b/src/draw/sw/lv_draw_sw_blend.c
@@ -26,13 +26,15 @@
 static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_coord_t dest_stride,
                         lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stide);
 
-static void /* LV_ATTRIBUTE_FAST_MEM */ fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                                    lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void /* LV_ATTRIBUTE_FAST_MEM */ fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                                    lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa,
+                                                    const lv_opa_t * mask, lv_coord_t mask_stride);
 
 
 #if LV_COLOR_SCREEN_TRANSP
-static void /* LV_ATTRIBUTE_FAST_MEM */ fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                                  lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void /* LV_ATTRIBUTE_FAST_MEM */ fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                                  lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa,
+                                                  const lv_opa_t * mask, lv_coord_t mask_stride);
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
 #if LV_DRAW_COMPLEX
@@ -41,15 +43,19 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_
 #endif  /*LV_DRAW_COMPLEX*/
 
 static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                       const lv_opa_t * mask, lv_coord_t mask_stride);
 
-static void /* LV_ATTRIBUTE_FAST_MEM */ map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                                   const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride);
+static void /* LV_ATTRIBUTE_FAST_MEM */ map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                                   lv_coord_t dest_stride, const lv_color_t * src_buf,
+                                                   lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask,
+                                                   lv_coord_t mask_stride);
 
 #if LV_COLOR_SCREEN_TRANSP
-static void /* LV_ATTRIBUTE_FAST_MEM */ map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                                 const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                                                 const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode);
+static void /* LV_ATTRIBUTE_FAST_MEM */ map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                                 lv_coord_t dest_stride, const lv_color_t * src_buf,
+                                                 lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask,
+                                                 lv_coord_t mask_stride, lv_blend_mode_t blend_mode);
 
 #endif /*LV_COLOR_SCREEN_TRANSP*/
 
@@ -101,7 +107,8 @@ void lv_draw_sw_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * d
     ((lv_draw_sw_ctx_t *)draw_ctx)->blend(draw_ctx, dsc);
 }
 
-void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc)
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_basic(lv_draw_ctx_t * draw_ctx,
+                                                  const lv_draw_sw_blend_dsc_t * dsc)
 {
     lv_opa_t * mask;
     if(dsc->mask_buf == NULL) mask = NULL;
@@ -237,8 +244,9 @@ static void fill_set_px(lv_color_t * dest_buf, const lv_area_t * blend_area, lv_
     }
 }
 
-static LV_ATTRIBUTE_FAST_MEM void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                              lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static LV_ATTRIBUTE_FAST_MEM void fill_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                              lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa,
+                                              const lv_opa_t * mask, lv_coord_t mask_stride)
 {
     int32_t w = lv_area_get_width(dest_area);
     int32_t h = lv_area_get_height(dest_area);
@@ -442,8 +450,9 @@ static inline void set_px_argb_blend(uint8_t * buf, lv_color_t color, lv_opa_t o
 
 }
 
-static void LV_ATTRIBUTE_FAST_MEM fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                            lv_color_t color, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static void LV_ATTRIBUTE_FAST_MEM fill_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                            lv_coord_t dest_stride, lv_color_t color, lv_opa_t opa,
+                                            const lv_opa_t * mask, lv_coord_t mask_stride)
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;
     int32_t w = lv_area_get_width(dest_area);
@@ -599,7 +608,8 @@ static void fill_blended(lv_color_t * dest_buf, const lv_area_t * dest_area,
 #endif
 
 static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+                       const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
+                       const lv_opa_t * mask, lv_coord_t mask_stride)
 
 {
     lv_disp_t * disp = _lv_refr_get_disp_refreshing();
@@ -633,8 +643,10 @@ static void map_set_px(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_co
     }
 }
 
-static void LV_ATTRIBUTE_FAST_MEM map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                             const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask, lv_coord_t mask_stride)
+static void LV_ATTRIBUTE_FAST_MEM map_normal(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                             lv_coord_t dest_stride, const lv_color_t * src_buf,
+                                             lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask,
+                                             lv_coord_t mask_stride)
 
 {
     int32_t w = lv_area_get_width(dest_area);
@@ -729,9 +741,10 @@ static void LV_ATTRIBUTE_FAST_MEM map_normal(lv_color_t * dest_buf, const lv_are
 
 
 #if LV_COLOR_SCREEN_TRANSP
-static void LV_ATTRIBUTE_FAST_MEM map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area, lv_coord_t dest_stride,
-                                           const lv_color_t * src_buf, lv_coord_t src_stride, lv_opa_t opa,
-                                           const lv_opa_t * mask, lv_coord_t mask_stride, lv_blend_mode_t blend_mode)
+static void LV_ATTRIBUTE_FAST_MEM map_argb(lv_color_t * dest_buf, const lv_area_t * dest_area,
+                                           lv_coord_t dest_stride, const lv_color_t * src_buf,
+                                           lv_coord_t src_stride, lv_opa_t opa, const lv_opa_t * mask,
+                                           lv_coord_t mask_stride, lv_blend_mode_t blend_mode)
 
 {
     uint8_t * dest_buf8 = (uint8_t *) dest_buf;

--- a/src/draw/sw/lv_draw_sw_blend.h
+++ b/src/draw/sw/lv_draw_sw_blend.h
@@ -56,7 +56,7 @@ void lv_draw_sw_blend(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_d
  * @param draw_ctx      pointer to a draw context
  * @param dsc           pointer to an initialized blend descriptor
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+void lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw_blend.h
+++ b/src/draw/sw/lv_draw_sw_blend.h
@@ -56,7 +56,8 @@ void lv_draw_sw_blend(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_d
  * @param draw_ctx      pointer to a draw context
  * @param dsc           pointer to an initialized blend descriptor
  */
-void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx,
+                                                        const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw_blend.h
+++ b/src/draw/sw/lv_draw_sw_blend.h
@@ -56,7 +56,7 @@ void lv_draw_sw_blend(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_d
  * @param draw_ctx      pointer to a draw context
  * @param dsc           pointer to an initialized blend descriptor
  */
-void lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_basic(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw_dither.c
+++ b/src/draw/sw/lv_draw_sw_dither.c
@@ -17,7 +17,7 @@
 
 #if _DITHER_GRADIENT
 
-LV_ATTRIBUTE_FAST_MEM void lv_dither_none(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
+void lv_dither_none(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
 {
     LV_UNUSED(x);
     LV_UNUSED(y);
@@ -40,7 +40,7 @@ static const uint8_t dither_ordered_threshold_matrix[8 * 8] = {
 }; /* Shift by 6 to normalize */
 
 
-LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
+void lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
 {
     LV_UNUSED(x);
     /* For vertical dithering, the error is spread on the next column (and not next line).
@@ -63,7 +63,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x,
         grad->map[j] = lv_color_hex(t.full);
     }
 }
-LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
+
+void lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
 {
     /* For vertical dithering, the error is spread on the next column (and not next line).
        Since the renderer is scanline based, it's not obvious what could be used to perform the rendering efficiently.
@@ -97,9 +98,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x,
     }
 }
 
-
 #if LV_DITHER_ERROR_DIFFUSION == 1
-LV_ATTRIBUTE_FAST_MEM void lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w)
+void lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
 {
     LV_UNUSED(xs);
     LV_UNUSED(y);
@@ -153,7 +153,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t x
     grad->map[grad->size - 1] = lv_color_hex(grad->hmap[grad->size - 1].full);
 }
 
-LV_ATTRIBUTE_FAST_MEM void lv_dither_err_diff_ver(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w)
+void lv_dither_err_diff_ver(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
 {
     /* Try to implement error diffusion on a vertical gradient and an horizontal map using those tricks:
         Since the given hi-resolution gradient (in src) is vertical, the Floyd Steinberg algorithm pass need to be rotated,

--- a/src/draw/sw/lv_draw_sw_dither.c
+++ b/src/draw/sw/lv_draw_sw_dither.c
@@ -17,7 +17,7 @@
 
 #if _DITHER_GRADIENT
 
-void lv_dither_none(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_dither_none(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
 {
     LV_UNUSED(x);
     LV_UNUSED(y);
@@ -40,7 +40,7 @@ static const uint8_t dither_ordered_threshold_matrix[8 * 8] = {
 }; /* Shift by 6 to normalize */
 
 
-void lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
 {
     LV_UNUSED(x);
     /* For vertical dithering, the error is spread on the next column (and not next line).
@@ -64,7 +64,7 @@ void lv_dither_ordered_hor(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coor
     }
 }
 
-void lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w)
 {
     /* For vertical dithering, the error is spread on the next column (and not next line).
        Since the renderer is scanline based, it's not obvious what could be used to perform the rendering efficiently.
@@ -99,7 +99,7 @@ void lv_dither_ordered_ver(lv_grad_t * grad, lv_coord_t x, lv_coord_t y, lv_coor
 }
 
 #if LV_DITHER_ERROR_DIFFUSION == 1
-void lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w)
 {
     LV_UNUSED(xs);
     LV_UNUSED(y);
@@ -153,7 +153,7 @@ void lv_dither_err_diff_hor(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_co
     grad->map[grad->size - 1] = lv_color_hex(grad->hmap[grad->size - 1].full);
 }
 
-void lv_dither_err_diff_ver(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_dither_err_diff_ver(lv_grad_t * grad, lv_coord_t xs, lv_coord_t y, lv_coord_t w)
 {
     /* Try to implement error diffusion on a vertical gradient and an horizontal map using those tricks:
         Since the given hi-resolution gradient (in src) is vertical, the Floyd Steinberg algorithm pass need to be rotated,

--- a/src/draw/sw/lv_draw_sw_dither.h
+++ b/src/draw/sw/lv_draw_sw_dither.h
@@ -45,7 +45,8 @@ typedef void (*lv_dither_func_t)(struct _lv_gradient_cache_t * grad, lv_coord_t 
  **********************/
 #if LV_DRAW_COMPLEX
 #if _DITHER_GRADIENT
-void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y,
+                                                lv_coord_t w);
 
 void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_ordered_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
                                                        const lv_coord_t y, const lv_coord_t w);

--- a/src/draw/sw/lv_draw_sw_dither.h
+++ b/src/draw/sw/lv_draw_sw_dither.h
@@ -45,18 +45,18 @@ typedef void (*lv_dither_func_t)(struct _lv_gradient_cache_t * grad, lv_coord_t 
  **********************/
 #if LV_DRAW_COMPLEX
 #if _DITHER_GRADIENT
-void lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w);
 
-void lv_dither_ordered_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                           const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
-void lv_dither_ordered_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                           const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_ordered_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                                                       const lv_coord_t y, const lv_coord_t w);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_ordered_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                                                       const lv_coord_t y, const lv_coord_t w);
 
 #if LV_DITHER_ERROR_DIFFUSION == 1
-void lv_dither_err_diff_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                            const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
-void lv_dither_err_diff_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                            const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_err_diff_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                                                        const lv_coord_t y, const lv_coord_t w);
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_dither_err_diff_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                                                        const lv_coord_t y, const lv_coord_t w);
 #endif /* LV_DITHER_ERROR_DIFFUSION */
 
 #endif /* _DITHER_GRADIENT */

--- a/src/draw/sw/lv_draw_sw_dither.h
+++ b/src/draw/sw/lv_draw_sw_dither.h
@@ -45,18 +45,18 @@ typedef void (*lv_dither_func_t)(struct _lv_gradient_cache_t * grad, lv_coord_t 
  **********************/
 #if LV_DRAW_COMPLEX
 #if _DITHER_GRADIENT
-LV_ATTRIBUTE_FAST_MEM void lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w);
+void lv_dither_none(struct _lv_gradient_cache_t * grad, lv_coord_t x, lv_coord_t y, lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
 
-LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                                                 const lv_coord_t y, const lv_coord_t w);
-LV_ATTRIBUTE_FAST_MEM void lv_dither_ordered_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                                                 const lv_coord_t y, const lv_coord_t w);
+void lv_dither_ordered_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                           const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
+void lv_dither_ordered_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                           const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
 
 #if LV_DITHER_ERROR_DIFFUSION == 1
-LV_ATTRIBUTE_FAST_MEM void lv_dither_err_diff_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                                                  const lv_coord_t y, const lv_coord_t w);
-LV_ATTRIBUTE_FAST_MEM void lv_dither_err_diff_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
-                                                  const lv_coord_t y, const lv_coord_t w);
+void lv_dither_err_diff_hor(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                            const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
+void lv_dither_err_diff_ver(struct _lv_gradient_cache_t * grad, const lv_coord_t xs,
+                            const lv_coord_t y, const lv_coord_t w) /* LV_ATTRIBUTE_FAST_MEM */;
 #endif /* LV_DITHER_ERROR_DIFFUSION */
 
 #endif /* _DITHER_GRADIENT */

--- a/src/draw/sw/lv_draw_sw_gradient.c
+++ b/src/draw/sw/lv_draw_sw_gradient.c
@@ -293,8 +293,8 @@ lv_grad_t * lv_gradient_get(const lv_grad_dsc_t * g, lv_coord_t w, lv_coord_t h)
     return item;
 }
 
-LV_ATTRIBUTE_FAST_MEM lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
-                                                            lv_coord_t frac)
+lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
+                                      lv_coord_t frac) LV_ATTRIBUTE_FAST_MEM
 {
     lv_grad_color_t tmp;
     lv_color32_t one, two;

--- a/src/draw/sw/lv_draw_sw_gradient.c
+++ b/src/draw/sw/lv_draw_sw_gradient.c
@@ -293,8 +293,8 @@ lv_grad_t * lv_gradient_get(const lv_grad_dsc_t * g, lv_coord_t w, lv_coord_t h)
     return item;
 }
 
-lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
-                                      lv_coord_t frac) LV_ATTRIBUTE_FAST_MEM
+lv_grad_color_t LV_ATTRIBUTE_FAST_MEM lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
+                                                            lv_coord_t frac)
 {
     lv_grad_color_t tmp;
     lv_color32_t one, two;

--- a/src/draw/sw/lv_draw_sw_gradient.h
+++ b/src/draw/sw/lv_draw_sw_gradient.h
@@ -69,8 +69,8 @@ typedef struct _lv_gradient_cache_t {
  * @param range     The range to use in computation.
  * @param frac      The current part used in the range. frac is in [0; range]
  */
-lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
-                                      lv_coord_t frac) /* LV_ATTRIBUTE_FAST_MEM */;
+lv_grad_color_t /* LV_ATTRIBUTE_FAST_MEM */ lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
+                                                                  lv_coord_t frac);
 
 /**
  * Set the gradient cache size

--- a/src/draw/sw/lv_draw_sw_gradient.h
+++ b/src/draw/sw/lv_draw_sw_gradient.h
@@ -69,8 +69,8 @@ typedef struct _lv_gradient_cache_t {
  * @param range     The range to use in computation.
  * @param frac      The current part used in the range. frac is in [0; range]
  */
-LV_ATTRIBUTE_FAST_MEM lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
-                                                            lv_coord_t frac);
+lv_grad_color_t lv_gradient_calculate(const lv_grad_dsc_t * dsc, lv_coord_t range,
+                                      lv_coord_t frac) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Set the gradient cache size

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -42,8 +42,8 @@ static void convert_cb(const lv_area_t * dest_area, const void * src_buf, lv_coo
  **********************/
 
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                  const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf)
+void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                            const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf) LV_ATTRIBUTE_FAST_MEM
 {
     /*Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -42,8 +42,10 @@ static void convert_cb(const lv_area_t * dest_area, const void * src_buf, lv_coo
  **********************/
 
 
-void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                                                  const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf)
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx,
+                                                  const lv_draw_img_dsc_t * draw_dsc,
+                                                  const lv_area_t * coords, const uint8_t * src_buf,
+                                                  lv_img_cf_t cf)
 {
     /*Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -42,8 +42,8 @@ static void convert_cb(const lv_area_t * dest_area, const void * src_buf, lv_coo
  **********************/
 
 
-void lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
-                            const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_img_decoded(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_img_dsc_t * draw_dsc,
+                                                  const lv_area_t * coords, const uint8_t * src_buf, lv_img_cf_t cf)
 {
     /*Use the clip area as draw area*/
     lv_area_t draw_area;

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -27,8 +27,8 @@
  *  STATIC PROTOTYPES
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                                                     const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p);
+static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) /* LV_ATTRIBUTE_FAST_MEM */;
 
 
 #if LV_DRAW_COMPLEX && LV_USE_FONT_SUBPX
@@ -162,8 +162,8 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
  *   STATIC FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                                                     const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p)
+static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) LV_ATTRIBUTE_FAST_MEM
 {
 
     const uint8_t * bpp_opa_table_p;

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -27,8 +27,8 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                                           const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p);
 
 
 #if LV_DRAW_COMPLEX && LV_USE_FONT_SUBPX
@@ -162,8 +162,8 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
  *   STATIC FUNCTIONS
  **********************/
 
-static void draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
-                               const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_letter_normal(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                                     const lv_point_t * pos, lv_font_glyph_dsc_t * g, const uint8_t * map_p)
 {
 
     const uint8_t * bpp_opa_table_p;

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -23,12 +23,12 @@
  *  STATIC PROTOTYPES
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                 const lv_point_t * point1, const lv_point_t * point2);
-LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                const lv_point_t * point1, const lv_point_t * point2);
-LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                const lv_point_t * point1, const lv_point_t * point2);
+static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                           const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
+static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                          const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
+static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                          const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**********************
  *  STATIC VARIABLES
@@ -49,8 +49,8 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx
  * @param clip the line will be drawn only in this area
  * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                           const lv_point_t * point1, const lv_point_t * point2)
+void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                     const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -109,8 +109,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, con
  **********************/
 
 
-LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                const lv_point_t * point1, const lv_point_t * point2)
+static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                          const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -195,8 +195,8 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx
 #endif /*LV_DRAW_COMPLEX*/
 }
 
-LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                const lv_point_t * point1, const lv_point_t * point2)
+static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                          const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -275,8 +275,8 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx
 #endif /*LV_DRAW_COMPLEX*/
 }
 
-LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                                                 const lv_point_t * point1, const lv_point_t * point2)
+static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                           const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
 {
 #if LV_DRAW_COMPLEX
     /*Keep the great y in p1*/

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -23,12 +23,12 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                           const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
-static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                          const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
-static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                          const lv_point_t * point1, const lv_point_t * point2) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                       const lv_point_t * point1, const lv_point_t * point2);
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                      const lv_point_t * point1, const lv_point_t * point2);
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                      const lv_point_t * point1, const lv_point_t * point2);
 
 /**********************
  *  STATIC VARIABLES
@@ -49,8 +49,8 @@ static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_d
  * @param clip the line will be drawn only in this area
  * @param dsc pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                     const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                           const lv_point_t * point1, const lv_point_t * point2)
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -109,8 +109,8 @@ void lv_draw_sw_line(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t 
  **********************/
 
 
-static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                          const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                const lv_point_t * point1, const lv_point_t * point2)
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -195,8 +195,8 @@ static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_d
 #endif /*LV_DRAW_COMPLEX*/
 }
 
-static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                          const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                const lv_point_t * point1, const lv_point_t * point2)
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -275,8 +275,8 @@ static void draw_line_ver(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_d
 #endif /*LV_DRAW_COMPLEX*/
 }
 
-static void draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
-                           const lv_point_t * point1, const lv_point_t * point2) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
+                                                 const lv_point_t * point1, const lv_point_t * point2)
 {
 #if LV_DRAW_COMPLEX
     /*Keep the great y in p1*/

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -35,11 +35,11 @@ static void draw_border(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
 static void draw_outline(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords);
 
 #if LV_DRAW_COMPLEX
-LV_ATTRIBUTE_FAST_MEM static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
-                                              const lv_area_t * coords);
-LV_ATTRIBUTE_FAST_MEM static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t s,
-                                                         lv_coord_t r);
-LV_ATTRIBUTE_FAST_MEM static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf);
+static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
+                        const lv_area_t * coords) /* LV_ATTRIBUTE_FAST_MEM */;
+static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t s,
+                                   lv_coord_t r) /* LV_ATTRIBUTE_FAST_MEM */;
+static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf) /* LV_ATTRIBUTE_FAST_MEM */;
 #endif
 
 void draw_border_generic(lv_draw_ctx_t * draw_ctx, const lv_area_t * outer_area, const lv_area_t * inner_area,
@@ -430,8 +430,8 @@ static void draw_border(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
 }
 
 #if LV_DRAW_COMPLEX
-LV_ATTRIBUTE_FAST_MEM static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
-                                              const lv_area_t * coords)
+static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
+                        const lv_area_t * coords) LV_ATTRIBUTE_FAST_MEM
 {
     /*Check whether the shadow is visible*/
     if(dsc->shadow_width == 0) return;
@@ -950,8 +950,8 @@ LV_ATTRIBUTE_FAST_MEM static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv
  * @param sw shadow width
  * @param r radius
  */
-LV_ATTRIBUTE_FAST_MEM static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t sw,
-                                                         lv_coord_t r)
+static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t sw,
+                                   lv_coord_t r) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t sw_ori = sw;
     int32_t size = sw_ori  + r;
@@ -1037,7 +1037,7 @@ LV_ATTRIBUTE_FAST_MEM static void shadow_draw_corner_buf(const lv_area_t * coord
 
 }
 
-LV_ATTRIBUTE_FAST_MEM static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf)
+static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf) LV_ATTRIBUTE_FAST_MEM
 {
     int32_t s_left = sw >> 1;
     int32_t s_right = (sw >> 1);

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -37,8 +37,8 @@ static void draw_outline(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * ds
 #if LV_DRAW_COMPLEX
 static void /* LV_ATTRIBUTE_FAST_MEM */ draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
                                                     const lv_area_t * coords);
-static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t s,
-                                                               lv_coord_t r);
+static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf,
+                                                               lv_coord_t s, lv_coord_t r);
 static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf);
 #endif
 
@@ -950,8 +950,8 @@ static void LV_ATTRIBUTE_FAST_MEM draw_shadow(lv_draw_ctx_t * draw_ctx, const lv
  * @param sw shadow width
  * @param r radius
  */
-static void LV_ATTRIBUTE_FAST_MEM shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t sw,
-                                                         lv_coord_t r)
+static void LV_ATTRIBUTE_FAST_MEM shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf,
+                                                         lv_coord_t sw, lv_coord_t r)
 {
     int32_t sw_ori = sw;
     int32_t size = sw_ori  + r;

--- a/src/draw/sw/lv_draw_sw_rect.c
+++ b/src/draw/sw/lv_draw_sw_rect.c
@@ -35,11 +35,11 @@ static void draw_border(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
 static void draw_outline(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords);
 
 #if LV_DRAW_COMPLEX
-static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
-                        const lv_area_t * coords) /* LV_ATTRIBUTE_FAST_MEM */;
-static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t s,
-                                   lv_coord_t r) /* LV_ATTRIBUTE_FAST_MEM */;
-static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf) /* LV_ATTRIBUTE_FAST_MEM */;
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
+                                                    const lv_area_t * coords);
+static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t s,
+                                                               lv_coord_t r);
+static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf);
 #endif
 
 void draw_border_generic(lv_draw_ctx_t * draw_ctx, const lv_area_t * outer_area, const lv_area_t * inner_area,
@@ -430,8 +430,8 @@ static void draw_border(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
 }
 
 #if LV_DRAW_COMPLEX
-static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
-                        const lv_area_t * coords) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc,
+                                              const lv_area_t * coords)
 {
     /*Check whether the shadow is visible*/
     if(dsc->shadow_width == 0) return;
@@ -950,8 +950,8 @@ static void draw_shadow(lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc
  * @param sw shadow width
  * @param r radius
  */
-static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t sw,
-                                   lv_coord_t r) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, lv_coord_t sw,
+                                                         lv_coord_t r)
 {
     int32_t sw_ori = sw;
     int32_t size = sw_ori  + r;
@@ -1037,7 +1037,7 @@ static void shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, 
 
 }
 
-static void shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf) LV_ATTRIBUTE_FAST_MEM
+static void LV_ATTRIBUTE_FAST_MEM shadow_blur_corner(lv_coord_t size, lv_coord_t sw, uint16_t * sh_ups_buf)
 {
     int32_t s_left = sw >> 1;
     int32_t s_right = (sw >> 1);

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -513,7 +513,7 @@ lv_coord_t lv_disp_get_dpi(const lv_disp_t * disp)
  * Call in the display driver's `flush_cb` function when the flushing is finished
  * @param disp_drv pointer to display driver in `flush_cb` where this function is called
  */
-LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
+void lv_disp_flush_ready(lv_disp_drv_t * disp_drv) LV_ATTRIBUTE_FLUSH_READY
 {
     disp_drv->draw_buf->flushing = 0;
     disp_drv->draw_buf->flushing_last = 0;
@@ -525,7 +525,7 @@ LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
  * @param disp_drv pointer to display driver
  * @return true: it's the last area to flush; false: there are other areas too which will be refreshed soon
  */
-LV_ATTRIBUTE_FLUSH_READY bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv)
+bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv) LV_ATTRIBUTE_FLUSH_READY
 {
     return disp_drv->draw_buf->flushing_last;
 }

--- a/src/hal/lv_hal_disp.c
+++ b/src/hal/lv_hal_disp.c
@@ -513,7 +513,7 @@ lv_coord_t lv_disp_get_dpi(const lv_disp_t * disp)
  * Call in the display driver's `flush_cb` function when the flushing is finished
  * @param disp_drv pointer to display driver in `flush_cb` where this function is called
  */
-void lv_disp_flush_ready(lv_disp_drv_t * disp_drv) LV_ATTRIBUTE_FLUSH_READY
+void LV_ATTRIBUTE_FLUSH_READY lv_disp_flush_ready(lv_disp_drv_t * disp_drv)
 {
     disp_drv->draw_buf->flushing = 0;
     disp_drv->draw_buf->flushing_last = 0;
@@ -525,7 +525,7 @@ void lv_disp_flush_ready(lv_disp_drv_t * disp_drv) LV_ATTRIBUTE_FLUSH_READY
  * @param disp_drv pointer to display driver
  * @return true: it's the last area to flush; false: there are other areas too which will be refreshed soon
  */
-bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv) LV_ATTRIBUTE_FLUSH_READY
+bool LV_ATTRIBUTE_FLUSH_READY lv_disp_flush_is_last(lv_disp_drv_t * disp_drv)
 {
     return disp_drv->draw_buf->flushing_last;
 }

--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -332,7 +332,7 @@ lv_disp_rot_t lv_disp_get_rotation(lv_disp_t * disp);
  * Call in the display driver's `flush_cb` function when the flushing is finished
  * @param disp_drv pointer to display driver in `flush_cb` where this function is called
  */
-LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
+void lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
 
 /**
  * Tell if it's the last area of the refreshing process.
@@ -340,7 +340,7 @@ LV_ATTRIBUTE_FLUSH_READY void lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
  * @param disp_drv pointer to display driver
  * @return true: it's the last area to flush; false: there are other areas too which will be refreshed soon
  */
-LV_ATTRIBUTE_FLUSH_READY bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv);
+bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv);
 
 //! @endcond
 

--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -173,10 +173,8 @@ typedef struct _lv_disp_t {
     struct _lv_obj_t * top_layer;   /**< @see lv_disp_get_layer_top*/
     struct _lv_obj_t * sys_layer;   /**< @see lv_disp_get_layer_sys*/
     uint32_t screen_cnt;
-uint8_t draw_prev_over_act  :
-    1;          /**< 1: Draw previous screen over active screen*/
-uint8_t del_prev  :
-    1;          /**< 1: Automatically delete the previous screen when the screen load animation is ready*/
+    uint8_t draw_prev_over_act : 1; /**< 1: Draw previous screen over active screen*/
+    uint8_t del_prev : 1;           /**< 1: Automatically delete the previous screen when the screen load animation is ready*/
     uint8_t rendering_in_progress : 1; /**< 1: The current screen rendering is in progress*/
 
     lv_opa_t bg_opa;                /**<Opacity of the background color or wallpaper*/

--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -332,7 +332,7 @@ lv_disp_rot_t lv_disp_get_rotation(lv_disp_t * disp);
  * Call in the display driver's `flush_cb` function when the flushing is finished
  * @param disp_drv pointer to display driver in `flush_cb` where this function is called
  */
-void lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
+void /* LV_ATTRIBUTE_FLUSH_READY */ lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
 
 /**
  * Tell if it's the last area of the refreshing process.
@@ -340,7 +340,7 @@ void lv_disp_flush_ready(lv_disp_drv_t * disp_drv);
  * @param disp_drv pointer to display driver
  * @return true: it's the last area to flush; false: there are other areas too which will be refreshed soon
  */
-bool lv_disp_flush_is_last(lv_disp_drv_t * disp_drv);
+bool /* LV_ATTRIBUTE_FLUSH_READY */ lv_disp_flush_is_last(lv_disp_drv_t * disp_drv);
 
 //! @endcond
 

--- a/src/hal/lv_hal_disp.h
+++ b/src/hal/lv_hal_disp.h
@@ -174,7 +174,7 @@ typedef struct _lv_disp_t {
     struct _lv_obj_t * sys_layer;   /**< @see lv_disp_get_layer_sys*/
     uint32_t screen_cnt;
     uint8_t draw_prev_over_act : 1; /**< 1: Draw previous screen over active screen*/
-    uint8_t del_prev : 1;           /**< 1: Automatically delete the previous screen when the screen load animation is ready*/
+    uint8_t del_prev : 1;           /**< 1: Automatically delete the previous screen when the screen load anim. is ready*/
     uint8_t rendering_in_progress : 1; /**< 1: The current screen rendering is in progress*/
 
     lv_opa_t bg_opa;                /**<Opacity of the background color or wallpaper*/

--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -46,7 +46,7 @@
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
-LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
+void lv_tick_inc(uint32_t tick_period) LV_ATTRIBUTE_TICK_INC
 {
     tick_irq_flag = 0;
     sys_time += tick_period;

--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -46,7 +46,7 @@
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
-void lv_tick_inc(uint32_t tick_period) LV_ATTRIBUTE_TICK_INC
+void LV_ATTRIBUTE_TICK_INC lv_tick_inc(uint32_t tick_period)
 {
     tick_irq_flag = 0;
     sys_time += tick_period;

--- a/src/hal/lv_hal_tick.h
+++ b/src/hal/lv_hal_tick.h
@@ -40,7 +40,7 @@ extern "C" {
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
-LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period);
+void lv_tick_inc(uint32_t tick_period);
 #endif
 
 //! @endcond

--- a/src/hal/lv_hal_tick.h
+++ b/src/hal/lv_hal_tick.h
@@ -40,7 +40,7 @@ extern "C" {
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
-void lv_tick_inc(uint32_t tick_period);
+void /* LV_ATTRIBUTE_TICK_INC */ lv_tick_inc(uint32_t tick_period);
 #endif
 
 //! @endcond

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -33,7 +33,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-LV_ATTRIBUTE_FAST_MEM void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num)
+void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num) LV_ATTRIBUTE_FAST_MEM
 {
 #if LV_COLOR_DEPTH == 16
     uintptr_t buf_int = (uintptr_t)buf;

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -33,7 +33,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num)
 {
 #if LV_COLOR_DEPTH == 16
     uintptr_t buf_int = (uintptr_t)buf;

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -436,7 +436,7 @@ static inline uint32_t lv_color_to32(lv_color_t color)
  * @param mix The ratio of the colors. 0: full `c2`, 255: full `c1`, 127: half `c1` and half`c2`
  * @return the mixed color
  */
-LV_ATTRIBUTE_FAST_MEM static inline lv_color_t lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix)
+static inline lv_color_t lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix) LV_ATTRIBUTE_FAST_MEM
 {
     lv_color_t ret;
 
@@ -472,7 +472,7 @@ LV_ATTRIBUTE_FAST_MEM static inline lv_color_t lv_color_mix(lv_color_t c1, lv_co
     return ret;
 }
 
-LV_ATTRIBUTE_FAST_MEM static inline void lv_color_premult(lv_color_t c, uint8_t mix, uint16_t * out)
+static inline void lv_color_premult(lv_color_t c, uint8_t mix, uint16_t * out) LV_ATTRIBUTE_FAST_MEM
 {
 #if LV_COLOR_DEPTH != 1
     out[0] = (uint16_t)LV_COLOR_GET_R(c) * mix;
@@ -497,7 +497,7 @@ LV_ATTRIBUTE_FAST_MEM static inline void lv_color_premult(lv_color_t c, uint8_t 
  * @return the mixed color
  * @note 255 won't give clearly `c1`.
  */
-LV_ATTRIBUTE_FAST_MEM static inline lv_color_t lv_color_mix_premult(uint16_t * premult_c1, lv_color_t c2, uint8_t mix)
+static inline lv_color_t lv_color_mix_premult(uint16_t * premult_c1, lv_color_t c2, uint8_t mix) LV_ATTRIBUTE_FAST_MEM
 {
     lv_color_t ret;
 #if LV_COLOR_DEPTH != 1
@@ -528,9 +528,9 @@ LV_ATTRIBUTE_FAST_MEM static inline lv_color_t lv_color_mix_premult(uint16_t * p
  * @param res_color the result color
  * @param res_opa the result opacity
  */
-LV_ATTRIBUTE_FAST_MEM static inline void lv_color_mix_with_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
-                                                                 lv_color_t fg_color, lv_opa_t fg_opa,
-                                                                 lv_color_t * res_color, lv_opa_t * res_opa)
+static inline void lv_color_mix_with_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
+                                           lv_color_t fg_color, lv_opa_t fg_opa,
+                                           lv_color_t * res_color, lv_opa_t * res_opa) LV_ATTRIBUTE_FAST_MEM
 {
     /*Pick the foreground if it's fully opaque or the Background is fully transparent*/
     if(fg_opa >= LV_OPA_MAX || bg_opa <= LV_OPA_MIN) {
@@ -644,7 +644,7 @@ static inline void lv_color_filter_dsc_init(lv_color_filter_dsc_t * dsc, lv_colo
 
 //! @cond Doxygen_Suppress
 //!
-LV_ATTRIBUTE_FAST_MEM void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num);
+void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num) LV_ATTRIBUTE_FAST_MEM;
 
 //! @endcond
 lv_color_t lv_color_lighten(lv_color_t c, lv_opa_t lvl);

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -436,7 +436,7 @@ static inline uint32_t lv_color_to32(lv_color_t color)
  * @param mix The ratio of the colors. 0: full `c2`, 255: full `c1`, 127: half `c1` and half`c2`
  * @return the mixed color
  */
-static inline lv_color_t lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix) LV_ATTRIBUTE_FAST_MEM
+static inline lv_color_t LV_ATTRIBUTE_FAST_MEM lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix)
 {
     lv_color_t ret;
 
@@ -472,7 +472,7 @@ static inline lv_color_t lv_color_mix(lv_color_t c1, lv_color_t c2, uint8_t mix)
     return ret;
 }
 
-static inline void lv_color_premult(lv_color_t c, uint8_t mix, uint16_t * out) LV_ATTRIBUTE_FAST_MEM
+static inline void LV_ATTRIBUTE_FAST_MEM lv_color_premult(lv_color_t c, uint8_t mix, uint16_t * out)
 {
 #if LV_COLOR_DEPTH != 1
     out[0] = (uint16_t)LV_COLOR_GET_R(c) * mix;
@@ -497,7 +497,7 @@ static inline void lv_color_premult(lv_color_t c, uint8_t mix, uint16_t * out) L
  * @return the mixed color
  * @note 255 won't give clearly `c1`.
  */
-static inline lv_color_t lv_color_mix_premult(uint16_t * premult_c1, lv_color_t c2, uint8_t mix) LV_ATTRIBUTE_FAST_MEM
+static inline lv_color_t LV_ATTRIBUTE_FAST_MEM lv_color_mix_premult(uint16_t * premult_c1, lv_color_t c2, uint8_t mix)
 {
     lv_color_t ret;
 #if LV_COLOR_DEPTH != 1
@@ -528,9 +528,9 @@ static inline lv_color_t lv_color_mix_premult(uint16_t * premult_c1, lv_color_t 
  * @param res_color the result color
  * @param res_opa the result opacity
  */
-static inline void lv_color_mix_with_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
-                                           lv_color_t fg_color, lv_opa_t fg_opa,
-                                           lv_color_t * res_color, lv_opa_t * res_opa) LV_ATTRIBUTE_FAST_MEM
+static inline void LV_ATTRIBUTE_FAST_MEM lv_color_mix_with_alpha(lv_color_t bg_color, lv_opa_t bg_opa,
+                                                                 lv_color_t fg_color, lv_opa_t fg_opa,
+                                                                 lv_color_t * res_color, lv_opa_t * res_opa)
 {
     /*Pick the foreground if it's fully opaque or the Background is fully transparent*/
     if(fg_opa >= LV_OPA_MAX || bg_opa <= LV_OPA_MIN) {
@@ -644,7 +644,7 @@ static inline void lv_color_filter_dsc_init(lv_color_filter_dsc_t * dsc, lv_colo
 
 //! @cond Doxygen_Suppress
 //!
-void lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num) LV_ATTRIBUTE_FAST_MEM;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_color_fill(lv_color_t * buf, lv_color_t color, uint32_t px_num);
 
 //! @endcond
 lv_color_t lv_color_lighten(lv_color_t c, lv_opa_t lvl);

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -45,7 +45,7 @@ static const int16_t sin0_90_table[] = {
  * @param angle
  * @return sinus of 'angle'. sin(-90) = -32767, sin(90) = 32767
  */
-int16_t lv_trigo_sin(int16_t angle) LV_ATTRIBUTE_FAST_MEM
+int16_t LV_ATTRIBUTE_FAST_MEM lv_trigo_sin(int16_t angle)
 {
     int16_t ret = 0;
     angle       = angle % 360;
@@ -106,7 +106,7 @@ uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t 
  * If root < 256: mask = 0x800
  * Else: mask = 0x8000
  */
-void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask)
 {
     x = x << 8; /*To get 4 bit precision. (sqrt(256) = 16 = 4 bit)*/
 

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -45,7 +45,7 @@ static const int16_t sin0_90_table[] = {
  * @param angle
  * @return sinus of 'angle'. sin(-90) = -32767, sin(90) = 32767
  */
-LV_ATTRIBUTE_FAST_MEM int16_t lv_trigo_sin(int16_t angle)
+int16_t lv_trigo_sin(int16_t angle) LV_ATTRIBUTE_FAST_MEM
 {
     int16_t ret = 0;
     angle       = angle % 360;
@@ -106,7 +106,7 @@ uint32_t lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t 
  * If root < 256: mask = 0x800
  * Else: mask = 0x8000
  */
-LV_ATTRIBUTE_FAST_MEM void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask)
+void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask) LV_ATTRIBUTE_FAST_MEM
 {
     x = x << 8; /*To get 4 bit precision. (sqrt(256) = 16 = 4 bit)*/
 

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -44,9 +44,9 @@ typedef struct {
  * @param angle
  * @return sinus of 'angle'. sin(-90) = -32767, sin(90) = 32767
  */
-LV_ATTRIBUTE_FAST_MEM int16_t lv_trigo_sin(int16_t angle);
+int16_t lv_trigo_sin(int16_t angle) /* LV_ATTRIBUTE_FAST_MEM */;
 
-static inline LV_ATTRIBUTE_FAST_MEM int16_t lv_trigo_cos(int16_t angle)
+static inline int16_t lv_trigo_cos(int16_t angle) LV_ATTRIBUTE_FAST_MEM
 {
     return lv_trigo_sin(angle + 90);
 }
@@ -84,7 +84,7 @@ uint16_t lv_atan2(int x, int y);
  * If root < 256: mask = 0x800
  * Else: mask = 0x8000
  */
-LV_ATTRIBUTE_FAST_MEM void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask);
+void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask) /* LV_ATTRIBUTE_FAST_MEM */;
 
 //! @endcond
 

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -44,9 +44,9 @@ typedef struct {
  * @param angle
  * @return sinus of 'angle'. sin(-90) = -32767, sin(90) = 32767
  */
-int16_t lv_trigo_sin(int16_t angle) /* LV_ATTRIBUTE_FAST_MEM */;
+int16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_trigo_sin(int16_t angle);
 
-static inline int16_t lv_trigo_cos(int16_t angle) LV_ATTRIBUTE_FAST_MEM
+static inline int16_t LV_ATTRIBUTE_FAST_MEM lv_trigo_cos(int16_t angle)
 {
     return lv_trigo_sin(angle + 90);
 }
@@ -84,7 +84,7 @@ uint16_t lv_atan2(int x, int y);
  * If root < 256: mask = 0x800
  * Else: mask = 0x8000
  */
-void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask);
 
 //! @endcond
 

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -365,7 +365,7 @@ void lv_mem_buf_free_all(void)
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-void * lv_memcpy(void * dst, const void * src, size_t len) LV_ATTRIBUTE_FAST_MEM
+void * LV_ATTRIBUTE_FAST_MEM lv_memcpy(void * dst, const void * src, size_t len)
 {
     uint8_t * d8 = dst;
     const uint8_t * s8 = src;
@@ -427,7 +427,7 @@ void * lv_memcpy(void * dst, const void * src, size_t len) LV_ATTRIBUTE_FAST_MEM
  * @param v value to set [0..255]
  * @param len number of byte to set
  */
-void lv_memset(void * dst, uint8_t v, size_t len) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_memset(void * dst, uint8_t v, size_t len)
 {
 
     uint8_t * d8 = (uint8_t *)dst;
@@ -470,7 +470,7 @@ void lv_memset(void * dst, uint8_t v, size_t len) LV_ATTRIBUTE_FAST_MEM
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-void lv_memset_00(void * dst, size_t len) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_memset_00(void * dst, size_t len)
 {
     uint8_t * d8 = (uint8_t *)dst;
     uintptr_t d_align = (lv_uintptr_t) d8 & ALIGN_MASK;
@@ -508,7 +508,7 @@ void lv_memset_00(void * dst, size_t len) LV_ATTRIBUTE_FAST_MEM
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-void lv_memset_ff(void * dst, size_t len) LV_ATTRIBUTE_FAST_MEM
+void LV_ATTRIBUTE_FAST_MEM lv_memset_ff(void * dst, size_t len)
 {
     uint8_t * d8 = (uint8_t *)dst;
     uintptr_t d_align = (lv_uintptr_t) d8 & ALIGN_MASK;

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -365,7 +365,7 @@ void lv_mem_buf_free_all(void)
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-LV_ATTRIBUTE_FAST_MEM void * lv_memcpy(void * dst, const void * src, size_t len)
+void * lv_memcpy(void * dst, const void * src, size_t len) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t * d8 = dst;
     const uint8_t * s8 = src;
@@ -427,7 +427,7 @@ LV_ATTRIBUTE_FAST_MEM void * lv_memcpy(void * dst, const void * src, size_t len)
  * @param v value to set [0..255]
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
+void lv_memset(void * dst, uint8_t v, size_t len) LV_ATTRIBUTE_FAST_MEM
 {
 
     uint8_t * d8 = (uint8_t *)dst;
@@ -470,7 +470,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset_00(void * dst, size_t len)
+void lv_memset_00(void * dst, size_t len) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t * d8 = (uint8_t *)dst;
     uintptr_t d_align = (lv_uintptr_t) d8 & ALIGN_MASK;
@@ -508,7 +508,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset_00(void * dst, size_t len)
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset_ff(void * dst, size_t len)
+void lv_memset_ff(void * dst, size_t len) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t * d8 = (uint8_t *)dst;
     uintptr_t d_align = (lv_uintptr_t) d8 & ALIGN_MASK;

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -183,7 +183,7 @@ static inline void lv_memset_ff(void * dst, size_t len)
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-LV_ATTRIBUTE_FAST_MEM void * lv_memcpy(void * dst, const void * src, size_t len);
+void * lv_memcpy(void * dst, const void * src, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Same as `memcpy` but optimized to copy only a few bytes.
@@ -191,7 +191,7 @@ LV_ATTRIBUTE_FAST_MEM void * lv_memcpy(void * dst, const void * src, size_t len)
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-LV_ATTRIBUTE_FAST_MEM static inline void * lv_memcpy_small(void * dst, const void * src, size_t len)
+static inline void * lv_memcpy_small(void * dst, const void * src, size_t len) LV_ATTRIBUTE_FAST_MEM
 {
     uint8_t * d8 = (uint8_t *)dst;
     const uint8_t * s8 = (const uint8_t *)src;
@@ -212,21 +212,21 @@ LV_ATTRIBUTE_FAST_MEM static inline void * lv_memcpy_small(void * dst, const voi
  * @param v value to set [0..255]
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len);
+void lv_memset(void * dst, uint8_t v, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Same as `memset(dst, 0x00, len)` but optimized for 4 byte operation.
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset_00(void * dst, size_t len);
+void lv_memset_00(void * dst, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
 
 /**
  * Same as `memset(dst, 0xFF, len)` but optimized for 4 byte operation.
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-LV_ATTRIBUTE_FAST_MEM void lv_memset_ff(void * dst, size_t len);
+void lv_memset_ff(void * dst, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
 
 //! @endcond
 

--- a/src/misc/lv_mem.h
+++ b/src/misc/lv_mem.h
@@ -183,7 +183,7 @@ static inline void lv_memset_ff(void * dst, size_t len)
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-void * lv_memcpy(void * dst, const void * src, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
+void * /* LV_ATTRIBUTE_FAST_MEM */ lv_memcpy(void * dst, const void * src, size_t len);
 
 /**
  * Same as `memcpy` but optimized to copy only a few bytes.
@@ -191,7 +191,7 @@ void * lv_memcpy(void * dst, const void * src, size_t len) /* LV_ATTRIBUTE_FAST_
  * @param src pointer to the source buffer
  * @param len number of byte to copy
  */
-static inline void * lv_memcpy_small(void * dst, const void * src, size_t len) LV_ATTRIBUTE_FAST_MEM
+static inline void * LV_ATTRIBUTE_FAST_MEM lv_memcpy_small(void * dst, const void * src, size_t len)
 {
     uint8_t * d8 = (uint8_t *)dst;
     const uint8_t * s8 = (const uint8_t *)src;
@@ -212,21 +212,21 @@ static inline void * lv_memcpy_small(void * dst, const void * src, size_t len) L
  * @param v value to set [0..255]
  * @param len number of byte to set
  */
-void lv_memset(void * dst, uint8_t v, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_memset(void * dst, uint8_t v, size_t len);
 
 /**
  * Same as `memset(dst, 0x00, len)` but optimized for 4 byte operation.
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-void lv_memset_00(void * dst, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_memset_00(void * dst, size_t len);
 
 /**
  * Same as `memset(dst, 0xFF, len)` but optimized for 4 byte operation.
  * @param dst pointer to the destination buffer
  * @param len number of byte to set
  */
-void lv_memset_ff(void * dst, size_t len) /* LV_ATTRIBUTE_FAST_MEM */;
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_memset_ff(void * dst, size_t len);
 
 //! @endcond
 

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -64,7 +64,7 @@ void _lv_timer_core_init(void)
  * Call it periodically to handle lv_timers.
  * @return the time after which it must be called again
  */
-LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
+uint32_t lv_timer_handler(void) LV_ATTRIBUTE_TIMER_HANDLER
 {
     TIMER_TRACE("begin");
 

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -64,7 +64,7 @@ void _lv_timer_core_init(void)
  * Call it periodically to handle lv_timers.
  * @return the time after which it must be called again
  */
-uint32_t lv_timer_handler(void) LV_ATTRIBUTE_TIMER_HANDLER
+uint32_t LV_ATTRIBUTE_TIMER_HANDLER lv_timer_handler(void)
 {
     TIMER_TRACE("begin");
 

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -65,7 +65,7 @@ void _lv_timer_core_init(void);
  * Call it periodically to handle lv_timers.
  * @return time till it needs to be run next (in ms)
  */
-LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
+uint32_t lv_timer_handler(void);
 
 //! @endcond
 
@@ -75,7 +75,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
  * This function is used to simplify the porting.
  * @param __ms the period for running lv_timer_handler()
  */
-static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period(uint32_t ms)
+static inline uint32_t lv_timer_handler_run_in_period(uint32_t ms) LV_ATTRIBUTE_TIMER_HANDLER
 {
     static uint32_t last_tick = 0;
     uint32_t curr_tick = lv_tick_get();

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -65,7 +65,7 @@ void _lv_timer_core_init(void);
  * Call it periodically to handle lv_timers.
  * @return time till it needs to be run next (in ms)
  */
-uint32_t lv_timer_handler(void);
+uint32_t /* LV_ATTRIBUTE_TIMER_HANDLER */ lv_timer_handler(void);
 
 //! @endcond
 
@@ -75,7 +75,7 @@ uint32_t lv_timer_handler(void);
  * This function is used to simplify the porting.
  * @param __ms the period for running lv_timer_handler()
  */
-static inline uint32_t lv_timer_handler_run_in_period(uint32_t ms) LV_ATTRIBUTE_TIMER_HANDLER
+static inline uint32_t LV_ATTRIBUTE_TIMER_HANDLER lv_timer_handler_run_in_period(uint32_t ms)
 {
     static uint32_t last_tick = 0;
     uint32_t curr_tick = lv_tick_get();


### PR DESCRIPTION
### Description of the feature or fix

Continue of #4391

removed function attributes from prototypes and kept only on function declarations or static inline functions:
- `LV_ATTRIBUTE_TICK_INC`
- `LV_ATTRIBUTE_TIMER_HANDLER`
- `LV_ATTRIBUTE_FLUSH_READY`
- `LV_ATTRIBUTE_FAST_MEM`

This fixes an issue in ESP-IDF where section attributes use  `__COUNTER__` macro, and this results in prototype and declaration having different sections assigned