### PR TITLE
fix(disp): should clean up event_cb when deleting lv_disp and lv_obj

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -385,10 +385,7 @@ static void obj_del_core(lv_obj_t * obj)
     }
 
     /*Clean registered event_cb*/
-    uint32_t event_cnt = lv_obj_get_event_count(obj);
-    for(uint32_t i = 0; i < event_cnt; i++) {
-        lv_obj_remove_event(obj, i);
-    }
+    if(obj->spec_attr) lv_event_remove_all(&(obj->spec_attr->event_list));
 
     /*Recursively delete the children*/
     lv_obj_t * child = lv_obj_get_child(obj, 0);

--- a/src/disp/lv_disp.c
+++ b/src/disp/lv_disp.c
@@ -138,6 +138,7 @@ void lv_disp_remove(lv_disp_t * disp)
     if(disp == lv_disp_get_default()) was_default = true;
 
     lv_disp_send_event(disp, LV_EVENT_DELETE, NULL);
+    lv_event_remove_all(&(disp->event_list));
 
     /*Detach the input devices*/
     lv_indev_t * indev;

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -140,6 +140,16 @@ bool lv_event_remove(lv_event_list_t * list, uint32_t index)
     return true;
 }
 
+void lv_event_remove_all(lv_event_list_t * list)
+{
+    LV_ASSERT_NULL(list);
+    if(list && list->dsc) {
+        lv_free(list->dsc);
+        list->dsc = NULL;
+        list->cnt = 0;
+    }
+}
+
 void * lv_event_get_current_target(lv_event_t * e)
 {
     return e->current_target;

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -163,6 +163,8 @@ void * lv_event_dsc_get_user_data(lv_event_dsc_t * dsc);
 
 bool lv_event_remove(lv_event_list_t * list, uint32_t index);
 
+void lv_event_remove_all(lv_event_list_t * list);
+
 /**
  * Get the object originally targeted by the event. It's the same even if the event is bubbled.
  * @param e     pointer to the event descriptor


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
