### PR TITLE
chore(image): add image flag bitfield

### DIFF
--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -42,6 +42,33 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
+typedef enum _lv_image_flags_t {
+    /**
+     * For RGB map of the image data, mark if it's pre-multiplied with alpha.
+     * For indexed image, this bit indicated palette data is pre-multiplied with alpha.
+     */
+    LV_IMAGE_FLAGS_PREMULTIPLIED = 0x01,
+
+    /**
+     * If the image data is malloced and can be processed in place.
+     * In image decoder post processing, this flag means we modify it in-place.
+     */
+    LV_IMAGE_FLAGS_MODIFIABLE    = 0x02,
+
+    /**
+     * Flags reserved for user, lvgl won't use these bits.
+     */
+    LV_IMAGE_FLAGS_USER1         = 0x1000,
+    LV_IMAGE_FLAGS_USER2         = 0x2000,
+    LV_IMAGE_FLAGS_USER3         = 0x4000,
+    LV_IMAGE_FLAGS_USER4         = 0x8000,
+    LV_IMAGE_FLAGS_USER5         = 0x0100,
+    LV_IMAGE_FLAGS_USER6         = 0x0200,
+    LV_IMAGE_FLAGS_USER7         = 0x0400,
+    LV_IMAGE_FLAGS_USER8         = 0x0800,
+} lv_image_flags_t;
+
 /**
  * The first 8 bit is very important to distinguish the different source types.
  * For more info see `lv_image_get_src_type()` in lv_img.c
@@ -61,13 +88,12 @@ typedef struct {
 } lv_image_header_t;
 #else
 typedef struct {
-    uint32_t cf : 5;          /*Color format: See `lv_color_format_t`*/
-    uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
-                                 non-printable character*/
+    uint32_t cf : 5;            /*Color format: See `lv_color_format_t`*/
+    uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
+                                  non-printable character*/
 
-    uint32_t format: 8;       /*Image format? To be defined by LVGL*/
-    uint32_t user: 8;
-    uint32_t reserved: 8;   /*Reserved to be used later*/
+    uint32_t format: 8;         /*Image format? To be defined by LVGL*/
+    uint32_t flag: 16;          /*Image flags, see `lv_image_flags_t`*/
 
     uint32_t w: 16;
     uint32_t h: 16;

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -48,25 +48,31 @@ typedef enum _lv_image_flags_t {
      * For RGB map of the image data, mark if it's pre-multiplied with alpha.
      * For indexed image, this bit indicated palette data is pre-multiplied with alpha.
      */
-    LV_IMAGE_FLAGS_PREMULTIPLIED = 0x01,
+    LV_IMAGE_FLAGS_PREMULTIPLIED    = 0x01,
 
     /**
      * If the image data is malloced and can be processed in place.
      * In image decoder post processing, this flag means we modify it in-place.
      */
-    LV_IMAGE_FLAGS_MODIFIABLE    = 0x02,
+    LV_IMAGE_FLAGS_MODIFIABLE       = 0x02,
+
+    /**
+     * Indicating it's a vector image instead of default raster image.
+     * Some of the flags are not usable for vector image, like PREMULTIPLIED.
+     */
+    LV_IMAGE_FLAGS_VECTORS          = 0x04,
 
     /**
      * Flags reserved for user, lvgl won't use these bits.
      */
-    LV_IMAGE_FLAGS_USER1         = 0x1000,
-    LV_IMAGE_FLAGS_USER2         = 0x2000,
-    LV_IMAGE_FLAGS_USER3         = 0x4000,
-    LV_IMAGE_FLAGS_USER4         = 0x8000,
-    LV_IMAGE_FLAGS_USER5         = 0x0100,
-    LV_IMAGE_FLAGS_USER6         = 0x0200,
-    LV_IMAGE_FLAGS_USER7         = 0x0400,
-    LV_IMAGE_FLAGS_USER8         = 0x0800,
+    LV_IMAGE_FLAGS_USER1            = 0x1000,
+    LV_IMAGE_FLAGS_USER2            = 0x2000,
+    LV_IMAGE_FLAGS_USER3            = 0x4000,
+    LV_IMAGE_FLAGS_USER4            = 0x8000,
+    LV_IMAGE_FLAGS_USER5            = 0x0100,
+    LV_IMAGE_FLAGS_USER6            = 0x0200,
+    LV_IMAGE_FLAGS_USER7            = 0x0400,
+    LV_IMAGE_FLAGS_USER8            = 0x0800,
 } lv_image_flags_t;
 
 /**

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -93,7 +93,7 @@ typedef struct {
                                   non-printable character*/
 
     uint32_t format: 8;         /*Image format? To be defined by LVGL*/
-    uint32_t flag: 16;          /*Image flags, see `lv_image_flags_t`*/
+    uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/
 
     uint32_t w: 16;
     uint32_t h: 16;

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -105,6 +105,9 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
                 LV_LOG_WARN("Read file header failed: %d", res);
                 return LV_RESULT_INVALID;
             }
+
+            /*File is always read to buf, thus data can be modified.*/
+            header->flag |= LV_IMAGE_FLAGS_MODIFIABLE;
         }
     }
     else if(src_type == LV_IMAGE_SRC_SYMBOL) {
@@ -120,6 +123,9 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
         LV_LOG_WARN("Image get info found unknown src type");
         return LV_RESULT_INVALID;
     }
+
+    /*For backward compatibility, all images are not premultiplied for now.*/
+    header->flag &= ~LV_IMAGE_FLAGS_PREMULTIPLIED;
 
     return LV_RESULT_OK;
 }

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -107,7 +107,7 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
             }
 
             /*File is always read to buf, thus data can be modified.*/
-            header->flag |= LV_IMAGE_FLAGS_MODIFIABLE;
+            header->flags |= LV_IMAGE_FLAGS_MODIFIABLE;
         }
     }
     else if(src_type == LV_IMAGE_SRC_SYMBOL) {
@@ -125,7 +125,7 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
     }
 
     /*For backward compatibility, all images are not premultiplied for now.*/
-    header->flag &= ~LV_IMAGE_FLAGS_PREMULTIPLIED;
+    header->flags &= ~LV_IMAGE_FLAGS_PREMULTIPLIED;
 
     return LV_RESULT_OK;
 }


### PR DESCRIPTION


### Description of the feature or fix

Use `flag` field to mark if image is premultiplied. And mark if image data is const so the post-process know if it needs a copy of data.

`premultiplied` could potentially boost software renderer performance by eliminating three multiplication.

```c
static inline lv_color32_t lv_color_mix32(lv_color32_t fg, lv_color32_t bg)
{
    if(fg.alpha >= LV_OPA_MAX) {
        fg.alpha = bg.alpha;
        return fg;
    }
    if(fg.alpha <= LV_OPA_MIN) {
        return bg;
    }
    bg.red = (uint32_t)((uint32_t)fg.red * fg.alpha + (uint32_t)bg.red * (255 - fg.alpha)) >> 8;
    bg.green = (uint32_t)((uint32_t)fg.green * fg.alpha + (uint32_t)bg.green * (255 - fg.alpha)) >> 8;
    bg.blue = (uint32_t)((uint32_t)fg.blue * fg.alpha + (uint32_t)bg.blue * (255 - fg.alpha)) >> 8;
    return bg;
}
```

cc @FASTSHIFT 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
