### PR TITLE
fix(tiny_ttf): Add line_height as a parameter in font glyph cache

### DIFF
--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -141,7 +141,7 @@ static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t 
     uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_A8);
     lv_cache_lock();
     uint32_t cp = unicode_letter;
-    lv_cache_entry_t * cache = lv_cache_find(font + cp, LV_CACHE_SRC_TYPE_PTR, font->line_height, 0);
+    lv_cache_entry_t * cache = lv_cache_find(font, LV_CACHE_SRC_TYPE_PTR, font->line_height, cp);
     if(cache) {
         uint8_t * buffer = (uint8_t *)lv_cache_get_data(cache);
         lv_cache_unlock();
@@ -155,9 +155,10 @@ static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t 
         return NULL;
     }
     /* This smells. We add the codepoint to the base pointer to get a key. */
-    entry->src = font + cp;
+    entry->src = font;
     entry->src_type = LV_CACHE_SRC_TYPE_PTR;
     entry->param1 = font->line_height;
+    entry->param2 = cp;
     uint8_t * buffer = lv_draw_buf_malloc(szb, LV_COLOR_FORMAT_A8);
     if(NULL == buffer) {
         LV_LOG_ERROR("tiny_ttf: out of memory\n");

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -141,7 +141,7 @@ static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t 
     uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_A8);
     lv_cache_lock();
     uint32_t cp = unicode_letter;
-    lv_cache_entry_t * cache = lv_cache_find(font + cp, LV_CACHE_SRC_TYPE_PTR, 0, 0);
+    lv_cache_entry_t * cache = lv_cache_find(font + cp, LV_CACHE_SRC_TYPE_PTR, font->line_height, 0);
     if(cache) {
         uint8_t * buffer = (uint8_t *)lv_cache_get_data(cache);
         lv_cache_unlock();
@@ -157,6 +157,7 @@ static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t 
     /* This smells. We add the codepoint to the base pointer to get a key. */
     entry->src = font + cp;
     entry->src_type = LV_CACHE_SRC_TYPE_PTR;
+    entry->param1 = font->line_height;
     uint8_t * buffer = lv_draw_buf_malloc(szb, LV_COLOR_FORMAT_A8);
     if(NULL == buffer) {
         LV_LOG_ERROR("tiny_ttf: out of memory\n");


### PR DESCRIPTION
### Description of the feature or fix

Glyph line_height information should be included as a cached data. Otherwise, font size change API ` lv_tiny_ttf_set_size()` doesn't work correctly and shows cached old size glyph image.

This PR effectively fixes behavior of lv_example_tiny_ttf_3.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
