### PR TITLE
fix: fix typos

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -161,7 +161,7 @@ menu "LVGL configuration"
 				default 1
 				help
 					> 1 requires an operating system enabled in `LV_USE_OS`
-					> 1 means multply threads will render the screen in parallel
+					> 1 means multiply threads will render the screen in parallel
 
 			config LV_DRAW_SW_COMPLEX
 				bool "Enable complex draw engine"

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -36,7 +36,7 @@ typedef enum {
 
     /**Temporarily display the `flush_cb` so the pure rendering time will be measured.
      * The display is not updated during the benchmark, only at the end when the summary table is shown.
-     * Render a given number of frames from each scene adn calculate the FPS from them.*/
+     * Render a given number of frames from each scene and calculate the FPS from them.*/
     LV_DEMO_BENCHMARK_MODE_RENDER_ONLY,
 } lv_demo_benchmark_mode_t;
 

--- a/demos/music/README.md
+++ b/demos/music/README.md
@@ -13,7 +13,7 @@ The music player demo shows what kind of modern, smartphone-like user interfaces
 
 ## How the spectrum animation works
 - `assets/spectrum.py` creates an array of spectrum values from a music. 4 band are created with 33 samples/sec: bass, bass-mid, mid, mid-treble.
-- The spectrum meter UI does the followings:
+- The spectrum meter UI does the following:
 	- Zoom the album cover proportionality to the current bass value
 	- Display the 4 bands on the left side of a circle by default at 0°, 45°, 90°, 135°
 	- Add extra bars next to the "main bars" with a cosine shape. Add more bars for the lower bands.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -146,7 +146,7 @@ Fixes
    `3856 <https://github.com/lvgl/lvgl/pull/3856>`__
 -  fix(esp.cmake): add demos and examples
    `3784 <https://github.com/lvgl/lvgl/pull/3784>`__
--  fix(indev): fix scrolling on transformed obejcts
+-  fix(indev): fix scrolling on transformed objects
    `84cf05d <https://github.com/lvgl/lvgl/commit/84cf05d8b23b31e000db757a278545e58fcbcbe8>`__
 -  fix(style): add the missing support for pct pivot in tranasform style
    properties
@@ -168,13 +168,13 @@ Fixes
    `716e5e2 <https://github.com/lvgl/lvgl/commit/716e5e2c8bd2a22e7d56e8d7ca33054a11a1f4ed>`__
 -  fix(gridnav): fix stucking in pressed state with encoder
    `ad56dfa <https://github.com/lvgl/lvgl/commit/ad56dfaf7046a9bb8c05e877a8c8852cd14a59af>`__
--  fix(darw): add back the disappeared antialising=0 support
+-  fix(darw): add back the disappeared antialiasing=0 support
    `2c17b28 <https://github.com/lvgl/lvgl/commit/2c17b28ac476c95a4153ab6cabb77b1c7208bb74>`__
 -  fix(msg): fix typos in API by adding wrappers
    `41fa416 <https://github.com/lvgl/lvgl/commit/41fa41613455260ccdeb87ecb890ce026ff0a435>`__
 -  fix(draw): fix transformation accuracy
    `e06f03d <https://github.com/lvgl/lvgl/commit/e06f03db72f98439078118518158f52439dd7bf8>`__
--  fix(style): remove the reduntant define of LV_GRADIENT_MAX_STOPS
+-  fix(style): remove the redundant define of LV_GRADIENT_MAX_STOPS
    `903e94b <https://github.com/lvgl/lvgl/commit/903e94b716ca1b32cdb51de11df679953699e53b>`__
 -  demo(benchmark): fix lv_label_set_text_fmt format strings
    `ae38258 <https://github.com/lvgl/lvgl/commit/ae3825871e31cd42cad2f310bdfc605150670511>`__
@@ -803,12 +803,12 @@ Examples
    `3428 <https://github.com/lvgl/lvgl/pull/3428>`__
 -  example(imgfont): fix lvgl.h include path
    `3405 <https://github.com/lvgl/lvgl/pull/3405>`__
--  example(btnmatrix): update lv_example_btnmatrix_2 to expicitly check
+-  example(btnmatrix): update lv_example_btnmatrix_2 to explicitly check
    which part is drawn
    `6b2eac1 <https://github.com/lvgl/lvgl/commit/6b2eac1dd70df62916b46cee8d4b981ff088b1a7>`__
 -  example(slider): make lv_example_slider_3 work with dark theme too
    `4a766c5 <https://github.com/lvgl/lvgl/commit/4a766c516db7c2572a075ec5ffe748d30af8c7b9>`__
