### PR TITLE
feat(indev): Add 'lv_indev_read' to allow read events from specified indev

### DIFF
--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -201,7 +201,7 @@ The default value of the following parameters can be changed in :cpp:type:`lv_in
 - ``long_press_repeat_time`` Interval of sending :cpp:enumerator:`LV_EVENT_LONG_PRESSED_REPEAT` (in milliseconds)
 - ``read_timer`` pointer to the ``lv_timer`` which reads the input device. Its parameters
   can be changed by ``lv_timer_...()`` functions. :c:macro:`LV_DEF_REFR_PERIOD`
-  in ``lv_hal_disp.h`` sets the default read period.
+  in ``lv_conf.h`` sets the default read period.
 
 Feedback
 --------
@@ -231,6 +231,28 @@ that buffers measured data. In ``read_cb`` you can report the buffered
 data instead of directly reading the input device. Setting the
 ``data->continue_reading`` flag will tell LVGL there is more data to
 read and it should call ``read_cb`` again.
+
+Decoupling the input device read timer
+--------------------------------------
+
+Normally the input event is read every :c:macro:`LV_DEF_REFR_PERIOD`
+milliseconds (set in ``lv_conf.h``).  However, in some cases, you might
+need more control over when to read the input device. For example, you
+might need to read it by polling file descriptor (fd).
+
+You can do this in the following way:
+
+.. code:: c
+
+   /*Delete the original input device read timer*/
+   lv_timer_del(indev->read_timer);
+   indev->read_timer = NULL;
+
+
+   /*Call this anywhere you want to read the input device*/
+   lv_indev_read(indev);
+
+.. note:: that :cpp:func:`lv_indev_read`, :cpp:func:`lv_timer_handler` and :cpp:func:`_lv_disp_refr_timer` can not run at the same time.
 
 Further reading
 ***************

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -70,6 +70,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev);
 static void indev_click_focus(lv_indev_t * indev);
 static void indev_gesture(lv_indev_t * indev);
 static bool indev_reset_check(lv_indev_t * indev);
+void indev_read(lv_indev_t * indev, lv_indev_data_t * data);
 
 /**********************
  *  STATIC VARIABLES
@@ -121,7 +122,7 @@ void lv_indev_delete(lv_indev_t * indev)
 {
     LV_ASSERT_NULL(indev);
     /*Clean up the read timer first*/
-    lv_timer_del(indev->read_timer);
+    if(indev->read_timer) lv_timer_del(indev->read_timer);
     /*Remove the input device from the list*/
     _lv_ll_remove(indev_ll_head, indev);
     /*Free the memory of the input device*/
@@ -136,7 +137,7 @@ lv_indev_t * lv_indev_get_next(lv_indev_t * indev)
         return _lv_ll_get_next(indev_ll_head, indev);
 }
 
-void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
+void indev_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
     LV_PROFILER_BEGIN;
     lv_memzero(data, sizeof(lv_indev_data_t));
@@ -168,11 +169,16 @@ void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data)
 
 void lv_indev_read_timer_cb(lv_timer_t * timer)
 {
+    lv_indev_read(timer->user_data);
+}
+
+void lv_indev_read(lv_indev_t * indev_p)
+{
+    if(!indev_p) return;
+
     INDEV_TRACE("begin");
 
-    lv_indev_data_t data;
-
-    lv_indev_t * indev_p = indev_act = timer->user_data;
+    indev_act = indev_p;
 
     /*Read and process all indevs*/
     if(indev_p->disp == NULL) return; /*Not assigned to any displays*/
@@ -186,9 +192,11 @@ void lv_indev_read_timer_cb(lv_timer_t * timer)
     LV_PROFILER_BEGIN;
 
     bool continue_reading;
+    lv_indev_data_t data;
+
     do {
         /*Read the data*/
-        _lv_indev_read(indev_p, &data);
+        indev_read(indev_p, &data);
         continue_reading = data.continue_reading;
 
         /*The active object might be deleted even in the read function*/
@@ -523,7 +531,7 @@ lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point)
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
     lv_disp_t * disp = i->disp;
-    /*Save the raw points so they can be used again in _lv_indev_read*/
+    /*Save the raw points so they can be used again in indev_read*/
     i->pointer.last_raw_point.x = data->point.x;
     i->pointer.last_raw_point.y = data->point.y;
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -70,7 +70,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev);
 static void indev_click_focus(lv_indev_t * indev);
 static void indev_gesture(lv_indev_t * indev);
 static bool indev_reset_check(lv_indev_t * indev);
-void indev_read(lv_indev_t * indev, lv_indev_data_t * data);
+static void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data);
 
 /**********************
  *  STATIC VARIABLES
@@ -137,7 +137,7 @@ lv_indev_t * lv_indev_get_next(lv_indev_t * indev)
         return _lv_ll_get_next(indev_ll_head, indev);
 }
 
-void indev_read(lv_indev_t * indev, lv_indev_data_t * data)
+void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data)
 {
     LV_PROFILER_BEGIN;
     lv_memzero(data, sizeof(lv_indev_data_t));
@@ -196,7 +196,7 @@ void lv_indev_read(lv_indev_t * indev_p)
 
     do {
         /*Read the data*/
-        indev_read(indev_p, &data);
+        indev_read_core(indev_p, &data);
         continue_reading = data.continue_reading;
 
         /*The active object might be deleted even in the read function*/
@@ -531,7 +531,7 @@ lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point)
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
     lv_disp_t * disp = i->disp;
-    /*Save the raw points so they can be used again in indev_read*/
+    /*Save the raw points so they can be used again in indev_read_core*/
     i->pointer.last_raw_point.x = data->point.x;
     i->pointer.last_raw_point.y = data->point.y;
 

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -82,9 +82,8 @@ lv_indev_t * lv_indev_get_next(lv_indev_t * indev);
 /**
  * Read data from an input device.
  * @param indev pointer to an input device
- * @param data input device will write its data here
  */
-void _lv_indev_read(lv_indev_t * indev, lv_indev_data_t * data);
+void lv_indev_read(lv_indev_t * indev);
 
 /**
  * Called periodically to read the input devices


### PR DESCRIPTION
Add 'lv_indev_read' to allow read events from specified input device actively without relying on timer-driven

### Description of the feature
In many operating systems, there is the ability to listen to file descriptor (fd) using poll/epoll/select. The active listening approach to input fd is much more efficient than the timer loop method, and it also consumes much less power. 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
