### PR TITLE
fix(ime):fix cand_panel will only show '<' after select the Chinese character

### DIFF
--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -959,6 +959,9 @@ static void pinyin_ime_clear_data(lv_obj_t * obj)
         pinyin_ime->k9_legal_py_count = 0;
         lv_memzero(pinyin_ime->k9_input_str,  LV_IME_PINYIN_K9_MAX_INPUT);
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
+         for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++){
+            lv_strcpy(lv_pinyin_k9_cand_str[i], " ");
+         }
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
     }
@@ -1118,11 +1121,16 @@ static void pinyin_k9_fill_cand(lv_obj_t * obj)
     ll_index = _lv_ll_get_head(&pinyin_ime->k9_legal_py_ll);
     lv_strcpy(pinyin_ime->input_char, ll_index->py_str);
     while(ll_index) {
-        if((index >= LV_IME_PINYIN_K9_CAND_TEXT_NUM) || \
-           (index >= pinyin_ime->k9_legal_py_count))
+        if(index >= LV_IME_PINYIN_K9_CAND_TEXT_NUM)
             break;
 
-        lv_strcpy(lv_pinyin_k9_cand_str[index], ll_index->py_str);
+        if(index >= pinyin_ime->k9_legal_py_count){
+            lv_strcpy(lv_pinyin_k9_cand_str[index], " ");
+        }
+        else{
+            lv_strcpy(lv_pinyin_k9_cand_str[index], ll_index->py_str);
+        }
+
         ll_index = _lv_ll_get_next(&pinyin_ime->k9_legal_py_ll, ll_index); /*Find the next list*/
         index++;
     }

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -959,9 +959,9 @@ static void pinyin_ime_clear_data(lv_obj_t * obj)
         pinyin_ime->k9_legal_py_count = 0;
         lv_memzero(pinyin_ime->k9_input_str,  LV_IME_PINYIN_K9_MAX_INPUT);
         lv_memzero(lv_pinyin_k9_cand_str, sizeof(lv_pinyin_k9_cand_str));
-         for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++){
+        for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
             lv_strcpy(lv_pinyin_k9_cand_str[i], " ");
-         }
+        }
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM], LV_SYMBOL_RIGHT"\0");
         lv_strcpy(lv_pinyin_k9_cand_str[LV_IME_PINYIN_K9_CAND_TEXT_NUM + 1], "\0");
     }
@@ -1124,10 +1124,10 @@ static void pinyin_k9_fill_cand(lv_obj_t * obj)
         if(index >= LV_IME_PINYIN_K9_CAND_TEXT_NUM)
             break;
 
-        if(index >= pinyin_ime->k9_legal_py_count){
+        if(index >= pinyin_ime->k9_legal_py_count) {
             lv_strcpy(lv_pinyin_k9_cand_str[index], " ");
         }
-        else{
+        else {
             lv_strcpy(lv_pinyin_k9_cand_str[index], ll_index->py_str);
         }
 

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -829,6 +829,8 @@ static void pinyin_page_proc(lv_obj_t * obj, uint16_t dir)
     uint16_t page_num = pinyin_ime->cand_num / LV_IME_PINYIN_CAND_TEXT_NUM;
     uint16_t remainder = pinyin_ime->cand_num % LV_IME_PINYIN_CAND_TEXT_NUM;
 
+    if (!pinyin_ime->cand_str) return;
+
     if(dir == 0) {
         if(pinyin_ime->py_page) {
             pinyin_ime->py_page--;

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -963,7 +963,10 @@ static void pinyin_ime_clear_data(lv_obj_t * obj)
 #endif
 
     pinyin_ime->ta_count = 0;
-    lv_memzero(lv_pinyin_cand_str, (sizeof(lv_pinyin_cand_str)));
+    for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
+        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_pinyin_cand_str[i][0] = ' ';
+    }
     lv_memzero(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));
 
     lv_obj_add_flag(pinyin_ime->cand_panel, LV_OBJ_FLAG_HIDDEN);

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -655,7 +655,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
                 strcat(pinyin_ime->input_char, txt);
                 pinyin_input_proc(obj);
 
-                for(int index = 0; index <  tmp_button_str_len; index++) {
+                for(int index = 0; index < (pinyin_ime->ta_count + tmp_button_str_len); index++) {
                     lv_textarea_delete_char(ta);
                 }
 

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -809,7 +809,7 @@ static void pinyin_input_proc(lv_obj_t * obj)
     pinyin_ime->py_page = 0;
 
     for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
-        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
         lv_pinyin_cand_str[i][0] = ' ';
     }
 
@@ -845,7 +845,7 @@ static void pinyin_page_proc(lv_obj_t * obj, uint16_t dir)
     }
 
     for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
-        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
         lv_pinyin_cand_str[i][0] = ' ';
     }
 
@@ -964,7 +964,7 @@ static void pinyin_ime_clear_data(lv_obj_t * obj)
 
     pinyin_ime->ta_count = 0;
     for(uint8_t i = 0; i < LV_IME_PINYIN_CAND_TEXT_NUM; i++) {
-        memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
+        lv_memset(lv_pinyin_cand_str[i], 0x00, sizeof(lv_pinyin_cand_str[i]));
         lv_pinyin_cand_str[i][0] = ' ';
     }
     lv_memzero(pinyin_ime->input_char, sizeof(pinyin_ime->input_char));

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -829,7 +829,7 @@ static void pinyin_page_proc(lv_obj_t * obj, uint16_t dir)
     uint16_t page_num = pinyin_ime->cand_num / LV_IME_PINYIN_CAND_TEXT_NUM;
     uint16_t remainder = pinyin_ime->cand_num % LV_IME_PINYIN_CAND_TEXT_NUM;
 
-    if (!pinyin_ime->cand_str) return;
+    if(!pinyin_ime->cand_str) return;
 
     if(dir == 0) {
         if(pinyin_ime->py_page) {


### PR DESCRIPTION
**1:fix(ime):fix cand_panel will only show '<' after select the Chinese character**

**2:chone(ime):replace memset with lv_memset**

**3:fix(ime):Selecting Pinyin in k9 mode will also add the Pinyin content repeatedly to the input box**

**4:fix(ime):fix issue where selecting the next page could cause compiler exceptions when no candidate words were matched**

**5:fix(ime):fix issue where keyboard right-click disappears in k9 mode**

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
