### PR TITLE
Try to fix a label bug.

### DIFF
--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -172,6 +172,31 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     lv_label_refr_text(obj);
 }
 
+void lv_label_set_text_vfmt(lv_obj_t * obj, const char* fmt, va_list args)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    LV_ASSERT_NULL(fmt);
+
+    lv_obj_invalidate(obj);
+    lv_label_t * label = (lv_label_t *)obj;
+
+    /*If text is NULL then refresh*/
+    if(fmt == NULL) {
+        lv_label_refr_text(obj);
+        return;
+    }
+
+    if(label->text != NULL && label->static_txt == 0) {
+        lv_mem_free(label->text);
+        label->text = NULL;
+    }
+
+    label->text = _lv_txt_set_text_vfmt(fmt, args);
+    label->static_txt = 0; /*Now the text is dynamically allocated*/
+
+    lv_label_refr_text(obj);
+}
+
 void lv_label_set_text_static(lv_obj_t * obj, const char * text)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -849,18 +849,10 @@ static void draw_main(lv_event_t * e)
         lv_area_move(&txt_coords, 0, -s);
         txt_coords.y2 = obj->coords.y2;
     }
-    if(label->long_mode == LV_LABEL_LONG_SCROLL || label->long_mode == LV_LABEL_LONG_SCROLL_CIRCULAR) {
-        const lv_area_t * clip_area_ori = draw_ctx->clip_area;
-        draw_ctx->clip_area = &txt_clip;
-        lv_draw_label(draw_ctx, &label_draw_dsc, &txt_coords, label->text, hint);
-        draw_ctx->clip_area = clip_area_ori;
-    }
-    else {
-        lv_draw_label(draw_ctx, &label_draw_dsc, &txt_coords, label->text, hint);
-    }
 
-    const lv_area_t * clip_area_ori = draw_ctx->clip_area;
+    const lv_area_t* clip_area_ori = draw_ctx->clip_area;
     draw_ctx->clip_area = &txt_clip;
+    lv_draw_label(draw_ctx, &label_draw_dsc, &txt_coords, label->text, hint);
 
     if(label->long_mode == LV_LABEL_LONG_SCROLL_CIRCULAR) {
         lv_point_t size;

--- a/src/widgets/lv_label.h
+++ b/src/widgets/lv_label.h
@@ -109,6 +109,15 @@ void lv_label_set_text(lv_obj_t * obj, const char * text);
 void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTRIBUTE(2, 3);
 
 /**
+ * Set a new formatted text for a label. Memory will be allocated to store the text by the label.
+ * It's also used for c++ binding when package a new format function.
+ * @param obj           pointer to a label object
+ * @param fmt           `printf`-like format
+ * @param args          argument list.
+ */
+void lv_label_set_text_vfmt(lv_obj_t * obj, const char* fmt, va_list args);
+
+/**
  * Set a static text. It will not be saved by the label so the 'text' variable
  * has to be 'alive' while the label exists.
  * @param obj           pointer to a label object


### PR DESCRIPTION
### Feature
- Add a interface for label, used for set a formated text with argument list.
 
### Fix
- Fix label text paint will overflow the border when long mode set to LV_LABEL_LONG_CLIP.
