### PR TITLE
fix(docs): dropdown: fix function name in description of static options

### DIFF
--- a/docs/widgets/core/dropdown.md
+++ b/docs/widgets/core/dropdown.md
@@ -43,7 +43,7 @@ Options are passed to the drop-down list as a string with `lv_dropdown_set_optio
 
 The `lv_dropdown_add_option(dropdown, "New option", pos)` function inserts a new option to `pos` index.
 
-To save memory the options can set from a static(constant) string too with `lv_dropdown_set_static_options(dropdown, options)`.
+To save memory the options can set from a static(constant) string too with `lv_dropdown_set_options_static(dropdown, options)`.
 In this case the options string should be alive while the drop-down list exists and `lv_dropdown_add_option` can't be used
 
 You can select an option manually with `lv_dropdown_set_selected(dropdown, id)`, where `id` is the index of an option.


### PR DESCRIPTION
### Description 

Docs say that adding a static option list is done via `lv_dropdown_set_static_options`, correct is `lv_dropdown_set_options_static` (as in API below in the page)