### PR TITLE
Update lv_example_roller_1.c - lv_roller_set_options() parameter issue

### DIFF
--- a/examples/widgets/roller/lv_example_roller_1.c
+++ b/examples/widgets/roller/lv_example_roller_1.c
@@ -17,22 +17,9 @@ static void event_handler(lv_event_t * e)
  */
 void lv_example_roller_1(void)
 {
+    const char * opts = "January\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember";
     lv_obj_t * roller1 = lv_roller_create(lv_screen_active());
-    lv_roller_set_options(roller1,
-                          "January\n"
-                          "February\n"
-                          "March\n"
-                          "April\n"
-                          "May\n"
-                          "June\n"
-                          "July\n"
-                          "August\n"
-                          "September\n"
-                          "October\n"
-                          "November\n"
-                          "December",
-                          LV_ROLLER_MODE_INFINITE);
-
+    lv_roller_set_options(roller1, opts, LV_ROLLER_MODE_INFINITE);
     lv_roller_set_visible_row_count(roller1, 4);
     lv_obj_center(roller1);
     lv_obj_add_event(roller1, event_handler, LV_EVENT_ALL, NULL);


### PR DESCRIPTION
The example uses the old format for passing options to the lv_roller_set_options() function call, which results in a complile error. 

The "Styling the roller" example which is the next one to follow in the documentation does it correctly.

As a result, the attached code has been modified to use the new format for passing options.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
