### PR TITLE
chore(lv_label): remove codes for recolor feature

### DIFF
--- a/examples/widgets/label/lv_example_label_1.c
+++ b/examples/widgets/label/lv_example_label_1.c
@@ -8,9 +8,7 @@ void lv_example_label_1(void)
 {
     lv_obj_t * label1 = lv_label_create(lv_screen_active());
     lv_label_set_long_mode(label1, LV_LABEL_LONG_WRAP);     /*Break the long lines*/
-    lv_label_set_recolor(label1, true);                      /*Enable re-coloring by commands in the text*/
-    lv_label_set_text(label1, "#0000ff Re-color# #ff00ff words# #ff0000 of a# label, align the lines to the center "
-                      "and wrap long text automatically.");
+    lv_label_set_text(label1, "Recolor is not supported for v9 now.");
     lv_obj_set_width(label1, 150);  /*Set smaller width to make the lines wrap*/
     lv_obj_set_style_text_align(label1, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(label1, LV_ALIGN_CENTER, 0, -40);

--- a/examples/widgets/label/lv_example_label_1.py
+++ b/examples/widgets/label/lv_example_label_1.py
@@ -8,9 +8,7 @@ import display_driver
 #
 label1 = lv.label(lv.screen_active())
 label1.set_long_mode(lv.label.LONG.WRAP)      # Break the long lines*/
-label1.set_recolor(True)                      # Enable re-coloring by commands in the text
-label1.set_text("#0000ff Re-color# #ff00ff words# #ff0000 of a# label, align the lines to the center "
-                              "and  wrap long text automatically.")
+label1.set_text("Recolor is not supported for v9 now.")
 label1.set_width(150)                         # Set smaller width to make the lines wrap
 label1.set_style_text_align(lv.TEXT_ALIGN.CENTER, 0)
 label1.align(lv.ALIGN.CENTER, 0, -40)

--- a/src/misc/lv_text.h
+++ b/src/misc/lv_text.h
@@ -39,9 +39,8 @@ extern "C" {
 
 enum _lv_text_flag_t {
     LV_TEXT_FLAG_NONE    = 0x00,
-    LV_TEXT_FLAG_RECOLOR = 0x01, /**< Enable parsing of recolor command*/
-    LV_TEXT_FLAG_EXPAND  = 0x02, /**< Ignore max-width to avoid automatic word wrapping*/
-    LV_TEXT_FLAG_FIT     = 0x04, /**< Max-width is already equal to the longest line. (Used to skip some calculation)*/
+    LV_TEXT_FLAG_EXPAND  = 0x01, /**< Ignore max-width to avoid automatic word wrapping*/
+    LV_TEXT_FLAG_FIT     = 0x02, /**< Max-width is already equal to the longest line. (Used to skip some calculation)*/
 };
 
 #ifdef DOXYGEN

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -46,7 +46,6 @@ static bool button_is_inactive(lv_buttonmatrix_ctrl_t ctrl_bits);
 static bool button_is_click_trig(lv_buttonmatrix_ctrl_t ctrl_bits);
 static bool button_is_popover(lv_buttonmatrix_ctrl_t ctrl_bits);
 static bool button_is_checkable(lv_buttonmatrix_ctrl_t ctrl_bits);
-static bool button_is_recolor(lv_buttonmatrix_ctrl_t ctrl_bits);
 static bool button_get_checked(lv_buttonmatrix_ctrl_t ctrl_bits);
 static uint32_t get_button_from_point(lv_obj_t * obj, lv_point_t * p);
 static void allocate_button_areas_and_controls(const lv_obj_t * obj, const char ** map);

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -750,8 +750,6 @@ static void draw_main(lv_event_t * e)
 
         draw_rect_dsc_act.base.id1 = btn_i;
 
-        bool recolor = button_is_recolor(btnm->ctrl_bits[btn_i]);
-
         /*Remove borders on the edges if `LV_BORDER_SIDE_INTERNAL`*/
         if(draw_rect_dsc_act.border_side & LV_BORDER_SIDE_INTERNAL) {
             draw_rect_dsc_act.border_side = LV_BORDER_SIDE_FULL;

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -751,8 +751,6 @@ static void draw_main(lv_event_t * e)
         draw_rect_dsc_act.base.id1 = btn_i;
 
         bool recolor = button_is_recolor(btnm->ctrl_bits[btn_i]);
-        if(recolor) draw_label_dsc_act.flag |= LV_TEXT_FLAG_RECOLOR;
-        else draw_label_dsc_act.flag &= ~LV_TEXT_FLAG_RECOLOR;
 
         /*Remove borders on the edges if `LV_BORDER_SIDE_INTERNAL`*/
         if(draw_rect_dsc_act.border_side & LV_BORDER_SIDE_INTERNAL) {

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -903,10 +903,6 @@ static bool button_get_checked(lv_buttonmatrix_ctrl_t ctrl_bits)
     return ctrl_bits & LV_BUTTONMATRIX_CTRL_CHECKED;
 }
 
-static bool button_is_recolor(lv_buttonmatrix_ctrl_t ctrl_bits)
-{
-    return ctrl_bits & LV_BUTTONMATRIX_CTRL_RECOLOR;
-}
 /**
  * Gives the button id of a button under a given point
  * @param obj pointer to a button matrix object

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.h
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.h
@@ -40,9 +40,9 @@ enum _lv_buttonmatrix_ctrl_t {
     LV_BUTTONMATRIX_CTRL_CHECKED      = 0x0100, /**< Button is currently toggled (e.g. checked).*/
     LV_BUTTONMATRIX_CTRL_CLICK_TRIG   = 0x0200, /**< 1: Send LV_EVENT_VALUE_CHANGE on CLICK, 0: Send LV_EVENT_VALUE_CHANGE on PRESS*/
     LV_BUTTONMATRIX_CTRL_POPOVER      = 0x0400, /**< Show a popover when pressing this key*/
-    LV_BUTTONMATRIX_CTRL_RECOLOR      = 0x0800, /**< Enable text recoloring with `#color`*/
-    _LV_BUTTONMATRIX_CTRL_RESERVED_1  = 0x1000, /**< Reserved for later use*/
-    _LV_BUTTONMATRIX_CTRL_RESERVED_2  = 0x2000, /**< Reserved for later use*/
+    _LV_BUTTONMATRIX_CTRL_RESERVED_1  = 0x0800, /**< Reserved for later use*/
+    _LV_BUTTONMATRIX_CTRL_RESERVED_2  = 0x1000, /**< Reserved for later use*/
+    _LV_BUTTONMATRIX_CTRL_RESERVED_3  = 0x2000, /**< Reserved for later use*/
     LV_BUTTONMATRIX_CTRL_CUSTOM_1     = 0x4000, /**< Custom free to use flag*/
     LV_BUTTONMATRIX_CTRL_CUSTOM_2     = 0x8000, /**< Custom free to use flag*/
 };

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -205,19 +205,6 @@ void lv_label_set_long_mode(lv_obj_t * obj, lv_label_long_mode_t long_mode)
     lv_label_refr_text(obj);
 }
 
-void lv_label_set_recolor(lv_obj_t * obj, bool en)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_label_t * label = (lv_label_t *)obj;
-    if(label->recolor == en) return;
-
-    label->recolor = en ? 1 : 0;
-
-    /*Refresh the text because the potential color codes in text needs to be hidden or revealed*/
-    lv_label_refr_text(obj);
-}
-
 void lv_label_set_text_selection_start(lv_obj_t * obj, uint32_t index)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -262,14 +249,6 @@ lv_label_long_mode_t lv_label_get_long_mode(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_label_t * label = (lv_label_t *)obj;
     return label->long_mode;
-}
-
-bool lv_label_get_recolor(const lv_obj_t * obj)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_label_t * label = (lv_label_t *)obj;
-    return label->recolor;
 }
 
 void lv_label_get_letter_pos(const lv_obj_t * obj, uint32_t char_id, lv_point_t * pos)
