### PR TITLE
Added macro redefinations for lv device state

### DIFF
--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -95,6 +95,8 @@ static inline void lv_obj_move_background(lv_obj_t * obj)
 #define LV_RES_OK         LV_RESULT_OK
 #define LV_RES_INV        LV_RESULT_INVALID
 
+#define LV_INDEV_STATE_PR   LV_INDEV_STATE_PRESSED
+#define LV_INDEV_STATE_REL  LV_INDEV_STATE_RELEASED
 
 #define lv_disp_create                   lv_display_create
 #define lv_disp_remove                   lv_display_remove


### PR DESCRIPTION
LV_INDEV_STATE_PR and LV_INDEV_STATE_REL macros are still used on the vendor specific lvgl portable code. Example- touchpad.c in lvgl/lv_port_stm32f769_disco repo still uses these macros to be compatible with released/stable versions of lvgl library (mainly 8.3.x/8.2.x). In the master (unstable) branch of lvgl library, these macros are removed and replaced with LV_INDEV_STATE_PRESSED and LV_INDEV_STATE_RELEASED macros respectively. To make vendor specific lvgl portable code compatible with master branch of lvgl library, these redefines are added. They can be removed in the future when vendor portable code is updated to use next released (stable) version of lvgl library

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
