### PR TITLE
chore(cmake): add support for user-specified lv_conf.h path

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -63,6 +63,12 @@ install(
   FILES_MATCHING
   PATTERN "*.h")
 
+install(
+  FILES "${LV_CONF_PATH}"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${INC_INSTALL_DIR}/"
+  RENAME "lv_conf.h"
+  OPTIONAL)
+
 set_target_properties(
   lvgl
   PROPERTIES OUTPUT_NAME lvgl


### PR DESCRIPTION
When passing LV_CONF_PATH to cmake through command line, the lv_conf.h need to be installed to install directory. And then I make this PR(my first PR).