### PR TITLE
build(cmake): pass freetype build flags to parent

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -12,6 +12,16 @@ if( LV_CONF_PATH )
     get_filename_component(LV_CONF_DIR ${LV_CONF_PATH} DIRECTORY)
 endif( LV_CONF_PATH )
 
+find_package(PkgConfig REQUIRED)
+
+# Option LV_USE_FREETYPE
+# If set, libfreetype2 is added to the dependencies of lvgl so that dependants
+# have the compilation and linking flags automatically set.
+if( LV_USE_FREETYPE )
+    pkg_check_modules( FREETYPE freetype2>=2.0 REQUIRED )
+endif( LV_USE_FREETYPE )
+
+
 # Option to build shared libraries (as opposed to static), default: OFF
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
@@ -32,6 +42,16 @@ target_compile_definitions(
 if(LV_CONF_PATH)
   target_compile_definitions(lvgl PUBLIC LV_CONF_PATH=${LV_CONF_PATH})
 endif()
+
+target_compile_options(
+  lvgl PUBLIC $<$<BOOL:${LV_USE_FREETYPE}>:${FREETYPE_CFLAGS}>)
+
+target_link_libraries(
+  lvgl PUBLIC $<$<BOOL:${LV_USE_FREETYPE}>:${FREETYPE_LIBRARIES}>)
+
+target_link_options(
+  lvgl PUBLIC $<$<BOOL:${LV_USE_FREETYPE}>:${FREETYPE_LDFLAGS}>)
+
 
 # Include root and optional parent path of LV_CONF_PATH
 target_include_directories(lvgl SYSTEM PUBLIC ${LVGL_ROOT_DIR} ${LV_CONF_DIR})


### PR DESCRIPTION
If using freetype, the parent CMake project will need to know the freetype include and link dirs as well as the list of freetype libraries to link to.

This commit defines an option in the CMake project - LV_USE_FREETYPE -, which, if set, makes LVGL look for the freetype library using pkgconfig, and add the include dirs, link dirs and libraries to the cmake library, so that these are automatically passed along to dependants through the PUBLIC interface.

In the example below:
```cmake
add_subdirectory( path/to/lvgl )
add_executable( myapp ... )
target_link_libraries( myapp PRIVATE lvgl:lvgl )
```

If lv_conf.h has:
```C
#define LV_USE_FREETYPE 1
```

The build will fail because the compiler will need to know about the includes and freetype libraries.

This commit fixes that and spares parent projects from having to add the freetype library by hand.

This is mostly about developer-experience. Thanks for having a look and feel free to consider including it in LVGL if that's useful.

Cheers,
António