### PR TITLE
fix(obj): fix arduino compile warnings

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -149,9 +149,9 @@ void lv_init(void)
     lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE);
 #endif
     /*Test if the IDE has UTF-8 encoding*/
-    char * txt = "Á";
+    const char * txt = "Á";
 
-    uint8_t * txt_u8 = (uint8_t *)txt;
+    const uint8_t * txt_u8 = (uint8_t *)txt;
     if(txt_u8[0] != 0xc3 || txt_u8[1] != 0x81 || txt_u8[2] != 0x00) {
         LV_LOG_WARN("The strings have no UTF-8 encoding. Non-ASCII characters won't be displayed.");
     }

--- a/src/widgets/lv_checkbox.c
+++ b/src/widgets/lv_checkbox.c
@@ -74,14 +74,16 @@ void lv_checkbox_set_text(lv_obj_t * obj, const char * txt)
     size_t len = strlen(txt);
 #endif
 
-    if(!cb->static_txt) cb->txt = lv_mem_realloc(cb->txt, len + 1);
-    else  cb->txt = lv_mem_alloc(len + 1);
+    char * _txt = (char *)cb->txt;
+    if(!cb->static_txt) _txt = lv_mem_realloc(_txt, len + 1);
+    else _txt = lv_mem_alloc(len + 1);
 #if LV_USE_ARABIC_PERSIAN_CHARS
-    _lv_txt_ap_proc(txt, cb->txt);
+    _lv_txt_ap_proc(txt, _txt);
 #else
-    strcpy(cb->txt, txt);
+    strcpy(_txt, txt);
 #endif
 
+    cb->txt = _txt;
     cb->static_txt = 0;
 
     lv_obj_refresh_self_size(obj);
@@ -92,7 +94,7 @@ void lv_checkbox_set_text_static(lv_obj_t * obj, const char * txt)
 {
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
 
-    if(!cb->static_txt) lv_mem_free(cb->txt);
+    if(!cb->static_txt) lv_mem_free((void *)cb->txt);
 
     cb->txt = (char *)txt;
     cb->static_txt = 1;
@@ -138,7 +140,7 @@ static void lv_checkbox_destructor(const lv_obj_class_t * class_p, lv_obj_t * ob
 
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
     if(!cb->static_txt) {
-        lv_mem_free(cb->txt);
+        lv_mem_free((void *)cb->txt);
         cb->txt = NULL;
     }
     LV_TRACE_OBJ_CREATE("finished");

--- a/src/widgets/lv_checkbox.h
+++ b/src/widgets/lv_checkbox.h
@@ -28,7 +28,7 @@ extern "C" {
 
 typedef struct {
     lv_obj_t obj;
-    char * txt;
+    const char * txt;
     uint32_t static_txt : 1;
 } lv_checkbox_t;
 


### PR DESCRIPTION
### Description of the feature or fix

Fix warning found on arduino.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
