### PR TITLE
fix: build on Windows (MinGW environment)

### DIFF
--- a/examples/lv_examples.mk
+++ b/examples/lv_examples.mk
@@ -1,1 +1,1 @@
-CSRCS += $(shell find -L $(LVGL_DIR)/$(LVGL_DIR_NAME)/examples -name \*.c)
+CSRCS += $(shell find -L $(LVGL_DIR)/$(LVGL_DIR_NAME)/examples -name "*.c")

--- a/src/extra/lv_extra.mk
+++ b/src/extra/lv_extra.mk
@@ -1,1 +1,1 @@
-CSRCS += $(shell find -L $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/extra -name \*.c)
+CSRCS += $(shell find -L $(LVGL_DIR)/$(LVGL_DIR_NAME)/src/extra -name "*.c")


### PR DESCRIPTION
### Fix build on Windows (MinGW environment)

On Windows environment edited lines (in files `lv_examples.mk` and `lv_extra.mk`) don't work properly, so edited them to work both on Linux and MinGW, like it's done in `lv_demos.mk`.
