### PR TITLE
fix(chart): fix off-by-one error in chart widget

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -575,7 +575,6 @@ static void analytics_create(lv_obj_t * parent)
     lv_chart_set_next_value(chart1, ser1, lv_rand(10, 80));
     lv_chart_set_next_value(chart1, ser1, lv_rand(10, 80));
     lv_chart_set_next_value(chart1, ser1, lv_rand(10, 80));
-    lv_chart_set_next_value(chart1, ser1, lv_rand(10, 80));
 
     lv_obj_t * chart2_cont = lv_obj_create(parent);
     lv_obj_add_flag(chart2_cont, LV_OBJ_FLAG_FLEX_IN_NEW_TRACK);
@@ -628,10 +627,8 @@ static void analytics_create(lv_obj_t * parent)
     lv_chart_set_next_value(chart2, ser2, lv_rand(10, 80));
     lv_chart_set_next_value(chart2, ser2, lv_rand(10, 80));
     lv_chart_set_next_value(chart2, ser2, lv_rand(10, 80));
-    lv_chart_set_next_value(chart2, ser2, lv_rand(10, 80));
 
     ser3 = lv_chart_add_series(chart2, lv_theme_get_color_primary(chart1), LV_CHART_AXIS_PRIMARY_Y);
-    lv_chart_set_next_value(chart2, ser3, lv_rand(10, 80));
     lv_chart_set_next_value(chart2, ser3, lv_rand(10, 80));
     lv_chart_set_next_value(chart2, ser3, lv_rand(10, 80));
     lv_chart_set_next_value(chart2, ser3, lv_rand(10, 80));
@@ -810,11 +807,6 @@ void shop_create(lv_obj_t * parent)
     lv_obj_add_event(chart3, shop_chart_event_cb, LV_EVENT_ALL, NULL);
 
     ser4 = lv_chart_add_series(chart3, lv_theme_get_color_primary(chart3), LV_CHART_AXIS_PRIMARY_Y);
-    lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
-    lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
-    lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
-    lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
-    lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
     lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
     lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));
     lv_chart_set_next_value(chart3, ser4, lv_rand(60, 90));

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -987,7 +987,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                 point_area.x2 = line_dsc.p2.x + point_w;
                 point_area.y1 = line_dsc.p2.y - point_h;
                 point_area.y2 = line_dsc.p2.y + point_h;
-                point_dsc_default.base.id2 = i;
+                point_dsc_default.base.id2 = i - 1;
                 lv_draw_rect(layer, &point_dsc_default, &point_area);
             }
 

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -969,7 +969,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                     }
 
                     if(point_w && point_h && ser->y_points[p_prev] != LV_CHART_POINT_NONE) {
-                        point_dsc_default.base.id2 = i;
+                        point_dsc_default.base.id2 = i - 1;
                         lv_draw_rect(layer, &point_dsc_default, &point_area);
                     }
                 }

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -892,7 +892,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
     if(LV_MIN(point_w, point_h) > line_dsc.width / 2) line_dsc.raw_end = 1;
     if(line_dsc.width == 1) line_dsc.raw_end = 1;
 
-    /*If there are at least as much points as pixels then draw only vertical lines*/
+    /*If there are at least as many points as pixels then draw only vertical lines*/
     bool crowded_mode = chart->point_cnt >= w ? true : false;
 
     /*Go through all data lines*/


### PR DESCRIPTION
### Description of the feature or fix

Adjusted the index for drawing chart points in lvgl. This update corrects an off-by-one error, ensuring that the correct point is highlighted. The change was necessary as the previous code was index 1 position ahead causing potential out-of-bounds accidents.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
