### PR TITLE
chore(color): use lv_color_fomat_get_bpp instead of get_size

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -146,7 +146,8 @@ static void * buf_align(void * buf, lv_color_format_t color_format)
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
     uint32_t width_byte;
-    width_byte =  w * lv_color_format_get_size(color_format);
+    width_byte = w * lv_color_format_get_bpp(color_format);
+    width_byte = (width_byte + 7) >> 3; /*Round up*/
     return (width_byte + LV_DRAW_BUF_STRIDE_ALIGN - 1) & ~(LV_DRAW_BUF_STRIDE_ALIGN - 1);
 }
 

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -41,31 +41,6 @@ const lv_color_filter_dsc_t lv_color_filter_shade = {.filter_cb = lv_color_filte
  *   GLOBAL FUNCTIONS
  **********************/
 
-uint8_t lv_color_format_get_size(lv_color_format_t cf)
-{
-    switch(cf) {
-        case LV_COLOR_FORMAT_NATIVE_REVERSED:
-            return LV_COLOR_DEPTH / 8;
-        case LV_COLOR_FORMAT_L8:
-        case LV_COLOR_FORMAT_A8:
-        case LV_COLOR_FORMAT_I8:
-            return 1;
-        case LV_COLOR_FORMAT_RGB565:
-            return 2;
-
-        case LV_COLOR_FORMAT_RGB565A8:
-        case LV_COLOR_FORMAT_RGB888:
-            return 3;
-        case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
-            return 4;
-
-        case LV_COLOR_FORMAT_UNKNOWN:
-        default:
-            return 0;
-    }
-}
-
 uint8_t lv_color_format_get_bpp(lv_color_format_t cf)
 {
     switch(cf) {

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -166,18 +166,21 @@ typedef uint8_t lv_color_format_t;
  **********************/
 
 /**
- * Get the pixel size of a color format in bytes
- * @param src_cf a color format (`LV_COLOR_FORMAT_...`)
- * @return the pixel size in bytes
- */
-uint8_t lv_color_format_get_size(lv_color_format_t src_cf);
-
-/**
  * Get the pixel size of a color format in bits, bpp
  * @param src_cf a color format (`LV_COLOR_FORMAT_...`)
  * @return the pixel size in bits
  */
 uint8_t lv_color_format_get_bpp(lv_color_format_t cf);
+
+/**
+ * Get the pixel size of a color format in bytes
+ * @param src_cf a color format (`LV_COLOR_FORMAT_...`)
+ * @return the pixel size in bytes
+ */
+static inline uint8_t lv_color_format_get_size(lv_color_format_t cf)
+{
+    return (lv_color_format_get_bpp(cf) + 7) >> 3;
+}
 
 /**
  * Check if a color format has alpha channel or not


### PR DESCRIPTION
### Description of the feature or fix

Use `bit per pixel` is more friendly for images like I1/2/4/8.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
