### PR TITLE
feat(stdlib): add and use lv_malloc_zeroed

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -262,11 +262,9 @@ void lv_obj_allocate_spec_attr(lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     if(obj->spec_attr == NULL) {
-        obj->spec_attr = lv_malloc(sizeof(_lv_obj_spec_attr_t));
+        obj->spec_attr = lv_malloc_zeroed(sizeof(_lv_obj_spec_attr_t));
         LV_ASSERT_MALLOC(obj->spec_attr);
         if(obj->spec_attr == NULL) return;
-
-        lv_memzero(obj->spec_attr, sizeof(_lv_obj_spec_attr_t));
 
         obj->spec_attr->scroll_dir = LV_DIR_ALL;
         obj->spec_attr->scrollbar_mode = LV_SCROLLBAR_MODE_AUTO;
@@ -728,8 +726,7 @@ static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
     obj->state = new_state;
 
 
-    _lv_obj_style_transition_dsc_t * ts = lv_malloc(sizeof(_lv_obj_style_transition_dsc_t) * STYLE_TRANSITION_MAX);
-    lv_memzero(ts, sizeof(_lv_obj_style_transition_dsc_t) * STYLE_TRANSITION_MAX);
+    _lv_obj_style_transition_dsc_t * ts = lv_malloc_zeroed(sizeof(_lv_obj_style_transition_dsc_t) * STYLE_TRANSITION_MAX);
     uint32_t tsi = 0;
     uint32_t i;
     for(i = 0; i < obj->style_cnt && tsi < STYLE_TRANSITION_MAX; i++) {

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -47,9 +47,8 @@ lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * pa
 {
     LV_TRACE_OBJ_CREATE("Creating object with %p class on %p parent", (void *)class_p, (void *)parent);
     uint32_t s = get_instance_size(class_p);
-    lv_obj_t * obj = lv_malloc(s);
+    lv_obj_t * obj = lv_malloc_zeroed(s);
     if(obj == NULL) return NULL;
-    lv_memzero(obj, s);
     obj->class_p = class_p;
     obj->parent = parent;
 

--- a/src/dev/display/drm/lv_linux_drm.c
+++ b/src/dev/display/drm/lv_linux_drm.c
@@ -110,10 +110,9 @@ static void drm_flush(lv_display_t * disp, const lv_area_t * area, uint8_t * px_
 
 lv_display_t * lv_linux_drm_create(void)
 {
-    drm_dev_t * drm_dev = lv_malloc(sizeof(drm_dev_t));
+    drm_dev_t * drm_dev = lv_malloc_zeroed(sizeof(drm_dev_t));
     LV_ASSERT_MALLOC(drm_dev);
     if(drm_dev == NULL) return NULL;
-    lv_memzero(drm_dev, sizeof(drm_dev_t));
 
     lv_display_t * disp = lv_display_create(800, 480);
     if(disp == NULL) {

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -91,10 +91,9 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
 
 lv_display_t * lv_linux_fbdev_create(void)
 {
-    lv_linux_fb_t * dsc = lv_malloc(sizeof(lv_linux_fb_t));
+    lv_linux_fb_t * dsc = lv_malloc_zeroed(sizeof(lv_linux_fb_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_linux_fb_t));
 
     lv_display_t * disp = lv_display_create(800, 480);
     if(disp == NULL) {

--- a/src/dev/display/tft_espi/lv_tft_espi.cpp
+++ b/src/dev/display/tft_espi/lv_tft_espi.cpp
@@ -41,10 +41,9 @@ static void flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t * colo
 
 lv_disp_t * lv_tft_espi_create(uint32_t hor_res, uint32_t ver_res, void * buf, uint32_t buf_size_bytes)
 {
-    lv_tft_espi_t * dsc = (lv_tft_espi_t *)lv_malloc(sizeof(lv_tft_espi_t));
+    lv_tft_espi_t * dsc = lv_malloc_zeroed(sizeof(lv_tft_espi_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_tft_espi_t));
 
     lv_disp_t * disp = lv_disp_create(hor_res, ver_res);
     if(disp == NULL) {

--- a/src/dev/evdev/lv_evdev.c
+++ b/src/dev/evdev/lv_evdev.c
@@ -164,10 +164,9 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
 
 lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path)
 {
-    lv_evdev_t * dsc = lv_malloc(sizeof(lv_evdev_t));
+    lv_evdev_t * dsc = lv_malloc_zeroed(sizeof(lv_evdev_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_evdev_t));
 
     dsc->fd = open(dev_path, O_RDONLY | O_NOCTTY | O_CLOEXEC);
     if(dsc->fd < 0) {

--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -64,10 +64,9 @@ static void _display_refr_timer_cb(lv_timer_t * tmr);
 
 lv_display_t * lv_nuttx_fbdev_create(void)
 {
-    lv_nuttx_fb_t * dsc = lv_malloc(sizeof(lv_nuttx_fb_t));
+    lv_nuttx_fb_t * dsc = lv_malloc_zeroed(sizeof(lv_nuttx_fb_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_nuttx_fb_t));
 
     lv_display_t * disp = lv_display_create(800, 480);
     if(disp == NULL) {
@@ -154,7 +153,7 @@ static void _display_refr_timer_cb(lv_timer_t * tmr)
     lv_nuttx_fb_t * dsc = lv_display_get_driver_data(disp);
     struct pollfd pfds[1];
 
-    lv_memset(pfds, 0, sizeof(pfds));
+    lv_memzero(pfds, sizeof(pfds));
     pfds[0].fd = dsc->fd;
     pfds[0].events = POLLOUT;
 
@@ -250,7 +249,7 @@ static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
     struct fb_planeinfo_s pinfo;
     int ret;
 
-    lv_memset(&pinfo, 0, sizeof(pinfo));
+    lv_memzero(&pinfo, sizeof(pinfo));
 
     /* Get display[1] planeinfo */
 

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -151,13 +151,12 @@ static lv_display_t * lcd_init(int fd, int hor_res, int ver_res)
 {
     lv_color_t * draw_buf = NULL;
     lv_color_t * draw_buf_2 = NULL;
-    lv_nuttx_lcd_t * lcd = lv_malloc(sizeof(lv_nuttx_lcd_t));
+    lv_nuttx_lcd_t * lcd = lv_malloc_zeroed(sizeof(lv_nuttx_lcd_t));
     LV_ASSERT_MALLOC(lcd);
     if(lcd == NULL) {
         LV_LOG_ERROR("lv_nuttx_lcd_t malloc failed");
         return NULL;
     }
-    lv_memzero(lcd, sizeof(lv_nuttx_lcd_t));
 
     lv_display_t * disp = lv_display_create(hor_res, ver_res);
     if(disp == NULL) {

--- a/src/dev/nuttx/lv_nuttx_libuv.c
+++ b/src/dev/nuttx/lv_nuttx_libuv.c
@@ -75,10 +75,9 @@ void * lv_nuttx_uv_init(lv_nuttx_uv_t * uv_info)
     lv_nuttx_uv_ctx_t * uv_ctx;
     int ret;
 
-    uv_ctx = lv_malloc(sizeof(lv_nuttx_uv_ctx_t));
+    uv_ctx = lv_malloc_zeroed(sizeof(lv_nuttx_uv_ctx_t));
     LV_ASSERT_MALLOC(uv_ctx);
     if(uv_ctx == NULL) return NULL;
-    lv_memset(uv_ctx, 0, sizeof(lv_nuttx_uv_ctx_t));
 
     if((ret = lv_nuttx_uv_timer_init(uv_info, uv_ctx)) < 0) {
         LV_LOG_ERROR("lv_nuttx_uv_timer_init fail : %d", ret);

--- a/src/dev/sdl/lv_sdl_keyboard.c
+++ b/src/dev/sdl/lv_sdl_keyboard.c
@@ -42,10 +42,9 @@ static uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key);
 
 lv_indev_t * lv_sdl_keyboard_create(void)
 {
-    lv_sdl_keyboard_t * dsc = lv_malloc(sizeof(lv_sdl_keyboard_t));
+    lv_sdl_keyboard_t * dsc = lv_malloc_zeroed(sizeof(lv_sdl_keyboard_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_sdl_keyboard_t));
 
     lv_indev_t * indev = lv_indev_create();
     LV_ASSERT_MALLOC(indev);

--- a/src/dev/sdl/lv_sdl_mouse.c
+++ b/src/dev/sdl/lv_sdl_mouse.c
@@ -42,10 +42,9 @@ typedef struct {
 
 lv_indev_t * lv_sdl_mouse_create(void)
 {
-    lv_sdl_mouse_t * dsc = lv_malloc(sizeof(lv_sdl_mouse_t));
+    lv_sdl_mouse_t * dsc = lv_malloc_zeroed(sizeof(lv_sdl_mouse_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_sdl_mouse_t));
 
     lv_indev_t * indev = lv_indev_create();
     LV_ASSERT_MALLOC(indev);

--- a/src/dev/sdl/lv_sdl_mousewheel.c
+++ b/src/dev/sdl/lv_sdl_mousewheel.c
@@ -38,10 +38,9 @@ typedef struct {
 
 lv_indev_t * lv_sdl_mousewheel_create(void)
 {
-    lv_sdl_mousewheel_t * dsc = lv_malloc(sizeof(lv_sdl_mousewheel_t));
+    lv_sdl_mousewheel_t * dsc = lv_malloc_zeroed(sizeof(lv_sdl_mousewheel_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_sdl_mousewheel_t));
 
     lv_indev_t * indev = lv_indev_create();
     if(indev == NULL) {

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -78,10 +78,9 @@ lv_display_t * lv_sdl_window_create(int32_t hor_res, int32_t ver_res)
         inited = true;
     }
 
-    lv_sdl_window_t * dsc = lv_malloc(sizeof(lv_sdl_window_t));
+    lv_sdl_window_t * dsc = lv_malloc_zeroed(sizeof(lv_sdl_window_t));
     LV_ASSERT_MALLOC(dsc);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, sizeof(lv_sdl_window_t));
 
     lv_display_t * disp = lv_display_create(hor_res, ver_res);
     if(disp == NULL) {

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -72,10 +72,9 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
     disp->dpi              = LV_DPI_DEF;
     disp->color_format = LV_COLOR_FORMAT_NATIVE;
 
-    disp->layer_head = lv_malloc(sizeof(lv_layer_t));
+    disp->layer_head = lv_malloc_zeroed(sizeof(lv_layer_t));
     LV_ASSERT_MALLOC(disp->layer_head);
     if(disp->layer_head == NULL) return NULL;
-    lv_memzero(disp->layer_head, sizeof(lv_layer_t));
 
     if(disp->layer_init) disp->layer_init(disp, disp->layer_head);
     disp->layer_head->buf_area.x1 = 0;

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -52,8 +52,7 @@ void lv_draw_init(void)
 
 void * lv_draw_create_unit(size_t size)
 {
-    lv_draw_unit_t * new_unit = lv_malloc(size);
-    lv_memzero(new_unit, size);
+    lv_draw_unit_t * new_unit = lv_malloc_zeroed(size);
 
     new_unit->next = _draw_info.unit_head;
     _draw_info.unit_head = new_unit;
@@ -64,8 +63,7 @@ void * lv_draw_create_unit(size_t size)
 lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords)
 {
     LV_PROFILER_BEGIN;
-    lv_draw_task_t * new_task = lv_malloc(sizeof(lv_draw_task_t));
-    lv_memzero(new_task, sizeof(*new_task));
+    lv_draw_task_t * new_task = lv_malloc_zeroed(sizeof(lv_draw_task_t));
 
     new_task->area = *coords;
     new_task->clip_area = layer->clip_area;
@@ -313,10 +311,9 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
 lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t color_format, const lv_area_t * area)
 {
     lv_display_t * disp = _lv_refr_get_disp_refreshing();
-    lv_layer_t * new_layer = lv_malloc(sizeof(lv_layer_t));
+    lv_layer_t * new_layer = lv_malloc_zeroed(sizeof(lv_layer_t));
     LV_ASSERT_MALLOC(new_layer);
     if(new_layer == NULL) return NULL;
-    lv_memzero(new_layer, sizeof(lv_layer_t));
 
     new_layer->parent = parent_layer;
     new_layer->clip_area = *area;

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -338,14 +338,13 @@ static lv_image_decoder_built_in_data_t * get_decoder_data(lv_image_decoder_dsc_
 {
     lv_image_decoder_built_in_data_t * data = dsc->user_data;
     if(data == NULL) {
-        data = lv_malloc(sizeof(lv_image_decoder_built_in_data_t));
+        data = lv_malloc_zeroed(sizeof(lv_image_decoder_built_in_data_t));
         LV_ASSERT_MALLOC(data);
         if(data == NULL) {
             LV_LOG_ERROR("out of memory");
             return NULL;
         }
 
-        lv_memzero(data, sizeof(lv_image_decoder_built_in_data_t));
         dsc->user_data = data;
     }
 
@@ -581,7 +580,7 @@ lv_result_t lv_image_decoder_built_in_open(lv_image_decoder_t * decoder, lv_imag
 
         if(res != LV_RESULT_OK) {
             lv_fs_close(&f);
-            lv_memset(&decoder_data->f, 0, sizeof(decoder_data->f));
+            lv_memzero(&decoder_data->f, sizeof(decoder_data->f));
         }
 
         return res;

--- a/src/draw/nxp/vglite/lv_draw_vglite_arc.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_arc.c
@@ -572,7 +572,7 @@ static void _vglite_draw_arc(const lv_point_t * center, const lv_area_t * clip_a
 
     /* path: max size = 16 cubic bezier (7 words each) */
     int32_t arc_path[16 * 7];
-    lv_memset(arc_path, 0, sizeof(arc_path));
+    lv_memzero(arc_path, sizeof(arc_path));
 
     /*** Init path ***/
     int32_t width = dsc->width;  /* inner arc radius = outer arc radius - width */

--- a/src/draw/nxp/vglite/lv_draw_vglite_fill.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_fill.c
@@ -212,7 +212,7 @@ static void _vglite_draw_rect(const lv_area_t * coords, const lv_area_t * clip_a
             colors[i] = vglite_get_color(col32[i], true);
         }
 
-        lv_memset(&gradient, 0, sizeof(vg_lite_linear_gradient_t));
+        lv_memzero(&gradient, sizeof(vg_lite_linear_gradient_t));
 
         err = vg_lite_init_grad(&gradient);
         LV_ASSERT_MSG(err == VG_LITE_SUCCESS, "Init gradient failed");

--- a/src/draw/nxp/vglite/lv_draw_vglite_label.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_label.c
@@ -175,7 +175,7 @@ static void _vglite_draw_letter(const lv_area_t * dest_area,
     mask_vgbuf.height = (int32_t)lv_area_get_height(mask_area);
     mask_vgbuf.stride = (int32_t)mask_stride;
 
-    lv_memset(&mask_vgbuf.yuv, 0, sizeof(mask_vgbuf.yuv));
+    lv_memzero(&mask_vgbuf.yuv, sizeof(mask_vgbuf.yuv));
 
     mask_vgbuf.memory = (void *)mask_buf;
     mask_vgbuf.address = (uint32_t)mask_vgbuf.memory;

--- a/src/draw/nxp/vglite/lv_vglite_buf.c
+++ b/src/draw/nxp/vglite/lv_vglite_buf.c
@@ -97,7 +97,7 @@ void vglite_set_buf(vg_lite_buffer_t * vgbuf, void * buf,
     vgbuf->height = (int32_t)height;
     vgbuf->stride = (int32_t)stride;
 
-    lv_memset(&vgbuf->yuv, 0, sizeof(vgbuf->yuv));
+    lv_memzero(&vgbuf->yuv, sizeof(vgbuf->yuv));
 
     vgbuf->memory = buf;
     vgbuf->address = (uint32_t)vgbuf->memory;

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -379,9 +379,8 @@ void lv_draw_sw_mask_radius_init(lv_draw_sw_mask_radius_param_t * param, const l
 
     /*There is no unused entry. Allocate one temporarily*/
     if(!entry) {
-        entry = lv_malloc(sizeof(_lv_draw_sw_mask_radius_circle_dsc_t));
+        entry = lv_malloc_zeroed(sizeof(_lv_draw_sw_mask_radius_circle_dsc_t));
         LV_ASSERT_MALLOC(entry);
-        lv_memzero(entry, sizeof(_lv_draw_sw_mask_radius_circle_dsc_t));
         entry->life = -1;
     }
     else {
@@ -1152,8 +1151,7 @@ static void circ_calc_aa4(_lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t radi
     }
 
     const size_t cir_xy_size = (radius + 1) * 2 * 2 * sizeof(int32_t);
-    int32_t * cir_x = lv_malloc(cir_xy_size);
-    lv_memset(cir_x, 0, cir_xy_size);
+    int32_t * cir_x = lv_malloc_zeroed(cir_xy_size);
     int32_t * cir_y = &cir_x[(radius + 1) * 2];
 
     uint32_t y_8th_cnt = 0;

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -172,13 +172,12 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint16_t size, uint16
     }
 
     size_t need_size = sizeof(lv_freetype_font_dsc_t) + sizeof(lv_font_t);
-    lv_freetype_font_dsc_t * dsc = lv_malloc(need_size);
+    lv_freetype_font_dsc_t * dsc = lv_malloc_zeroed(need_size);
     LV_ASSERT_MALLOC(dsc);
     if(!dsc) {
         LV_LOG_ERROR("malloc failed for lv_freetype_font_dsc");
         return NULL;
     }
-    lv_memzero(dsc, need_size);
 
     dsc->font = (lv_font_t *)(((uint8_t *)dsc) + sizeof(lv_freetype_font_dsc_t));
 

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -11,8 +11,6 @@
 #define STBTT_HEAP_FACTOR_SIZE_DEFAULT 10
 #define STBTT_malloc(x, u) ((void)(u), lv_malloc(x))
 #define STBTT_free(x, u) ((void)(u), lv_free(x))
-#define TTF_MALLOC(x) (lv_malloc(x))
-#define TTF_FREE(x) (lv_free(x))
 
 #if LV_TINY_TTF_FILE_SUPPORT != 0
 /* a hydra stream that can be in memory or from a file*/
@@ -183,7 +181,7 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
         LV_LOG_ERROR("tiny_ttf: invalid argument\n");
         return NULL;
     }
-    ttf_font_desc_t * dsc = (ttf_font_desc_t *)TTF_MALLOC(sizeof(ttf_font_desc_t));
+    ttf_font_desc_t * dsc = lv_malloc_zeroed(sizeof(ttf_font_desc_t));
     if(dsc == NULL) {
         LV_LOG_ERROR("tiny_ttf: out of memory\n");
         return NULL;
@@ -191,21 +189,18 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
 #if LV_TINY_TTF_FILE_SUPPORT != 0
     if(path != NULL) {
         if(LV_FS_RES_OK != lv_fs_open(&dsc->file, path, LV_FS_MODE_RD)) {
-            TTF_FREE(dsc);
+            lv_free(dsc);
             LV_LOG_ERROR("tiny_ttf: unable to open %s\n", path);
             return NULL;
         }
         dsc->stream.file = &dsc->file;
     }
     else {
-        dsc->stream.file = NULL;
         dsc->stream.data = (const uint8_t *)data;
         dsc->stream.size = data_size;
-        dsc->stream.position = 0;
     }
     if(0 == stbtt_InitFont(&dsc->info, &dsc->stream, stbtt_GetFontOffsetForIndex(&dsc->stream, 0))) {
-        TTF_FREE(dsc);
-
+        lv_free(dsc);
         LV_LOG_ERROR("tiny_ttf: init failed\n");
         return NULL;
     }
@@ -213,19 +208,18 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
 #else
     dsc->stream = (const uint8_t *)data;
     if(0 == stbtt_InitFont(&dsc->info, dsc->stream, stbtt_GetFontOffsetForIndex(dsc->stream, 0))) {
-        TTF_FREE(dsc);
+        lv_free(dsc);
         LV_LOG_ERROR("tiny_ttf: init failed\n");
         return NULL;
     }
 #endif
 
-    lv_font_t * out_font = (lv_font_t *)TTF_MALLOC(sizeof(lv_font_t));
+    lv_font_t * out_font = lv_malloc_zeroed(sizeof(lv_font_t));
     if(out_font == NULL) {
-        TTF_FREE(dsc);
+        lv_free(dsc);
         LV_LOG_ERROR("tiny_ttf: out of memory\n");
         return NULL;
     }
-    lv_memzero(out_font, sizeof(lv_font_t));
     out_font->get_glyph_dsc = ttf_get_glyph_dsc_cb;
     out_font->get_glyph_bitmap = ttf_get_glyph_bitmap_cb;
     out_font->dsc = dsc;
@@ -273,9 +267,9 @@ void lv_tiny_ttf_destroy(lv_font_t * font)
                 lv_fs_close(&ttf->file);
             }
 #endif
-            TTF_FREE(ttf);
+            lv_free(ttf);
         }
-        TTF_FREE(font);
+        lv_free(font);
     }
 }
 #endif

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -68,7 +68,7 @@ static inline void lv_global_init(lv_global_t * global)
         return;
     }
 
-    lv_memset(global, 0, sizeof(lv_global_t));
+    lv_memzero(global, sizeof(lv_global_t));
 
     _lv_ll_init(&(global->disp_ll), sizeof(lv_display_t));
     _lv_ll_init(&(global->indev_ll), sizeof(lv_indev_t));

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -40,12 +40,8 @@ static void lv_anim_timeline_virtual_exec_cb(void * var, int32_t v);
 
 lv_anim_timeline_t * lv_anim_timeline_create(void)
 {
-    lv_anim_timeline_t * at = (lv_anim_timeline_t *)lv_malloc(sizeof(lv_anim_timeline_t));
-
+    lv_anim_timeline_t * at = lv_malloc_zeroed(sizeof(lv_anim_timeline_t));
     LV_ASSERT_MALLOC(at);
-
-    if(at) lv_memzero(at, sizeof(lv_anim_timeline_t));
-
     return at;
 }
 

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -99,9 +99,8 @@ lv_fs_res_t lv_fs_open(lv_fs_file_t * file_p, const char * path, lv_fs_mode_t mo
     }
 
     if(drv->cache_size) {
-        file_p->cache = lv_malloc(sizeof(lv_fs_file_cache_t));
+        file_p->cache = lv_malloc_zeroed(sizeof(lv_fs_file_cache_t));
         LV_ASSERT_MALLOC(file_p->cache);
-        lv_memzero(file_p->cache, sizeof(lv_fs_file_cache_t));
 
         /* If this is a memory-mapped file, then set "cache" to the memory buffer */
         if(drv->cache_size == LV_FS_CACHE_FROM_BUFFER) {

--- a/src/misc/lv_lru.c
+++ b/src/misc/lv_lru.c
@@ -75,8 +75,7 @@ lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_c
                          lv_lru_free_cb_t key_free)
 {
     // create the cache
-    lv_lru_t * cache = (lv_lru_t *) lv_malloc(sizeof(lv_lru_t));
-    lv_memzero(cache, sizeof(lv_lru_t));
+    lv_lru_t * cache = lv_malloc_zeroed(sizeof(lv_lru_t));
     if(!cache) {
         LV_LOG_WARN("LRU Cache unable to create cache object");
         return NULL;
@@ -90,8 +89,7 @@ lv_lru_t * lv_lru_create(size_t cache_size, size_t average_length, lv_lru_free_c
     cache->key_free = key_free ? key_free : lv_free;
 
     // size the hash table to a guestimate of the number of slots required (assuming a perfect hash)
-    cache->items = (lv_lru_item_t **) lv_malloc(sizeof(lv_lru_item_t *) * cache->hash_table_size);
-    lv_memzero(cache->items, sizeof(lv_lru_item_t *) * cache->hash_table_size);
+    cache->items = lv_malloc_zeroed(sizeof(lv_lru_item_t *) * cache->hash_table_size);
     if(!cache->items) {
         LV_LOG_WARN("LRU Cache unable to create cache hash table");
         lv_free(cache);
@@ -342,8 +340,7 @@ static lv_lru_item_t * lv_lru_pop_or_create_item(lv_lru_t * cache)
         lv_memzero(item, sizeof(lv_lru_item_t));
     }
     else {
-        item = (lv_lru_item_t *) lv_malloc(sizeof(lv_lru_item_t));
-        lv_memzero(item, sizeof(lv_lru_item_t));
+        item = lv_malloc_zeroed(sizeof(lv_lru_item_t));
     }
 
     return item;

--- a/src/others/fragment/lv_fragment.c
+++ b/src/others/fragment/lv_fragment.c
@@ -27,8 +27,7 @@ lv_fragment_t * lv_fragment_create(const lv_fragment_class_t * cls, void * args)
     LV_ASSERT_NULL(cls);
     LV_ASSERT_NULL(cls->create_obj_cb);
     LV_ASSERT(cls->instance_size >= sizeof(lv_fragment_t));
-    lv_fragment_t * instance = lv_malloc(cls->instance_size);
-    lv_memzero(instance, cls->instance_size);
+    lv_fragment_t * instance = lv_malloc_zeroed(cls->instance_size);
     instance->cls = cls;
     instance->child_manager = lv_fragment_manager_create(instance);
     if(cls->constructor_cb) {

--- a/src/others/fragment/lv_fragment_manager.c
+++ b/src/others/fragment/lv_fragment_manager.c
@@ -65,8 +65,7 @@ static lv_fragment_managed_states_t * fragment_attach(lv_fragment_manager_t * ma
 
 lv_fragment_manager_t * lv_fragment_manager_create(lv_fragment_t * parent)
 {
-    lv_fragment_manager_t * instance = lv_malloc(sizeof(lv_fragment_manager_t));
-    lv_memzero(instance, sizeof(lv_fragment_manager_t));
+    lv_fragment_manager_t * instance = lv_malloc_zeroed(sizeof(lv_fragment_manager_t));
     instance->parent = parent;
     _lv_ll_init(&instance->attached, sizeof(lv_fragment_managed_states_t));
     _lv_ll_init(&instance->stack, sizeof(lv_fragment_stack_item_t));

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -51,9 +51,8 @@ lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_path_cb_t path_cb,
                   "LV_IMGFONT_PATH_MAX_LEN must be greater than sizeof(lv_image_dsc_t)");
 
     size_t size = sizeof(imgfont_dsc_t) + sizeof(lv_font_t);
-    imgfont_dsc_t * dsc = (imgfont_dsc_t *)lv_malloc(size);
+    imgfont_dsc_t * dsc = lv_malloc_zeroed(size);
     if(dsc == NULL) return NULL;
-    lv_memzero(dsc, size);
 
     dsc->font = (lv_font_t *)(((char *)dsc) + sizeof(imgfont_dsc_t));
     dsc->path_cb = path_cb;

--- a/src/others/monkey/lv_monkey.c
+++ b/src/others/monkey/lv_monkey.c
@@ -64,10 +64,8 @@ void lv_monkey_config_init(lv_monkey_config_t * config)
 
 lv_monkey_t * lv_monkey_create(const lv_monkey_config_t * config)
 {
-    lv_monkey_t * monkey = lv_malloc(sizeof(lv_monkey_t));
+    lv_monkey_t * monkey = lv_malloc_zeroed(sizeof(lv_monkey_t));
     LV_ASSERT_MALLOC(monkey);
-
-    lv_memzero(monkey, sizeof(lv_monkey_t));
 
     monkey->config = *config;
     monkey->timer = lv_timer_create(lv_monkey_timer_cb, monkey->config.period_range.min, monkey);

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -186,7 +186,7 @@ void lv_free_core(void * p)
 void lv_mem_monitor_core(lv_mem_monitor_t * mon_p)
 {
     /*Init the data*/
-    lv_memset(mon_p, 0, sizeof(lv_mem_monitor_t));
+    lv_memzero(mon_p, sizeof(lv_mem_monitor_t));
     LV_TRACE_MEM("begin");
 
     lv_pool_t * pool_p;

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -83,8 +83,8 @@ void * lv_malloc(size_t size)
         LV_LOG_INFO("used: %6d (%3d %%), frag: %3d %%, biggest free: %6d",
                     (int)(mon.total_size - mon.free_size), mon.used_pct, mon.frag_pct,
                     (int)mon.free_biggest_size);
-        return NULL;
 #endif
+        return NULL;
     }
 
 #if LV_MEM_ADD_JUNK
@@ -92,7 +92,33 @@ void * lv_malloc(size_t size)
 #endif
 
     LV_TRACE_MEM("allocated at %p", alloc);
+    return alloc;
+}
 
+void * lv_malloc_zeroed(size_t size)
+{
+    LV_TRACE_MEM("allocating %lu bytes", (unsigned long)size);
+    if(size == 0) {
+        LV_TRACE_MEM("using zero_mem");
+        return &zero_mem;
+    }
+
+    void * alloc = lv_malloc_core(size);
+    if(alloc == NULL) {
+        LV_LOG_INFO("couldn't allocate memory (%lu bytes)", (unsigned long)size);
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+        lv_mem_monitor_t mon;
+        lv_mem_monitor(&mon);
+        LV_LOG_INFO("used: %6d (%3d %%), frag: %3d %%, biggest free: %6d",
+                    (int)(mon.total_size - mon.free_size), mon.used_pct, mon.frag_pct,
+                    (int)mon.free_biggest_size);
+#endif
+        return NULL;
+    }
+
+    lv_memzero(alloc, size);
+
+    LV_TRACE_MEM("allocated at %p", alloc);
     return alloc;
 }
 
@@ -107,7 +133,6 @@ void lv_free(void * data)
     if(data == NULL) return;
 
     lv_free_core(data);
-
 }
 
 /**
@@ -151,7 +176,7 @@ lv_result_t lv_mem_test(void)
 
 void lv_mem_monitor(lv_mem_monitor_t * mon_p)
 {
-    lv_memset(mon_p, 0, sizeof(lv_mem_monitor_t));
+    lv_memzero(mon_p, sizeof(lv_mem_monitor_t));
     lv_mem_monitor_core(mon_p);
 }
 

--- a/src/stdlib/lv_mem.h
+++ b/src/stdlib/lv_mem.h
@@ -64,11 +64,18 @@ lv_mem_pool_t lv_mem_add_pool(void * mem, size_t bytes);
 void lv_mem_remove_pool(lv_mem_pool_t pool);
 
 /**
- * Allocate a memory dynamically
- * @param size size of the memory to allocate in bytes
- * @return pointer to the allocated memory
+ * Allocate memory dynamically
+ * @param size requested size in bytes
+ * @return pointer to allocated uninitialized memory, or NULL on failure
  */
 void * lv_malloc(size_t size);
+
+/**
+ * Allocate zeroed memory dynamically
+ * @param size requested size in bytes
+ * @return pointer to allocated zeroed memory, or NULL on failure
+ */
+void * lv_malloc_zeroed(size_t size);
 
 /**
  * Free an allocated data
@@ -91,8 +98,6 @@ void * lv_realloc(void * data_p, size_t new_size);
  * @param size      size in bytes to `malloc`
  */
 void * lv_malloc_core(size_t size);
-
-
 
 /**
  * Used internally to execute a plain `free` operation

--- a/src/themes/basic/lv_theme_basic.c
+++ b/src/themes/basic/lv_theme_basic.c
@@ -161,8 +161,7 @@ lv_theme_t * lv_theme_basic_init(lv_display_t * disp)
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_basic_is_inited()) {
-        theme_def  = (my_theme_t *)lv_malloc(sizeof(my_theme_t));
-        lv_memzero(theme_def, sizeof(my_theme_t));
+        theme_def  = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     struct _my_theme_t * theme = theme_def;

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -667,8 +667,7 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
      *In a general case styles could be in a simple `static lv_style_t my_style...` variables*/
 
     if(!lv_theme_default_is_inited()) {
-        theme_def = (my_theme_t *)lv_malloc(sizeof(my_theme_t));
-        lv_memzero(theme_def, sizeof(my_theme_t));
+        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     struct _my_theme_t * theme = theme_def;

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -198,8 +198,7 @@ lv_theme_t * lv_theme_mono_init(lv_display_t * disp, bool dark_bg, const lv_font
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_mono_is_inited()) {
-        theme_def = (my_theme_t *)lv_malloc(sizeof(my_theme_t));
-        lv_memzero(theme_def, sizeof(my_theme_t));
+        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     struct _my_theme_t * theme = theme_def;


### PR DESCRIPTION
`lv_malloc()` followed by `lv_memzero()` is a very common pattern. We could introduce `lv_calloc()` for brevity and to use:

* `calloc()` for `LV_STDLIB_CLIB`
* `m_malloc0()` for MicroPython