### PR TITLE
fix(arc): Handle click outside background angle range

### DIFF
--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -505,9 +505,9 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(angle < 0) angle += 360;
 
         const uint32_t circumference = (uint32_t)((2U * r * 314U) / 100U);  /* Equivalent to: 2r * 3.14, avoiding floats */
-        const uint32_t tolerance_deg = 360U * lv_dpx(50U) / circumference;
+        const uint32_t tolerance_deg = (360U * lv_dpx(50U)) / circumference;
 
-        bool is_angle_within_bg_bounds = lv_arc_angle_within_bg_bounds(obj, (uint32_t) angle, tolerance_deg);
+        const bool is_angle_within_bg_bounds = lv_arc_angle_within_bg_bounds(obj, (uint32_t) angle, tolerance_deg);
         if(!is_angle_within_bg_bounds) {
             return;
         }

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -40,6 +40,7 @@ static lv_coord_t get_angle(const lv_obj_t * obj);
 static void get_knob_area(lv_obj_t * arc, const lv_point_t * center, lv_coord_t r, lv_area_t * knob_area);
 static void value_update(lv_obj_t * arc);
 static lv_coord_t knob_get_extra_size(lv_obj_t * obj);
+static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const int16_t angle);
 
 /**********************
  *  STATIC VARIABLES
@@ -501,6 +502,11 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         if(angle < 0) angle += 360;
 
+        bool is_angle_within_bg_bounds = lv_arc_angle_within_bg_bounds(obj, angle);
+        if(!is_angle_within_bg_bounds) {
+            return;
+        }
+
         int16_t deg_range = bg_end - arc->bg_angle_start;
 
         int16_t last_angle_rel = arc->last_angle - arc->bg_angle_start;
@@ -865,6 +871,32 @@ static lv_coord_t knob_get_extra_size(lv_obj_t * obj)
     knob_outline_size += lv_obj_get_style_outline_pad(obj, LV_PART_KNOB);
 
     return LV_MAX(knob_shadow_size, knob_outline_size);
+}
+
+/**
+ * Check if angle is within arc background bounds
+ *
+ * In order to avoid unexpected value update of the arc value when the user clicks
+ * outside of the arc background we need to check if the angle (of the clicked point)
+ * is within the bounds of the background.
+ *
+ * A tolerance (extra room) also should be taken into consideration.
+ *
+ * E.g. Arc with start angle of 0° and end angle of 90°, the background is only visible in
+ * that range, from 90° to 360° the background is invisible. Click in 150° should not update
+ * the arc value, click within the arc angle range should.
+ *
+ * @param obj   Pointer to lv_arc
+ * @param angle Angle to be checked
+ *
+ * @return true if angle is within arc background bounds, false otherwise
+ */
+static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const int16_t angle)
+{
+    LV_UNUSED(obj);
+    LV_UNUSED(angle);
+
+    return true;
 }
 
 #endif

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -934,12 +934,12 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
         smaller_angle = arc->bg_angle_start;
     }
     else {
-        bigger_angle = arc->bg_angle_start;
-        smaller_angle = arc->bg_angle_end;
+        bigger_angle = 360U - arc->bg_angle_end;
+        smaller_angle = arc->bg_angle_start;
     }
 
     /* Angle is between both background angles */
