### PR TITLE
fix(render): make parallel rendering work based on Nuttx Simulator

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -261,9 +261,6 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
             lv_draw_unit_t * u = _draw_info.unit_head;
             while(u) {
                 int32_t taken_cnt = u->dispatch_cb(u, layer);
-                if(taken_cnt < 0) {
-                    break;
-                }
                 if(taken_cnt >= 0) render_running = true;
                 u = u->next;
             }

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -147,17 +147,17 @@ void lv_draw_finalize_task_creation(lv_layer_t * layer, lv_draw_task_t * t)
 void lv_draw_dispatch(void)
 {
     LV_PROFILER_BEGIN;
-    bool one_taken = false;
+    bool render_running = false;
     lv_display_t * disp = lv_display_get_next(NULL);
     while(disp) {
         lv_layer_t * layer = disp->layer_head;
         while(layer) {
-            bool ret = lv_draw_dispatch_layer(disp, layer);
-            if(ret) one_taken = true;
+            if(lv_draw_dispatch_layer(disp, layer))
+                render_running = true;
             layer = layer->next;
         }
 
-        if(!one_taken) {
+        if(!render_running) {
             lv_draw_dispatch_request();
         }
         disp = lv_display_get_next(disp);
@@ -223,7 +223,7 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
         t = t_next;
     }
 
-    bool one_taken = false;
+    bool render_running = false;
 
     /*This layer is ready, enable blending its buffer*/
     if(layer->parent && layer->all_tasks_added && layer->draw_task_head == NULL) {
@@ -264,14 +264,13 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
                 if(taken_cnt < 0) {
                     break;
                 }
-                if(taken_cnt > 0) one_taken = true;
+                if(taken_cnt >= 0) render_running = true;
                 u = u->next;
             }
         }
     }
 
-    return one_taken;
-
+    return render_running;
 }
 
 void lv_draw_dispatch_wait_for_request(void)

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -119,8 +119,10 @@ typedef struct _lv_draw_unit_t {
      * @return              >=0:    The number of taken draw task:
      *                                  0 means the task has not yet been completed.
      *                                  1 means a new task has been accepted.
-     *                      -1:     There are no available draw tasks at all.
-     *                              Also means to no call the dispatcher of the other draw units as there is no draw task to take
+     *                      -1:     The draw unit wanted to work on a task but couldn't do that
+     *                              due to some errors (e.g. out of memory).
+     *                              It signals that LVGL should call the dispatcher later again
+     *                              to let draw unit try to start the rendering again.
      */
     int32_t (*dispatch_cb)(struct _lv_draw_unit_t * draw_unit, struct _lv_layer_t * layer);
 

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -116,8 +116,10 @@ typedef struct _lv_draw_unit_t {
      * A draw task should be assign only if the draw unit can draw it too
      * @param draw_unit     pointer to the draw unit
      * @param layer         pointer to a layer on which the draw task should be drawn
-     * @return              >=0:    The number of taken draw task
-     *                      -1:     There where no available draw tasks at all.
+     * @return              >=0:    The number of taken draw task:
+     *                                  0 means the task has not yet been completed.
+     *                                  1 means a new task has been accepted.
+     *                      -1:     There are no available draw tasks at all.
      *                              Also means to no call the dispatcher of the other draw units as there is no draw task to take
      */
     int32_t (*dispatch_cb)(struct _lv_draw_unit_t * draw_unit, struct _lv_layer_t * layer);

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -113,7 +113,7 @@ static int32_t lv_draw_sw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * laye
 
 #if LV_USE_OS
     /*Let the render thread work*/
-    lv_thread_sync_signal(&draw_sw_unit->sync);
+    if(draw_sw_unit->inited) lv_thread_sync_signal(&draw_sw_unit->sync);
 #else
     execute_drawing(draw_sw_unit);
 
@@ -133,6 +133,7 @@ static void render_thread_cb(void * ptr)
     lv_draw_sw_unit_t * u = ptr;
 
     lv_thread_sync_init(&u->sync);
+    u->inited = true;
 
     while(1) {
         while(u->task_act == NULL) {
@@ -148,6 +149,8 @@ static void render_thread_cb(void * ptr)
         /*The draw unit is free now. Request a new dispatching as it can get a new task*/
         lv_draw_dispatch_request();
     }
+    u->inited = false;
+    lv_thread_sync_delete(&u->sync);
 }
 #endif
 

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -36,6 +36,7 @@ typedef struct {
     lv_thread_sync_t sync;
     lv_thread_t thread;
     volatile bool inited;
+    volatile bool exit_status;
 #endif
     uint32_t idx;
 } lv_draw_sw_unit_t;

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -35,6 +35,7 @@ typedef struct {
 #if LV_USE_OS
     lv_thread_sync_t sync;
     lv_thread_t thread;
+    volatile bool inited;
 #endif
     uint32_t idx;
 } lv_draw_sw_unit_t;

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -51,8 +51,12 @@ lv_result_t lv_thread_init(lv_thread_t * thread, lv_thread_prio_t prio, void (*c
 
 lv_result_t lv_thread_delete(lv_thread_t * thread)
 {
-    LV_UNUSED(thread);
-    /*How?*/
+    int ret = pthread_join(thread->thread, NULL);
+    if(ret != 0) {
+        LV_LOG_WARN("Error: %d", ret);
+        return LV_RESULT_INVALID;
+    }
+
     return LV_RESULT_OK;
 }
 


### PR DESCRIPTION
### Description of the feature or fix

Fix the white screen display issue caused by a busy loop and potential use of uninitialized condition on Nuttx simulator.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
