### PR TITLE
feat(qrcode): add QR code scan support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1014,6 +1014,9 @@ menu "LVGL configuration"
 		config LV_USE_QRCODE
 			bool "QR code library"
 
+		config LV_USE_QRSCAN
+			bool "QR scan library"
+
 		config LV_USE_BARCODE
 			bool "Barcode library"
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -583,6 +583,9 @@
 /*QR code library*/
 #define LV_USE_QRCODE 0
 
+/*QR scan library*/
+#define LV_USE_QRSCAN 0
+
 /*Barcode code library*/
 #define LV_USE_BARCODE 0
 

--- a/src/libs/qrscan/lv_qrscan.c
+++ b/src/libs/qrscan/lv_qrscan.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2023 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_qrscan.h"
+#if LV_USE_QRSCAN
+
+#include "quirc.h"
+#include "quirc_internal.h"
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void * lv_qrscan_create(void)
+{
+    return quirc_new();
+}
+
+void lv_qrscan_destory(void * handle)
+{
+    quirc_destroy(handle);
+}
+
+int lv_qrscan_scan(void * handle, int width, int height,
+                   uint8_t * in, char ** out)
+{
+    struct quirc * qr = handle;
+    char * msg = NULL;
+    size_t len = 0;
+    uint8_t * buf;
+    int count;
+    int i;
+
+    if(*out || !in) {
+        LV_LOG_ERROR("error: invalid parameter\n");
+        return -1;
+    }
+
+    if(quirc_resize(qr, width, height) < 0) {
+        LV_LOG_ERROR("couldn't allocate QR buffer");
+        return -1;
+    }
+
+    buf = quirc_begin(qr, &width, &height);
+    qr->image = in; /* override to avoid copying */
+    quirc_end(qr);
+
+    count = quirc_count(qr);
+
+    for(i = 0; i < count; i++) {
+        struct quirc_code code;
+        struct quirc_data data;
+
+        quirc_extract(qr, i, &code);
+
+        quirc_decode_error_t err = quirc_decode(&code, &data);
+        if(err == QUIRC_ERROR_DATA_ECC) {
+            quirc_flip(&code);
+            err = quirc_decode(&code, &data);
+        }
+
+        if(!err) {
+            size_t paylen = strlen((char *)data.payload) + 1;
+            char * tmp = lv_mem_realloc(msg, len + paylen + 1);
+            if(tmp == NULL) {
+                lv_mem_free(msg);
+                return -1;
+            }
+            msg = tmp;
+
+            lv_memcpy(msg + len, data.payload, paylen);
+            len += paylen;
+            msg[len] = '\0';
+        }
+        else {
+            LV_LOG_ERROR("error: %s\n", quirc_strerror(err));
+        }
+    }
+
+    *out = msg;
+
+    qr->image = buf; /* restore the original address */
+
+    return 0;
+}
+
+void yuyv_to_gray(const uint8_t * src, int src_pitch,
+                  int w, int h, uint8_t * dst, int dst_pitch)
+{
+    int y;
+
+    for(y = 0; y < h; y++) {
+        const uint8_t * yuv = src + y * src_pitch;
+        uint8_t * gray = dst + y * dst_pitch;
+        int x;
+
+        for(x = 0; x < w; x += 2) {
+            *(gray++) = yuv[0];
+            *(gray++) = yuv[2];
+            yuv += 4;
+        }
+    }
+}
+
+void bgra8888_to_gray(const uint8_t * src, int src_pitch,
+                      int w, int h, uint8_t * dst, int dst_pitch)
+{
+    int y;
+
+    for(y = 0; y < h; y++) {
+        const uint8_t * rgb32 = src + src_pitch * y;
+        uint8_t * gray = dst + y * dst_pitch;
+        int i;
+
+        for(i = 0; i < w; i++) {
+            /* packed BGRA 8:8:8:8, 32bpp, (msb)8B 8G 8R 8A(lsb) */
+            int r = (int)rgb32[2];
+            int g = (int)rgb32[1];
+            int b = (int)rgb32[0];
+            int sum = 66 * r + 129 * g + 25 * b + 0x1080;
+
+            *(gray++) = sum >> 8;
+            rgb32 += 4;
+        }
+    }
+}
+
+void rgb565_to_gray(const uint8_t * src, int w, int h, uint8_t * dst)
+{
+    int y;
+
+    for(y = 0; y < h; y++) {
+        const uint16_t * rgb565 = (uint16_t *)(src + y * w * 2);
+        uint8_t * gray = dst + y * w;
+        int i;
+
+        for(i = 0; i < w; i++) {
+            /* packed RGB 5:6:5, 16bpp, (msb)5R 6G 5B(lsb) */
+            int b = (int)(rgb565[i] >> 11) & 0x1F;
+            int g = (int)(rgb565[i] >> 5) & 0x3F;
+            int r = (int)rgb565[i] & 0x1F;
+            int sum = 66 * r + 129 * g + 25 * b + 0x1080;
+
+            *(gray++) = sum >> 8;
+        }
+    }
+}
+
+void rgb332_to_gray(const uint8_t * src, int w, int h, uint8_t * dst)
+{
+    int y;
+
+    for(y = 0; y < h; y++) {
+        const uint8_t * rgb332 = src + y * w;
+        uint8_t * gray = dst + y * w;
+        int i;
+
+        for(i = 0; i < w; i++) {
+            /* packed RGB 3:3:2,  8bpp, (msb)3R 3G 2B(lsb) */
+            int r = (int)(rgb332[i] >> 5) & 0x7;
+            int g = (int)(rgb332[i] >> 2) & 0x7;
+            int b = (int)rgb332[i] & 0x3;
+            int sum = 66 * r + 129 * g + 25 * b + 0x1080;
+
+            *(gray++) = sum >> 8;
+        }
+    }
+}
+
+
+#endif /* LV_USE_QRSCAN */

