### PR TITLE
fix(typos): fix some typos

### DIFF
--- a/docs/integration/driver/X11.rst
+++ b/docs/integration/driver/X11.rst
@@ -34,7 +34,7 @@ Configure X11 driver
 
             #define LV_X11_DIRECT_EXIT  1 /*preferred default - ends the application automatically if last window has been closed*/
             // or
-            #define LV_X11_DIRECT_EXIT  0 /*applicaion is responsible for ending the application (e.g. by own LV_EVENT_DELETE handler*/
+            #define LV_X11_DIRECT_EXIT  0 /*application is responsible for ending the application (e.g. by own LV_EVENT_DELETE handler*/
 
 
     -  Double buffering
@@ -111,7 +111,7 @@ Usage
         lv_x11_inputs_create(disp, &my_mouse_cursor_icon);
 
         #if !LV_X11_DIRECT_EXIT
-        /* set optional window close callback to enable applicaton cleanup and exit */
+        /* set optional window close callback to enable application cleanup and exit */
         lv_x11_window_set_close_cb(disp, on_close_cb, disp);
         #endif
 

--- a/docs/others/observer.rst
+++ b/docs/others/observer.rst
@@ -267,7 +267,7 @@ Label
 
 Bind an integer, string, or pointer (pointing to a string) subject to a label.
 An optional format string can be added with 1 format specifier (e.g. "%d °C")
-If the format string is NULL the value will be used directly. In this case on string ans pointer type subjects can be used.
+If the format string is NULL the value will be used directly. In this case on string and pointer type subjects can be used.
 
 .. code:: c
 

--- a/docs/widgets/scale.rst
+++ b/docs/widgets/scale.rst
@@ -37,7 +37,7 @@ Sections
 
 A section is the space between a minor and a major range. They can be created with :cpp:expr:`lv_scale_add_section(scale)` and it handles back an :cpp:expr:`lv_scale_section_t` pointer.
 
-The range of the section is configured with :cpp:expr:`lv_scale_section_set_range(section, minor_range, major_range)`. The style of each of the three parts of the scale section can be set with :cpp:expr:`lv_scale_section_set_style(section, PART, style_pointer)`, where `PART` can be :cpp:enumarator: `LV_PART_MAIN`, :cpp:enumarator: `LV_PART_ITEMS` or :cpp:enumarator: `LV_PART_INDICATOR`, :cpp:expr:`style_pointer` should point to a global or static :cpp:expr:`lv_style_t` variable.
+The range of the section is configured with :cpp:expr:`lv_scale_section_set_range(section, minor_range, major_range)`. The style of each of the three parts of the scale section can be set with :cpp:expr:`lv_scale_section_set_style(section, PART, style_pointer)`, where `PART` can be :cpp:enumerator: `LV_PART_MAIN`, :cpp:enumerator: `LV_PART_ITEMS` or :cpp:enumerator: `LV_PART_INDICATOR`, :cpp:expr:`style_pointer` should point to a global or static :cpp:expr:`lv_style_t` variable.
 
 For labels the following properties can be configured:
 :cpp:expr:`lv_style_set_text_font`, :cpp:expr:`lv_style_set_text_color`, :cpp:expr:`lv_style_set_text_letter_space`, :cpp:expr:`lv_style_set_text_opa`.

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -735,7 +735,7 @@ void lv_obj_move_to(lv_obj_t * obj, int32_t x, int32_t y)
     lv_obj_invalidate(obj);
 
     /*If the object was out of the parent invalidate the new scrollbar area too.
-     *If it wasn't out of the parent but out now, also invalidate the srollbars*/
+     *If it wasn't out of the parent but out now, also invalidate the scrollbars*/
     if(parent) {
         bool on2 = _lv_area_is_in(&obj->coords, &parent_fit_area, 0);
         if(on1 || (!on1 && on2)) lv_obj_scrollbar_invalidate(parent);

--- a/src/libs/barcode/lv_barcode.c
+++ b/src/libs/barcode/lv_barcode.c
@@ -221,7 +221,7 @@ static bool lv_barcode_change_buf_size(lv_obj_t * obj, int32_t w, int32_t h)
 
     uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_I1);
     uint32_t buf_size = stride * h;
-    /*+8 for the 2x4 byte pallette*/
+    /*+8 for the 2x4 byte palette*/
     buf = lv_draw_buf_malloc(buf_size + 8, LV_COLOR_FORMAT_I1);
     LV_ASSERT_MALLOC(buf);
 

--- a/src/libs/tjpgd/tjpgd.c
+++ b/src/libs/tjpgd/tjpgd.c
@@ -16,9 +16,9 @@
 / Oct 04, 2011 R0.01  First release.
 / Feb 19, 2012 R0.01a Fixed decompression fails when scan starts with an escape seq.
 / Sep 03, 2012 R0.01b Added JD_TBLCLIP option.
-/ Mar 16, 2019 R0.01c Supprted stdint.h.
+/ Mar 16, 2019 R0.01c Supported stdint.h.
 / Jul 01, 2020 R0.01d Fixed wrong integer type usage.
-/ May 08, 2021 R0.02  Supprted grayscale image. Separated configuration options.
+/ May 08, 2021 R0.02  Supported grayscale image. Separated configuration options.
 / Jun 11, 2021 R0.02a Some performance improvement.
 / Jul 01, 2021 R0.03  Added JD_FASTDECODE option.
 /                     Some performance improvement.
