### PR TITLE
cleanup LV_USE_MSG

### DIFF
--- a/.devcontainer/__lv_conf.h__
+++ b/.devcontainer/__lv_conf.h__
@@ -709,9 +709,6 @@
     #define LV_IMGFONT_USE_IMG_CACHE_HEADER 0
 #endif
 
-/*1: Enable a published subscriber based messaging system */
-#define LV_USE_MSG 0
-
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/
 #define LV_USE_IME_PINYIN 0

--- a/Kconfig
+++ b/Kconfig
@@ -1144,10 +1144,6 @@ menu "LVGL configuration"
 			depends on LV_USE_IMGFONT
 			default n
 
-		config LV_USE_MSG
-			bool "Enable a published subscriber based messaging system"
-			default n
-
 		config LV_USE_IME_PINYIN
 			bool "Enable Pinyin input method"
 			default n

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -693,9 +693,6 @@
     #define LV_IMGFONT_USE_IMAGE_CACHE_HEADER 0
 #endif
 
-/*1: Enable a published subscriber based messaging system */
-#define LV_USE_MSG 0
-
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/
 #if LV_USE_IME_PINYIN

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -170,12 +170,6 @@ typedef struct _lv_global_t {
     lv_profiler_builtin_ctx_t profiler_context;
 #endif
 
-#if LV_USE_MSG
-    bool msg_restart_notify;
-    unsigned int msg_recursion_counter;
-    lv_ll_t msg_subs_ll;
-#endif
-
 #if LV_USE_FILE_EXPLORER != 0
     lv_style_t fe_list_button_style;
 #endif

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -97,10 +97,6 @@ typedef enum {
     LV_EVENT_GET_SELF_SIZE,       /**< Get the internal size of a widget*/
 
     /** Events of optional LVGL components*/
-#if LV_USE_MSG
-    LV_EVENT_MSG_RECEIVED,
-#endif
-
     LV_EVENT_INVALIDATE_AREA,
     LV_EVENT_RENDER_START,
     LV_EVENT_RENDER_READY,

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -71,7 +71,6 @@
 #define LV_USE_FRAGMENT     1
 #define LV_USE_IMGFONT      1
 #define LV_USE_IME_PINYIN       1
-#define LV_USE_MSG              1
 #define LV_USE_OBSERVER         1
 #define LV_USE_FILE_EXPLORER    1
 #define LV_USE_TINY_TTF         1

--- a/tests/src/lv_test_conf_minimal.h
+++ b/tests/src/lv_test_conf_minimal.h
@@ -19,5 +19,3 @@
 #define  LV_USE_BMP                     1
 #define  LV_USE_GIF                     1
 #define  LV_USE_QRCODE                  1
-#define  LV_USE_MSG                     1   /*For test_msg*/
-


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
