### PR TITLE
feat(timer): add auto delete flag and get pause status

### DIFF
--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -52,9 +52,6 @@ static void lv_timer_handler_resume(void);
  *   GLOBAL FUNCTIONS
  **********************/
 
-/**
- * Init the lv_timer module
- */
 void _lv_timer_core_init(void)
 {
     _lv_ll_init(timer_ll_p, sizeof(lv_timer_t));
@@ -63,10 +60,6 @@ void _lv_timer_core_init(void)
     lv_timer_enable(true);
 }
 
-/**
- * Call it periodically to handle lv_timers.
- * @return the time after which it must be called again
- */
 LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
 {
     LV_TRACE_TIMER("begin");
@@ -160,25 +153,11 @@ LV_ATTRIBUTE_TIMER_HANDLER void lv_timer_periodic_handler(void)
     }
 }
 
-/**
- * Create an "empty" timer. It needs to be initialized with at least
- * `lv_timer_set_cb` and `lv_timer_set_period`
- * @return pointer to the created timer
- */
 lv_timer_t * lv_timer_create_basic(void)
 {
     return lv_timer_create(NULL, DEF_PERIOD, NULL);
 }
 
-/**
- * Create a new lv_timer
- * @param timer_xcb a callback which is the timer itself. It will be called periodically.
- *                 (the 'x' in the argument name indicates that it's not a fully generic function because it not follows
- *                  the `func_name(object, callback, ...)` convention)
- * @param period call period in ms unit
- * @param user_data custom parameter
- * @return pointer to the new timer
- */
 lv_timer_t * lv_timer_create(lv_timer_cb_t timer_xcb, uint32_t period, void * user_data)
 {
     lv_timer_t * new_timer = NULL;
@@ -202,20 +181,11 @@ lv_timer_t * lv_timer_create(lv_timer_cb_t timer_xcb, uint32_t period, void * us
     return new_timer;
 }
 
-/**
- * Set the callback to the timer (the function to call periodically)
- * @param timer pointer to a timer
- * @param timer_cb the function to call periodically
- */
 void lv_timer_set_cb(lv_timer_t * timer, lv_timer_cb_t timer_cb)
 {
     timer->timer_cb = timer_cb;
 }
 
-/**
- * Delete a lv_timer
- * @param timer pointer to timer created by timer
- */
 void lv_timer_delete(lv_timer_t * timer)
 {
     _lv_ll_remove(timer_ll_p, timer);
@@ -224,10 +194,6 @@ void lv_timer_delete(lv_timer_t * timer)
     lv_free(timer);
 }
 
-/**
- * Pause/resume a timer.
- * @param timer pointer to an lv_timer
- */
 void lv_timer_pause(lv_timer_t * timer)
 {
     timer->paused = true;
@@ -239,99 +205,53 @@ void lv_timer_resume(lv_timer_t * timer)
     lv_timer_handler_resume();
 }
 
-/**
- * Set new period for a lv_timer
- * @param timer pointer to a lv_timer
- * @param period the new period
- */
 void lv_timer_set_period(lv_timer_t * timer, uint32_t period)
 {
     timer->period = period;
 }
 
-/**
- * Make a lv_timer ready. It will not wait its period.
- * @param timer pointer to a lv_timer.
- */
 void lv_timer_ready(lv_timer_t * timer)
 {
     timer->last_run = lv_tick_get() - timer->period - 1;
 }
 
-/**
- * Set the number of times a timer will repeat.
- * @param timer pointer to a lv_timer.
- * @param repeat_count -1 : infinity;  0 : stop ;  n >0: residual times
- */
 void lv_timer_set_repeat_count(lv_timer_t * timer, int32_t repeat_count)
 {
     timer->repeat_count = repeat_count;
 }
 
-/**
- * Set whether a lv_timer will be deleted automatically when it is called `repeat_count` times.
- * @param timer pointer to a lv_timer.
- * @param auto_delete true: auto delete; false: timer will be paused when it is called `repeat_count` times.
- */
 void lv_timer_set_auto_delete(lv_timer_t * timer, bool auto_delete)
 {
     timer->auto_delete = auto_delete;
 }
 
-/**
- * Set custom parameter to the lv_timer.
- * @param timer pointer to a lv_timer.
- * @param user_data custom parameter
- */
 void lv_timer_set_user_data(lv_timer_t * timer, void * user_data)
 {
     timer->user_data = user_data;
 }
 
-/**
- * Reset a lv_timer.
- * It will be called the previously set period milliseconds later.
- * @param timer pointer to a lv_timer.
- */
 void lv_timer_reset(lv_timer_t * timer)
 {
     timer->last_run = lv_tick_get();
     lv_timer_handler_resume();
 }
 
-/**
- * Enable or disable the whole lv_timer handling
- * @param en true: lv_timer handling is running, false: lv_timer handling is suspended
- */
 void lv_timer_enable(bool en)
 {
     state.lv_timer_run = en;
     if(en) lv_timer_handler_resume();
 }
 
-/**
- * Get idle percentage
- * @return the lv_timer idle in percentage
- */
 uint8_t lv_timer_get_idle(void)
 {
     return state.idle_last;
 }
 
-/**
- * Get idle period start tick
- * @return the lv_timer idle period start tick
- */
 uint32_t lv_timer_get_time_until_next(void)
 {
     return state.timer_time_until_next;
 }
 
-/**
- * Iterate through the timers
- * @param timer NULL to start iteration or the previous return value to get the next timer
- * @return the next timer or NULL if there is no more timer
- */
 lv_timer_t * lv_timer_get_next(lv_timer_t * timer)
 {
     if(timer == NULL) return _lv_ll_get_head(timer_ll_p);

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -151,11 +151,15 @@ lv_timer_t * lv_timer_create(lv_timer_cb_t timer_xcb, uint32_t period, void * us
 void lv_timer_delete(lv_timer_t * timer);
 
 /**
- * Pause/resume a timer.
+ * Pause a timer.
  * @param timer pointer to an lv_timer
  */
 void lv_timer_pause(lv_timer_t * timer);
 
+/**
+ * Resume a timer.
+ * @param timer pointer to an lv_timer
+ */
 void lv_timer_resume(lv_timer_t * timer);
 
 /**

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -241,7 +241,7 @@ static inline void * lv_timer_get_user_data(lv_timer_t * timer)
     return timer->user_data;
 }
 
-inline bool lv_timer_get_paused(lv_timer_t * timer)
+static inline bool lv_timer_get_paused(lv_timer_t * timer)
 {
     return timer->paused;
 }

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -241,6 +241,11 @@ static inline void * lv_timer_get_user_data(lv_timer_t * timer)
     return timer->user_data;
 }
 
+/**
+ * Get the pause state of a timer
+ * @param timer pointer to a lv_timer
+ * @return true: timer is paused; false: timer is running
+ */
 static inline bool lv_timer_get_paused(lv_timer_t * timer)
 {
     return timer->paused;

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -54,6 +54,7 @@ typedef struct _lv_timer_t {
     void * user_data; /**< Custom user data*/
     int32_t repeat_count; /**< 1: One time;  -1 : infinity;  n>0: residual times*/
     uint32_t paused : 1;
+    uint32_t auto_delete : 1;
 } lv_timer_t;
 
 typedef struct {
@@ -185,6 +186,13 @@ void lv_timer_ready(lv_timer_t * timer);
 void lv_timer_set_repeat_count(lv_timer_t * timer, int32_t repeat_count);
 
 /**
+ * Set whether a lv_timer will be deleted automatically when it is called `repeat_count` times.
+ * @param timer pointer to a lv_timer.
+ * @param auto_delete true: auto delete; false: timer will be paused when it is called `repeat_count` times.
+ */
+void lv_timer_set_auto_delete(lv_timer_t * timer, bool auto_delete);
+
+/**
  * Set custom parameter to the lv_timer.
  * @param timer pointer to a lv_timer.
  * @param user_data custom parameter
@@ -231,6 +239,11 @@ lv_timer_t * lv_timer_get_next(lv_timer_t * timer);
 static inline void * lv_timer_get_user_data(lv_timer_t * timer)
 {
     return timer->user_data;
+}
+
+inline bool lv_timer_get_paused(lv_timer_t * timer)
+{
+    return timer->paused;
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

When your timer sets the number of repetitions, and the timer is over, the timer is destroyed, so that you can't know that the timer is over by the original timer without adding other counting methods.

So added

```cpp
lv_timer_get_paused(timer);
lv_timer_set_auto_delete(timer, bool);
```

By default, the timer is deleted. You can manually set not to delete the timer. At this time, the timer is paused, and then you can call `lv_timer_get_paused(timer);` to know the status of the current timer.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
