### PR TITLE
fix(draw): Check for decoder result in sw_draw_img

### DIFF
--- a/src/dev/disp/lcd/lv_nuttx_lcd.c
+++ b/src/dev/disp/lcd/lv_nuttx_lcd.c
@@ -162,11 +162,12 @@ static lv_disp_t * lcd_init(int fd, int hor_res, int ver_res)
         return NULL;
     }
 
+    uint32_t px_size = lv_color_format_get_size(lv_disp_get_color_format(disp));
 #if LV_NUTTX_LCD_BUFFER_COUNT > 0
-    uint32_t buf_size = hor_res * ver_res * sizeof(lv_color_t);
+    uint32_t buf_size = hor_res * ver_res * px_size;
     lv_disp_render_mode_t render_mode = LV_DISP_RENDER_MODE_FULL;
 #else
-    uint32_t buf_size = hor_res * LV_NUTTX_LCD_BUFFER_SIZE * sizeof(lv_color_t);
+    uint32_t buf_size = hor_res * LV_NUTTX_LCD_BUFFER_SIZE * px_size;
     lv_disp_render_mode_t render_mode = LV_DISP_RENDER_MODE_PARTIAL;
 #endif
 

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -168,7 +168,11 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img(lv_draw_unit_t * draw_unit, const lv_d
     bool transformed = draw_dsc->angle != 0 || draw_dsc->zoom != LV_ZOOM_NONE ? true : false;
 
     lv_img_decoder_dsc_t decoder_dsc;
-    lv_img_decoder_open(&decoder_dsc, draw_dsc->src, draw_dsc->recolor, -1);
+    lv_res_t res = lv_img_decoder_open(&decoder_dsc, draw_dsc->src, draw_dsc->recolor, -1);
+    if(res != LV_RES_OK) {
+        LV_LOG_ERROR("Failed to open image");
+        return;
+    }
     const uint8_t * src_buf = decoder_dsc.img_data;
 
     lv_color_format_t cf = decoder_dsc.header.cf;


### PR DESCRIPTION
### Description of the feature or fix

Refine error handle logic in sw_draw_img, otherwise image src will be closed twice and double-freed. 
Fix pixel size in lv_nuttx_lcd.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
