### PR TITLE
feat(theme): avoid reinitializing the default theme

### DIFF
--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -658,11 +658,26 @@ lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, l
     }
 
     struct _my_theme_t * theme = theme_def;
-    if(LV_HOR_RES <= 320) theme->disp_size = DISP_SMALL;
-    else if(LV_HOR_RES < 720) theme->disp_size = DISP_MEDIUM;
-    else theme->disp_size = DISP_LARGE;
+    lv_coord_t hor_res = lv_disp_get_hor_res(disp);
+    disp_size_t new_disp_size;
 
-    theme->base.disp = disp;
+    if(hor_res <= 320) new_disp_size = DISP_SMALL;
+    else if(hor_res < 720) new_disp_size = DISP_MEDIUM;
+    else new_disp_size = DISP_LARGE;
+
+    /* check theme information whether will change or not*/
+    if(theme->inited && (theme->base.disp == disp || lv_disp_get_dpi(theme->base.disp) == lv_disp_get_dpi(disp)) &&
+       theme->disp_size == new_disp_size &&
+       lv_color_eq(theme->base.color_primary, color_primary) &&
+       lv_color_eq(theme->base.color_secondary, color_secondary) &&
+       theme->base.flags == dark ? MODE_DARK : 0 &&
+       theme->base.font_small == font) {
+        return (lv_theme_t *) theme;
+
+    }
+
+    theme->disp_size = new_disp_size;
+    theme->base.disp = disp == NULL ? lv_disp_get_default() : disp;
     theme->base.color_primary = color_primary;
     theme->base.color_secondary = color_secondary;
     theme->base.font_small = font;

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -20,7 +20,7 @@
 #define theme_def (LV_GLOBAL_DEFAULT()->theme_default)
 
 #define MODE_DARK 1
-#define RADIUS_DEFAULT (theme->disp_size == DISP_LARGE ? lv_disp_dpx(theme->base.disp, 12) : lv_disp_dpx(theme->base.disp, 8))
+#define RADIUS_DEFAULT _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 12 : 8)
 
 /*SCREEN*/
 #define LIGHT_COLOR_SCR        lv_palette_lighten(LV_PALETTE_GREY, 4)
@@ -33,12 +33,12 @@
 #define DARK_COLOR_GREY        lv_color_hex(0x2f3237)
 
 #define TRANSITION_TIME         LV_THEME_DEFAULT_TRANSITION_TIME
-#define BORDER_WIDTH            lv_disp_dpx(theme->base.disp, 2)
-#define OUTLINE_WIDTH           lv_disp_dpx(theme->base.disp, 3)
+#define BORDER_WIDTH            _LV_DPX_CALC(theme->disp_dpi, 2)
+#define OUTLINE_WIDTH           _LV_DPX_CALC(theme->disp_dpi, 3)
 
