### PR TITLE
chore(demos): fix warning

### DIFF
--- a/demos/flex_layout/lv_demo_flex_layout_view_child_node.c
+++ b/demos/flex_layout/lv_demo_flex_layout_view_child_node.c
@@ -50,7 +50,7 @@ lv_obj_t * obj_child_node_create(lv_obj_t * par, view_t * ui)
     lv_obj_add_style(obj, &ui->obj_checked_style, LV_STATE_CHECKED);
 
     lv_obj_t * label = lv_label_create(obj);
-    lv_label_set_text_fmt(label, "%d", cnt);
+    lv_label_set_text_fmt(label, "%" LV_PRIu32, cnt);
     lv_obj_add_flag(label, LV_OBJ_FLAG_IGNORE_LAYOUT | LV_OBJ_FLAG_FLOATING);
     lv_obj_center(label);
 

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -79,7 +79,7 @@ static void obj_test_task_cb(lv_timer_t * tmr)
 
                 if(mem_free_start == 0)  mem_free_start = mon.free_size;
 
-                LV_LOG_USER("mem leak since start: %d, frag: %3d %%",  mem_free_start - mon.free_size, mon.frag_pct);
+                LV_LOG_USER("mem leak since start: %" LV_PRIu32 ", frag: %3d %%", mem_free_start - mon.free_size, mon.frag_pct);
             }
             break;
         case 0:

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -186,7 +186,7 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
                     uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, layer_drawn->color_format);
 
                     _draw_info.used_memory_for_layers_kb -= layer_size_byte < 1024 ? 1 : layer_size_byte >> 10;
-                    LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
+                    LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
                     lv_draw_buf_free(layer_drawn->buf_unaligned);
                 }
 
@@ -365,7 +365,7 @@ void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
 
         uint32_t kb = layer_size_byte < 1024 ? 1 : layer_size_byte >> 10;
         _draw_info.used_memory_for_layers_kb += kb;
-        LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
+        LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
 
         if(lv_color_format_has_alpha(layer->color_format)) {
             lv_area_t a;


### PR DESCRIPTION
### Description of the feature or fix

```
lvgl/demos/flex_layout/lv_demo_flex_layout_view_child_node.c: In function 'obj_child_node_create':
lvgl/demos/flex_layout/lv_demo_flex_layout_view_child_node.c:53:36: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
   53 |     lv_label_set_text_fmt(label, "%d", cnt);
      |                                   ~^   ~~~
      |                                    |   |
      |                                    int uint32_t {aka long unsigned int}
      |                                   %ld
CC:  lvgl/demos/widgets/assets/img_lvgl_logo.c In file included from lvgl/demos/stress/../../lvgl.h:30,
                 from lvgl/demos/stress/../lv_demos.h:16,
                 from lvgl/demos/stress/lv_demo_stress.h:16,
                 from lvgl/demos/stress/lv_demo_stress.c:9:
lvgl/demos/stress/lv_demo_stress.c: In function 'obj_test_task_cb':
lvgl/demos/stress/lv_demo_stress.c:82:29: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
   82 |                 LV_LOG_USER("mem leak since start: %d, frag: %3d %%",  mem_free_start - mon.free_size, mon.frag_pct);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                       |
      |                                                                                       uint32_t {aka long unsigned int}
lvgl/demos/stress/../../src/misc/lv_log.h:132:97: note: in definition of macro 'LV_LOG_USER'
  132 | #    define LV_LOG_USER(...) _lv_log_add(LV_LOG_LEVEL_USER, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
      |                                                                                                 ^~~~~~~~~~~
lvgl/demos/stress/lv_demo_stress.c:82:53: note: format string is defined here
   82 |                 LV_LOG_USER("mem leak since start: %d, frag: %3d %%",  mem_free_start - mon.free_size, mon.frag_pct);
      |                                                    ~^
      |                                                     |
      |                                                     int
      |                                                    %ld
CC:  lvgl/src/draw/lv_draw_line.c In file included from lvgl/src/draw/../misc/lv_assert.h:17,
                 from lvgl/src/draw/../misc/lv_color.h:17,
                 from lvgl/src/draw/../misc/lv_style.h:19,
                 from lvgl/src/draw/lv_draw.h:18,
                 from lvgl/src/draw/lv_draw.c:9:
lvgl/src/draw/lv_draw.c: In function 'lv_draw_dispatch_layer':
lvgl/src/draw/lv_draw.c:192:33: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  192 |                     LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/../misc/lv_log.h:108:97: note: in definition of macro 'LV_LOG_INFO'
  108 | #    define LV_LOG_INFO(...) _lv_log_add(LV_LOG_LEVEL_INFO, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
      |                                                                                                 ^~~~~~~~~~~
lvgl/src/draw/lv_draw.c:192:54: note: format string is defined here
  192 |                     LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
      |                                                     ~^
      |                                                      |
      |                                                      int
      |                                                     %ld
CC:  lvgl/src/draw/lv_draw_mask.c In file included from lvgl/src/draw/../misc/lv_assert.h:17,
                 from lvgl/src/draw/../misc/lv_color.h:17,
                 from lvgl/src/draw/../misc/lv_style.h:19,
                 from lvgl/src/draw/lv_draw.h:18,
                 from lvgl/src/draw/lv_draw.c:9:
lvgl/src/draw/lv_draw.c: In function 'lv_draw_layer_alloc_buf':
lvgl/src/draw/lv_draw.c:370:21: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  370 |         LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/../misc/lv_log.h:108:97: note: in definition of macro 'LV_LOG_INFO'
  108 | #    define LV_LOG_INFO(...) _lv_log_add(LV_LOG_LEVEL_INFO, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
      |                                                                                                 ^~~~~~~~~~~
lvgl/src/draw/lv_draw.c:370:42: note: format string is defined here
  370 |         LV_LOG_INFO("Layer memory used: %d kB\n", _draw_info.used_memory_for_layers_kb);
      |                                         ~^
      |                                          |
      |                                          int
      |                                         %ld
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
