### PR TITLE
feat(gif): add API to pause/resume gif timer

### DIFF
--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -106,6 +106,18 @@ void lv_gif_restart(lv_obj_t * obj)
     lv_timer_reset(gifobj->timer);
 }
 
+void lv_gif_pause(lv_obj_t * obj)
+{
+    lv_gif_t * gifobj = (lv_gif_t *) obj;
+    lv_timer_pause(gifobj->timer);
+}
+
+void lv_gif_resume(lv_obj_t * obj)
+{
+    lv_gif_t * gifobj = (lv_gif_t *) obj;
+    lv_timer_resume(gifobj->timer);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/libs/gif/lv_gif.h
+++ b/src/libs/gif/lv_gif.h
@@ -41,9 +41,38 @@ extern const lv_obj_class_t lv_gif_class;
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Create a gif object
+ * @param parent    pointer to an object, it will be the parent of the new gif.
+ * @return          pointer to the gif obj
+ */
 lv_obj_t * lv_gif_create(lv_obj_t * parent);
+
+/**
+ * Set the gif data to display on the object
+ * @param obj       pointer to a gif object
+ * @param src       1) pointer to an ::lv_image_dsc_t descriptor (which contains gif raw data) or
+ *                  2) path to a gif file (e.g. "S:/dir/anim.gif")
+ */
 void lv_gif_set_src(lv_obj_t * obj, const void * src);
-void lv_gif_restart(lv_obj_t * gif);
+
+/**
+ * Restart a gif animation.
+ * @param obj pointer to a gif obj
+ */
+void lv_gif_restart(lv_obj_t * obj);
+
+/**
+ * Pause a gif animation.
+ * @param obj pointer to a gif obj
+ */
+void lv_gif_pause(lv_obj_t * obj);
+
+/**
+ * Resume a gif animation.
+ * @param obj pointer to a gif obj
+ */
+void lv_gif_resume(lv_obj_t * obj);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### add API to pause/resume gif timer

We need to pause gif timer to pause animation in sometimes. So we add API `lv_gif_pause` and `lv_gif_resume` to pause or resume gif. Also, I add some annoations of these functions in `lv_gif.h`.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