-#define PAD_DEF     (theme->disp_size == DISP_LARGE ? lv_disp_dpx(theme->base.disp, 24) : theme->disp_size == DISP_MEDIUM ? lv_disp_dpx(theme->base.disp, 20) : lv_disp_dpx(theme->base.disp, 16))
-#define PAD_SMALL   (theme->disp_size == DISP_LARGE ? lv_disp_dpx(theme->base.disp, 14) : theme->disp_size == DISP_MEDIUM ? lv_disp_dpx(theme->base.disp, 12) : lv_disp_dpx(theme->base.disp, 10))
-#define PAD_TINY   (theme->disp_size == DISP_LARGE ? lv_disp_dpx(theme->base.disp, 8) : theme->disp_size == DISP_MEDIUM ? lv_disp_dpx(theme->base.disp, 6) : lv_disp_dpx(theme->base.disp, 2))
+#define PAD_DEF     _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 24 : theme->disp_size == DISP_MEDIUM ? 20 : 16)
+#define PAD_SMALL   _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 14 : theme->disp_size == DISP_MEDIUM ? 12 : 10)
+#define PAD_TINY    _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 8 : theme->disp_size == DISP_MEDIUM ? 6 : 2)
 
 /**********************
  *      TYPEDEFS
@@ -158,6 +158,7 @@ typedef enum {
 typedef struct _my_theme_t {
     lv_theme_t base;
     disp_size_t disp_size;
+    lv_coord_t disp_dpi;
     lv_color_t color_scr;
     lv_color_t color_text;
     lv_color_t color_card;
@@ -243,8 +244,8 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_bg_color(&theme->styles.scrollbar, sb_color);
 
     lv_style_set_radius(&theme->styles.scrollbar, LV_RADIUS_CIRCLE);
-    lv_style_set_pad_all(&theme->styles.scrollbar, lv_disp_dpx(theme->base.disp, 7));
-    lv_style_set_width(&theme->styles.scrollbar,  lv_disp_dpx(theme->base.disp, 5));
+    lv_style_set_pad_all(&theme->styles.scrollbar, _LV_DPX_CALC(theme->disp_dpi, 7));
+    lv_style_set_width(&theme->styles.scrollbar,  _LV_DPX_CALC(theme->disp_dpi, 5));
     lv_style_set_bg_opa(&theme->styles.scrollbar,  LV_OPA_40);
 #if TRANSITION_TIME
     lv_style_set_transition(&theme->styles.scrollbar, &theme->trans_normal);
@@ -273,7 +274,7 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_pad_row(&theme->styles.card, PAD_SMALL);
     lv_style_set_pad_column(&theme->styles.card, PAD_SMALL);
     lv_style_set_line_color(&theme->styles.card, lv_palette_main(LV_PALETTE_GREY));
-    lv_style_set_line_width(&theme->styles.card, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_line_width(&theme->styles.card, _LV_DPX_CALC(theme->disp_dpi, 1));
 
     style_init_reset(&theme->styles.outline_primary);
     lv_style_set_outline_color(&theme->styles.outline_primary, theme->base.color_primary);
@@ -287,21 +288,21 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_outline_opa(&theme->styles.outline_secondary, LV_OPA_50);
 
     style_init_reset(&theme->styles.btn);
-    lv_style_set_radius(&theme->styles.btn, (theme->disp_size == DISP_LARGE ? lv_disp_dpx(theme->base.disp,
-                                                                                          16) : theme->disp_size == DISP_MEDIUM ? lv_disp_dpx(theme->base.disp, 12) : lv_disp_dpx(theme->base.disp, 8)));
+    lv_style_set_radius(&theme->styles.btn,
+                        _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 16 : theme->disp_size == DISP_MEDIUM ? 12 : 8));
     lv_style_set_bg_opa(&theme->styles.btn, LV_OPA_COVER);
     lv_style_set_bg_color(&theme->styles.btn, theme->color_grey);
     if(!(theme->base.flags & MODE_DARK)) {
         lv_style_set_shadow_color(&theme->styles.btn, lv_palette_main(LV_PALETTE_GREY));
         lv_style_set_shadow_width(&theme->styles.btn, LV_DPX(3));
         lv_style_set_shadow_opa(&theme->styles.btn, LV_OPA_50);
-        lv_style_set_shadow_ofs_y(&theme->styles.btn, lv_disp_dpx(theme->base.disp, LV_DPX(4)));
+        lv_style_set_shadow_ofs_y(&theme->styles.btn, _LV_DPX_CALC(theme->disp_dpi, LV_DPX(4)));
     }
     lv_style_set_text_color(&theme->styles.btn, theme->color_text);
     lv_style_set_pad_hor(&theme->styles.btn, PAD_DEF);
     lv_style_set_pad_ver(&theme->styles.btn, PAD_SMALL);
-    lv_style_set_pad_column(&theme->styles.btn, lv_disp_dpx(theme->base.disp, 5));
-    lv_style_set_pad_row(&theme->styles.btn, lv_disp_dpx(theme->base.disp, 5));
+    lv_style_set_pad_column(&theme->styles.btn, _LV_DPX_CALC(theme->disp_dpi, 5));
+    lv_style_set_pad_row(&theme->styles.btn, _LV_DPX_CALC(theme->disp_dpi, 5));
 
     lv_color_filter_dsc_init(&theme->dark_filter, dark_color_filter_cb);
     lv_color_filter_dsc_init(&theme->grey_filter, grey_filter_cb);
@@ -328,11 +329,11 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_pad_gap(&theme->styles.pad_small, PAD_SMALL);
 
     style_init_reset(&theme->styles.pad_gap);
-    lv_style_set_pad_row(&theme->styles.pad_gap, lv_disp_dpx(theme->base.disp, 10));
-    lv_style_set_pad_column(&theme->styles.pad_gap, lv_disp_dpx(theme->base.disp, 10));
+    lv_style_set_pad_row(&theme->styles.pad_gap, _LV_DPX_CALC(theme->disp_dpi, 10));
+    lv_style_set_pad_column(&theme->styles.pad_gap, _LV_DPX_CALC(theme->disp_dpi, 10));
 
     style_init_reset(&theme->styles.line_space_large);
-    lv_style_set_text_line_space(&theme->styles.line_space_large, lv_disp_dpx(theme->base.disp, 20));
+    lv_style_set_text_line_space(&theme->styles.line_space_large, _LV_DPX_CALC(theme->disp_dpi, 20));
 
     style_init_reset(&theme->styles.text_align_center);
     lv_style_set_text_align(&theme->styles.text_align_center, LV_TEXT_ALIGN_CENTER);
@@ -385,14 +386,14 @@ static void style_init(struct _my_theme_t * theme)
 
 #if LV_THEME_DEFAULT_GROW
     style_init_reset(&theme->styles.grow);
-    lv_style_set_transform_width(&theme->styles.grow, lv_disp_dpx(theme->base.disp, 3));
-    lv_style_set_transform_height(&theme->styles.grow, lv_disp_dpx(theme->base.disp, 3));
+    lv_style_set_transform_width(&theme->styles.grow, _LV_DPX_CALC(theme->disp_dpi, 3));
+    lv_style_set_transform_height(&theme->styles.grow, _LV_DPX_CALC(theme->disp_dpi, 3));
 #endif
 
     style_init_reset(&theme->styles.knob);
     lv_style_set_bg_color(&theme->styles.knob, theme->base.color_primary);
     lv_style_set_bg_opa(&theme->styles.knob, LV_OPA_COVER);
-    lv_style_set_pad_all(&theme->styles.knob, lv_disp_dpx(theme->base.disp, 6));
+    lv_style_set_pad_all(&theme->styles.knob, _LV_DPX_CALC(theme->disp_dpi, 6));
     lv_style_set_radius(&theme->styles.knob, LV_RADIUS_CIRCLE);
 
     style_init_reset(&theme->styles.anim);
@@ -404,7 +405,7 @@ static void style_init(struct _my_theme_t * theme)
 #if LV_USE_ARC
     style_init_reset(&theme->styles.arc_indic);
     lv_style_set_arc_color(&theme->styles.arc_indic, theme->color_grey);
-    lv_style_set_arc_width(&theme->styles.arc_indic, lv_disp_dpx(theme->base.disp, 15));
+    lv_style_set_arc_width(&theme->styles.arc_indic, _LV_DPX_CALC(theme->disp_dpi, 15));
     lv_style_set_arc_rounded(&theme->styles.arc_indic, true);
 
     style_init_reset(&theme->styles.arc_indic_primary);
@@ -417,7 +418,7 @@ static void style_init(struct _my_theme_t * theme)
 #endif
 #if LV_USE_CHECKBOX
     style_init_reset(&theme->styles.cb_marker);
-    lv_style_set_pad_all(&theme->styles.cb_marker, lv_disp_dpx(theme->base.disp, 3));
+    lv_style_set_pad_all(&theme->styles.cb_marker, _LV_DPX_CALC(theme->disp_dpi, 3));
     lv_style_set_border_width(&theme->styles.cb_marker, BORDER_WIDTH);
     lv_style_set_border_color(&theme->styles.cb_marker, theme->base.color_primary);
     lv_style_set_bg_color(&theme->styles.cb_marker, theme->color_card);
@@ -432,7 +433,7 @@ static void style_init(struct _my_theme_t * theme)
 
 #if LV_USE_SWITCH
     style_init_reset(&theme->styles.switch_knob);
-    lv_style_set_pad_all(&theme->styles.switch_knob, - lv_disp_dpx(theme->base.disp, 4));
+    lv_style_set_pad_all(&theme->styles.switch_knob, - _LV_DPX_CALC(theme->disp_dpi, 4));
     lv_style_set_bg_color(&theme->styles.switch_knob, lv_color_white());
 #endif
 
@@ -445,25 +446,27 @@ static void style_init(struct _my_theme_t * theme)
 #if LV_USE_CHART
     style_init_reset(&theme->styles.chart_bg);
     lv_style_set_border_post(&theme->styles.chart_bg, false);
-    lv_style_set_pad_column(&theme->styles.chart_bg, lv_disp_dpx(theme->base.disp, 10));
+    lv_style_set_pad_column(&theme->styles.chart_bg, _LV_DPX_CALC(theme->disp_dpi, 10));
     lv_style_set_line_color(&theme->styles.chart_bg, theme->color_grey);
 
     style_init_reset(&theme->styles.chart_series);
-    lv_style_set_line_width(&theme->styles.chart_series, lv_disp_dpx(theme->base.disp, 3));
-    lv_style_set_radius(&theme->styles.chart_series, lv_disp_dpx(theme->base.disp, 3));
-    lv_style_set_size(&theme->styles.chart_series, lv_disp_dpx(theme->base.disp, 8), lv_disp_dpx(theme->base.disp, 8));
-    lv_style_set_pad_column(&theme->styles.chart_series, lv_disp_dpx(theme->base.disp, 2));
+    lv_style_set_line_width(&theme->styles.chart_series, _LV_DPX_CALC(theme->disp_dpi, 3));
+    lv_style_set_radius(&theme->styles.chart_series, _LV_DPX_CALC(theme->disp_dpi, 3));
+
+    lv_coord_t chart_size = _LV_DPX_CALC(theme->disp_dpi, 8);
+    lv_style_set_size(&theme->styles.chart_series, chart_size, chart_size);
+    lv_style_set_pad_column(&theme->styles.chart_series, _LV_DPX_CALC(theme->disp_dpi, 2));
 
     style_init_reset(&theme->styles.chart_indic);
     lv_style_set_radius(&theme->styles.chart_indic, LV_RADIUS_CIRCLE);
-    lv_style_set_size(&theme->styles.chart_indic, lv_disp_dpx(theme->base.disp, 8), lv_disp_dpx(theme->base.disp, 8));
+    lv_style_set_size(&theme->styles.chart_indic, chart_size, chart_size);
     lv_style_set_bg_color(&theme->styles.chart_indic, theme->base.color_primary);
     lv_style_set_bg_opa(&theme->styles.chart_indic, LV_OPA_COVER);
 
     style_init_reset(&theme->styles.chart_ticks);
-    lv_style_set_line_width(&theme->styles.chart_ticks, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_line_width(&theme->styles.chart_ticks, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_line_color(&theme->styles.chart_ticks, theme->color_text);
-    lv_style_set_pad_all(&theme->styles.chart_ticks, lv_disp_dpx(theme->base.disp, 2));
+    lv_style_set_pad_all(&theme->styles.chart_ticks, _LV_DPX_CALC(theme->disp_dpi, 2));
     lv_style_set_text_color(&theme->styles.chart_ticks, lv_palette_main(LV_PALETTE_GREY));
 #endif
 
@@ -486,7 +489,7 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_pad_hor(&theme->styles.menu_cont, PAD_SMALL);
     lv_style_set_pad_ver(&theme->styles.menu_cont, PAD_SMALL);
     lv_style_set_pad_gap(&theme->styles.menu_cont, PAD_SMALL);
-    lv_style_set_border_width(&theme->styles.menu_cont, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.menu_cont, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_opa(&theme->styles.menu_cont, LV_OPA_10);
     lv_style_set_border_color(&theme->styles.menu_cont, theme->color_text);
     lv_style_set_border_side(&theme->styles.menu_cont, LV_BORDER_SIDE_NONE);
@@ -494,7 +497,7 @@ static void style_init(struct _my_theme_t * theme)
     style_init_reset(&theme->styles.menu_sidebar_cont);
     lv_style_set_pad_all(&theme->styles.menu_sidebar_cont, 0);
     lv_style_set_pad_gap(&theme->styles.menu_sidebar_cont, 0);
-    lv_style_set_border_width(&theme->styles.menu_sidebar_cont, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.menu_sidebar_cont, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_opa(&theme->styles.menu_sidebar_cont, LV_OPA_10);
     lv_style_set_border_color(&theme->styles.menu_sidebar_cont, theme->color_text);
     lv_style_set_border_side(&theme->styles.menu_sidebar_cont, LV_BORDER_SIDE_RIGHT);
@@ -530,21 +533,25 @@ static void style_init(struct _my_theme_t * theme)
 
 #if LV_USE_METER
     style_init_reset(&theme->styles.meter_marker);
-    lv_style_set_line_width(&theme->styles.meter_marker, lv_disp_dpx(theme->base.disp, 5));
+    lv_style_set_line_width(&theme->styles.meter_marker, _LV_DPX_CALC(theme->disp_dpi, 5));
     lv_style_set_line_color(&theme->styles.meter_marker, theme->color_text);
-    lv_style_set_size(&theme->styles.meter_marker, lv_disp_dpx(theme->base.disp, 20), lv_disp_dpx(theme->base.disp, 20));
-    lv_style_set_pad_left(&theme->styles.meter_marker, lv_disp_dpx(theme->base.disp, 15));
+
+    lv_coord_t meter_size = _LV_DPX_CALC(theme->disp_dpi, 20);
+    lv_style_set_size(&theme->styles.meter_marker, meter_size, meter_size);
+
+    meter_size = _LV_DPX_CALC(theme->disp_dpi, 15);
+    lv_style_set_pad_left(&theme->styles.meter_marker, meter_size);
 
     style_init_reset(&theme->styles.meter_indic);
     lv_style_set_radius(&theme->styles.meter_indic, LV_RADIUS_CIRCLE);
     lv_style_set_bg_color(&theme->styles.meter_indic, theme->color_text);
     lv_style_set_bg_opa(&theme->styles.meter_indic, LV_OPA_COVER);
-    lv_style_set_size(&theme->styles.meter_indic, lv_disp_dpx(theme->base.disp, 15), lv_disp_dpx(theme->base.disp, 15));
+    lv_style_set_size(&theme->styles.meter_indic, meter_size, meter_size);
 #endif
 
 #if LV_USE_TABLE
     style_init_reset(&theme->styles.table_cell);
-    lv_style_set_border_width(&theme->styles.table_cell, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.table_cell, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_color(&theme->styles.table_cell, theme->color_grey);
     lv_style_set_border_side(&theme->styles.table_cell, LV_BORDER_SIDE_TOP | LV_BORDER_SIDE_BOTTOM);
 #endif
@@ -552,8 +559,8 @@ static void style_init(struct _my_theme_t * theme)
 #if LV_USE_TEXTAREA
     style_init_reset(&theme->styles.ta_cursor);
     lv_style_set_border_color(&theme->styles.ta_cursor, theme->color_text);
-    lv_style_set_border_width(&theme->styles.ta_cursor, lv_disp_dpx(theme->base.disp, 2));
-    lv_style_set_pad_left(&theme->styles.ta_cursor, - lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.ta_cursor, _LV_DPX_CALC(theme->disp_dpi, 2));
+    lv_style_set_pad_left(&theme->styles.ta_cursor, - _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_side(&theme->styles.ta_cursor, LV_BORDER_SIDE_LEFT);
     lv_style_set_anim_time(&theme->styles.ta_cursor, 400);
 
@@ -569,7 +576,7 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_pad_gap(&theme->styles.calendar_btnm_bg, PAD_SMALL / 2);
 
     style_init_reset(&theme->styles.calendar_btnm_day);
-    lv_style_set_border_width(&theme->styles.calendar_btnm_day, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.calendar_btnm_day, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_color(&theme->styles.calendar_btnm_day, theme->color_grey);
     lv_style_set_bg_color(&theme->styles.calendar_btnm_day, theme->color_card);
     lv_style_set_bg_opa(&theme->styles.calendar_btnm_day, LV_OPA_20);
@@ -584,7 +591,7 @@ static void style_init(struct _my_theme_t * theme)
 #if LV_USE_MSGBOX
     /*To add space for for the button shadow*/
     style_init_reset(&theme->styles.msgbox_btn_bg);
