### PR TITLE
docs: fix typos

### DIFF
--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -499,14 +499,14 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
     lv_coord_t bottom_space = lv_obj_get_style_pad_bottom(obj, LV_PART_SCROLLBAR);
     lv_coord_t left_space = lv_obj_get_style_pad_left(obj, LV_PART_SCROLLBAR);
     lv_coord_t right_space = lv_obj_get_style_pad_right(obj, LV_PART_SCROLLBAR);
-    lv_coord_t tickness = lv_obj_get_style_width(obj, LV_PART_SCROLLBAR);
+    lv_coord_t thickness = lv_obj_get_style_width(obj, LV_PART_SCROLLBAR);
 
     lv_coord_t obj_h = lv_obj_get_height(obj);
     lv_coord_t obj_w = lv_obj_get_width(obj);
 
     /*Space required for the vertical and horizontal scrollbars*/
-    lv_coord_t ver_reg_space = ver_draw ? tickness : 0;
-    lv_coord_t hor_req_space = hor_draw ? tickness : 0;
+    lv_coord_t ver_reg_space = ver_draw ? thickness : 0;
+    lv_coord_t hor_req_space = hor_draw ? thickness : 0;
     lv_coord_t rem;
 
     if(lv_obj_get_style_bg_opa(obj, LV_PART_SCROLLBAR) < LV_OPA_MIN &&
@@ -521,11 +521,11 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
         ver_area->y2 = obj->coords.y2;
         if(rtl) {
             ver_area->x1 = obj->coords.x1 + left_space;
-            ver_area->x2 = ver_area->x1 + tickness - 1;
+            ver_area->x2 = ver_area->x1 + thickness - 1;
         }
         else {
             ver_area->x2 = obj->coords.x2 - right_space;
-            ver_area->x1 = ver_area->x2 - tickness + 1;
+            ver_area->x1 = ver_area->x2 - thickness + 1;
         }
 
         lv_coord_t sb_h = ((obj_h - top_space - bottom_space - hor_req_space) * obj_h) / content_h;
@@ -562,7 +562,7 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
     lv_coord_t content_w = obj_w + sl + sr;
     if(hor_draw && content_w) {
         hor_area->y2 = obj->coords.y2 - bottom_space;
-        hor_area->y1 = hor_area->y2 - tickness + 1;
+        hor_area->y1 = hor_area->y2 - thickness + 1;
         hor_area->x1 = obj->coords.x1;
         hor_area->x2 = obj->coords.x2;
 

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -73,7 +73,7 @@ lv_draw_buf_handlers_t * lv_draw_buf_get_handlers(void);
 /**
  * Allocate a buffer with the given size. It might allocate slightly larger buffer to fulfill the alignment requirements.
  * @param size          the size to allocate in bytes
- * @param color_format  the color format of the buffer to allcoate
+ * @param color_format  the color format of the buffer to allocate
  * @return              the allocated buffer.
  * @note The returned value can be saved in draw_buf->buf
  * @note lv_draw_buf_align can be sued the align the returned pointer
@@ -87,7 +87,7 @@ void * lv_draw_buf_malloc(size_t size_bytes, lv_color_format_t color_format);
 void lv_draw_buf_free(void  * buf);
 
 /**
- * Align the address of a buffer. The buffer needs to be large enough for the real data after alignement
+ * Align the address of a buffer. The buffer needs to be large enough for the real data after alignment
  * @param buf           the data to align
  * @param color_format  the color format of the buffer
  * @return              the aligned buffer

--- a/src/draw/nxp/vglite/lv_draw_vglite_arc.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_arc.c
@@ -160,7 +160,7 @@ static void _rotate_point(int32_t angle, int32_t * x, int32_t * y)
  */
 static void _set_full_arc(vg_arc * fullarc)
 {
-    /* the tangent lenght for the bezier circle approx */
+    /* the tangent length for the bezier circle approx */
     float tang = ((float)fullarc->rad) * BEZIER_OPTIM_CIRCLE;
     switch(fullarc->quarter) {
         case 0:

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -62,7 +62,7 @@ typedef enum {
     LV_EVENT_DEFOCUSED,           /**< The object is defocused*/
     LV_EVENT_LEAVE,               /**< The object is defocused but still selected*/
     LV_EVENT_HIT_TEST,            /**< Perform advanced hit-testing*/
-    LV_EVENT_INDEV_RESET,         /**< Indev has been reseted*/
+    LV_EVENT_INDEV_RESET,         /**< Indev has been reset*/
 
     /** Drawing events*/
     LV_EVENT_COVER_CHECK,        /**< Check if the object fully covers an area. The event parameter is `lv_cover_check_info_t *`.*/

--- a/src/widgets/scale/lv_scale.h
+++ b/src/widgets/scale/lv_scale.h
@@ -179,7 +179,7 @@ void lv_scale_set_text_src(lv_obj_t * obj, const char * txt_src[]);
 /**
  * Draw the scale after all the children are drawn
  * @param obj       pointer to a scale object
- * @param en        true: eanble post draw
+ * @param en        true: enable post draw
  */
 void lv_scale_set_post_draw(lv_obj_t * obj, bool en);
 

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -89,7 +89,7 @@ typedef void * lv_user_data_t;
 #undef LV_LOG_PRINTF
 
 //#define LV_DRAW_BUF_STRIDE_ALIGN                64
-//#define LV_DRAW_BUF_ALIGN                       40  /*Use non power of 2 to avoid the case when `malloc` returns aligned ponter by default*/
+//#define LV_DRAW_BUF_ALIGN                       40  /*Use non power of 2 to avoid the case when `malloc` returns aligned pointer by default*/
 
 /*For screenshots*/
 #undef LV_USE_PERF_MONITOR

--- a/tests/src/test_cases/test_obj_flags.c
+++ b/tests/src/test_cases/test_obj_flags.c
@@ -82,7 +82,7 @@ void test_obj_flag_overflow_visible_1(void)
     /*The left part of the right button (should trigger click event)*/
     lv_test_mouse_click_at(650, 220);
 
-    /*The outter part of the right button (should trigger click event as obj_child_2 has LV_OBJ_FLAG_OVERFLOW_VISIBLE)*/
+    /*The outer part of the right button (should trigger click event as obj_child_2 has LV_OBJ_FLAG_OVERFLOW_VISIBLE)*/
     lv_test_mouse_click_at(690, 220);
 
     TEST_ASSERT_EQUAL_UINT32(1, cnt_1);
@@ -130,7 +130,7 @@ void test_obj_flag_overflow_visible_1(void)
     /*The left part of the right button (should trigger click event)*/
     lv_test_mouse_click_at(590, 370);
 
-    /*The outter part of the right button (should trigger click event as obj_child_2 has LV_OBJ_FLAG_OVERFLOW_VISIBLE)*/
+    /*The outer part of the right button (should trigger click event as obj_child_2 has LV_OBJ_FLAG_OVERFLOW_VISIBLE)*/
     lv_test_mouse_click_at(600, 430);
 
     /*The clipped part of the right button (clipped because it's out of the red panel's ext draw size, shouldn't trigger click event)*/


### PR DESCRIPTION
Found via `codespell -S docs,env_support,./src/libs -L ser,nam,te,nd,bu,nin,varius,ridiculus`

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
