### PR TITLE
feat(log): add file line number printing option

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -365,6 +365,11 @@ menu "LVGL configuration"
 				default y
 				depends on LV_USE_LOG
 
+			config LV_LOG_USE_FILE_LINE
+				bool "Enable print file and line number"
+				default y
+				depends on LV_USE_LOG
+
 			config LV_LOG_TRACE_MEM
 				bool "Enable/Disable LV_LOG_TRACE in mem module"
 				default y

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -169,6 +169,10 @@
      *0: Disable print timestamp*/
     #define LV_LOG_USE_TIMESTAMP 1
 
+    /*1: Print file and line number of the log;
+     *0: Do not print file and line number of the log*/
+    #define LV_LOG_USE_FILE_LINE 1
+
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1
     #define LV_LOG_TRACE_TIMER      1

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -401,6 +401,20 @@
         #endif
     #endif
 
+    /*1: Print file and line number of the log;
+     *0: Do not print file and line number of the log*/
+    #ifndef LV_LOG_USE_FILE_LINE
+        #ifdef _LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_LOG_USE_FILE_LINE
+                #define LV_LOG_USE_FILE_LINE CONFIG_LV_LOG_USE_FILE_LINE
+            #else
+                #define LV_LOG_USE_FILE_LINE 0
+            #endif
+        #else
+            #define LV_LOG_USE_FILE_LINE 1
+        #endif
+    #endif
+
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #ifndef LV_LOG_TRACE_MEM
         #ifdef _LV_KCONFIG_PRESENT

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -37,6 +37,14 @@
     #define LOG_TIMESTAMP_EXPR
 #endif
 
+#if LV_LOG_USE_FILE_LINE
+    #define LOG_FILE_LINE_FMT "\t(in %s line #%d)"
+    #define LOG_FILE_LINE_EXPR , &file[p], line
+#else
+    #define LOG_FILE_LINE_FMT
+    #define LOG_FILE_LINE_EXPR
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -85,6 +93,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
         va_list args;
         va_start(args, format);
 
+#if LV_LOG_USE_FILE_LINE
         /*Use only the file name not the path*/
         size_t p;
         for(p = lv_strlen(file); p > 0; p--) {
@@ -93,6 +102,11 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
                 break;
             }
         }
+#else
+        LV_UNUSED(file);
+        LV_UNUSED(line);
+#endif
+
 #if LV_LOG_USE_TIMESTAMP
         uint32_t t = lv_tick_get();
 #endif
@@ -102,14 +116,14 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
         printf("[%s]" LOG_TIMESTAMP_FMT " %s: ",
                lvl_prefix[level], LOG_TIMESTAMP_EXPR func);
         vprintf(format, args);
-        printf(" \t(in %s line #%d)\n", &file[p], line);
+        printf(LOG_FILE_LINE_FMT "\n" LOG_FILE_LINE_EXPR);
 #else
         if(custom_print_cb) {
             char buf[512];
             char msg[256];
             lv_vsnprintf(msg, sizeof(msg), format, args);
-            lv_snprintf(buf, sizeof(buf), "[%s]" LOG_TIMESTAMP_FMT " %s: %s \t(in %s line #%d)\n",
-                        lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg, &file[p], line);
+            lv_snprintf(buf, sizeof(buf), "[%s]" LOG_TIMESTAMP_FMT " %s: %s" LOG_FILE_LINE_FMT "\n",
+                        lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg LOG_FILE_LINE_EXPR);
             custom_print_cb(level, buf);
         }
 #endif

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -42,6 +42,15 @@ LV_EXPORT_CONST_INT(LV_LOG_LEVEL_NONE);
 typedef int8_t lv_log_level_t;
 
 #if LV_USE_LOG
+
+#if LV_LOG_USE_FILE_LINE
+#define LV_LOG_FILE __FILE__
+#define LV_LOG_LINE __LINE__
+#else
+#define LV_LOG_FILE NULL
+#define LV_LOG_LINE 0
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -88,7 +97,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
  **********************/
 #ifndef LV_LOG_TRACE
 #  if LV_LOG_LEVEL <= LV_LOG_LEVEL_TRACE
-#    define LV_LOG_TRACE(...) _lv_log_add(LV_LOG_LEVEL_TRACE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#    define LV_LOG_TRACE(...) _lv_log_add(LV_LOG_LEVEL_TRACE, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
 #  else
 #    define LV_LOG_TRACE(...) do {}while(0)
 #  endif
@@ -96,7 +105,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 
 #ifndef LV_LOG_INFO
 #  if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
-#    define LV_LOG_INFO(...) _lv_log_add(LV_LOG_LEVEL_INFO, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#    define LV_LOG_INFO(...) _lv_log_add(LV_LOG_LEVEL_INFO, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
 #  else
 #    define LV_LOG_INFO(...) do {}while(0)
 #  endif
@@ -104,7 +113,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 
 #ifndef LV_LOG_WARN
 #  if LV_LOG_LEVEL <= LV_LOG_LEVEL_WARN
-#    define LV_LOG_WARN(...) _lv_log_add(LV_LOG_LEVEL_WARN, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#    define LV_LOG_WARN(...) _lv_log_add(LV_LOG_LEVEL_WARN, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
 #  else
 #    define LV_LOG_WARN(...) do {}while(0)
 #  endif
@@ -112,7 +121,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 
 #ifndef LV_LOG_ERROR
 #  if LV_LOG_LEVEL <= LV_LOG_LEVEL_ERROR
-#    define LV_LOG_ERROR(...) _lv_log_add(LV_LOG_LEVEL_ERROR, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#    define LV_LOG_ERROR(...) _lv_log_add(LV_LOG_LEVEL_ERROR, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
 #  else
 #    define LV_LOG_ERROR(...) do {}while(0)
 #  endif
@@ -120,7 +129,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line,
 
 #ifndef LV_LOG_USER
 #  if LV_LOG_LEVEL <= LV_LOG_LEVEL_USER
-#    define LV_LOG_USER(...) _lv_log_add(LV_LOG_LEVEL_USER, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#    define LV_LOG_USER(...) _lv_log_add(LV_LOG_LEVEL_USER, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
 #  else
 #    define LV_LOG_USER(...) do {}while(0)
 #  endif


### PR DESCRIPTION
### Description of the feature or fix

1. Reduce code size (because the `__FILE__` string is very long).
2. Improve LOG printing speed.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
