### PR TITLE
Use lv_strdup where possible

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -85,8 +85,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_layer_t * layer, const lv_draw_label
     /*The text is stored in a local variable so malloc memory for it*/
     if(dsc->text_local) {
         lv_draw_label_dsc_t * new_dsc = t->draw_dsc;
-        new_dsc->text = lv_malloc(lv_strlen(new_dsc->text) + 1);
-        lv_strcpy((char *)new_dsc->text, dsc->text);
+        new_dsc->text = lv_strdup(dsc->text);
     }
 
     lv_draw_finalize_task_creation(layer, t);

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -118,15 +118,8 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
         *dir_str = NULL;
     }
 
-    /*Get the size of the text*/
-    size_t len = lv_strlen(path) + 1;
-
     /*Allocate space for the new text*/
-    *dir_str = lv_malloc(len);
-    LV_ASSERT_MALLOC(*dir_str);
-    if(*dir_str == NULL) return;
-
-    lv_strcpy(*dir_str, path);
+    *dir_str = lv_strdup(path);
 }
 
 #endif

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -11,6 +11,7 @@
 #include "../../misc/lv_log.h"
 #include "../../misc/lv_math.h"
 #include "../../stdlib/lv_string.h"
+#include "../../stdlib/lv_mem.h"
 
 /*********************
  *      DEFINES
@@ -168,6 +169,16 @@ char * lv_strcpy(char * dst, const char * src)
     char * tmp = dst;
     while((*dst++ = *src++) != '\0');
     return tmp;
+}
+
+char * lv_strdup(const char * src)
+{
+    size_t len = lv_strlen(src) + 1;
+    char * dst = lv_malloc(len);
+    if(dst == NULL) return NULL;
+
+    lv_memcpy(dst, src, len); /*do memcpy is faster than strncpy since we already know string length*/
+    return dst;
 }
 
 /**********************

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -177,7 +177,7 @@ char * lv_strdup(const char * src)
     char * dst = lv_malloc(len);
     if(dst == NULL) return NULL;
 
-    lv_memcpy(dst, src, len); /*do memcpy is faster than strncpy since we already know string length*/
+    lv_memcpy(dst, src, len); /*do memcpy is faster than strncpy when length is known*/
     return dst;
 }
 

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -64,6 +64,11 @@ char * lv_strcpy(char * dst, const char * src)
     return strcpy(dst, src);
 }
 
+char * lv_strdup(const char * src)
+{
+    return strdup(src);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -83,6 +83,12 @@ char * lv_strncpy(char * dst, const char * src, size_t dest_size);
  */
 char * lv_strcpy(char * dst, const char * src);
 
+/**
+ * @brief Duplicate a string by allocating a new one and copying the content.
+ * @param src Pointer to the source of data to be copied.
+ * @return A pointer to the new allocated string. NULL if failed.
+ */
+char * lv_strdup(const char * src);
 
 /**********************
  *      MACROS

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -198,13 +198,9 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     /*Convert static options to dynamic*/
     if(dropdown->static_txt != 0) {
         char * static_options = dropdown->options;
-        size_t len = lv_strlen(static_options) + 1;
-
-        dropdown->options = lv_malloc(len);
+        dropdown->options = lv_strdup(static_options);
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;
-
-        lv_strcpy(dropdown->options, static_options);
         dropdown->static_txt = 0;
     }
 

--- a/src/widgets/img/lv_img.c
+++ b/src/widgets/img/lv_img.c
@@ -118,10 +118,9 @@ void lv_img_set_src(lv_obj_t * obj, const void * src)
             if(img->src_type == LV_IMG_SRC_FILE || img->src_type == LV_IMG_SRC_SYMBOL) {
                 old_src = img->src;
             }
-            char * new_str = lv_malloc(lv_strlen(src) + 1);
+            char * new_str = lv_strdup(src);
             LV_ASSERT_MALLOC(new_str);
             if(new_str == NULL) return;
-            lv_strcpy(new_str, src);
             img->src = new_str;
 
             if(old_src) lv_free((void *)old_src);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -393,15 +393,12 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
     }
 
     if(title) {
-        size_t len = lv_strlen(title) + 1;
-        page->title        = lv_malloc(len);
         page->static_title = false;
-
+        page->title = lv_strdup(title);
         LV_ASSERT_MALLOC(page->title);
         if(page->title == NULL) {
             return;
         }
-        lv_strcpy(page->title, title);
     }
     else {
         page->title        = NULL;

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -178,7 +178,7 @@ void lv_span_set_text(lv_span_t * span, const char * text)
     if(span->txt == NULL) return;
 
     span->static_flag = 0;
-    lv_strcpy(span->txt, text);
+    lv_memcpy(span->txt, text, text_alloc_len);
 
     refresh_self_size(span->spangroup);
 }

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -89,10 +89,8 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
     if(tabview->tab_pos & LV_DIR_VER) {
         new_map = lv_malloc((tab_id + 1) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1));
