### PR TITLE
feat(obj): rename lv_obj_set_flag to lv_obj_update_flag

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -152,8 +152,7 @@ void lv_obj_remove_flag(lv_obj_t * obj, lv_obj_flag_t f)
 
 }
 
-
-void lv_obj_set_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v)
+void lv_obj_update_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v)
 {
     if(v) lv_obj_add_flag(obj, f);
     else lv_obj_remove_flag(obj, f);

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -223,7 +223,7 @@ lv_obj_t * lv_obj_create(lv_obj_t * parent);
 void lv_obj_add_flag(lv_obj_t * obj, lv_obj_flag_t f);
 
 /**
- * Clear one or more flags
+ * Remove one or more flags
  * @param obj   pointer to an object
  * @param f     OR-ed values from `lv_obj_flag_t` to set.
  */
@@ -232,10 +232,10 @@ void lv_obj_remove_flag(lv_obj_t * obj, lv_obj_flag_t f);
 /**
  * Set add or remove one or more flags.
  * @param obj   pointer to an object
- * @param f     OR-ed values from `lv_obj_flag_t` to set.
+ * @param f     OR-ed values from `lv_obj_flag_t` to update.
  * @param v     true: add the flags; false: remove the flags
  */
-void lv_obj_set_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v);
+void lv_obj_update_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v);
 
 /**
  * Add one or more states to the object. The other state bits will remain unchanged.


### PR DESCRIPTION
### Description of the feature or fix

~~Add API to update/get obj flags.
`Update`  means either add or remove flags depending on `LV_OBJ_FLAG_ACTION_REMOVE` is cleared or not.~~

Rename `lv_obj_set_flag()` to `lv_obj_update_flag` since `lv_obj_set_flag(obj, f, false)` is actually clear flag but not `set` which is confusing. 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
