### PR TITLE
fix(draw_line): use lv_point_precise_t to describe coordinates

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -1419,17 +1419,17 @@ static void chart_event_cb(lv_event_t * e)
             lv_draw_triangle_dsc_t tri_dsc;
 
             lv_draw_triangle_dsc_init(&tri_dsc);
-            tri_dsc.p[0].x = (int32_t)draw_line_dsc->p1_x;
-            tri_dsc.p[0].y = (int32_t)draw_line_dsc->p1_y;
-            tri_dsc.p[1].x = (int32_t)draw_line_dsc->p2_x;
-            tri_dsc.p[1].y = (int32_t)draw_line_dsc->p2_y;
-            tri_dsc.p[2].x = (int32_t)(draw_line_dsc->p1_y < draw_line_dsc->p2_y ? draw_line_dsc->p1_x : draw_line_dsc->p2_x);
-            tri_dsc.p[2].y = (int32_t)LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y);
+            tri_dsc.p[0].x = (int32_t)draw_line_dsc->p1.x;
+            tri_dsc.p[0].y = (int32_t)draw_line_dsc->p1.y;
+            tri_dsc.p[1].x = (int32_t)draw_line_dsc->p2.x;
+            tri_dsc.p[1].y = (int32_t)draw_line_dsc->p2.y;
+            tri_dsc.p[2].x = (int32_t)(draw_line_dsc->p1.y < draw_line_dsc->p2.y ? draw_line_dsc->p1.x : draw_line_dsc->p2.x);
+            tri_dsc.p[2].y = (int32_t)LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y);
             tri_dsc.bg_grad.dir = LV_GRAD_DIR_VER;
 
             int32_t full_h = lv_obj_get_height(obj);
-            int32_t fract_uppter = (int32_t)(LV_MIN(draw_line_dsc->p1_y, draw_line_dsc->p2_y) - obj->coords.y1) * 255 / full_h;
-            int32_t fract_lower = (int32_t)(LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y) - obj->coords.y1) * 255 / full_h;
+            int32_t fract_uppter = (int32_t)(LV_MIN(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - obj->coords.y1) * 255 / full_h;
+            int32_t fract_lower = (int32_t)(LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - obj->coords.y1) * 255 / full_h;
             tri_dsc.bg_grad.stops[0].color = ser->color;
             tri_dsc.bg_grad.stops[0].opa = 255 - fract_uppter;
             tri_dsc.bg_grad.stops[0].frac = 0;
@@ -1450,9 +1450,9 @@ static void chart_event_cb(lv_event_t * e)
             rect_dsc.bg_grad.stops[1].opa = 0;
 
             lv_area_t rect_area;
-            rect_area.x1 = (int32_t)draw_line_dsc->p1_x;
-            rect_area.x2 = (int32_t)draw_line_dsc->p2_x;
-            rect_area.y1 = (int32_t)LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y) + 1;
+            rect_area.x1 = (int32_t)draw_line_dsc->p1.x;
+            rect_area.x2 = (int32_t)draw_line_dsc->p2.x;
+            rect_area.y1 = (int32_t)LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y) + 1;
             rect_area.y2 = (int32_t)obj->coords.y2;
             lv_draw_rect(base_dsc->layer, &rect_dsc, &rect_area);
         }

--- a/examples/widgets/canvas/lv_example_canvas_7.c
+++ b/examples/widgets/canvas/lv_example_canvas_7.c
@@ -27,10 +27,10 @@ void lv_example_canvas_7(void)
     dsc.width = 4;
     dsc.round_end = 1;
     dsc.round_start = 1;
-    dsc.p1_x = 15;
-    dsc.p1_y = 15;
-    dsc.p2_x = 35;
-    dsc.p2_y = 10;
+    dsc.p1.x = 15;
+    dsc.p1.y = 15;
+    dsc.p2.x = 35;
+    dsc.p2.y = 10;
     lv_draw_line(&layer, &dsc);
 
     lv_canvas_finish_layer(canvas, &layer);

--- a/examples/widgets/canvas/lv_example_canvas_7.py
+++ b/examples/widgets/canvas/lv_example_canvas_7.py
@@ -23,10 +23,10 @@ dsc.color = lv.palette_main(lv.PALETTE.RED)
 dsc.width = 4
 dsc.round_end = 1
 dsc.round_start = 1
-dsc.p1_x = 15;
-dsc.p1_y = 15;
-dsc.p2_x = 35;
-dsc.p2_y = 10;
+dsc.p1.x = 15;
+dsc.p1.y = 15;
+dsc.p2.x = 35;
+dsc.p2.y = 10;
 
 layer = lv.layer_t()
 canvas.init_layer(layer);

--- a/examples/widgets/chart/lv_example_chart_5.c
+++ b/examples/widgets/chart/lv_example_chart_5.c
@@ -61,17 +61,17 @@ static void add_faded_area(lv_event_t * e)
     lv_draw_triangle_dsc_t tri_dsc;
 
     lv_draw_triangle_dsc_init(&tri_dsc);
