### PR TITLE
fix(draw): fix rect descritptor opacity handling

### DIFF
--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -134,12 +134,14 @@ void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t
         }
     }
 
-    if(opa < LV_OPA_MAX) {
-        draw_dsc->bg_opa = LV_OPA_MIX2(draw_dsc->bg_opa, opa);
-        draw_dsc->bg_img_opa = LV_OPA_MIX2(draw_dsc->bg_img_opa, opa);
-        draw_dsc->border_opa = LV_OPA_MIX2(draw_dsc->border_opa, opa);
-        draw_dsc->shadow_opa = LV_OPA_MIX2(draw_dsc->shadow_opa, opa);
-        draw_dsc->outline_opa = LV_OPA_MIX2(draw_dsc->outline_opa, opa);
+    if(part != LV_PART_MAIN) {
+        if(opa < LV_OPA_MAX) {
+            draw_dsc->bg_opa = LV_OPA_MIX2(draw_dsc->bg_opa, opa);
+            draw_dsc->bg_img_opa = LV_OPA_MIX2(draw_dsc->bg_img_opa, opa);
+            draw_dsc->border_opa = LV_OPA_MIX2(draw_dsc->border_opa, opa);
+            draw_dsc->shadow_opa = LV_OPA_MIX2(draw_dsc->shadow_opa, opa);
+            draw_dsc->outline_opa = LV_OPA_MIX2(draw_dsc->outline_opa, opa);
+        }
     }
 }
 


### PR DESCRIPTION
### Description of the feature or fix

Fixes coloring of elements on ANIM_FADE_ON, resolves #4611.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
