### PR TITLE
feat(global): move `_lv_disp_ll` to `lv_global`

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -61,11 +61,13 @@ struct _lv_freetype_context_t;
 
 typedef struct {
     bool inited;
-
     bool style_refresh;
+
     struct _lv_disp_t * disp_refresh;
-    struct _lv_group_t * group_default;
     struct _lv_disp_t * disp_default;
+    lv_ll_t  disp_ll;
+
+    struct _lv_group_t * group_default;
     lv_img_cache_manager_t img_cache_mgr;
 
     struct _lv_indev_t * indev_active;

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -16,11 +16,13 @@
 #include "../misc/lv_anim.h"
 #include "../misc/lv_gc.h"
 #include "../misc/lv_async.h"
+#include "../core/lv_global.h"
 
 /*********************
  *      DEFINES
  *********************/
 #define MY_CLASS &lv_obj_class
+#define disp_ll_p &(lv_global_default()->disp_ll)
 
 /**********************
  *      TYPEDEFS
@@ -288,7 +290,8 @@ lv_disp_t * lv_obj_get_disp(const lv_obj_t * obj)
     else scr = lv_obj_get_screen(obj);  /*get the screen of `obj`*/
 
     lv_disp_t * d;
-    _LV_LL_READ(&LV_GC_ROOT(_lv_disp_ll), d) {
+    lv_ll_t * disp_head = disp_ll_p;
+    _LV_LL_READ(disp_head, d) {
         uint32_t i;
         for(i = 0; i < d->screen_cnt; i++) {
             if(d->screens[i] == scr) return d;

--- a/src/disp/lv_disp.c
+++ b/src/disp/lv_disp.c
@@ -24,6 +24,7 @@
  *      DEFINES
  *********************/
 #define disp_def lv_global_default()->disp_default
+#define disp_ll_p &(lv_global_default()->disp_ll)
 
 /**********************
  *      TYPEDEFS
@@ -56,7 +57,7 @@ static bool is_out_anim(lv_scr_load_anim_t a);
 
 lv_disp_t * lv_disp_create(lv_coord_t hor_res, lv_coord_t ver_res)
 {
-    lv_disp_t * disp = _lv_ll_ins_head(&LV_GC_ROOT(_lv_disp_ll));
+    lv_disp_t * disp = _lv_ll_ins_head(disp_ll_p);
     LV_ASSERT_MALLOC(disp);
     if(!disp) return NULL;
 
@@ -164,11 +165,11 @@ void lv_disp_remove(lv_disp_t * disp)
         lv_obj_del(disp->screens[0]);
     }
 
-    _lv_ll_remove(&LV_GC_ROOT(_lv_disp_ll), disp);
+    _lv_ll_remove(disp_ll_p, disp);
     if(disp->refr_timer) lv_timer_del(disp->refr_timer);
     lv_free(disp);
 
-    if(was_default) lv_disp_set_default(_lv_ll_get_head(&LV_GC_ROOT(_lv_disp_ll)));
+    if(was_default) lv_disp_set_default(_lv_ll_get_head(disp_ll_p));
 }
 
 void lv_disp_set_default(lv_disp_t * disp)
@@ -184,9 +185,9 @@ lv_disp_t * lv_disp_get_default(void)
 lv_disp_t * lv_disp_get_next(lv_disp_t * disp)
 {
     if(disp == NULL)
-        return _lv_ll_get_head(&LV_GC_ROOT(_lv_disp_ll));
+        return _lv_ll_get_head(disp_ll_p);
     else
-        return _lv_ll_get_next(&LV_GC_ROOT(_lv_disp_ll), disp);
+        return _lv_ll_get_next(disp_ll_p, disp);
 }
 
 /*---------------------

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -59,6 +59,8 @@ static inline void lv_global_init(lv_global_t * global)
 
     lv_memset(global, 0, sizeof(lv_global_t));
 
+    _lv_ll_init(&(global->disp_ll), sizeof(lv_disp_t));
+
     global->style_refresh = true;
     global->layout_count = _LV_LAYOUT_LAST;
     global->style_last_custom_prop_id = (uint16_t)_LV_STYLE_LAST_BUILT_IN_PROP;
@@ -133,7 +135,6 @@ void lv_init(void)
 #endif
 
     _lv_obj_style_init();
-    _lv_ll_init(&LV_GC_ROOT(_lv_disp_ll), sizeof(lv_disp_t));
     _lv_ll_init(&LV_GC_ROOT(_lv_indev_ll), sizeof(lv_indev_t));
 
     /*Initialize the screen refresh system*/

--- a/src/misc/lv_gc.h
+++ b/src/misc/lv_gc.h
@@ -44,7 +44,6 @@ extern "C" {
 
 #define LV_ITERATE_ROOTS(f)                                                                            \
     LV_DISPATCH(f, lv_ll_t, _lv_timer_ll) /*Linked list to store the lv_timers*/                       \
-    LV_DISPATCH(f, lv_ll_t, _lv_disp_ll)  /*Linked list of display device*/                            \
     LV_DISPATCH(f, lv_ll_t, _lv_indev_ll) /*Linked list of input device*/                              \
     LV_DISPATCH(f, lv_ll_t, _lv_fsdrv_ll)                                                              \
     LV_DISPATCH(f, lv_ll_t, _lv_anim_ll)                                                               \


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
