### PR TITLE
Adds additional SDL support features

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -726,6 +726,9 @@
     #define LV_SDL_BUF_COUNT       1   /*1 or 2*/
     #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
     #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL widows are closed*/
+    #ifndef LV_SDL_TICK_THREAD
+        #define LV_SDL_TICK_THREAD 1
+    #endif
 #endif
 
 /*Driver for /dev/fb*/

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -87,69 +87,69 @@ void lv_sdl_window_set_pos(lv_disp_t * disp, lv_coord_t x, lv_coord_t y)
 lv_coord_t lv_sdl_window_get_x(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *x = 0;
-    int *y = 0;
+    int * x = 0;
+    int * y = 0;
 
     SDL_GetWindowPosition(dsc->window, x, y);
-    return (lv_coord_t) *x;
+    return (lv_coord_t)(* x);
 }
 
 lv_coord_t lv_sdl_window_get_y(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *x = 0;
-    int *y = 0;
+    int * x = 0;
+    int * y = 0;
 
     SDL_GetWindowPosition(dsc->window, x, y);
-    return (lv_coord_t) *y;
+    return (lv_coord_t)(* y);
 }
 
 lv_coord_t lv_sdl_window_get_left_border_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *top = 0;
-    int *left = 0;
-    int *bottom = 0;
-    int *right = 0;
+    int * top = 0;
+    int * left = 0;
+    int * bottom = 0;
+    int * right = 0;
 
     SDL_GetWindowBordersSize(dsc->window, top, left, bottom, right);
-    return (lv_coord_t) *left;
+    return (lv_coord_t)(* left);
 }
 
 lv_coord_t lv_sdl_window_get_right_border_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *top = 0;
-    int *left = 0;
-    int *bottom = 0;
-    int *right = 0;
+    int * top = 0;
+    int * left = 0;
+    int * bottom = 0;
+    int * right = 0;
 
     SDL_GetWindowBordersSize(dsc->window, top, left, bottom, right);
-    return (lv_coord_t) *right;
+    return (lv_coord_t)(* right);
 }
 
 lv_coord_t lv_sdl_window_get_top_border_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *top = 0;
-    int *left = 0;
-    int *bottom = 0;
-    int *right = 0;
+    int * top = 0;
+    int * left = 0;
+    int * bottom = 0;
+    int * right = 0;
 
     SDL_GetWindowBordersSize(dsc->window, top, left, bottom, right);
-    return (lv_coord_t) *top;
+    return (lv_coord_t)(* top);
 }
 
 lv_coord_t lv_sdl_window_get_bottom_border_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *top = 0;
-    int *left = 0;
-    int *bottom = 0;
-    int *right = 0;
+    int * top = 0;
+    int * left = 0;
+    int * bottom = 0;
+    int * right = 0;
 
     SDL_GetWindowBordersSize(dsc->window, top, left, bottom, right);
-    return (lv_coord_t) *bottom;
+    return (lv_coord_t)(* bottom);
 }
 
 void lv_sdl_window_set_minimum_size(lv_disp_t * disp, lv_coord_t width, lv_coord_t height)
@@ -162,21 +162,21 @@ void lv_sdl_window_set_minimum_size(lv_disp_t * disp, lv_coord_t width, lv_coord
 lv_coord_t lv_sdl_window_get_minimum_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *w = 0;
-    int *h = 0;
+    int * w = 0;
+    int * h = 0;
 
     SDL_GetWindowMinimumSize(dsc->window, w, h);
-    return (lv_coord_t) *w;
+    return (lv_coord_t)(* w);
 }
 
 lv_coord_t lv_sdl_window_get_minimum_height(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *w = 0;
-    int *h = 0;
+    int * w = 0;
+    int * h = 0;
 
     SDL_GetWindowMinimumSize(dsc->window, w, h);
-    return (lv_coord_t) *h;
+    return (lv_coord_t)(* h);
 }
 
 void lv_sdl_window_set_maximum_size(lv_disp_t * disp, lv_coord_t width, lv_coord_t height)
@@ -188,21 +188,21 @@ void lv_sdl_window_set_maximum_size(lv_disp_t * disp, lv_coord_t width, lv_coord
 lv_coord_t lv_sdl_window_get_maximum_width(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *w = 0;
-    int *h = 0;
+    int * w = 0;
+    int * h = 0;
 
     SDL_GetWindowMaximumSize(dsc->window, w, h);
-    return (lv_coord_t) *w;
+    return (lv_coord_t)(* w);
 }
 
 lv_coord_t lv_sdl_window_get_maximum_height(lv_disp_t * disp)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
-    int *w = 0;
-    int *h = 0;
+    int * w = 0;
+    int * h = 0;
 
     SDL_GetWindowMaximumSize(dsc->window, w, h);
-    return (lv_coord_t) *h;
+    return (lv_coord_t)(* h);
 }
 
 void lv_sdl_window_set_bordered(lv_disp_t * disp, bool value)