@@ -641,7 +620,6 @@ static void lv_label_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
     label->text       = NULL;
     label->static_txt = 0;
-    label->recolor    = 0;
     label->dot_end    = LV_LABEL_DOT_END_INV;
     label->long_mode  = LV_LABEL_LONG_WRAP;
     label->offset.x = 0;
@@ -709,7 +687,6 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
             int32_t letter_space = lv_obj_get_style_text_letter_space(obj, LV_PART_MAIN);
             int32_t line_space = lv_obj_get_style_text_line_space(obj, LV_PART_MAIN);
             lv_text_flag_t flag = LV_TEXT_FLAG_NONE;
-            if(label->recolor != 0) flag |= LV_TEXT_FLAG_RECOLOR;
             if(label->expand != 0) flag |= LV_TEXT_FLAG_EXPAND;
 
             int32_t w = lv_obj_get_content_width(obj);
@@ -740,7 +717,6 @@ static void draw_main(lv_event_t * e)
     lv_obj_get_content_coords(obj, &txt_coords);
 
     lv_text_flag_t flag = LV_TEXT_FLAG_NONE;
-    if(label->recolor) flag |= LV_TEXT_FLAG_RECOLOR;
     if(label->expand != 0) flag |= LV_TEXT_FLAG_EXPAND;
     if(lv_obj_get_style_width(obj, LV_PART_MAIN) == LV_SIZE_CONTENT && !obj->w_layout) flag |= LV_TEXT_FLAG_FIT;
 
