### PR TITLE
STM32U5 DMA2D support (8.3)

### DIFF
--- a/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
+++ b/src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c
@@ -34,6 +34,19 @@
     #error "Cannot use DMA2D with LV_COLOR_DEPTH other than 16 or 32"
 #endif
 
+#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    #define LV_STM32_DMA2D_USE_M7_CACHE
+#endif
+
+#if defined (LV_STM32_DMA2D_USE_M7_CACHE)
+    // Cortex-M7 DCache present
+    #define __lv_gpu_stm32_dma2d_clean_cache(address, offset, width, height, pixel_size) _lv_gpu_stm32_dma2d_clean_cache(address, offset, width, height, pixel_size)
+    #define __lv_gpu_stm32_dma2d_invalidate_cache(address, offset, width, height, pixel_size) _lv_gpu_stm32_dma2d_invalidate_cache(address, offset, width, height, pixel_size)
+#else
+    #define __lv_gpu_stm32_dma2d_clean_cache(address, offset, width, height, pixel_size)
+    #define __lv_gpu_stm32_dma2d_invalidate_cache(address, offset, width, height, pixel_size)
+#endif
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -61,13 +74,19 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * d
                                                             const lv_area_t * draw_area, const lv_color_t * src_buf, lv_coord_t src_stride, const lv_point_t * src_offset);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_await_dma_transfer_finish(lv_disp_drv_t * disp_drv);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void);
+
+#if defined (LV_STM32_DMA2D_USE_M7_CACHE)
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address, lv_coord_t offset,
                                                                 lv_coord_t width, lv_coord_t height, uint8_t pixel_size);
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
                                                            lv_coord_t height, uint8_t pixel_size);
-LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void);
-LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void);
-LV_STM32_DMA2D_STATIC uint32_t _lv_gpu_stm32_dwt_get_us(void);
+#endif
+
+#if defined(LV_STM32_DMA2D_TEST)
+    LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void);
+    LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void);
+    LV_STM32_DMA2D_STATIC uint32_t _lv_gpu_stm32_dwt_get_us(void);
+#endif
 
 static bool isDma2dInProgess = false; // indicates whether DMA2D transfer *initiated here* is in progress
 
@@ -77,21 +96,21 @@ static bool isDma2dInProgess = false; // indicates whether DMA2D transfer *initi
 void lv_draw_stm32_dma2d_init(void)
 {
     // Enable DMA2D clock
-#if defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32U5)
     RCC->AHB1ENR |= RCC_AHB1ENR_DMA2DEN; // enable DMA2D
+    // wait for hardware access to complete
+    __asm volatile("DSB\n");
+    volatile uint32_t temp = RCC->AHB1ENR;
+    LV_UNUSED(temp);
 #elif defined(STM32H7)
     RCC->AHB3ENR |= RCC_AHB3ENR_DMA2DEN;
+    // wait for hardware access to complete
+    __asm volatile("DSB\n");
+    volatile uint32_t temp = RCC->AHB3ENR;
+    LV_UNUSED(temp);
 #else
 # warning "LVGL can't enable the clock of DMA2D"
 #endif
-
-    // Wait for hardware access to complete
-    __asm volatile("DSB\n");
-
-    // Delay after setting peripheral clock
-    volatile uint32_t temp = RCC->AHB1ENR;
-    LV_UNUSED(temp);
-
     // AHB master timer configuration
     DMA2D->AMTCR = 0; // AHB bus guaranteed dead time disabled
 #if defined(LV_STM32_DMA2D_TEST)
@@ -206,7 +225,7 @@ static void lv_draw_stm32_dma2d_blend(lv_draw_ctx_t * draw_ctx, const lv_draw_sw
             // lv_coord_t draw_width = lv_area_get_width(&draw_area);
             // lv_coord_t draw_height = lv_area_get_height(&draw_area);
             // uint32_t dest_address = (uint32_t)(draw_ctx->buf + (dest_stride * draw_area.y1) + draw_area.x1);
-            // _lv_gpu_stm32_dma2d_clean_cache(dest_address, dest_stride - draw_width, draw_width, draw_height, sizeof(lv_color_t));
+            // __lv_gpu_stm32_dma2d_clean_cache(dest_address, dest_stride - draw_width, draw_width, draw_height, sizeof(lv_color_t));
 #endif
         }
     }
@@ -412,7 +431,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_fill(const lv_color_t * de
         DMA2D->BGMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
         DMA2D->BGOR = dest_stride - draw_width;
         DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
-        _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+        __lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
 
         DMA2D->OPFCCR = LvglColorFormat;
 #if defined(DMA2D_OPFCCR_RBS_Pos)
@@ -500,7 +519,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * des
     DMA2D->FGMAR = ((uint32_t)src_buf) + srcBpp * ((src_stride * src_offset->y) + src_offset->x);
     DMA2D->FGOR = src_stride - draw_width;
     DMA2D->FGCOLR = 0;  // used in A4 and A8 modes only
-    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, srcBpp);
+    __lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, srcBpp);
 
     DMA2D->OPFCCR = LvglColorFormat;
 #if defined(DMA2D_OPFCCR_RBS_Pos)
@@ -519,7 +538,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_map(const lv_color_t * des
         DMA2D->BGMAR = DMA2D->OMAR;
         DMA2D->BGOR = DMA2D->OOR;
         DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
-        _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+        __lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
     }
 
     // PL - pixel per lines (14 bit), NL - number of lines (16 bit)
@@ -556,7 +575,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * d
     DMA2D->FGMAR = (uint32_t)(mask_buf + (mask_stride * mask_offset->y) + mask_offset->x);
     DMA2D->FGOR = mask_stride - draw_width;
     DMA2D->FGCOLR = lv_color_to32(color) & 0x00ffffff;  // swap FGCOLR R/B bits if FGPFCCR.RBS (RBS_BIT) bit is set
