### PR TITLE
feat(timer): support lv_timer_handler_set_resume_cb

### DIFF
--- a/docs/overview/timer.rst
+++ b/docs/overview/timer.rst
@@ -69,6 +69,18 @@ You can make a timer repeat only a given number of times with
 automatically be deleted after it's called the defined number of times.
 Set the count to ``-1`` to repeat indefinitely.
 
+Enable and Disable
+******************
+
+You can enable or disable a timer with :cpp:expr:`lv_timer_enable(en)`.
+
+Pause and Resume
+****************
+
+:cpp:expr:`lv_timer_pause(timer)` pauses the specified timer.
+
+:cpp:expr:`lv_timer_resume(timer)` resumes the specified timer.
+
 Measure idle time
 *****************
 
@@ -77,6 +89,14 @@ You can get the idle percentage time of :cpp:func:`lv_timer_handler` with
 the overall system, only :cpp:func:`lv_timer_handler`. It can be misleading if
 you use an operating system and call :cpp:func:`lv_timer_handler` in a timer, as
 it won't actually measure the time the OS spends in an idle thread.
+
+Timer handler resume callback
+*****************************
+
+When the `lv_timer_handler` is stopped, if you want to pay attention to the wake-up
+timing of the `lv_timer_handler`, you can set a resume callback using
+:cpp:expr:`lv_timer_handler_set_resume_cb(cb, user_data)`.
+The callback should have a ``void (*lv_timer_handler_resume_cb_t)(void*)`` prototype.
 
 Asynchronous calls
 ******************

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -394,4 +394,13 @@ static void lv_timer_handler_resume(void)
 {
     /*If there is a timer which is ready to run then resume the timer loop*/
     state.timer_time_until_next = 0;
+    if(state.resume_cb) {
+        state.resume_cb(state.resume_data);
+    }
+}
+
+void lv_timer_handler_set_resume_cb(lv_timer_handler_resume_cb_t cb, void * data)
+{
+    state.resume_cb = cb;
+    state.resume_data = data;
 }

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -40,6 +40,11 @@ struct _lv_timer_t;
 typedef void (*lv_timer_cb_t)(struct _lv_timer_t *);
 
 /**
+ * Timer handler resume this type of function.
+ */
+typedef void (*lv_timer_handler_resume_cb_t)(void * data);
+
+/**
  * Descriptor of a lv_timer
  */
 typedef struct _lv_timer_t {
@@ -65,6 +70,9 @@ typedef struct {
     uint32_t busy_time;
     uint32_t idle_period_start;
     uint32_t run_cnt;
+
+    lv_timer_handler_resume_cb_t resume_cb;
+    void * resume_data;
 } lv_timer_state_t;
 
 /**********************
@@ -109,6 +117,13 @@ static inline LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler_run_in_period
  * This function is used to simplify the porting.
  */
 LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void);
+
+/**
+ * Set the resume callback to the timer handler
+ * @param cb the function to call when timer handler is resumed
+ * @param data pointer to a resume data
+ */
+void lv_timer_handler_set_resume_cb(lv_timer_handler_resume_cb_t cb, void * data);
 
 /**
  * Create an "empty" timer. It needs to be initialized with at least


### PR DESCRIPTION
### Description of the feature or fix

This feature allows events to be customized when the timer handler is awakened.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
