### PR TITLE
feat(libs): add tjpgd and lodepng deinit method

### DIFF
--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -54,6 +54,17 @@ void lv_lodepng_init(void)
     lv_image_decoder_set_close_cb(dec, decoder_close);
 }
 
+void lv_lodepng_deinit(void)
+{
+    lv_image_decoder_t * dec = NULL;
+    while((dec = lv_image_decoder_get_next(dec)) != NULL) {
+        if(dec->info_cb == decoder_info) {
+            lv_image_decoder_delete(dec);
+            break;
+        }
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/libs/lodepng/lv_lodepng.h
+++ b/src/libs/lodepng/lv_lodepng.h
@@ -33,6 +33,8 @@ extern "C" {
  */
 void lv_lodepng_init(void);
 
+void lv_lodepng_deinit(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -94,6 +94,17 @@ void lv_tjpgd_init(void)
     lv_image_decoder_set_close_cb(dec, decoder_close);
 }
 
+void lv_tjpgd_deinit(void)
+{
+    lv_image_decoder_t * dec = NULL;
+    while((dec = lv_image_decoder_get_next(dec)) != NULL) {
+        if(dec->info_cb == decoder_info) {
+            lv_image_decoder_delete(dec);
+            break;
+        }
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/libs/tjpgd/lv_tjpgd.h
+++ b/src/libs/tjpgd/lv_tjpgd.h
@@ -30,6 +30,8 @@ extern "C" {
 
 void lv_tjpgd_init(void);
 
+void lv_tjpgd_deinit(void);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

Related discussions: https://github.com/lvgl/lvgl/pull/4567

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