-    lv_style_set_pad_all(&theme->styles.msgbox_btn_bg, lv_disp_dpx(theme->base.disp, 4));
+    lv_style_set_pad_all(&theme->styles.msgbox_btn_bg, _LV_DPX_CALC(theme->disp_dpi, 4));
 
     style_init_reset(&theme->styles.msgbox_bg);
     lv_style_set_max_width(&theme->styles.msgbox_bg, lv_pct(100));
@@ -618,7 +625,7 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_clip_corner(&theme->styles.list_bg, true);
 
     style_init_reset(&theme->styles.list_btn);
-    lv_style_set_border_width(&theme->styles.list_btn, lv_disp_dpx(theme->base.disp, 1));
+    lv_style_set_border_width(&theme->styles.list_btn, _LV_DPX_CALC(theme->disp_dpi, 1));
     lv_style_set_border_color(&theme->styles.list_btn, theme->color_grey);
     lv_style_set_border_side(&theme->styles.list_btn, LV_BORDER_SIDE_BOTTOM);
     lv_style_set_pad_all(&theme->styles.list_btn, PAD_SMALL);
@@ -635,9 +642,9 @@ static void style_init(struct _my_theme_t * theme)
     lv_style_set_bg_color(&theme->styles.led, lv_color_white());
     lv_style_set_bg_grad_color(&theme->styles.led, lv_palette_main(LV_PALETTE_GREY));
     lv_style_set_radius(&theme->styles.led, LV_RADIUS_CIRCLE);
