### PR TITLE
feat/dashed-chart-lines

### DIFF
--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -988,6 +988,7 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                                 lv_draw_line_dsc_init(&draw_dashed_line);
                                 draw_dashed_line.dash_gap = lv_dpx(10);
                                 draw_dashed_line.dash_width = lv_dpx(10);
+                                draw_dashed_line.width = lv_dpx(3);
                                 draw_dashed_line.color = ser->color;
                                 lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
                             } else {
@@ -1021,6 +1022,7 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                             lv_draw_line_dsc_init(&draw_dashed_line);
                             draw_dashed_line.dash_gap = lv_dpx(10);
                             draw_dashed_line.dash_width = lv_dpx(10);
+                            draw_dashed_line.width = lv_dpx(3);
                             draw_dashed_line.color = ser->color;
                             lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
                         } else { // Draw a solid line (Default)

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -336,6 +336,14 @@ void lv_chart_refresh(lv_obj_t * obj)
 }
 
 /*======================
+ * Series Styles
+ *=====================*/
+
+void lv_chart_set_series_line_style(lv_chart_series_t * ser, lv_chart_line_style_t line_style) {
+    ser->line_style = line_style;
+}
+
+/*======================
  * Series
  *=====================*/
 
@@ -352,6 +360,7 @@ lv_chart_series_t * lv_chart_add_series(lv_obj_t * obj, lv_color_t color, lv_cha
 
     lv_coord_t def = LV_CHART_POINT_NONE;
 
+    ser->line_style = LV_CHART_LINE_SOLID; // Default style is solid
     ser->color  = color;
     ser->y_points = lv_mem_alloc(sizeof(lv_coord_t) * chart->point_cnt);
     LV_ASSERT_MALLOC(ser->y_points);
@@ -974,7 +983,17 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                             p1.y = y_min;
                             p2.y = y_max;
                             if(p1.y == p2.y) p2.y++;    /*If they are the same no line will be drawn*/
-                            lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
+                            if (ser->line_style == LV_CHART_LINE_DASHED) {
+                                lv_draw_line_dsc_t draw_dashed_line;
+                                lv_draw_line_dsc_init(&draw_dashed_line);
+                                draw_dashed_line.dash_gap = lv_dpx(10);
+                                draw_dashed_line.dash_width = lv_dpx(10);
+                                draw_dashed_line.color = ser->color;
+                                lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+                            } else {
+                                // Draw a solid line
+                                lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
+                            }
                             p2.x++;         /*Compensate the previous x--*/
                             y_min = y_cur;  /*Start the line of the next x from the current last y*/
                             y_max = y_cur;
@@ -997,7 +1016,16 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                     lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
                     if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                        lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
+                        if (ser->line_style == LV_CHART_LINE_DASHED) {
+                            lv_draw_line_dsc_t draw_dashed_line;
+                            lv_draw_line_dsc_init(&draw_dashed_line);
+                            draw_dashed_line.dash_gap = lv_dpx(10);
+                            draw_dashed_line.dash_width = lv_dpx(10);
+                            draw_dashed_line.color = ser->color;
+                            lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+                        } else { // Draw a solid line (Default)
+                            lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
+                        }
                     }
 
                     if(point_w && point_h && ser->y_points[p_prev] != LV_CHART_POINT_NONE) {

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -984,14 +984,35 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                             p1.y = y_min;
                             p2.y = y_max;
                             if(p1.y == p2.y) p2.y++;    /*If they are the same no line will be drawn*/
-                            if(ser->line_style == LV_CHART_LINE_DASHED) {
+                            if (ser->line_style == LV_CHART_LINE_DASHED) {
                                 lv_draw_line_dsc_t draw_dashed_line;
                                 lv_draw_line_dsc_init(&draw_dashed_line);
+
+                                // Set the dash gap and dash width
                                 draw_dashed_line.dash_gap = lv_dpx(10);
                                 draw_dashed_line.dash_width = lv_dpx(10);
                                 draw_dashed_line.width = lv_dpx(3);
+
+                                // Set the color
                                 draw_dashed_line.color = ser->color;
-                                lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+
+                                // Calculate the absolute difference between x and y coordinates of p1 and p2
+                                lv_coord_t dx = LV_ABS(p1.x - p2.x);
+                                lv_coord_t dy = LV_ABS(p1.y - p2.y);
+
+                                // Determine if the line is closer to horizontal or vertical based on the difference
+                                if (dx > dy) {
+                                    // Line is closer to horizontal, draw a dashed horizontal line
+                                    lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+                                } else {
+                                    // Line is closer to vertical, draw a dashed vertical line
+                                    lv_area_t vline;
+                                    vline.x1 = p1.x;
+                                    vline.x2 = p1.x + 5; // Very narrow width
+                                    vline.y1 = LV_MIN(p1.y, p2.y);
+                                    vline.y2 = LV_MAX(p1.y, p2.y)+5;
+                                    lv_draw_rect(draw_ctx, (const lv_draw_rect_dsc_t *)&draw_dashed_line, &vline);
+                                }
                             }
                             else { // Draw a solid line (Default)
                                 lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
@@ -1018,14 +1039,35 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                     lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
                     if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                        if(ser->line_style == LV_CHART_LINE_DASHED) {
+                        if (ser->line_style == LV_CHART_LINE_DASHED) {
                             lv_draw_line_dsc_t draw_dashed_line;
                             lv_draw_line_dsc_init(&draw_dashed_line);
+
+                            // Set the dash gap and dash width
                             draw_dashed_line.dash_gap = lv_dpx(10);
                             draw_dashed_line.dash_width = lv_dpx(10);
                             draw_dashed_line.width = lv_dpx(3);
+
+                            // Set the color
                             draw_dashed_line.color = ser->color;
-                            lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+
+                            // Calculate the absolute difference between x and y coordinates of p1 and p2
+                            lv_coord_t dx = LV_ABS(p1.x - p2.x);
+                            lv_coord_t dy = LV_ABS(p1.y - p2.y);
+
+                            // Determine if the line is closer to horizontal or vertical based on the difference
+                            if (dx >= dy) {
+                                // Line is closer to horizontal, draw a dashed horizontal line
+                                lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
+                            } else {
+                                // Line is closer to vertical, draw a dashed vertical line
+                                lv_area_t vline;
+                                vline.x1 = p1.x;
+                                vline.x2 = p1.x + 5; // Very narrow width
+                                vline.y1 = LV_MIN(p1.y, p2.y);
+                                vline.y2 = LV_MAX(p1.y, p2.y)+5;
+                                lv_draw_rect(draw_ctx, (const lv_draw_rect_dsc_t *)&draw_dashed_line, &vline);
+                            }
                         }
                         else { // Draw a solid line (Default)
                             lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -339,7 +339,8 @@ void lv_chart_refresh(lv_obj_t * obj)
  * Series Styles
  *=====================*/
 
-void lv_chart_set_series_line_style(lv_chart_series_t * ser, lv_chart_line_style_t line_style) {
+void lv_chart_set_series_line_style(lv_chart_series_t * ser, lv_chart_line_style_t line_style)
+{
     ser->line_style = line_style;
 }
 
@@ -983,7 +984,7 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                             p1.y = y_min;
                             p2.y = y_max;
                             if(p1.y == p2.y) p2.y++;    /*If they are the same no line will be drawn*/
-                            if (ser->line_style == LV_CHART_LINE_DASHED) {
+                            if(ser->line_style == LV_CHART_LINE_DASHED) {
                                 lv_draw_line_dsc_t draw_dashed_line;
                                 lv_draw_line_dsc_init(&draw_dashed_line);
                                 draw_dashed_line.dash_gap = lv_dpx(10);
@@ -991,8 +992,8 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                                 draw_dashed_line.width = lv_dpx(3);
                                 draw_dashed_line.color = ser->color;
                                 lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
-                            } else {
-                                // Draw a solid line
+                            }
+                            else { // Draw a solid line (Default)
                                 lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
                             }
                             p2.x++;         /*Compensate the previous x--*/
@@ -1017,7 +1018,7 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                     lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
                     if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                        if (ser->line_style == LV_CHART_LINE_DASHED) {
+                        if(ser->line_style == LV_CHART_LINE_DASHED) {
                             lv_draw_line_dsc_t draw_dashed_line;
                             lv_draw_line_dsc_init(&draw_dashed_line);
                             draw_dashed_line.dash_gap = lv_dpx(10);
@@ -1025,7 +1026,8 @@ static void draw_series_line(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx)
                             draw_dashed_line.width = lv_dpx(3);
                             draw_dashed_line.color = ser->color;
                             lv_draw_line(draw_ctx, &draw_dashed_line, &p1, &p2);
-                        } else { // Draw a solid line (Default)
+                        }
+                        else { // Draw a solid line (Default)
                             lv_draw_line(draw_ctx, &line_dsc_default, &p1, &p2);
                         }
                     }

--- a/src/extra/widgets/chart/lv_chart.h
+++ b/src/extra/widgets/chart/lv_chart.h
@@ -54,6 +54,15 @@ enum {
 typedef uint8_t lv_chart_update_mode_t;
 
 /**
+ * Chart line series style`
+ */
+enum {
+    LV_CHART_LINE_SOLID,  // Solid line (default)
+    LV_CHART_LINE_DASHED, // Dashed line
+};
+typedef uint8_t lv_chart_line_style_t;
+
+/**
  * Enumeration of the axis'
  */
 enum {
@@ -78,6 +87,7 @@ typedef struct {
     uint8_t y_ext_buf_assigned : 1;
     uint8_t x_axis_sec : 1;
     uint8_t y_axis_sec : 1;
+    lv_chart_line_style_t line_style;
 } lv_chart_series_t;
 
 typedef struct {
@@ -261,6 +271,12 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint1
  * @param   chart pointer to chart object
  */
 void lv_chart_refresh(lv_obj_t * obj);
+
+/*======================
+ * Series Styles
+ *=====================*/
+
+void lv_chart_set_series_line_style(lv_chart_series_t * ser, lv_chart_line_style_t line_style);
 
 /*======================
  * Series


### PR DESCRIPTION
Hi - thx for this awesome lib first of all!

So i have a project where i was needing to have dashed chart lines and sadly discovered they aren't an oob option so instead of following the online sources of custom drawing the lines outside the chart widget i thought introducing this as an option for the chart itself will be a much nicer way :)
![image](https://github.com/lvgl/lvgl/assets/42692077/9ae877bd-4ec4-47bf-992b-e8ef23b921bd)

It's not in a fully ready state yet because i hardcoded some styling values like dash width and gap but those can also be handled gracefully by adding their own options  in a separate or existing struct. 

So what i did is added a new enum to be able to specify the line type:
```cpp
LV_CHART_LINE_SOLID,  // Solid line (default)
LV_CHART_LINE_DASHED, // Dashed line
```
Defined a new property in the **lv_chart_series_t** struct:
```cpp
lv_chart_line_style_t line_style;
```

And added a function to set the line type:
```cpp
void lv_chart_set_series_line_style(lv_chart_series_t * ser, lv_chart_line_style_t line_style);
```

Then it can be used in the main code just byt setting it's style after a series is initialised, ex:

```cpp
lv_chart_series_t *example_series = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_RED), LV_CHART_AXIS_SECONDARY_Y);
lv_chart_set_series_line_style(example_series, LV_CHART_LINE_DASHED);
```

P.S. I'm going to make it more customisable as i'm working on making it draw dashed in all the directions but wanted to raise this PR to see what's the general consensus on adding this to the official codebase ?