### PR TITLE
feat(stdlib): add lv_memmove

### DIFF
--- a/src/libs/lz4/lz4.h
+++ b/src/libs/lz4/lz4.h
@@ -46,10 +46,7 @@ extern "C" {
 #define LZ4_FREESTANDING    1
 #define LZ4_memset  lv_memset
 #define LZ4_memcpy  lv_memcpy
-#define LZ4_memmove memmove
-/**
- * @todo add LZ4_memmove
- */
+#define LZ4_memmove lv_memmove
 
 #ifndef LZ4_H_2983827168210
 #define LZ4_H_2983827168210

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -260,4 +260,4 @@ static void lv_mem_walker(void * ptr, size_t size, int used, void * user)
             mon_p->free_biggest_size = size;
     }
 }
-#endif /*LV_USE_BUILTIN_MALLOC*/
+#endif /*LV_STDLIB_BUILTIN*/

--- a/src/stdlib/builtin/lv_sprintf_builtin.c
+++ b/src/stdlib/builtin/lv_sprintf_builtin.c
@@ -883,4 +883,4 @@ int lv_vsnprintf(char * buffer, size_t count, const char * format, va_list va)
     return _lv_vsnprintf(_out_buffer, buffer, count, format, va);
 }
 
-#endif /*LV_USE_BUILTIN_SNPRINTF*/
+#endif /*LV_STDLIB_BUILTIN*/

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -145,6 +145,22 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
     }
 }
 
+LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t len)
+{
+    if(dst < src || (char *)dst > ((char *)src + len)) {
+        return lv_memcpy(dst, src, len);
+    }
+    else {
+        char * tmp = (char *)dst + len;
+        char * s = (char *) src + len;
+
+        while(len--) {
+            *--tmp = *--s;
+        }
+        return dst;
+    }
+}
+
 /* See https://en.cppreference.com/w/c/string/byte/strlen for reference */
 size_t lv_strlen(const char * str)
 {

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -210,4 +210,4 @@ char * lv_strdup(const char * src)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_BUILTIN_MEMCPY*/
+#endif /*LV_STDLIB_BUILTIN*/

--- a/src/stdlib/builtin/lv_tlsf.c
+++ b/src/stdlib/builtin/lv_tlsf.c
@@ -1242,4 +1242,4 @@ void * lv_tlsf_realloc(lv_tlsf_t tlsf, void * ptr, size_t size)
     return p;
 }
 
-#endif /* LV_USE_BUILTIN_MALLOC */
+#endif /*LV_STDLIB_BUILTIN*/

--- a/src/stdlib/builtin/lv_tlsf.h
+++ b/src/stdlib/builtin/lv_tlsf.h
@@ -105,4 +105,4 @@ int lv_tlsf_check_pool(lv_pool_t pool);
 
 #endif /*LV_TLSF_H*/
 
-#endif /* LV_USE_BUILTIN_MALLOC */
+#endif /*LV_STDLIB_BUILTIN*/

--- a/src/stdlib/clib/lv_mem_core_clib.c
+++ b/src/stdlib/clib/lv_mem_core_clib.c
@@ -91,4 +91,4 @@ lv_result_t lv_mem_test_core(void)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_BUILTIN_MALLOC*/
+#endif /*LV_STDLIB_CLIB*/

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -48,9 +48,9 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
     memset(dst, v, len);
 }
 
-LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t count)
+LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t len)
 {
-    return memmove(dst, src, count);
+    return memmove(dst, src, len);
 }
 
 size_t lv_strlen(const char * str)

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -48,6 +48,11 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
     memset(dst, v, len);
 }
 
+LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t count)
+{
+    return memmove(dst, src, count);
+}
+
 size_t lv_strlen(const char * str)
 {
     return strlen(str);

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -8,6 +8,7 @@
 #include "../../lv_conf_internal.h"
 #if LV_USE_STDLIB_STRING == LV_STDLIB_CLIB
 #include "../lv_string.h"
+#include "../lv_mem.h" /*Need lv_malloc*/
 #include <string.h>
 
 /*********************

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -10,10 +10,6 @@
 #include "../lv_string.h"
 #include <string.h>
 
-#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
-    #include "../lv_mem.h"
-#endif
-
 /*********************
  *      DEFINES
  *********************/
@@ -97,4 +93,4 @@ char * lv_strdup(const char * src)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_BUILTIN_MEMCPY*/
+#endif /*LV_STDLIB_CLIB*/

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -49,6 +49,15 @@ void * lv_memcpy(void * dst, const void * src, size_t len);
 void lv_memset(void * dst, uint8_t v, size_t len);
 
 /**
+ * @brief Move a block of memory from source to destination
+ * @param dst Pointer to the destination array where the content is to be copied.
+ * @param src Pointer to the source of data to be copied.
+ * @param count Number of bytes to copy.
+ * @return Pointer to the destination array.
+ */
+void * lv_memmove(void * dst, const void * src, size_t count);
+
+/**
  * Same as `memset(dst, 0x00, len)`.
  * @param dst pointer to the destination buffer
  * @param len number of byte to set

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -51,11 +51,11 @@ void lv_memset(void * dst, uint8_t v, size_t len);
 /**
  * @brief Move a block of memory from source to destination
  * @param dst Pointer to the destination array where the content is to be copied.
- * @param src Pointer to the source of data to be copied.
+ * @param len Pointer to the source of data to be copied.
  * @param count Number of bytes to copy.
  * @return Pointer to the destination array.
  */
-void * lv_memmove(void * dst, const void * src, size_t count);
+void * lv_memmove(void * dst, const void * src, size_t len);
 
 /**
  * Same as `memset(dst, 0x00, len)`.

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -51,8 +51,8 @@ void lv_memset(void * dst, uint8_t v, size_t len);
 /**
  * @brief Move a block of memory from source to destination
  * @param dst Pointer to the destination array where the content is to be copied.
- * @param len Pointer to the source of data to be copied.
- * @param count Number of bytes to copy.
+ * @param src Pointer to the source of data to be copied.
+ * @param len Number of bytes to copy
  * @return Pointer to the destination array.
  */
 void * lv_memmove(void * dst, const void * src, size_t len);

--- a/src/stdlib/micropython/lv_mem_core_micropython.c
+++ b/src/stdlib/micropython/lv_mem_core_micropython.c
@@ -92,4 +92,4 @@ lv_result_t lv_mem_test_core(void)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_BUILTIN_MALLOC*/
+#endif /*LV_STDLIB_MICROPYTHON*/

--- a/src/stdlib/rtthread/lv_mem_core_rtthread.c
+++ b/src/stdlib/rtthread/lv_mem_core_rtthread.c
@@ -95,4 +95,4 @@ lv_result_t lv_mem_test_core(void)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_STDLIB_MALLOC*/
+#endif /*LV_STDLIB_RTTHREAD*/

--- a/src/stdlib/rtthread/lv_sprintf_rtthread.c
+++ b/src/stdlib/rtthread/lv_sprintf_rtthread.c
@@ -58,4 +58,4 @@ int lv_vsnprintf(char * buffer, size_t count, const char * format, va_list va)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_STDLIB_SPRINTF*/
+#endif /*LV_STDLIB_RTTHREAD*/

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -10,10 +10,6 @@
 #include "../lv_string.h"
 #include <rtthread.h>
 
-#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
-    #include "../lv_mem.h"
-#endif
-
 /*********************
  *      DEFINES
  *********************/
@@ -92,4 +88,4 @@ char * lv_strdup(const char * src)
  *   STATIC FUNCTIONS
  **********************/
 
-#endif /*LV_USE_STDLIB_STRING*/
+#endif /*LV_STDLIB_RTTHREAD*/

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -48,6 +48,11 @@ LV_ATTRIBUTE_FAST_MEM void lv_memset(void * dst, uint8_t v, size_t len)
     rt_memset(dst, v, len);
 }
 
+LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t len)
+{
+    return rt_memmove(dst, src, len);
+}
+
 size_t lv_strlen(const char * str)
 {
     return rt_strlen(str);

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -8,6 +8,7 @@
 #include "../../lv_conf_internal.h"
 #if LV_USE_STDLIB_STRING == LV_STDLIB_RTTHREAD
 #include "../lv_string.h"
+#include "../lv_mem.h" /*Need lv_malloc*/
 #include <rtthread.h>
 
 /*********************


### PR DESCRIPTION
### Description of the feature or fix

Add lv_memmove, and use it in lz4 lib.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
