### PR TITLE
feat(nuttx): refactor Nuttx porting layer

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1240,6 +1240,11 @@ menu "LVGL configuration"
 			bool "Use Nuttx to open window and handle touchscreen"
 			default n
 
+		config LV_USE_NUTTX_CUSTOM_INIT
+			bool "Use Custom Nuttx init API to open window and handle touchscreen"
+			depends on LV_USE_NUTTX
+			default n
+
 		config LV_USE_NUTTX_LCD
 			bool "Use NuttX LCD device"
 			depends on LV_USE_NUTTX

--- a/Kconfig
+++ b/Kconfig
@@ -1236,12 +1236,13 @@ menu "LVGL configuration"
 			depends on LV_USE_LINUX_FBDEV && LV_LINUX_FBDEV_CUSTOM_BUFFER
 			default 60
 
-		config LV_USE_NUTTX_FBDEV
-			bool "Use Nuttx framebuffer device"
+		config LV_USE_NUTTX
+			bool "Use Nuttx to open window and handle touchscreen"
 			default n
 
 		config LV_USE_NUTTX_LCD
 			bool "Use NuttX LCD device"
+			depends on LV_USE_NUTTX
 			default n
 
 		choice
@@ -1272,16 +1273,17 @@ menu "LVGL configuration"
 			depends on LV_USE_NUTTX_LCD && LV_NUTTX_LCD_CUSTOM_BUFFER
 			default 60
 
+		config LV_USE_NUTTX_TOUCHSCREEN
+			bool "Use NuttX touchscreen driver"
+			depends on LV_USE_NUTTX
+			default n
+
 		config LV_USE_LINUX_DRM
 			bool "Use Linux DRM device"
 			default n
 
 		config LV_USE_TFT_ESPI
 			bool "Use TFT_eSPI driver"
-			default n
-
-		config LV_USE_NUTTX_TOUCHSCREEN
-			bool "Use NuttX touchscreen driver"
 			default n
 	endmenu
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -751,7 +751,8 @@
     #define LV_LINUX_FBDEV_BUFFER_SIZE   60
 #endif
 
-#define LV_USE_NUTTX_FBDEV     0
+/*Use Nuttx to open window and handle touchscreen*/
+#define LV_USE_NUTTX    0
 
 /*Driver for /dev/lcd*/
 #define LV_USE_NUTTX_LCD      0
@@ -760,14 +761,14 @@
     #define LV_NUTTX_LCD_BUFFER_SIZE     60
 #endif
 
+/*Driver for /dev/input*/
+#define LV_USE_NUTTX_TOUCHSCREEN    0
+
 /*Driver for /dev/dri/card*/
 #define LV_USE_LINUX_DRM        0
 
 /*Interface for TFT_eSPI*/
 #define LV_USE_TFT_ESPI         0
-
-/*Driver for /dev/input*/
-#define LV_USE_NUTTX_TOUCHSCREEN    0
 
 /*==================
 * EXAMPLES

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -754,6 +754,9 @@
 /*Use Nuttx to open window and handle touchscreen*/
 #define LV_USE_NUTTX    0
 
+/*Use Nuttx custom init API to open window and handle touchscreen*/
+#define LV_USE_NUTTX_CUSTOM_INIT    0
+
 /*Driver for /dev/lcd*/
 #define LV_USE_NUTTX_LCD      0
 #if LV_USE_NUTTX_LCD

