### PR TITLE
lv_slider: Add API for knob_inside functionality

### DIFF
--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -77,6 +77,16 @@ bool lv_slider_is_dragged(const lv_obj_t * obj)
     return slider->dragging ? true : false;
 }
 
+void lv_slider_set_knob_inside(lv_obj_t * obj, uint8_t enable)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_slider_t * slider = (lv_slider_t *)obj;
+
+    slider->knob_inside = enable;
+
+    lv_obj_invalidate(obj);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -90,6 +100,7 @@ static void lv_slider_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     slider->value_to_set = NULL;
     slider->dragging = 0U;
     slider->left_knob_focus = 0U;
+    slider->knob_inside = 0U;
 
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -271,6 +271,38 @@ static void draw_knob(lv_event_t * e)
     lv_obj_init_draw_rect_dsc(obj, LV_PART_KNOB, &knob_rect_dsc);
     /* Update knob area with knob style */
     position_knob(obj, &knob_area, knob_size, is_horizontal);
+    LV_LOG_USER("Knob area X1: %d, Y1: %d, X2: %d, Y2: %d", knob_area.x1, knob_area.y1, knob_area.x2, knob_area.y2);
+
+    /* Adjust knob area when knob must be kept inside the bar */
+    /* TODO work on vertical bar */
+    if(slider->knob_inside) {
+        LV_LOG_USER("Keeping knob inside");
+
+        lv_area_t indicator_coords;
+        lv_obj_get_coords((lv_obj_t *) &slider->bar, &indicator_coords);
+        LV_LOG_USER("Indicator area X1: %d, Y1: %d, X2: %d, Y2: %d", indicator_coords.x1, indicator_coords.y1,
+                    indicator_coords.x2, indicator_coords.y2);
+
+        lv_coord_t left_limit = indicator_coords.x1 + (knob_size / 2U);
+        lv_coord_t right_limit = indicator_coords.x2 - (knob_size / 2U);
+
+        LV_LOG_USER("Left limit: %d, Right limit: %d", left_limit, right_limit);
+
+        if(left_limit > knob_area.x1) {
+            /* Indicator value tracks the left side of the knob. See update_knob_pos */
+            knob_area.x1 = left_limit;
+            knob_area.x2 = knob_area.x1 + 22U; /* How can I get this 22 from? Knob size seems to be 13 (is padding missing?) */
+        }
+        else if(right_limit < knob_area.x2) {
+            /* Indicator value tracks the right side of the knob. See update_knob_pos */
+            knob_area.x2 = right_limit;
+            knob_area.x1 = knob_area.x2 - 22U;
+        }
+        else { /* Indicator value tracks knob center */ }
+
+        LV_LOG_USER("Knob area X1: %d, Y1: %d, X2: %d, Y2: %d", knob_area.x1, knob_area.y1, knob_area.x2, knob_area.y2);
+    }
+
     /* Update right knob area with calculated knob area */
     lv_area_copy(&slider->right_knob_area, &knob_area);
 

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -51,6 +51,7 @@ typedef struct {
     int32_t * value_to_set; /*Which bar value to set*/
     uint8_t dragging : 1;       /*1: the slider is being dragged*/
     uint8_t left_knob_focus : 1; /*1: with encoder now the right knob can be adjusted*/
+    uint8_t knob_inside : 1;
 } lv_slider_t;
 
 extern const lv_obj_class_t lv_slider_class;
@@ -112,6 +113,13 @@ static inline void lv_slider_set_mode(lv_obj_t * obj, lv_slider_mode_t mode)
 {
     lv_bar_set_mode(obj, (lv_bar_mode_t)mode);
 }
+
+/**
+ * Set the knob inside functionality.
+ * @param obj       pointer to a slider object
+ * @param enable    Configure knob inside functionality
+ */
+void lv_slider_set_knob_inside(lv_obj_t * obj, uint8_t enable);
 
 /*=====================
  * Getter functions


### PR DESCRIPTION
### Description of the feature or fix

Closes #4412 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
