### PR TITLE
fix: do not copy invalid areas if not double buffered mode

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -329,6 +329,11 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
 
         /*Copy invalid areas for sync next refresh*/
         if(disp_refr->driver->direct_mode) {
+
+            /*Do not copy areas if not double buffered*/
+            if(disp_refr->driver->draw_buf->buf2 == NULL)
+                return;
+
             uint16_t i;
             for(i = 0; i < disp_refr->inv_p; i++) {
                 if(disp_refr->inv_area_joined[i])


### PR DESCRIPTION
Sync areas should not be copied if we are using direct mode with single buffer - otherwise we have memleak.