-    lv_style_set_shadow_width(&theme->styles.led, lv_disp_dpx(theme->base.disp, 15));
+    lv_style_set_shadow_width(&theme->styles.led, _LV_DPX_CALC(theme->disp_dpi, 15));
     lv_style_set_shadow_color(&theme->styles.led, lv_color_white());
-    lv_style_set_shadow_spread(&theme->styles.led, lv_disp_dpx(theme->base.disp, 5));
+    lv_style_set_shadow_spread(&theme->styles.led, _LV_DPX_CALC(theme->disp_dpi, 5));
 #endif
 }
 
@@ -658,16 +665,19 @@ lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, l
     }
 
     struct _my_theme_t * theme = theme_def;
-    lv_coord_t hor_res = lv_disp_get_hor_res(disp);
-    disp_size_t new_disp_size;
 
-    if(hor_res <= 320) new_disp_size = DISP_SMALL;
-    else if(hor_res < 720) new_disp_size = DISP_MEDIUM;
-    else new_disp_size = DISP_LARGE;
+    lv_disp_t * new_disp = disp == NULL ? lv_disp_get_default() : disp;
+    lv_coord_t new_dpi = lv_disp_get_dpi(new_disp);
+    lv_coord_t hor_res = lv_disp_get_hor_res(new_disp);
+    disp_size_t new_size;
+
+    if(hor_res <= 320) new_size = DISP_SMALL;
+    else if(hor_res < 720) new_size = DISP_MEDIUM;
+    else new_size = DISP_LARGE;
 
     /* check theme information whether will change or not*/
