### PR TITLE
feat(obj): construct obj with specified class_p

### DIFF
--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -28,7 +28,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void lv_obj_construct(lv_obj_t * obj);
+static void lv_obj_construct(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static uint32_t get_instance_size(const lv_obj_class_t * class_p);
 
 /**********************
@@ -100,7 +100,7 @@ void lv_obj_class_init_obj(lv_obj_t * obj)
     lv_obj_enable_style_refresh(false);
 
     lv_theme_apply(obj);
-    lv_obj_construct(obj);
+    lv_obj_construct(obj->class_p, obj);
 
     lv_obj_enable_style_refresh(true);
     lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
@@ -165,22 +165,23 @@ bool lv_obj_is_group_def(lv_obj_t * obj)
  *   STATIC FUNCTIONS
  **********************/
 
-static void lv_obj_construct(lv_obj_t * obj)
+static void lv_obj_construct(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
-    const lv_obj_class_t * original_class_p = obj->class_p;
-
     if(obj->class_p->base_class) {
+        const lv_obj_class_t * original_class_p = obj->class_p;
+
         /*Don't let the descendant methods run during constructing the ancestor type*/
         obj->class_p = obj->class_p->base_class;
 
         /*Construct the base first*/
-        lv_obj_construct(obj);
+        lv_obj_construct(class_p, obj);
+
+        /*Restore the original class*/
+        obj->class_p = original_class_p;
     }
 
-    /*Restore the original class*/
-    obj->class_p = original_class_p;
 
-    if(obj->class_p->constructor_cb) obj->class_p->constructor_cb(obj->class_p, obj);
+    if(obj->class_p->constructor_cb) obj->class_p->constructor_cb(class_p, obj);
 }
 
 static uint32_t get_instance_size(const lv_obj_class_t * class_p)

--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -54,8 +54,11 @@ typedef void (*lv_obj_class_event_cb_t)(struct _lv_obj_class_t * class_p, struct
  */
 typedef struct _lv_obj_class_t {
     const struct _lv_obj_class_t * base_class;
+    /*class_p is the final class while obj->class_p is the class currently being [de]constructed.*/
     void (*constructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
     void (*destructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
+
+    /*class_p is the class in which event is being processed.*/
     void (*event_cb)(const struct _lv_obj_class_t * class_p,
                      struct _lv_event_t * e);  /**< Widget type specific event function*/
     void * user_data;


### PR DESCRIPTION
### Description of the feature or fix

Follow up of #4548

When construting a new object, use `class_p` to pass the final/actual class this obj will be.
`obj->class_p` is the class that constructing right now.


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