-    if(angle <= (bigger_angle - smaller_angle)) {
+    if((smaller_angle <= angle) && (angle <= bigger_angle)) {
 
         if(((bigger_angle - smaller_angle) / 2U) >= angle) {
             arc->min_close = 1;

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -905,12 +905,22 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
     lv_arc_t * arc = (lv_arc_t *)obj;
 
     /* Angle is between both background angles */
-    if((arc->bg_angle_end - arc->bg_angle_start) >= angle) {
+    if(angle <= (arc->bg_angle_end - arc->bg_angle_start)) {
+
+        if(((arc->bg_angle_end - arc->bg_angle_start) / 2U) >= angle) {
+            arc->min_close = 1;
+        }
+        else {
+            arc->min_close = 0;
+        }
+
         return true;
     }
     /* Distance between background start and end angles is less than tolerance */
     else if(((arc->bg_angle_start - tolerance_deg) <= 0U) &&
             (360U - (arc->bg_angle_end + (arc->bg_angle_start - tolerance_deg)))) {
+
+        arc->min_close = 1;
         return true;
     }
 
@@ -927,6 +937,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
        /* (360° - T) --- A --- 360° */
        && ((angle >= (360U - tolerance_deg)) && (angle <= 360U))) {
 
+        arc->min_close = 1;
         return true;
     }
     /* Tolerance is bigger than bg start angle */
@@ -934,6 +945,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
             /* (360° - (T - S)) --- A --- 360° */
             && (((360U - (tolerance_deg - arc->bg_angle_start)) <= angle)) && (angle <= 360U)) {
 
+        arc->min_close = 1;
         return true;
     }
     /* 360° is bigger than background end angle + tolerance */
@@ -942,6 +954,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
             && ((arc->bg_angle_end <= (angle + arc->bg_angle_start)) &&
                 ((angle + arc->bg_angle_start) <= (arc->bg_angle_end + tolerance_deg)))) {
 
+        arc->min_close = 0;
         return true;
     }
     /* Background end angle + tolerance is bigger than 360° and bg_start_angle + tolerance is not near 0° + ((bg_end_angle + tolerance) - 360°)
@@ -949,6 +962,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
     else if((360U < (arc->bg_angle_end + tolerance_deg))
             && (angle <= 0U + ((arc->bg_angle_end + tolerance_deg) - 360U)) && (angle > arc->bg_angle_end)) {
 
+        arc->min_close = 0;
         return true;
     }
     else {

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -590,7 +590,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_HIT_TEST) {
-        lv_hit_test_info_t * info = lv_event_get_param(e);;
+        lv_hit_test_info_t * info = lv_event_get_param(e);
 
         lv_point_t p;
         lv_coord_t r;

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -21,6 +21,8 @@
 #define MY_CLASS &lv_arc_class
 
 #define VALUE_UNSET INT16_MIN
+#define CLICK_OUTSIDE_BG_ANGLES ((uint32_t) 0x00U)
+#define CLICK_INSIDE_BG_ANGLES  ((uint32_t) 0x01U)
 
 /**********************
  *      TYPEDEFS
@@ -421,7 +423,7 @@ static void lv_arc_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     arc->chg_rate = 720;
     arc->last_tick = lv_tick_get();
     arc->last_angle = arc->indic_angle_end;
-    arc->in_out = 0;
+    arc->in_out = CLICK_OUTSIDE_BG_ANGLES;
 
     lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN | LV_OBJ_FLAG_SCROLLABLE);
@@ -526,7 +528,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
         else { /* Nothing to do. arc->min_close is determined in lv_arc_angle_within_bg_bounds */ }
 
         /* Check if click was outside the background arc start and end angles */
-        if(0 == arc->in_out) {
+        if(CLICK_OUTSIDE_BG_ANGLES == arc->in_out) {
             if(arc->min_close) angle = -deg_range;
             else angle = deg_range;
         }
@@ -933,16 +935,17 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
             arc->min_close = 0;
         }
 
-        arc->in_out = 1;
+        arc->in_out = CLICK_INSIDE_BG_ANGLES;
 
         return true;
     }
-    /* Distance between background start and end angles is less than tolerance */
+    /* Distance between background start and end angles is less than tolerance,
+     * consider the click inside the arc */
     else if(((smaller_angle - tolerance_deg) <= 0U) &&
             (360U - (bigger_angle + (smaller_angle - tolerance_deg)))) {
 
         arc->min_close = 1;
-        arc->in_out = 1; /* NOTE: When both angles are really close consider the click inside the arc */
+        arc->in_out = CLICK_INSIDE_BG_ANGLES;
         return true;
     }
     else { /* Case handled below */ }
@@ -961,7 +964,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
        && ((angle >= (360U - tolerance_deg)) && (angle <= 360U))) {
 
         arc->min_close = 1;
-        arc->in_out = 0;
+        arc->in_out = CLICK_OUTSIDE_BG_ANGLES;
         return true;
     }
     /* Tolerance is bigger than bg start angle */
@@ -970,7 +973,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
             && (((360U - (tolerance_deg - smaller_angle)) <= angle)) && (angle <= 360U)) {
 
         arc->min_close = 1;
-        arc->in_out = 0;
+        arc->in_out = CLICK_OUTSIDE_BG_ANGLES;
         return true;
     }
     /* 360° is bigger than background end angle + tolerance */
@@ -980,7 +983,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
                 ((angle + smaller_angle) <= (bigger_angle + tolerance_deg)))) {
 
         arc->min_close = 0;
-        arc->in_out = 0;
+        arc->in_out = CLICK_OUTSIDE_BG_ANGLES;
         return true;
     }
     /* Background end angle + tolerance is bigger than 360° and bg_start_angle + tolerance is not near 0° + ((bg_end_angle + tolerance) - 360°)
@@ -989,7 +992,7 @@ static bool lv_arc_angle_within_bg_bounds(lv_obj_t * obj, const uint32_t angle, 
             && (angle <= 0U + ((bigger_angle + tolerance_deg) - 360U)) && (angle > bigger_angle)) {
 
         arc->min_close = 0;
-        arc->in_out = 0;
+        arc->in_out = CLICK_OUTSIDE_BG_ANGLES;
         return true;
     }
     else {

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -52,6 +52,7 @@ typedef struct {
     uint32_t dragging    : 1;
     uint32_t type        : 2;
     uint32_t min_close   : 1;   /*1: the last pressed angle was closer to minimum end*/
