### PR TITLE
feat(lv_group): Get group count and retrieve by index

### DIFF
--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -372,6 +372,26 @@ uint32_t lv_group_get_obj_count(lv_group_t * group)
 {
     return _lv_ll_get_len(&group->obj_ll);
 }
+
+uint32_t lv_group_get_count(void)
+{
+    return _lv_ll_get_len(group_ll_p);
+}
+
+lv_group_t  * lv_group_by_index(uint32_t index)
+{
+    uint32_t len = 0;
+    void * node;
+
+    for(node = _lv_ll_get_tail(group_ll_p); node != NULL; node = _lv_ll_get_prev(group_ll_p, node)) {
+        if(len == index) {
+            return (lv_group_t *) node;
+        }
+        len++;
+    }
+
+    return NULL;
+}
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -259,6 +259,18 @@ bool lv_group_get_wrap(lv_group_t * group);
  */
 uint32_t lv_group_get_obj_count(lv_group_t * group);
 
+/**
+ * Get the number of groups
+ * @return              number of groups
+ */
+uint32_t lv_group_get_count(void);
+
+/**
+ * Get a group by its index
+ * @return              pointer to the group
+ */
+lv_group_t  * lv_group_by_index(uint32_t index);
+
 /**********************
  *      MACROS
  **********************/

--- a/tests/src/test_cases/test_group.c
+++ b/tests/src/test_cases/test_group.c
@@ -1,0 +1,41 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_group_count(void)
+{
+    lv_group_t * group_1 = lv_group_create();
+    lv_group_t * group_2 = lv_group_create();
+
+    TEST_ASSERT_EQUAL_UINT32(lv_group_get_count(), 2U);
+
+    lv_group_del(group_2);
+    TEST_ASSERT_EQUAL_UINT32(lv_group_get_count(), 1U);
+
+    lv_group_del(group_1);
+    TEST_ASSERT_EQUAL_UINT32(lv_group_get_count(), 0U);
+}
+
+void test_group_by_index(void)
+{
+    lv_group_t * group_1 = lv_group_create();
+    lv_group_t * group_2 = lv_group_create();
+
+    TEST_ASSERT_EQUAL_PTR(lv_group_by_index(2), NULL);
+    TEST_ASSERT_EQUAL_PTR(lv_group_by_index(0), group_1);
+    TEST_ASSERT_EQUAL_PTR(lv_group_by_index(1), group_2);
+
+    lv_group_del(group_1);
+    lv_group_del(group_2);
+}
+
+#endif


### PR DESCRIPTION
### Description of the feature or fix

Adds functions to get the group count and retrieve a group by its index.
Needed for an implementation where I want to change the group an `lv_monkey` points to but do not have 
access to all groups that might have been created.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
