### PR TITLE
feat(indev):Add an indev reset event

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -649,6 +649,9 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_DRAW_MAIN || code == LV_EVENT_DRAW_POST || code == LV_EVENT_COVER_CHECK) {
         lv_obj_draw(e);
     }
+    else if(code == LV_EVENT_INDEV_RESET) {
+        lv_obj_set_state(obj, LV_STATE_DEFAULT);
+    }
 }
 
 /**

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -650,7 +650,8 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_draw(e);
     }
     else if(code == LV_EVENT_INDEV_RESET) {
-        lv_obj_set_state(obj, LV_STATE_DEFAULT);
+        lv_obj_clear_state(obj, LV_STATE_PRESSED);
+        lv_obj_clear_state(obj, LV_STATE_SCROLLED);
     }
 }
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -336,6 +336,8 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev)
 
 void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
+    lv_obj_t* act_obj = NULL;
+
     if(indev) {
         indev->reset_query = 1;
         if(indev_act == indev) indev_obj_act = NULL;
@@ -344,7 +346,13 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
                 indev->pointer.last_pressed = NULL;
             }
             if(obj == NULL || indev->pointer.act_obj == obj) {
-                indev->pointer.act_obj = NULL;
+                if(indev->pointer.act_obj) {
+                    /* Avoid recursive calls */
+                    act_obj = indev->pointer.act_obj;
+                    indev->pointer.act_obj = NULL;
+                    lv_obj_send_event(act_obj, LV_EVENT_PRESS_LOST, indev);
+                    act_obj = NULL;
+                }
             }
             if(obj == NULL || indev->pointer.last_obj == obj) {
                 indev->pointer.last_obj = NULL;
@@ -360,7 +368,13 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
                     i->pointer.last_pressed = NULL;
                 }
                 if(obj == NULL || i->pointer.act_obj == obj) {
-                    i->pointer.act_obj = NULL;
+                    if(i->pointer.act_obj) {
+                        /* Avoid recursive calls */
+                        act_obj = i->pointer.act_obj;
+                        i->pointer.act_obj = NULL;
+                        lv_obj_send_event(act_obj, LV_EVENT_PRESS_LOST, i);
+                        act_obj = NULL;
+                    }
                 }
                 if(obj == NULL || i->pointer.last_obj == obj) {
                     i->pointer.last_obj = NULL;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -350,7 +350,7 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
                     /* Avoid recursive calls */
                     act_obj = indev->pointer.act_obj;
                     indev->pointer.act_obj = NULL;
-                    lv_obj_send_event(act_obj, LV_EVENT_PRESS_LOST, indev);
+                    lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
                     act_obj = NULL;
                 }
             }
@@ -372,7 +372,7 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
                         /* Avoid recursive calls */
                         act_obj = i->pointer.act_obj;
                         i->pointer.act_obj = NULL;
-                        lv_obj_send_event(act_obj, LV_EVENT_PRESS_LOST, i);
+                        lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, i);
                         act_obj = NULL;
                     }
                 }

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -337,6 +337,7 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev)
 void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
     lv_obj_t * act_obj = NULL;
+    lv_obj_t * scroll_obj = NULL;
 
     if(indev) {
         indev->reset_query = 1;
@@ -356,6 +357,15 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
             }
             if(obj == NULL || indev->pointer.last_obj == obj) {
                 indev->pointer.last_obj = NULL;
+            }
+            if(obj == NULL || indev->pointer.scroll_obj == obj) {
+                if(indev->pointer.scroll_obj) {
+                    /* Avoid recursive calls */
+                    scroll_obj = indev->pointer.scroll_obj;
+                    indev->pointer.scroll_obj = NULL;
+                    lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
+                    scroll_obj = NULL;
+                }
             }
         }
     }
@@ -378,6 +388,15 @@ void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
                 }
                 if(obj == NULL || i->pointer.last_obj == obj) {
                     i->pointer.last_obj = NULL;
+                }
+                if(obj == NULL || i->pointer.scroll_obj == obj) {
+                    if(i->pointer.scroll_obj) {
+                        /* Avoid recursive calls */
+                        scroll_obj = i->pointer.scroll_obj;
+                        i->pointer.scroll_obj = NULL;
+                        lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, i);
+                        scroll_obj = NULL;
+                    }
                 }
             }
             i = lv_indev_get_next(i);

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -336,7 +336,7 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev)
 
 void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
-    lv_obj_t* act_obj = NULL;
+    lv_obj_t * act_obj = NULL;
 
     if(indev) {
         indev->reset_query = 1;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -71,6 +71,7 @@ static void indev_click_focus(lv_indev_t * indev);
 static void indev_gesture(lv_indev_t * indev);
 static bool indev_reset_check(lv_indev_t * indev);
 static void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data);
+static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -336,69 +337,13 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev)
 
 void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
