### PR TITLE
feat(indev): start scroll_throw animation using lv_anim_start

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1501,7 +1501,6 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
 {
     LV_ASSERT_NULL(var);
     LV_UNUSED(v);
-
     lv_indev_t * indev = (lv_indev_t *)var;
 
     _lv_indev_scroll_throw_handler(indev);
@@ -1529,11 +1528,12 @@ static void indev_scroll_throw_anim_start(lv_indev_t * indev)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, indev);
-    lv_anim_set_time(&a, 5000);
-    lv_anim_set_values(&a, 0, 100);
+    lv_anim_set_time(&a, 1024);
+    lv_anim_set_values(&a, 0, 1024);
     lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
     lv_anim_set_ready_cb(&a, indev_scroll_throw_anim_ready_cb);
     lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_ready_cb);
+    lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     indev->scroll_throw_anim = lv_anim_start(&a);
 }

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -73,6 +73,18 @@ static void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data);
 static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj);
 static lv_result_t send_event(lv_event_code_t code, void * param);
 
+static void indev_scroll_throw_anim_start(lv_indev_t * indev);
+static void indev_scroll_throw_anim_cb(void * var, int32_t v);
+static void indev_scroll_throw_anim_ready_cb(lv_anim_t * anim);
+static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
+{
+    if(indev) {
+        indev->pointer.scroll_throw_vect.x = 0;
+        indev->pointer.scroll_throw_vect.y = 0;
+        indev->scroll_throw_anim = NULL;
+    }
+}
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -1056,8 +1068,12 @@ static void indev_proc_press(lv_indev_t * indev)
 
     /*The last object might have scroll throw. Stop it manually*/
     if(new_obj_searched && indev->pointer.last_obj) {
-        indev->pointer.scroll_throw_vect.x = 0;
-        indev->pointer.scroll_throw_vect.y = 0;
+
+        /*Attempt to stop scroll throw animation firstly*/
+        if(!indev->scroll_throw_anim || !lv_anim_delete(indev, indev_scroll_throw_anim_cb)) {
+            indev_scroll_throw_anim_reset(indev);
+        }
+
         _lv_indev_scroll_throw_handler(indev);
         if(indev_reset_check(indev)) return;
     }
@@ -1233,7 +1249,10 @@ static void indev_proc_release(lv_indev_t * indev)
     }
 
     if(scroll_obj) {
-        _lv_indev_scroll_throw_handler(indev);
+        if(!indev->scroll_throw_anim) {
+            indev_scroll_throw_anim_start(indev);
+        }
+
         if(indev_reset_check(indev)) return;
     }
 }
@@ -1476,4 +1495,45 @@ static lv_result_t send_event(lv_event_code_t code, void * param)
     }
 
     return LV_RESULT_OK;
+}
+
+static void indev_scroll_throw_anim_cb(void * var, int32_t v)
+{
+    LV_ASSERT_NULL(var);
+    LV_UNUSED(v);
+
+    lv_indev_t * indev = (lv_indev_t *)var;
+
+    _lv_indev_scroll_throw_handler(indev);
+
+    if(indev->pointer.scroll_dir == LV_DIR_NONE || indev->pointer.scroll_obj == NULL) {
+        if(indev->scroll_throw_anim) {
+            /*hacky*/
+            LV_LOG_INFO("stop animation");
+            lv_anim_set_time(indev->scroll_throw_anim, 0);
+        }
+    }
+}
+
+static void indev_scroll_throw_anim_ready_cb(lv_anim_t * anim)
+{
+    if(anim) {
+        indev_scroll_throw_anim_reset((lv_indev_t *)anim->var);
+    }
+}
+
+static void indev_scroll_throw_anim_start(lv_indev_t * indev)
+{
+    LV_ASSERT_NULL(indev);
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, indev);
+    lv_anim_set_time(&a, 5000);
+    lv_anim_set_values(&a, 0, 100);
+    lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
+    lv_anim_set_ready_cb(&a, indev_scroll_throw_anim_ready_cb);
+    lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_ready_cb);
+
+    indev->scroll_throw_anim = lv_anim_start(&a);
 }

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "lv_indev.h"
+#include "../misc/lv_anim.h"
 /*********************
  *      DEFINES
  *********************/
@@ -103,6 +104,7 @@ struct _lv_indev_t {
                                       here by the buttons*/
 
     lv_event_list_t event_list;
+    lv_anim_t * scroll_throw_anim;
 };
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/indev/lv_indev_scroll.c
+++ b/src/indev/lv_indev_scroll.c
@@ -118,8 +118,7 @@ void _lv_indev_scroll_throw_handler(lv_indev_t * indev)
     if(scroll_obj == NULL) return;
     if(indev->pointer.scroll_dir == LV_DIR_NONE) return;
 
-    lv_indev_t * indev_act = lv_indev_active();
-    int32_t scroll_throw = indev_act->scroll_throw;
+    int32_t scroll_throw = indev->scroll_throw;
 
     if(lv_obj_has_flag(scroll_obj, LV_OBJ_FLAG_SCROLL_MOMENTUM) == false) {
         indev->pointer.scroll_throw_vect.y = 0;
@@ -217,7 +216,7 @@ void _lv_indev_scroll_throw_handler(lv_indev_t * indev)
             }
         }
 
-        lv_obj_send_event(scroll_obj, LV_EVENT_SCROLL_END, indev_act);
+        lv_obj_send_event(scroll_obj, LV_EVENT_SCROLL_END, indev);
         if(indev->reset_query) return;
 
         indev->pointer.scroll_dir = LV_DIR_NONE;
@@ -270,8 +269,7 @@ static lv_obj_t * find_scroll_obj(lv_indev_t * indev)
 {
     lv_obj_t * obj_candidate = NULL;
     lv_dir_t dir_candidate = LV_DIR_NONE;
-    lv_indev_t * indev_act = lv_indev_active();
-    int32_t scroll_limit = indev_act->scroll_limit;
+    int32_t scroll_limit = indev->scroll_limit;
 
     /*Go until find a scrollable object in the current direction
      *More precisely:
@@ -595,8 +593,7 @@ static int32_t scroll_throw_predict_y(lv_indev_t * indev)
     int32_t y = indev->pointer.scroll_throw_vect.y;
     int32_t move = 0;
 
-    lv_indev_t * indev_act = lv_indev_active();
-    int32_t scroll_throw = indev_act->scroll_throw;
+    int32_t scroll_throw = indev->scroll_throw;
 
     while(y) {
         move += y;
@@ -610,8 +607,7 @@ static int32_t scroll_throw_predict_x(lv_indev_t * indev)
     int32_t x = indev->pointer.scroll_throw_vect.x;
     int32_t move = 0;
 
-    lv_indev_t * indev_act = lv_indev_active();
-    int32_t scroll_throw = indev_act->scroll_throw;
+    int32_t scroll_throw = indev->scroll_throw;
 
     while(x) {
         move += x;


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
