### PR TITLE
chore(conf): clean up duplicate configuration items

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -77,11 +77,6 @@
  *========================*/
 
 /*Align the stride of all layers and images to this bytes*/
-#define LV_DRAW_BUF_STRIDE_ALIGN                1          /*Multiple of these Bytes*/
-/*Align the start address of draw_buf addresses to this bytes*/
-#define LV_DRAW_BUF_ALIGN                       4
-
-/*Align the stride of all layers and images to this bytes*/
 #define LV_DRAW_BUF_STRIDE_ALIGN                1
 
 /*Align the start address of draw_buf addresses to this bytes*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -195,27 +195,6 @@
             #define LV_DRAW_BUF_STRIDE_ALIGN 0
         #endif
     #else
-        #define LV_DRAW_BUF_STRIDE_ALIGN                1          /*Multiple of these Bytes*/
-    #endif
-#endif
-/*Align the start address of draw_buf addresses to this bytes*/
-#ifndef LV_DRAW_BUF_ALIGN
-    #ifdef CONFIG_LV_DRAW_BUF_ALIGN
-        #define LV_DRAW_BUF_ALIGN CONFIG_LV_DRAW_BUF_ALIGN
-    #else
-        #define LV_DRAW_BUF_ALIGN                       4
-    #endif
-#endif
-
-/*Align the stride of all layers and images to this bytes*/
-#ifndef LV_DRAW_BUF_STRIDE_ALIGN
-    #ifdef _LV_KCONFIG_PRESENT
-        #ifdef CONFIG_LV_DRAW_BUF_STRIDE_ALIGN
-            #define LV_DRAW_BUF_STRIDE_ALIGN CONFIG_LV_DRAW_BUF_STRIDE_ALIGN
-        #else
-            #define LV_DRAW_BUF_STRIDE_ALIGN 0
-        #endif
-    #else
         #define LV_DRAW_BUF_STRIDE_ALIGN                1
     #endif
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Remove duplicate `LV_DRAW_BUF_STRIDE_ALIGN` and `LV_DRAW_BUF_ALIGN` configurations.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
