### PR TITLE
chore: remove not needed "expression ? true : false"

### DIFF
--- a/examples/widgets/btnmatrix/lv_example_btnmatrix_3.c
+++ b/examples/widgets/btnmatrix/lv_example_btnmatrix_3.c
@@ -5,8 +5,8 @@ static void event_cb(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target(e);
     uint32_t id = lv_btnmatrix_get_selected_btn(obj);
-    bool prev = id == 0 ? true : false;
-    bool next = id == 6 ? true : false;
+    bool prev = id == 0;
+    bool next = id == 6;
     if(prev || next) {
         /*Find the checked button*/
         uint32_t i;

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -359,13 +359,13 @@ lv_group_edge_cb_t lv_group_get_edge_cb(const lv_group_t * group)
 bool lv_group_get_editing(const lv_group_t * group)
 {
     if(!group) return false;
-    return group->editing ? true : false;
+    return group->editing;
 }
 
 bool lv_group_get_wrap(lv_group_t * group)
 {
     if(!group) return false;
-    return group->wrap ? true : false;
+    return group->wrap;
 }
 
 uint32_t lv_group_get_obj_count(lv_group_t * group)

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -183,14 +183,14 @@ bool lv_obj_has_flag(const lv_obj_t * obj, lv_obj_flag_t f)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
-    return (obj->flags & f)  == f ? true : false;
+    return (obj->flags & f)  == f;
 }
 
 bool lv_obj_has_flag_any(const lv_obj_t * obj, lv_obj_flag_t f)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
-    return (obj->flags & f) ? true : false;
+    return !!(obj->flags & f);
 }
 
 lv_state_t lv_obj_get_state(const lv_obj_t * obj)
@@ -204,7 +204,7 @@ bool lv_obj_has_state(const lv_obj_t * obj, lv_state_t state)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
-    return obj->state & state ? true : false;
+    return !!(obj->state & state);
 }
 
 lv_group_t * lv_obj_get_group(const lv_obj_t * obj)
@@ -238,7 +238,7 @@ void lv_obj_allocate_spec_attr(lv_obj_t * obj)
 bool lv_obj_check_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
     if(obj == NULL) return false;
-    return obj->class_p == class_p ? true : false;
+    return obj->class_p == class_p;
 }
 
 bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -146,7 +146,7 @@ bool lv_obj_is_editable(lv_obj_t * obj)
 
     if(class_p == NULL) return false;
 
-    return class_p->editable == LV_OBJ_CLASS_EDITABLE_TRUE ? true : false;
+    return class_p->editable == LV_OBJ_CLASS_EDITABLE_TRUE;
 }
 
 bool lv_obj_is_group_def(lv_obj_t * obj)
@@ -158,7 +158,7 @@ bool lv_obj_is_group_def(lv_obj_t * obj)
 
     if(class_p == NULL) return false;
 