--- a/src/libs/qrscan/lv_qrscan.h
+++ b/src/libs/qrscan/lv_qrscan.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __LV_QR_SCAN_H__
+#define __LV_QR_SCAN_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../../lvgl.h"
+#if LV_USE_QRSCAN
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * create the scanner
+ * @return the scanner handle, NULL means failed
+ */
+void * lv_qrscan_create(void);
+
+/**
+ * destroy the scanner
+ * @param handle pointer to the initialized scanner
+ */
+void lv_qrscan_destory(void * handle);
+
+/**
+ * decode the gray image buffer and store result in the out buff
+ * @param handle pointer to the initialized scanner
+ * @param width width of the gray image
+ * @param height height of the gray image
+ * @param in pointer to the gray image buffer
+ * @param out address of pointer to the buffer which used to store the result
+ * @return 0: scan successfully
+ *         -ENOMEM: no memory
+ *         -ENOBUFS: buffer full
+ *         -EINVAL: invalid parameter
+ *         -EPERM: the scanner is not available
+ */
+int lv_qrscan_scan(void * handle, int width, int height,
+                   uint8_t * in, char ** out);
+
+/**
+ * convert to gray image from YUYV
+ * @param src pointer to the YUYV buffer
+ * @param src_pitch pitch between lines(YUYV: w*4)
+ * @param w width of the YUYV image
+ * @param h height of the YUYV image
+ * @param dst pointer to the gray image buffer
+ * @param dst_pitch pitch between lines(gray: w)
+ */
+void yuyv_to_gray(const uint8_t * src, int src_pitch,
+                  int w, int h, uint8_t * dst, int dst_pitch);
+
+/**
+ * convert to gray image from bgra8888
+ * @param src pointer to the bgra8888 buffer
+ * @param src_pitch pitch between lines(bgra8888: w*4)
+ * @param w width of the bgra8888 image
+ * @param h height of the bgra8888 image
+ * @param dst pointer to the gray image buffer
+ * @param dst_pitch pitch between lines(gray: w)
+ */
+void bgra8888_to_gray(const uint8_t * src, int src_pitch,
+                      int w, int h, uint8_t * dst, int dst_pitch);
+
+/**
+ * convert to gray image from rgb565
+ * @param src pointer to the rgb565 buffer
+ * @param w width of the rgb565 image
+ * @param h height of the rgb565 image
+ * @param dst pointer to the gray image buffer
+ */
+void rgb565_to_gray(const uint8_t * src, int w, int h, uint8_t * dst);
+
+/**
+ * convert to gray image from rgb332
+ * @param src pointer to the rgb332 buffer
+ * @param w width of the rgb332 image
+ * @param h height of the rgb332 image
+ * @param dst pointer to the gray image buffer
+ */
+void rgb332_to_gray(const uint8_t * src, int w, int h, uint8_t * dst);
+
+#endif /* LV_USE_QRSCAN  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LV_QR_SCAN_H__ */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1929,6 +1929,15 @@
     #endif
 #endif
 
+/*QR scan library*/
+#ifndef LV_USE_QRSCAN
+    #ifdef CONFIG_LV_USE_QRSCAN
+        #define LV_USE_QRSCAN CONFIG_LV_USE_QRSCAN
+    #else
+        #define LV_USE_QRSCAN 0
+    #endif
+#endif
+
 /*Barcode code library*/
 #ifndef LV_USE_BARCODE
     #ifdef CONFIG_LV_USE_BARCODE


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
