### PR TITLE
added Python version of lv_example_tiny_ttf_3

### DIFF
--- a/examples/libs/tiny_ttf/lv_example_tiny_ttf_3.py
+++ b/examples/libs/tiny_ttf/lv_example_tiny_ttf_3.py
@@ -1,0 +1,65 @@
+from ubuntu_font import ubuntu_font
+
+DISPLAY_TEXT = "Hello World!"
+MSG_NEW_SIZE = 1
+
+#
+# Change font size with Tiny_TTF
+#
+
+lsize = 25
+
+# Define the object that will be sent as msg payload
+class NewValue:
+    def __init__(self, value):
+        self.value = value
+    def __repr__(self):
+        return f"{self.value} %"
+    
+def slider_event_cb(e,label):
+
+    slider = e.get_target_obj()
+    lsize = slider.get_value()
+    label.set_text("{:d}".format(lsize))
+    lv.msg_send(MSG_NEW_SIZE, NewValue(lsize))
+
+
+def label_event_cb(e,font):
+
+    label = e.get_target_obj()
+    m = e.get_msg()
+    payload  = m.get_payload()
+    v = payload.__cast__()
+    lv.tiny_ttf_set_size(font, v.value)
+    label.set_text(DISPLAY_TEXT)
+
+# Create style with the new font
+style = lv.style_t()
+style.init()
+font = lv.tiny_ttf_create_data(ubuntu_font, len(ubuntu_font),lsize)
+style.set_text_font(font)
+style.set_text_align(lv.TEXT_ALIGN.CENTER)
+
+slider = lv.slider(lv.scr_act())
+slider.center()
+slider.set_range(5, 50)
+slider.set_value(lsize, lv.ANIM.OFF)
+slider.align(lv.ALIGN.BOTTOM_MID, 0, -50)
+
+slider_label = lv.label(lv.scr_act())
+slider_label.set_text("{:d}".format(lsize))
+slider_label.align_to(slider, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
+
+slider.add_event(lambda e: slider_event_cb(e,slider_label), lv.EVENT.VALUE_CHANGED, None)
+
+# Create a label with the new style
+label = lv.label(lv.scr_act())
+label.add_style(style, 0)
+label.add_event(lambda e: label_event_cb(e,font), lv.EVENT.MSG_RECEIVED, None)
+label.set_size(lv.SIZE_CONTENT, lv.SIZE_CONTENT)
+label.center()
+
+lv.msg_subscribe_obj(MSG_NEW_SIZE, label, None)
+lv.msg_send(MSG_NEW_SIZE, NewValue(lsize))
+
+


### PR DESCRIPTION
### Description of the feature or fix
addition of MP version of lv_example_tiny_ttf_3

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