-    tri_dsc.p[0].x = draw_line_dsc->p1_x;
-    tri_dsc.p[0].y = draw_line_dsc->p1_y;
-    tri_dsc.p[1].x = draw_line_dsc->p2_x;
-    tri_dsc.p[1].y = draw_line_dsc->p2_y;
-    tri_dsc.p[2].x = draw_line_dsc->p1_y < draw_line_dsc->p2_y ? draw_line_dsc->p1_x : draw_line_dsc->p2_x;
-    tri_dsc.p[2].y = LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y);
+    tri_dsc.p[0].x = draw_line_dsc->p1.x;
+    tri_dsc.p[0].y = draw_line_dsc->p1.y;
+    tri_dsc.p[1].x = draw_line_dsc->p2.x;
+    tri_dsc.p[1].y = draw_line_dsc->p2.y;
+    tri_dsc.p[2].x = draw_line_dsc->p1.y < draw_line_dsc->p2.y ? draw_line_dsc->p1.x : draw_line_dsc->p2.x;
+    tri_dsc.p[2].y = LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y);
     tri_dsc.bg_grad.dir = LV_GRAD_DIR_VER;
 
     int32_t full_h = lv_obj_get_height(obj);
-    int32_t fract_uppter = (int32_t)(LV_MIN(draw_line_dsc->p1_y, draw_line_dsc->p2_y) - obj->coords.y1) * 255 / full_h;
-    int32_t fract_lower = (int32_t)(LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y) - obj->coords.y1) * 255 / full_h;
+    int32_t fract_uppter = (int32_t)(LV_MIN(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - obj->coords.y1) * 255 / full_h;
+    int32_t fract_lower = (int32_t)(LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - obj->coords.y1) * 255 / full_h;
     tri_dsc.bg_grad.stops[0].color = ser->color;
     tri_dsc.bg_grad.stops[0].opa = 255 - fract_uppter;
     tri_dsc.bg_grad.stops[0].frac = 0;
@@ -93,9 +93,9 @@ static void add_faded_area(lv_event_t * e)
     rect_dsc.bg_grad.stops[1].opa = 0;
 
     lv_area_t rect_area;
-    rect_area.x1 = (int32_t)draw_line_dsc->p1_x;
-    rect_area.x2 = (int32_t)draw_line_dsc->p2_x - 1;
-    rect_area.y1 = (int32_t)LV_MAX(draw_line_dsc->p1_y, draw_line_dsc->p2_y) - 1;
+    rect_area.x1 = (int32_t)draw_line_dsc->p1.x;
+    rect_area.x2 = (int32_t)draw_line_dsc->p2.x - 1;
+    rect_area.y1 = (int32_t)LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - 1;
     rect_area.y2 = (int32_t)obj->coords.y2;
     lv_draw_rect(base_dsc->layer, &rect_dsc, &rect_area);
 }
@@ -107,7 +107,7 @@ static void hook_division_lines(lv_event_t * e)
     lv_draw_line_dsc_t * line_dsc = draw_task->draw_dsc;
 
     /*Vertical line*/
