### PR TITLE
Fix/compiler error on lv log warn msg

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [v8.3.10](https://github.com/lvgl/lvgl/compare/v8.3.10...v8.3.9) Date TBD
+
+
+### Fixes
+
+- fix(draw): fix compiler error in lv_draw_sw_transform.c [`?`](https://github.com/lvgl/lvgl/pull/?)
+
+
 ## [v8.3.9](https://github.com/lvgl/lvgl/compare/v8.3.9...v8.3.8) 6 August 2023
 
 

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -103,7 +103,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
         if(letter >= 0x20 &&
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" PRIX32, letter);
+            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", letter);
 
 #if LV_USE_FONT_PLACEHOLDER
             /* draw placeholder */

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -103,7 +103,7 @@ void lv_draw_sw_letter(lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc
         if(letter >= 0x20 &&
            letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
            letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", letter);
+            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%X", (unsigned int)letter);
 
 #if LV_USE_FONT_PLACEHOLDER
             /* draw placeholder */

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -273,7 +273,7 @@ static void argb_and_rgb_aa(const uint8_t * src, lv_coord_t src_w, lv_coord_t sr
     int32_t ys_ups_start = ys_ups;
     bool has_alpha;
     int32_t px_size;
-    lv_color_t ck = {0};
+    lv_color_t ck = _LV_COLOR_ZERO_INITIALIZER;
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR:
             has_alpha = false;


### PR DESCRIPTION
### Description of the feature or fix

fix(draw):  fix compiler error when LV_USE_LOG == 1

lv_draw_sw_letter() function had a LV_LOG_WARN() message that had syntax only legal when PRIX32 translates to a recognized string (sprintf format character "X").  However, the symbol PRIX32 is only implemented in the in the 'master' branch, not in 'release/v8.3' branch, causing PRIX32 to be an unrecognized symbol.

Handled by adding sprintf format character 'X' to end of string and removing PRIX32 symbol, simulating original intention in 'master' branch.

Note I thought it might be a courtesy to send this as a "fix/compiler_error_on_lv_log_warn_msg" branch from the "release/v8.3" branch in case that is more convenient to simply merge at a convenient point instead of going through possible conflicts.  Please let me know if that is not desired.