### PR TITLE
fixed lvgl.pc source dir in install step if using FetchContent

### DIFF
--- a/docs/integration/driver/X11.rst
+++ b/docs/integration/driver/X11.rst
@@ -1,29 +1,29 @@
-=======
-X11
-=======
+=========================
+X11 Display/Inputs driver
+=========================
 
 Overview
 -------------
 
-The `X11 display/input driver <https://github.com/lvgl/lvgl/src/dev/x11>`__ offers support for simulating the LVGL display
-in a X11 desktop window. It is an alternative to Wayland, XCB, SDL or Qt.
+| The **X11** display/input `driver <https://github.com/lvgl/lvgl/src/dev/x11>`__ offers support for simulating the LVGL display and keyboard/mouse inputs in an X11 desktop window.
+| It is an alternative to **Wayland**, **XCB**, **SDL** or **Qt**.
 
-The main purpose for this display driver is for testing/debugging the LVGL application in a Linux simulation window.
+The main purpose for this driver is for testing/debugging the LVGL application in a **Linux** simulation window.
 
 
 Prerequisites
 -------------
 
-The X11 display driver uses XLib to access the linux window manager.
+The X11 driver uses XLib to access the linux window manager.
 
 1. Install XLib: ``sudo apt-get install libx11-6`` (should be installed already)
 2. Install XLib development package: ``sudo apt-get install libx11-dev``
 
 
-Configure X11 display driver
-----------------------------
+Configure X11 driver
+--------------------
 
-1. Enable the X11 display driver support in lv_conf.h, by cmake compiler define or by KConfig
+1. Enable the X11 driver support in lv_conf.h, by cmake compiler define or by KConfig
     .. code:: c
 
         #define LV_USE_X11  1
@@ -56,7 +56,8 @@ Configure X11 display driver
 Usage
 -----
 
-The minimal initialisation (e.g. in main.c, LV_X11_DIRECT_EXIT must be 1):
+| The minimal initialisation opening a window and enabling keyboard/mouse support
+| (e.g. in main.c, LV_X11_DIRECT_EXIT must be 1):
 
 .. code:: c
 
@@ -81,8 +82,8 @@ The minimal initialisation (e.g. in main.c, LV_X11_DIRECT_EXIT must be 1):
         }
     }
 
-Full initialisation with mouse pointer symbol and
-own application exit handling dependent on LV_X11_DIRECT_EXIT (can be 1 or 0)
+| Full initialisation with mouse pointer symbol and own application exit handling
+| (dependent on LV_X11_DIRECT_EXIT (can be 1 or 0))
 
 .. code:: c
 

--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -85,7 +85,7 @@ install(
 configure_file("${LVGL_ROOT_DIR}/lvgl.pc.in" lvgl.pc @ONLY)
 
 install(
-  FILES "${CMAKE_BINARY_DIR}/lvgl.pc"
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/lvgl.pc"
   DESTINATION "${LIB_INSTALL_DIR}/pkgconfig/")
 
 set_target_properties(

--- a/src/dev/x11/lv_x11_display.c
+++ b/src/dev/x11/lv_x11_display.c
@@ -320,9 +320,9 @@ static void x11_window_create(lv_display_t * disp, char const * title)
     xd->window = XCreateSimpleWindow(xd->hdr.display, DefaultRootWindow(xd->hdr.display),
                                      0, 0, hor_res, ver_res, 0, col_fg, col_bg);
 #else
-    xd->window = XCreateWindow(xd->hdr.display, DefaultRootWindow(xd->hdr.display),
+    xd->window = XCreateWindow(xd->hdr.display, XDefaultRootWindow(xd->hdr.display),
                                0, 0, hor_res, ver_res, 0,
-                               DefaultDepth(xd->hdr.display, screen), InputOutput,
+                               XDefaultDepth(xd->hdr.display, screen), InputOutput,
                                xd->visual, 0, NULL);
 #endif
     /* window manager properties (yes, use of StdProp is obsolete) */


### PR DESCRIPTION
If using LVGL by FetchContent in an own project the binary directory is selected by cmake (prefixed in _deps normally).
This fixes the install step respecting the current binary dir and not the global one.

No checkpoint items applied as it is only a minor change in cmake.