### PR TITLE
fix(draw): use byte as stride unit instead of pixel

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -36,6 +36,8 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
 
 LV_ATTRIBUTE_FAST_MEM static inline uint16_t lv_color_24_16_mix(const uint8_t * c1, uint16_t c2, uint8_t mix);
 
+LV_ATTRIBUTE_FAST_MEM static inline void * drawbuf_next_row(const void * buf, uint32_t stride);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -70,7 +72,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
     const lv_opa_t * mask = dsc->mask_buf;
     int32_t mask_stride = dsc->mask_stride;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
-    int32_t dest_stride_px = dsc->dest_stride / 2;
+    int32_t dest_stride = dsc->dest_stride;
 
     int32_t x;
     int32_t y;
@@ -106,7 +108,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
                 dest_buf_u16++;
             }
 
-            dest_buf_u16 += dest_stride_px - w;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+            dest_buf_u16 -= w;
         }
     }
     /*Opacity only*/
@@ -145,7 +148,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
             for(; x < w ; x++) {
                 dest_buf_u16[x] = lv_color_16_16_mix(color16, dest_buf_u16[x], opa);
             }
-            dest_buf_u16 += dest_stride_px;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
         }
     }
 
@@ -183,7 +186,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
             for(; x < w ; x++) {
                 dest_buf_u16[x] = lv_color_16_16_mix(color16, dest_buf_u16[x], mask[x]);
             }
-            dest_buf_u16 += dest_stride_px;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             mask += mask_stride;
         }
     }
@@ -193,7 +196,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
             for(x = 0; x < w; x++) {
                 dest_buf_u16[x] = lv_color_16_16_mix(color16, dest_buf_u16[x], LV_OPA_MIX2(mask[x], opa));
             }
-            dest_buf_u16 += dest_stride_px;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             mask += mask_stride;
         }
     }
@@ -201,7 +204,6 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_color_to_rgb565(_lv_draw_sw_blend_fi
 
 LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_blend_image_to_rgb565(_lv_draw_sw_blend_image_dsc_t * dsc)
 {
-
     switch(dsc->src_color_format) {
         case LV_COLOR_FORMAT_RGB565:
             rgb565_image_blend(dsc);
@@ -231,9 +233,9 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
-    int32_t dest_stride_px = dsc->dest_stride / 2;
+    int32_t dest_stride = dsc->dest_stride;
     const uint16_t * src_buf_u16 = dsc->src_buf;
-    int32_t src_stride_px = dsc->src_stride / 2;
+    int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
     int32_t mask_stride = dsc->mask_stride;
 
@@ -245,8 +247,8 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
             uint32_t line_in_bytes = w * 2;
             for(y = 0; y < h; y++) {
                 lv_memcpy(dest_buf_u16, src_buf_u16, line_in_bytes);
-                dest_buf_u16 += dest_stride_px;
-                src_buf_u16 += src_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+                src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
             }
         }
         else if(mask_buf == NULL && opa < LV_OPA_MAX) {
@@ -254,8 +256,8 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
                 for(x = 0; x < w; x++) {
                     dest_buf_u16[x] = lv_color_16_16_mix(src_buf_u16[x], dest_buf_u16[x], opa);
                 }
-                dest_buf_u16 += dest_stride_px;
-                src_buf_u16 += src_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+                src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
@@ -263,8 +265,8 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
                 for(x = 0; x < w; x++) {
                     dest_buf_u16[x] = lv_color_16_16_mix(src_buf_u16[x], dest_buf_u16[x], mask_buf[x]);
                 }
-                dest_buf_u16 += dest_stride_px;
-                src_buf_u16 += src_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+                src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
                 mask_buf += mask_stride;
             }
         }
@@ -273,8 +275,8 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
                 for(x = 0; x < w; x++) {
                     dest_buf_u16[x] = lv_color_16_16_mix(src_buf_u16[x], dest_buf_u16[x], LV_OPA_MIX2(mask_buf[x], opa));
                 }
-                dest_buf_u16 += dest_stride_px;
-                src_buf_u16 += src_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+                src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
                 mask_buf += mask_stride;
             }
         }