-    lv_obj_t * act_obj = NULL;
-    lv_obj_t * scroll_obj = NULL;
-
     if(indev) {
-        indev->reset_query = 1;
-        if(indev_act == indev) indev_obj_act = NULL;
-        if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_KEYPAD) {
-            if(obj == NULL || indev->pointer.last_pressed == obj) {
-                indev->pointer.last_pressed = NULL;
-            }
-            if(obj == NULL || indev->pointer.act_obj == obj) {
-                if(indev->pointer.act_obj) {
-                    /* Avoid recursive calls */
-                    act_obj = indev->pointer.act_obj;
-                    indev->pointer.act_obj = NULL;
-                    lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
-                    act_obj = NULL;
-                }
-            }
-            if(obj == NULL || indev->pointer.last_obj == obj) {
-                indev->pointer.last_obj = NULL;
-            }
-            if(obj == NULL || indev->pointer.scroll_obj == obj) {
-                if(indev->pointer.scroll_obj) {
-                    /* Avoid recursive calls */
-                    scroll_obj = indev->pointer.scroll_obj;
-                    indev->pointer.scroll_obj = NULL;
-                    lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
-                    scroll_obj = NULL;
-                }
-            }
-        }
+        indev_reset_core(indev, obj);
     }
     else {
         lv_indev_t * i = lv_indev_get_next(NULL);
         while(i) {
-            i->reset_query = 1;
-            if(i->type == LV_INDEV_TYPE_POINTER || i->type == LV_INDEV_TYPE_KEYPAD) {
-                if(obj == NULL || i->pointer.last_pressed == obj) {
-                    i->pointer.last_pressed = NULL;
-                }
-                if(obj == NULL || i->pointer.act_obj == obj) {
-                    if(i->pointer.act_obj) {
-                        /* Avoid recursive calls */
-                        act_obj = i->pointer.act_obj;
-                        i->pointer.act_obj = NULL;
-                        lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, i);
-                        act_obj = NULL;
-                    }
-                }
-                if(obj == NULL || i->pointer.last_obj == obj) {
-                    i->pointer.last_obj = NULL;
-                }
-                if(obj == NULL || i->pointer.scroll_obj == obj) {
-                    if(i->pointer.scroll_obj) {
-                        /* Avoid recursive calls */
-                        scroll_obj = i->pointer.scroll_obj;
-                        i->pointer.scroll_obj = NULL;
-                        lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, i);
-                        scroll_obj = NULL;
-                    }
-                }
-            }
+            indev_reset_core(i, obj);
             i = lv_indev_get_next(i);
         }
         indev_obj_act = NULL;
@@ -1415,4 +1360,44 @@ static bool indev_reset_check(lv_indev_t * indev)
     }
 
     return indev->reset_query;
+}
+
+/**
+ * Reset the indev and send event to active obj and scroll obj
+ * @param indev pointer to an input device
+ * @param obj pointer to obj
+*/
+static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj)
+{
+    lv_obj_t * act_obj = NULL;
+    lv_obj_t * scroll_obj = NULL;
+
+    indev->reset_query = 1;
+    if(indev_act == indev) indev_obj_act = NULL;
+    if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_KEYPAD) {
+        if(obj == NULL || indev->pointer.last_pressed == obj) {
+            indev->pointer.last_pressed = NULL;
+        }
+        if(obj == NULL || indev->pointer.act_obj == obj) {
+            if(indev->pointer.act_obj) {
+                /* Avoid recursive calls */
+                act_obj = indev->pointer.act_obj;
+                indev->pointer.act_obj = NULL;
+                lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
+                act_obj = NULL;
+            }
+        }
+        if(obj == NULL || indev->pointer.last_obj == obj) {
+            indev->pointer.last_obj = NULL;
+        }
+        if(obj == NULL || indev->pointer.scroll_obj == obj) {
+            if(indev->pointer.scroll_obj) {
+                /* Avoid recursive calls */
+                scroll_obj = indev->pointer.scroll_obj;
+                indev->pointer.scroll_obj = NULL;
+                lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
+                scroll_obj = NULL;
+            }
+        }
+    }
 }

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -62,6 +62,7 @@ typedef enum {
     LV_EVENT_DEFOCUSED,           /**< The object is defocused*/
     LV_EVENT_LEAVE,               /**< The object is defocused but still selected*/
     LV_EVENT_HIT_TEST,            /**< Perform advanced hit-testing*/
+    LV_EVENT_INDEV_RESET,         /**< Indev has been reseted*/
 
     /** Drawing events*/
     LV_EVENT_COVER_CHECK,        /**< Check if the object fully covers an area. The event parameter is `lv_cover_check_info_t *`.*/


### PR DESCRIPTION
### Add an indev reset event

When someone calls lv_indev_reset, the active obj will always stay in the pressed state or other state. We need to send it a indev reset event to restore its default state.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