-    if(theme->inited && (theme->base.disp == disp || lv_disp_get_dpi(theme->base.disp) == lv_disp_get_dpi(disp)) &&
-       theme->disp_size == new_disp_size &&
+    if(theme->inited && theme->disp_dpi == new_dpi &&
+       theme->disp_size == new_size &&
        lv_color_eq(theme->base.color_primary, color_primary) &&
        lv_color_eq(theme->base.color_secondary, color_secondary) &&
        theme->base.flags == dark ? MODE_DARK : 0 &&
@@ -676,8 +686,9 @@ lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, l
 
     }
 
-    theme->disp_size = new_disp_size;
-    theme->base.disp = disp == NULL ? lv_disp_get_default() : disp;
+    theme->disp_size = new_size;
+    theme->disp_dpi = new_dpi;
+    theme->base.disp = new_disp;
     theme->base.color_primary = color_primary;
     theme->base.color_secondary = color_secondary;
     theme->base.font_small = font;


### PR DESCRIPTION
avoid reinitializing the default theme when providing the same configuration.

### Description of the feature or fix
When `lv_theme_default_init` is repeatedly called multiple times using the same configuration, the style changed will cause cumulative delays.
```
#if LV_USE_THEME_DEFAULT
    lv_theme_default_init(NULL, lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED), LV_THEME_DEFAULT_DARK,
                          font_normal);
#endif
```
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