@@ -318,8 +320,8 @@ LV_ATTRIBUTE_FAST_MEM static void rgb565_image_blend(_lv_draw_sw_blend_image_dsc
                 }
             }
 
-            dest_buf_u16 += dest_stride_px;
-            src_buf_u16 += src_stride_px;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
+            src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
             if(mask_buf) mask_buf += mask_stride;
         }
     }
@@ -331,7 +333,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
-    int32_t dest_stride_px = dsc->dest_stride / 2;
+    int32_t dest_stride = dsc->dest_stride;
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
@@ -349,7 +351,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
                                             ((src_buf_u8[src_x + 1] & 0xFC) << 3) +
                                             ((src_buf_u8[src_x + 0] & 0xF8) >> 3);
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
             }
         }
@@ -358,7 +360,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
                 for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x], opa);
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
             }
         }
@@ -367,7 +369,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
                 for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x], mask_buf[dest_x]);
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
                 mask_buf += mask_stride;
             }
@@ -377,7 +379,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
                 for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x], LV_OPA_MIX2(mask_buf[dest_x], opa));
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
                 mask_buf += mask_stride;
             }
@@ -420,7 +422,7 @@ LV_ATTRIBUTE_FAST_MEM static void rgb888_image_blend(_lv_draw_sw_blend_image_dsc
             }
         }
 
-        dest_buf_u16 += dest_stride_px;
+        dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
         src_buf_u8 += src_stride;
         if(mask_buf) mask_buf += mask_stride;
     }
@@ -432,7 +434,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
-    int32_t dest_stride_px = dsc->dest_stride / 2;
+    int32_t dest_stride = dsc->dest_stride;
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
@@ -448,7 +450,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
                 for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += 4) {
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x], src_buf_u8[src_x + 3]);
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
             }
         }
@@ -458,7 +460,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x], LV_OPA_MIX2(src_buf_u8[src_x + 3],
                                                                                                                     opa));
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
             }
         }
@@ -468,7 +470,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x],
                                                               LV_OPA_MIX2(src_buf_u8[src_x + 3], mask_buf[dest_x]));
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
                 mask_buf += mask_stride;
             }
@@ -479,7 +481,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
                     dest_buf_u16[dest_x] = lv_color_24_16_mix(&src_buf_u8[src_x], dest_buf_u16[dest_x],
                                                               LV_OPA_MIX3(src_buf_u8[src_x + 3], mask_buf[dest_x], opa));
                 }
-                dest_buf_u16 += dest_stride_px;
+                dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
                 src_buf_u8 += src_stride;
                 mask_buf += mask_stride;
             }
@@ -524,7 +526,7 @@ LV_ATTRIBUTE_FAST_MEM static void argb8888_image_blend(_lv_draw_sw_blend_image_d
                 }
             }
 
-            dest_buf_u16 += dest_stride_px;
+            dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_u8 += src_stride;
             if(mask_buf) mask_buf += mask_stride;
         }
@@ -546,6 +548,11 @@ LV_ATTRIBUTE_FAST_MEM static inline uint16_t lv_color_24_16_mix(const uint8_t * 
                ((((c1[1] >> 2) * mix + ((c2 >> 5) & 0x3F) * mix_inv) >> 3) & 0x07E0) +
                (((c1[0] >> 3) * mix + (c2 & 0x1F) * mix_inv) >> 8);
     }
+}
+
+LV_ATTRIBUTE_FAST_MEM static inline void * drawbuf_next_row(const void * buf, uint32_t stride)
+{
+    return (void *)((uint8_t *)buf + stride);
 }
 
 #endif


### PR DESCRIPTION

### Description of the feature or fix

For image source that stride is aligned to certain bytes, use pixel as draw unit will fail.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