@@ -227,9 +227,10 @@ void lv_sdl_window_set_show(lv_disp_t * disp, bool value)
 {
     lv_sdl_window_t * dsc = lv_disp_get_driver_data(disp);
 
-    if (value) {
+    if(value) {
         SDL_ShowWindow(dsc->window);
-    } else {
+    }
+    else {
         SDL_HideWindow(dsc->window);
     }
 }
@@ -308,10 +309,10 @@ void lv_sdl_window_flash(lv_disp_t * disp, lv_sdl_window_flash_t flash)
 
 lv_disp_t * lv_sdl_window_create(lv_coord_t hor_res, lv_coord_t ver_res, lv_sdl_window_flags_t flags)
 {
-    if (flags == -1) {
+    if(flags == -1) {
         flags = 0;
     }
-    if (flags == 0) {
+    else if(flags == 0) {
         flags = LV_SDL_WINDOW_FLAGS_DEFAULT;
     }
 
@@ -505,7 +506,7 @@ static void window_create(lv_disp_t * disp, lv_sdl_window_flags_t flags)
     int flag = 0;
     unsigned int window_pos = SDL_WINDOWPOS_UNDEFINED;
 
-    if (flags & LV_SDL_WINDOW_FLAGS_CENTERED) {
+    if(flags & LV_SDL_WINDOW_FLAGS_CENTERED) {
         window_pos = SDL_WINDOWPOS_CENTERED;
         flags ^= LV_SDL_WINDOW_FLAGS_CENTERED;
     }
@@ -584,7 +585,7 @@ static void res_chg_event_cb(lv_event_t * e)
     texture_resize(disp);
 }
 
-#if !LV_SDL_TICK_THREAD
+#if !LV_TICK_CUSTOM
 static int tick_thread(void * ptr)
 {
     LV_UNUSED(ptr);

--- a/src/dev/sdl/lv_sdl_window.h
+++ b/src/dev/sdl/lv_sdl_window.h
@@ -27,8 +27,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef enum
-{
+typedef enum {
     LV_SDL_WINDOW_FLASH_CANCEL,                   /**< Cancel any window flash state */
     LV_SDL_WINDOW_FLASH_BRIEFLY,                  /**< Flash the window briefly to get attention */
     LV_SDL_WINDOW_FLASH_UNTIL_FOCUSED             /**< Flash the window until it gets focus */
@@ -46,7 +45,7 @@ typedef enum {
     LV_SDL_WINDOW_FLAGS_MOUSE_GRABBED = 0x00000100,      /**< window has grabbed mouse input */
     LV_SDL_WINDOW_FLAGS_INPUT_FOCUS = 0x00000200,        /**< window has input focus */
     LV_SDL_WINDOW_FLAGS_MOUSE_FOCUS = 0x00000400,        /**< window has mouse focus */
-    LV_SDL_WINDOW_FLAGS_FULLSCREEN_DESKTOP = ( LV_SDL_WINDOW_FLAGS_FULLSCREEN | 0x00001000 ),
+    LV_SDL_WINDOW_FLAGS_FULLSCREEN_DESKTOP = (LV_SDL_WINDOW_FLAGS_FULLSCREEN | 0x00001000),
     // LV_SDL_WINDOW_FLAGS_FOREIGN = 0x00000800,            /**< window not created by SDL */
     LV_SDL_WINDOW_FLAGS_ALLOW_HIGHDPI = 0x00002000,      /**< window should be created in high-DPI mode if supported.
                                                      On macOS NSHighResolutionCapable must be set true in the
@@ -64,7 +63,7 @@ typedef enum {
     LV_SDL_WINDOW_FLAGS_CENTERED         = 0x01000000,   /**< window is centered on desktop */
 
     LV_SDL_WINDOW_FLAGS_INPUT_GRABBED = LV_SDL_WINDOW_FLAGS_MOUSE_GRABBED, /**< equivalent to SDL_WINDOW_MOUSE_GRABBED for compatibility */
-    LV_SDL_WINDOW_FLAGS_DEFAULT = LV_SDL_WINDOW_FLAGS_CENTERED | LV_SDL_WINDOW_FLAGS_RESIZABLE | LV_SDL_WINDOW_FLAGS_SHOWN /**< window flags default value */
+    LV_SDL_WINDOW_FLAGS_DEFAULT = (LV_SDL_WINDOW_FLAGS_CENTERED | LV_SDL_WINDOW_FLAGS_RESIZABLE | LV_SDL_WINDOW_FLAGS_SHOWN) /**< window flags default value */
 } lv_sdl_window_flags_t;
 
 typedef enum {

--- a/src/dev/sdl/lv_sdl_window.h
+++ b/src/dev/sdl/lv_sdl_window.h
@@ -27,11 +27,113 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef enum
+{
+    LV_SDL_WINDOW_FLASH_CANCEL,                   /**< Cancel any window flash state */
+    LV_SDL_WINDOW_FLASH_BRIEFLY,                  /**< Flash the window briefly to get attention */
+    LV_SDL_WINDOW_FLASH_UNTIL_FOCUSED             /**< Flash the window until it gets focus */
+} lv_sdl_window_flash_t;
+
+typedef enum {
+    LV_SDL_WINDOW_FLAGS_FULLSCREEN = 0x00000001,         /**< fullscreen window */
+    LV_SDL_WINDOW_FLAGS_OPENGL = 0x00000002,             /**< window usable with OpenGL context */
+    LV_SDL_WINDOW_FLAGS_SHOWN = 0x00000004,              /**< window is visible */
+    LV_SDL_WINDOW_FLAGS_HIDDEN = 0x00000008,             /**< window is not visible */
+    LV_SDL_WINDOW_FLAGS_BORDERLESS = 0x00000010,         /**< no window decoration */
+    LV_SDL_WINDOW_FLAGS_RESIZABLE = 0x00000020,          /**< window can be resized */
+    LV_SDL_WINDOW_FLAGS_MINIMIZED = 0x00000040,          /**< window is minimized */
+    LV_SDL_WINDOW_FLAGS_MAXIMIZED = 0x00000080,          /**< window is maximized */
+    LV_SDL_WINDOW_FLAGS_MOUSE_GRABBED = 0x00000100,      /**< window has grabbed mouse input */
+    LV_SDL_WINDOW_FLAGS_INPUT_FOCUS = 0x00000200,        /**< window has input focus */
+    LV_SDL_WINDOW_FLAGS_MOUSE_FOCUS = 0x00000400,        /**< window has mouse focus */
+    LV_SDL_WINDOW_FLAGS_FULLSCREEN_DESKTOP = ( LV_SDL_WINDOW_FLAGS_FULLSCREEN | 0x00001000 ),
+    // LV_SDL_WINDOW_FLAGS_FOREIGN = 0x00000800,            /**< window not created by SDL */
+    LV_SDL_WINDOW_FLAGS_ALLOW_HIGHDPI = 0x00002000,      /**< window should be created in high-DPI mode if supported.
+                                                     On macOS NSHighResolutionCapable must be set true in the
+                                                     application's Info.plist for this to have any effect. */
+    LV_SDL_WINDOW_FLAGS_MOUSE_CAPTURE    = 0x00004000,   /**< window has mouse captured (unrelated to MOUSE_GRABBED) */
+    LV_SDL_WINDOW_FLAGS_ALWAYS_ON_TOP    = 0x00008000,   /**< window should always be above others */
+    LV_SDL_WINDOW_FLAGS_SKIP_TASKBAR     = 0x00010000,   /**< window should not be added to the taskbar */
+    LV_SDL_WINDOW_FLAGS_UTILITY          = 0x00020000,   /**< window should be treated as a utility window */
+    LV_SDL_WINDOW_FLAGS_TOOLTIP          = 0x00040000,   /**< window should be treated as a tooltip */
+    LV_SDL_WINDOW_FLAGS_POPUP_MENU       = 0x00080000,   /**< window should be treated as a popup menu */
+    LV_SDL_WINDOW_FLAGS_KEYBOARD_GRABBED = 0x00100000,   /**< window has grabbed keyboard input */
+    LV_SDL_WINDOW_FLAGS_VULKAN           = 0x10000000,   /**< window usable for Vulkan surface */
+    LV_SDL_WINDOW_FLAGS_METAL            = 0x20000000,   /**< window usable for Metal view */
+
+    LV_SDL_WINDOW_FLAGS_CENTERED         = 0x01000000,   /**< window is centered on desktop */
+
+    LV_SDL_WINDOW_FLAGS_INPUT_GRABBED = LV_SDL_WINDOW_FLAGS_MOUSE_GRABBED, /**< equivalent to SDL_WINDOW_MOUSE_GRABBED for compatibility */
+    LV_SDL_WINDOW_FLAGS_DEFAULT = LV_SDL_WINDOW_FLAGS_CENTERED | LV_SDL_WINDOW_FLAGS_RESIZABLE | LV_SDL_WINDOW_FLAGS_SHOWN /**< window flags default value */
+} lv_sdl_window_flags_t;
+
+typedef enum {
+    LV_SDL_FULLSCREEN_FLAGS_DESKTOP = LV_SDL_WINDOW_FLAGS_FULLSCREEN_DESKTOP,
+    LV_SDL_FULLSCREEN_FLAGS_DEFAULT = LV_SDL_WINDOW_FLAGS_FULLSCREEN
+} lv_sdl_fullscreen_flags_t;
+
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_disp_t * lv_sdl_window_create(lv_coord_t hor_res, lv_coord_t ver_res);
+const char * lv_sdl_window_get_title(lv_disp_t * disp);
+
+void lv_sdl_window_set_pos(lv_disp_t * disp, lv_coord_t x, lv_coord_t y);
+
+lv_coord_t lv_sdl_window_get_x(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_y(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_left_border_width(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_right_border_width(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_top_border_width(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_bottom_border_width(lv_disp_t * disp);
+
+void lv_sdl_window_set_minimum_size(lv_disp_t * disp, lv_coord_t width, lv_coord_t height);
+
+lv_coord_t lv_sdl_window_get_minimum_width(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_minimum_height(lv_disp_t * disp);
+
+void lv_sdl_window_set_maximum_size(lv_disp_t * disp, lv_coord_t width, lv_coord_t height);
+
+lv_coord_t lv_sdl_window_get_maximum_width(lv_disp_t * disp);
+
+lv_coord_t lv_sdl_window_get_maximum_height(lv_disp_t * disp);
+
+void lv_sdl_window_set_bordered(lv_disp_t * disp, bool value);
+
+void lv_sdl_window_set_resizeable(lv_disp_t * disp, bool value);
+
+void lv_sdl_window_set_always_on_top(lv_disp_t * disp, bool value);
+
+void lv_sdl_window_set_show(lv_disp_t * disp, bool value);
+
+void lv_sdl_window_raise(lv_disp_t * disp);
+
+void lv_sdl_window_maximize(lv_disp_t * disp);
+
+void lv_sdl_window_minimize(lv_disp_t * disp);
+
+void lv_sdl_window_restore(lv_disp_t * disp);
+
+void lv_sdl_window_fullscreen(lv_disp_t * disp);
+
+void lv_sdl_window_set_brightness(lv_disp_t * disp, uint8_t level);
+
+uint8_t lv_sdl_window_get_brightness(lv_disp_t * disp);
+
+void lv_sdl_window_set_opacity(lv_disp_t * disp, lv_opa_t opa);
+
+lv_opa_t lv_sdl_window_get_opacity(lv_disp_t * disp);
+
+void lv_sdl_window_flash(lv_disp_t * disp, lv_sdl_window_flash_t flash);
+
+lv_disp_t * lv_sdl_window_create(lv_coord_t hor_res, lv_coord_t ver_res, lv_sdl_window_flags_t flags);
 
 void lv_sdl_window_set_zoom(lv_disp_t * disp, uint8_t zoom);
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2372,6 +2372,19 @@
             #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL widows are closed*/
         #endif
     #endif
+    #ifndef LV_SDL_TICK_THREAD
+        #ifndef LV_SDL_TICK_THREAD
+            #ifdef _LV_KCONFIG_PRESENT
+                #ifdef CONFIG_LV_SDL_TICK_THREAD
+                    #define LV_SDL_TICK_THREAD CONFIG_LV_SDL_TICK_THREAD
+                #else
+                    #define LV_SDL_TICK_THREAD 0
+                #endif
+            #else
+                #define LV_SDL_TICK_THREAD 1
+            #endif
+        #endif
+    #endif
 #endif
 
 /*Driver for /dev/fb*/


### PR DESCRIPTION
Adds functions for setting position, brightness and other various things for an SDL window. It also exposes flags for controlling various elements of the the window creation, like resizing and displaying a title bar and border.

This is an API Breaking change. There is a new parameter added to the create function. If this parameter is supplied a zero it will behave exactly like it did prior. If a -1 is supplied to the additional parameter that would be specifying no flags at all. The flags can be or'ed together.

The flags are in a new enumeration named  `lv_sdl_window_flags_t`. There is a flag that is added to center the window to the desktop and that is used as a default.

There is also a flag for high dpi support if the OS and video driver support it.

I still have to complete the documentation for the added features. I wanted to see if this is of interest before I spend the time to do that. 