--  example(span): avoid ambiguous meaing
+-  example(span): avoid ambiguous meaning
    `7bb09e3 <https://github.com/lvgl/lvgl/commit/7bb09e358026aff3d55d881237624baac77db890>`__
 -  demo(benchmark): add LV_DEMO_BENCHMARK_RGB565A8 option
    `afaa8c9 <https://github.com/lvgl/lvgl/commit/afaa8c93006a88db9f115b2b318eef790928d2a6>`__
@@ -1206,7 +1206,7 @@ Fixes
 -  fix(align) fix LV_SIZE_CONTENT size calculation with not LEFT or TOP
    alignment
    `9c67642 <https://github.com/littlevgl/lvgl/commit/9c676421ff159de1a96409f5557d36090c1728f9>`__
--  fix(draw): futher bg_img draw fixes
+-  fix(draw): further bg_img draw fixes
    `81bfb76 <https://github.com/littlevgl/lvgl/commit/81bfb765e5baba359e61dcb030f3ee96160a6335>`__
 -  fix(btnmatrix): keep the selected button even on release
    `d47cd1d <https://github.com/littlevgl/lvgl/commit/d47cd1d7fe910efc189e2f43f046a09184cfff13>`__
@@ -3962,7 +3962,7 @@ Bugfixes
    settings)
 -  lv_chart fix X tick drawing
 -  Fix vertical dashed line drawing
--  Some additional minor fixes and formattings
+-  Some additional minor fixes and formatting
 
 v7.0.0 (18.05.2020)
 -------------------

--- a/docs/ROADMAP.rst
+++ b/docs/ROADMAP.rst
@@ -51,7 +51,7 @@ Architecture
 - |uncheck| Add more feature to key presses (long press, release, etc).
   (see `here <https://forum.lvgl.io/t/keypad-input-device-why-lv-event-long-pressed-only-on-enter/10263>`__) 
 - |uncheck| Variable binding. I.e create properties which can be bound to
-  objects and those obejcts are notified on value change. Maybe based on `lv_msg`?
+  objects and those objects are notified on value change. Maybe based on `lv_msg`?
 - |uncheck| Add GPU abstraction for display rotation 
 - |uncheck| Replace the `read_line_cb` of the image decoders with `get_area_cb`
 - |uncheck| Limit the image caching size in bytes instead of image count 
@@ -81,7 +81,7 @@ Widgets
 Drawing and rendering
 ~~~~~~~~~~~~~~~~~~~~~
 
-- |uncheck| Automatically recalculate the layout if a coordinte is get with `lv_obj_get_width/height/x/y/etc`
+- |uncheck| Automatically recalculate the layout if a coordinate is get with `lv_obj_get_width/height/x/y/etc`
 
 Animations
 ~~~~~~~~~~
@@ -101,7 +101,7 @@ Planned in general
 CI
 ~~
 
-- |uncheck| Plaform independent bechmarking #3443
+- |uncheck| Platform independent benchmarking #3443
 - |uncheck| Run static analyzer
 - |uncheck| Release script
 - |uncheck| Unit test for all widgets #2337

--- a/docs/build.py
+++ b/docs/build.py
@@ -2,7 +2,7 @@
 
 # ****************************************************************************
 # IMPOTRANT: If you are getting a lexer error for an example you need to check
-#            for extra lines at the edn of the file. Only a single empty line
+#            for extra lines at the end of the file. Only a single empty line
 #            is allowed!!! Ask me how long it took me to figure this out
 # ****************************************************************************
 
@@ -19,7 +19,7 @@ import config_builder
 # due to the modifications that take place to the documentation files
 # when the documentaation builds it is better to copy the source files to a
 # temporary folder and modify the copies. Not setting it up this way makes it
-# a real headache when making alterations that need to be comitted as the
+# a real headache when making alterations that need to be committed as the
 # alterations trigger the files as changed.
 
 # If there is debugging that needs to be done you can provide a command line

--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -53,7 +53,7 @@ void lv_example_file_explorer_1(void)
     char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
     strcpy(home_dir, "A:");
-    /* get the user's home directory from the HOME enviroment variable*/
+    /* get the user's home directory from the HOME environment variable*/
     strcat(home_dir, getenv(envvar));
     LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -83,7 +83,7 @@ void lv_example_file_explorer_2(void)
     char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
     strcpy(home_dir, "A:");
-    /* get the user's home directory from the HOME enviroment variable*/
+    /* get the user's home directory from the HOME environment variable*/
     strcat(home_dir, getenv(envvar));
     LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -97,7 +97,7 @@ void lv_example_file_explorer_3(void)
     char * envvar = "HOME";
     char home_dir[LV_FS_MAX_PATH_LENGTH];
     strcpy(home_dir, "A:");
-    /* get the user's home directory from the HOME enviroment variable*/
+    /* get the user's home directory from the HOME environment variable*/
     strcat(home_dir, getenv(envvar));
     LV_LOG_USER("home_dir: %s\n", home_dir);
     lv_file_explorer_set_quick_access_path(file_explorer, LV_EXPLORER_HOME_DIR, home_dir);

