### PR TITLE
feat(global): support multi-instance feature using a single global variable lv_global

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -131,14 +131,6 @@ menu "LVGL configuration"
 	endmenu
 
 	menu "HAL Settings"
-		config LV_TICK_CUSTOM
-			bool "Use a custom tick source"
-
-		config LV_TICK_CUSTOM_INCLUDE
-			string "Header for the system time function"
-			default "Arduino.h"
-			depends on LV_TICK_CUSTOM
-
 		config LV_DPI_DEF
 			int "Default Dots Per Inch (in px)."
 			default 130

--- a/docs/porting/project.rst
+++ b/docs/porting/project.rst
@@ -104,6 +104,21 @@ from ``lv_conf.h`` or build settings (``-D...``) overwrite the values
 set in Kconfig. To ignore the configs from ``lv_conf.h`` simply remove
 its content, or define :c:macro:`LV_CONF_SKIP`.
 
+To enable multi-instance feature, set :c:macro:`LV_GLOBAL_CUSTOM` in
+``lv_conf.h`` and provide a custom function to
+:cpp:func:`lv_global_default` using ``__thread`` or ``pthread_key_t``.
+
+For example:
+
+.. code:: c
+
+   lv_global_t * lv_global_default(void)
+   {
+     static __thread lv_global_t lv_global;
+     return &lv_global;
+   }
+
+
 Initialization
 --------------
 

--- a/docs/porting/tick.rst
+++ b/docs/porting/tick.rst
@@ -7,6 +7,16 @@ Tick interface
 LVGL needs a system tick to know elapsed time for animations and other
 tasks.
 
+If you want to use a custom function to :cpp:func:`lv_tick_get`, you can
+register a "tick_get_cb" with :cpp:func:`lv_tick_set_cb`.
+
+For example:
+
+.. code:: c
+
+   lv_tick_set_cb(SDL_GetTicks);
+
+
 You need to call the :cpp:expr:`lv_tick_inc(tick_period)` function periodically
 and provide the call period in milliseconds. For example,
 :cpp:expr:`lv_tick_inc(1)` when calling every millisecond.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -138,12 +138,6 @@
     #define LV_OS_CUSTOM_INCLUDE <stdint.h>
 #endif
 
-/* Declare the keyword for thread-local storage. Possible options:
- * -
- * - __thread
- */
-#define LV_THREAD_LOCAL     
-
 /*=======================
  * FEATURE CONFIGURATION
  *=======================*/
@@ -253,6 +247,9 @@
 #if LV_ENABLE_GC != 0
     #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
 #endif /*LV_ENABLE_GC*/
+
+/*For custom `lv_global_default()` implementation set to 1*/
+#define LV_GLOBAL_CUSTOM 0
 
 /*Default image cache size. Image caching keeps some images opened.
  *If only the built-in image formats are used there is no real advantage of caching.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -68,17 +68,6 @@
 /*Default display refresh, input device read and animation step period.*/
 #define LV_DEF_REFR_PERIOD  33      /*[ms]*/
 
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#define LV_TICK_CUSTOM 0
-#if LV_TICK_CUSTOM
-    #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-    /*If using lvgl as ESP32 component*/
-    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
-#endif   /*LV_TICK_CUSTOM*/
-
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #define LV_DPI_DEF 130     /*[px/inch]*/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -138,6 +138,11 @@
     #define LV_OS_CUSTOM_INCLUDE <stdint.h>
 #endif
 
+/* Declare the keyword for thread-local storage. Possible options:
+ * -
+ * - __thread
+ */
+#define LV_THREAD_LOCAL     
 
 /*=======================
  * FEATURE CONFIGURATION

--- a/lvgl.h
+++ b/lvgl.h
@@ -118,6 +118,7 @@ extern "C" {
 
 #include "src/dev/input/touchscreen/lv_nuttx_touchscreen.h"
 
+#include "src/core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -179,7 +180,7 @@ static inline int lv_version_patch(void)
     return LVGL_VERSION_PATCH;
 }
 
-static inline const char *lv_version_info(void)
+static inline const char * lv_version_info(void)
 {
     return LVGL_VERSION_INFO;
 }

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -34,6 +34,7 @@ extern "C" {
 #include "../font/lv_font_fmt_txt.h"
 #endif
 
+#include "../tick/lv_tick.h"
 /*********************
  *      DEFINES
  *********************/
