### PR TITLE
fix(table):fix issue with abnormal string output of 'lv_table_set_cell_value_fmt'

### DIFF
--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -178,14 +178,14 @@ void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, con
     lv_free(raw_txt);
 #else
     table->cell_data[cell] = lv_realloc(table->cell_data[cell],
-                                        sizeof(lv_table_cell_t) + len + 2); /*+1: trailing '\0; */
+                                        sizeof(lv_table_cell_t) + len + 1); /*+1: trailing '\0; */
     LV_ASSERT_MALLOC(table->cell_data[cell]);
     if(table->cell_data[cell] == NULL) {
         va_end(ap2);
         return;
     }
 
-    table->cell_data[cell]->txt[len + 1] = 0; /*Ensure NULL termination*/
+    table->cell_data[cell]->txt[len] = 0; /*Ensure NULL termination*/
 
     lv_vsnprintf(table->cell_data[cell]->txt, len + 1, fmt, ap2);
 #endif

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -178,16 +178,16 @@ void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, con
     lv_free(raw_txt);
 #else
     table->cell_data[cell] = lv_realloc(table->cell_data[cell],
-                                        sizeof(lv_table_cell_t) + len + 1); /*+1: trailing '\0; */
+                                        sizeof(lv_table_cell_t) + len + 2); /*+1: trailing '\0; */
     LV_ASSERT_MALLOC(table->cell_data[cell]);
     if(table->cell_data[cell] == NULL) {
         va_end(ap2);
         return;
     }
 
-    table->cell_data[cell]->txt[len] = 0; /*Ensure NULL termination*/
+    table->cell_data[cell]->txt[len + 1] = 0; /*Ensure NULL termination*/
 
-    lv_vsnprintf(table->cell_data[cell]->txt, len, fmt, ap2);
+    lv_vsnprintf(table->cell_data[cell]->txt, len + 1, fmt, ap2);
 #endif
 
     va_end(ap2);


### PR DESCRIPTION
fix(table):fix issue with abnormal string output of 'lv_table_set_cell_value_fmt'

**test code：**
```c
void lv_table_test(void)
{
    lv_obj_t *table = lv_table_create(lv_screen_active());
    lv_obj_set_style_pad_all(table, 8, LV_PART_ITEMS);
    lv_obj_set_style_text_align(table, LV_TEXT_ALIGN_CENTER, LV_PART_ITEMS);
    lv_obj_set_size(table, 280, 280);
    lv_obj_center(table);

    for(int i;i<20;i++)
    {
        lv_table_set_cell_value_fmt(table,
                            i,
                            0,
                            "%d",
                            i);

        lv_table_set_cell_value_fmt(table,
                            i,
                            1,
                            "%.3f",
                            0.123f+i);
    }
}
```
**Picture before fix：**
![屏幕截图 2023-11-11 091925](https://github.com/lvgl/lvgl/assets/18370433/15d8ada4-e71d-4600-a67c-41340f98f42d)

**Picture after fix：**
![屏幕截图 2023-11-11 091509](https://github.com/lvgl/lvgl/assets/18370433/3398c5ea-5f55-4c61-870e-a51a1cd5f0d0)

Similarly, the **V8 version** also has the same issue
