### PR TITLE
fix(lv_disp): fix lv_scr_load_anim being called twice quickly

### DIFF
--- a/src/disp/lv_disp.c
+++ b/src/disp/lv_disp.c
@@ -507,9 +507,13 @@ void lv_scr_load_anim(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t
     lv_disp_t * d = lv_obj_get_disp(new_scr);
     lv_obj_t * act_scr = lv_scr_act();
 
+    if(act_scr == new_scr || d->scr_to_load == new_scr) {
+        return;
+    }
+
     /*If another screen load animation is in progress
      *make target screen loaded immediately. */
-    if(d->scr_to_load && act_scr != d->scr_to_load) {
+    if(d->scr_to_load) {
         scr_load_internal(d->scr_to_load);
         lv_anim_del(d->scr_to_load, NULL);
         lv_obj_set_pos(d->scr_to_load, 0, 0);
@@ -546,6 +550,7 @@ void lv_scr_load_anim(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t
     if(time == 0 && delay == 0) {
 
         scr_load_internal(new_scr);
+        d->scr_to_load = NULL;
         if(auto_del) lv_obj_del(act_scr);
         return;
     }


### PR DESCRIPTION
Adds a check to prevent transitions from the current to the current screen and loading of a new screen if a load for that one is already in progress.

### Description of the feature or fix

Addresses the issue over at: [issues/4482](https://github.com/lvgl/lvgl/issues/4482).
From my perspective it does not really make sense that a screen can load with animation to itsself.
Also it prohibits the loading of a screen which is currently already loading, which also seems like it should not be possible.

I do not know if this is the 'correct' way to fix it,. When looking at the code, what struck me as odd is the fact that on `scr_load_anim_start` the "screen swap" already occurs. So if you somehow manage to trigger the same `lv_scr_load_anim` you will run into the situation `lv_act_scr() == new_scr`. 

Anyways I let the minimal reproducible example from the issue run for about 30 minutes and have not observed the issue since.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
