### PR TITLE
chore(demos): adapt new benchmark demo

### DIFF
--- a/demos/lv_demos.c
+++ b/demos/lv_demos.c
@@ -18,8 +18,6 @@
 /*********************
  *      DEFINES
  *********************/
-#define DEMO_BENCHMARK_NAME "benchmark"
-#define DEMO_BENCHMARK_SCENE_NAME "benchmark_scene"
 #define LV_DEMOS_COUNT (sizeof(demos_entry_info) / sizeof(demo_entry_info_t) - 1)
 
 /**********************
@@ -27,35 +25,15 @@
  **********************/
 
 typedef void (*demo_method_cb)(void);
-#if LV_USE_DEMO_BENCHMARK
-    //    typedef void (*demo_method_benchmark_cb)(lv_demo_benchmark_mode_t);
-    //    typedef void (*demo_method_benchmark_scene_cb)(lv_demo_benchmark_mode_t, uint16_t);
-#endif
 
 typedef struct  {
     const char * name;
-    union {
-        demo_method_cb entry_cb;
-#if LV_USE_DEMO_BENCHMARK
-        //        demo_method_benchmark_cb entry_benchmark_cb;
-        //        demo_method_benchmark_scene_cb entry_benchmark_scene_cb;
-#endif
-    };
-    int arg_count : 8;
+    demo_method_cb entry_cb;
 } demo_entry_info_t;
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static inline bool demo_is_benchmark(const demo_entry_info_t * entry)
-{
-    return (entry) && entry->arg_count == 1 && strcmp(entry->name, DEMO_BENCHMARK_NAME) == 0 ? true : false;
-}
-
-static inline bool demo_is_benchmark_scene(const demo_entry_info_t * entry)
-{
-    return (entry) && entry->arg_count == 2 && strcmp(entry->name, DEMO_BENCHMARK_SCENE_NAME) == 0 ? true : false;
-}
 
 /**********************
  *  STATIC VARIABLES
@@ -96,10 +74,9 @@ static const demo_entry_info_t demos_entry_info[] = {
     { "vector_graphic", .entry_cb = lv_demo_vector_graphic },
 #endif
 
-    //#if LV_USE_DEMO_BENCHMARK
-    //    { DEMO_BENCHMARK_NAME, .entry_benchmark_cb = lv_demo_benchmark, 1 },
-    //    { DEMO_BENCHMARK_SCENE_NAME, .entry_benchmark_scene_cb = lv_demo_benchmark_run_scene, 2 },
-    //#endif
+#if LV_USE_DEMO_BENCHMARK
+    { "benchmark", .entry_cb = lv_demo_benchmark },
+#endif
 
     { "", .entry_cb = NULL }
 };
@@ -125,11 +102,10 @@ bool lv_demos_create(char * info[], int size)
     if(size <= 0) { /* default: first demo*/
         entry_info = &demos_entry_info[0];
     }
-
-    if(entry_info == NULL && info) {
+    else if(entry_info == NULL && info) {
         const char * name = info[0];
         for(int i = 0; i < demos_count; i++) {
-            if(strcmp(name, demos_entry_info[i].name) == 0 && size - 1 >= demos_entry_info[i].arg_count) {
+            if(strcmp(name, demos_entry_info[i].name) == 0) {
                 entry_info = &demos_entry_info[i];
             }
         }
@@ -140,22 +116,10 @@ bool lv_demos_create(char * info[], int size)
         return false;
     }
 
-    if(entry_info->arg_count == 0) {
-        if(entry_info->entry_cb) {
-            entry_info->entry_cb();
-            return true;
-        }
+    if(entry_info->entry_cb) {
+        entry_info->entry_cb();
+        return true;
     }
-    //#if LV_USE_DEMO_BENCHMARK
-    //    else if(demo_is_benchmark(entry_info) && entry_info->entry_benchmark_cb) {
-    //        entry_info->entry_benchmark_cb((lv_demo_benchmark_mode_t)atoi(info[1]));
-    //        return true;
-    //    }
-    //    else if(demo_is_benchmark_scene(entry_info) && entry_info->entry_benchmark_scene_cb) {
-    //        entry_info->entry_benchmark_scene_cb((lv_demo_benchmark_mode_t)atoi(info[1]), (uint16_t)atoi(info[2]));
-    //        return true;
-    //    }
-    //#endif
 
     return false;
 }
@@ -174,16 +138,6 @@ void lv_demos_show_help(void)
     LV_LOG("\ndemo list:\n");
 
     for(i = 0; i < demos_count; i++) {
-        if(demos_entry_info[i].arg_count == 0) {
-            LV_LOG("     %s \n", demos_entry_info[i].name);
-        }
-        else if(demo_is_benchmark(&demos_entry_info[i])) {
-            LV_LOG("     %s [0, 1, 2] \t\t\t(0 for Render&Driver, 1 for Real Render, 2 for Render Only)\n",
-                   demos_entry_info[i].name);
-        }
-        else if(demo_is_benchmark_scene(&demos_entry_info[i])) {
-            LV_LOG("     %s [0, 1, 2] scene_no \t(0 for Render&Driver, 1 for Real Render, 2 for Render Only)\n",
-                   demos_entry_info[i].name);
-        }
+        LV_LOG("     %s \n", demos_entry_info[i].name);
     }
 }


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