@@ -142,7 +142,7 @@ static void * alloc_pool(   /* Pointer to allocated memory block (NULL:no memory
     if(jd->sz_pool >= ndata) {
         jd->sz_pool -= ndata;
         rp = (char *)jd->pool;          /* Get start of available memory pool */
-        jd->pool = (void *)(rp + ndata); /* Allocate requierd bytes */
+        jd->pool = (void *)(rp + ndata); /* Allocate required bytes */
     }
 
     return (void *)rp;  /* Return allocated memory block (NULL:no memory to allocate) */
@@ -381,7 +381,7 @@ static int huffext(     /* >=0: decoded data, <0: error code */
     jd->wreg = w;
 
 #if JD_FASTDECODE == 2
-    /* Table serch for the short codes */
+    /* Table search for the short codes */
     d = (unsigned int)(w >> (wbit - HUFF_BIT)); /* Short code as table index */
     if(cls) {   /* AC element */
         d = jd->hufflut_ac[id][d];  /* Table decode */
@@ -398,13 +398,13 @@ static int huffext(     /* >=0: decoded data, <0: error code */
         }
     }
 
-    /* Incremental serch for the codes longer than HUFF_BIT */
+    /* Incremental search for the codes longer than HUFF_BIT */
     hb = jd->huffbits[id][cls] + HUFF_BIT;              /* Bit distribution table */
     hc = jd->huffcode[id][cls] + jd->longofs[id][cls];  /* Code word table */
     hd = jd->huffdata[id][cls] + jd->longofs[id][cls];  /* Data table */
     bl = HUFF_BIT + 1;
 #else
-    /* Incremental serch for all codes */
+    /* Incremental search for all codes */
     hb = jd->huffbits[id][cls]; /* Bit distribution table */
     hc = jd->huffcode[id][cls]; /* Code word table */
     hd = jd->huffdata[id][cls]; /* Data table */
@@ -533,7 +533,7 @@ static int bitext(  /* >=0: extracted data, <0: error code */
 
 JRESULT jd_restart(
     JDEC * jd,      /* Pointer to the decompressor object */
-    uint16_t rstn   /* Expected restert sequense number */
+    uint16_t rstn   /* Expected restert sequence number */
 )
 {
     unsigned int i;
@@ -795,7 +795,7 @@ JRESULT jd_mcu_load(
             if(JD_FORMAT != 2 || !cmp) {    /* C components may not be processed if in grayscale output */
                 if(z == 1 || (JD_USE_SCALE &&
                               jd->scale ==
-                              3)) {    /* If no AC element or scale ratio is 1/8, IDCT can be ommited and the block is filled with DC value */
+                              3)) {    /* If no AC element or scale ratio is 1/8, IDCT can be omitted and the block is filled with DC value */
                     d = (jd_yuv_t)((*tmp / 256) + 128);
                     if(JD_FASTDECODE >= 1) {
                         for(i = 0; i < 64; bp[i++] = d) ;
@@ -874,7 +874,7 @@ JRESULT jd_mcu_output(
                     cb = pc[0] - 128;   /* Get Cb/Cr component and remove offset */
                     cr = pc[64] - 128;
                     if(mx == 16) {                  /* Double block width? */
-                        if(ix == 8) py += 64 - 8;   /* Jump to next block if double block heigt */
+                        if(ix == 8) py += 64 - 8;   /* Jump to next block if double block height */
                         pc += ix & 1;               /* Step forward chroma pointer every two pixels */
                     }
                     else {                          /* Single block width */
@@ -954,7 +954,7 @@ JRESULT jd_prepare(
 
     memset(jd, 0, sizeof(
                JDEC));    /* Clear decompression object (this might be a problem if machine's null pointer is not all bits zero) */
-    jd->pool = pool;        /* Work memroy */
+    jd->pool = pool;        /* Work memory */
     jd->pool_original = pool;
     jd->sz_pool = sz_pool;  /* Size of given work memory */
     jd->infunc = infunc;    /* Stream input function */

--- a/src/libs/tjpgd/tjpgd.h
+++ b/src/libs/tjpgd/tjpgd.h
@@ -59,13 +59,13 @@ struct JDEC {
     size_t dctr;                /* Number of bytes available in the input buffer */
     uint8_t * dptr;             /* Current data read ptr */
     uint8_t * inbuf;            /* Bit stream input buffer */
-    uint8_t dbit;               /* Number of bits availavble in wreg or reading bit mask */
+    uint8_t dbit;               /* Number of bits available in wreg or reading bit mask */
     uint8_t scale;              /* Output scaling ratio */
     uint8_t msx, msy;           /* MCU size in unit of block (width, height) */
     uint8_t qtid[3];            /* Quantization table ID of each component, Y, Cb, Cr */
     uint8_t ncomp;              /* Number of color components 1:grayscale, 3:color */
     int16_t dcv[3];             /* Previous DC element of each component */
-    uint16_t nrst;              /* Restart inverval */
+    uint16_t nrst;              /* Restart interval */
     uint16_t rst;              /* Restart count*/
     uint16_t rsc;               /* Expected restart sequence ID*/
     uint16_t width, height;     /* Size of the input image (pixel) */
@@ -86,9 +86,9 @@ struct JDEC {
     jd_yuv_t * mcubuf;          /* Working buffer for the MCU */
     void * pool;                /* Pointer to available memory pool */
     void * pool_original;       /* Pointer to original pool */
-    size_t sz_pool;             /* Size of momory pool (bytes available) */
+    size_t sz_pool;             /* Size of memory pool (bytes available) */
     size_t (*infunc)(JDEC *, uint8_t *, size_t); /* Pointer to jpeg stream input function */
-    void * device;              /* Pointer to I/O device identifiler for the session */
+    void * device;              /* Pointer to I/O device identifier for the session */
 };
 
 


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
