### PR TITLE
allow correct use of LV_CONF_PATH

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -8,7 +8,9 @@ option(LV_CONF_INCLUDE_SIMPLE
 
 # Option LV_CONF_PATH, which should be the path for lv_conf.h
 # If set parent path LV_CONF_DIR is added to includes
-get_filename_component(LV_CONF_DIR ${LV_CONF_PATH} DIRECTORY)
+if( LV_CONF_PATH )
+    get_filename_component(LV_CONF_DIR ${LV_CONF_PATH} DIRECTORY)
+endif( LV_CONF_PATH )
 
 # Option to build shared libraries (as opposed to static), default: OFF
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)

--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -6,9 +6,8 @@ option(LV_LVGL_H_INCLUDE_SIMPLE
 option(LV_CONF_INCLUDE_SIMPLE
        "Use #include \"lv_conf.h\" instead of #include \"../../lv_conf.h\"" ON)
 
-# Option to set LV_CONF_PATH, if set parent path LV_CONF_DIR is added to
-# includes
-option(LV_CONF_PATH "Path defined for lv_conf.h")
+# Option LV_CONF_PATH, which should be the path for lv_conf.h
+# If set parent path LV_CONF_DIR is added to includes
 get_filename_component(LV_CONF_DIR ${LV_CONF_PATH} DIRECTORY)
 
 # Option to build shared libraries (as opposed to static), default: OFF


### PR DESCRIPTION
Hi, this is simple change that fixed usability issues with the LV_CONF_PATH variable.

Assuming that lv_conf.h is placed alongside the lvgl directory, if we bundle lvgl in a cmake application as shown below:

```
set(LV_CONF_PATH /path/to/lvgl.h)
include_subdirectory( /path/to/lvgl )

add_executable( myapp ...)
target_link_libraries( myapp PRIVATE lvgl::lvgl )
```

The following code will not work:

```C
#include <lvgl/...>
```

This is traced to custom.cmake setting LV_CONF_PATH to a boolean (see [option](https://cmake.org/cmake/help/latest/command/option.html) )

If we declare the variable with option, any previous value is discarded and we can't use it as a path.

This PR fixes that.

Thanks,
António
