### PR TITLE
docs: Add explanation for LV_INDEV_TYPE_BUTTON

### DIFF
--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -181,8 +181,11 @@ should look like ``const lv_point_t points_array[] = { {12,30},{60,90}, ...}``
           data->state = LV_INDEV_STATE_RELEASED; /*Set the released state*/
        }
 
-       data->btn = last_btn;            /*Save the last button*/
+       data->btn_id = last_btn;         /*Save the last button*/
    }
+
+When the ``button_read`` callback in the example above changes the ``data->btn_id`` to ``0``
+a press/release action at the first index of the ``points_array`` will be performed (``{12,30}``).
 
 Other features
 **************


### PR DESCRIPTION
Adds an explanation which refrences the code sample and fixes the field name to `btn_id`.

### Adjust the docs and hopefully clarify them a bit

While implementing indevs as pseudo devices for zephyr [pull-req](https://github.com/zephyrproject-rtos/zephyr/pull/60867) I had  misunderstanding in regards to how the `lv_indev_data_t` struct should be filled for the buttons. Hopefully my patch clarifies this a bit more. :^)

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- Does not apply
