### PR TITLE
fixes MSVC compiler warnings

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -1,3 +1,9 @@
+
+if (MSVC)
+    add_compile_options(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
+
 # Option to define LV_LVGL_H_INCLUDE_SIMPLE, default: ON
 option(LV_LVGL_H_INCLUDE_SIMPLE
        "Use #include \"lvgl.h\" instead of #include \"../../lvgl.h\"" ON)

--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -69,8 +69,8 @@ void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t
                 if(draw_dsc->bg_grad.dir != LV_GRAD_DIR_NONE) {
                     draw_dsc->bg_grad.stops[0].color = lv_obj_get_style_bg_color_filtered(obj, part);
                     draw_dsc->bg_grad.stops[1].color = lv_obj_get_style_bg_grad_color_filtered(obj, part);
-                    draw_dsc->bg_grad.stops[0].frac = lv_obj_get_style_bg_main_stop(obj, part);
-                    draw_dsc->bg_grad.stops[1].frac = lv_obj_get_style_bg_grad_stop(obj, part);
+                    draw_dsc->bg_grad.stops[0].frac = (uint8_t)lv_obj_get_style_bg_main_stop(obj, part);
+                    draw_dsc->bg_grad.stops[1].frac = (uint8_t)lv_obj_get_style_bg_grad_stop(obj, part);
                     draw_dsc->bg_grad.stops[0].opa = lv_obj_get_style_bg_main_opa(obj, part);
                     draw_dsc->bg_grad.stops[1].opa = lv_obj_get_style_bg_grad_opa(obj, part);
                 }

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -788,7 +788,7 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_part_t part, lv_sty
     const uint32_t group = (uint32_t)1 << _lv_style_get_prop_group(prop);
     const lv_state_t state = obj->state;
     const lv_state_t state_inv = ~state;
-    const bool skip_trans = obj->skip_trans;
+    const bool skip_trans = (const bool)obj->skip_trans;
     int32_t weight = -1;
     lv_style_res_t found;
     uint32_t i;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -929,9 +929,9 @@ void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
 
 static uint32_t get_max_row(lv_display_t * disp, lv_coord_t area_w, lv_coord_t area_h)
 {
-    bool has_alpha = lv_color_format_has_alpha(disp->color_format);
+    bool has_alpha = lv_color_format_has_alpha((uint8_t)disp->color_format);
     uint32_t px_size_disp =  lv_color_format_get_size(disp->color_format);
-    uint8_t px_size_render = has_alpha ? sizeof(lv_color32_t) : px_size_disp;
+    uint8_t px_size_render = (uint8_t)(has_alpha ? sizeof(lv_color32_t) : px_size_disp);
     int32_t max_row = (uint32_t)disp->buf_size_in_bytes / LV_MAX(px_size_render, px_size_disp) / area_w;
 
     if(max_row > area_h) max_row = area_h;

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -159,9 +159,9 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
 
             circle_mask_tmp += width;
         }
-        get_rounded_area(start_angle, dsc->radius, width, &round_area_1);
+        get_rounded_area(start_angle, dsc->radius, (uint8_t)width, &round_area_1);
         lv_area_move(&round_area_1, dsc->center.x, dsc->center.y);
-        get_rounded_area(end_angle, dsc->radius, width, &round_area_2);
+        get_rounded_area(end_angle, dsc->radius, (uint8_t)width, &round_area_2);
         lv_area_move(&round_area_2, dsc->center.x, dsc->center.y);
 
     }

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -649,7 +649,7 @@ LV_ATTRIBUTE_FAST_MEM static void shadow_draw_corner_buf(const lv_area_t * coord
     int32_t x;
     lv_opa_t * res_buf = (lv_opa_t *)sh_buf;
     for(x = 0; x < size * size; x++) {
-        res_buf[x] = sh_buf[x];
+        res_buf[x] = (lv_opa_t)sh_buf[x];
     }
 #endif
 

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -138,7 +138,7 @@ void lv_draw_sw_transform(lv_draw_unit_t * draw_unit, const lv_area_t * dest_are
         alpha_buf = NULL;
     }
 
-    bool aa = draw_dsc->antialias;
+    bool aa = (bool)draw_dsc->antialias;
 
     lv_coord_t y;
     for(y = 0; y < dest_h; y++) {

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -246,7 +246,7 @@ static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter)
 
             if(p) {
                 lv_uintptr_t ofs = p - fdsc->cmaps[i].unicode_list;
-                glyph_id = fdsc->cmaps[i].glyph_id_start + ofs;
+                glyph_id = (uint32_t)(fdsc->cmaps[i].glyph_id_start + ofs);
             }
         }
         else if(fdsc->cmaps[i].type == LV_FONT_FMT_TXT_CMAP_SPARSE_FULL) {

--- a/src/font/lv_font_loader.c
+++ b/src/font/lv_font_loader.c
@@ -263,7 +263,7 @@ static bool load_cmaps_tables(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_ds
 
         switch(cmap_table[i].format_type) {
             case LV_FONT_FMT_TXT_CMAP_FORMAT0_FULL: {
-                    uint8_t ids_size = sizeof(uint8_t) * cmap_table[i].data_entries_count;
+                    uint8_t ids_size = (uint8_t)(sizeof(uint8_t) * cmap_table[i].data_entries_count);
                     uint8_t * glyph_id_ofs_list = lv_malloc(ids_size);
 
                     cmap->glyph_id_ofs_list = glyph_id_ofs_list;
@@ -507,8 +507,8 @@ static bool lvgl_load_font(lv_fs_file_t * fp, lv_font_t * font)
     font->get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt;
     font->get_glyph_bitmap = lv_font_get_bitmap_fmt_txt;
     font->subpx = font_header.subpixels_mode;
-    font->underline_position = font_header.underline_position;
-    font->underline_thickness = font_header.underline_thickness;
+    font->underline_position = (uint8_t)font_header.underline_position;
+    font->underline_thickness = (uint8_t)font_header.underline_thickness;
 
     font_dsc->bpp = font_header.bits_per_pixel;
     font_dsc->kern_scale = font_header.kerning_scale;

--- a/src/layouts/lv_layout.c
+++ b/src/layouts/lv_layout.c
@@ -63,7 +63,7 @@ uint32_t lv_layout_register(lv_layout_update_cb_t cb, void * user_data)
 void _lv_layout_apply(lv_obj_t * obj)
 {
     lv_layout_t layout_id = lv_obj_get_style_layout(obj, LV_PART_MAIN);
-    if(layout_id > 0 && layout_id <= layout_cnt) {
+    if(layout_id > 0 && layout_id <= (lv_layout_t)layout_cnt) {
         void  * user_data = layout_list_def[layout_id].user_data;
         layout_list_def[layout_id].cb(obj, user_data);
     }

--- a/src/libs/tjpgd/tjpgd.c
+++ b/src/libs/tjpgd/tjpgd.c
@@ -977,7 +977,7 @@ JRESULT jd_prepare(
         len = LDB_WORD(seg + 2);    /* Length field */
         if(len <= 2 || (marker >> 8) != 0xFF) return JDR_FMT1;
         len -= 2;           /* Segent content size */
-        ofs += 4 + len;     /* Number of bytes loaded */
+        ofs += (unsigned int)(4 + len);     /* Number of bytes loaded */
 
         switch(marker & 0xFF) {
             case 0xC0:  /* SOF0 (baseline JPEG) */

--- a/src/misc/lv_cache_builtin.c
+++ b/src/misc/lv_cache_builtin.c
@@ -91,7 +91,7 @@ static lv_cache_entry_t * add_cb(size_t size)
 
     lv_cache_entry_t * entry = _lv_ll_ins_head(&dsc.entry_ll);
     lv_memzero(entry, sizeof(lv_cache_entry_t));
-    entry->data_size = size;
+    entry->data_size = (uint32_t)size;
     entry->weight = 1;
     entry->temporary = temporary;
 
@@ -100,7 +100,7 @@ static lv_cache_entry_t * add_cb(size_t size)
     }
     else {
         LV_TRACE_CACHE("Add cache: %lu bytes", (unsigned long)size);
-        dsc.cur_size += size;
+        dsc.cur_size += (uint32_t)size;
     }
 
     return entry;

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -199,7 +199,7 @@ lv_lru_res_t lv_lru_get(lv_lru_t * cache, const void * key, size_t key_size, voi
     uint32_t hash_index = lv_lru_hash(cache, key, (uint32_t)key_size);
     lv_lru_item_t * item = cache->items[hash_index];
 
-    while(item && lv_lru_cmp_keys(item, key,(uint32_t)key_size))
+    while(item && lv_lru_cmp_keys(item, key, (uint32_t)key_size))
         item = (lv_lru_item_t *) item->next;
 
     if(item) {

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -145,12 +145,12 @@ lv_lru_res_t lv_lru_set(lv_lru_t * cache, const void * key, size_t key_length, v
     test_for_value_too_large();
 
     // see if the key already exists
-    uint32_t hash_index = lv_lru_hash(cache, key, key_length);
+    uint32_t hash_index = lv_lru_hash(cache, key, (uint32_t)key_length);
     int required = 0;
     lv_lru_item_t * item = NULL, * prev = NULL;
     item = cache->items[hash_index];
 
-    while(item && lv_lru_cmp_keys(item, key, key_length)) {
+    while(item && lv_lru_cmp_keys(item, key, (uint32_t)key_length)) {
         prev = item;
         item = (lv_lru_item_t *) item->next;
     }
@@ -196,10 +196,10 @@ lv_lru_res_t lv_lru_get(lv_lru_t * cache, const void * key, size_t key_size, voi
     test_for_missing_key();
 
     // loop until we find the item, or hit the end of a chain
-    uint32_t hash_index = lv_lru_hash(cache, key, key_size);
+    uint32_t hash_index = lv_lru_hash(cache, key, (uint32_t)key_size);
     lv_lru_item_t * item = cache->items[hash_index];
 
-    while(item && lv_lru_cmp_keys(item, key, key_size))
+    while(item && lv_lru_cmp_keys(item, key,(uint32_t)key_size))
         item = (lv_lru_item_t *) item->next;
 
     if(item) {
@@ -220,10 +220,10 @@ lv_lru_res_t lv_lru_remove(lv_lru_t * cache, const void * key, size_t key_size)
 
     // loop until we find the item, or hit the end of a chain
     lv_lru_item_t * item = NULL, * prev = NULL;
-    uint32_t hash_index = lv_lru_hash(cache, key, key_size);
+    uint32_t hash_index = lv_lru_hash(cache, key, (uint32_t)key_size);
     item = cache->items[hash_index];
 
-    while(item && lv_lru_cmp_keys(item, key, key_size)) {
+    while(item && lv_lru_cmp_keys(item, key, (uint32_t)key_size)) {
         prev = item;
         item = (lv_lru_item_t *) item->next;
     }

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -218,7 +218,7 @@ lv_style_prop_t lv_style_register_prop(uint8_t flag)
             return LV_STYLE_PROP_INV;
         }
         _lv_style_custom_prop_flag_lookup_table = new_p;
-        _lv_style_custom_prop_flag_lookup_table_size = required_size;
+        _lv_style_custom_prop_flag_lookup_table_size = (uint32_t)required_size;
     }
     last_custom_prop_id++;
     /* This should never happen - we should bail out above */

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -140,7 +140,7 @@ void * lv_malloc_core(size_t size)
 #if LV_USE_OS
     lv_mutex_lock(&state.mutex);
 #endif
-    state.cur_used += size;
+    state.cur_used += (uint32_t)size;
     state.max_used = LV_MAX(state.cur_used, state.max_used);
     void * p = lv_tlsf_malloc(state.tlsf, size);
 
@@ -175,7 +175,7 @@ void lv_free_core(void * p)
     lv_memset(p, 0xbb, lv_tlsf_block_size(data));
 #endif
     size_t size = lv_tlsf_free(state.tlsf, p);
-    if(state.cur_used > size) state.cur_used -= size;
+    if(state.cur_used > size) state.cur_used -= (uint32_t)size;
     else state.cur_used = 0;
 
 #if LV_USE_OS
@@ -249,15 +249,15 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user)
     LV_UNUSED(ptr);
 
     lv_mem_monitor_t * mon_p = user;
-    mon_p->total_size += size;
+    mon_p->total_size += (uint32_t)size;
     if(used) {
         mon_p->used_cnt++;
     }
     else {
         mon_p->free_cnt++;
-        mon_p->free_size += size;
+        mon_p->free_size += (uint32_t)size;
         if(size > mon_p->free_biggest_size)
-            mon_p->free_biggest_size = size;
+            mon_p->free_biggest_size = (uint32_t)size;
     }
 }
 #endif /*LV_USE_BUILTIN_MALLOC*/

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -71,7 +71,7 @@ void lv_animimg_set_src(lv_obj_t * obj, const void * dsc[], size_t num)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
     animimg->dsc = dsc;
-    animimg->pic_count = num;
+    animimg->pic_count = (int8_t)num;
     lv_anim_set_values(&animimg->anim, 0, (int32_t)num - 1);
 }
 

--- a/src/widgets/calendar/lv_calendar.c
+++ b/src/widgets/calendar/lv_calendar.c
@@ -133,7 +133,7 @@ void lv_calendar_set_showed_date(lv_obj_t * obj, uint32_t year, uint32_t month)
     uint8_t act_mo_len = get_month_length(d.year, d.month);
     uint8_t day_first = get_day_of_week(d.year, d.month, 1);
     uint8_t c;
-    for(i = day_first, c = 1; i < act_mo_len + day_first; i++, c++) {
+    for(i = day_first, c = 1; i < (uint32_t)(act_mo_len + day_first); i++, c++) {
         lv_snprintf(calendar->nums[i], sizeof(calendar->nums[0]), "%d", c);
     }
 

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -223,7 +223,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     dropdown->options[old_len] = '\0';
 
     /*Find the insert character position*/
-    uint32_t insert_pos = old_len;
+    uint32_t insert_pos = (uint32_t)old_len;
     if(pos != LV_DROPDOWN_POS_LAST) {
         uint32_t opcnt = 0;
         for(insert_pos = 0; dropdown->options[insert_pos] != 0; insert_pos++) {

--- a/src/widgets/imgbtn/lv_imgbtn.c
+++ b/src/widgets/imgbtn/lv_imgbtn.c
@@ -204,7 +204,7 @@ static void lv_imgbtn_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(imgbtn->src_left[state].img_src == NULL &&
            imgbtn->src_mid[state].img_src != NULL &&
            imgbtn->src_right[state].img_src == NULL) {
-            p->x = LV_MAX(p->x, imgbtn->src_mid[state].header.w);
+            p->x = LV_MAX((uint32_t)p->x, imgbtn->src_mid[state].header.w);
         }
     }
 }

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -924,7 +924,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
             }
             if(txt_pos.y + max_line_h + next_line_h - line_space > coords.y2 + 1) { /* for overflow if is end line. */
                 if(last_snippet->txt[last_snippet->bytes] != '\0') {
-                    last_snippet->bytes = lv_strlen(last_snippet->txt);
+                    last_snippet->bytes = (uint32_t)lv_strlen(last_snippet->txt);
                     last_snippet->txt_w = lv_text_get_width(last_snippet->txt, last_snippet->bytes, last_snippet->font,
                                                             last_snippet->letter_space);
                 }

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -113,8 +113,8 @@ void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t 
 
     if(digit_count < LV_SPINBOX_MAX_DIGIT_COUNT) {
         const int64_t max_val = lv_pow(10, digit_count);
-        if(spinbox->range_max > max_val - 1) spinbox->range_max = max_val - 1;
-        if(spinbox->range_min < -max_val  + 1) spinbox->range_min = -max_val  + 1;
+        if(spinbox->range_max > max_val - 1) spinbox->range_max = (int32_t)(max_val - 1);
+        if(spinbox->range_min < -max_val  + 1) spinbox->range_min = (int32_t)(-max_val  + 1);
     }
 
     spinbox->digit_count   = digit_count;
@@ -168,7 +168,7 @@ void lv_spinbox_set_cursor_pos(lv_obj_t * obj, uint32_t pos)
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     const int32_t step_limit = LV_MAX(spinbox->range_max, LV_ABS(spinbox->range_min));
-    const int32_t new_step = lv_pow(10, pos);
+    const int32_t new_step = (const int32_t)lv_pow(10, pos);
 
     if(pos <= 0) spinbox->step = 1;
     else if(new_step <= step_limit) spinbox->step = new_step;
@@ -383,7 +383,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
                     }
                     else {
                         /*Restart from the MSB*/
-                        spinbox->step = lv_pow(10, spinbox->digit_count - 2);
+                        spinbox->step = (int32_t)lv_pow(10, spinbox->digit_count - 2);
                         lv_spinbox_step_prev(obj);
                     }
                 }
@@ -412,7 +412,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
             /* Cursor is already in the right-most digit */
             else if(spinbox->ta.cursor.pos == (uint32_t)txt_len) {
-                lv_textarea_set_cursor_pos(obj, txt_len - 1);
+                lv_textarea_set_cursor_pos(obj, (int32_t)(txt_len - 1));
             }
             /* Cursor is already in the left-most digit AND range_min is negative */
             else if(spinbox->ta.cursor.pos == 0 && spinbox->range_min < 0) {
@@ -424,7 +424,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
             if(spinbox->ta.cursor.pos > spinbox->dec_point_pos && spinbox->dec_point_pos != 0) cp--;
 
             const size_t len = spinbox->digit_count - 1;
-            uint32_t pos = len - cp;
+            uint32_t pos = (uint32_t)(len - cp);
 
             if(spinbox->range_min < 0) pos++;
 
@@ -488,7 +488,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     int32_t i;
     const size_t digits_len = lv_strlen(digits);
 
-    const int leading_zeros_cnt = spinbox->digit_count - digits_len;
+    const int leading_zeros_cnt = (const int)(spinbox->digit_count - digits_len);
     if(leading_zeros_cnt) {
         for(i = (int32_t) digits_len; i >= 0; i--) {
             digits[i + leading_zeros_cnt] = digits[i];
@@ -511,7 +511,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
         (*buf_p) = '.';
         buf_p++;
 
-        for(/*Leave i*/; i < spinbox->digit_count && digits[i] != '\0'; i++) {
+        for(/*Leave i*/; i < (int32_t)(spinbox->digit_count && digits[i] != '\0'); i++) {
             (*buf_p) = digits[i];
             buf_p++;
         }


### PR DESCRIPTION

### Description of the feature or fix

There was a large assortment of compiler warnings when compiling under MSVC. This PR fixes those warnings.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
