### PR TITLE
feat(grad): optional support for alpha channel in gradient colors

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -168,6 +168,10 @@
     #define LV_DITHER_ERROR_DIFFUSION 0
 #endif
 
+/* Allow opacity (alpha) channel for gradient color stops.
+ * */
+#define LV_GRADIENT_OPACITY 0
+
 /*Maximum buffer size to allocate for rotation.
  *Only used if software rotation is enabled in the display driver.*/
 #define LV_DISP_ROT_MAX_BUF (10*1024)

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -508,10 +508,35 @@ static void lv_obj_draw(lv_event_t * e)
             return;
         }
 
-        if(lv_obj_get_style_bg_opa(obj, LV_PART_MAIN) < LV_OPA_MAX) {
+        lv_opa_t bg_opa = lv_obj_get_style_bg_opa(obj, LV_PART_MAIN);
+        if(bg_opa < LV_OPA_MAX) {
             info->res = LV_COVER_RES_NOT_COVER;
             return;
         }
+#if LV_GRADIENT_OPACITY
+        if(bg_opa > LV_OPA_MIN) {
+            const lv_grad_dsc_t * grad = lv_obj_get_style_bg_grad(obj, LV_PART_MAIN);
+            if(grad && grad->dir != LV_GRAD_DIR_NONE) {
+                for(int i = 0; i < grad->stops_count; i++) {
+                    if(grad->stops[i].color.ch.alpha < LV_OPA_MAX) {
+                        info->res = LV_COVER_RES_NOT_COVER;
+                        return;
+                    }
+                }
+            }
+            else {
+                lv_grad_dir_t bg_grad_dir = lv_obj_get_style_bg_grad_dir(obj, LV_PART_MAIN);
+                if(bg_grad_dir != LV_GRAD_DIR_NONE) {
+                    lv_color_t color_0 = lv_obj_get_style_bg_color_filtered(obj, LV_PART_MAIN);
+                    lv_color_t color_1 = lv_obj_get_style_bg_grad_color_filtered(obj, LV_PART_MAIN);
+                    if(color_0.ch.alpha < LV_OPA_MAX || color_1.ch.alpha < LV_OPA_MAX) {
+                        info->res = LV_COVER_RES_NOT_COVER;
+                        return;
+                    }
+                }
+            }
+        }
+#endif
 
         info->res = LV_COVER_RES_COVER;
 

--- a/src/draw/sw/lv_draw_sw_gradient.c
+++ b/src/draw/sw/lv_draw_sw_gradient.c
@@ -335,6 +335,9 @@ lv_grad_color_t LV_ATTRIBUTE_FAST_MEM lv_gradient_calculate(const lv_grad_dsc_t 
     lv_grad_color_t r = GRAD_CM(LV_UDIV255(two.ch.red * mix   + one.ch.red * imix),
                                 LV_UDIV255(two.ch.green * mix + one.ch.green * imix),
                                 LV_UDIV255(two.ch.blue * mix  + one.ch.blue * imix));
+#if LV_GRADIENT_OPACITY
+    r.ch.alpha = LV_UDIV255(two.ch.alpha * mix + one.ch.alpha * imix);
+#endif
     return r;
 }
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -402,6 +402,16 @@
     #endif
 #endif
 
+/* Allow opacity (alpha) channel for gradient color stops.
+ * */
+#ifndef LV_GRADIENT_OPACITY
+    #ifdef CONFIG_LV_GRADIENT_OPACITY
+        #define LV_GRADIENT_OPACITY CONFIG_LV_GRADIENT_OPACITY
+    #else
+        #define LV_GRADIENT_OPACITY 0
+    #endif
+#endif
+
 /*Maximum buffer size to allocate for rotation.
  *Only used if software rotation is enabled in the display driver.*/
 #ifndef LV_DISP_ROT_MAX_BUF


### PR DESCRIPTION
### Description of the feature or fix

Currently when drawing gradients, it's always opaque unless mixed with none-opaque color. This PR allows transparency while drawing gradients.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
