### PR TITLE
docs: fix misc typos throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Our team is ready to help you with graphics design, UI implementation and consul
   - A fully portable C (C++ compatible) library with no external dependencies.
   - Can be compiled to any MCU or MPU, with any (RT)OS.
   - Supports monochrome, ePaper, OLED or TFT displays, or even monitors. [Porting Guide](https://docs.lvgl.io/master/porting/project.html)
-  - Distributed under the MIT licence, so you can easily use it in commercial projects too.
+  - Distributed under the MIT license, so you can easily use it in commercial projects too.
   - Needs only 32kB RAM and 128 kB Flash, a frame buffer, and at least an 1/10 screen sized buffer for rendering.
   - OS, External memory and GPU are supported but not required.
 

--- a/docs/get-started/bindings/javascript.rst
+++ b/docs/get-started/bindings/javascript.rst
@@ -30,7 +30,7 @@ Features
 
 -  Support all lvgl built-in components
 -  Fully support lvgl flex and grid style
--  support most lvgl style，just write like html5 css
+-  support most lvgl style, just write like html5 css
 -  support dynamic load image
 -  Fully support lvgl animation
 
@@ -85,7 +85,7 @@ Components
 Font
 ----
 
-`Buitin-Symbol <https://github.com/lvgl/lv_binding_js/blob/master/doc/Symbol/symbol.md>`__
+`Builtin-Symbol <https://github.com/lvgl/lv_binding_js/blob/master/doc/Symbol/symbol.md>`__
 
 Animation
 ---------

--- a/docs/get-started/bindings/micropython.rst
+++ b/docs/get-started/bindings/micropython.rst
@@ -185,7 +185,7 @@ follow some coding conventions:
 - In function arguments use ``type name[]`` declaration for array parameters instead of :cpp:expr:`type * name`
 - Use typed pointers instead of :cpp:expr:`void *` pointers
 - Widget constructor must follow the ``lv_<widget_name>_create(lv_obj_t * parent)`` pattern.
-- Widget members function must start with ``lv_<modul_name>`` and should receive :cpp:expr:`lv_obj_t *` as first
+- Widget members function must start with ``lv_<module_name>`` and should receive :cpp:expr:`lv_obj_t *` as first
   argument which is a pointer to widget object itself.
 - ``struct`` APIs should follow the widgets' conventions. That is to receive a pointer to the ``struct`` as the
   first argument, and the prefix of the ``struct`` name should be used as the prefix of the

--- a/docs/get-started/platforms/stm32.rst
+++ b/docs/get-started/platforms/stm32.rst
@@ -226,7 +226,7 @@ variables:
      }
    }
    /* LVGL tick source */