-    return class_p->group_def == LV_OBJ_CLASS_GROUP_DEF_TRUE ? true : false;
+    return class_p->group_def == LV_OBJ_CLASS_GROUP_DEF_TRUE;
 }
 
 /**********************

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -97,8 +97,8 @@ bool lv_obj_refr_size(lv_obj_t * obj)
     }
     else {
         w = lv_obj_get_style_width(obj, LV_PART_MAIN);
-        w_is_content = w == LV_SIZE_CONTENT ? true : false;
-        w_is_pct = LV_COORD_IS_PCT(w) ? true : false;
+        w_is_content = w == LV_SIZE_CONTENT;
+        w_is_pct = LV_COORD_IS_PCT(w);
         lv_coord_t parent_w = lv_obj_get_content_width(parent);
 
         if(w_is_content) {
@@ -129,8 +129,8 @@ bool lv_obj_refr_size(lv_obj_t * obj)
     }
     else {
         h = lv_obj_get_style_height(obj, LV_PART_MAIN);
-        h_is_content = h == LV_SIZE_CONTENT ? true : false;
-        h_is_pct = LV_COORD_IS_PCT(h) ? true : false;
+        h_is_content = h == LV_SIZE_CONTENT;
+        h_is_pct = LV_COORD_IS_PCT(h);
         lv_coord_t parent_h = lv_obj_get_content_height(parent);
 
         if(h_is_content) {
@@ -761,7 +761,7 @@ void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive
 {
     if(obj) {
         lv_layer_type_t layer_type = _lv_obj_get_layer_type(obj);
-        bool do_tranf = layer_type == LV_LAYER_TYPE_TRANSFORM ? true : false;
+        bool do_tranf = layer_type == LV_LAYER_TYPE_TRANSFORM;
         if(inv) {
             if(recursive) lv_obj_transform_point(lv_obj_get_parent(obj), p, recursive, inv);
             if(do_tranf) transform_point(obj, p, inv);

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -493,7 +493,7 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
 
     if(!hor_draw && !ver_draw) return;
 
-    bool rtl = lv_obj_get_style_base_dir(obj, LV_PART_SCROLLBAR) == LV_BASE_DIR_RTL ? true : false;
+    bool rtl = lv_obj_get_style_base_dir(obj, LV_PART_SCROLLBAR) == LV_BASE_DIR_RTL;
 
     lv_coord_t top_space = lv_obj_get_style_pad_top(obj, LV_PART_SCROLLBAR);
     lv_coord_t bottom_space = lv_obj_get_style_pad_bottom(obj, LV_PART_SCROLLBAR);

--- a/src/disp/lv_disp.c
+++ b/src/disp/lv_disp.c
@@ -418,7 +418,7 @@ bool lv_disp_get_antialiasing(lv_disp_t * disp)
     if(disp == NULL) disp = lv_disp_get_default();
     if(disp == NULL) return false;
 
-    return disp->antialiasing ? true : false;
+    return disp->antialiasing;
 }
 
 
@@ -435,7 +435,7 @@ LV_ATTRIBUTE_FLUSH_READY bool lv_disp_flush_is_last(lv_disp_t * disp)
 
 bool lv_disp_is_double_buffered(lv_disp_t * disp)
 {
-    return disp->buf_2 ? true : false;
+    return disp->buf_2 != NULL;
 }
 
 /*---------------------

--- a/src/draw/sw/lv_draw_sw_border.c
+++ b/src/draw/sw/lv_draw_sw_border.c
@@ -131,12 +131,12 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
     core_area.y2 = LV_MIN(outer_area->y2 - rout, inner_area->y2);
     lv_coord_t core_w = lv_area_get_width(&core_area);
 
-    bool top_side = outer_area->y1 <= inner_area->y1 ? true : false;
-    bool bottom_side = outer_area->y2 >= inner_area->y2 ? true : false;
+    bool top_side = outer_area->y1 <= inner_area->y1;
+    bool bottom_side = outer_area->y2 >= inner_area->y2;
 
     /*No masks*/
