### PR TITLE
Removes unused macro

### DIFF
--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -21,8 +21,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define LV_REFR_TASK_PRIO LV_TASK_PRIO_MID
-
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
removes the following macro from lv_refr.h

```c
#define LV_REFR_TASK_PRIO LV_TASK_PRIO_MID
```

both `LV_REFR_TASK_PRIO` and  `LV_TASK_PRIO_MID` are not used in LVGL at all.