@@ -876,7 +852,6 @@ static void lv_label_refr_text(lv_obj_t * obj)
     /*Calc. the height and longest line*/
     lv_point_t size;
     lv_text_flag_t flag = LV_TEXT_FLAG_NONE;
-    if(label->recolor) flag |= LV_TEXT_FLAG_RECOLOR;
     if(label->expand != 0) flag |= LV_TEXT_FLAG_EXPAND;
     if(lv_obj_get_style_width(obj, LV_PART_MAIN) == LV_SIZE_CONTENT && !obj->w_layout) flag |= LV_TEXT_FLAG_FIT;
 
@@ -1270,7 +1245,6 @@ static lv_text_flag_t get_label_flags(lv_label_t * label)
 {
     lv_text_flag_t flag = LV_TEXT_FLAG_NONE;
 
-    if(label->recolor) flag |= LV_TEXT_FLAG_RECOLOR;
     if(label->expand) flag |= LV_TEXT_FLAG_EXPAND;
 
     return flag;

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -83,7 +83,6 @@ typedef struct {
     lv_point_t offset; /*Text draw position offset*/
     lv_label_long_mode_t long_mode : 3; /*Determine what to do with the long texts*/
     uint8_t static_txt : 1;             /*Flag to indicate the text is static*/
-    uint8_t recolor : 1;                /*Enable in-line letter re-coloring*/
     uint8_t expand : 1;                 /*Ignore real width (used by the library with LV_LABEL_LONG_SCROLL)*/
     uint8_t dot_tmp_alloc : 1;          /*1: dot is allocated, 0: dot directly holds up to 4 chars*/
     uint8_t invalid_size_cache : 1;     /*1: Recalculate size and update cache*/
@@ -138,14 +137,6 @@ void lv_label_set_text_static(lv_obj_t * obj, const char * text);
 void lv_label_set_long_mode(lv_obj_t * obj, lv_label_long_mode_t long_mode);
 
 /**
- * Enable the recoloring by in-line commands
- * @param obj           pointer to a label object
- * @param en            true: enable recoloring, false: disable
- * @example "This is a #ff0000 red# word"
- */
-void lv_label_set_recolor(lv_obj_t * obj, bool en);
-
-/**
  * Set where text selection should start
  * @param obj       pointer to a label object
  * @param index     character index from where selection should start. `LV_LABEL_TEXT_SELECTION_OFF` for no selection
@@ -176,13 +167,6 @@ char * lv_label_get_text(const lv_obj_t * obj);
  * @return          the current long mode
  */
 lv_label_long_mode_t lv_label_get_long_mode(const lv_obj_t * obj);
-
-/**
- * Get the recoloring attribute
- * @param obj       pointer to a label object
- * @return          true: recoloring is enabled, false: disable
- */
-bool lv_label_get_recolor(const lv_obj_t * obj);
 
 /**
  * Get the relative x and y coordinates of a letter

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -492,7 +492,6 @@ static void draw_main(lv_event_t * e)
         area_ok = _lv_area_intersect(&mask_sel, &layer->clip_area, &sel_area);
         if(area_ok) {
             lv_obj_t * label = get_label(obj);
-            if(lv_label_get_recolor(label)) label_dsc.flag |= LV_TEXT_FLAG_RECOLOR;
 
             /*Get the size of the "selected text"*/
             lv_point_t res_p;
@@ -546,7 +545,6 @@ static void draw_label(lv_event_t * e)
     lv_draw_label_dsc_t label_draw_dsc;
     lv_draw_label_dsc_init(&label_draw_dsc);
     lv_obj_init_draw_label_dsc(roller, LV_PART_MAIN, &label_draw_dsc);
-    if(lv_label_get_recolor(label_obj)) label_draw_dsc.flag |= LV_TEXT_FLAG_RECOLOR;
 
     lv_layer_t * layer = lv_event_get_layer(e);
 

--- a/tests/src/test_cases/widgets/test_label.c
+++ b/tests/src/test_cases/widgets/test_label.c
@@ -42,15 +42,6 @@ void test_label_creation(void)
     TEST_ASSERT_EQUAL(lv_label_get_long_mode(label), LV_LABEL_LONG_WRAP);
 }
 
-void test_label_recolor(void)
-{
-    lv_label_set_recolor(label, true);
-    TEST_ASSERT(lv_label_get_recolor(label));
-
-    lv_label_set_recolor(label, false);
-    TEST_ASSERT_FALSE(lv_label_get_recolor(label));
-}
-
 void test_label_set_text(void)
 {
     const char * new_text = "Hello world";


### PR DESCRIPTION
### Description of the feature or fix

#4599

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