-   void LGVLTick(void const * argument)
+   void LVGLTick(void const * argument)
    {
      for(;;)
      {

--- a/docs/libs/rlottie.rst
+++ b/docs/libs/rlottie.rst
@@ -263,7 +263,7 @@ IDF) with the appropriate :c:expr:`MALLOC_CAP` call - for SPIRAM usage this is
 
 .. code:: c
 
-   rlottie->allocated_buf = heap_caps_malloc(allocaled_buf_size+1, MALLOC_CAP_SPIRAM);
+   rlottie->allocated_buf = heap_caps_malloc(allocated_buf_size+1, MALLOC_CAP_SPIRAM);
 
 Example
 -------

--- a/docs/others/file_explorer.rst
+++ b/docs/others/file_explorer.rst
@@ -209,7 +209,7 @@ default sorting to :c:enumerator:`LV_EXPLORER_SORT_NONE`. The default is
 Event
 -----
 
--  :c:enumerator:`LV_EVENT_READY` sent shen a directory is opened. You can customize
+-  :c:enumerator:`LV_EVENT_READY` sent when a directory is opened. You can customize
    the sort.
 
 -  :c:enumerator:`LV_EVENT_VALUE_CHANGED` sent when an item(file) in the file list

--- a/docs/others/msg.rst
+++ b/docs/others/msg.rst
@@ -75,7 +75,7 @@ Subscribe with an lv_obj
 ------------------------
 
 It's quite typical that an LVGL widget is interested in some messages.
-To make it simpler :c:expr:`lv_msg_subsribe_obj(msg_id, obj, user_data)` can
+To make it simpler :c:expr:`lv_msg_subscribe_obj(msg_id, obj, user_data)` can
 be used. If a new message is published with ``msg_id`` an
 :c:enumerator:`LV_EVENT_MSG_RECEIVED` event will be sent to the object.
 
@@ -84,7 +84,7 @@ For example:
 .. code:: c
 
    lv_obj_add_event(user_name_label, user_name_label_event_cb, LV_EVENT_MSG_RECEIVED, NULL);
-   lv_msg_subsribe_obj(MSG_USER_NAME_CHANGED, user_name_label, NULL);
+   lv_msg_subscribe_obj(MSG_USER_NAME_CHANGED, user_name_label, NULL);
 
    ...
 
@@ -100,7 +100,7 @@ Here ``msg_id`` also can be a variable's address:
 .. code:: c
 
    char name[64];
-   lv_msg_subsribe_obj(name, user_name_label, NULL);
+   lv_msg_subscribe_obj(name, user_name_label, NULL);
 
 Unsubscribe
 ~~~~~~~~~~~
@@ -136,10 +136,10 @@ variable's value the subscribers can be notified like this:
    lv_msg_update_value(&v); //Notify all the subscribers of `(lv_msg_id_t)&v`
 
 It's handy way of creating API for the UI too. If the UI provides some
-global variables (e.g. ``int current_tempereature``) and anyone can
+global variables (e.g. ``int current_temperature``) and anyone can
 read and write this variable. After writing they can notify all the
 elements who are interested in that value. E.g. an ``lv_label`` can
-subscribe to :c:expr:`(lv_msg_id_t)&current_tempereature` and update its text
+subscribe to :c:expr:`(lv_msg_id_t)&current_temperature` and update its text
 when it's notified about the new temperature.
 
 Example

--- a/docs/porting/disp.rst
+++ b/docs/porting/disp.rst
@@ -103,7 +103,7 @@ other hardware should be used to transfer data to the display so the MCU
 can continue drawing. This way, the rendering and refreshing of the
 display become parallel operations.
 
-Advnaced options
+Advanced options
 ****************
 
 Resolution

--- a/docs/widgets/chart.rst
+++ b/docs/widgets/chart.rst
@@ -101,7 +101,7 @@ that point, column, or line segment.
 
 For :cpp:enumerator:`LV_CHART_TYPE_SCATTER` type
 :cpp:expr:`lv_chart_set_value_by_id2(chart, ser, id, value)` and
-:cpp:expr:`lv_chart_set_next_value2(chart, ser, x_valuem y_value)` can be used
+:cpp:expr:`lv_chart_set_next_value2(chart, ser, x_value, y_value)` can be used
 as well.
 
 Update modes

--- a/docs/widgets/checkbox.rst
+++ b/docs/widgets/checkbox.rst
@@ -42,7 +42,7 @@ common state add/clear function:
 
 .. code:: c
 
-   lv_obj_add_state(cb, LV_STATE_CHECKED);   /*Make the chekbox checked*/
+   lv_obj_add_state(cb, LV_STATE_CHECKED);   /*Make the checkbox checked*/
    lv_obj_clear_state(cb, LV_STATE_CHECKED); /*MAke the checkbox unchecked*/
    lv_obj_add_state(cb, LV_STATE_CHECKED | LV_STATE_DISABLED); /*Make the checkbox checked and disabled*/
 

--- a/docs/widgets/keyboard.rst
+++ b/docs/widgets/keyboard.rst
@@ -66,12 +66,12 @@ New Keymap
 You can specify a new map (layout) for the keyboard with
 :cpp:expr:`lv_keyboard_set_map(kb, LV_KEYBOARD_MODE_..., kb_map, kb_ctrl)`. See
 the `Button matrix </widgets/btnmatrix>`__ for more information about
-creating new maps a ctrls.
+creating new maps and ctrls.
 
 Keep in mind that using following keywords will have the same effect as
 with the original map:
 
-- :c:macro:`LV_SYMBOL_OK` Send ``LV_EVENT_RADY`` to the assigned Text area.
+- :c:macro:`LV_SYMBOL_OK` Send ``LV_EVENT_READY`` to the assigned Text area.
 - :c:macro:`LV_SYMBOL_CLOSE` or :c:macro:`LV_SYMBOL_KEYBOARD` Send :cpp:enumerator:`LV_EVENT_CANCEL` to the assigned Text area.
 - :c:macro:`LV_SYMBOL_BACKSPACE` Delete on the left.
 - :c:macro:`LV_SYMBOL_LEFT` Move the cursor left.

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -29,7 +29,7 @@ Scale
 The Scale has minor and major ticks, and labels on the major ticks.
 
 The minor tick lines can be configured with:
-:cpp:expr:`lv_meter_set_scale_ticks(meter, tick_count, line_width, tick_length, ctick_olor)`.
+:cpp:expr:`lv_meter_set_scale_ticks(meter, tick_count, line_width, tick_length, tick_color)`.
 
 To show major tick lines use
 :cpp:expr:`lv_meter_set_scale_major_ticks(meter, nth_major, tick_width, tick_length, tick_color, label_gap)`.
@@ -70,7 +70,7 @@ needle pointing to the right like this ``-O--->``. ``pivot_x`` and
 ``pivot_y`` sets the pivot point of the rotation relative to the top
 left corner of the image.
 
-:cpp:expr:`lv_meter_set_indicator_value(meter, inidicator, value)` sets the
+:cpp:expr:`lv_meter_set_indicator_value(meter, indicator, value)` sets the
 value of the indicator.
 
 Arc
@@ -81,7 +81,7 @@ and arc indicator. . By default, the radius of the arc is the same as
 the scale's radius but ``r_mod`` changes the radius.
 
 :cpp:expr:`lv_meter_set_indicator_start_value(meter, indic, value)` and
-:cpp:expr:`lv_meter_set_indicator_end_value(meter, inidicator, value)` sets the
+:cpp:expr:`lv_meter_set_indicator_end_value(meter, indicator, value)` sets the
 value of the indicator.
 
 Scale lines (ticks)
@@ -96,8 +96,8 @@ start and end value of the scale and only a "slice" of that color
 gradient will be visible in the indicator's start and end value range.
 ``width_mod`` modifies the width of the tick lines.
 
-:cpp:expr:`lv_meter_set_indicator_start_value(meter, inidicator, value)` and
-:cpp:expr:`lv_meter_set_indicator_end_value(meter, inidicator, value)` sets the
+:cpp:expr:`lv_meter_set_indicator_start_value(meter, indicator, value)` and
+:cpp:expr:`lv_meter_set_indicator_end_value(meter, indicator, value)` sets the
 value of the indicator.
 
 Events

--- a/docs/widgets/obj.rst
+++ b/docs/widgets/obj.rst
@@ -61,7 +61,7 @@ will shift the object by 10;20 px from the center of its parent:
    lv_obj_align(obj, LV_ALIGN_CENTER, 10, 20);
 
 To align one object to another use:
-:cpp:expr:`lv_obj_align_to(obj_to_align, obj_referece, LV_ALIGN_..., x, y)`
+:cpp:expr:`lv_obj_align_to(obj_to_align, obj_reference, LV_ALIGN_..., x, y)`
 
 For example, to align a text below an image:
 :cpp:expr:`lv_obj_align_to(text, image, LV_ALIGN_OUT_BOTTOM_MID, 0, 10)`.

--- a/docs/widgets/tabview.rst
+++ b/docs/widgets/tabview.rst
@@ -22,7 +22,7 @@ Parts and Styles
 ****************
 
 There are no special parts on the Tab view but the ``lv_obj`` and
-``lv_btnnmatrix`` widgets are used to create the Tab view.
+``lv_btnmatrix`` widgets are used to create the Tab view.
 
 Usage
 *****

--- a/docs/widgets/tileview.rst
+++ b/docs/widgets/tileview.rst
@@ -39,7 +39,7 @@ Change tile
 
 The Tile view can scroll to a tile with
 :cpp:expr:`lv_obj_set_tile(tileview, tile_obj, LV_ANIM_ON/OFF)` or
-:cpp:expr:`lv_obj_set_tile_id(tileviewv, col_id, row_id, LV_ANIM_ON/OFF)`
+:cpp:expr:`lv_obj_set_tile_id(tileview, col_id, row_id, LV_ANIM_ON/OFF)`
 
 Events
 ******


### PR DESCRIPTION
Fixes typos throughout the docs.