-    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_opa_t));
+    __lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_opa_t));
 
     DMA2D->BGPFCCR = LvglColorFormat;
 #if defined(DMA2D_BGPFCCR_RBS_Pos)
@@ -565,7 +584,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_blend_paint(const lv_color_t * d
     DMA2D->BGMAR = (uint32_t)(dest_buf + (dest_stride * draw_area->y1) + draw_area->x1);
     DMA2D->BGOR = dest_stride - draw_width;
     DMA2D->BGCOLR = 0;  // used in A4 and A8 modes only
-    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
+    __lv_gpu_stm32_dma2d_clean_cache(DMA2D->BGMAR, DMA2D->BGOR, draw_width, draw_height, sizeof(lv_color_t));
 
     DMA2D->OPFCCR = LvglColorFormat;
 #if defined(DMA2D_OPFCCR_RBS_Pos)
@@ -602,7 +621,7 @@ LV_STM32_DMA2D_STATIC void _lv_draw_stm32_dma2d_copy_buffer(const lv_color_t * d
     DMA2D->FGMAR = (uint32_t)(src_buf + (src_stride * src_offset->y) + src_offset->x);
     DMA2D->FGOR = src_stride - draw_width;
     DMA2D->FGCOLR = 0;  // used in A4 and A8 modes only
-    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_color_t));
+    __lv_gpu_stm32_dma2d_clean_cache(DMA2D->FGMAR, DMA2D->FGOR, draw_width, draw_height, sizeof(lv_color_t));
 
     // Note BG* registers do not need to be set up since BG is not used
 
@@ -627,8 +646,8 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_start_dma_transfer(void)
     DMA2D->IFCR = 0x3FU; // trigger ISR flags reset
     // Note: cleaning output buffer cache is needed only when buffer may be misaligned or adjacent area may have been drawn in sw-fashion, e.g. using lv_draw_sw_blend_basic()
 #if LV_COLOR_DEPTH == 16
-    _lv_gpu_stm32_dma2d_clean_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos,
-                                    (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
+    __lv_gpu_stm32_dma2d_clean_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos,
+                                     (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
 #endif
     DMA2D->CR |= DMA2D_CR_START;
     // Note: for some reason mask buffer gets damaged during transfer if waiting is postponed
@@ -660,15 +679,16 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_await_dma_transfer_finish(lv_disp
 
     if(isDma2dInProgess) {
         // invalidate output buffer cached memory ONLY after DMA2D transfer
-        //_lv_gpu_stm32_dma2d_invalidate_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos, (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
+        //__lv_gpu_stm32_dma2d_invalidate_cache(DMA2D->OMAR, DMA2D->OOR, (DMA2D->NLR & DMA2D_NLR_PL_Msk) >> DMA2D_NLR_PL_Pos, (DMA2D->NLR & DMA2D_NLR_NL_Msk) >> DMA2D_NLR_NL_Pos, sizeof(lv_color_t));
         isDma2dInProgess = false;
     }
 }
 
+#if defined (LV_STM32_DMA2D_USE_M7_CACHE)
+// Cortex-M7 DCache present
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
                                                                 lv_coord_t height, uint8_t pixel_size)
 {
-#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     if(((SCB->CCR) & SCB_CCR_DC_Msk) == 0) return; // L1 data cache is disabled
     uint16_t stride = pixel_size * (width + offset); // in bytes
     uint16_t ll = pixel_size * width; // line length in bytes
@@ -694,13 +714,11 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_invalidate_cache(uint32_t address
 
     __DSB();
     __ISB();
-#endif
 }
 
 LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_coord_t offset, lv_coord_t width,
                                                            lv_coord_t height, uint8_t pixel_size)
 {
-#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     if(((SCB->CCR) & SCB_CCR_DC_Msk) == 0) return; // L1 data cache is disabled
     uint16_t stride = pixel_size * (width + offset); // in bytes
     uint16_t ll = pixel_size * width; // line length in bytes
@@ -725,9 +743,10 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dma2d_clean_cache(uint32_t address, lv_
 
     __DSB();
     __ISB();
-#endif
 }
+#endif // LV_STM32_DMA2D_USE_M7_CACHE
 
+#if defined(LV_STM32_DMA2D_TEST)
 // initialize µs timer
 LV_STM32_DMA2D_STATIC bool _lv_gpu_stm32_dwt_init(void)
 {
@@ -773,5 +792,5 @@ LV_STM32_DMA2D_STATIC void _lv_gpu_stm32_dwt_reset(void)
 {
     DWT->CYCCNT = 0;
 }
-
-#endif
+#endif // LV_STM32_DMA2D_TEST
+#endif // LV_USE_GPU_STM32_DMA2D


### PR DESCRIPTION
This PR adds STM32U5 family DMA2D support and eliminates compiler "defined but not used" warnings if Cortex-M7 DCache is not present.
On STM32U5A9 DMA2D increased `lv_demo_benchmark` performance from 21 to 38 weighted fps (!) - tested with 800x480 display, LVGL 32b ARGB color DMA2D-copied/converted to LTDC 24b RGB buffer placed in internal SRAM, max HCLK speed 160MHz, ICache enabled, code GCC-compiled for DEBUG with no optimization and XThread running.
DCache is irrelevant since on STM32U5 it is used only for external memory (DCache1) and GPU2D (DCache2) - see [AN5212](https://www.st.com/content/ccc/resource/technical/document/application_note/group1/67/31/96/a8/91/d2/40/12/DM00532735/files/DM00532735.pdf/jcr:content/translations/en.DM00532735.pdf).