-    if(line_dsc->p1_x == line_dsc->p2_x) {
+    if(line_dsc->p1.x == line_dsc->p2.x) {
         line_dsc->color  = lv_palette_lighten(LV_PALETTE_GREY, 1);
         if(base_dsc->id1 == 3) {
             line_dsc->width = 2;

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -47,10 +47,10 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line(struct _lv_layer_t * layer, const lv_dra
 {
     LV_PROFILER_BEGIN;
     lv_area_t a;
-    a.x1 = (int32_t)LV_MIN(dsc->p1_x, dsc->p2_x) - dsc->width;
-    a.x2 = (int32_t)LV_MAX(dsc->p1_x, dsc->p2_x) + dsc->width;
-    a.y1 = (int32_t)LV_MIN(dsc->p1_y, dsc->p2_y) - dsc->width;
-    a.y2 = (int32_t)LV_MAX(dsc->p1_y, dsc->p2_y) + dsc->width;
+    a.x1 = (int32_t)LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width;
+    a.x2 = (int32_t)LV_MAX(dsc->p1.x, dsc->p2.x) + dsc->width;
+    a.y1 = (int32_t)LV_MIN(dsc->p1.y, dsc->p2.y) - dsc->width;
+    a.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &a);
 

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -28,10 +28,8 @@ extern "C" {
 typedef struct {
     lv_draw_dsc_base_t base;
 
-    lv_value_precise_t p1_x;
-    lv_value_precise_t p1_y;
-    lv_value_precise_t p2_x;
-    lv_value_precise_t p2_y;
+    lv_point_precise_t p1;
+    lv_point_precise_t p2;
     lv_color_t color;
     int32_t width;
     int32_t dash_width;

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -54,20 +54,20 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    if(dsc->p1_x == dsc->p2_x && dsc->p1_y == dsc->p2_y) return;
+    if(dsc->p1.x == dsc->p2.x && dsc->p1.y == dsc->p2.y) return;
 
     lv_area_t clip_line;
-    clip_line.x1 = (int32_t)LV_MIN(dsc->p1_x, dsc->p2_x) - dsc->width / 2;
-    clip_line.x2 = (int32_t)LV_MAX(dsc->p1_x, dsc->p2_x) + dsc->width / 2;
-    clip_line.y1 = (int32_t)LV_MIN(dsc->p1_y, dsc->p2_y) - dsc->width / 2;
-    clip_line.y2 = (int32_t)LV_MAX(dsc->p1_y, dsc->p2_y) + dsc->width / 2;
+    clip_line.x1 = (int32_t)LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width / 2;
+    clip_line.x2 = (int32_t)LV_MAX(dsc->p1.x, dsc->p2.x) + dsc->width / 2;
+    clip_line.y1 = (int32_t)LV_MIN(dsc->p1.y, dsc->p2.y) - dsc->width / 2;
+    clip_line.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width / 2;
 
     bool is_common;
     is_common = _lv_area_intersect(&clip_line, &clip_line, draw_unit->clip_area);
     if(!is_common) return;
 
-    if(dsc->p1_y == dsc->p2_y) draw_line_hor(draw_unit, dsc);
-    else if(dsc->p1_x == dsc->p2_x) draw_line_ver(draw_unit, dsc);
+    if(dsc->p1.y == dsc->p2.y) draw_line_hor(draw_unit, dsc);
+    else if(dsc->p1.x == dsc->p2.x) draw_line_ver(draw_unit, dsc);
     else draw_line_skew(draw_unit, dsc);
 
     if(dsc->round_end || dsc->round_start) {
@@ -82,18 +82,18 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_
         lv_area_t cir_area;
 
         if(dsc->round_start) {
-            cir_area.x1 = (int32_t)dsc->p1_x - r;
-            cir_area.y1 = (int32_t)dsc->p1_y - r;
-            cir_area.x2 = (int32_t)dsc->p1_x + r - r_corr;
-            cir_area.y2 = (int32_t)dsc->p1_y + r - r_corr ;
+            cir_area.x1 = (int32_t)dsc->p1.x - r;
+            cir_area.y1 = (int32_t)dsc->p1.y - r;
+            cir_area.x2 = (int32_t)dsc->p1.x + r - r_corr;
+            cir_area.y2 = (int32_t)dsc->p1.y + r - r_corr ;
             lv_draw_sw_fill(draw_unit, &cir_dsc, &cir_area);
         }
 
         if(dsc->round_end) {
-            cir_area.x1 = (int32_t)dsc->p2_x - r;
-            cir_area.y1 = (int32_t)dsc->p2_y - r;
-            cir_area.x2 = (int32_t)dsc->p2_x + r - r_corr;
-            cir_area.y2 = (int32_t)dsc->p2_y + r - r_corr ;
+            cir_area.x1 = (int32_t)dsc->p2.x - r;
+            cir_area.y1 = (int32_t)dsc->p2.y - r;
+            cir_area.x2 = (int32_t)dsc->p2.x + r - r_corr;
+            cir_area.y2 = (int32_t)dsc->p2.y + r - r_corr ;
             lv_draw_sw_fill(draw_unit, &cir_dsc, &cir_area);
         }
     }
@@ -109,10 +109,10 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(lv_draw_unit_t * draw_unit, cons
     int32_t w_half1 = w_half0 + (w & 0x1); /*Compensate rounding error*/
 
     lv_area_t blend_area;
-    blend_area.x1 = (int32_t)LV_MIN(dsc->p1_x, dsc->p2_x);
-    blend_area.x2 = (int32_t)LV_MAX(dsc->p1_x, dsc->p2_x)  - 1;
-    blend_area.y1 = (int32_t)dsc->p1_y - w_half1;
-    blend_area.y2 = (int32_t)dsc->p1_y + w_half0;
+    blend_area.x1 = (int32_t)LV_MIN(dsc->p1.x, dsc->p2.x);
+    blend_area.x2 = (int32_t)LV_MAX(dsc->p1.x, dsc->p2.x)  - 1;
+    blend_area.y1 = (int32_t)dsc->p1.y - w_half1;
+    blend_area.y2 = (int32_t)dsc->p1.y + w_half0;
 
     bool is_common;
     is_common = _lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
@@ -184,10 +184,10 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(lv_draw_unit_t * draw_unit, cons
     int32_t w_half1 = w_half0 + (w & 0x1); /*Compensate rounding error*/
 
     lv_area_t blend_area;
-    blend_area.x1 = (int32_t)dsc->p1_x - w_half1;
-    blend_area.x2 = (int32_t)dsc->p1_x + w_half0;
-    blend_area.y1 = (int32_t)LV_MIN(dsc->p1_y, dsc->p2_y);
-    blend_area.y2 = (int32_t)LV_MAX(dsc->p1_y, dsc->p2_y) - 1;
+    blend_area.x1 = (int32_t)dsc->p1.x - w_half1;
+    blend_area.x2 = (int32_t)dsc->p1.x + w_half0;
+    blend_area.y1 = (int32_t)LV_MIN(dsc->p1.y, dsc->p2.y);
+    blend_area.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) - 1;
 
     bool is_common;
     is_common = _lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
@@ -255,17 +255,17 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(lv_draw_unit_t * draw_unit, con
     /*Keep the great y in p1*/
     lv_point_t p1;
     lv_point_t p2;
-    if(dsc->p1_y < dsc->p2_y) {
-        p1.y = (int32_t)dsc->p1_y;
-        p2.y = (int32_t)dsc->p2_y;
-        p1.x = (int32_t)dsc->p1_x;
-        p2.x = (int32_t)dsc->p2_x;
+    if(dsc->p1.y < dsc->p2.y) {
+        p1.y = (int32_t)dsc->p1.y;
+        p2.y = (int32_t)dsc->p2.y;
+        p1.x = (int32_t)dsc->p1.x;
+        p2.x = (int32_t)dsc->p2.x;
     }
     else {
-        p1.y = (int32_t)dsc->p2_y;
-        p2.y = (int32_t)dsc->p1_y;
-        p1.x = (int32_t)dsc->p2_x;
-        p2.x = (int32_t)dsc->p1_x;
+        p1.y = (int32_t)dsc->p2.y;
+        p2.y = (int32_t)dsc->p1.y;
+        p1.x = (int32_t)dsc->p2.x;
+        p2.x = (int32_t)dsc->p1.x;
     }
 
     int32_t xdiff = p2.x - p1.x;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -746,8 +746,8 @@ static void draw_div_lines(lv_obj_t * obj, lv_layer_t * layer)
     int32_t scroll_top = lv_obj_get_scroll_top(obj);
     if(chart->hdiv_cnt != 0) {
         int32_t y_ofs = obj->coords.y1 + pad_top - scroll_top;
-        line_dsc.p1_x = obj->coords.x1;
-        line_dsc.p2_x = obj->coords.x2;
+        line_dsc.p1.x = obj->coords.x1;
+        line_dsc.p2.x = obj->coords.x2;
 
         i_start = 0;
         i_end = chart->hdiv_cnt;
@@ -757,9 +757,9 @@ static void draw_div_lines(lv_obj_t * obj, lv_layer_t * layer)
         }
 
         for(i = i_start; i < i_end; i++) {
-            line_dsc.p1_y = (int32_t)((int32_t)h * i) / (chart->hdiv_cnt - 1);
-            line_dsc.p1_y += y_ofs;
-            line_dsc.p2_y = line_dsc.p1_y;
+            line_dsc.p1.y = (int32_t)((int32_t)h * i) / (chart->hdiv_cnt - 1);
+            line_dsc.p1.y += y_ofs;
+            line_dsc.p2.y = line_dsc.p1.y;
             line_dsc.base.id1 = i;
 
             lv_draw_line(layer, &line_dsc);
@@ -768,8 +768,8 @@ static void draw_div_lines(lv_obj_t * obj, lv_layer_t * layer)
 
     if(chart->vdiv_cnt != 0) {
         int32_t x_ofs = obj->coords.x1 + pad_left - scroll_left;
-        line_dsc.p1_y = obj->coords.y1;
-        line_dsc.p2_y = obj->coords.y2;
+        line_dsc.p1.y = obj->coords.y1;
+        line_dsc.p2.y = obj->coords.y2;
         i_start = 0;
         i_end = chart->vdiv_cnt;
         if(border_opa > LV_OPA_MIN && border_w > 0) {
@@ -778,9 +778,9 @@ static void draw_div_lines(lv_obj_t * obj, lv_layer_t * layer)
         }
 
         for(i = i_start; i < i_end; i++) {
-            line_dsc.p1_x = (int32_t)((int32_t)w * i) / (chart->vdiv_cnt - 1);
-            line_dsc.p1_x += x_ofs;
-            line_dsc.p2_x = line_dsc.p1_x;
+            line_dsc.p1.x = (int32_t)((int32_t)w * i) / (chart->vdiv_cnt - 1);
+            line_dsc.p1.x += x_ofs;
+            line_dsc.p2.x = line_dsc.p1.x;
             line_dsc.base.id1 = i;
 
             lv_draw_line(layer, &line_dsc);
@@ -843,32 +843,32 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
         int32_t start_point = chart->update_mode == LV_CHART_UPDATE_MODE_SHIFT ? ser->start_point : 0;
 
-        line_dsc.p1_x = x_ofs;
-        line_dsc.p2_x = x_ofs;
+        line_dsc.p1.x = x_ofs;
+        line_dsc.p2.x = x_ofs;
 
         int32_t p_act = start_point;
         int32_t p_prev = start_point;
         int32_t y_tmp = (int32_t)((int32_t)ser->y_points[p_prev] - chart->ymin[ser->y_axis_sec]) * h;
         y_tmp  = y_tmp / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec]);
-        line_dsc.p2_y   = h - y_tmp + y_ofs;
+        line_dsc.p2.y   = h - y_tmp + y_ofs;
 
-        lv_value_precise_t y_min = line_dsc.p2_y;
-        lv_value_precise_t y_max = line_dsc.p2_y;
+        lv_value_precise_t y_min = line_dsc.p2.y;
+        lv_value_precise_t y_max = line_dsc.p2.y;
 
         for(i = 0; i < chart->point_cnt; i++) {
-            line_dsc.p1_x = line_dsc.p2_x;
-            line_dsc.p1_y = line_dsc.p2_y;
+            line_dsc.p1.x = line_dsc.p2.x;
+            line_dsc.p1.y = line_dsc.p2.y;
 
-            if(line_dsc.p1_x > clip_area_ori.x2 + point_w + 1) break;
-            line_dsc.p2_x = (lv_value_precise_t)((w * i) / (chart->point_cnt - 1)) + x_ofs;
+            if(line_dsc.p1.x > clip_area_ori.x2 + point_w + 1) break;
+            line_dsc.p2.x = (lv_value_precise_t)((w * i) / (chart->point_cnt - 1)) + x_ofs;
 
             p_act = (start_point + i) % chart->point_cnt;
 
             y_tmp = (int32_t)((int32_t)ser->y_points[p_act] - chart->ymin[ser->y_axis_sec]) * h;
             y_tmp = y_tmp / (chart->ymax[ser->y_axis_sec] - chart->ymin[ser->y_axis_sec]);
-            line_dsc.p2_y  = h - y_tmp + y_ofs;
+            line_dsc.p2.y  = h - y_tmp + y_ofs;
 
-            if(line_dsc.p2_x < clip_area_ori.x1 - point_w - 1) {
+            if(line_dsc.p2.x < clip_area_ori.x1 - point_w - 1) {
                 p_prev = p_act;
                 continue;
             }
@@ -878,17 +878,17 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                 if(crowded_mode) {
                     if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                         /*Draw only one vertical line between the min and max y-values on the same x-value*/
-                        y_max = LV_MAX(y_max, line_dsc.p2_y);
-                        y_min = LV_MIN(y_min, line_dsc.p2_y);
-                        if(line_dsc.p1_x != line_dsc.p2_x) {
-                            lv_value_precise_t y_cur = line_dsc.p2_y;
-                            line_dsc.p2_x--;         /*It's already on the next x value*/
-                            line_dsc.p1_x = line_dsc.p2_x;
-                            line_dsc.p1_y = y_min;
-                            line_dsc.p2_y = y_max;
-                            if(line_dsc.p1_y == line_dsc.p2_y) line_dsc.p2_y++;    /*If they are the same no line will be drawn*/
+                        y_max = LV_MAX(y_max, line_dsc.p2.y);
+                        y_min = LV_MIN(y_min, line_dsc.p2.y);
+                        if(line_dsc.p1.x != line_dsc.p2.x) {
+                            lv_value_precise_t y_cur = line_dsc.p2.y;
+                            line_dsc.p2.x--;         /*It's already on the next x value*/
+                            line_dsc.p1.x = line_dsc.p2.x;
+                            line_dsc.p1.y = y_min;
+                            line_dsc.p2.y = y_max;
+                            if(line_dsc.p1.y == line_dsc.p2.y) line_dsc.p2.y++;    /*If they are the same no line will be drawn*/
                             lv_draw_line(layer, &line_dsc);
-                            line_dsc.p2_x++;         /*Compensate the previous x--*/
+                            line_dsc.p2.x++;         /*Compensate the previous x--*/
                             y_min = y_cur;  /*Start the line of the next x from the current last y*/
                             y_max = y_cur;
                         }
@@ -896,10 +896,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                 }
                 else {
                     lv_area_t point_area;
-                    point_area.x1 = (int32_t)line_dsc.p1_x - point_w;
-                    point_area.x2 = (int32_t)line_dsc.p1_x + point_w;
-                    point_area.y1 = (int32_t)line_dsc.p1_y - point_h;
-                    point_area.y2 = (int32_t)line_dsc.p1_y + point_h;
+                    point_area.x1 = (int32_t)line_dsc.p1.x - point_w;
+                    point_area.x2 = (int32_t)line_dsc.p1.x + point_w;
+                    point_area.y1 = (int32_t)line_dsc.p1.y - point_h;
+                    point_area.y2 = (int32_t)line_dsc.p1.y + point_h;
 
                     if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                         line_dsc.base.id2 = i;
@@ -921,10 +921,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
             if(ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                 lv_area_t point_area;
-                point_area.x1 = (int32_t)line_dsc.p2_x - point_w;
-                point_area.x2 = (int32_t)line_dsc.p2_x + point_w;
-                point_area.y1 = (int32_t)line_dsc.p2_y - point_h;
-                point_area.y2 = (int32_t)line_dsc.p2_y + point_h;
+                point_area.x1 = (int32_t)line_dsc.p2.x - point_w;
+                point_area.x2 = (int32_t)line_dsc.p2.x + point_w;
+                point_area.y1 = (int32_t)line_dsc.p2.y - point_h;
+                point_area.y2 = (int32_t)line_dsc.p2.y + point_h;
                 point_dsc_default.base.id2 = i - 1;
                 lv_draw_rect(layer, &point_dsc_default, &point_area);
             }
@@ -981,36 +981,36 @@ static void draw_series_scatter(lv_obj_t * obj, lv_layer_t * layer)
 
         int32_t start_point = chart->update_mode == LV_CHART_UPDATE_MODE_SHIFT ? ser->start_point : 0;
 
-        line_dsc.p1_x = x_ofs;
-        line_dsc.p2_x = x_ofs;
+        line_dsc.p1.x = x_ofs;
+        line_dsc.p2.x = x_ofs;
 
         int32_t p_act = start_point;
         int32_t p_prev = start_point;
         if(ser->y_points[p_act] != LV_CHART_POINT_CNT_DEF) {
-            line_dsc.p2_x = lv_map(ser->x_points[p_act], chart->xmin[ser->x_axis_sec], chart->xmax[ser->x_axis_sec], 0, w);
-            line_dsc.p2_x += x_ofs;
+            line_dsc.p2.x = lv_map(ser->x_points[p_act], chart->xmin[ser->x_axis_sec], chart->xmax[ser->x_axis_sec], 0, w);
+            line_dsc.p2.x += x_ofs;
 
-            line_dsc.p2_y = lv_map(ser->y_points[p_act], chart->ymin[ser->y_axis_sec], chart->ymax[ser->y_axis_sec], 0, h);
-            line_dsc.p2_y = h - line_dsc.p2_y;
-            line_dsc.p2_y += y_ofs;
+            line_dsc.p2.y = lv_map(ser->y_points[p_act], chart->ymin[ser->y_axis_sec], chart->ymax[ser->y_axis_sec], 0, h);
+            line_dsc.p2.y = h - line_dsc.p2.y;
+            line_dsc.p2.y += y_ofs;
         }
         else {
-            line_dsc.p2_x = (lv_value_precise_t)LV_COORD_MIN;
-            line_dsc.p2_y = (lv_value_precise_t)LV_COORD_MIN;
+            line_dsc.p2.x = (lv_value_precise_t)LV_COORD_MIN;
+            line_dsc.p2.y = (lv_value_precise_t)LV_COORD_MIN;
         }
 
         for(i = 0; i < chart->point_cnt; i++) {
-            line_dsc.p1_x = line_dsc.p2_x;
-            line_dsc.p1_y = line_dsc.p2_y;
+            line_dsc.p1.x = line_dsc.p2.x;
+            line_dsc.p1.y = line_dsc.p2.y;
 
             p_act = (start_point + i) % chart->point_cnt;
             if(ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                line_dsc.p2_y = lv_map(ser->y_points[p_act], chart->ymin[ser->y_axis_sec], chart->ymax[ser->y_axis_sec], 0, h);
-                line_dsc.p2_y = h - line_dsc.p2_y;
-                line_dsc.p2_y += y_ofs;
+                line_dsc.p2.y = lv_map(ser->y_points[p_act], chart->ymin[ser->y_axis_sec], chart->ymax[ser->y_axis_sec], 0, h);
+                line_dsc.p2.y = h - line_dsc.p2.y;
+                line_dsc.p2.y += y_ofs;
 
-                line_dsc.p2_x = lv_map(ser->x_points[p_act], chart->xmin[ser->x_axis_sec], chart->xmax[ser->x_axis_sec], 0, w);
-                line_dsc.p2_x += x_ofs;
+                line_dsc.p2.x = lv_map(ser->x_points[p_act], chart->xmin[ser->x_axis_sec], chart->xmax[ser->x_axis_sec], 0, w);
+                line_dsc.p2.x += x_ofs;
             }
             else {
                 p_prev = p_act;
@@ -1020,10 +1020,10 @@ static void draw_series_scatter(lv_obj_t * obj, lv_layer_t * layer)
             /*Don't draw the first point. A second point is also required to draw the line*/
             if(i != 0) {
                 lv_area_t point_area;
-                point_area.x1 = (int32_t)line_dsc.p1_x - point_w;
-                point_area.x2 = (int32_t)line_dsc.p1_x + point_w;
-                point_area.y1 = (int32_t)line_dsc.p1_y - point_h;
-                point_area.y2 = (int32_t)line_dsc.p1_y + point_h;
+                point_area.x1 = (int32_t)line_dsc.p1.x - point_w;
+                point_area.x2 = (int32_t)line_dsc.p1.x + point_w;
+                point_area.y1 = (int32_t)line_dsc.p1.y - point_h;
+                point_area.y2 = (int32_t)line_dsc.p1.y + point_h;
 
                 if(ser->y_points[p_prev] != LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                     line_dsc.base.id2 = i;
@@ -1042,10 +1042,10 @@ static void draw_series_scatter(lv_obj_t * obj, lv_layer_t * layer)
 
                 if(ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                     lv_area_t point_area;
-                    point_area.x1 = (int32_t)line_dsc.p2_x - point_w;
-                    point_area.x2 = (int32_t)line_dsc.p2_x + point_w;
-                    point_area.y1 = (int32_t)line_dsc.p2_y - point_h;
-                    point_area.y2 = (int32_t)line_dsc.p2_y + point_h;
+                    point_area.x1 = (int32_t)line_dsc.p2.x - point_w;
+                    point_area.x2 = (int32_t)line_dsc.p2.x + point_w;
+                    point_area.y1 = (int32_t)line_dsc.p2.y - point_h;
+                    point_area.y2 = (int32_t)line_dsc.p2.y + point_h;
 
                     point_dsc_default.base.id2 = i;
                     lv_draw_rect(layer, &point_dsc_default, &point_area);
@@ -1192,10 +1192,10 @@ static void draw_cursors(lv_obj_t * obj, lv_layer_t * layer)
         point_area.y2 = cy + point_h;
 
         if(cursor->dir & LV_DIR_HOR) {
-            line_dsc.p1_x = cursor->dir & LV_DIR_LEFT ? obj->coords.x1 : cx;
-            line_dsc.p1_y = cy;
-            line_dsc.p2_x = cursor->dir & LV_DIR_RIGHT ? obj->coords.x2 : cx;
-            line_dsc.p2_y = line_dsc.p1_y;
+            line_dsc.p1.x = cursor->dir & LV_DIR_LEFT ? obj->coords.x1 : cx;
+            line_dsc.p1.y = cy;
+            line_dsc.p2.x = cursor->dir & LV_DIR_RIGHT ? obj->coords.x2 : cx;
+            line_dsc.p2.y = line_dsc.p1.y;
 
             line_dsc.base.id2 = 0;
             point_dsc_tmp.base.id2 = 0;
@@ -1208,10 +1208,10 @@ static void draw_cursors(lv_obj_t * obj, lv_layer_t * layer)
         }
 
         if(cursor->dir & LV_DIR_VER) {
-            line_dsc.p1_x = cx;
-            line_dsc.p1_y = cursor->dir & LV_DIR_TOP ? obj->coords.y1 : cy;
-            line_dsc.p2_x = line_dsc.p1_x;
-            line_dsc.p2_y = cursor->dir & LV_DIR_BOTTOM ? obj->coords.y2 : cy;
+            line_dsc.p1.x = cx;
+            line_dsc.p1.y = cursor->dir & LV_DIR_TOP ? obj->coords.y1 : cy;
+            line_dsc.p2.x = line_dsc.p1.x;
+            line_dsc.p2.y = cursor->dir & LV_DIR_BOTTOM ? obj->coords.y2 : cy;
 
             line_dsc.base.id2 = 1;
             point_dsc_tmp.base.id2 = 1;

--- a/src/widgets/line/lv_line.c
+++ b/src/widgets/line/lv_line.c
@@ -195,19 +195,19 @@ static void lv_line_event(const lv_obj_class_t * class_p, lv_event_t * e)
             int32_t w = lv_obj_get_width(obj);
             int32_t h = lv_obj_get_height(obj);
 
-            line_dsc.p1_x = resolve_point_coord(line->point_array[i].x, w) + x_ofs;
-            line_dsc.p1_y = resolve_point_coord(line->point_array[i].y, h);
+            line_dsc.p1.x = resolve_point_coord(line->point_array[i].x, w) + x_ofs;
+            line_dsc.p1.y = resolve_point_coord(line->point_array[i].y, h);
 
-            line_dsc.p2_x = resolve_point_coord(line->point_array[i + 1].x, w) + x_ofs;
-            line_dsc.p2_y = resolve_point_coord(line->point_array[i + 1].y, h);
+            line_dsc.p2.x = resolve_point_coord(line->point_array[i + 1].x, w) + x_ofs;
+            line_dsc.p2.y = resolve_point_coord(line->point_array[i + 1].y, h);
 
             if(line->y_inv == 0) {
-                line_dsc.p1_y = line_dsc.p1_y + y_ofs;
-                line_dsc.p2_y = line_dsc.p2_y + y_ofs;
+                line_dsc.p1.y = line_dsc.p1.y + y_ofs;
+                line_dsc.p2.y = line_dsc.p2.y + y_ofs;
             }
             else {
-                line_dsc.p1_y = h - line_dsc.p1_y + y_ofs;
-                line_dsc.p2_y = h - line_dsc.p2_y + y_ofs;
+                line_dsc.p1.y = h - line_dsc.p1.y + y_ofs;
+                line_dsc.p2.y = h - line_dsc.p2.y + y_ofs;
             }
 
             lv_draw_line(layer, &line_dsc);

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -450,17 +450,17 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
                                                              tick_value, tick_idx, &tick_point_a);
 
             if(is_major_tick) {
-                major_tick_dsc.p1_x = tick_point_a.x;
-                major_tick_dsc.p1_y = tick_point_a.y;
-                major_tick_dsc.p2_x = tick_point_b.x;
-                major_tick_dsc.p2_y = tick_point_b.y;
+                major_tick_dsc.p1.x = tick_point_a.x;
+                major_tick_dsc.p1.y = tick_point_a.y;
+                major_tick_dsc.p2.x = tick_point_b.x;
+                major_tick_dsc.p2.y = tick_point_b.y;
                 lv_draw_line(layer, &major_tick_dsc);
             }
             else {
-                minor_tick_dsc.p1_x = tick_point_a.x;
-                minor_tick_dsc.p1_y = tick_point_a.y;
-                minor_tick_dsc.p2_x = tick_point_b.x;
-                minor_tick_dsc.p2_y = tick_point_b.y;
+                minor_tick_dsc.p1.x = tick_point_a.x;
+                minor_tick_dsc.p1.y = tick_point_a.y;
+                minor_tick_dsc.p2.x = tick_point_b.x;
+                minor_tick_dsc.p2.y = tick_point_b.y;
                 lv_draw_line(layer, &minor_tick_dsc);
             }
         }
@@ -557,17 +557,17 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
             scale_store_main_line_tick_width_compensation(obj, tick_idx, is_major_tick, major_tick_dsc.width, minor_tick_dsc.width);
 
             if(is_major_tick) {
-                major_tick_dsc.p1_x = tick_point_a.x;
-                major_tick_dsc.p1_y = tick_point_a.y;
-                major_tick_dsc.p2_x = tick_point_b.x;
-                major_tick_dsc.p2_y = tick_point_b.y;
+                major_tick_dsc.p1.x = tick_point_a.x;
+                major_tick_dsc.p1.y = tick_point_a.y;
+                major_tick_dsc.p2.x = tick_point_b.x;
+                major_tick_dsc.p2.y = tick_point_b.y;
                 lv_draw_line(layer, &major_tick_dsc);
             }
             else {
-                minor_tick_dsc.p1_x = tick_point_a.x;
-                minor_tick_dsc.p1_y = tick_point_a.y;
-                minor_tick_dsc.p2_x = tick_point_b.x;
-                minor_tick_dsc.p2_y = tick_point_b.y;
+                minor_tick_dsc.p1.x = tick_point_a.x;
+                minor_tick_dsc.p1.y = tick_point_a.y;
+                minor_tick_dsc.p2.x = tick_point_b.x;
+                minor_tick_dsc.p2.y = tick_point_b.y;
                 lv_draw_line(layer, &minor_tick_dsc);
             }
         }
@@ -644,10 +644,10 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
             main_line_point_b.x += scale->first_tick_width / 2U;
         }
 
-        line_dsc.p1_x = main_line_point_a.x;
-        line_dsc.p1_y = main_line_point_a.y;
-        line_dsc.p2_x = main_line_point_b.x;
-        line_dsc.p2_y = main_line_point_b.y;
+        line_dsc.p1.x = main_line_point_a.x;
+        line_dsc.p1.y = main_line_point_a.y;
+        line_dsc.p2.x = main_line_point_b.x;
+        line_dsc.p2.y = main_line_point_b.y;
         lv_draw_line(layer, &line_dsc);
 
         lv_scale_section_t * section;
@@ -686,10 +686,10 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
 
             scale_set_line_properties(obj, &main_line_section_dsc, section->main_style, LV_PART_MAIN);
 
-            main_line_section_dsc.p1_x = main_point_a.x;
-            main_line_section_dsc.p1_y = main_point_a.y;
-            main_line_section_dsc.p2_x = main_point_b.x;
-            main_line_section_dsc.p2_y = main_point_b.y;
+            main_line_section_dsc.p1.x = main_point_a.x;
+            main_line_section_dsc.p1.y = main_point_a.y;
+            main_line_section_dsc.p2.x = main_point_b.x;
+            main_line_section_dsc.p2.y = main_point_b.y;
             lv_draw_line(layer, &main_line_section_dsc);
         }
     }

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -1032,18 +1032,18 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
                 line_dsc.blend_mode = label_draw_dsc.blend_mode;
 
                 if(decor & LV_TEXT_DECOR_STRIKETHROUGH) {
-                    line_dsc.p1_x = txt_pos.x;
-                    line_dsc.p1_y = pos.y + ((pinfo->line_h - line_space) >> 1)  + (line_dsc.width >> 1);
-                    line_dsc.p2_x = pos.x;
-                    line_dsc.p2_y = line_dsc.p1_y;
+                    line_dsc.p1.x = txt_pos.x;
+                    line_dsc.p1.y = pos.y + ((pinfo->line_h - line_space) >> 1)  + (line_dsc.width >> 1);
+                    line_dsc.p2.x = pos.x;
+                    line_dsc.p2.y = line_dsc.p1.y;
                     lv_draw_line(layer, &line_dsc);
                 }
 
                 if(decor & LV_TEXT_DECOR_UNDERLINE) {
-                    line_dsc.p1_x = txt_pos.x;
-                    line_dsc.p1_y = pos.y + pinfo->line_h - line_space - pinfo->font->base_line - pinfo->font->underline_position;
-                    line_dsc.p2_x = pos.x;
-                    line_dsc.p2_y = line_dsc.p1_y;
+                    line_dsc.p1.x = txt_pos.x;
+                    line_dsc.p1.y = pos.y + pinfo->line_h - line_space - pinfo->font->base_line - pinfo->font->underline_position;
+                    line_dsc.p2.x = pos.x;
+                    line_dsc.p2.y = line_dsc.p1.y;
                     lv_draw_line(layer, &line_dsc);
                 }
             }

--- a/tests/src/test_cases/test_bindings.c
+++ b/tests/src/test_cases/test_bindings.c
@@ -255,10 +255,10 @@ static void draw_to_canvas(lv_obj_t * canvas)
     line_draw_dsc.width = 8;
     line_draw_dsc.round_end = 1;
     line_draw_dsc.round_start = 1;
-    line_draw_dsc.p1_x = 150;
-    line_draw_dsc.p1_y = 30;
-    line_draw_dsc.p2_x = 350;
-    line_draw_dsc.p2_y = 55;
+    line_draw_dsc.p1.x = 150;
+    line_draw_dsc.p1.y = 30;
+    line_draw_dsc.p2.x = 350;
+    line_draw_dsc.p2.y = 55;
     lv_draw_line(&layer, &line_draw_dsc);
 
     lv_canvas_finish_layer(canvas, &layer);


### PR DESCRIPTION
### Description of the feature or fix

`lv_point_precise_t` should be used to describe the position of the point instead of `lv_value_precise_t`.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
