### PR TITLE
fix(kconfig): Change LV_CONF_SKIP default value

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -6,8 +6,8 @@ menu "LVGL configuration"
 	# without lv_conf.h file, the lv_conf_internal.h and
 	# lv_conf_kconfig.h files are used instead.
 	config LV_CONF_SKIP
-		bool "Uncheck this to use custom lv_conf.h"
-		default y
+		bool "Check this to not use custom lv_conf.h"
+		default n
 
 	config LV_CONF_MINIMAL
 		bool "LVGL minimal configuration."


### PR DESCRIPTION
Changes the LV_CONF_SKIP default value to be `n`. Reason for this is that a Kconfig bool symbol with default value `y` can not be overriden once it has been sourced first.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
Does not apply.
