### PR TITLE
fix(leak): fix memory leak on lv_demo_widgets

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -55,6 +55,8 @@ static void scroll_anim_y_cb(void * var, int32_t v);
 static void scroll_anim_y_cb(void * var, int32_t v);
 static void delete_timer_event_cb(lv_event_t * e);
 static void slideshow_anim_ready_cb(lv_anim_t * a_old);
+static void scale3_delete_event_cb(lv_event_t * e);
+static void tabview_delete_event_cb(lv_event_t * e);
 
 /**********************
  *  STATIC VARIABLES
@@ -87,6 +89,16 @@ static const lv_font_t * font_normal;
 static uint32_t session_desktop = 1000;
 static uint32_t session_tablet = 1000;
 static uint32_t session_mobile = 1000;
+
+static lv_style_t scale3_section1_main_style;
+static lv_style_t scale3_section1_indicator_style;
+static lv_style_t scale3_section1_tick_style;
+static lv_style_t scale3_section2_main_style;
+static lv_style_t scale3_section2_indicator_style;
+static lv_style_t scale3_section2_tick_style;
+static lv_style_t scale3_section3_main_style;
+static lv_style_t scale3_section3_indicator_style;
+static lv_style_t scale3_section3_tick_style;
 
 /**********************
  *      MACROS
@@ -166,6 +178,7 @@ void lv_demo_widgets(void)
     lv_style_set_radius(&style_bullet, LV_RADIUS_CIRCLE);
 
     tv = lv_tabview_create(lv_screen_active(), LV_DIR_TOP, tab_h);
+    lv_obj_add_event(tv, tabview_delete_event_cb, LV_EVENT_DELETE, NULL);
 
     lv_obj_set_style_text_font(lv_screen_active(), font_normal, 0);
 
@@ -775,16 +788,6 @@ static void analytics_create(lv_obj_t * parent)
     lv_scale_set_major_tick_length(scale3, 20);
     lv_scale_set_round_props(scale3, 225, 135);
 
-    static lv_style_t scale3_section1_main_style;
-    static lv_style_t scale3_section1_indicator_style;
-    static lv_style_t scale3_section1_tick_style;
-    static lv_style_t scale3_section2_main_style;
-    static lv_style_t scale3_section2_indicator_style;
-    static lv_style_t scale3_section2_tick_style;
-    static lv_style_t scale3_section3_main_style;
-    static lv_style_t scale3_section3_indicator_style;
-    static lv_style_t scale3_section3_tick_style;
-
     lv_style_init(&scale3_section1_main_style);
     lv_style_set_arc_width(&scale3_section1_main_style, 8);
     lv_style_set_arc_color(&scale3_section1_main_style, lv_palette_main(LV_PALETTE_RED));
@@ -820,6 +823,8 @@ static void analytics_create(lv_obj_t * parent)
     lv_style_init(&scale3_section3_tick_style);
     lv_style_set_line_width(&scale3_section3_tick_style, 4);
     lv_style_set_line_color(&scale3_section3_tick_style, lv_palette_darken(LV_PALETTE_GREEN, 2));
+
+    lv_obj_add_event(scale3, scale3_delete_event_cb, LV_EVENT_DELETE, NULL);
 
     lv_scale_section_t * section;
     section = lv_scale_add_section(scale3);
@@ -1671,4 +1676,32 @@ static void slideshow_anim_ready_cb(lv_anim_t * a_old)
     lv_anim_start(&a);
 }
 
+static void scale3_delete_event_cb(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+
+    if(code == LV_EVENT_DELETE) {
+        lv_style_reset(&scale3_section1_main_style);
+        lv_style_reset(&scale3_section1_indicator_style);
+        lv_style_reset(&scale3_section1_tick_style);
+        lv_style_reset(&scale3_section2_main_style);
+        lv_style_reset(&scale3_section2_indicator_style);
+        lv_style_reset(&scale3_section2_tick_style);
+        lv_style_reset(&scale3_section3_main_style);
+        lv_style_reset(&scale3_section3_indicator_style);
+        lv_style_reset(&scale3_section3_tick_style);
+    }
+}
+
+static void tabview_delete_event_cb(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+
+    if(code == LV_EVENT_DELETE) {
+        lv_style_reset(&style_text_muted);
+        lv_style_reset(&style_title);
+        lv_style_reset(&style_icon);
+        lv_style_reset(&style_bullet);
+    }
+}
 #endif


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
