### PR TITLE
fix(typos): fix some typos for style

### DIFF
--- a/docs/overview/style-props.md
+++ b/docs/overview/style-props.md
@@ -394,7 +394,7 @@ Set the opacity of the border. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means full
 </ul>
 
 ### border_width
-Set hte width of the border. Only pixel values can be used.
+Set the width of the border. Only pixel values can be used.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -586,7 +586,7 @@ Make the end points of the lines rounded. `true`: rounded, `false`: perpendicula
 </ul>
 
 ### line_color
-Set the color fo the lines.
+Set the color of the lines.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -898,7 +898,7 @@ An array to describe the columns of the grid. Should be LV_GRID_TEMPLATE_LAST te
 </ul>
 
 ### grid_column_align
-Defines how to ditribute the columns
+Defines how to distribute the columns
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -916,7 +916,7 @@ An array to describe the rows of the grid. Should be LV_GRID_TEMPLATE_LAST termi
 </ul>
 
 ### grid_row_align
-Defines how to ditribute the rows.
+Defines how to distribute the rows.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -77,7 +77,7 @@
  *========================*/
 /* Select a draw buffer implementation. Possible values:
  * - LV_DRAW_BUF_BASIC:     LVGL's built in implementation
- * - LV_DRAW_BUF_CUSTOM:    Implement teh function of lv_draw_buf.h externally
+ * - LV_DRAW_BUF_CUSTOM:    Implement the function of lv_draw_buf.h externally
  */
 #define LV_USE_DRAW_BUF    LV_DRAW_BUF_BASIC
 

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -412,7 +412,7 @@ props = [
 
 {'name': 'GRID_COLUMN_ALIGN',
  'style_type': 'num',   'var_type': 'lv_grid_align_t', 'default':'`LV_GRID_ALIGN_START`', 'inherited': 0, 'layout': 1, 'ext_draw': 0,
- 'dsc': "Defines how to ditribute the columns"},
+ 'dsc': "Defines how to distribute the columns"},
 
 
 {'name': 'GRID_ROW_DSC_ARRAY',
@@ -421,7 +421,7 @@ props = [
 
 {'name': 'GRID_ROW_ALIGN',
  'style_type': 'num',   'var_type': 'lv_grid_align_t', 'default':'`LV_GRID_ALIGN_START`', 'inherited': 0, 'layout': 1, 'ext_draw': 0,
- 'dsc': "Defines how to ditribute the rows."},
+ 'dsc': "Defines how to distribute the rows."},
 
 {'name': 'GRID_CELL_COLUMN_POS',
  'style_type': 'num',   'var_type': 'lv_coord_t', 'default':'`LV_GRID_ALIGN_START`', 'inherited': 0, 'layout': 1, 'ext_draw': 0,

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -422,7 +422,7 @@ lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_
     }
     else {
         /*Get the width and height from the class.
-         * WIDTH and HEIGHT are not inherited so add them in the `else` to skip checking them for inherited proeprties */
+         * WIDTH and HEIGHT are not inherited so add them in the `else` to skip checking them for inherited properties */
         if(part == LV_PART_MAIN && (prop == LV_STYLE_WIDTH || prop == LV_STYLE_HEIGHT)) {
             const lv_obj_class_t * cls = obj->class_p;
             while(cls) {

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -323,7 +323,7 @@ static inline lv_coord_t lv_obj_get_style_transform_zoom_safe(const struct _lv_o
 /**
  * Get the `opa` style property from all parents and multiply and `>> 8` them.
  * @param obj       the object whose opacity should be get
- * @param part      the part whose opacity should be get. Non-MAIN parts will consider the `opa` of teh MAIN part too
+ * @param part      the part whose opacity should be get. Non-MAIN parts will consider the `opa` of the MAIN part too
  * @return          the final opacity considering the parents' opacity too
  */
 lv_opa_t lv_obj_get_style_opa_recursive(const struct _lv_obj_t * obj, lv_part_t part);

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -187,7 +187,7 @@
  *========================*/
 /* Select a draw buffer implementation. Possible values:
  * - LV_DRAW_BUF_BASIC:     LVGL's built in implementation
- * - LV_DRAW_BUF_CUSTOM:    Implement teh function of lv_draw_buf.h externally
+ * - LV_DRAW_BUF_CUSTOM:    Implement the function of lv_draw_buf.h externally
  */
 #ifndef LV_USE_DRAW_BUF
     #ifdef CONFIG_LV_USE_DRAW_BUF

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -308,7 +308,7 @@ void lv_style_set_prop(lv_style_t * style, lv_style_prop_t prop, lv_style_value_
     }
     style->prop_cnt++;
 
-    /*Go to the new position wit the props*/
+    /*Go to the new position with the props*/
     props = values_and_props + style->prop_cnt * sizeof(lv_style_value_t);
     lv_style_value_t * values = (lv_style_value_t *)values_and_props;
 


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used. See a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the followings needs to be followed (see a detaild description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)): 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
