### PR TITLE
Update lv_port_indev_template.c

### DIFF
--- a/examples/porting/lv_port_indev_template.c
+++ b/examples/porting/lv_port_indev_template.c
@@ -321,7 +321,7 @@ static uint32_t keypad_get_key(void)
  * Encoder
  * -----------------*/
 
-/*Initialize your keypad*/
+/*Initialize your encoder*/
 static void encoder_init(void)
 {
     /*Your code comes here*/


### PR DESCRIPTION
There is a comment error in “lv_port_indev_template.c” 324 line, changing “Initialize your keypad” to “Initialize your encoder”.
