### PR TITLE
feat(image_decoder): add image decoder list traversal method

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -231,6 +231,19 @@ void lv_image_decoder_delete(lv_image_decoder_t * decoder)
 }
 
 /**
+ * Get the next image decoder in the linked list of image decoders
+ * @param decoder pointer to an image decoder
+ * @return the next image decoder or NULL if no more image decoder exists
+ */
+lv_image_decoder_t * lv_image_decoder_get_next(lv_image_decoder_t * decoder)
+{
+    if(decoder == NULL)
+        return _lv_ll_get_head(img_decoder_ll_p);
+    else
+        return _lv_ll_get_next(img_decoder_ll_p, decoder);
+}
+
+/**
  * Set a callback to get information about the image
  * @param decoder pointer to an image decoder
  * @param info_cb a function to collect info about an image (fill an `lv_image_header_t` struct)

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -204,7 +204,7 @@ void lv_image_decoder_delete(lv_image_decoder_t * decoder);
 
 /**
  * Get the next image decoder in the linked list of image decoders
- * @param decoder pointer to an image decoder
+ * @param decoder pointer to an image decoder or NULL to get the first one
  * @return the next image decoder or NULL if no more image decoder exists
  */
 lv_image_decoder_t * lv_image_decoder_get_next(lv_image_decoder_t * decoder);

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -203,6 +203,13 @@ lv_image_decoder_t * lv_image_decoder_create(void);
 void lv_image_decoder_delete(lv_image_decoder_t * decoder);
 
 /**
+ * Get the next image decoder in the linked list of image decoders
+ * @param decoder pointer to an image decoder
+ * @return the next image decoder or NULL if no more image decoder exists
+ */
+lv_image_decoder_t * lv_image_decoder_get_next(lv_image_decoder_t * decoder);
+
+/**
  * Set a callback to get information about the image
  * @param decoder pointer to an image decoder
  * @param info_cb a function to collect info about an image (fill an `lv_image_header_t` struct)


### PR DESCRIPTION
### Description of the feature or fix

Related discussions: https://github.com/lvgl/lvgl/pull/4567

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
