### PR TITLE
feat(point): add helpers to operate point and precise point

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -160,8 +160,7 @@ void lv_draw_label_iterate_letters(lv_draw_unit_t * draw_unit, const lv_draw_lab
     /*Init variables for the first line*/
     int32_t line_width = 0;
     lv_point_t pos;
-    pos.x = coords->x1;
-    pos.y = coords->y1;
+    lv_point_set(&pos, coords->x1, coords->y1);
 
     int32_t x_ofs = 0;
     int32_t y_ofs = 0;

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -256,16 +256,12 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(lv_draw_unit_t * draw_unit, con
     lv_point_t p1;
     lv_point_t p2;
     if(dsc->p1.y < dsc->p2.y) {
-        p1.y = (int32_t)dsc->p1.y;
-        p2.y = (int32_t)dsc->p2.y;
-        p1.x = (int32_t)dsc->p1.x;
-        p2.x = (int32_t)dsc->p2.x;
+        p1 = lv_point_from_precise(&dsc->p1);
+        p2 = lv_point_from_precise(&dsc->p2);
     }
     else {
-        p1.y = (int32_t)dsc->p2.y;
-        p2.y = (int32_t)dsc->p1.y;
-        p1.x = (int32_t)dsc->p2.x;
-        p2.x = (int32_t)dsc->p1.x;
+        p1 = lv_point_from_precise(&dsc->p2);
+        p2 = lv_point_from_precise(&dsc->p1);
     }
 
     int32_t xdiff = p2.x - p1.x;

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -177,14 +177,11 @@ void lv_draw_sw_mask_line_points_init(lv_draw_sw_mask_line_param_t * param, int3
         p1y = t;
     }
 
-    param->cfg.p1.x = p1x;
-    param->cfg.p1.y = p1y;
-    param->cfg.p2.x = p2x;
-    param->cfg.p2.y = p2y;
+    lv_point_set(&param->cfg.p1, p1x, p1y);
+    lv_point_set(&param->cfg.p2, p2x, p2y);
     param->cfg.side = side;
 
-    param->origo.x = p1x;
-    param->origo.y = p1y;
+    lv_point_set(&param->origo, p1x, p1y);
     param->flat = (LV_ABS(p2x - p1x) > LV_ABS(p2y - p1y)) ? 1 : 0;
     param->yx_steep = 0;
     param->xy_steep = 0;
@@ -302,8 +299,7 @@ void lv_draw_sw_mask_angle_init(lv_draw_sw_mask_angle_param_t * param, int32_t v
 
     param->cfg.start_angle = start_angle;
     param->cfg.end_angle = end_angle;
-    param->cfg.vertex_p.x = vertex_x;
-    param->cfg.vertex_p.y = vertex_y;
+    lv_point_set(&param->cfg.vertex_p, vertex_x, vertex_y);
     param->dsc.cb = (lv_draw_sw_mask_xcb_t)lv_draw_mask_angle;
     param->dsc.type = LV_DRAW_SW_MASK_TYPE_ANGLE;
 

--- a/src/draw/sw/lv_draw_sw_triangle.c
+++ b/src/draw/sw/lv_draw_sw_triangle.c
@@ -28,8 +28,6 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_point_t point_to_normal(const lv_point_precise_t * p);
-static void point_swap(lv_point_t * p1, lv_point_t * p2);
 
 /**********************
  *  STATIC VARIABLES
@@ -60,35 +58,35 @@ void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_
     lv_point_t p[3];
     /*If there is a vertical side use it as p[0] and p[1]*/
     if(dsc->p[0].x == dsc->p[1].x) {
-        p[0] = point_to_normal(&dsc->p[0]);
-        p[1] = point_to_normal(&dsc->p[1]);
-        p[2] = point_to_normal(&dsc->p[2]);
+        p[0] = lv_point_from_precise(&dsc->p[0]);
+        p[1] = lv_point_from_precise(&dsc->p[1]);
+        p[2] = lv_point_from_precise(&dsc->p[2]);
     }
     else if(dsc->p[0].x == dsc->p[2].x) {
-        p[0] = point_to_normal(&dsc->p[0]);
-        p[1] = point_to_normal(&dsc->p[2]);
-        p[2] = point_to_normal(&dsc->p[1]);
+        p[0] = lv_point_from_precise(&dsc->p[0]);
+        p[1] = lv_point_from_precise(&dsc->p[2]);
+        p[2] = lv_point_from_precise(&dsc->p[1]);
     }
     else if(dsc->p[1].x == dsc->p[2].x) {
-        p[0] = point_to_normal(&dsc->p[1]);
-        p[1] = point_to_normal(&dsc->p[2]);
-        p[2] = point_to_normal(&dsc->p[0]);
+        p[0] = lv_point_from_precise(&dsc->p[1]);
+        p[1] = lv_point_from_precise(&dsc->p[2]);
+        p[2] = lv_point_from_precise(&dsc->p[0]);
     }
     else {
-        p[0] = point_to_normal(&dsc->p[0]);
-        p[1] = point_to_normal(&dsc->p[1]);
-        p[2] = point_to_normal(&dsc->p[2]);
+        p[0] = lv_point_from_precise(&dsc->p[0]);
+        p[1] = lv_point_from_precise(&dsc->p[1]);
+        p[2] = lv_point_from_precise(&dsc->p[2]);
 
         /*Set the smallest y as p[0]*/
-        if(p[0].y > p[1].y) point_swap(&p[0], &p[1]);
-        if(p[0].y > p[2].y) point_swap(&p[0], &p[2]);
+        if(p[0].y > p[1].y) lv_point_swap(&p[0], &p[1]);
+        if(p[0].y > p[2].y) lv_point_swap(&p[0], &p[2]);
 
         /*Set the greatest y as p[1]*/
-        if(p[1].y < p[2].y) point_swap(&p[1], &p[2]);
+        if(p[1].y < p[2].y) lv_point_swap(&p[1], &p[2]);
     }
 
     /*Be sure p[0] is on the top*/
-    if(p[0].y > p[1].y) point_swap(&p[0], &p[1]);
+    if(p[0].y > p[1].y) lv_point_swap(&p[0], &p[1]);
 
     /*If right == true p[2] is on the right side of the p[0] p[1] line*/
     bool right = ((p[1].x - p[0].x) * (p[2].y - p[0].y) - (p[1].y - p[0].y) * (p[2].x - p[0].x)) < 0;
@@ -189,21 +187,5 @@ void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-static lv_point_t point_to_normal(const lv_point_precise_t * p)
-{
-    lv_point_t p_out;
-    p_out.x = (int32_t)p->x;
-    p_out.y = (int32_t)p->y;
-
-    return p_out;
-}
-
-static void point_swap(lv_point_t * p1, lv_point_t * p2)
-{
-    lv_point_t tmp = *p1;
-    *p1 = *p2;
-    *p2 = tmp;
-}
 
 #endif /*LV_USE_DRAW_SW*/

--- a/src/misc/lv_area.c
+++ b/src/misc/lv_area.c
@@ -336,20 +336,16 @@ bool _lv_area_is_in(const lv_area_t * ain_p, const lv_area_t * aholder_p, int32_
     /*Check if the corner points are inside the radius or not*/
     lv_point_t p;
 
-    p.x = ain_p->x1;
-    p.y = ain_p->y1;
+    lv_point_set(&p, ain_p->x1, ain_p->y1);
     if(_lv_area_is_point_on(aholder_p, &p, radius) == false) return false;
 
-    p.x = ain_p->x2;
-    p.y = ain_p->y1;
+    lv_point_set(&p, ain_p->x2, ain_p->y1);
     if(_lv_area_is_point_on(aholder_p, &p, radius) == false) return false;
 
-    p.x = ain_p->x1;
-    p.y = ain_p->y2;
+    lv_point_set(&p, ain_p->x1, ain_p->y2);
     if(_lv_area_is_point_on(aholder_p, &p, radius) == false) return false;
 
-    p.x = ain_p->x2;
-    p.y = ain_p->y2;
+    lv_point_set(&p, ain_p->x2, ain_p->y2);
     if(_lv_area_is_point_on(aholder_p, &p, radius) == false) return false;
 
     return true;
@@ -374,20 +370,16 @@ bool _lv_area_is_out(const lv_area_t * aout_p, const lv_area_t * aholder_p, int3
     /*Check if the corner points are outside the radius or not*/
     lv_point_t p;
 
-    p.x = aout_p->x1;
-    p.y = aout_p->y1;
+    lv_point_set(&p, aout_p->x1, aout_p->y1);
     if(_lv_area_is_point_on(aholder_p, &p, radius)) return false;
 
-    p.x = aout_p->x2;
-    p.y = aout_p->y1;
+    lv_point_set(&p, aout_p->x2, aout_p->y1);
     if(_lv_area_is_point_on(aholder_p, &p, radius)) return false;
 
-    p.x = aout_p->x1;
-    p.y = aout_p->y2;
+    lv_point_set(&p, aout_p->x1, aout_p->y2);
     if(_lv_area_is_point_on(aholder_p, &p, radius)) return false;
 
-    p.x = aout_p->x2;
-    p.y = aout_p->y2;
+    lv_point_set(&p, aout_p->x2, aout_p->y2);
     if(_lv_area_is_point_on(aholder_p, &p, radius)) return false;
 
     return true;

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -264,6 +264,47 @@ void lv_area_align(const lv_area_t * base, lv_area_t * to_align, lv_align_t alig
 void lv_point_transform(lv_point_t * p, int32_t angle, int32_t scale_x, int32_t scale_y, const lv_point_t * pivot,
                         bool zoom_first);
 
+static inline lv_point_t lv_point_from_precise(const lv_point_precise_t * p)
+{
+    return (lv_point_t) {
+        (int32_t)p->x, (int32_t)p->y
+    };
+}
+
+static inline lv_point_precise_t lv_point_to_precise(const lv_point_t * p)
+{
+    return (lv_point_precise_t) {
+        p->x, p->y
+    };
+}
+
+static inline void lv_point_set(lv_point_t * p, int32_t x, int32_t y)
+{
+    p->x = x;
+    p->y = y;
+}
+
+static inline void lv_point_precise_set(lv_point_precise_t * p, lv_value_precise_t x, lv_value_precise_t y)
+{
+    p->x = x;
+    p->y = y;
+}
+
+static inline void lv_point_swap(lv_point_t * p1, lv_point_t * p2)
+{
+    lv_point_t tmp = *p1;
+    *p1 = *p2;
+    *p2 = tmp;
+}
+
+static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_precise_t * p2)
+{
+    lv_point_precise_t tmp = *p1;
+    *p1 = *p2;
+    *p2 = tmp;
+}
+
+
 /**********************
  *      MACROS
  **********************/

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -304,7 +304,6 @@ static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_preci
     *p2 = tmp;
 }
 
-
 /**********************
  *      MACROS
  **********************/

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -405,8 +405,7 @@ lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_di
     LV_ASSERT_MALLOC(cursor);
     if(cursor == NULL) return NULL;
 
-    cursor->pos.x = LV_CHART_POINT_NONE;
-    cursor->pos.y = LV_CHART_POINT_NONE;
+    lv_point_set(&cursor->pos, LV_CHART_POINT_NONE, LV_CHART_POINT_NONE);
     cursor->point_id = LV_CHART_POINT_NONE;
     cursor->pos_set = 0;
     cursor->color = color;
@@ -427,8 +426,7 @@ void lv_chart_set_cursor_pos(lv_obj_t * chart, lv_chart_cursor_t * cursor, lv_po
     LV_ASSERT_NULL(cursor);
     LV_UNUSED(chart);
 
-    cursor->pos.x = pos->x;
-    cursor->pos.y = pos->y;
+    cursor->pos = *pos;
     cursor->pos_set = 1;
     lv_chart_refresh(chart);
 }

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -852,8 +852,7 @@ static void draw_main(lv_event_t * e)
             lv_draw_image_dsc_t img_dsc;
             lv_draw_image_dsc_init(&img_dsc);
             lv_obj_init_draw_image_dsc(obj, LV_PART_INDICATOR, &img_dsc);
-            img_dsc.pivot.x = symbol_w / 2;
-            img_dsc.pivot.y = symbol_h / 2;
+            lv_point_set(&img_dsc.pivot, symbol_w / 2, symbol_h / 2);
             img_dsc.rotation = lv_obj_get_style_transform_rotation(obj, LV_PART_INDICATOR);
             img_dsc.src = dropdown->symbol;
             lv_draw_image(layer, &img_dsc, &symbol_area);

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -305,8 +305,7 @@ void lv_image_set_pivot(lv_obj_t * obj, int32_t x, int32_t y)
     a.y2 += obj->coords.y1;
     lv_obj_invalidate_area(obj, &a);
 
-    img->pivot.x = x;
-    img->pivot.y = y;
+    lv_point_set(&img->pivot, x, y);
 
     /* Disable invalidations because lv_obj_refresh_ext_draw_size would invalidate
      * the whole ext draw area */
@@ -535,10 +534,8 @@ static void lv_image_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     img->scale_x      = LV_SCALE_NONE;
     img->scale_y      = LV_SCALE_NONE;
     img->antialias = LV_COLOR_DEPTH > 8 ? 1 : 0;
-    img->offset.x  = 0;
-    img->offset.y  = 0;
-    img->pivot.x   = LV_PCT(50); /*Default pivot to image center*/
-    img->pivot.y   = LV_PCT(50);
+    lv_point_set(&img->offset, 0, 0);
+    lv_point_set(&img->pivot, LV_PCT(50), LV_PCT(50)); /*Default pivot to image center*/
     img->align     = LV_IMAGE_ALIGN_CENTER;
 
     lv_obj_remove_flag(obj, LV_OBJ_FLAG_CLICKABLE);

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -188,8 +188,7 @@ void lv_label_set_long_mode(lv_obj_t * obj, lv_label_long_mode_t long_mode)
     /*Delete the old animation (if exists)*/
     lv_anim_delete(obj, set_ofs_x_anim);
     lv_anim_delete(obj, set_ofs_y_anim);
-    label->offset.x = 0;
-    label->offset.y = 0;
+    lv_point_set(&label->offset, 0, 0);
 
     if(long_mode == LV_LABEL_LONG_SCROLL || long_mode == LV_LABEL_LONG_SCROLL_CIRCULAR || long_mode == LV_LABEL_LONG_CLIP)
         label->expand = 1;
@@ -622,8 +621,7 @@ static void lv_label_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     label->static_txt = 0;
     label->dot_end    = LV_LABEL_DOT_END_INV;
     label->long_mode  = LV_LABEL_LONG_WRAP;
-    label->offset.x = 0;
-    label->offset.y = 0;
+    lv_point_set(&label->offset, 0, 0);
 
 #if LV_LABEL_LONG_TXT_HINT
     label->hint.line_start = -1;

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -450,17 +450,13 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
                                                              tick_value, tick_idx, &tick_point_a);
 
             if(is_major_tick) {
-                major_tick_dsc.p1.x = tick_point_a.x;
-                major_tick_dsc.p1.y = tick_point_a.y;
-                major_tick_dsc.p2.x = tick_point_b.x;
-                major_tick_dsc.p2.y = tick_point_b.y;
+                major_tick_dsc.p1 = lv_point_to_precise(&tick_point_a);
+                major_tick_dsc.p2 = lv_point_to_precise(&tick_point_b);
                 lv_draw_line(layer, &major_tick_dsc);
             }
             else {
-                minor_tick_dsc.p1.x = tick_point_a.x;
-                minor_tick_dsc.p1.y = tick_point_a.y;
-                minor_tick_dsc.p2.x = tick_point_b.x;
-                minor_tick_dsc.p2.y = tick_point_b.y;
+                minor_tick_dsc.p1 = lv_point_to_precise(&tick_point_a);
+                minor_tick_dsc.p2 = lv_point_to_precise(&tick_point_b);
                 lv_draw_line(layer, &minor_tick_dsc);
             }
         }
@@ -557,17 +553,13 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
             scale_store_main_line_tick_width_compensation(obj, tick_idx, is_major_tick, major_tick_dsc.width, minor_tick_dsc.width);
 
             if(is_major_tick) {
-                major_tick_dsc.p1.x = tick_point_a.x;
-                major_tick_dsc.p1.y = tick_point_a.y;
-                major_tick_dsc.p2.x = tick_point_b.x;
-                major_tick_dsc.p2.y = tick_point_b.y;
+                major_tick_dsc.p1 = lv_point_to_precise(&tick_point_a);
+                major_tick_dsc.p2 = lv_point_to_precise(&tick_point_b);
                 lv_draw_line(layer, &major_tick_dsc);
             }
             else {
-                minor_tick_dsc.p1.x = tick_point_a.x;
-                minor_tick_dsc.p1.y = tick_point_a.y;
-                minor_tick_dsc.p2.x = tick_point_b.x;
-                minor_tick_dsc.p2.y = tick_point_b.y;
+                minor_tick_dsc.p1 = lv_point_to_precise(&tick_point_a);
+                minor_tick_dsc.p2 = lv_point_to_precise(&tick_point_b);
                 lv_draw_line(layer, &minor_tick_dsc);
             }
         }
@@ -644,10 +636,8 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
             main_line_point_b.x += scale->first_tick_width / 2U;
         }
 