--- a/lvgl.h
+++ b/lvgl.h
@@ -118,10 +118,11 @@ extern "C" {
 
 #include "src/dev/display/drm/lv_linux_drm.h"
 #include "src/dev/display/fb/lv_linux_fbdev.h"
-#include "src/dev/display/fb/lv_nuttx_fbdev.h"
-#include "src/dev/display/lcd/lv_nuttx_lcd.h"
 
-#include "src/dev/input/touchscreen/lv_nuttx_touchscreen.h"
+#include "src/dev/nuttx/lv_nuttx_entry.h"
+#include "src/dev/nuttx/lv_nuttx_fbdev.h"
+#include "src/dev/nuttx/lv_nuttx_touchscreen.h"
+#include "src/dev/nuttx/lv_nuttx_lcd.h"
 
 #include "src/core/lv_global.h"
 /*********************

--- a/src/dev/nuttx/lv_nuttx_entry.c
+++ b/src/dev/nuttx/lv_nuttx_entry.c
@@ -82,6 +82,8 @@ lv_display_t * lv_nuttx_init(lv_nuttx_t * info)
 {
     lv_display_t * disp = NULL;
 
+#if !LV_USE_NUTTX_CUSTOM_INIT
+
     if(info && info->fb_path) {
 #if LV_USE_NUTTX_LCD
         disp = lv_nuttx_lcd_create(info->fb_path);
@@ -99,6 +101,11 @@ lv_display_t * lv_nuttx_init(lv_nuttx_t * info)
         lv_nuttx_touchscreen_create(info->input_path);
 #endif
     }
+
+#else
+
+    disp = lv_nuttx_init_custom(info);
+#endif
 
     lv_tick_set_cb(millis);
 

--- a/src/dev/nuttx/lv_nuttx_entry.c
+++ b/src/dev/nuttx/lv_nuttx_entry.c
@@ -1,0 +1,122 @@
+/**
+ * @file lv_nuttx_entry.h
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_nuttx_entry.h"
+
+#if LV_USE_NUTTX
+
+#include <time.h>
+#include <nuttx/tls.h>
+
+#include <lvgl/lvgl.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static uint32_t millis(void);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+#if LV_ENABLE_GLOBAL_CUSTOM
+
+/****************************************************************************
+ * Name: lv_global_free
+ ****************************************************************************/
+
+static void lv_global_free(void * data)
+{
+    if(data) {
+        free(data);
+    }
+}
+
+/****************************************************************************
+ * Name: lv_global_default
+ ****************************************************************************/
+
+lv_global_t * lv_global_default(void)
+{
+    static int index = -1;
+    lv_global_t * data;
+
+    if(index < 0) {
+        index = task_tls_alloc(lv_global_free);
+    }
+
+    if(index >= 0) {
+        data = (lv_global_t *)task_tls_get_value(index);
+        if(data == NULL) {
+            data = (lv_global_t *)calloc(1, sizeof(lv_global_t));
+            task_tls_set_value(index, (uintptr_t)data);
+        }
+    }
+    return data;
+}
+#endif
+
+lv_display_t * lv_nuttx_init(lv_nuttx_t * info)
+{
+    lv_display_t * disp = NULL;
+
+    if(info && info->fb_path) {
+#if LV_USE_NUTTX_LCD
+        disp = lv_nuttx_lcd_create(info->fb_path);
+#else
+        disp = lv_nuttx_fbdev_create();
+        if(lv_nuttx_fbdev_set_file(disp, info->fb_path) != 0) {
+            lv_display_remove(disp);
+            disp = NULL;
+        }
+#endif
+    }
+
+    if(info && info->input_path) {
+#if LV_USE_NUTTX_TOUCHSCREEN
+        lv_nuttx_touchscreen_create(info->input_path);
+#endif
+    }
+
+    lv_tick_set_cb(millis);
+
+    return disp;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static uint32_t millis(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint32_t tick = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+
+    return tick;
+}
+
+#endif /*LV_USE_NUTTX*/

--- a/src/dev/nuttx/lv_nuttx_entry.h
+++ b/src/dev/nuttx/lv_nuttx_entry.h
@@ -42,6 +42,10 @@ typedef struct {
 
 lv_display_t * lv_nuttx_init(lv_nuttx_t * info);
 
+#if LV_USE_NUTTX_CUSTOM_INIT
+lv_display_t * lv_nuttx_init_custom(lv_nuttx_t * info);
+#endif
+
 /**********************
  *      MACROS
  **********************/

--- a/src/dev/nuttx/lv_nuttx_entry.h
+++ b/src/dev/nuttx/lv_nuttx_entry.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_nuttx_touchscreen.h
+ * @file lv_nuttx_entry.h
  *
  */
 
@@ -7,8 +7,8 @@
  *      INCLUDES
  *********************/
 
-#ifndef LV_NUTTX_TOUCHSCREEN_H
-#define LV_NUTTX_TOUCHSCREEN_H
+#ifndef LV_NUTTX_ENTRY_H
+#define LV_NUTTX_ENTRY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,9 +18,10 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../indev/lv_indev.h"
+#include "../../display/lv_display.h"
+#include "../../indev/lv_indev.h"
 
-#if LV_USE_NUTTX_TOUCHSCREEN
+#if LV_USE_NUTTX
 
 /*********************
  *      DEFINES
@@ -29,21 +30,26 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+    const char * fb_path;
+    const char * input_path;
+    bool need_wait_vsync;
+} lv_nuttx_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_nuttx_touchscreen_create(const char * dev_path);
+lv_display_t * lv_nuttx_init(lv_nuttx_t * info);
 
 /**********************
  *      MACROS
  **********************/
 
-#endif /* LV_USE_NUTTX_TOUCHSCREEN */
+#endif /* LV_USE_NUTTX*/
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-#endif /* LV_NUTTX_TOUCHSCREEN_H */
+#endif /* LV_NUTTX_ENTRY_H */

--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_nuttx_fbdev.h"
-#if LV_USE_NUTTX_FBDEV
+#if LV_USE_NUTTX
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -18,8 +18,9 @@
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <nuttx/video/fb.h>
+
 #include <lvgl/lvgl.h>
-#include "../../../lvgl_private.h"
+#include "../../lvgl_private.h"
 
 /*********************
  *      DEFINES
@@ -286,4 +287,4 @@ static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
     return 0;
 }
 
-#endif /*LV_USE_NUTTX_FBDEV*/
+#endif /*LV_USE_NUTTX*/

--- a/src/dev/nuttx/lv_nuttx_fbdev.h
+++ b/src/dev/nuttx/lv_nuttx_fbdev.h
@@ -1,0 +1,46 @@
+/**
+ * @file lv_nuttx_fbdev_h
+ *
+ */
+
+#ifndef LV_NUTTX_FBDEV_H
+#define LV_NUTTX_FBDEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_nuttx_entry.h"
+
+#if LV_USE_NUTTX
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+lv_display_t * lv_nuttx_fbdev_create(void);
+
+int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /* LV_USE_NUTTX */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* LV_NUTTX_FBDEV_H */

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -8,6 +8,7 @@
  *********************/
 
 #include "lv_nuttx_lcd.h"
+
 #if LV_USE_NUTTX_LCD
 
 #include <sys/ioctl.h>
@@ -20,7 +21,7 @@
 #include <nuttx/lcd/lcd_dev.h>
 
 #include <lvgl/lvgl.h>
-#include "../../../lvgl_private.h"
+#include "../../lvgl_private.h"
 
 /*********************
  *      DEFINES

--- a/src/dev/nuttx/lv_nuttx_lcd.h
+++ b/src/dev/nuttx/lv_nuttx_lcd.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_nuttx_fbdev_h
+ * @file lv_nuttx_lcd.h
  *
  */
 
-#ifndef LV_NUTTX_FBDEV_H
-#define LV_NUTTX_FBDEV_H
+#ifndef LV_NUTTX_LCD_H
+#define LV_NUTTX_LCD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,9 +14,9 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../display/lv_display.h"
+#include "lv_nuttx_entry.h"
 
-#if LV_USE_NUTTX_FBDEV
+#if LV_USE_NUTTX_LCD
 
 /*********************
  *      DEFINES
@@ -29,18 +29,17 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-lv_display_t * lv_nuttx_fbdev_create(void);
 
-int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file);
+lv_display_t * lv_nuttx_lcd_create(const char * dev_path);
 
 /**********************
  *      MACROS
  **********************/
 
-#endif /* LV_USE_NUTTX_FBDEV */
+#endif /* LV_USE_NUTTX_LCD */
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-#endif /* LV_NUTTX_FBDEV_H */
+#endif /* LV_NUTTX_LCD_H */

--- a/src/dev/nuttx/lv_nuttx_touchscreen.c
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <nuttx/input/touchscreen.h>
-#include "../../../lvgl_private.h"
+#include "../../lvgl_private.h"
 
 /*********************
  *      DEFINES
@@ -137,4 +137,4 @@ static lv_indev_t * touchscreen_init(int fd)
     return touchscreen->indev_drv;
 }
 
-#endif /*LV_USE_NUTTX_SCREEN*/
+#endif /*LV_USE_NUTTX_TOUCHSCREEN*/

--- a/src/dev/nuttx/lv_nuttx_touchscreen.h
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.h
@@ -1,10 +1,14 @@
 /**
- * @file lv_nuttx_lcd.h
+ * @file lv_nuttx_touchscreen.h
  *
  */
 
-#ifndef LV_NUTTX_LCD_H
-#define LV_NUTTX_LCD_H
+/*********************
+ *      INCLUDES
+ *********************/
+
+#ifndef LV_NUTTX_TOUCHSCREEN_H
+#define LV_NUTTX_TOUCHSCREEN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,9 +18,9 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../display/lv_display.h"
+#include "lv_nuttx_entry.h"
 
-#if LV_USE_NUTTX_LCD
+#if LV_USE_NUTTX_TOUCHSCREEN
 
 /*********************
  *      DEFINES
@@ -30,16 +34,16 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_display_t * lv_nuttx_lcd_create(const char * dev_path);
+lv_indev_t * lv_nuttx_touchscreen_create(const char * dev_path);
 
 /**********************
  *      MACROS
  **********************/
 
-#endif /* LV_USE_NUTTX_LCD */
+#endif /* LV_USE_NUTTX_TOUCHSCREEN */
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-#endif /* LV_NUTTX_LCD_H */
+#endif /* LV_NUTTX_TOUCHSCREEN_H */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2478,6 +2478,15 @@
     #endif
 #endif
 
+/*Use Nuttx custom init API to open window and handle touchscreen*/
+#ifndef LV_USE_NUTTX_CUSTOM_INIT
+    #ifdef CONFIG_LV_USE_NUTTX_CUSTOM_INIT
+        #define LV_USE_NUTTX_CUSTOM_INIT CONFIG_LV_USE_NUTTX_CUSTOM_INIT
+    #else
+        #define LV_USE_NUTTX_CUSTOM_INIT    0
+    #endif
+#endif
+
 /*Driver for /dev/lcd*/
 #ifndef LV_USE_NUTTX_LCD
     #ifdef CONFIG_LV_USE_NUTTX_LCD

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2469,11 +2469,12 @@
     #endif
 #endif
 
-#ifndef LV_USE_NUTTX_FBDEV
-    #ifdef CONFIG_LV_USE_NUTTX_FBDEV
-        #define LV_USE_NUTTX_FBDEV CONFIG_LV_USE_NUTTX_FBDEV
+/*Use Nuttx to open window and handle touchscreen*/
+#ifndef LV_USE_NUTTX
+    #ifdef CONFIG_LV_USE_NUTTX
+        #define LV_USE_NUTTX CONFIG_LV_USE_NUTTX
     #else
-        #define LV_USE_NUTTX_FBDEV     0
+        #define LV_USE_NUTTX    0
     #endif
 #endif
 
@@ -2502,6 +2503,15 @@
     #endif
 #endif
 
+/*Driver for /dev/input*/
+#ifndef LV_USE_NUTTX_TOUCHSCREEN
+    #ifdef CONFIG_LV_USE_NUTTX_TOUCHSCREEN
+        #define LV_USE_NUTTX_TOUCHSCREEN CONFIG_LV_USE_NUTTX_TOUCHSCREEN
+    #else
+        #define LV_USE_NUTTX_TOUCHSCREEN    0
+    #endif
+#endif
+
 /*Driver for /dev/dri/card*/
 #ifndef LV_USE_LINUX_DRM
     #ifdef CONFIG_LV_USE_LINUX_DRM
@@ -2517,15 +2527,6 @@
         #define LV_USE_TFT_ESPI CONFIG_LV_USE_TFT_ESPI
     #else
         #define LV_USE_TFT_ESPI         0
-    #endif
-#endif
-
-/*Driver for /dev/input*/
-#ifndef LV_USE_NUTTX_TOUCHSCREEN
-    #ifdef CONFIG_LV_USE_NUTTX_TOUCHSCREEN
-        #define LV_USE_NUTTX_TOUCHSCREEN CONFIG_LV_USE_NUTTX_TOUCHSCREEN
-    #else
-        #define LV_USE_NUTTX_TOUCHSCREEN    0
     #endif
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

We refactor Nuttx porting layer to path `src/dev/nuttx/`. Now support `lv_nuttx_init` and `lv_global_default` for multi-instance implementation.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