@@ -93,8 +94,7 @@ typedef struct {
     lv_anim_state_t anim_state;
 
 #if !LV_TICK_CUSTOM
-    uint32_t tick_sys_time;
-    volatile uint8_t tick_sys_irq_flag;
+    lv_tick_state_t tick_state;
 #endif
 
 #if LV_IMG_CACHE_DEF_SIZE

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -92,10 +92,7 @@ typedef struct {
 
     lv_timer_state_t timer_state;
     lv_anim_state_t anim_state;
-
-#if !LV_TICK_CUSTOM
     lv_tick_state_t tick_state;
-#endif
 
 #if LV_IMG_CACHE_DEF_SIZE
     uint16_t img_cache_entry_cnt;

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -1,0 +1,201 @@
+/**
+ * @file lv_global.h
+ *
+ */
+
+#ifndef LV_GLOBAL_H
+#define LV_GLOBAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lv_conf_internal.h"
+
+#include <stdbool.h>
+#include "../draw/lv_img_cache.h"
+#include "../draw/sw/lv_draw_sw.h"
+#include "../misc/lv_anim.h"
+#include "../misc/lv_area.h"
+#include "../misc/lv_color_op.h"
+#include "../misc/lv_log.h"
+#include "../misc/lv_profiler_builtin.h"
+#include "../misc/lv_style.h"
+#include "../misc/lv_timer.h"
+#include "../osal/lv_os.h"
+#include "../stdlib/builtin/lv_tlsf.h"
+
+#if LV_USE_FONT_COMPRESSED
+#include "../font/lv_font_fmt_txt.h"
+#endif
+
+#if LV_USE_SYSMON
+#include "../others/sysmon/lv_sysmon.h"
+#endif
+/*********************
+ *      DEFINES
+ *********************/
+#define ZERO_MEM_SENTINEL  0xa1b2c3d4
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+struct _lv_disp_t;
+struct _lv_group_t;
+struct _my_theme_t;
+struct _lv_indev_t;
+struct _lv_event_t;
+struct _lv_obj_t;
+
+#if LV_USE_SPAN != 0
+struct _snippet_stack;
+#endif
+
+#if LV_USE_FREETYPE
+struct _lv_freetype_context_t;
+#endif
+
+typedef struct {
+    bool inited;
+
+    bool style_refresh;
+    struct _lv_disp_t * disp_refresh;
+    struct _lv_group_t * group_default;
+    struct _lv_disp_t * disp_default;
+    lv_img_cache_manager_t img_cache_mgr;
+
+    struct _lv_indev_t * indev_active;
+    struct _lv_obj_t * indev_obj_active;
+
+    uint32_t layout_count;
+    uint32_t memory_zero;
+
+    uint32_t math_rand_seed;
+    bool layout_update_mutex;
+
+    lv_area_transform_cache_t area_trans_cache;
+
+    uint32_t style_custom_table_size;
+    uint16_t style_last_custom_prop_id;
+
+    struct _lv_event_t * event_header;
+    uint32_t event_last_register_id;
+
+    lv_log_print_g_cb_t custom_log_print_cb;
+#if LV_LOG_USE_TIMESTAMP
+    uint32_t log_last_log_time;
+#endif
+
+    lv_timer_state_t timer_state;
+    lv_anim_state_t anim_state;
+
+#if !LV_TICK_CUSTOM
+    uint32_t tick_sys_time;
+    volatile uint8_t tick_irq_flag;
+#endif
+
+#if LV_IMG_CACHE_DEF_SIZE
+    uint16_t img_cache_entry_cnt;
+#endif
+
+    uint32_t draw_layer_used_mem_kb;
+#if LV_USE_OS
+    lv_thread_sync_t draw_sync;
+    lv_mutex_t draw_sw_circle_cache_mutex;
+#else
+    int draw_dispatch_req;
+#endif
+
+#if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0
+    lv_draw_sw_shadow_cache_t sw_shadow_cache;
+#endif
+
+#if LV_USE_THEME_BASIC
+    struct _my_theme_t * theme_basic;
+#endif
+
+#if LV_USE_THEME_DEFAULT
+    struct _my_theme_t * theme_default;
+#endif
+
+#if LV_USE_THEME_MONO
+    struct _my_theme_t * theme_mono;
+#endif
+
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
+    lv_tlsf_state_t tlsf_state;
+#endif
+
+#if LV_USE_FS_STDIO != '\0'
+    lv_fs_drv_t stdio_fs_drv;
+#endif
+#if LV_USE_FS_POSIX
+    lv_fs_drv_t posix_fs_drv;
+#endif
+
+#if LV_USE_FS_FATFS
+    lv_fs_drv_t fatfs_fs_drv;
+#endif
+
+#if LV_USE_FS_WIN32 != '\0'
+    lv_fs_drv_t win32_fs_drv;
+#endif
+
+#if LV_USE_FREETYPE
+    struct _lv_freetype_context_t * ft_context;
+#endif
+
+#if LV_USE_FONT_COMPRESSED
+    lv_font_fmt_rle_t font_fmt_rle;
+#endif
+
+#if LV_USE_SPAN != 0
+    struct _snippet_stack * span_snippet_stack;
+#endif
+
+#if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
+    lv_profiler_builtin_ctx_t profiler_context;
+#endif
+
+#if LV_USE_MSG
+    bool msg_restart_notify;
+    unsigned int msg_recursion_counter;
+#endif
+
+#if LV_USE_FILE_EXPLORER != 0
+    lv_style_t fe_list_btn_style;
+#endif
+
+#if LV_USE_SYSMON
+    perf_info_t sysmon_perf_info;
+#endif
+
+#if LV_USE_IME_PINYIN != 0
+    uint16_t ime_cand_len;
+#endif
+} lv_global_t;
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Get the default global object for current thread
+ * @return  pointer to the default global object
+ */
+lv_global_t * lv_global_default();
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_GLOBAL_H*/

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -17,7 +17,10 @@ extern "C" {
 
 #include <stdbool.h>
 #include "../draw/lv_img_cache.h"
+#include "../draw/lv_draw.h"
+#if LV_USE_DRAW_SW
 #include "../draw/sw/lv_draw_sw.h"
+#endif
 #include "../misc/lv_anim.h"
 #include "../misc/lv_area.h"
 #include "../misc/lv_color_op.h"
@@ -25,16 +28,12 @@ extern "C" {
 #include "../misc/lv_profiler_builtin.h"
 #include "../misc/lv_style.h"
 #include "../misc/lv_timer.h"
-#include "../osal/lv_os.h"
 #include "../stdlib/builtin/lv_tlsf.h"
 
 #if LV_USE_FONT_COMPRESSED
 #include "../font/lv_font_fmt_txt.h"
 #endif
 
-#if LV_USE_SYSMON
-#include "../others/sysmon/lv_sysmon.h"
-#endif
 /*********************
  *      DEFINES
  *********************/
@@ -95,21 +94,14 @@ typedef struct {
 
 #if !LV_TICK_CUSTOM
     uint32_t tick_sys_time;
-    volatile uint8_t tick_irq_flag;
+    volatile uint8_t tick_sys_irq_flag;
 #endif
 
 #if LV_IMG_CACHE_DEF_SIZE
     uint16_t img_cache_entry_cnt;
 #endif
 
-    uint32_t draw_layer_used_mem_kb;
-#if LV_USE_OS
-    lv_thread_sync_t draw_sync;
-    lv_mutex_t draw_sw_circle_cache_mutex;
-#else
-    int draw_dispatch_req;
-#endif
-
+    lv_draw_cache_t draw_cache;
 #if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0
     lv_draw_sw_shadow_cache_t sw_shadow_cache;
 #endif
@@ -170,8 +162,8 @@ typedef struct {
     lv_style_t fe_list_btn_style;
 #endif
 
-#if LV_USE_SYSMON
-    perf_info_t sysmon_perf_info;
+#if LV_USE_SYSMON && LV_USE_PERF_MONITOR
+    void * sysmon_perf_info;
 #endif
 
 #if LV_USE_IME_PINYIN != 0

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -11,11 +11,13 @@
 #include "lv_group.h"
 #include "../misc/lv_gc.h"
 #include "../core/lv_obj.h"
+#include "../core/lv_global.h"
 #include "../indev/lv_indev.h"
 
 /*********************
  *      DEFINES
  *********************/
+#define default_group lv_global_default()->group_default
 
 /**********************
  *      TYPEDEFS
@@ -32,7 +34,6 @@ static lv_indev_t * get_indev(const lv_group_t * g);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_group_t * default_group;
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -11,11 +11,13 @@
 #include "../disp/lv_disp_private.h"
 #include "lv_refr.h"
 #include "../misc/lv_gc.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
 #define MY_CLASS &lv_obj_class
+#define update_layout_mutex lv_global_default()->layout_update_mutex
 
 /**********************
  *      TYPEDEFS
@@ -287,12 +289,11 @@ void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
 
 void lv_obj_update_layout(const lv_obj_t * obj)
 {
-    static bool mutex = false;
-    if(mutex) {
+    if(update_layout_mutex) {
         LV_LOG_TRACE("Already running, returning");
         return;
     }
-    mutex = true;
+    update_layout_mutex = true;
 
     lv_obj_t * scr = lv_obj_get_screen(obj);
     /*Repeat until there are no more layout invalidations*/
@@ -303,7 +304,7 @@ void lv_obj_update_layout(const lv_obj_t * obj)
         LV_LOG_TRACE("Layout update end");
     }
 
-    mutex = false;
+    update_layout_mutex = false;
 }
 
 void lv_obj_set_align(lv_obj_t * obj, lv_align_t align)

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -12,11 +12,12 @@
 #include "../misc/lv_gc.h"
 #include "../misc/lv_color.h"
 #include "../stdlib/lv_string.h"
-
+#include "../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
 #define MY_CLASS &lv_obj_class
+#define style_refr lv_global_default()->style_refresh
 
 /**********************
  *      TYPEDEFS
@@ -61,7 +62,6 @@ static void fade_in_anim_ready(lv_anim_t * a);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static bool style_refr = true;
 
 /**********************
  *      MACROS

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -51,7 +51,6 @@ static void call_flush_cb(lv_disp_t * disp, const lv_area_t * area, uint8_t * px
 /**********************
  *      MACROS
  **********************/
-
 #if LV_LOG_TRACE_DISP_REFR
     #define REFR_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -17,10 +17,14 @@
 #include "../misc/lv_profiler.h"
 #include "../draw/lv_draw.h"
 #include "../font/lv_font_fmt_txt.h"
+#include "lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
+
+/*Display being refreshed*/
+#define disp_refr lv_global_default()->disp_refresh
 
 /**********************
  *      TYPEDEFS
@@ -44,11 +48,10 @@ static void call_flush_cb(lv_disp_t * disp, const lv_area_t * area, uint8_t * px
  *  STATIC VARIABLES
  **********************/
 
-static lv_disp_t * disp_refr; /*Display being refreshed*/
-
 /**********************
  *      MACROS
  **********************/
+
 #if LV_LOG_TRACE_DISP_REFR
     #define REFR_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -51,9 +51,6 @@ void _lv_sdl_mousewheel_handler(SDL_Event * event);
 void _lv_sdl_keyboard_handler(SDL_Event * event);
 static void res_chg_event_cb(lv_event_t * e);
 
-#if !LV_TICK_CUSTOM
-    static int tick_thread(void * ptr);
-#endif
 static bool inited = false;
 
 /**********************
@@ -75,9 +72,7 @@ lv_disp_t * lv_sdl_window_create(lv_coord_t hor_res, lv_coord_t ver_res)
         SDL_Init(SDL_INIT_VIDEO);
         SDL_StartTextInput();
         event_handler_timer = lv_timer_create(sdl_event_handler, 5, NULL);
-#if !LV_TICK_CUSTOM
-        SDL_CreateThread(tick_thread, "LVGL thread", NULL);
-#endif
+        lv_tick_set_cb(SDL_GetTicks);
         inited = true;
     }
 
@@ -335,23 +330,6 @@ static void res_chg_event_cb(lv_event_t * e)
 
     texture_resize(disp);
 }
-
-#if !LV_TICK_CUSTOM
-static int tick_thread(void * ptr)
-{
-    LV_UNUSED(ptr);
-    static uint32_t tick_prev = 0;
-
-    while(1) {
-        uint32_t tick_now = SDL_GetTicks();
-        lv_tick_inc(tick_now - tick_prev);
-        tick_prev = tick_now;
-        SDL_Delay(5);
-    }
-
-    return 0;
-}
-#endif
 
 static void release_disp_cb(lv_event_t * e)
 {

--- a/src/disp/lv_disp.c
+++ b/src/disp/lv_disp.c
@@ -13,6 +13,7 @@
 #include "../misc/lv_gc.h"
 #include "../stdlib/lv_string.h"
 #include "../themes/lv_theme.h"
+#include "../core/lv_global.h"
 
 #if LV_USE_DRAW_SW
     #include "../draw/sw/lv_draw_sw.h"
@@ -22,6 +23,7 @@
 /*********************
  *      DEFINES
  *********************/
+#define disp_def lv_global_default()->disp_default
 
 /**********************
  *      TYPEDEFS
@@ -43,7 +45,6 @@ static bool is_out_anim(lv_scr_load_anim_t a);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_disp_t * disp_def;
 
 /**********************
  *      MACROS

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -97,14 +97,15 @@ void lv_draw_finalize_task_creation(lv_layer_t * layer, lv_draw_task_t * t)
      *and not on the draw tasks added in the event.
      *Sending LV_EVENT_DRAW_TASK_ADDED events might cause recursive event sends
      *Dispatching might remove the "main" draw task while it's still being used in the event*/
-    static bool running = false;
-    if(running == false) {
-        running = true;
+    lv_draw_cache_t * cache = &_draw_cache;
+
+    if(cache->task_running == false) {
+        cache->task_running = true;
         if(base_dsc->obj && lv_obj_has_flag(base_dsc->obj, LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS)) {
             lv_obj_send_event(base_dsc->obj, LV_EVENT_DRAW_TASK_ADDED, t);
         }
         lv_draw_dispatch();
-        running = false;
+        cache->task_running = false;
     }
 }
 

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -9,6 +9,7 @@
 #include "lv_draw.h"
 #include "sw/lv_draw_sw.h"
 #include "../disp/lv_disp_private.h"
+#include "../core/lv_global.h"
 #include "../core/lv_refr.h"
 #include "../stdlib/lv_string.h"
 #include "../misc/lv_gc.h"
@@ -16,6 +17,9 @@
 /*********************
  *      DEFINES
  *********************/
+#define used_memory_for_layers_kb lv_global_default()->draw_layer_used_mem_kb
+#define sync lv_global_default()->draw_sync
+#define dispatch_req lv_global_default()->draw_dispatch_req
 
 /**********************
  *      TYPEDEFS
@@ -29,13 +33,6 @@ static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check);
 /**********************
  *  STATIC VARIABLES
  **********************/
-#if LV_USE_OS
-    static lv_thread_sync_t sync;
-#else
-    static int dispatch_req = 0;
-#endif
-
-static uint32_t used_memory_for_layers_kb = 0;
 
 /**********************
  *  STATIC VARIABLES

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -186,6 +186,7 @@ typedef struct {
 #else
     int dispatch_req;
 #endif
+    bool task_running;
 } lv_draw_cache_t;
 
 /**********************

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -20,7 +20,7 @@ extern "C" {
 #include "../misc/lv_profiler.h"
 #include "lv_img_decoder.h"
 #include "lv_img_cache.h"
-
+#include "../osal/lv_os.h"
 /*********************
  *      DEFINES
  *********************/
@@ -177,6 +177,16 @@ typedef struct {
     uint32_t id2;
     lv_layer_t * layer;
 } lv_draw_dsc_base_t;
+
+typedef struct {
+    uint32_t used_memory_for_layers_kb;
+#if LV_USE_OS
+    lv_thread_sync_t sync;
+    lv_mutex_t circle_cache_mutex;
+#else
+    int dispatch_req;
+#endif
+} lv_draw_cache_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/draw/lv_img_cache.c
+++ b/src/draw/lv_img_cache.c
@@ -8,10 +8,12 @@
  *********************/
 #include "lv_img_cache.h"
 #include "../stdlib/lv_string.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
+#define img_cache_manager lv_global_default()->img_cache_mgr
 
 /**********************
  *      TYPEDEFS
@@ -24,8 +26,6 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-static lv_img_cache_manager_t img_cache_manager = { 0 };
 
 /**********************
  *      MACROS

--- a/src/draw/lv_img_cache_builtin.c
+++ b/src/draw/lv_img_cache_builtin.c
@@ -13,10 +13,15 @@
 #include "../tick/lv_tick.h"
 #include "../misc/lv_assert.h"
 #include "../misc/lv_gc.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
+#if LV_IMG_CACHE_DEF_SIZE
+    #define entry_cnt lv_global_default()->img_cache_entry_cnt
+#endif
+
 
 /** Count the cache entries's life. Add `time_to_open` to `life` when the entry is used.
  * Decrement all lifes by one every in every ::lv_img_cache_open.
@@ -53,9 +58,6 @@ static void lv_img_cache_invalidate_src_builtin(const void * src);
 /**********************
  *  STATIC VARIABLES
  **********************/
-#if LV_IMG_CACHE_DEF_SIZE
-    static uint16_t entry_cnt;
-#endif
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -39,6 +39,12 @@ typedef struct {
     uint32_t idx;
 } lv_draw_sw_unit_t;
 
+typedef struct {
+    uint8_t cache[LV_DRAW_SW_SHADOW_CACHE_SIZE * LV_DRAW_SW_SHADOW_CACHE_SIZE];
+    int32_t cache_size;
+    int32_t cache_r;
+} lv_draw_sw_shadow_cache_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -99,10 +99,11 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     lv_opa_t * sh_buf;
 
 #if LV_DRAW_SW_SHADOW_CACHE_SIZE
-    if(shadow_cache.cache_size == corner_size && shadow_cache.cache_r == r_sh) {
+    lv_draw_sw_shadow_cache_t * cache = &shadow_cache;
+    if(cache->cache_size == corner_size && cache->cache_r == r_sh) {
         /*Use the cache if available*/
         sh_buf = lv_malloc(corner_size * corner_size);
-        lv_memcpy(sh_buf, shadow_cache.cache, corner_size * corner_size);
+        lv_memcpy(sh_buf, cache->cache, corner_size * corner_size);
     }
     else {
         /*A larger buffer is required for calculation*/
@@ -110,10 +111,10 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
         shadow_draw_corner_buf(&core_area, (uint16_t *)sh_buf, dsc->width, r_sh);
 
         /*Cache the corner if it fits into the cache size*/
-        if((uint32_t)corner_size * corner_size < sizeof(shadow_cache.cache)) {
-            lv_memcpy(shadow_cache.cache, sh_buf, corner_size * corner_size);
-            shadow_cache.cache_size = corner_size;
-            shadow_cache.cache_r = r_sh;
+        if((uint32_t)corner_size * corner_size < sizeof(cache->cache)) {
+            lv_memcpy(cache->cache, sh_buf, corner_size * corner_size);
+            cache->cache_size = corner_size;
+            cache->cache_r = r_sh;
         }
     }
 #else

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -10,6 +10,7 @@
 #if LV_USE_DRAW_SW
 
 #include "blend/lv_draw_sw_blend.h"
+#include "../../core/lv_global.h"
 #include "../../misc/lv_math.h"
 #include "../../core/lv_refr.h"
 #include "../../misc/lv_assert.h"
@@ -21,6 +22,10 @@
  *********************/
 #define SHADOW_UPSCALE_SHIFT    6
 #define SHADOW_ENHANCE          1
+
+#if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0
+    #define shadow_cache lv_global_default()->sw_shadow_cache
+#endif
 
 /**********************
  *      TYPEDEFS
@@ -39,11 +44,6 @@ LV_ATTRIBUTE_FAST_MEM static void shadow_blur_corner(lv_coord_t size, lv_coord_t
 /**********************
  *  STATIC VARIABLES
  **********************/
-#if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0
-    static uint8_t sh_cache[LV_DRAW_SW_SHADOW_CACHE_SIZE * LV_DRAW_SW_SHADOW_CACHE_SIZE];
-    static int32_t sh_cache_size = -1;
-    static int32_t sh_cache_r = -1;
-#endif
 
 /**********************
  *      MACROS
@@ -99,10 +99,10 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     lv_opa_t * sh_buf;
 
 #if LV_DRAW_SW_SHADOW_CACHE_SIZE
-    if(sh_cache_size == corner_size && sh_cache_r == r_sh) {
+    if(shadow_cache.cache_size == corner_size && shadow_cache.cache_r == r_sh) {
         /*Use the cache if available*/
         sh_buf = lv_malloc(corner_size * corner_size);
-        lv_memcpy(sh_buf, sh_cache, corner_size * corner_size);
+        lv_memcpy(sh_buf, shadow_cache.cache, corner_size * corner_size);
     }
     else {
         /*A larger buffer is required for calculation*/
@@ -110,10 +110,10 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
         shadow_draw_corner_buf(&core_area, (uint16_t *)sh_buf, dsc->width, r_sh);
 
         /*Cache the corner if it fits into the cache size*/
-        if((uint32_t)corner_size * corner_size < sizeof(sh_cache)) {
-            lv_memcpy(sh_cache, sh_buf, corner_size * corner_size);
-            sh_cache_size = corner_size;
-            sh_cache_r = r_sh;
+        if((uint32_t)corner_size * corner_size < sizeof(shadow_cache.cache)) {
+            lv_memcpy(shadow_cache.cache, sh_buf, corner_size * corner_size);
+            shadow_cache.cache_size = corner_size;
+            shadow_cache.cache_r = r_sh;
         }
     }
 #else

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -10,6 +10,7 @@
 
 #if LV_DRAW_SW_COMPLEX
 #include "lv_draw_sw_mask.h"
+#include "../../core/lv_global.h"
 #include "../../misc/lv_math.h"
 #include "../../misc/lv_log.h"
 #include "../../misc/lv_assert.h"
@@ -22,6 +23,9 @@
  *********************/
 #define CIRCLE_CACHE_LIFE_MAX   1000
 #define CIRCLE_CACHE_AGING(life, r)   life = LV_MIN(life + (r < 16 ? 1 : (r >> 4)), 1000)
+#if LV_USE_OS
+    #define circle_cache_mutex lv_global_default()->draw_sw_circle_cache_mutex
+#endif
 
 /**********************
  *      TYPEDEFS
@@ -66,9 +70,6 @@ LV_ATTRIBUTE_FAST_MEM static inline lv_opa_t mask_mix(lv_opa_t mask_act, lv_opa_
 /**********************
  *  STATIC VARIABLES
  **********************/
-#if LV_USE_OS
-    static lv_mutex_t circle_cache_mutex;
-#endif
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -24,7 +24,7 @@
 #define CIRCLE_CACHE_LIFE_MAX   1000
 #define CIRCLE_CACHE_AGING(life, r)   life = LV_MIN(life + (r < 16 ? 1 : (r >> 4)), 1000)
 #if LV_USE_OS
-    #define circle_cache_mutex lv_global_default()->draw_sw_circle_cache_mutex
+    #define circle_cache_mutex lv_global_default()->draw_cache.circle_cache_mutex
 #endif
 
 /**********************

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -471,65 +471,67 @@ static inline uint8_t get_bits(const uint8_t * in, uint32_t bit_pos, uint8_t len
 
 static inline void rle_init(const uint8_t * in,  uint8_t bpp)
 {
-    font_rle.in = in;
-    font_rle.bpp = bpp;
-    font_rle.state = RLE_STATE_SINGLE;
-    font_rle.rdp = 0;
-    font_rle.prev_v = 0;
-    font_rle.count = 0;
+    lv_font_fmt_rle_t * rle = &font_rle;
+    rle->in = in;
+    rle->bpp = bpp;
+    rle->state = RLE_STATE_SINGLE;
+    rle->rdp = 0;
+    rle->prev_v = 0;
+    rle->count = 0;
 }
 
 static inline uint8_t rle_next(void)
 {
     uint8_t v = 0;
     uint8_t ret = 0;
+    lv_font_fmt_rle_t * rle = &font_rle;
 
-    if(font_rle.state == RLE_STATE_SINGLE) {
-        ret = get_bits(font_rle.in, font_rle.rdp, font_rle.bpp);
-        if(font_rle.rdp != 0 && font_rle.prev_v == ret) {
-            font_rle.count = 0;
-            font_rle.state = RLE_STATE_REPEATE;
+    if(rle->state == RLE_STATE_SINGLE) {
+        ret = get_bits(rle->in, rle->rdp, rle->bpp);
+        if(rle->rdp != 0 && rle->prev_v == ret) {
+            rle->count = 0;
+            rle->state = RLE_STATE_REPEATE;
         }
 
-        font_rle.prev_v = ret;
-        font_rle.rdp += font_rle.bpp;
+        rle->prev_v = ret;
+        rle->rdp += rle->bpp;
     }
-    else if(font_rle.state == RLE_STATE_REPEATE) {
-        v = get_bits(font_rle.in, font_rle.rdp, 1);
-        font_rle.count++;
-        font_rle.rdp += 1;
+    else if(rle->state == RLE_STATE_REPEATE) {
+        v = get_bits(rle->in, rle->rdp, 1);
+        rle->count++;
+        rle->rdp += 1;
         if(v == 1) {
-            ret = font_rle.prev_v;
-            if(font_rle.count == 11) {
-                font_rle.count = get_bits(font_rle.in, font_rle.rdp, 6);
-                font_rle.rdp += 6;
-                if(font_rle.count != 0) {
-                    font_rle.state = RLE_STATE_COUNTER;
+            ret = rle->prev_v;
+            if(rle->count == 11) {
+                rle->count = get_bits(rle->in, rle->rdp, 6);
+                rle->rdp += 6;
+                if(rle->count != 0) {
+                    rle->state = RLE_STATE_COUNTER;
                 }
                 else {
-                    ret = get_bits(font_rle.in, font_rle.rdp, font_rle.bpp);
-                    font_rle.prev_v = ret;
-                    font_rle.rdp += font_rle.bpp;
-                    font_rle.state = RLE_STATE_SINGLE;
+                    ret = get_bits(rle->in, rle->rdp, rle->bpp);
+                    rle->prev_v = ret;
+                    rle->rdp += rle->bpp;
+                    rle->state = RLE_STATE_SINGLE;
                 }
             }
         }
         else {
-            ret = get_bits(font_rle.in, font_rle.rdp, font_rle.bpp);
-            font_rle.prev_v = ret;
-            font_rle.rdp += font_rle.bpp;
-            font_rle.state = RLE_STATE_SINGLE;
+            ret = get_bits(rle->in, rle->rdp, rle->bpp);
+            rle->prev_v = ret;
+            rle->rdp += rle->bpp;
+            rle->state = RLE_STATE_SINGLE;
         }
 
     }
-    else if(font_rle.state == RLE_STATE_COUNTER) {
-        ret = font_rle.prev_v;
-        font_rle.count--;
-        if(font_rle.count == 0) {
-            ret = get_bits(font_rle.in, font_rle.rdp, font_rle.bpp);
-            font_rle.prev_v = ret;
-            font_rle.rdp += font_rle.bpp;
-            font_rle.state = RLE_STATE_SINGLE;
+    else if(rle->state == RLE_STATE_COUNTER) {
+        ret = rle->prev_v;
+        rle->count--;
+        if(rle->count == 0) {
+            ret = get_bits(rle->in, rle->rdp, rle->bpp);
+            rle->prev_v = ret;
+            rle->rdp += rle->bpp;
+            rle->state = RLE_STATE_SINGLE;
         }
     }
 

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -194,6 +194,23 @@ typedef struct {
     uint16_t bitmap_format  : 2;
 } lv_font_fmt_txt_dsc_t;
 
+#if LV_USE_FONT_COMPRESSED
+typedef enum {
+    RLE_STATE_SINGLE = 0,
+    RLE_STATE_REPEATE,
+    RLE_STATE_COUNTER,
+} lv_font_fmt_rle_state_t;
+
+typedef struct {
+    uint32_t rdp;
+    const uint8_t * in;
+    uint8_t bpp;
+    uint8_t prev_v;
+    uint8_t count;
+    lv_font_fmt_rle_state_t state;
+} lv_font_fmt_rle_t;
+#endif
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -9,6 +9,7 @@
 #include "lv_indev_private.h"
 #include "lv_indev_scroll.h"
 #include "../disp/lv_disp_private.h"
+#include "../core/lv_global.h"
 #include "../core/lv_obj.h"
 #include "../core/lv_group.h"
 #include "../core/lv_refr.h"
@@ -47,6 +48,9 @@
     #warning "LV_INDEV_DRAG_THROW must be greater than 0"
 #endif
 
+#define indev_act lv_global_default()->indev_active
+#define indev_obj_act lv_global_default()->indev_obj_active
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -69,8 +73,6 @@ static bool indev_reset_check(lv_indev_t * indev);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_indev_t * indev_act;
-static lv_obj_t * indev_obj_act = NULL;
 
 /**********************
  *      MACROS

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -953,7 +953,7 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
     lv_coord_t x = i->btn_points[data->btn_id].x;
     lv_coord_t y = i->btn_points[data->btn_id].y;
 
-    if(i->pointer.prev_state != data->state) {
+    if(LV_INDEV_STATE_RELEASED != data->state) {
         if(data->state == LV_INDEV_STATE_PRESSED) {
             LV_LOG_INFO("button %" LV_PRIu32 " is pressed (x:%d y:%d)", data->btn_id, (int)x, (int)y);
         }

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -953,8 +953,7 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
     lv_coord_t x = i->btn_points[data->btn_id].x;
     lv_coord_t y = i->btn_points[data->btn_id].y;
 
-    static lv_indev_state_t prev_state = LV_INDEV_STATE_RELEASED;
-    if(prev_state != data->state) {
+    if(i->pointer.prev_state != data->state) {
         if(data->state == LV_INDEV_STATE_PRESSED) {
             LV_LOG_INFO("button %" LV_PRIu32 " is pressed (x:%d y:%d)", data->btn_id, (int)x, (int)y);
         }

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -93,8 +93,6 @@ struct _lv_indev_t {
         lv_dir_t scroll_dir : 4;
         lv_dir_t gesture_dir : 4;
         uint8_t gesture_sent : 1;
-
-        lv_indev_state_t prev_state;
     } pointer;
     struct {
         /*Keypad data*/

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -93,6 +93,8 @@ struct _lv_indev_t {
         lv_dir_t scroll_dir : 4;
         lv_dir_t gesture_dir : 4;
         uint8_t gesture_sent : 1;
+
+        lv_indev_state_t prev_state;
     } pointer;
     struct {
         /*Keypad data*/

--- a/src/layouts/lv_layout.c
+++ b/src/layouts/lv_layout.c
@@ -8,11 +8,13 @@
  *********************/
 #include "lv_layout.h"
 #include "../misc/lv_gc.h"
+#include "../core/lv_global.h"
 #include "../core/lv_obj.h"
 
 /*********************
  *      DEFINES
  *********************/
+#define layout_cnt lv_global_default()->layout_count
 
 /**********************
  *      TYPEDEFS
@@ -25,7 +27,6 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
-static uint32_t layout_cnt = _LV_LAYOUT_LAST;
 
 /**********************
  *      MACROS

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -17,6 +17,7 @@
 #include FT_IMAGE_H
 #include FT_OUTLINE_H
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -31,6 +32,8 @@
 #if LV_FREETYPE_CACHE_SIZE <= 0
     #error "LV_FREETYPE_CACHE_SIZE must > 0"
 #endif
+
+#define ft_ctx lv_global_default()->ft_context
 
 /**********************
  *      TYPEDEFS
@@ -80,8 +83,6 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font,
 *  STATIC VARIABLES
 **********************/
 
-static lv_freetype_context_t ft_ctx;
-
 /**********************
  *      MACROS
  **********************/
@@ -94,39 +95,46 @@ lv_res_t lv_freetype_init(uint16_t max_faces, uint16_t max_sizes, uint32_t max_b
 {
     FT_Error error;
 
-    error = FT_Init_FreeType(&ft_ctx.library);
+    ft_ctx = lv_malloc(sizeof(lv_freetype_context_t));
+    LV_ASSERT_MALLOC(ft_ctx);
+    if(!ft_ctx) {
+        LV_LOG_ERROR("malloc failed for lv_freetype_context_t");
+        return LV_RES_INV;
+    }
+
+    error = FT_Init_FreeType(&ft_ctx->library);
     if(error) {
         FT_ERROR_MSG("FT_Init_FreeType", error);
         return LV_RES_INV;
     }
 
-    error = FTC_Manager_New(ft_ctx.library,
+    error = FTC_Manager_New(ft_ctx->library,
                             max_faces,
                             max_sizes,
                             max_bytes,
                             freetpye_face_requester,
                             NULL,
-                            &ft_ctx.cache_manager);
+                            &ft_ctx->cache_manager);
     if(error) {
-        FT_Done_FreeType(ft_ctx.library);
+        FT_Done_FreeType(ft_ctx->library);
         FT_ERROR_MSG("FTC_Manager_New", error);
         return LV_RES_INV;
     }
 
-    error = FTC_CMapCache_New(ft_ctx.cache_manager, &ft_ctx.cmap_cache);
+    error = FTC_CMapCache_New(ft_ctx->cache_manager, &ft_ctx->cmap_cache);
     if(error) {
         FT_ERROR_MSG("FTC_CMapCache_New", error);
         goto failed;
     }
 
 #if LV_FREETYPE_SBIT_CACHE
-    error = FTC_SBitCache_New(ft_ctx.cache_manager, &ft_ctx.sbit_cache);
+    error = FTC_SBitCache_New(ft_ctx->cache_manager, &ft_ctx->sbit_cache);
     if(error) {
         FT_ERROR_MSG("FTC_SBitCache_New", error);
         goto failed;
     }
 #else
-    error = FTC_ImageCache_New(ft_ctx.cache_manager, &ft_ctx.image_cache);
+    error = FTC_ImageCache_New(ft_ctx->cache_manager, &ft_ctx->image_cache);
     if(error) {
         FT_ERROR_MSG("FTC_ImageCache_New", error);
         goto failed;
@@ -135,15 +143,18 @@ lv_res_t lv_freetype_init(uint16_t max_faces, uint16_t max_sizes, uint32_t max_b
 
     return LV_RES_OK;
 failed:
-    FTC_Manager_Done(ft_ctx.cache_manager);
-    FT_Done_FreeType(ft_ctx.library);
+    FTC_Manager_Done(ft_ctx->cache_manager);
+    FT_Done_FreeType(ft_ctx->library);
     return LV_RES_INV;
 }
 
 void lv_freetype_uninit(void)
 {
-    FTC_Manager_Done(ft_ctx.cache_manager);
-    FT_Done_FreeType(ft_ctx.library);
+    LV_ASSERT_NULL(ft_ctx);
+    FTC_Manager_Done(ft_ctx->cache_manager);
+    FT_Done_FreeType(ft_ctx->library);
+    lv_free(ft_ctx);
+    ft_ctx = NULL;
 }
 
 lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16_t style)
@@ -187,7 +198,7 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16
     scaler.width = size;
     scaler.height = size;
     scaler.pixel = 1;
-    FT_Error error = FTC_Manager_LookupSize(ft_ctx.cache_manager,
+    FT_Error error = FTC_Manager_LookupSize(ft_ctx->cache_manager,
                                             &scaler,
                                             &face_size);
     if(error) {
@@ -218,7 +229,7 @@ void lv_freetype_font_del(lv_font_t * font)
     LV_ASSERT_NULL(font);
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)(font->dsc);
     LV_ASSERT_NULL(dsc);
-    FTC_Manager_RemoveFaceID(ft_ctx.cache_manager, (FTC_FaceID)dsc);
+    FTC_Manager_RemoveFaceID(ft_ctx->cache_manager, (FTC_FaceID)dsc);
     lv_free(dsc->pathname);
     lv_free(dsc);
 }
@@ -238,7 +249,7 @@ static FT_Error freetpye_face_requester(FTC_FaceID face_id,
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)face_id;
     FT_Error error;
 
-    error = FT_New_Face(ft_ctx.library, dsc->pathname, 0, aface);
+    error = FT_New_Face(ft_ctx->library, dsc->pathname, 0, aface);
     if(error) {
         FT_ERROR_MSG("FT_New_Face", error);
     }
@@ -311,7 +322,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     scaler.width = dsc->size;
     scaler.height = dsc->size;
     scaler.pixel = 1;
-    error = FTC_Manager_LookupSize(ft_ctx.cache_manager, &scaler, &face_size);
+    error = FTC_Manager_LookupSize(ft_ctx->cache_manager, &scaler, &face_size);
     if(error) {
         FT_ERROR_MSG("FTC_Manager_LookupSize", error);
         return false;
@@ -319,7 +330,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
 
     FT_Face face = face_size->face;
     FT_UInt charmap_index = FT_Get_Charmap_Index(face->charmap);
-    FT_UInt glyph_index = FTC_CMapCache_Lookup(ft_ctx.cmap_cache, face_id, charmap_index, unicode_letter);
+    FT_UInt glyph_index = FTC_CMapCache_Lookup(ft_ctx->cmap_cache, face_id, charmap_index, unicode_letter);
     dsc_out->is_placeholder = glyph_index == 0;
 
     if(dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) {
@@ -332,10 +343,10 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     }
 
     if(dsc->style & LV_FREETYPE_FONT_STYLE_BOLD) {
-        ft_ctx.current_face = face;
+        ft_ctx->current_face = face;
         error = freetype_get_bold_glyph(font, face, glyph_index, dsc_out);
         if(error) {
-            ft_ctx.current_face = NULL;
+            ft_ctx->current_face = NULL;
             return false;
         }
         goto end;
@@ -348,17 +359,17 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     desc_type.width = dsc->size;
 
 #if LV_FREETYPE_SBIT_CACHE
-    error = FTC_SBitCache_Lookup(ft_ctx.sbit_cache,
+    error = FTC_SBitCache_Lookup(ft_ctx->sbit_cache,
                                  &desc_type,
                                  glyph_index,
-                                 &ft_ctx.sbit,
+                                 &ft_ctx->sbit,
                                  NULL);
     if(error) {
         FT_ERROR_MSG("FTC_SBitCache_Lookup", error);
         return false;
     }
 
-    FTC_SBit sbit = ft_ctx.sbit;
+    FTC_SBit sbit = ft_ctx->sbit;
     dsc_out->adv_w = sbit->xadvance;
     dsc_out->box_h = sbit->height;  /*Height of the bitmap in [px]*/
     dsc_out->box_w = sbit->width;   /*Width of the bitmap in [px]*/
@@ -366,21 +377,21 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     dsc_out->ofs_y = sbit->top - sbit->height; /*Y offset of the bitmap measured from the as line*/
     dsc_out->bpp = 8;               /*Bit per pixel: 1/2/4/8*/
 #else
-    error = FTC_ImageCache_Lookup(ft_ctx.image_cache,
+    error = FTC_ImageCache_Lookup(ft_ctx->image_cache,
                                   &desc_type,
                                   glyph_index,
-                                  &ft_ctx.image_glyph,
+                                  &ft_ctx->image_glyph,
                                   NULL);
     if(error) {
         FT_ERROR_MSG("ImageCache_Lookup", error);
         return false;
     }
-    if(ft_ctx.image_glyph->format != FT_GLYPH_FORMAT_BITMAP) {
+    if(ft_ctx->image_glyph->format != FT_GLYPH_FORMAT_BITMAP) {
         LV_LOG_ERROR("image_glyph->format != FT_GLYPH_FORMAT_BITMAP");
         return false;
     }
 
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx.image_glyph;
+    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx->image_glyph;
     dsc_out->adv_w = (glyph_bitmap->root.advance.x >> 16);
     dsc_out->box_h = glyph_bitmap->bitmap.rows;         /*Height of the bitmap in [px]*/
     dsc_out->box_w = glyph_bitmap->bitmap.width;        /*Width of the bitmap in [px]*/
@@ -405,16 +416,16 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, uint
 
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     if(dsc->style & LV_FREETYPE_FONT_STYLE_BOLD) {
-        if(ft_ctx.current_face && ft_ctx.current_face->glyph->format == FT_GLYPH_FORMAT_BITMAP) {
-            return (const uint8_t *)(ft_ctx.current_face->glyph->bitmap.buffer);
+        if(ft_ctx->current_face && ft_ctx->current_face->glyph->format == FT_GLYPH_FORMAT_BITMAP) {
+            return (const uint8_t *)(ft_ctx->current_face->glyph->bitmap.buffer);
         }
         return NULL;
     }
 
 #if LV_FREETYPE_SBIT_CACHE
-    return (const uint8_t *)ft_ctx.sbit->buffer;
+    return (const uint8_t *)ft_ctx->sbit->buffer;
 #else
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx.image_glyph;
+    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx->image_glyph;
     return (const uint8_t *)glyph_bitmap->bitmap.buffer;
 #endif
 }

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -94,47 +94,46 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font,
 lv_res_t lv_freetype_init(uint16_t max_faces, uint16_t max_sizes, uint32_t max_bytes)
 {
     FT_Error error;
-
-    ft_ctx = lv_malloc(sizeof(lv_freetype_context_t));
-    LV_ASSERT_MALLOC(ft_ctx);
-    if(!ft_ctx) {
+    lv_freetype_context_t * context = ft_ctx = lv_malloc(sizeof(lv_freetype_context_t));
+    LV_ASSERT_MALLOC(context);
+    if(!context) {
         LV_LOG_ERROR("malloc failed for lv_freetype_context_t");
         return LV_RES_INV;
     }
 
-    error = FT_Init_FreeType(&ft_ctx->library);
+    error = FT_Init_FreeType(&context->library);
     if(error) {
         FT_ERROR_MSG("FT_Init_FreeType", error);
         return LV_RES_INV;
     }
 
-    error = FTC_Manager_New(ft_ctx->library,
+    error = FTC_Manager_New(context->library,
                             max_faces,
                             max_sizes,
                             max_bytes,
                             freetpye_face_requester,
                             NULL,
-                            &ft_ctx->cache_manager);
+                            &context->cache_manager);
     if(error) {
-        FT_Done_FreeType(ft_ctx->library);
+        FT_Done_FreeType(context->library);
         FT_ERROR_MSG("FTC_Manager_New", error);
         return LV_RES_INV;
     }
 
-    error = FTC_CMapCache_New(ft_ctx->cache_manager, &ft_ctx->cmap_cache);
+    error = FTC_CMapCache_New(context->cache_manager, &context->cmap_cache);
     if(error) {
         FT_ERROR_MSG("FTC_CMapCache_New", error);
         goto failed;
     }
 
 #if LV_FREETYPE_SBIT_CACHE
-    error = FTC_SBitCache_New(ft_ctx->cache_manager, &ft_ctx->sbit_cache);
+    error = FTC_SBitCache_New(context->cache_manager, &context->sbit_cache);
     if(error) {
         FT_ERROR_MSG("FTC_SBitCache_New", error);
         goto failed;
     }
 #else
-    error = FTC_ImageCache_New(ft_ctx->cache_manager, &ft_ctx->image_cache);
+    error = FTC_ImageCache_New(context->cache_manager, &context->image_cache);
     if(error) {
         FT_ERROR_MSG("FTC_ImageCache_New", error);
         goto failed;
@@ -143,17 +142,21 @@ lv_res_t lv_freetype_init(uint16_t max_faces, uint16_t max_sizes, uint32_t max_b
 
     return LV_RES_OK;
 failed:
-    FTC_Manager_Done(ft_ctx->cache_manager);
-    FT_Done_FreeType(ft_ctx->library);
+    FTC_Manager_Done(context->cache_manager);
+    FT_Done_FreeType(context->library);
     return LV_RES_INV;
 }
 
 void lv_freetype_uninit(void)
 {
-    LV_ASSERT_NULL(ft_ctx);
-    FTC_Manager_Done(ft_ctx->cache_manager);
-    FT_Done_FreeType(ft_ctx->library);
-    lv_free(ft_ctx);
+    lv_freetype_context_t * context = ft_ctx;
+    if(!context) {
+        return;
+    }
+
+    FTC_Manager_Done(context->cache_manager);
+    FT_Done_FreeType(context->library);
+    lv_free(context);
     ft_ctx = NULL;
 }
 
@@ -312,6 +315,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
         return true;
     }
 
+    lv_freetype_context_t * context = ft_ctx;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)(font->dsc);
 
     FTC_FaceID face_id = (FTC_FaceID)dsc;
@@ -322,7 +326,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     scaler.width = dsc->size;
     scaler.height = dsc->size;
     scaler.pixel = 1;
-    error = FTC_Manager_LookupSize(ft_ctx->cache_manager, &scaler, &face_size);
+    error = FTC_Manager_LookupSize(context->cache_manager, &scaler, &face_size);
     if(error) {
         FT_ERROR_MSG("FTC_Manager_LookupSize", error);
         return false;
@@ -330,7 +334,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
 
     FT_Face face = face_size->face;
     FT_UInt charmap_index = FT_Get_Charmap_Index(face->charmap);
-    FT_UInt glyph_index = FTC_CMapCache_Lookup(ft_ctx->cmap_cache, face_id, charmap_index, unicode_letter);
+    FT_UInt glyph_index = FTC_CMapCache_Lookup(context->cmap_cache, face_id, charmap_index, unicode_letter);
     dsc_out->is_placeholder = glyph_index == 0;
 
     if(dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) {
@@ -343,10 +347,10 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     }
 
     if(dsc->style & LV_FREETYPE_FONT_STYLE_BOLD) {
-        ft_ctx->current_face = face;
+        context->current_face = face;
         error = freetype_get_bold_glyph(font, face, glyph_index, dsc_out);
         if(error) {
-            ft_ctx->current_face = NULL;
+            context->current_face = NULL;
             return false;
         }
         goto end;
@@ -359,17 +363,17 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     desc_type.width = dsc->size;
 
 #if LV_FREETYPE_SBIT_CACHE
-    error = FTC_SBitCache_Lookup(ft_ctx->sbit_cache,
+    error = FTC_SBitCache_Lookup(context->sbit_cache,
                                  &desc_type,
                                  glyph_index,
-                                 &ft_ctx->sbit,
+                                 &context->sbit,
                                  NULL);
     if(error) {
         FT_ERROR_MSG("FTC_SBitCache_Lookup", error);
         return false;
     }
 
-    FTC_SBit sbit = ft_ctx->sbit;
+    FTC_SBit sbit = context->sbit;
     dsc_out->adv_w = sbit->xadvance;
     dsc_out->box_h = sbit->height;  /*Height of the bitmap in [px]*/
     dsc_out->box_w = sbit->width;   /*Width of the bitmap in [px]*/
@@ -377,21 +381,21 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     dsc_out->ofs_y = sbit->top - sbit->height; /*Y offset of the bitmap measured from the as line*/
     dsc_out->bpp = 8;               /*Bit per pixel: 1/2/4/8*/
 #else
-    error = FTC_ImageCache_Lookup(ft_ctx->image_cache,
+    error = FTC_ImageCache_Lookup(context->image_cache,
                                   &desc_type,
                                   glyph_index,
-                                  &ft_ctx->image_glyph,
+                                  &context->image_glyph,
                                   NULL);
     if(error) {
         FT_ERROR_MSG("ImageCache_Lookup", error);
         return false;
     }
-    if(ft_ctx->image_glyph->format != FT_GLYPH_FORMAT_BITMAP) {
+    if(context->image_glyph->format != FT_GLYPH_FORMAT_BITMAP) {
         LV_LOG_ERROR("image_glyph->format != FT_GLYPH_FORMAT_BITMAP");
         return false;
     }
 
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx->image_glyph;
+    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)context->image_glyph;
     dsc_out->adv_w = (glyph_bitmap->root.advance.x >> 16);
     dsc_out->box_h = glyph_bitmap->bitmap.rows;         /*Height of the bitmap in [px]*/
     dsc_out->box_w = glyph_bitmap->bitmap.width;        /*Width of the bitmap in [px]*/
@@ -415,17 +419,19 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, uint
     LV_UNUSED(buf_out);
 
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
+    lv_freetype_context_t * context = ft_ctx;
+
     if(dsc->style & LV_FREETYPE_FONT_STYLE_BOLD) {
-        if(ft_ctx->current_face && ft_ctx->current_face->glyph->format == FT_GLYPH_FORMAT_BITMAP) {
-            return (const uint8_t *)(ft_ctx->current_face->glyph->bitmap.buffer);
+        if(context->current_face && context->current_face->glyph->format == FT_GLYPH_FORMAT_BITMAP) {
+            return (const uint8_t *)(context->current_face->glyph->bitmap.buffer);
         }
         return NULL;
     }
 
 #if LV_FREETYPE_SBIT_CACHE
-    return (const uint8_t *)ft_ctx->sbit->buffer;
+    return (const uint8_t *)context->sbit->buffer;
 #else
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)ft_ctx->image_glyph;
+    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)context->image_glyph;
     return (const uint8_t *)glyph_bitmap->bitmap.buffer;
 #endif
 }

--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -11,6 +11,7 @@
 #if LV_USE_FS_FATFS
 #include "ff.h"
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -62,25 +63,25 @@ void lv_fs_fatfs_init(void)
      *--------------------------------------------------*/
 
     /*Add a simple drive to open images*/
-    static lv_fs_drv_t fs_drv; /*A driver descriptor*/
-    lv_fs_drv_init(&fs_drv);
+    lv_fs_drv_t * fs_drv_p = &(lv_global_default()->fatfs_fs_drv);
+    lv_fs_drv_init(fs_drv_p);
 
     /*Set up fields...*/
-    fs_drv.letter = LV_FS_FATFS_LETTER;
-    fs_drv.cache_size = LV_FS_FATFS_CACHE_SIZE;
+    fs_drv_p->letter = LV_FS_FATFS_LETTER;
+    fs_drv_p->cache_size = LV_FS_FATFS_CACHE_SIZE;
 
-    fs_drv.open_cb = fs_open;
-    fs_drv.close_cb = fs_close;
-    fs_drv.read_cb = fs_read;
-    fs_drv.write_cb = fs_write;
-    fs_drv.seek_cb = fs_seek;
-    fs_drv.tell_cb = fs_tell;
+    fs_drv_p->open_cb = fs_open;
+    fs_drv_p->close_cb = fs_close;
+    fs_drv_p->read_cb = fs_read;
+    fs_drv_p->write_cb = fs_write;
+    fs_drv_p->seek_cb = fs_seek;
+    fs_drv_p->tell_cb = fs_tell;
 
-    fs_drv.dir_close_cb = fs_dir_close;
-    fs_drv.dir_open_cb = fs_dir_open;
-    fs_drv.dir_read_cb = fs_dir_read;
+    fs_drv_p->dir_close_cb = fs_dir_close;
+    fs_drv_p->dir_open_cb = fs_dir_open;
+    fs_drv_p->dir_read_cb = fs_dir_read;
 
-    lv_fs_drv_register(&fs_drv);
+    lv_fs_drv_register(fs_drv_p);
 }
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -21,6 +21,7 @@
     #include <windows.h>
 #endif
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -68,25 +69,25 @@ void lv_fs_posix_init(void)
      *--------------------------------------------------*/
 
     /*Add a simple drive to open images*/
-    static lv_fs_drv_t fs_drv; /*A driver descriptor*/
-    lv_fs_drv_init(&fs_drv);
+    lv_fs_drv_t * fs_drv_p = &(lv_global_default()->posix_fs_drv);
+    lv_fs_drv_init(fs_drv_p);
 
     /*Set up fields...*/
-    fs_drv.letter = LV_FS_POSIX_LETTER;
-    fs_drv.cache_size = LV_FS_POSIX_CACHE_SIZE;
+    fs_drv_p->letter = LV_FS_POSIX_LETTER;
+    fs_drv_p->cache_size = LV_FS_POSIX_CACHE_SIZE;
 
-    fs_drv.open_cb = fs_open;
-    fs_drv.close_cb = fs_close;
-    fs_drv.read_cb = fs_read;
-    fs_drv.write_cb = fs_write;
-    fs_drv.seek_cb = fs_seek;
-    fs_drv.tell_cb = fs_tell;
+    fs_drv_p->open_cb = fs_open;
+    fs_drv_p->close_cb = fs_close;
+    fs_drv_p->read_cb = fs_read;
+    fs_drv_p->write_cb = fs_write;
+    fs_drv_p->seek_cb = fs_seek;
+    fs_drv_p->tell_cb = fs_tell;
 
-    fs_drv.dir_close_cb = fs_dir_close;
-    fs_drv.dir_open_cb = fs_dir_open;
-    fs_drv.dir_read_cb = fs_dir_read;
+    fs_drv_p->dir_close_cb = fs_dir_close;
+    fs_drv_p->dir_open_cb = fs_dir_open;
+    fs_drv_p->dir_read_cb = fs_dir_read;
 
-    lv_fs_drv_register(&fs_drv);
+    lv_fs_drv_register(fs_drv_p);
 }
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -18,6 +18,7 @@
     #include <windows.h>
 #endif
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -70,25 +71,25 @@ void lv_fs_stdio_init(void)
      *--------------------------------------------------*/
 
     /*Add a simple drive to open images*/
-    static lv_fs_drv_t fs_drv; /*A driver descriptor*/
-    lv_fs_drv_init(&fs_drv);
+    lv_fs_drv_t * fs_drv_p = &(lv_global_default()->stdio_fs_drv);
+    lv_fs_drv_init(fs_drv_p);
 
     /*Set up fields...*/
-    fs_drv.letter = LV_FS_STDIO_LETTER;
-    fs_drv.cache_size = LV_FS_STDIO_CACHE_SIZE;
+    fs_drv_p->letter = LV_FS_STDIO_LETTER;
+    fs_drv_p->cache_size = LV_FS_STDIO_CACHE_SIZE;
 
-    fs_drv.open_cb = fs_open;
-    fs_drv.close_cb = fs_close;
-    fs_drv.read_cb = fs_read;
-    fs_drv.write_cb = fs_write;
-    fs_drv.seek_cb = fs_seek;
-    fs_drv.tell_cb = fs_tell;
+    fs_drv_p->open_cb = fs_open;
+    fs_drv_p->close_cb = fs_close;
+    fs_drv_p->read_cb = fs_read;
+    fs_drv_p->write_cb = fs_write;
+    fs_drv_p->seek_cb = fs_seek;
+    fs_drv_p->tell_cb = fs_tell;
 
-    fs_drv.dir_close_cb = fs_dir_close;
-    fs_drv.dir_open_cb = fs_dir_open;
-    fs_drv.dir_read_cb = fs_dir_read;
+    fs_drv_p->dir_close_cb = fs_dir_close;
+    fs_drv_p->dir_open_cb = fs_dir_open;
+    fs_drv_p->dir_read_cb = fs_dir_read;
 
-    lv_fs_drv_register(&fs_drv);
+    lv_fs_drv_register(fs_drv_p);
 }
 
 /**********************
@@ -282,7 +283,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
     do {
         entry = readdir(handle->dir_p);
         if(entry) {
-            if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) snprintf(fn, strlen(entry->d_name), "/%s", entry->d_name);
             else lv_strcpy(fn, entry->d_name);
         }
         else {

--- a/src/libs/fsdrv/lv_fs_win32.c
+++ b/src/libs/fsdrv/lv_fs_win32.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <limits.h>
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -66,25 +67,25 @@ void lv_fs_win32_init(void)
      *--------------------------------------------------*/
 
     /*Add a simple driver to open images*/
-    static lv_fs_drv_t fs_drv; /*A driver descriptor*/
-    lv_fs_drv_init(&fs_drv);
+    lv_fs_drv_t * fs_drv_p = &(lv_global_default()->win32_fs_drv);
+    lv_fs_drv_init(fs_drv_p);
 
     /*Set up fields...*/
-    fs_drv.letter = LV_FS_WIN32_LETTER;
-    fs_drv.cache_size = LV_FS_WIN32_CACHE_SIZE;
+    fs_drv_p->letter = LV_FS_WIN32_LETTER;
+    fs_drv_p->cache_size = LV_FS_WIN32_CACHE_SIZE;
 
-    fs_drv.open_cb = fs_open;
-    fs_drv.close_cb = fs_close;
-    fs_drv.read_cb = fs_read;
-    fs_drv.write_cb = fs_write;
-    fs_drv.seek_cb = fs_seek;
-    fs_drv.tell_cb = fs_tell;
+    fs_drv_p->open_cb = fs_open;
+    fs_drv_p->close_cb = fs_close;
+    fs_drv_p->read_cb = fs_read;
+    fs_drv_p->write_cb = fs_write;
+    fs_drv_p->seek_cb = fs_seek;
+    fs_drv_p->tell_cb = fs_tell;
 
-    fs_drv.dir_close_cb = fs_dir_close;
-    fs_drv.dir_open_cb = fs_dir_open;
-    fs_drv.dir_read_cb = fs_dir_read;
+    fs_drv_p->dir_close_cb = fs_dir_close;
+    fs_drv_p->dir_open_cb = fs_dir_open;
+    fs_drv_p->dir_read_cb = fs_dir_read;
 
-    lv_fs_drv_register(&fs_drv);
+    lv_fs_drv_register(fs_drv_p);
 }
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -332,11 +332,6 @@
     #endif
 #endif
 
-#if !defined(LV_THREAD_LOCAL) && LV_USE_OS != LV_OS_PTHREAD
-    /*Don't support multi-instance*/
-    #define LV_THREAD_LOCAL
-#endif
-
 
 /*=======================
  * FEATURE CONFIGURATION

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -332,6 +332,11 @@
     #endif
 #endif
 
+#if !defined(LV_THREAD_LOCAL) && LV_USE_OS != LV_OS_PTHREAD
+    /*Don't support multi-instance*/
+    #define LV_THREAD_LOCAL
+#endif
+
 
 /*=======================
  * FEATURE CONFIGURATION

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -172,35 +172,6 @@
     #endif
 #endif
 
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#ifndef LV_TICK_CUSTOM
-    #ifdef CONFIG_LV_TICK_CUSTOM
-        #define LV_TICK_CUSTOM CONFIG_LV_TICK_CUSTOM
-    #else
-        #define LV_TICK_CUSTOM 0
-    #endif
-#endif
-#if LV_TICK_CUSTOM
-    #ifndef LV_TICK_CUSTOM_INCLUDE
-        #ifdef CONFIG_LV_TICK_CUSTOM_INCLUDE
-            #define LV_TICK_CUSTOM_INCLUDE CONFIG_LV_TICK_CUSTOM_INCLUDE
-        #else
-            #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-        #endif
-    #endif
-    #ifndef LV_TICK_CUSTOM_SYS_TIME_EXPR
-        #ifdef CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
-        #else
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-        #endif
-    #endif
-    /*If using lvgl as ESP32 component*/
-    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
-#endif   /*LV_TICK_CUSTOM*/
-
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #ifndef LV_DPI_DEF

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_anim.h"
 
+#include "../core/lv_global.h"
 #include "../tick/lv_tick.h"
 #include "lv_assert.h"
 #include "lv_timer.h"
@@ -21,15 +22,11 @@
  *********************/
 #define LV_ANIM_RESOLUTION 1024
 #define LV_ANIM_RES_SHIFT 10
+#define state lv_global_default()->anim_state
 
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct {
-    bool anim_list_changed;
-    bool anim_run_round;
-    lv_timer_t * timer;
-} lv_anim_state_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -43,7 +40,6 @@ static int32_t lv_anim_path_cubic_bezier(const lv_anim_t * a, int32_t x1,
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_anim_state_t state;
 
 /**********************
  *      MACROS
@@ -65,6 +61,7 @@ void _lv_anim_core_init(void)
     state.timer = lv_timer_create(anim_timer, LV_DEF_REFR_PERIOD, NULL);
     anim_mark_list_change(); /*Turn off the animation timer*/
     state.anim_list_changed = false;
+    state.anim_run_round = false;
 }
 
 void lv_anim_init(lv_anim_t * a)

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 #include "lv_math.h"
+#include "lv_timer.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -88,6 +89,12 @@ typedef enum {
 
 struct _lv_anim_t;
 struct _lv_timer_t;
+
+typedef struct {
+    bool anim_list_changed;
+    bool anim_run_round;
+    struct _lv_timer_t * timer;
+} lv_anim_state_t;
 
 /** Get the current value during an animation*/
 typedef int32_t (*lv_anim_path_cb_t)(const struct _lv_anim_t *);

--- a/src/misc/lv_area.c
+++ b/src/misc/lv_area.c
@@ -473,7 +473,8 @@ void lv_point_transform(lv_point_t * p, int32_t angle, int32_t zoom, const lv_po
         p->y = (((int32_t)(p->y) * zoom) >> 8) + pivot->y;
         return;
     }
-    if(trans_cache.angle_prev != angle) {
+    lv_area_transform_cache_t * cache = &trans_cache;
+    if(cache->angle_prev != angle) {
         int32_t angle_limited = angle;
         if(angle_limited > 3600) angle_limited -= 3600;
         if(angle_limited < 0) angle_limited += 3600;
@@ -488,21 +489,21 @@ void lv_point_transform(lv_point_t * p, int32_t angle, int32_t zoom, const lv_po
         int32_t c1 = lv_trigo_sin(angle_low + 90);
         int32_t c2 = lv_trigo_sin(angle_high + 90);
 
-        trans_cache.sinma = (s1 * (10 - angle_rem) + s2 * angle_rem) / 10;
-        trans_cache.cosma = (c1 * (10 - angle_rem) + c2 * angle_rem) / 10;
-        trans_cache.sinma = trans_cache.sinma >> (LV_TRIGO_SHIFT - _LV_TRANSFORM_TRIGO_SHIFT);
-        trans_cache.cosma = trans_cache.cosma >> (LV_TRIGO_SHIFT - _LV_TRANSFORM_TRIGO_SHIFT);
-        trans_cache.angle_prev = angle;
+        cache->sinma = (s1 * (10 - angle_rem) + s2 * angle_rem) / 10;
+        cache->cosma = (c1 * (10 - angle_rem) + c2 * angle_rem) / 10;
+        cache->sinma = cache->sinma >> (LV_TRIGO_SHIFT - _LV_TRANSFORM_TRIGO_SHIFT);
+        cache->cosma = cache->cosma >> (LV_TRIGO_SHIFT - _LV_TRANSFORM_TRIGO_SHIFT);
+        cache->angle_prev = angle;
     }
     int32_t x = p->x;
     int32_t y = p->y;
     if(zoom == 256) {
-        p->x = ((trans_cache.cosma * x - trans_cache.sinma * y) >> _LV_TRANSFORM_TRIGO_SHIFT) + pivot->x;
-        p->y = ((trans_cache.sinma * x + trans_cache.cosma * y) >> _LV_TRANSFORM_TRIGO_SHIFT) + pivot->y;
+        p->x = ((cache->cosma * x - cache->sinma * y) >> _LV_TRANSFORM_TRIGO_SHIFT) + pivot->x;
+        p->y = ((cache->sinma * x + cache->cosma * y) >> _LV_TRANSFORM_TRIGO_SHIFT) + pivot->y;
     }
     else {
-        p->x = (((trans_cache.cosma * x - trans_cache.sinma * y) * zoom) >> (_LV_TRANSFORM_TRIGO_SHIFT + 8)) + pivot->x;
-        p->y = (((trans_cache.sinma * x + trans_cache.cosma * y) * zoom) >> (_LV_TRANSFORM_TRIGO_SHIFT + 8)) + pivot->y;
+        p->x = (((cache->cosma * x - cache->sinma * y) * zoom) >> (_LV_TRANSFORM_TRIGO_SHIFT + 8)) + pivot->x;
+        p->y = (((cache->sinma * x + cache->cosma * y) * zoom) >> (_LV_TRANSFORM_TRIGO_SHIFT + 8)) + pivot->y;
     }
 }
 

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -99,6 +99,11 @@ typedef _lv_dir_t lv_dir_t;
 typedef uint8_t lv_dir_t;
 #endif /*DOXYGEN*/
 
+typedef struct  {
+    int32_t angle_prev;
+    int32_t sinma;
+    int32_t cosma;
+} lv_area_transform_cache_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -7,6 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_event.h"
+#include "../core/lv_global.h"
 #include "../stdlib/lv_mem.h"
 #include "lv_assert.h"
 #include <stddef.h>
@@ -14,6 +15,9 @@
 /*********************
  *      DEFINES
  *********************/
+
+#define event_head lv_global_default()->event_header
+#define event_last_id lv_global_default()->event_last_register_id
 
 /**********************
  *      TYPEDEFS
@@ -26,11 +30,11 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_event_t * event_head;
 
 /**********************
  *      MACROS
  **********************/
+
 #if LV_LOG_TRACE_EVENT
     #define EVENT_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
@@ -173,9 +177,8 @@ void lv_event_stop_processing(lv_event_t * e)
 
 uint32_t lv_event_register_id(void)
 {
-    static uint32_t last_id = _LV_EVENT_LAST;
-    last_id ++;
-    return last_id;
+    event_last_id ++;
+    return event_last_id;
 }
 
 void _lv_event_mark_deleted(void * target)

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -15,6 +15,7 @@
 #include "../stdlib/lv_mem.h"
 #include "../stdlib/lv_string.h"
 #include "../tick/lv_tick.h"
+#include "../core/lv_global.h"
 
 #if LV_LOG_PRINTF
     #include <stdio.h>
@@ -23,6 +24,10 @@
 /*********************
  *      DEFINES
  *********************/
+#if LV_LOG_USE_TIMESTAMP
+    #define last_log_time lv_global_default()->log_last_log_time
+#endif
+#define custom_print_cb lv_global_default()->custom_log_print_cb
 
 #if LV_LOG_USE_TIMESTAMP
     #define LOG_TIMESTAMP_FMT  "\t(%" LV_PRIu32 ".%03" LV_PRIu32 ", +%" LV_PRIu32 ")\t"
@@ -43,7 +48,6 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_log_print_g_cb_t custom_print_cb;
 
 /**********************
  *      MACROS
@@ -76,10 +80,6 @@ void lv_log_register_print_cb(lv_log_print_g_cb_t print_cb)
 void _lv_log_add(lv_log_level_t level, const char * file, int line, const char * func, const char * format, ...)
 {
     if(level >= _LV_LOG_LEVEL_NUM) return; /*Invalid level*/
-
-#if LV_LOG_USE_TIMESTAMP
-    static uint32_t last_log_time = 0;
-#endif
 
     if(level >= LV_LOG_LEVEL) {
         va_list args;

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -7,10 +7,12 @@
  *      INCLUDES
  *********************/
 #include "lv_math.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
+#define rand_seed lv_global_default()->math_rand_seed
 
 /**********************
  *      TYPEDEFS
@@ -377,16 +379,14 @@ int32_t lv_map(int32_t x, int32_t min_in, int32_t max_in, int32_t min_out, int32
 
 uint32_t lv_rand(uint32_t min, uint32_t max)
 {
-    static uint32_t a = 0x1234ABCD; /*Seed*/
-
     /*Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs"*/
-    uint32_t x = a;
+    uint32_t x = rand_seed;
     x ^= x << 13;
     x ^= x >> 17;
     x ^= x << 5;
-    a = x;
+    rand_seed = x;
 
-    return (a % (max - min + 1)) + min;
+    return (rand_seed % (max - min + 1)) + min;
 }
 
 /**********************

--- a/src/misc/lv_profiler_builtin.c
+++ b/src/misc/lv_profiler_builtin.c
@@ -9,6 +9,7 @@
 
 #include "lv_profiler_builtin.h"
 #include "../lvgl.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
@@ -16,31 +17,15 @@
 
 #if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 
+#define profiler_ctx lv_global_default()->profiler_context
+
+
 #define LV_PROFILER_STR_MAX_LEN 128
 #define LV_PROFILER_TICK_PER_SEC_MAX 1000000
 
 /**********************
  *      TYPEDEFS
  **********************/
-
-/**
- * @brief Structure representing a built-in profiler item in LVGL
- */
-typedef struct {
-    char tag;          /**< The tag of the profiler item */
-    uint32_t tick;     /**< The tick value of the profiler item */
-    const char * func; /**< A pointer to the function associated with the profiler item */
-} lv_profiler_builtin_item_t;
-
-/**
- * @brief Structure representing a context for the LVGL built-in profiler
- */
-typedef struct {
-    lv_profiler_builtin_item_t * item_arr; /**< Pointer to an array of profiler items */
-    uint32_t item_num;                     /**< Number of profiler items in the array */
-    uint32_t cur_index;                    /**< Index of the current profiler item */
-    lv_profiler_builtin_config_t config;   /**< Configuration for the built-in profiler */
-} lv_profiler_builtin_ctx_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -51,8 +36,6 @@ static void default_flush_cb(const char * buf);
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-static lv_profiler_builtin_ctx_t profiler_ctx = { 0 };
 
 /**********************
  *      MACROS

--- a/src/misc/lv_profiler_builtin.h
+++ b/src/misc/lv_profiler_builtin.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_profiler_builtin.h.h
+ * @file lv_profiler_builtin.h
  *
  */
 
@@ -42,6 +42,26 @@ typedef struct {
     uint32_t (*tick_get_cb)(void);      /**< Callback function to get the current tick count */
     void (*flush_cb)(const char * buf); /**< Callback function to flush the profiling data */
 } lv_profiler_builtin_config_t;
+
+
+/**
+ * @brief Structure representing a built-in profiler item in LVGL
+ */
+typedef struct {
+    char tag;          /**< The tag of the profiler item */
+    uint32_t tick;     /**< The tick value of the profiler item */
+    const char * func; /**< A pointer to the function associated with the profiler item */
+} lv_profiler_builtin_item_t;
+
+/**
+ * @brief Structure representing a context for the LVGL built-in profiler
+ */
+typedef struct {
+    lv_profiler_builtin_item_t * item_arr; /**< Pointer to an array of profiler items */
+    uint32_t item_num;                     /**< Number of profiler items in the array */
+    uint32_t cur_index;                    /**< Index of the current profiler item */
+    lv_profiler_builtin_config_t config;   /**< Configuration for the built-in profiler */
+} lv_profiler_builtin_ctx_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_style.h"
 #include "lv_gc.h"
+#include "../core/lv_global.h"
 #include "../stdlib/lv_mem.h"
 #include "lv_assert.h"
 #include "lv_types.h"
@@ -15,6 +16,8 @@
 /*********************
  *      DEFINES
  *********************/
+#define _lv_style_custom_prop_flag_lookup_table_size lv_global_default()->style_custom_table_size
+#define last_custom_prop_id lv_global_default()->style_last_custom_prop_id
 
 /**********************
  *      TYPEDEFS
@@ -154,13 +157,9 @@ const uint8_t _lv_style_builtin_prop_flag_lookup_table[_LV_STYLE_NUM_BUILT_IN_PR
 
 };
 
-uint32_t _lv_style_custom_prop_flag_lookup_table_size = 0;
-
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-static uint16_t last_custom_prop_id = (uint16_t)_LV_STYLE_LAST_BUILT_IN_PROP;
 static const lv_style_value_t null_style_value = { .num = 0 };
 
 /**********************
@@ -398,8 +397,8 @@ uint8_t _lv_style_get_prop_group(lv_style_prop_t prop)
 
 uint8_t _lv_style_prop_lookup_flags(lv_style_prop_t prop)
 {
-    extern const uint8_t _lv_style_builtin_prop_flag_lookup_table[];
-    extern uint32_t _lv_style_custom_prop_flag_lookup_table_size;
+    //    extern const uint8_t _lv_style_builtin_prop_flag_lookup_table[];
+    //    extern uint32_t _lv_style_custom_prop_flag_lookup_table_size;
     if(prop == LV_STYLE_PROP_ANY) return LV_STYLE_PROP_FLAG_ALL; /*Any prop can have any flags*/
     if(prop == LV_STYLE_PROP_INV) return 0;
 

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -397,8 +397,6 @@ uint8_t _lv_style_get_prop_group(lv_style_prop_t prop)
 
 uint8_t _lv_style_prop_lookup_flags(lv_style_prop_t prop)
 {
-    //    extern const uint8_t _lv_style_builtin_prop_flag_lookup_table[];
-    //    extern uint32_t _lv_style_custom_prop_flag_lookup_table_size;
     if(prop == LV_STYLE_PROP_ANY) return LV_STYLE_PROP_FLAG_ALL; /*Any prop can have any flags*/
     if(prop == LV_STYLE_PROP_INV) return 0;
 

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -87,10 +87,9 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
     uint32_t handler_start = lv_tick_get();
 
     if(handler_start == 0) {
-        static uint32_t run_cnt = 0;
-        run_cnt++;
-        if(run_cnt > 100) {
-            run_cnt = 0;
+        state.run_cnt++;
+        if(state.run_cnt > 100) {
+            state.run_cnt = 0;
             LV_LOG_WARN("It seems lv_tick_inc() is not called.");
         }
     }

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -50,6 +50,19 @@ typedef struct _lv_timer_t {
     uint32_t paused : 1;
 } lv_timer_t;
 
+typedef struct {
+    bool lv_timer_run;
+    uint8_t idle_last;
+    bool timer_deleted;
+    bool timer_created;
+    uint32_t timer_time_until_next;
+
+    bool already_running;
+    uint32_t periodic_last_tick;
+    uint32_t busy_time;
+    uint32_t idle_period_start;
+} lv_timer_state_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -61,6 +61,7 @@ typedef struct {
     uint32_t periodic_last_tick;
     uint32_t busy_time;
     uint32_t idle_period_start;
+    uint32_t run_cnt;
 } lv_timer_state_t;
 
 /**********************

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -9,6 +9,8 @@
 #include "lv_file_explorer.h"
 #if LV_USE_FILE_EXPLORER != 0
 
+#include "../../core/lv_global.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -16,6 +18,8 @@
 
 #define FILE_EXPLORER_QUICK_ACCESS_AREA_WIDTH       (22)
 #define FILE_EXPLORER_BROWSER_AREA_WIDTH            (100 - FILE_EXPLORER_QUICK_ACCESS_AREA_WIDTH)
+
+#define quick_access_list_btn_style (lv_global_default()->fe_list_btn_style)
 
 /**********************
  *      TYPEDEFS
@@ -43,7 +47,6 @@ static bool is_end_with(const char * str1, const char * str2);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_style_t quick_access_list_btn_style;
 
 const lv_obj_class_t lv_file_explorer_class = {
     .constructor_cb = lv_file_explorer_constructor,

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -10,11 +10,13 @@
 #if LV_USE_IME_PINYIN != 0
 
 #include <stdio.h>
+#include "../../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
 #define MY_CLASS    &lv_ime_pinyin_class
+#define cand_len lv_global_default()->ime_cand_len
 
 /**********************
  *      TYPEDEFS
@@ -1104,7 +1106,6 @@ static bool pinyin_k9_is_valid_py(lv_obj_t * obj, char * py_str)
 
 static void pinyin_k9_fill_cand(lv_obj_t * obj)
 {
-    static uint16_t len = 0;
     uint16_t index = 0, tmp_len = 0;
     ime_pinyin_k9_py_str_t * ll_index = NULL;
 
@@ -1112,11 +1113,11 @@ static void pinyin_k9_fill_cand(lv_obj_t * obj)
 
     tmp_len = pinyin_ime->k9_legal_py_count;
 
-    if(tmp_len != len) {
+    if(tmp_len != cand_len) {
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
-        len = tmp_len;
+        cand_len = tmp_len;
     }
 
     ll_index = _lv_ll_get_head(&pinyin_ime->k9_legal_py_ll);

--- a/src/others/msg/lv_msg.c
+++ b/src/others/msg/lv_msg.c
@@ -9,13 +9,16 @@
 #include "lv_msg.h"
 #if LV_USE_MSG
 
+#include "../../core/lv_global.h"
 #include "../../misc/lv_assert.h"
 #include "../../misc/lv_ll.h"
 #include "../../misc/lv_gc.h"
-
 /*********************
  *      DEFINES
  *********************/
+
+#define restart_notify lv_global_default()->msg_restart_notify
+#define _recursion_counter lv_global_default()->msg_recursion_counter
 
 /**********************
  *      TYPEDEFS
@@ -40,7 +43,6 @@ static void obj_delete_event_cb(lv_event_t * e);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static bool restart_notify;
 
 /**********************
  *  GLOBAL VARIABLES
@@ -159,7 +161,6 @@ lv_msg_t * lv_event_get_msg(lv_event_t * e)
 
 static void notify(lv_msg_t * m)
 {
-    static unsigned int _recursion_counter = 0;
     _recursion_counter++;
 
     /*First clear all _checked flags*/

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -11,6 +11,7 @@
 
 #if LV_USE_SYSMON
 
+#include "../../core/lv_global.h"
 /*********************
  *      DEFINES
  *********************/
@@ -21,18 +22,6 @@
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct {
-    uint32_t    refr_start;
-    uint32_t    refr_interval_sum;
-    uint32_t    refr_elaps_sum;
-    uint32_t    refr_cnt;
-    uint32_t    render_start;
-    uint32_t    render_elaps_sum;
-    uint32_t    render_cnt;
-    uint32_t    flush_start;
-    uint32_t    flush_elaps_sum;
-    uint32_t    flush_cnt;
-} perf_info_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -202,13 +191,12 @@ static void perf_monitor_event_cb(lv_event_t * e)
 
 static void perf_monitor_init(void)
 {
-    static perf_info_t info = { 0 };
     lv_disp_t * disp = lv_disp_get_default();
 
     lv_obj_t * sysmon = lv_sysmon_create(lv_layer_sys());
     lv_obj_align(sysmon, LV_USE_PERF_MONITOR_POS, 0, 0);
     lv_obj_set_style_text_align(sysmon, LV_TEXT_ALIGN_RIGHT, 0);
-    lv_obj_set_user_data(sysmon, &info);
+    lv_obj_set_user_data(sysmon, &(lv_global_default()->sysmon_perf_info));
     lv_obj_add_event(sysmon, perf_monitor_event_cb, LV_EVENT_REFRESH, NULL);
     lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_ALL, sysmon);
 

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -12,6 +12,7 @@
 #if LV_USE_SYSMON
 
 #include "../../core/lv_global.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -19,9 +20,23 @@
 
 #define SYSMON_REFR_PERIOD_DEF 300 /* ms */
 
+#define perf_info lv_global_default()->sysmon_perf_info
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+    uint32_t    refr_start;
+    uint32_t    refr_interval_sum;
+    uint32_t    refr_elaps_sum;
+    uint32_t    refr_cnt;
+    uint32_t    render_start;
+    uint32_t    render_elaps_sum;
+    uint32_t    render_cnt;
+    uint32_t    flush_start;
+    uint32_t    flush_elaps_sum;
+    uint32_t    flush_cnt;
+} perf_info_t;
+
 
 /**********************
  *  STATIC PROTOTYPES
@@ -79,6 +94,15 @@ void _lv_sysmon_builtin_init(void)
     lv_async_call(sysmon_async_cb, NULL);
 }
 
+void _lv_sysmon_builtin_deinit(void)
+{
+    lv_async_call_cancel(sysmon_async_cb, NULL);
+#if LV_USE_PERF_MONITOR
+    if(perf_info) {
+        lv_free(perf_info);
+    }
+#endif
+}
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -196,7 +220,11 @@ static void perf_monitor_init(void)
     lv_obj_t * sysmon = lv_sysmon_create(lv_layer_sys());
     lv_obj_align(sysmon, LV_USE_PERF_MONITOR_POS, 0, 0);
     lv_obj_set_style_text_align(sysmon, LV_TEXT_ALIGN_RIGHT, 0);
-    lv_obj_set_user_data(sysmon, &(lv_global_default()->sysmon_perf_info));
+
+    perf_info_t * info = perf_info = lv_malloc(sizeof(perf_info_t));
+    LV_ASSERT_MALLOC(info);
+
+    lv_obj_set_user_data(sysmon, info);
     lv_obj_add_event(sysmon, perf_monitor_event_cb, LV_EVENT_REFRESH, NULL);
     lv_disp_add_event(disp, perf_monitor_disp_event_cb, LV_EVENT_ALL, sysmon);
 

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -18,6 +18,19 @@ extern "C" {
 
 #if LV_USE_SYSMON
 
+typedef struct {
+    uint32_t    refr_start;
+    uint32_t    refr_interval_sum;
+    uint32_t    refr_elaps_sum;
+    uint32_t    refr_cnt;
+    uint32_t    render_start;
+    uint32_t    render_elaps_sum;
+    uint32_t    render_cnt;
+    uint32_t    flush_start;
+    uint32_t    flush_elaps_sum;
+    uint32_t    flush_cnt;
+} perf_info_t;
+
 #if LV_USE_LABEL == 0
 #error "lv_sysmon: lv_label is required. Enable it in lv_conf.h (LV_USE_LABEL  1) "
 #endif

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -18,19 +18,6 @@ extern "C" {
 
 #if LV_USE_SYSMON
 
-typedef struct {
-    uint32_t    refr_start;
-    uint32_t    refr_interval_sum;
-    uint32_t    refr_elaps_sum;
-    uint32_t    refr_cnt;
-    uint32_t    render_start;
-    uint32_t    render_elaps_sum;
-    uint32_t    render_cnt;
-    uint32_t    flush_start;
-    uint32_t    flush_elaps_sum;
-    uint32_t    flush_cnt;
-} perf_info_t;
-
 #if LV_USE_LABEL == 0
 #error "lv_sysmon: lv_label is required. Enable it in lv_conf.h (LV_USE_LABEL  1) "
 #endif
@@ -71,6 +58,11 @@ void lv_sysmon_set_refr_period(lv_obj_t * obj, uint32_t period);
  * Initialize built-in system monitor, such as performance and memory monitor.
  */
 void _lv_sysmon_builtin_init(void);
+
+/**
+ * DeInitialize built-in system monitor, such as performance and memory monitor.
+ */
+void _lv_sysmon_builtin_deinit(void);
 
 /**********************
  *      MACROS

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -71,6 +71,8 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user);
 
 void lv_mem_init(void)
 {
+    lv_global_default()->memory_zero = ZERO_MEM_SENTINEL;
+
 #if LV_MEM_ADR == 0
 #ifdef LV_MEM_POOL_ALLOC
     state.tlsf = lv_tlsf_create_with_pool((void *)LV_MEM_POOL_ALLOC(LV_MEM_SIZE), LV_MEM_SIZE);

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -15,6 +15,7 @@
 #include "../../misc/lv_ll.h"
 #include "../../misc/lv_math.h"
 #include "../../osal/lv_os.h"
+#include "../../core/lv_global.h"
 
 #ifdef LV_MEM_POOL_INCLUDE
     #include LV_MEM_POOL_INCLUDE
@@ -35,20 +36,12 @@
     #define MEM_UNIT         uint32_t
     #define ALIGN_MASK       0x3
 #endif
+#define state lv_global_default()->tlsf_state
 
 
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct {
-#if LV_USE_OS
-    lv_mutex_t mutex;
-#endif
-    lv_tlsf_t tlsf;
-    uint32_t cur_used;
-    uint32_t max_used;
-    lv_ll_t  pool_ll;
-} lv_tlsf_state_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -58,7 +51,6 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_tlsf_state_t state;
 
 /**********************
  *      MACROS

--- a/src/stdlib/builtin/lv_tlsf.h
+++ b/src/stdlib/builtin/lv_tlsf.h
@@ -43,6 +43,9 @@
 
 #include <stddef.h>
 
+#include "../../osal/lv_os.h"
+#include "../../misc/lv_ll.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -51,6 +54,16 @@ extern "C" {
 /* lv_pool_t: a block of memory that TLSF can manage. */
 typedef void * lv_tlsf_t;
 typedef void * lv_pool_t;
+
+typedef struct {
+#if LV_USE_OS
+    lv_mutex_t mutex;
+#endif
+    lv_tlsf_t tlsf;
+    uint32_t cur_used;
+    uint32_t max_used;
+    lv_ll_t  pool_ll;
+} lv_tlsf_state_t;
 
 /* Create/destroy a memory pool. */
 lv_tlsf_t lv_tlsf_create(void * mem);

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -9,6 +9,7 @@
 #include "lv_string.h"
 #include "../misc/lv_assert.h"
 #include "../misc/lv_log.h"
+#include "../core/lv_global.h"
 
 #if LV_USE_OS == LV_OS_PTHREAD
     #include <pthread.h>
@@ -22,7 +23,7 @@
     #define LV_MEM_ADD_JUNK  0
 #endif
 
-#define ZERO_MEM_SENTINEL  0xa1b2c3d4
+#define zero_mem lv_global_default()->memory_zero
 
 /**********************
  *      TYPEDEFS
@@ -45,7 +46,7 @@ lv_res_t lv_mem_test_core(void);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static uint32_t zero_mem = ZERO_MEM_SENTINEL; /*Give the address of this variable if 0 byte should be allocated*/
+//static uint32_t zero_mem = ZERO_MEM_SENTINEL; /*Give the address of this variable if 0 byte should be allocated*/
 
 /**********************
  *      MACROS

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -46,7 +46,6 @@ lv_res_t lv_mem_test_core(void);
 /**********************
  *  STATIC VARIABLES
  **********************/
-//static uint32_t zero_mem = ZERO_MEM_SENTINEL; /*Give the address of this variable if 0 byte should be allocated*/
 
 /**********************
  *      MACROS

--- a/src/themes/basic/lv_theme_basic.c
+++ b/src/themes/basic/lv_theme_basic.c
@@ -12,10 +12,13 @@
 
 #include "lv_theme_basic.h"
 #include "../../misc/lv_gc.h"
+#include "../../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
+#define theme_def (lv_global_default()->theme_basic)
+
 #define COLOR_SCR     lv_palette_lighten(LV_PALETTE_GREY, 4)
 #define COLOR_WHITE   lv_color_white()
 #define COLOR_LIGHT   lv_palette_lighten(LV_PALETTE_GREY, 2)
@@ -44,7 +47,7 @@ typedef struct {
 } my_theme_styles_t;
 
 
-typedef struct {
+typedef struct _my_theme_t {
     lv_theme_t base;
     my_theme_styles_t styles;
     bool inited;
@@ -59,7 +62,6 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static my_theme_t * theme;
 
 /**********************
  *      MACROS
@@ -69,7 +71,7 @@ static my_theme_t * theme;
  *   STATIC FUNCTIONS
  **********************/
 
-static void style_init(void)
+static void style_init(struct _my_theme_t * theme)
 {
     style_init_reset(&theme->styles.scrollbar);
     lv_style_set_bg_opa(&theme->styles.scrollbar, LV_OPA_COVER);
@@ -141,21 +143,31 @@ static void style_init(void)
 
 bool lv_theme_basic_is_inited(void)
 {
+    struct _my_theme_t * theme = theme_def;
     if(theme == NULL) return false;
     return theme->inited;
 }
 
+void lv_theme_basic_deinit(void)
+{
+    if(theme_def) {
+        lv_free(theme_def);
+        theme_def = NULL;
+    }
+}
+
 lv_theme_t * lv_theme_basic_init(lv_disp_t * disp)
 {
-
     /*This trick is required only to avoid the garbage collection of
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_basic_is_inited()) {
         LV_GC_ROOT(_lv_theme_basic_data) = lv_malloc(sizeof(my_theme_t));
-        theme  = (my_theme_t *)LV_GC_ROOT(_lv_theme_basic_data);
-        lv_memzero(theme, sizeof(my_theme_t));
+        theme_def  = (my_theme_t *)LV_GC_ROOT(_lv_theme_basic_data);
+        lv_memzero(theme_def, sizeof(my_theme_t));
     }
+
+    struct _my_theme_t * theme = theme_def;
 
     theme->base.disp = disp;
     theme->base.font_small = LV_FONT_DEFAULT;
@@ -163,7 +175,7 @@ lv_theme_t * lv_theme_basic_init(lv_disp_t * disp)
     theme->base.font_large = LV_FONT_DEFAULT;
     theme->base.apply_cb = theme_apply;
 
-    style_init();
+    style_init(theme);
 
     if(disp == NULL || lv_disp_get_theme(disp) == (lv_theme_t *)theme) {
         lv_obj_report_style_change(NULL);
@@ -171,13 +183,14 @@ lv_theme_t * lv_theme_basic_init(lv_disp_t * disp)
 
     theme->inited = true;
 
-    return (lv_theme_t *)&theme;
+    return (lv_theme_t *)theme_def;
 }
-
 
 static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 {
     LV_UNUSED(th);
+
+    struct _my_theme_t * theme = theme_def;
 
     if(lv_obj_get_parent(obj) == NULL) {
         lv_obj_add_style(obj, &theme->styles.scr, 0);

--- a/src/themes/basic/lv_theme_basic.h
+++ b/src/themes/basic/lv_theme_basic.h
@@ -43,6 +43,11 @@ lv_theme_t * lv_theme_basic_init(lv_disp_t * disp);
 */
 bool lv_theme_basic_is_inited(void);
 
+/**
+ * Deinitialize the basic theme
+ */
+void lv_theme_basic_deinit(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/themes/default/lv_theme_default.h
+++ b/src/themes/default/lv_theme_default.h
@@ -53,6 +53,11 @@ lv_theme_t * lv_theme_default_get(void);
  */
 bool lv_theme_default_is_inited(void);
 
+/**
+ * Deinitialize the default theme
+ */
+void lv_theme_default_deinit(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/themes/mono/lv_theme_mono.h
+++ b/src/themes/mono/lv_theme_mono.h
@@ -44,6 +44,11 @@ lv_theme_t * lv_theme_mono_init(lv_disp_t * disp, bool dark_bg, const lv_font_t 
 */
 bool lv_theme_mono_is_inited(void);
 
+/**
+ * Deinitialize the mono theme
+ */
+void lv_theme_mono_deinit(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/tick/lv_tick.c
+++ b/src/tick/lv_tick.c
@@ -22,7 +22,7 @@
     #if !LV_USE_SDL
         #define sys_time lv_global_default()->tick_sys_time
     #endif
-    #define irq_flag lv_global_default()->tick_irq_flag
+    #define tick_irq_flag lv_global_default()->tick_sys_irq_flag
 #endif
 
 /**********************
@@ -55,7 +55,7 @@
  */
 LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
 {
-    irq_flag = 0;
+    tick_irq_flag = 0;
     sys_time += tick_period;
 }
 #endif
@@ -71,13 +71,13 @@ uint32_t lv_tick_get(void)
     /*If `lv_tick_inc` is called from an interrupt while `sys_time` is read
      *the result might be corrupted.
      *This loop detects if `lv_tick_inc` was called while reading `sys_time`.
-     *If `irq_flag` was cleared in `lv_tick_inc` try to read again
-     *until `irq_flag` remains `1`.*/
+     *If `tick_irq_flag` was cleared in `lv_tick_inc` try to read again
+     *until `tick_irq_flag` remains `1`.*/
     uint32_t result;
     do {
-        irq_flag = 1;
+        tick_irq_flag = 1;
         result        = sys_time;
-    } while(!irq_flag); /*Continue until see a non interrupted cycle*/
+    } while(!tick_irq_flag); /*Continue until see a non interrupted cycle*/
 
     return result;
 #else

--- a/src/tick/lv_tick.c
+++ b/src/tick/lv_tick.c
@@ -18,11 +18,11 @@
  *      DEFINES
  *********************/
 #if !LV_TICK_CUSTOM
+    #define state lv_global_default()->tick_state
     /*Warning: sys_time is modified across threads by SDL backend, which prevents the ability to use multiple instances of this variable in SDL.*/
     #if !LV_USE_SDL
-        #define sys_time lv_global_default()->tick_sys_time
+        #define sys_time state.sys_time
     #endif
-    #define tick_irq_flag lv_global_default()->tick_sys_irq_flag
 #endif
 
 /**********************
@@ -55,7 +55,7 @@
  */
 LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
 {
-    tick_irq_flag = 0;
+    state.sys_irq_flag = 0;
     sys_time += tick_period;
 }
 #endif
@@ -67,6 +67,7 @@ LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
 uint32_t lv_tick_get(void)
 {
 #if LV_TICK_CUSTOM == 0
+    lv_tick_state_t * state_p = &state;
 
     /*If `lv_tick_inc` is called from an interrupt while `sys_time` is read
      *the result might be corrupted.
@@ -75,9 +76,9 @@ uint32_t lv_tick_get(void)
      *until `tick_irq_flag` remains `1`.*/
     uint32_t result;
     do {
-        tick_irq_flag = 1;
+        state_p->sys_irq_flag = 1;
         result        = sys_time;
-    } while(!tick_irq_flag); /*Continue until see a non interrupted cycle*/
+    } while(!state_p->sys_irq_flag); /*Continue until see a non interrupted cycle*/
 
     return result;
 #else

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -28,26 +28,23 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef uint32_t (*lv_tick_get_cb_t)(void);
+
 typedef struct {
     uint32_t sys_time;
     volatile uint8_t sys_irq_flag;
+    lv_tick_get_cb_t tick_get_cb;
 } lv_tick_state_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-//! @cond Doxygen_Suppress
-
-#if !LV_TICK_CUSTOM
 /**
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
 LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period);
-#endif
-
-//! @endcond
 
 /**
  * Get the elapsed milliseconds since start up
@@ -61,6 +58,12 @@ uint32_t lv_tick_get(void);
  * @return the elapsed milliseconds since 'prev_tick'
  */
 uint32_t lv_tick_elaps(uint32_t prev_tick);
+
+/**
+ * Set the custom callback for 'lv_tick_get'
+ * @param cb call this callback on 'lv_tick_get'
+ */
+void lv_tick_set_cb(lv_tick_get_cb_t cb);
 
 /**********************
  *      MACROS

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -28,6 +28,10 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+    uint32_t sys_time;
+    volatile uint8_t sys_irq_flag;
+} lv_tick_state_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -11,11 +11,13 @@
 #if LV_USE_SPAN != 0
 
 #include "../../misc/lv_assert.h"
+#include "../../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
 #define MY_CLASS &lv_spangroup_class
+#define snippet_stack lv_global_default()->span_snippet_stack
 
 /**********************
  *      TYPEDEFS
@@ -66,7 +68,6 @@ static lv_coord_t convert_indent_pct(lv_obj_t * spans, lv_coord_t width);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static struct _snippet_stack snippet_stack;
 
 const lv_obj_class_t lv_spangroup_class  = {
     .base_class = &lv_obj_class,
@@ -85,6 +86,22 @@ const lv_obj_class_t lv_spangroup_class  = {
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
+void lv_span_stack_init(void)
+{
+    snippet_stack = lv_malloc(sizeof(struct _snippet_stack));
+    LV_ASSERT_MALLOC(snippet_stack);
+    if(!snippet_stack) {
+        LV_LOG_ERROR("malloc failed for snippet_stack");
+    }
+}
+
+void lv_span_stack_deinit(void)
+{
+    if(snippet_stack) {
+        lv_free(snippet_stack);
+        snippet_stack = NULL;
+    }
+}
 
 lv_obj_t * lv_spangroup_create(lv_obj_t * par)
 {
@@ -637,9 +654,9 @@ static bool lv_txt_get_snippet(const char * txt, const lv_font_t * font,
 
 static void lv_snippet_push(lv_snippet_t * item)
 {
-    if(snippet_stack.index < LV_SPAN_SNIPPET_STACK_SIZE) {
-        memcpy(&snippet_stack.stack[snippet_stack.index], item, sizeof(lv_snippet_t));
-        snippet_stack.index++;
+    if(snippet_stack->index < LV_SPAN_SNIPPET_STACK_SIZE) {
+        memcpy(&snippet_stack->stack[snippet_stack->index], item, sizeof(lv_snippet_t));
+        snippet_stack->index++;
     }
     else {
         LV_LOG_ERROR("span draw stack overflow, please set LV_SPAN_SNIPPET_STACK_SIZE too larger");
@@ -648,17 +665,17 @@ static void lv_snippet_push(lv_snippet_t * item)
 
 static uint16_t lv_get_snippet_cnt(void)
 {
-    return snippet_stack.index;
+    return snippet_stack->index;
 }
 
 static lv_snippet_t * lv_get_snippet(uint16_t index)
 {
-    return &snippet_stack.stack[index];
+    return &snippet_stack->stack[index];
 }
 
 static void lv_snippet_clear(void)
 {
-    snippet_stack.index = 0;
+    snippet_stack->index = 0;
 }
 
 static const lv_font_t * lv_span_get_style_text_font(lv_obj_t * par, lv_span_t * span)

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -88,19 +88,16 @@ const lv_obj_class_t lv_spangroup_class  = {
  **********************/
 void lv_span_stack_init(void)
 {
-    snippet_stack = lv_malloc(sizeof(struct _snippet_stack));
-    LV_ASSERT_MALLOC(snippet_stack);
-    if(!snippet_stack) {
+    struct _snippet_stack * stack = snippet_stack = lv_malloc(sizeof(struct _snippet_stack));
+    LV_ASSERT_MALLOC(stack);
+    if(!stack) {
         LV_LOG_ERROR("malloc failed for snippet_stack");
     }
 }
 
 void lv_span_stack_deinit(void)
 {
-    if(snippet_stack) {
-        lv_free(snippet_stack);
-        snippet_stack = NULL;
-    }
+    lv_free(snippet_stack);
 }
 
 lv_obj_t * lv_spangroup_create(lv_obj_t * par)
@@ -654,9 +651,10 @@ static bool lv_txt_get_snippet(const char * txt, const lv_font_t * font,
 
 static void lv_snippet_push(lv_snippet_t * item)
 {
-    if(snippet_stack->index < LV_SPAN_SNIPPET_STACK_SIZE) {
-        memcpy(&snippet_stack->stack[snippet_stack->index], item, sizeof(lv_snippet_t));
-        snippet_stack->index++;
+    struct _snippet_stack * stack_p = snippet_stack;
+    if(stack_p->index < LV_SPAN_SNIPPET_STACK_SIZE) {
+        memcpy(&stack_p->stack[stack_p->index], item, sizeof(lv_snippet_t));
+        stack_p->index++;
     }
     else {
         LV_LOG_ERROR("span draw stack overflow, please set LV_SPAN_SNIPPET_STACK_SIZE too larger");

--- a/src/widgets/span/lv_span.h
+++ b/src/widgets/span/lv_span.h
@@ -77,6 +77,9 @@ extern const lv_obj_class_t lv_spangroup_class;
  * GLOBAL PROTOTYPES
  **********************/
 
+void lv_span_stack_init(void);
+void lv_span_stack_deinit(void);
+
 /**
  * Create a spangroup object
  * @param par pointer to an object, it will be the parent of the new spangroup


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