-        line_dsc.p1.x = main_line_point_a.x;
-        line_dsc.p1.y = main_line_point_a.y;
-        line_dsc.p2.x = main_line_point_b.x;
-        line_dsc.p2.y = main_line_point_b.y;
+        line_dsc.p1 = lv_point_to_precise(&main_line_point_a);
+        line_dsc.p2 = lv_point_to_precise(&main_line_point_b);
         lv_draw_line(layer, &line_dsc);
 
         lv_scale_section_t * section;

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -433,8 +433,7 @@ int32_t lv_spangroup_get_expand_height(lv_obj_t * obj, int32_t width)
 
     /* coords of draw span-txt */
     lv_point_t txt_pos;
-    txt_pos.y = 0;
-    txt_pos.x = 0 + indent; /* first line need add indent */
+    lv_point_set(&txt_pos, 0, indent); /* first line need add indent */
 
     lv_span_t * cur_span = _lv_ll_get_head(&spans->child_ll);
     const char * cur_txt = cur_span->txt;
@@ -1032,18 +1031,16 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
                 line_dsc.blend_mode = label_draw_dsc.blend_mode;
 
                 if(decor & LV_TEXT_DECOR_STRIKETHROUGH) {
-                    line_dsc.p1.x = txt_pos.x;
-                    line_dsc.p1.y = pos.y + ((pinfo->line_h - line_space) >> 1)  + (line_dsc.width >> 1);
-                    line_dsc.p2.x = pos.x;
-                    line_dsc.p2.y = line_dsc.p1.y;
+                    int32_t y = pos.y + ((pinfo->line_h - line_space) >> 1)  + (line_dsc.width >> 1);
+                    lv_point_precise_set(&line_dsc.p1, txt_pos.x, y);
+                    lv_point_precise_set(&line_dsc.p2, pos.x, y);
                     lv_draw_line(layer, &line_dsc);
                 }
 
                 if(decor & LV_TEXT_DECOR_UNDERLINE) {
-                    line_dsc.p1.x = txt_pos.x;
-                    line_dsc.p1.y = pos.y + pinfo->line_h - line_space - pinfo->font->base_line - pinfo->font->underline_position;
-                    line_dsc.p2.x = pos.x;
-                    line_dsc.p2.y = line_dsc.p1.y;
+                    int32_t y = pos.y + pinfo->line_h - line_space - pinfo->font->base_line - pinfo->font->underline_position;
+                    lv_point_precise_set(&line_dsc.p1, txt_pos.x, y);
+                    lv_point_precise_set(&line_dsc.p2, pos.x, y);
                     lv_draw_line(layer, &line_dsc);
                 }
             }