-    bool left_side = outer_area->x1 <= inner_area->x1 ? true : false;
-    bool right_side = outer_area->x2 >= inner_area->x2 ? true : false;
+    bool left_side = outer_area->x1 <= inner_area->x1;
+    bool right_side = outer_area->x2 >= inner_area->x2;
 
     bool split_hor = true;
     if(left_side && right_side && top_side && bottom_side &&
@@ -296,10 +296,10 @@ static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * out
     blend_dsc.color = color;
     blend_dsc.opa = opa;
 
-    bool top_side = outer_area->y1 <= inner_area->y1 ? true : false;
-    bool bottom_side = outer_area->y2 >= inner_area->y2 ? true : false;
-    bool left_side = outer_area->x1 <= inner_area->x1 ? true : false;
-    bool right_side = outer_area->x2 >= inner_area->x2 ? true : false;
+    bool top_side = outer_area->y1 <= inner_area->y1;
+    bool bottom_side = outer_area->y2 >= inner_area->y2;
+    bool left_side = outer_area->x1 <= inner_area->x1;
+    bool right_side = outer_area->x2 >= inner_area->x2;
 
     /*Top*/
     a.x1 = outer_area->x1;

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -123,7 +123,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
 #endif
 
     /*Skip a lot of masking if the background will cover the shadow that would be masked out*/
-    bool simple = dsc->bg_cover ? true : false;
+    bool simple = dsc->bg_cover;
 
     /*Create a radius mask to clip remove shadow on the bg area*/
 

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -165,7 +165,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_img(lv_draw_unit_t * draw_unit, const lv_d
         return;
     }
 
-    bool transformed = draw_dsc->angle != 0 || draw_dsc->zoom != LV_ZOOM_NONE ? true : false;
+    bool transformed = draw_dsc->angle != 0 || draw_dsc->zoom != LV_ZOOM_NONE;
 
     lv_img_decoder_dsc_t decoder_dsc;
     lv_res_t res = lv_img_decoder_open(&decoder_dsc, draw_dsc->src, draw_dsc->recolor, -1);

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -118,7 +118,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(lv_draw_unit_t * draw_unit, cons
     is_common = _lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
     if(!is_common) return;
 
-    bool dashed = dsc->dash_gap && dsc->dash_width ? true : false;
+    bool dashed = dsc->dash_gap && dsc->dash_width;
 
     lv_draw_sw_blend_dsc_t blend_dsc;
     lv_memzero(&blend_dsc, sizeof(blend_dsc));
@@ -193,7 +193,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(lv_draw_unit_t * draw_unit, cons
     is_common = _lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
     if(!is_common) return;
 
-    bool dashed = dsc->dash_gap && dsc->dash_width ? true : false;
+    bool dashed = dsc->dash_gap && dsc->dash_width;
 
     lv_draw_sw_blend_dsc_t blend_dsc;
     lv_memzero(&blend_dsc, sizeof(blend_dsc));
@@ -267,7 +267,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(lv_draw_unit_t * draw_unit, con
 
     int32_t xdiff = p2.x - p1.x;
     int32_t ydiff = p2.y - p1.y;
-    bool flat = LV_ABS(xdiff) > LV_ABS(ydiff) ? true : false;
+    bool flat = LV_ABS(xdiff) > LV_ABS(ydiff);
 
     static const uint8_t wcorr[] = {
         128, 128, 128, 129, 129, 130, 130, 131,

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -1122,7 +1122,7 @@ static void circ_init(lv_point_t * c, lv_coord_t * tmp, lv_coord_t radius)
  */
 static bool circ_cont(lv_point_t * c)
 {
-    return c->y <= c->x ? true : false;
+    return c->y <= c->x;
 }
 
 /**

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -146,7 +146,7 @@ const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, uint32_t unic
     /*Handle compressed bitmap*/
     else {
 #if LV_USE_FONT_COMPRESSED
-        bool prefilter = fdsc->bitmap_format == LV_FONT_FMT_TXT_COMPRESSED ? true : false;
+        bool prefilter = fdsc->bitmap_format == LV_FONT_FMT_TXT_COMPRESSED;
         decompress(&fdsc->glyph_bitmap[gdsc->bitmap_index], bitmap_out, gdsc->box_w, gdsc->box_h,
                    (uint8_t)fdsc->bpp, prefilter);
         return bitmap_out;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1373,5 +1373,5 @@ static bool indev_reset_check(lv_indev_t * indev)
         indev_obj_act = NULL;
     }
 
-    return indev->reset_query ? true : false;
+    return indev->reset_query;
 }

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -139,7 +139,7 @@ static void flex_update(lv_obj_t * cont, void * user_data)
     f.cross_place = lv_obj_get_style_flex_cross_place(cont, LV_PART_MAIN);
     f.track_place = lv_obj_get_style_flex_track_place(cont, LV_PART_MAIN);
 
-    bool rtl = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL ? true : false;
+    bool rtl = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL;
     lv_coord_t track_gap = !f.row ? lv_obj_get_style_pad_column(cont, LV_PART_MAIN) : lv_obj_get_style_pad_row(cont,
                                                                                                                LV_PART_MAIN);
     lv_coord_t item_gap = f.row ? lv_obj_get_style_pad_column(cont, LV_PART_MAIN) : lv_obj_get_style_pad_row(cont,
@@ -366,7 +366,7 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
     }
 
 
-    bool rtl = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL ? true : false;
+    bool rtl = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL;
 
     lv_coord_t main_pos = 0;
 

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -234,16 +234,16 @@ static void calc(lv_obj_t * cont, _lv_grid_calc_t * calc_out)
     lv_coord_t col_gap = lv_obj_get_style_pad_column(cont, LV_PART_MAIN);
     lv_coord_t row_gap = lv_obj_get_style_pad_row(cont, LV_PART_MAIN);
 
-    bool rev = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL ? true : false;
+    bool rev = lv_obj_get_style_base_dir(cont, LV_PART_MAIN) == LV_BASE_DIR_RTL;
 
     lv_coord_t w_set = lv_obj_get_style_width(cont, LV_PART_MAIN);
     lv_coord_t h_set = lv_obj_get_style_height(cont, LV_PART_MAIN);
-    bool auto_w = (w_set == LV_SIZE_CONTENT && !cont->w_layout) ? true : false;
+    bool auto_w = w_set == LV_SIZE_CONTENT && !cont->w_layout;
     lv_coord_t cont_w = lv_obj_get_content_width(cont);
     calc_out->grid_w = grid_align(cont_w, auto_w, get_grid_col_align(cont), col_gap, calc_out->col_num, calc_out->w,
                                   calc_out->x, rev);
 
-    bool auto_h = (h_set == LV_SIZE_CONTENT && !cont->h_layout) ? true : false;
+    bool auto_h = h_set == LV_SIZE_CONTENT && !cont->h_layout;
     lv_coord_t cont_h = lv_obj_get_content_height(cont);
     calc_out->grid_h = grid_align(cont_h, auto_h, get_grid_row_align(cont), row_gap, calc_out->row_num, calc_out->h,
                                   calc_out->y, false);

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -337,7 +337,7 @@ static bool ffmpeg_pix_fmt_has_alpha(enum AVPixelFormat pix_fmt)
         return true;
     }
 
-    return (desc->flags & AV_PIX_FMT_FLAG_ALPHA) ? true : false;
+    return desc->flags & AV_PIX_FMT_FLAG_ALPHA;
 }
 
 static bool ffmpeg_pix_fmt_is_yuv(enum AVPixelFormat pix_fmt)

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -152,7 +152,7 @@ void lv_init(void)
 
     uint32_t endianess_test = 0x11223344;
     uint8_t * endianess_test_p = (uint8_t *) &endianess_test;
-    bool big_endian = endianess_test_p[0] == 0x11 ? true : false;
+    bool big_endian = endianess_test_p[0] == 0x11;
 
     if(big_endian) {
         LV_ASSERT_MSG(LV_BIG_ENDIAN_SYSTEM == 1,

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -275,15 +275,14 @@ void lv_point_transform(lv_point_t * p, int32_t angle, int32_t zoom, const lv_po
 #define _LV_COORD_TYPE_SPEC     (1 << _LV_COORD_TYPE_SHIFT)
 #define _LV_COORD_TYPE_PX_NEG   (3 << _LV_COORD_TYPE_SHIFT)
 
-#define LV_COORD_IS_PX(x)       (_LV_COORD_TYPE(x) == _LV_COORD_TYPE_PX || \
-                                 _LV_COORD_TYPE(x) == _LV_COORD_TYPE_PX_NEG ? true : false)
-#define LV_COORD_IS_SPEC(x)     (_LV_COORD_TYPE(x) == _LV_COORD_TYPE_SPEC ? true : false)
+#define LV_COORD_IS_PX(x)       (_LV_COORD_TYPE(x) == _LV_COORD_TYPE_PX || _LV_COORD_TYPE(x) == _LV_COORD_TYPE_PX_NEG)
+#define LV_COORD_IS_SPEC(x)     (_LV_COORD_TYPE(x) == _LV_COORD_TYPE_SPEC)
 
 #define LV_COORD_SET_SPEC(x)    ((x) | _LV_COORD_TYPE_SPEC)
 
 /*Special coordinates*/
 #define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(1000 - (x)) : LV_COORD_SET_SPEC(x))
-#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= 2000) ? true : false)
+#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= 2000))
 #define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > 1000 ? 1000 - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
 #define LV_SIZE_CONTENT         LV_COORD_SET_SPEC(2001)
 

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -405,7 +405,7 @@ bool lv_style_is_empty(const lv_style_t * style)
 {
     LV_ASSERT_STYLE(style);
 
-    return style->prop_cnt == 0 ? true : false;
+    return style->prop_cnt == 0;
 }
 
 uint8_t _lv_style_prop_lookup_flags(lv_style_prop_t prop)

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -267,7 +267,7 @@ static void draw_indic(lv_event_t * e)
         range = 1;
     }
 
-    bool hor = barw >= barh ? true : false;
+    bool hor = barw >= barh;
     bool sym = false;
     if(bar->mode == LV_BAR_MODE_SYMMETRICAL && bar->min_value < 0 && bar->max_value > 0 &&
        bar->start_value == bar->min_value) sym = true;

--- a/src/widgets/btnmatrix/lv_btnmatrix.c
+++ b/src/widgets/btnmatrix/lv_btnmatrix.c
@@ -340,7 +340,7 @@ bool lv_btnmatrix_has_btn_ctrl(lv_obj_t * obj, uint16_t btn_id, lv_btnmatrix_ctr
     lv_btnmatrix_t * btnm = (lv_btnmatrix_t *)obj;;
     if(btn_id >= btnm->btn_cnt) return false;
 
-    return ((btnm->ctrl_bits[btn_id] & ctrl) == ctrl) ? true : false;
+    return (btnm->ctrl_bits[btn_id] & ctrl) == ctrl;
 }
 
 bool lv_btnmatrix_get_one_checked(const lv_obj_t * obj)
@@ -865,47 +865,47 @@ static uint8_t get_button_width(lv_btnmatrix_ctrl_t ctrl_bits)
 
 static bool button_is_hidden(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_HIDDEN) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_HIDDEN;
 }
 
 static bool button_is_checked(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_CHECKED) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_CHECKED;
 }
 
 static bool button_is_repeat_disabled(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_NO_REPEAT) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_NO_REPEAT;
 }
 
 static bool button_is_inactive(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_DISABLED) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_DISABLED;
 }
 
 static bool button_is_click_trig(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_CLICK_TRIG) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_CLICK_TRIG;
 }
 
 static bool button_is_popover(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_POPOVER) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_POPOVER;
 }
 
 static bool button_is_checkable(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_CHECKABLE) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_CHECKABLE;
 }
 
 static bool button_get_checked(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_CHECKED) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_CHECKED;
 }
 
 static bool button_is_recolor(lv_btnmatrix_ctrl_t ctrl_bits)
 {
-    return (ctrl_bits & LV_BTNMATRIX_CTRL_RECOLOR) ? true : false;
+    return ctrl_bits & LV_BTNMATRIX_CTRL_RECOLOR;
 }
 /**
  * Gives the button id of a button under a given point

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -893,7 +893,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
     if(line_dsc.width == 1) line_dsc.raw_end = 1;
 
     /*If there are at least as many points as pixels then draw only vertical lines*/
