### PR TITLE
Removes unused function

### DIFF
--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -45,8 +45,6 @@ typedef struct {
 
 void lv_draw_sw_init(void);
 
-void lv_draw_unit_sw_create(lv_disp_t * disp, uint32_t cnt);
-
 LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img(lv_draw_unit_t * draw_unit, const lv_draw_img_dsc_t * draw_dsc,
                                           const lv_area_t * coords);
 


### PR DESCRIPTION
Function `void lv_draw_unit_sw_create(lv_disp_t * disp, uint32_t cnt);` causes linking errors because it has no body. So It should be removed.