--- a/tests/src/lv_test_indev.c
+++ b/tests/src/lv_test_indev.c
@@ -18,8 +18,7 @@ static bool enc_pressed;
 void lv_test_mouse_read_cb(lv_indev_t * indev, lv_indev_data_t * data)
 {
     LV_UNUSED(indev);
-    data->point.x = x_act;
-    data->point.y = y_act;
+    lv_point_set(&data->point, x_act, y_act);
     data->state = mouse_pressed ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 }
 

--- a/tests/src/test_cases/test_bindings.c
+++ b/tests/src/test_cases/test_bindings.c
@@ -255,10 +255,8 @@ static void draw_to_canvas(lv_obj_t * canvas)
     line_draw_dsc.width = 8;
     line_draw_dsc.round_end = 1;
     line_draw_dsc.round_start = 1;
-    line_draw_dsc.p1.x = 150;
-    line_draw_dsc.p1.y = 30;
-    line_draw_dsc.p2.x = 350;
-    line_draw_dsc.p2.y = 55;
+    lv_point_precise_set(&line_draw_dsc.p1, 150, 30);
+    lv_point_precise_set(&line_draw_dsc.p2, 350, 55);
     lv_draw_line(&layer, &line_draw_dsc);
 
     lv_canvas_finish_layer(canvas, &layer);


### PR DESCRIPTION
### Description of the feature or fix

Follow up of https://github.com/lvgl/lvgl/pull/4858

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
