### PR TITLE
fix(obj): copy check to the front of obj_del_core

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -51,7 +51,7 @@ void lv_obj_del(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
-    LV_LOG_TRACE("begin (delete %p)", (void *)obj);
+    LV_LOG_INFO("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_obj_invalidate(obj);
 
@@ -86,7 +86,7 @@ void lv_obj_del(lv_obj_t * obj)
     }
 
     LV_ASSERT_MEM_INTEGRITY();
-    LV_LOG_TRACE("finished (delete %p)", (void *)obj);
+    LV_LOG_INFO("finished (delete %p)", (void *)obj);
 }
 
 void lv_obj_clean(lv_obj_t * obj)
@@ -375,11 +375,11 @@ static void obj_del_core(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
+    obj->is_deleting = true;
+
     /*Let the user free the resources used in `LV_EVENT_DELETE`*/
     lv_res_t res = lv_obj_send_event(obj, LV_EVENT_DELETE, NULL);
     if(res == LV_RES_INV) return;
-
-    obj->is_deleting = true;
 
     /*Clean registered event_cb*/
     uint32_t event_cnt = lv_obj_get_event_count(obj);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -51,8 +51,6 @@ void lv_obj_del(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
-    obj->is_deleting = true;
-
     LV_LOG_TRACE("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_obj_invalidate(obj);
@@ -377,11 +375,11 @@ static void obj_del_core(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
-    obj->is_deleting = true;
-
     /*Let the user free the resources used in `LV_EVENT_DELETE`*/
     lv_res_t res = lv_obj_send_event(obj, LV_EVENT_DELETE, NULL);
     if(res == LV_RES_INV) return;
+
+    obj->is_deleting = true;
 
     /*Clean registered event_cb*/
     uint32_t event_cnt = lv_obj_get_event_count(obj);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -374,6 +374,11 @@ static void lv_obj_del_async_cb(void * obj)
 
 static void obj_del_core(lv_obj_t * obj)
 {
+    if(obj->is_deleting)
+        return;
+
+    obj->is_deleting = true;
+
     /*Let the user free the resources used in `LV_EVENT_DELETE`*/
     lv_res_t res = lv_obj_send_event(obj, LV_EVENT_DELETE, NULL);
     if(res == LV_RES_INV) return;

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -51,7 +51,7 @@ void lv_obj_del(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
-    LV_LOG_INFO("begin (delete %p)", (void *)obj);
+    LV_LOG_TRACE("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_obj_invalidate(obj);
 
@@ -86,7 +86,7 @@ void lv_obj_del(lv_obj_t * obj)
     }
 
     LV_ASSERT_MEM_INTEGRITY();
-    LV_LOG_INFO("finished (delete %p)", (void *)obj);
+    LV_LOG_TRACE("finished (delete %p)", (void *)obj);
 }
 
 void lv_obj_clean(lv_obj_t * obj)

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -51,6 +51,8 @@ void lv_obj_del(lv_obj_t * obj)
     if(obj->is_deleting)
         return;
 
+    obj->is_deleting = true;
+
     LV_LOG_TRACE("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_obj_invalidate(obj);
@@ -375,8 +377,6 @@ static void obj_del_core(lv_obj_t * obj)
     /*Let the user free the resources used in `LV_EVENT_DELETE`*/
     lv_res_t res = lv_obj_send_event(obj, LV_EVENT_DELETE, NULL);
     if(res == LV_RES_INV) return;
-
-    obj->is_deleting = true;
 
     /*Clean registered event_cb*/
     uint32_t event_cnt = lv_obj_get_event_count(obj);


### PR DESCRIPTION
### Copy judgement to obj_del_core

During deletion of obj we should not send multiple deleted events.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
