### PR TITLE
chore: fix some comment issue

### DIFF
--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -57,7 +57,7 @@ void lv_refr_now(lv_display_t * disp);
 
 /**
  * Redrawn on object an all its children using the passed draw context
- * @param draw_ctx  pointer to an initialized draw context
+ * @param layer pointer to a layer where to draw.
  * @param obj   the start object from the redraw should start
  */
 void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj);

--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -69,14 +69,18 @@ void lv_draw_image_dsc_init(lv_draw_image_dsc_t * dsc);
 
 /**
  * Draw an image
- * @param draw_ctx      pointer to the current draw context
+ * @param layer         pointer to a layer
  * @param dsc           pointer to an initialized `lv_draw_image_dsc_t` variable
  * @param coords        the coordinates of the image
- * @param src           pointer to a lv_color_t array which contains the pixels of the image
  */
 void lv_draw_image(struct _lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
-
+/**
+ * Draw a layer on an other layer
+ * @param layer         pointer to a layer
+ * @param dsc           pointer to an initialized `lv_draw_image_dsc_t` variable
+ * @param coords        the coordinates of the layer
+ */
 void lv_draw_layer(struct _lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
 /**

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -107,16 +107,22 @@ void lv_draw_letter_dsc_init(lv_draw_glyph_dsc_t * dsc);
 
 /**
  * Write a text
- * @param draw_ctx      pointer to the current draw context
+ * @param layer         pointer to a layer
  * @param dsc           pointer to draw descriptor
  * @param coords        coordinates of the label
- * @param txt           `\0` terminated text to write
- * @param hint          pointer to a `lv_draw_label_hint_t` variable.
  * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
  */
 LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_layer_t * layer, const lv_draw_label_dsc_t * dsc,
                                          const lv_area_t * coords);
 
+/**
+ * Write a text
+ * @param layer          pointer to a layer
+ * @param dsc            pointer to draw descriptor
+ * @param point          position of the label
+ * @param unicode_letter the letter to draw
+ * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
+ */
 LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(lv_layer_t * layer, lv_draw_label_dsc_t * dsc,
                                           const lv_point_t * point, uint32_t unicode_letter);
 

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -51,10 +51,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
 
 /**
  * Draw a line
- * @param draw_ctx      pointer to the current draw context
+ * @param layer         pointer to a layer
  * @param dsc           pointer to an initialized `lv_draw_line_dsc_t` variable
- * @param point1        first point of the line
- * @param point2        second point of the line
  */
 void lv_draw_line(struct _lv_layer_t * layer, const lv_draw_line_dsc_t * dsc);
 

--- a/src/draw/lv_draw_rect.h
+++ b/src/draw/lv_draw_rect.h
@@ -136,7 +136,7 @@ void lv_draw_bg_image_dsc_init(lv_draw_bg_image_dsc_t * dsc);
 
 /**
  * Draw a rectangle
- * @param draw_ctx      pointer to the current draw context
+ * @param layer         pointer to a layer
  * @param dsc           pointer to an initialized `lv_draw_rect_dsc_t` variable
  * @param coords        the coordinates of the rectangle
  */

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -112,7 +112,8 @@ void lv_image_buf_free(lv_image_dsc_t * dsc);
  * @param w width of the rectangle to transform
  * @param h height of the rectangle to transform
  * @param angle angle of rotation
- * @param zoom zoom, (256 no zoom)
+ * @param zoom_x zoom in x direction, (256 no zoom)
+ * @param zoom_y zoom in y direction, (256 no zoom)
  * @param pivot x,y pivot coordinates of rotation
  */
 void _lv_image_buf_get_transformed_area(lv_area_t * res, lv_coord_t w, lv_coord_t h, lv_coord_t angle, uint16_t zoom_x,

--- a/src/draw/sw/lv_draw_sw_triangle.c
+++ b/src/draw/sw/lv_draw_sw_triangle.c
@@ -179,10 +179,8 @@ void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_
     }
 
 #else
-    LV_UNUSED(points);
-    LV_UNUSED(point_cnt);
-    LV_UNUSED(draw_ctx);
-    LV_UNUSED(draw_dsc);
+    LV_UNUSED(draw_unit);
+    LV_UNUSED(dsc);
     LV_LOG_WARN("Can't draw triangles with LV_DRAW_SW_COMPLEX == 0");
 #endif /*LV_DRAW_SW_COMPLEX*/
 }


### PR DESCRIPTION
### Description of the feature or fix

fix some comment issue

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