-        size_t len = lv_strlen(name) + 1;
-        new_map[tab_id - 1] = lv_malloc(len);
+        new_map[tab_id - 1] = lv_strdup(name);
         LV_ASSERT_MALLOC(new_map[tab_id - 1]);
-        lv_strcpy((char *)new_map[tab_id - 1], name);
         new_map[tab_id] = (char *)"";
     }
     /*left or right dir*/
@@ -100,18 +98,14 @@ lv_obj_t * lv_tabview_add_tab(lv_obj_t * obj, const char * name)
         new_map = lv_malloc((tab_id * 2) * sizeof(const char *));
         lv_memcpy(new_map, old_map, sizeof(const char *) * (tab_id - 1) * 2);
         if(tabview->tab_cnt == 0) {
-            size_t len = lv_strlen(name) + 1;
-            new_map[0] = lv_malloc(len);
+            new_map[0] = lv_strdup(name);
             LV_ASSERT_MALLOC(new_map[0]);
-            lv_strcpy((char *)new_map[0], name);
             new_map[1] = (char *)"";
         }
         else {
-            size_t len = lv_strlen(name) + 1;
             new_map[tab_id * 2 - 3] = (char *)"\n";
-            new_map[tab_id * 2 - 2] = lv_malloc(len);
+            new_map[tab_id * 2 - 2] = lv_strdup(name);
             new_map[tab_id * 2 - 1] = (char *)"";
-            lv_strcpy((char *)new_map[(tab_id * 2) - 2], name);
         }
     }
     tabview->map = new_map;
@@ -140,10 +134,8 @@ void lv_tabview_rename_tab(lv_obj_t * obj, uint32_t id, const char * new_name)
     if(tabview->tab_pos & LV_DIR_HOR) id *= 2;
 
     lv_free(tabview->map[id]);
-    size_t len = lv_strlen(new_name) + 1;
-    tabview->map[id] = lv_malloc(len);
+    tabview->map[id] = lv_strdup(new_name);
     LV_ASSERT_MALLOC(tabview->map[id]);
-    lv_strcpy(tabview->map[id], new_name);
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -301,11 +301,9 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
     }
 
     if(ta->pwd_mode) {
-        size_t len = lv_strlen(txt) + 1;
-        ta->pwd_tmp = lv_realloc(ta->pwd_tmp, len);
+        ta->pwd_tmp = lv_strdup(txt);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
-        lv_strcpy(ta->pwd_tmp, txt);
 
         /*Auto hide characters*/
         auto_hide_characters(obj);
@@ -414,13 +412,9 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
     /*Pwd mode is now enabled*/
     if(en) {
         char * txt = lv_label_get_text(ta->label);
-        size_t len = lv_strlen(txt);
-
-        ta->pwd_tmp = lv_malloc(len + 1);
+        ta->pwd_tmp = lv_strdup(txt);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
-
-        lv_strcpy(ta->pwd_tmp, txt);
 
         pwd_char_hider(obj);
 
@@ -460,7 +454,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
             return;
         }
 
-        lv_strcpy(ta->pwd_bullet, bullet);
+        lv_memcpy(ta->pwd_bullet, bullet, txt_len);
         ta->pwd_bullet[txt_len] = '\0';
     }
 


### PR DESCRIPTION
### Description of the feature or fix

Added lv_strdup and use it where possible.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