+    uint32_t in_out   	 : 1;	/* 1: The click was within the background arc angles. 0: Click outside */
     uint32_t chg_rate;          /*Drag angle rate of change of the arc (degrees/sec)*/
     uint32_t last_tick;         /*Last dragging event timestamp of the arc*/
     int16_t last_angle;         /*Last dragging angle of the arc*/

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -52,7 +52,7 @@ typedef struct {
     uint32_t dragging    : 1;
     uint32_t type        : 2;
     uint32_t min_close   : 1;   /*1: the last pressed angle was closer to minimum end*/
-    uint32_t in_out   	 : 1;	/* 1: The click was within the background arc angles. 0: Click outside */
+    uint32_t in_out      : 1;   /* 1: The click was within the background arc angles. 0: Click outside */
     uint32_t chg_rate;          /*Drag angle rate of change of the arc (degrees/sec)*/
     uint32_t last_tick;         /*Last dragging event timestamp of the arc*/
     int16_t last_angle;         /*Last dragging angle of the arc*/

--- a/tests/src/test_cases/widgets/test_arc.c
+++ b/tests/src/test_cases/widgets/test_arc.c
@@ -175,31 +175,31 @@ void test_arc_click_sustained_from_start_to_end_does_not_set_value_to_max(void)
     event_cnt = 0;
 
     /* Click close to start angle */
-	event_cnt = 0;
-	lv_test_mouse_move_to(376, 285);
+    event_cnt = 0;
+    lv_test_mouse_move_to(376, 285);
     lv_test_mouse_press();
     lv_test_indev_wait(50);
     lv_test_mouse_release();
-	lv_test_indev_wait(50);
+    lv_test_indev_wait(50);
 
     TEST_ASSERT_EQUAL_UINT32(1, event_cnt);
-	TEST_ASSERT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_min_value(arc));
+    TEST_ASSERT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_min_value(arc));
 
-	/* Click close to end angle */
-	event_cnt = 0;
+    /* Click close to end angle */
+    event_cnt = 0;
 
-	lv_test_mouse_move_to(376, 285);
-	lv_test_mouse_press();
-	lv_test_indev_wait(50);
+    lv_test_mouse_move_to(376, 285);
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
     lv_test_mouse_move_to(415, 281);
     lv_test_indev_wait(50);
     lv_test_mouse_release();
     lv_test_indev_wait(50);
 
-	TEST_ASSERT_EQUAL_UINT32(1, event_cnt);
-	TEST_ASSERT_NOT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_max_value(arc));
+    TEST_ASSERT_EQUAL_UINT32(1, event_cnt);
+    TEST_ASSERT_NOT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_max_value(arc));
 
-	TEST_ASSERT_EQUAL_SCREENSHOT("arc_2.png");
+    TEST_ASSERT_EQUAL_SCREENSHOT("arc_2.png");
 }
 
 void test_arc_basic_render(void)

--- a/tests/src/test_cases/widgets/test_arc.c
+++ b/tests/src/test_cases/widgets/test_arc.c
@@ -163,6 +163,45 @@ void test_arc_click_area_with_adv_hittest(void)
     TEST_ASSERT_EQUAL_UINT32(0, event_cnt);
 }
 
+/* Check value doesn't go to max when clicking on the other side of the arc */
+void test_arc_click_sustained_from_start_to_end_does_not_set_value_to_max(void)
+{
+    arc = lv_arc_create(lv_scr_act());
+    lv_arc_set_value(arc, 0);
+
+    lv_obj_set_size(arc, 100, 100);
+    lv_obj_center(arc);
+    lv_obj_add_event(arc, dummy_event_cb, LV_EVENT_PRESSED, NULL);
+    event_cnt = 0;
+
+    /* Click close to start angle */
+	event_cnt = 0;
+	lv_test_mouse_move_to(376, 285);
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+    lv_test_mouse_release();
+	lv_test_indev_wait(50);
+
+    TEST_ASSERT_EQUAL_UINT32(1, event_cnt);
+	TEST_ASSERT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_min_value(arc));
+
+	/* Click close to end angle */
+	event_cnt = 0;
+
+	lv_test_mouse_move_to(376, 285);
+	lv_test_mouse_press();
+	lv_test_indev_wait(50);
+    lv_test_mouse_move_to(415, 281);
+    lv_test_indev_wait(50);
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
+
+	TEST_ASSERT_EQUAL_UINT32(1, event_cnt);
+	TEST_ASSERT_NOT_EQUAL_UINT32(lv_arc_get_value(arc), lv_arc_get_max_value(arc));
+
+	TEST_ASSERT_EQUAL_SCREENSHOT("arc_2.png");
+}
+
 void test_arc_basic_render(void)
 {
     arc = lv_arc_create(lv_scr_act());


### PR DESCRIPTION
### Description of the feature or fix

Fixes #4576 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
