### PR TITLE
fix(meter):  fix 5 meter defects...

### DIFF
--- a/src/extra/widgets/meter/lv_meter.c
+++ b/src/extra/widgets/meter/lv_meter.c
@@ -360,6 +360,8 @@ static void draw_arcs(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area_t 
         int32_t end_angle = lv_map(indic->end_value, scale->min, scale->max, scale->rotation,
                                    scale->rotation + scale->angle_range);
 
+        arc_dsc.start_angle = start_angle;
+        arc_dsc.end_angle = end_angle;
         part_draw_dsc.radius = r_out + indic->type_data.arc.r_mod;
         part_draw_dsc.sub_part_ptr = indic;
         part_draw_dsc.p1 = &scale_center;
@@ -511,7 +513,8 @@ static void draw_ticks_and_labels(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, cons
                 lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
                 lv_point_t label_size;
-                lv_txt_get_size(&label_size, part_draw_dsc.text, label_dsc.font, label_dsc.letter_space, label_dsc.line_space,
+                lv_txt_get_size(&label_size, part_draw_dsc.text, label_dsc_tmp.font, label_dsc_tmp.letter_space,
+                                label_dsc_tmp.line_space,
                                 LV_COORD_MAX, LV_TEXT_FLAG_NONE);
 
                 lv_area_t label_cord;
@@ -569,6 +572,7 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
     lv_obj_draw_dsc_init(&part_draw_dsc, draw_ctx);
     part_draw_dsc.class_p = MY_CLASS;
     part_draw_dsc.p1 = &scale_center;
+    part_draw_dsc.part = LV_PART_INDICATOR;
 
     lv_meter_indicator_t * indic;
     _LV_LL_READ_BACK(&meter->indicator_ll, indic) {
@@ -585,7 +589,7 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
             line_dsc.width = indic->type_data.needle_line.width;
             line_dsc.opa = indic->opa > LV_OPA_MAX ? opa_main : (opa_main * indic->opa) >> 8;
 
-            part_draw_dsc.id = LV_METER_DRAW_PART_NEEDLE_LINE;
+            part_draw_dsc.type = LV_METER_DRAW_PART_NEEDLE_LINE;
             part_draw_dsc.line_dsc = &line_dsc;
             part_draw_dsc.p2 = &p_end;
 
@@ -612,7 +616,7 @@ static void draw_needles(lv_obj_t * obj, lv_draw_ctx_t * draw_ctx, const lv_area
             if(angle > 3600) angle -= 3600;
             img_dsc.angle = angle;
 
-            part_draw_dsc.id = LV_METER_DRAW_PART_NEEDLE_IMG;
+            part_draw_dsc.type = LV_METER_DRAW_PART_NEEDLE_IMG;
             part_draw_dsc.img_dsc = &img_dsc;
 
             lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);

--- a/src/extra/widgets/meter/lv_meter.h
+++ b/src/extra/widgets/meter/lv_meter.h
@@ -42,7 +42,6 @@ typedef struct {
     uint16_t tick_major_width;
 
     int16_t label_gap;
-    int16_t label_color;
 
     int32_t min;
     int32_t max;


### PR DESCRIPTION
### Description of the feature or fix

- remove unused `label_color` field from `lv_scale_t`
- pass start/end angle to arc-drawing events
- include font, letter_space and line_space  (possibly changed by
  event hook) to `lv_txt_get_size()` before drawing
- pass part `LV_PART_INDICATOR` in `part` field in needle-drawing events
- pass event type in `type` (not `id`) field to needle-drawing events

### Checkpoints
- [trouble running this on Windows] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [n/a] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [n/a] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [n/a] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