-    bool crowded_mode = chart->point_cnt >= w ? true : false;
+    bool crowded_mode = chart->point_cnt >= w;
 
     /*Go through all data lines*/
     _LV_LL_READ_BACK(&chart->series_ll, ser) {

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -268,7 +268,7 @@ bool lv_label_get_recolor(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_label_t * label = (lv_label_t *)obj;
-    return label->recolor ? true : false;
+    return label->recolor;
 }
 
 void lv_label_get_letter_pos(const lv_obj_t * obj, uint32_t char_id, lv_point_t * pos)

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -74,7 +74,7 @@ bool lv_slider_is_dragged(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_slider_t * slider = (lv_slider_t *)obj;
 
-    return slider->dragging ? true : false;
+    return slider->dragging;
 }
 
 /**********************

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -924,7 +924,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
                     last_snippet->txt_w = lv_txt_get_width(last_snippet->txt, last_snippet->bytes, last_snippet->font,
                                                            last_snippet->letter_space);
                 }
-                ellipsis_valid = spans->overflow == LV_SPAN_OVERFLOW_ELLIPSIS ? true : false;
+                ellipsis_valid = spans->overflow == LV_SPAN_OVERFLOW_ELLIPSIS;
                 is_end_line = true;
             }
         }

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -732,7 +732,7 @@ static void draw_main(lv_event_t * e)
                 txt_area.y2 = cell_area.y2 - cell_bottom;
 
                 /*Align the content to the middle if not cropped*/
-                bool crop = ctrl & LV_TABLE_CELL_CTRL_TEXT_CROP ? true : false;
+                bool crop = ctrl & LV_TABLE_CELL_CTRL_TEXT_CROP;
                 if(crop) txt_flags = LV_TEXT_FLAG_EXPAND;
 
                 lv_txt_get_size(&txt_size, table->cell_data[cell] + 1, label_dsc_def.font,

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -611,7 +611,7 @@ bool lv_textarea_get_cursor_click_pos(lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
-    return ta->cursor.click_pos ? true : false;
+    return ta->cursor.click_pos;
 }
 
 bool lv_textarea_get_password_mode(const lv_obj_t * obj)


### PR DESCRIPTION
### Description of the feature or fix

Convert expression result to `true` or `false` is not needed. 
There's discussion here: https://stackoverflow.com/questions/31551888/casting-int-to-bool-in-c-c

> 2) C99 and C11 §6.3.1.2/1 “When any scalar value is converted to _Bool, the result is 0 if the value compares equal to 0; otherwise, the result is 1.”




### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
