### PR TITLE
changes `lv_lru_free_t` function pointer typedef 

### DIFF
--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -71,8 +71,8 @@ static lv_lru_item_t * lv_lru_pop_or_create_item(lv_lru_t * cache);
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t value_free,
-                         lv_lru_free_t key_free)
+lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_cb_t value_free,
+                         lv_lru_free_cb_t key_free)
 {
     // create the cache
     lv_lru_t * cache = (lv_lru_t *) lv_malloc(sizeof(lv_lru_t));

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -71,8 +71,8 @@ static lv_lru_item_t * lv_lru_pop_or_create_item(lv_lru_t * cache);
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t * value_free,
-                         lv_lru_free_t * key_free)
+lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t value_free,
+                         lv_lru_free_t key_free)
 {
     // create the cache
     lv_lru_t * cache = (lv_lru_t *) lv_malloc(sizeof(lv_lru_t));

--- a/src/misc/lv_lru.h
+++ b/src/misc/lv_lru.h
@@ -39,7 +39,7 @@ typedef enum {
     LV_LRU_VALUE_TOO_LARGE
 } lv_lru_res_t;
 
-typedef void (*lv_lru_free_t)(void * v);
+typedef void (*lv_lru_free_cb_t)(void * v);
 
 typedef struct _lv_lru_item_t lv_lru_item_t;
 
@@ -57,8 +57,8 @@ typedef struct /// @cond
     size_t average_item_length;
     size_t hash_table_size;
     uint32_t seed;
-    lv_lru_free_t value_free;
-    lv_lru_free_t key_free;
+    lv_lru_free_cb_t value_free;
+    lv_lru_free_cb_t key_free;
     lv_lru_item_t * free_items;
 } lv_lru_t;
 
@@ -67,8 +67,8 @@ typedef struct /// @cond
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t value_free,
-                         lv_lru_free_t key_free);
+lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_cb_t value_free,
+                         lv_lru_free_cb_t key_free);
 
 void lv_lru_del(lv_lru_t * cache);
 

--- a/src/misc/lv_lru.h
+++ b/src/misc/lv_lru.h
@@ -39,7 +39,7 @@ typedef enum {
     LV_LRU_VALUE_TOO_LARGE
 } lv_lru_res_t;
 
-typedef void lv_lru_free_t(void * v);
+typedef void (*lv_lru_free_t)(void * v);
 
 typedef struct _lv_lru_item_t lv_lru_item_t;
 
@@ -57,8 +57,8 @@ typedef struct /// @cond
     size_t average_item_length;
     size_t hash_table_size;
     uint32_t seed;
-    lv_lru_free_t * value_free;
-    lv_lru_free_t * key_free;
+    lv_lru_free_t value_free;
+    lv_lru_free_t key_free;
     lv_lru_item_t * free_items;
 } lv_lru_t;
 
@@ -67,8 +67,8 @@ typedef struct /// @cond
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t * value_free,
-                         lv_lru_free_t * key_free);
+lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_t value_free,
+                         lv_lru_free_t key_free);
 
 void lv_lru_del(lv_lru_t * cache);
 


### PR DESCRIPTION
changes `lv_lru_free_t` function pointer typedef  to conform to the way the rest of the function pointer typedefs are in LVGL.

The only thing I did not do which you can let me know if it should be done is to change the name of the function pointer to `lv_lru_free_cb_t` so it aligns with the rest of the API
