### PR TITLE
chore(cmsis-pack): prepare for release v8.3.9

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,7 +36,12 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-07-04" version="8.3.8" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.8.pack">
+    <release date="2023-08-01" version="8.3.9-dev" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.9-dev.pack">
+      - LVGL 8.3.9-dev
+      - Add snapshot, fragment, imgfont, gridnav, msg and monkey
+      - Other minor fixes
+    </release>
+    <release date="2023-07-04" version="8.3.8" url="https://github.com/lvgl/lvgl/raw/15433d69b9d8ae6aa74f49946874af81a0cc5921/env_support/cmsis-pack/LVGL.lvgl.8.3.8.pack">
       - LVGL 8.3.8
       - Add renesas-ra6m3 gpu adaptation
       - Improve performance and add more features for PXP and VGLite
@@ -294,7 +299,7 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.8">
+        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.9-dev">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
             <component Cgroup="lvgl" Csub="Essential" >
@@ -757,6 +762,97 @@
 
 /*! \brief enable ffmpeg support */
 #define LV_USE_IME_PINYIN         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Snapshot"  condition="LVGL-Essential">
+              <description>Add the Snapshot service</description>
+              <files>
+                <!-- src/extra/others/snapshot -->
+                <file category="sourceC"            name="src/extra/others/snapshot/lv_snapshot.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable snapshot support */
+#define LV_USE_SNAPSHOT         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Fragment"  condition="LVGL-Essential">
+              <description>Add the Fragment service</description>
+              <files>
+                <!-- src/extra/others/fragment -->
+                <file category="sourceC"            name="src/extra/others/fragment/lv_fragment.c" />
+                <file category="sourceC"            name="src/extra/others/fragment/lv_fragment_manager.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable fragment support */
+#define LV_USE_FRAGMENT         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Grid Navigation"  condition="LVGL-Essential">
+              <description>Add the Grid Navigation service</description>
+              <files>
+                <!-- src/extra/others/gridnav -->
+                <file category="sourceC"            name="src/extra/others/gridnav/lv_gridnav.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Grid Navigation support*/
+#define LV_USE_GRIDNAV         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Image Font"  condition="LVGL-Essential">
+              <description>Add the Image Font service</description>
+              <files>
+                <!-- src/extra/others/imgfont -->
+                <file category="sourceC"            name="src/extra/others/imgfont/lv_imgfont.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the image font support*/
+#define LV_USE_IMGFONT         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Monkey"  condition="LVGL-Essential">
+              <description>Add the Monkey service</description>
+              <files>
+                <!-- src/extra/others/monkey -->
+                <file category="sourceC"            name="src/extra/others/monkey/lv_monkey.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the monkey service support*/
+#define LV_USE_MONKEY         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="lvgl" Csub="Message"  condition="LVGL-Essential">
+              <description>Add the Message service</description>
+              <files>
+                <!-- src/extra/others/msg -->
+                <file category="sourceC"            name="src/extra/others/msg/lv_msg.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the message service support*/
+#define LV_USE_MSG         1
               </RTE_Components_h>
 
             </component>

--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,8 +36,8 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-08-01" version="8.3.9-dev" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.9-dev.pack">
-      - LVGL 8.3.9-dev
+    <release date="2023-08-04" version="8.3.9" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.9.pack">
+      - LVGL 8.3.9
       - Add snapshot, fragment, imgfont, gridnav, msg and monkey
       - Other minor fixes
     </release>
@@ -299,7 +299,7 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.9-dev">
+        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.9">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
             <component Cgroup="lvgl" Csub="Essential" >

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2023-07-04</timestamp>
+  <timestamp>2023-08-04</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.8"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.9"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.8
+ * Configuration file for v8.3.9
  */
 
 /* clang-format off */

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "lvgl",
-	"version": "8.3.8",
+	"version": "8.3.9",
 	"keywords": "graphics, gui, embedded, tft, lvgl",
 	"description": "Graphics library to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint. It offers anti-aliasing, opacity, and animations using only one frame buffer.",
 	"repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=lvgl
-version=8.3.8
+version=8.3.9
 author=kisvegabor
 maintainer=kisvegabor,embeddedt,pete-pjb
 sentence=Full-featured Graphics Library for Embedded Systems

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.8
+ * Configuration file for v8.3.9
  */
 
 /*

--- a/lvgl.h
+++ b/lvgl.h
@@ -15,7 +15,7 @@ extern "C" {
  ***************************/
 #define LVGL_VERSION_MAJOR 8
 #define LVGL_VERSION_MINOR 3
-#define LVGL_VERSION_PATCH 8
+#define LVGL_VERSION_PATCH 9
 #define LVGL_VERSION_INFO ""
 
 /*********************


### PR DESCRIPTION
### Description of the feature or fix

Add snapshot, fragment, imgfont, gridnav, msg and monkey to the cmsis-pack. Those components will be available on the next LVGL v8.3.9 release. 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
