### PR TITLE
Update custom.cmake

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -32,7 +32,6 @@ target_compile_definitions(
 # Add definition of LV_CONF_PATH only if needed
 if(LV_CONF_PATH)
   target_compile_definitions(lvgl PUBLIC LV_CONF_PATH=${LV_CONF_PATH})
-  target_compile_definitions(lvgl_thorvg PUBLIC LV_CONF_PATH=${LV_CONF_PATH})
 endif()
 
 # Include root and optional parent path of LV_CONF_PATH
@@ -43,6 +42,7 @@ if(NOT LV_CONF_BUILD_DISABLE_THORVG_INTERNAL)
     add_library(lvgl_thorvg ${THORVG_SOURCES})
     add_library(lvgl::thorvg ALIAS lvgl_thorvg)
     target_include_directories(lvgl_thorvg SYSTEM PUBLIC ${LVGL_ROOT_DIR}/src/libs/thorvg)
+    target_compile_definitions(lvgl_thorvg PUBLIC LV_CONF_PATH=${LV_CONF_PATH})
 endif()
 
 # Build LVGL example library


### PR DESCRIPTION
Error when cmake try `target_compile_definitions` for `lvgl_thorvg`.
Initialy on lin 35, the target does not exist.