### PR TITLE
fix(text): do not draw letters treated as marker

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -100,6 +100,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(lv_layer_t * layer, lv_draw_label_dsc_
         return;
     }
 
+    if(_lv_text_is_marker(unicode_letter)) return;
+
     lv_font_glyph_dsc_t g;
     lv_font_get_glyph_dsc(dsc->font, &g, unicode_letter, 0);
 
@@ -273,8 +275,6 @@ void lv_draw_label_iterate_letters(lv_draw_unit_t * draw_unit, const lv_draw_lab
             uint32_t letter;
             uint32_t letter_next;
             _lv_text_encoded_letter_next_2(bidi_txt, &letter, &letter_next, &i);
-            if(_lv_text_is_marker(letter)) /*Markers are valid letters but should not be rendered.*/
-                continue;
 
             letter_w = lv_font_get_glyph_width(font, letter, letter_next);
 
@@ -365,16 +365,14 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
 {
     lv_font_glyph_dsc_t g;
 
+    if(_lv_text_is_marker(letter)) /*Markers are valid letters but should not be rendered.*/
+        return;
+
     LV_PROFILER_BEGIN;
     bool g_ret = lv_font_get_glyph_dsc(font, &g, letter, '\0');
     if(g_ret == false) {
-        /*Add warning if the dsc is not found
-         *but do not print warning for non printable ASCII chars (e.g. '\n')*/
-        if(letter >= 0x20 &&
-           letter != 0xf8ff && /*LV_SYMBOL_DUMMY*/
-           letter != 0x200c) { /*ZERO WIDTH NON-JOINER*/
-            LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" LV_PRIX32, letter);
-        }
+        /*Add warning if the dsc is not found*/
+        LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" LV_PRIX32, letter);
     }
 
     /*Don't draw anything if the character is empty. E.g. space*/

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -273,7 +273,7 @@ void lv_draw_label_iterate_letters(lv_draw_unit_t * draw_unit, const lv_draw_lab
             uint32_t letter;
             uint32_t letter_next;
             _lv_text_encoded_letter_next_2(bidi_txt, &letter, &letter_next, &i);
-            if(_lv_text_is_invisible(letter))
+            if(_lv_text_is_marker(letter)) /*Markers are valid letters but should not be rendered.*/
                 continue;
 
             letter_w = lv_font_get_glyph_width(font, letter, letter_next);

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -273,6 +273,8 @@ void lv_draw_label_iterate_letters(lv_draw_unit_t * draw_unit, const lv_draw_lab
             uint32_t letter;
             uint32_t letter_next;
             _lv_text_encoded_letter_next_2(bidi_txt, &letter, &letter_next, &i);
+            if(_lv_text_is_invisible(letter))
+                continue;
 
             letter_w = lv_font_get_glyph_width(font, letter, letter_next);
 

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -8,9 +8,11 @@
  *********************/
 
 #include "lv_font.h"
+#include "../misc/lv_text.h"
 #include "../misc/lv_utils.h"
 #include "../misc/lv_log.h"
 #include "../misc/lv_assert.h"
+#include "../stdlib/lv_string.h"
 
 /*********************
  *      DEFINES
@@ -53,6 +55,11 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
     LV_ASSERT_NULL(font_p);
     LV_ASSERT_NULL(dsc_out);
 
+    if(_lv_text_is_marker(letter)) {
+        lv_memzero(dsc_out, sizeof(*dsc_out));
+        return false;
+    }
+
 #if LV_USE_FONT_PLACEHOLDER
     const lv_font_t * placeholder_font = NULL;
 #endif
@@ -86,21 +93,13 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
     }
 #endif
 
-    if(letter < 0x20 ||
-       letter == 0xf8ff || /*LV_SYMBOL_DUMMY*/
-       letter == 0x200c) { /*ZERO WIDTH NON-JOINER*/
-        dsc_out->box_w = 0;
-        dsc_out->adv_w = 0;
-    }
-    else {
 #if LV_USE_FONT_PLACEHOLDER
-        dsc_out->box_w = font_p->line_height / 2;
-        dsc_out->adv_w = dsc_out->box_w + 2;
+    dsc_out->box_w = font_p->line_height / 2;
+    dsc_out->adv_w = dsc_out->box_w + 2;
 #else
-        dsc_out->box_w = 0;
-        dsc_out->adv_w = 0;
+    dsc_out->box_w = 0;
+    dsc_out->adv_w = 0;
 #endif
-    }
 
     dsc_out->resolved_font = NULL;
     dsc_out->box_h = font_p->line_height;
@@ -116,6 +115,10 @@ uint16_t lv_font_get_glyph_width(const lv_font_t * font, uint32_t letter, uint32
 {
     LV_ASSERT_NULL(font);
     lv_font_glyph_dsc_t g;
+
+    /*Return zero if letter is marker*/
+    if(_lv_text_is_marker(letter)) return 0;
+
     lv_font_get_glyph_dsc(font, &g, letter, letter_next);
     return g.adv_w;
 }

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -55,11 +55,6 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
     LV_ASSERT_NULL(font_p);
     LV_ASSERT_NULL(dsc_out);
 
-    if(_lv_text_is_marker(letter)) {
-        lv_memzero(dsc_out, sizeof(*dsc_out));
-        return false;
-    }
-
 #if LV_USE_FONT_PLACEHOLDER
     const lv_font_t * placeholder_font = NULL;
 #endif

--- a/src/misc/lv_text.h
+++ b/src/misc/lv_text.h
@@ -229,7 +229,7 @@ static inline bool _lv_text_is_a_word(uint32_t letter)
  */
 static inline bool _lv_text_is_marker(uint32_t letter)
 {
-    if(letter == 0) return true;
+    if(letter < 0x20) return true;
 
     /*U+061C ARABIC LETTER MARK, see https://www.compart.com/en/unicode/block/U+0600*/
     if(letter == 0x061C) return true;
@@ -249,6 +249,8 @@ static inline bool _lv_text_is_marker(uint32_t letter)
 
     /*U+FEFF ZERO WIDTH NO-BREAK SPACE, see https://www.compart.com/en/unicode/block/U+FE70*/
     if(letter == 0xFEFF) return true;
+
+    if(letter == 0xF8FF) return true; /*LV_SYMBOL_DUMMY*/
 
     return false;
 }

--- a/src/misc/lv_text.h
+++ b/src/misc/lv_text.h
@@ -221,13 +221,13 @@ static inline bool _lv_text_is_a_word(uint32_t letter)
 }
 
 /**
- * Test if character is invisible
- * Note, this is not a full list, nor a official definition of invisibility.
+ * Test if character can be treated as marker, and don't need to be rendered.
+ * Note, this is not a full list. Add your findings to the list.
  *
  * @param letter a letter
  * @return true if so
  */
-static inline bool _lv_text_is_invisible(uint32_t letter)
+static inline bool _lv_text_is_marker(uint32_t letter)
 {
     if(letter == 0) return true;
 

--- a/src/misc/lv_text.h
+++ b/src/misc/lv_text.h
@@ -220,6 +220,39 @@ static inline bool _lv_text_is_a_word(uint32_t letter)
     return false;
 }
 
+/**
+ * Test if character is invisible
+ * Note, this is not a full list, nor a official definition of invisibility.
+ *
+ * @param letter a letter
+ * @return true if so
+ */
+static inline bool _lv_text_is_invisible(uint32_t letter)
+{
+    if(letter == 0) return true;
+
+    /*U+061C ARABIC LETTER MARK, see https://www.compart.com/en/unicode/block/U+0600*/
+    if(letter == 0x061C) return true;
+
+    /*U+115F HANGUL CHOSEONG FILLER, See https://www.compart.com/en/unicode/block/U+1100*/
+    if(letter == 0x115F) return true;
+    /*U+1160 HANGUL JUNGSEONG FILLER*/
+    if(letter == 0x1160) return true;
+
+    /*See https://www.compart.com/en/unicode/block/U+1800*/
+    if(letter >= 0x180B && letter <= 0x180E) return true;
+
+    /*See https://www.compart.com/en/unicode/block/U+2000*/
+    if(letter >= 0x200B && letter <= 0x200F) return true;
+    if(letter >= 0x2028 && letter <= 0x202F) return true;
+    if(letter >= 0x205F && letter <= 0x206F) return true;
+
+    /*U+FEFF ZERO WIDTH NO-BREAK SPACE, see https://www.compart.com/en/unicode/block/U+FE70*/
+    if(letter == 0xFEFF) return true;
+
+    return false;
+}
+
 /***************************************************************
  *  GLOBAL FUNCTION POINTERS FOR CHARACTER ENCODING INTERFACE
  ***************************************************************/


### PR DESCRIPTION

### Description of the feature or fix

Fix #4856

Refer to https://invisible-characters.com/ and double checked with https://www.compart.com/en/unicode/

Definitely not all unicodes are included because it's tricky to say which unicode is `invisible`.

This check could potentially affect rendering speed in case of long text to show.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