--- a/examples/others/msg/lv_example_msg_1.py
+++ b/examples/others/msg/lv_example_msg_1.py
@@ -21,8 +21,8 @@ def label_event_cb(e):
     # Respond only to MSG_NEW_TEMPERATURE message
     if msg.get_id() == MSG_NEW_TEMPERATURE:
         payload = msg.get_payload()
-        temprature = payload.__cast__()
-        label.set_text(str(temprature))
+        temperature = payload.__cast__()
+        label.set_text(str(temperature))
 
 # Create a slider in the center of the display
 slider = lv.slider(lv.scr_act())

--- a/examples/widgets/obj/lv_example_obj_2.c
+++ b/examples/widgets/obj/lv_example_obj_2.c
@@ -18,7 +18,7 @@ static void drag_event_handler(lv_event_t * e)
 
 
 /**
- * Make an object dragable.
+ * Make an object draggable.
  */
 void lv_example_obj_2(void)
 {

--- a/examples/widgets/obj/lv_example_obj_2.py
+++ b/examples/widgets/obj/lv_example_obj_2.py
@@ -12,7 +12,7 @@ def drag_event_handler(e):
 
 
 #
-# Make an object dragable.
+# Make an object draggable.
 #
 
 obj = lv.obj(lv.scr_act())

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -100,7 +100,7 @@
 #if LV_USE_DRAW_SW == 1
     /* Set the number of draw unit.
      * > 1 requires an operating system enabled in `LV_USE_OS`
-     * > 1 means multply threads will render the screen in parallel */
+     * > 1 means multiply threads will render the screen in parallel */
     #define LV_DRAW_SW_DRAW_UNIT_CNT    1
 
     /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode

--- a/scripts/changelog_gen.sh
+++ b/scripts/changelog_gen.sh
@@ -7,7 +7,7 @@
 # Usage:
 #    changelog-gen <next-version>
 #
-# Example: if the latest verision is v5.6.7 the followings can be used for bugfix, minor or major versions:
+# Example: if the latest verision is v5.6.7 the following can be used for bugfix, minor or major versions:
 #    changelog-gen v5.6.8
 #    changelog-gen v5.7.0
 #    changelog-gen v6.0.0

--- a/scripts/release/release.py
+++ b/scripts/release/release.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Create a new release from master. Execute the followings:
+# Create a new release from master. Execute the following:
 # - On lvgl, lv_demos, and lv_drivers:
 #   - Detect the current version of master. E.g. 8.1-dev
 #   - Create a new branch from the master for the release. E.g. release/v8.1

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -180,7 +180,7 @@ props = [
 
 {'name': 'BORDER_WIDTH',
  'style_type': 'num',   'var_type': 'lv_coord_t' ,  'default':0, 'inherited': 0, 'layout': 1, 'ext_draw': 0,
- 'dsc': "Set hte width of the border. Only pixel values can be used."},
+ 'dsc': "Set the width of the border. Only pixel values can be used."},
 
 {'name': 'BORDER_SIDE',
  'style_type': 'num',   'var_type': 'lv_border_side_t',  'default':'`LV_BORDER_SIDE_NONE`', 'inherited': 0, 'layout': 0, 'ext_draw': 0,
@@ -264,7 +264,7 @@ props = [
 
 {'name': 'LINE_COLOR',
  'style_type': 'color', 'var_type': 'lv_color_t' ,  'default':'`0x000000`', 'inherited': 0, 'layout': 0, 'ext_draw': 0, 'filtered': 1,
- 'dsc': "Set the color fo the lines."},
+ 'dsc': "Set the color of the lines."},
 
 {'name': 'LINE_OPA',
  'style_type': 'num',   'var_type': 'lv_opa_t' ,  'default':'`LV_OPA_COVER`', 'inherited': 0, 'layout': 0, 'ext_draw': 0,

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -81,7 +81,7 @@ lv_res_t lv_obj_event_base(const struct _lv_obj_class_t * class_p, lv_event_t * 
 
 /**
  * Get the current target of the event. It's the object which event handler being called.
- * If the event is not bubbled it's the same as "orignal" target.
+ * If the event is not bubbled it's the same as "original" target.
  * @param e     pointer to the event descriptor
  * @return      the target of the event_code
  */

--- a/src/disp/lv_disp.h
+++ b/src/disp/lv_disp.h
@@ -244,7 +244,7 @@ void lv_disp_set_draw_buffers(lv_disp_t * disp, void * buf1, void * buf2, uint32
                               lv_disp_render_mode_t render_mode);
 
 /**
- * Set the flush callback whcih will be called to copy the rendered image to the display.
+ * Set the flush callback which will be called to copy the rendered image to the display.
  * @param disp      pointer to a display
  * @param flush_cb  the flush callback (`px_map` contains the rendered image as raw pixel map and it should be copied to `area` on the display)
  */
@@ -255,7 +255,7 @@ void lv_disp_set_flush_cb(lv_disp_t * disp, lv_disp_flush_cb_t flush_cb);
  * to convert the rendered content to the desired color format.
  * @param disp              pointer to a display
  * @param color_format      By default `LV_COLOR_FORMAT_NATIVE` to render with L8, RGB565, RGB888 or ARGB8888.
- *                          `LV_COLOR_FORMAT_NATIVE_REVERSE` to change endianess.
+ *                          `LV_COLOR_FORMAT_NATIVE_REVERSE` to change endianness.
  *
  */
 void lv_disp_set_color_format(lv_disp_t * disp, lv_color_format_t color_format);
@@ -347,7 +347,7 @@ struct _lv_obj_t * lv_disp_get_layer_sys(lv_disp_t * disp);
 
 /**
  * Return the bottom layer. The bottom layer is the same on all screen and it is under the normal screen layer.
- * It's visble only if the the screen is transparent.
+ * It's visible only if the the screen is transparent.
  * @param disp      pointer to display (NULL to use the default screen)
  * @return          pointer to the bottom layer object
  */

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -102,7 +102,7 @@ typedef struct _lv_draw_unit_t {
      * @param layer         pointer to a layer on which the draw task should be drawn
      * @return              >=0:    The number of taken draw task
      *                      -1:     There where no available draw tasks at all.
-     *                              Also means to no call the dispatcher of the other draw units as there is no dra task to tkae
+     *                              Also means to no call the dispatcher of the other draw units as there is no draw task to take
      */
     int32_t (*dispatch)(struct _lv_draw_unit_t * draw_unit, struct _lv_layer_t * layer);
 } lv_draw_unit_t;

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -136,7 +136,7 @@ static void render_thread_cb(void * ptr)
 
         execute_drawing(u);
 
-        /*Cleaup*/
+        /*Cleanup*/
         u->task_act->state = LV_DRAW_TASK_STATE_READY;
         u->task_act = NULL;
 

--- a/src/draw/sw/lv_draw_sw_gradient.c
+++ b/src/draw/sw/lv_draw_sw_gradient.c
@@ -70,7 +70,7 @@ lv_grad_t * lv_gradient_get(const lv_grad_dsc_t * g, lv_coord_t w, lv_coord_t h)
     /* Step 1: Search cache for the given key */
     lv_grad_t * item = allocate_item(g, w, h);
     if(item == NULL) {
-        LV_LOG_WARN("Faild to allcoate item for teh gradient");
+        LV_LOG_WARN("Failed to allocate item for the gradient");
         return item;
     }
 

--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -75,7 +75,7 @@ void lv_gif_set_src(lv_obj_t * obj, const void * src)
         gifobj->gif = gd_open_gif_file(src);
     }
     if(gifobj->gif == NULL) {
-        LV_LOG_WARN("Could't load the source");
+        LV_LOG_WARN("Couldn't load the source");
         return;
     }
 

--- a/src/libs/png/lodepng.h
+++ b/src/libs/png/lodepng.h
@@ -911,7 +911,7 @@ unsigned lodepng_chunk_append(unsigned char ** out, size_t * outsize, const unsi
 Appends new chunk to out. The chunk to append is given by giving its length, type
 and data separately. The type is a 4-letter string.
 The out variable and outsize are updated to reflect the new reallocated buffer.
-Returne error code (0 if it went ok)
+Return error code (0 if it went ok)
 */
 unsigned lodepng_chunk_create(unsigned char ** out, size_t * outsize, unsigned length,
                               const char * type, const unsigned char * data);
@@ -1777,7 +1777,7 @@ state.decoder.remember_unknown_chunks: whether to read in unknown chunks
 state.info_raw.colortype: desired color type for decoded image
 state.info_raw.bitdepth: desired bit depth for decoded image
 state.info_raw....: more color settings, see struct LodePNGColorMode
-state.info_png....: no settings for decoder but ouput, see struct LodePNGInfo
+state.info_png....: no settings for decoder but output, see struct LodePNGInfo
 
 For encoding:
 

--- a/src/libs/png/lv_png.c
+++ b/src/libs/png/lv_png.c
@@ -224,7 +224,7 @@ static void decoder_close(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * dsc
 }
 
 /**
- * If the display is not in 32 bit format (ARGB888) then covert the image to the current color depth
+ * If the display is not in 32 bit format (ARGB888) then convert the image to the current color depth
  * @param img the ARGB888 image
  * @param px_cnt number of pixels in `img`
  */

--- a/src/libs/sjpg/lv_sjpg.c
+++ b/src/libs/sjpg/lv_sjpg.c
@@ -55,7 +55,7 @@
 /*********************
  *      DEFINES
  *********************/
-#define TJPGD_WORKBUFF_SIZE             4096    //Recommended by TJPGD libray
+#define TJPGD_WORKBUFF_SIZE             4096    //Recommended by TJPGD library
 
 //NEVER EDIT THESE OFFSET VALUES
 #define SJPEG_VERSION_OFFSET            8

--- a/src/libs/sjpg/tjpgd.c
+++ b/src/libs/sjpg/tjpgd.c
@@ -16,9 +16,9 @@
 / Oct 04, 2011 R0.01  First release.
 / Feb 19, 2012 R0.01a Fixed decompression fails when scan starts with an escape seq.
 / Sep 03, 2012 R0.01b Added JD_TBLCLIP option.
-/ Mar 16, 2019 R0.01c Supprted stdint.h.
+/ Mar 16, 2019 R0.01c Supported stdint.h.
 / Jul 01, 2020 R0.01d Fixed wrong integer type usage.
-/ May 08, 2021 R0.02  Supprted grayscale image. Separated configuration options.
+/ May 08, 2021 R0.02  Supported grayscale image. Separated configuration options.
 / Jun 11, 2021 R0.02a Some performance improvement.
 / Jul 01, 2021 R0.03  Added JD_FASTDECODE option.
 /                     Some performance improvement.
@@ -142,7 +142,7 @@ static void * alloc_pool( /* Pointer to allocated memory block (NULL:no memory a
     if(jd->sz_pool >= ndata) {
         jd->sz_pool -= ndata;
         rp = (char *)jd->pool;          /* Get start of available memory pool */
-        jd->pool = (void *)(rp + ndata); /* Allocate requierd bytes */
+        jd->pool = (void *)(rp + ndata); /* Allocate required bytes */
     }
 
     return (void *)rp;  /* Return allocated memory block (NULL:no memory to allocate) */
@@ -381,7 +381,7 @@ static int huffext(  /* >=0: decoded data, <0: error code */
     jd->wreg = w;
 
 #if JD_FASTDECODE == 2
-    /* Table serch for the short codes */
+    /* Table search for the short codes */
     d = (unsigned int)(w >> (wbit - HUFF_BIT)); /* Short code as table index */
     if(cls) {   /* AC element */
         d = jd->hufflut_ac[id][d];  /* Table decode */
@@ -398,13 +398,13 @@ static int huffext(  /* >=0: decoded data, <0: error code */
         }
     }
 
-    /* Incremental serch for the codes longer than HUFF_BIT */
+    /* Incremental search for the codes longer than HUFF_BIT */
     hb = jd->huffbits[id][cls] + HUFF_BIT;              /* Bit distribution table */
     hc = jd->huffcode[id][cls] + jd->longofs[id][cls];  /* Code word table */
     hd = jd->huffdata[id][cls] + jd->longofs[id][cls];  /* Data table */
     bl = HUFF_BIT + 1;
 #else
-    /* Incremental serch for all codes */
+    /* Incremental search for all codes */
     hb = jd->huffbits[id][cls]; /* Bit distribution table */
     hc = jd->huffcode[id][cls]; /* Code word table */
     hd = jd->huffdata[id][cls]; /* Data table */
@@ -533,7 +533,7 @@ static int bitext(  /* >=0: extracted data, <0: error code */
 
 static JRESULT restart(
     JDEC * jd,      /* Pointer to the decompressor object */
-    uint16_t rstn   /* Expected restert sequense number */
+    uint16_t rstn   /* Expected restert sequence number */
 )
 {
     unsigned int i;
@@ -795,7 +795,7 @@ static JRESULT mcu_load(
             if(JD_FORMAT != 2 || !cmp) {    /* C components may not be processed if in grayscale output */
                 if(z == 1 || (JD_USE_SCALE &&
                               jd->scale ==
-                              3)) {    /* If no AC element or scale ratio is 1/8, IDCT can be ommited and the block is filled with DC value */
+                              3)) {    /* If no AC element or scale ratio is 1/8, IDCT can be omitted and the block is filled with DC value */
                     d = (jd_yuv_t)((*tmp / 256) + 128);
                     if(JD_FASTDECODE >= 1) {
                         for(i = 0; i < 64; bp[i++] = d) ;
@@ -874,7 +874,7 @@ static JRESULT mcu_output(
                     cb = pc[0] - 128;   /* Get Cb/Cr component and remove offset */
                     cr = pc[64] - 128;
                     if(mx == 16) {                  /* Double block width? */
-                        if(ix == 8) py += 64 - 8;   /* Jump to next block if double block heigt */
+                        if(ix == 8) py += 64 - 8;   /* Jump to next block if double block height */
                         pc += ix & 1;               /* Step forward chroma pointer every two pixels */
                     }
                     else {                          /* Single block width */
@@ -907,7 +907,7 @@ static JRESULT mcu_output(
             unsigned int x, y, r, g, b, s, w, a;
             uint8_t * op;
 
-            /* Get averaged RGB value of each square correcponds to a pixel */
+            /* Get averaged RGB value of each square corresponds to a pixel */
             s = jd->scale * 2;  /* Number of shifts for averaging */
             w = 1 << jd->scale; /* Width of square */
             a = (mx - w) * (JD_FORMAT != 2 ? 3 : 1);    /* Bytes to skip for next line in the square */
@@ -1010,7 +1010,7 @@ static JRESULT mcu_output(
 
 JRESULT jd_prepare(
     JDEC * jd,              /* Blank decompressor object */
-    size_t (*infunc)(JDEC *, uint8_t *, size_t), /* JPEG strem input function */
+    size_t (*infunc)(JDEC *, uint8_t *, size_t), /* JPEG stream input function */
     void * pool,            /* Working buffer for the decompression session */
     size_t sz_pool,         /* Size of working buffer */
     void * dev              /* I/O device identifier for the session */
@@ -1025,7 +1025,7 @@ JRESULT jd_prepare(
 
     memset(jd, 0, sizeof(
                JDEC));    /* Clear decompression object (this might be a problem if machine's null pointer is not all bits zero) */
-    jd->pool = pool;        /* Work memroy */
+    jd->pool = pool;        /* Work memory */
     jd->sz_pool = sz_pool;  /* Size of given work memory */
     jd->infunc = infunc;    /* Stream input function */
     jd->device = dev;       /* I/O device identifier */

--- a/src/libs/sjpg/tjpgd.h
+++ b/src/libs/sjpg/tjpgd.h
@@ -49,13 +49,13 @@ struct _JDEC {
     size_t dctr;                /* Number of bytes available in the input buffer */
     uint8_t * dptr;             /* Current data read ptr */
     uint8_t * inbuf;            /* Bit stream input buffer */
-    uint8_t dbit;               /* Number of bits availavble in wreg or reading bit mask */
+    uint8_t dbit;               /* Number of bits available in wreg or reading bit mask */
     uint8_t scale;              /* Output scaling ratio */
     uint8_t msx, msy;           /* MCU size in unit of block (width, height) */
     uint8_t qtid[3];            /* Quantization table ID of each component, Y, Cb, Cr */
     uint8_t ncomp;              /* Number of color components 1:grayscale, 3:color */
     int16_t dcv[3];             /* Previous DC element of each component */
-    uint16_t nrst;              /* Restart inverval */
+    uint16_t nrst;              /* Restart interval */
     uint16_t width, height;     /* Size of the input image (pixel) */
     uint8_t * huffbits[2][2];   /* Huffman bit distribution tables [id][dcac] */
     uint16_t * huffcode[2][2];  /* Huffman code word tables [id][dcac] */
@@ -73,9 +73,9 @@ struct _JDEC {
     void * workbuf;             /* Working buffer for IDCT and RGB output */
     jd_yuv_t * mcubuf;          /* Working buffer for the MCU */
     void * pool;                /* Pointer to available memory pool */
-    size_t sz_pool;             /* Size of momory pool (bytes available) */
+    size_t sz_pool;             /* Size of memory pool (bytes available) */
     size_t (*infunc)(JDEC *, uint8_t *, size_t); /* Pointer to jpeg stream input function */
-    void * device;              /* Pointer to I/O device identifiler for the session */
+    void * device;              /* Pointer to I/O device identifier for the session */
 };
 
 

--- a/src/libs/tiny_ttf/stb_rect_pack.h
+++ b/src/libs/tiny_ttf/stb_rect_pack.h
@@ -317,7 +317,7 @@ static int stbrp__skyline_find_min_y(stbrp_context * c, stbrp_node * first, int 
         if(node->y > min_y) {
             // raise min_y higher.
             // we've accounted for all waste up to min_y,
-            // but we'll now add more waste for everything we've visted
+            // but we'll now add more waste for everything we've visited
             waste_area += visited_width * (node->y - min_y);
             min_y = node->y;
             // the first time through, visited_width might be reduced

--- a/src/libs/tiny_ttf/stb_truetype_htcw.h
+++ b/src/libs/tiny_ttf/stb_truetype_htcw.h
@@ -668,7 +668,7 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context * spc, unsigned int 
 STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context * spc, int skip);
 // If skip != 0, this tells stb_truetype to skip any codepoints for which
 // there is no corresponding glyph. If skip=0, which is the default, then
-// codepoints without a glyph recived the font's "missing character" glyph,
+// codepoints without a glyph received the font's "missing character" glyph,
 // typically an empty box by convention.
 
 STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar * chardata, int pw, int ph, // same data as above

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -260,7 +260,7 @@
 #if LV_USE_DRAW_SW == 1
     /* Set the number of draw unit.
      * > 1 requires an operating system enabled in `LV_USE_OS`
-     * > 1 means multply threads will render the screen in parallel */
+     * > 1 means multiply threads will render the screen in parallel */
     #ifndef LV_DRAW_SW_DRAW_UNIT_CNT
         #ifdef _LV_KCONFIG_PRESENT
             #ifdef CONFIG_LV_DRAW_SW_DRAW_UNIT_CNT

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -450,7 +450,7 @@ static void lv_style_set_prop_internal(lv_style_t * style, lv_style_prop_t prop_
         }
         style->prop_cnt++;
 
-        /*Go to the new position wit the props*/
+        /*Go to the new position with the props*/
         tmp = values_and_props + style->prop_cnt * sizeof(lv_style_value_t);
         props = (uint16_t *)tmp;
         lv_style_value_t * values = (lv_style_value_t *)values_and_props;

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -175,7 +175,7 @@ typedef uint8_t lv_dither_mode_t;
  */
 typedef struct {
     lv_color_t color;   /**< The stop color */
-    lv_opa_t   opa;     /**< The opacity fo the color*/
+    lv_opa_t   opa;     /**< The opacity of the color*/
     uint8_t    frac;    /**< The stop position in 1/255 unit */
 } lv_gradient_stop_t;
 

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -283,7 +283,7 @@ uint32_t _lv_txt_get_next_line(const char * txt, const lv_font_t * font,
 
     lv_coord_t line_w = 0;
 
-    /*If max_width doesn't mater simply find the new line character
+    /*If max_width doesn't matter simply find the new line character
      *without thinking about word wrapping*/
     if((flag & LV_TEXT_FLAG_EXPAND) || (flag & LV_TEXT_FLAG_FIT)) {
         uint32_t i;

--- a/src/others/msg/lv_msg.h
+++ b/src/others/msg/lv_msg.h
@@ -66,7 +66,7 @@ void * lv_msg_subscribe_obj(lv_msg_id_t msg_id, lv_obj_t * obj, void * user_data
 
 /**
  * Cancel a previous subscription
- * @param s             pointer to a "subscibe object".
+ * @param s             pointer to a "subscribe object".
  *                      Return value of `lv_msg_subscribe` or `lv_msg_subscribe_obj`
  */
 void lv_msg_unsubscribe(void * s);

--- a/src/widgets/animimg/lv_animimg.h
+++ b/src/widgets/animimg/lv_animimg.h
@@ -92,7 +92,7 @@ void lv_animimg_start(lv_obj_t * obj);
 void lv_animimg_set_duration(lv_obj_t * img, uint32_t duration);
 
 /**
- * Set the image animation repeatly play times.
+ * Set the image animation repeatedly play times.
  * @param img pointer to an animation image object
  * @param count the number of times to repeat the animation
  */

--- a/src/widgets/btnmatrix/lv_btnmatrix.h
+++ b/src/widgets/btnmatrix/lv_btnmatrix.h
@@ -121,7 +121,7 @@ void lv_btnmatrix_set_selected_btn(lv_obj_t * obj, uint16_t btn_id);
  * Set the attributes of a button of the button matrix
  * @param obj       pointer to button matrix object
  * @param btn_id    0 based index of the button to modify. (Not counting new lines)
- * @param ctrl      OR-ed attributs. E.g. `LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CHECKABLE`
+ * @param ctrl      OR-ed attributes. E.g. `LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CHECKABLE`
  */
 void lv_btnmatrix_set_btn_ctrl(lv_obj_t * obj, uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl);
 
@@ -129,7 +129,7 @@ void lv_btnmatrix_set_btn_ctrl(lv_obj_t * obj, uint16_t btn_id, lv_btnmatrix_ctr
  * Clear the attributes of a button of the button matrix
  * @param obj       pointer to button matrix object
  * @param btn_id    0 based index of the button to modify. (Not counting new lines)
- * @param ctrl      OR-ed attributs. E.g. `LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CHECKABLE`
+ * @param ctrl      OR-ed attributes. E.g. `LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CHECKABLE`
  */
 void lv_btnmatrix_clear_btn_ctrl(lv_obj_t * obj, uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl);
 

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -320,7 +320,7 @@ static void lv_roller_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
 #if LV_WIDGETS_HAS_DEFAULT_VALUE
     lv_roller_set_options(obj, "Option 1\nOption 2\nOption 3\nOption 4\nOption 5", LV_ROLLER_MODE_NORMAL);
 #endif
-    LV_LOG_TRACE("finshed");
+    LV_LOG_TRACE("finished");
 }
 
 static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -479,7 +479,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
         cur_shift_left++;
     }
 
-    /*Convert the numbers to string (the sign is already handled so always covert positive number)*/
+    /*Convert the numbers to string (the sign is already handled so always convert positive number)*/
     char digits[LV_SPINBOX_MAX_DIGIT_COUNT_WITH_4BYTES];
     lv_snprintf(digits, LV_SPINBOX_MAX_DIGIT_COUNT_WITH_4BYTES, "%" LV_PRId32, LV_ABS(spinbox->value));
 

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -813,7 +813,7 @@ static void refr_cell_size(lv_obj_t * obj, uint32_t row, uint32_t col)
     lv_coord_t prev_row_size = table->row_h[row];
     table->row_h[row] = LV_CLAMP(minh, calculated_height, maxh);
 
-    /*If the row height havn't changed invalidate only this cell*/
+    /*If the row height haven't changed invalidate only this cell*/
     if(prev_row_size == table->row_h[row]) {
         lv_area_t cell_area;
         get_cell_area(obj, row, col, &cell_area);

--- a/tests/src/test_cases/test_font_loader.c
+++ b/tests/src/test_cases/test_font_loader.c
@@ -45,7 +45,7 @@ extern lv_font_t font_3;
 
 void test_font_loader(void)
 {
-    /*Test with cahce ('A' has cache)*/
+    /*Test with cache ('A' has cache)*/
     lv_font_t * font_1_bin = lv_font_load("A:src/test_assets/font_1.fnt");
     lv_font_t * font_2_bin = lv_font_load("A:src/test_assets/font_2.fnt");
     lv_font_t * font_3_bin = lv_font_load("A:src/test_assets/font_3.fnt");
@@ -58,7 +58,7 @@ void test_font_loader(void)
     lv_font_free(font_2_bin);
     lv_font_free(font_3_bin);
 
-    /*Test with cahce ('B' has NO cache)*/
+    /*Test with cache ('B' has NO cache)*/
     font_1_bin = lv_font_load("B:src/test_assets/font_1.fnt");
     font_2_bin = lv_font_load("B:src/test_assets/font_2.fnt");
     font_3_bin = lv_font_load("B:src/test_assets/font_3.fnt");

--- a/tests/src/test_cases/test_table.c
+++ b/tests/src/test_cases/test_table.c
@@ -34,7 +34,7 @@ void test_table_should_grow_columns_automatically_when_setting_formatted_cell_va
     uint16_t original_column_count = lv_table_get_col_cnt(table);
     TEST_ASSERT_EQUAL_UINT16(1, original_column_count);
 
-    /* Table currently only has a cell at 0,0 (row, colum) */
+    /* Table currently only has a cell at 0,0 (row, column) */
     lv_table_set_cell_value_fmt(table, 0, 1, "LVGL %s", "Rocks!");
 
     /* Table now should have cells at 0,0 and 0,1, so 2 columns */

--- a/tests/src/test_cases/test_win.c
+++ b/tests/src/test_cases/test_win.c
@@ -118,7 +118,7 @@ void test_win_add_btn(void)
     TEST_ASSERT_EQUAL(1, lv_obj_get_child_cnt(btn));
     TEST_ASSERT_EQUAL(win_btn_width, lv_obj_get_width(btn));
 
-    // Check the output remains visualy consistent
+    // Check the output remains visually consistent
     TEST_ASSERT_EQUAL_SCREENSHOT("win_01.png");
 }
 
@@ -167,7 +167,7 @@ void test_win_add_multiple_elements(void)
     TEST_ASSERT_EQUAL(1, lv_obj_get_child_cnt(btn));
     TEST_ASSERT_EQUAL(win_btn_close_width, lv_obj_get_width(btn));
 
-    // Check the output remains visualy consistent
+    // Check the output remains visually consistent
     TEST_ASSERT_EQUAL_SCREENSHOT("win_02.png");
 }
 

--- a/tests/unity/generate_test_runner.rb
+++ b/tests/unity/generate_test_runner.rb
@@ -114,7 +114,7 @@ class UnityTestRunnerGenerator
     # @ is not a valid C character, so there should be no clashes with files genuinely containing these markers
     substring_subs = { '{' => '@co@', '}' => '@cc@', ';' => '@ss@', '/' => '@fs@' }
     substring_re = Regexp.union(substring_subs.keys)
-    substring_unsubs = substring_subs.invert                   # the inverse map will be used to fix the strings afterwords
+    substring_unsubs = substring_subs.invert                   # the inverse map will be used to fix the strings afterwards
     substring_unsubs['@quote@'] = '\\"'
     substring_unsubs['@apos@'] = '\\\''
     substring_unre = Regexp.union(substring_unsubs.keys)

--- a/tests/unity/unity.c
+++ b/tests/unity/unity.c
@@ -14,7 +14,7 @@
 #define PROGMEM
 #endif
 
-/* If omitted from header, declare overrideable prototypes here so they're ready for use */
+/* If omitted from header, declare overridable prototypes here so they're ready for use */
 #ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
 void UNITY_OUTPUT_CHAR(int);
 #endif


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
