### PR TITLE
chore: fix inconsistent comment style

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -760,7 +760,7 @@
     #define LV_IME_PINYIN_USE_K9_MODE      1
     #if LV_IME_PINYIN_USE_K9_MODE == 1
         #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
-    #endif // LV_IME_PINYIN_USE_K9_MODE
+    #endif /*LV_IME_PINYIN_USE_K9_MODE*/
 #endif
 
 /*1: Enable file explorer*/

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -174,7 +174,7 @@ void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
 
     /* Figure out the size of the screen in bytes*/
-    dsc->screensize =  dsc->finfo.smem_len; //finfo.line_length * vinfo.yres;
+    dsc->screensize =  dsc->finfo.smem_len;/*finfo.line_length * vinfo.yres;*/
 
     /* Map the device to memory*/
     dsc->fbp = (char *)mmap(0, dsc->screensize, PROT_READ | PROT_WRITE, MAP_SHARED, dsc->fbfd, 0);

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -59,7 +59,7 @@ static bool _is_identity_or_translation(const lv_matrix_t * matrix)
 
 static void _multiply_matrix(lv_matrix_t * matrix, const lv_matrix_t * mul)
 {
-    // TODO: use NEON to optimize this function on ARM architecture.
+    /*TODO: use NEON to optimize this function on ARM architecture.*/
     lv_matrix_t tmp;
 
     for(int y = 0; y < 3; y++) {
@@ -129,7 +129,7 @@ void lv_matrix_identity(lv_matrix_t * matrix)
 void lv_matrix_translate(lv_matrix_t * matrix, float dx, float dy)
 {
     if(_is_identity_or_translation(matrix)) {
-        // optimization for matrix translation.
+        /*optimization for matrix translation.*/
         matrix->m[0][2] += dx;
         matrix->m[1][2] += dy;
         return;
@@ -239,7 +239,7 @@ void lv_vector_path_move_to(lv_vector_path_t * path, const lv_fpoint_t * p)
 void lv_vector_path_line_to(lv_vector_path_t * path, const lv_fpoint_t * p)
 {
     if(lv_array_is_empty(&path->ops)) {
-        // first op must be move_to
+        /*first op must be move_to*/
         return;
     }
 
@@ -253,7 +253,7 @@ void lv_vector_path_line_to(lv_vector_path_t * path, const lv_fpoint_t * p)
 void lv_vector_path_quad_to(lv_vector_path_t * path, const lv_fpoint_t * p1, const lv_fpoint_t * p2)
 {
     if(lv_array_is_empty(&path->ops)) {
-        // first op must be move_to
+        /*first op must be move_to*/
         return;
     }
 
@@ -269,7 +269,7 @@ void lv_vector_path_cubic_to(lv_vector_path_t * path, const lv_fpoint_t * p1, co
                              const lv_fpoint_t * p3)
 {
     if(lv_array_is_empty(&path->ops)) {
-        // first op must be move_to
+        /*first op must be move_to*/
         return;
     }
 
@@ -285,7 +285,7 @@ void lv_vector_path_cubic_to(lv_vector_path_t * path, const lv_fpoint_t * p1, co
 void lv_vector_path_close(lv_vector_path_t * path)
 {
     if(lv_array_is_empty(&path->ops)) {
-        // first op must be move_to
+        /*first op must be move_to*/
         return;
     }
 
@@ -463,21 +463,21 @@ lv_vector_dsc_t * lv_vector_dsc_create(lv_layer_t * layer)
     fill_dsc->color = lv_color_to_32(lv_color_black(), 0xFF);
     fill_dsc->opa = LV_OPA_COVER;
     fill_dsc->fill_rule = LV_VECTOR_FILL_NONZERO;
-    lv_matrix_identity(&(fill_dsc->matrix)); // identity matrix
+    lv_matrix_identity(&(fill_dsc->matrix)); /*identity matrix*/
 
     lv_vector_stroke_dsc_t * stroke_dsc = &(dsc->current_dsc.stroke_dsc);
     stroke_dsc->style = LV_VECTOR_DRAW_STYLE_SOLID;
     stroke_dsc->color = lv_color_to_32(lv_color_black(), 0xFF);
-    stroke_dsc->opa = LV_OPA_0; // default no stroke
+    stroke_dsc->opa = LV_OPA_0; /*default no stroke*/
     stroke_dsc->width = 1.0f;
     stroke_dsc->cap = LV_VECTOR_STROKE_CAP_BUTT;
     stroke_dsc->join = LV_VECTOR_STROKE_JOIN_MITER;
     stroke_dsc->miter_limit = 4.0f;
-    lv_matrix_identity(&(stroke_dsc->matrix)); // identity matrix
+    lv_matrix_identity(&(stroke_dsc->matrix)); /*identity matrix*/
 
     dsc->current_dsc.blend_mode = LV_VECTOR_BLEND_SRC_OVER;
     dsc->current_dsc.scissor_area = layer->_clip_area;
-    lv_matrix_identity(&(dsc->current_dsc.matrix)); // identity matrix
+    lv_matrix_identity(&(dsc->current_dsc.matrix)); /*identity matrix*/
     dsc->tasks.task_list = NULL;
     return dsc;
 }
@@ -593,7 +593,7 @@ void lv_vector_dsc_set_stroke_dash(lv_vector_dsc_t * dsc, float * dash_pattern, 
             LV_ARRAY_APPEND_VALUE(dash_array, dash_pattern[i]);
         }
     }
-    else {   // clear dash
+    else {   /*clear dash*/
         lv_array_clear(dash_array);
     }
 }
@@ -702,7 +702,7 @@ void lv_draw_vector(lv_vector_dsc_t * dsc)
 /* draw dsc transform */
 void lv_vector_dsc_identity(lv_vector_dsc_t * dsc)
 {
-    lv_matrix_identity(&(dsc->current_dsc.matrix)); // identity matrix
+    lv_matrix_identity(&(dsc->current_dsc.matrix)); /*identity matrix*/
 }
 
 void lv_vector_dsc_scale(lv_vector_dsc_t * dsc, float scale_x, float scale_y)

--- a/src/draw/lv_draw_vector.h
+++ b/src/draw/lv_draw_vector.h
@@ -147,7 +147,7 @@ typedef struct {
 
 typedef struct {
     lv_draw_dsc_base_t base;
-    lv_ll_t * task_list; // draw task list.
+    lv_ll_t * task_list; /*draw task list.*/
 } lv_draw_vector_task_dsc_t;
 
 typedef struct {

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -113,7 +113,7 @@ void lv_draw_vglite_deinit(void)
 
 static inline bool _vglite_cf_supported(lv_color_format_t cf)
 {
-    // Add here the platform specific code for supported formats.
+    /*Add here the platform specific code for supported formats.*/
 
     bool is_cf_unsupported = (cf == LV_COLOR_FORMAT_RGB565A8 || cf == LV_COLOR_FORMAT_RGB888);
 

--- a/src/draw/nxp/vglite/lv_vglite_path.c
+++ b/src/draw/nxp/vglite/lv_vglite_path.c
@@ -118,7 +118,7 @@ void vglite_create_rect_path_data(int32_t * path_data, uint32_t * path_data_size
 
         /* Top side */
         path_data[pidx++] = VLC_OP_LINE;
-        path_data[pidx++] = coords->x2 - final_radius + 1;  // Extended for VGLite
+        path_data[pidx++] = coords->x2 - final_radius + 1;  /*Extended for VGLite*/
         path_data[pidx++] = coords->y1;
 
         /* Top-right corner */
@@ -132,8 +132,8 @@ void vglite_create_rect_path_data(int32_t * path_data, uint32_t * path_data_size
 
         /* Right side */
         path_data[pidx++] = VLC_OP_LINE;
-        path_data[pidx++] = coords->x2 + 1;                 // Extended for VGLite
-        path_data[pidx++] = coords->y2 - final_radius + 1;  // Extended for VGLite
+        path_data[pidx++] = coords->x2 + 1;                 /*Extended for VGLite*/
+        path_data[pidx++] = coords->y2 - final_radius + 1;  /*Extended for VGLite*/
 
         /* Bottom-right corner*/
         path_data[pidx++] = VLC_OP_CUBIC_REL;
@@ -147,7 +147,7 @@ void vglite_create_rect_path_data(int32_t * path_data, uint32_t * path_data_size
         /* Bottom side */
         path_data[pidx++] = VLC_OP_LINE;
         path_data[pidx++] = coords->x1 + final_radius;
-        path_data[pidx++] = coords->y2 + 1;                 // Extended for VGLite
+        path_data[pidx++] = coords->y2 + 1;                 /*Extended for VGLite*/
 
         /* Bottom-left corner */
         path_data[pidx++] = VLC_OP_CUBIC_REL;
@@ -184,18 +184,18 @@ void vglite_create_rect_path_data(int32_t * path_data, uint32_t * path_data_size
 
         /* Top side */
         path_data[pidx++] = VLC_OP_LINE;
-        path_data[pidx++] = coords->x2 + 1; // Extended for VGLite
+        path_data[pidx++] = coords->x2 + 1; /*Extended for VGLite*/
         path_data[pidx++] = coords->y1;
 
         /* Right side */
         path_data[pidx++] = VLC_OP_LINE;
-        path_data[pidx++] = coords->x2 + 1; // Extended for VGLite
-        path_data[pidx++] = coords->y2 + 1; // Extended for VGLite
+        path_data[pidx++] = coords->x2 + 1; /*Extended for VGLite*/
+        path_data[pidx++] = coords->y2 + 1; /*Extended for VGLite*/
 
         /* Bottom side */
         path_data[pidx++] = VLC_OP_LINE;
         path_data[pidx++] = coords->x1;
-        path_data[pidx++] = coords->y2 + 1; // Extended for VGLite
+        path_data[pidx++] = coords->y2 + 1; /*Extended for VGLite*/
 
         /* Left side*/
         path_data[pidx++] = VLC_OP_LINE;

--- a/src/draw/nxp/vglite/lv_vglite_utils.c
+++ b/src/draw/nxp/vglite/lv_vglite_utils.c
@@ -225,7 +225,7 @@ uint8_t vglite_get_px_size(lv_color_format_t cf)
 
 uint8_t vglite_get_alignment(lv_color_format_t cf)
 {
-    uint8_t align_bytes = LV_COLOR_DEPTH / 8 * 16; //16 pixels
+    uint8_t align_bytes = LV_COLOR_DEPTH / 8 * 16; /*16 pixels*/
 
     switch(cf) {
         case LV_COLOR_FORMAT_I1:

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -423,9 +423,9 @@ static void rotate90_rgb888(const uint8_t * src, uint8_t * dst, int32_t srcWidth
         for(int32_t y = 0; y < srcHeight; ++y) {
             int32_t srcIndex = y * srcStride + x * 3;
             int32_t dstIndex = (srcWidth - x - 1) * dstStride + y * 3;
-            dst[dstIndex] = src[srcIndex];       // Red
-            dst[dstIndex + 1] = src[srcIndex + 1]; // Green
-            dst[dstIndex + 2] = src[srcIndex + 2]; // Blue
+            dst[dstIndex] = src[srcIndex];       /*Red*/
+            dst[dstIndex + 1] = src[srcIndex + 1]; /*Green*/
+            dst[dstIndex + 2] = src[srcIndex + 2]; /*Blue*/
         }
     }
 }
@@ -452,9 +452,9 @@ static void rotate270_rgb888(const uint8_t * src, uint8_t * dst, int32_t width, 
         for(int32_t y = 0; y < height; ++y) {
             int32_t srcIndex = y * srcStride + x * 3;
             int32_t dstIndex = x * dstStride + (height - y - 1) * 3;
-            dst[dstIndex] = src[srcIndex];       // Red
-            dst[dstIndex + 1] = src[srcIndex + 1]; // Green
-            dst[dstIndex + 2] = src[srcIndex + 2]; // Blue
+            dst[dstIndex] = src[srcIndex];       /*Red*/
+            dst[dstIndex + 1] = src[srcIndex + 1]; /*Green*/
+            dst[dstIndex + 2] = src[srcIndex + 2]; /*Blue*/
         }
     }
 }

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -233,7 +233,7 @@ static void _set_paint_stroke(Tvg_Paint * obj, const lv_vector_stroke_dsc_t * ds
         _lv_color_to_tvg(&c, &dsc->color, dsc->opa);
         tvg_shape_set_stroke_color(obj, c.r, c.g, c.b, c.a);
     }
-    else {   // gradient
+    else {   /*gradient*/
         _set_paint_stroke_gradient(obj, &dsc->gradient, &dsc->matrix);
     }
 
@@ -367,7 +367,7 @@ static Tvg_Blend_Method _lv_blend_to_tvg(lv_vector_blend_t blend)
         case LV_VECTOR_BLEND_DST_OVER:
         case LV_VECTOR_BLEND_DST_IN:
         case LV_VECTOR_BLEND_SUBTRACTIVE:
-        // not support yet.
+        /*not support yet.*/
         default:
             return TVG_BLEND_METHOD_NORMAL;
     }
@@ -384,7 +384,7 @@ static void _task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_ve
 
     Tvg_Paint * obj = tvg_shape_new();
 
-    if(!path) {  // clear
+    if(!path) {  /*clear*/
         _tvg_rect rc;
         _lv_area_to_tvg(&rc, &dsc->scissor_area);
 

--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -48,7 +48,7 @@ typedef struct {
     const char * path;
 } lv_rlottie_create_info_t;
 
-// only used in lv_obj_class_create_obj, no affect multiple instances
+/*Only used in lv_obj_class_create_obj, no affect multiple instances*/
 static lv_rlottie_create_info_t create_info;
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2470,7 +2470,7 @@
                 #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
             #endif
         #endif
-    #endif // LV_IME_PINYIN_USE_K9_MODE
+    #endif /*LV_IME_PINYIN_USE_K9_MODE*/
 #endif
 
 /*1: Enable file explorer*/

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -215,13 +215,13 @@ extern "C" {
  * BIDI DIRECTION
  *-----------------*/
 
-// #ifdef CONFIG_LV_BASE_DIR_LTR
+#ifdef CONFIG_LV_BASE_DIR_LTR
 #  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_LTR
-// #elif defined(CONFIG_LV_BASE_DIR_RTL)
-// #  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_RTL
-// #elif defined(CONFIG_LV_BASE_DIR_AUTO)
-// #  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
-// #endif
+#elif defined(CONFIG_LV_BASE_DIR_RTL)
+#  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_RTL
+#elif defined(CONFIG_LV_BASE_DIR_AUTO)
+#  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
 
 /*------------------
  * LINUX FBDEV

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -235,7 +235,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask)
 
     uint32_t root = 0;
     uint32_t trial;
-    // http://ww1.microchip.com/...en/AppNotes/91040a.pdf
+    /*http://ww1.microchip.com/...en/AppNotes/91040a.pdf*/
     do {
         trial = root + mask;
         if(trial * trial <= x) root = trial;
@@ -254,75 +254,76 @@ LV_ATTRIBUTE_FAST_MEM void lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask)
  */
 uint16_t lv_atan2(int x, int y)
 {
-    // Fast XY vector to integer degree algorithm - Jan 2011 www.RomanBlack.com
-    // Converts any XY values including 0 to a degree value that should be
-    // within +/- 1 degree of the accurate value without needing
-    // large slow trig functions like ArcTan() or ArcCos().
-    // NOTE! at least one of the X or Y values must be non-zero!
-    // This is the full version, for all 4 quadrants and will generate
-    // the angle in integer degrees from 0-360.
-    // Any values of X and Y are usable including negative values provided
-    // they are between -1456 and 1456 so the 16bit multiply does not overflow.
-
+    /**
+     * Fast XY vector to integer degree algorithm - Jan 2011 www.RomanBlack.com
+     * Converts any XY values including 0 to a degree value that should be
+     * within +/- 1 degree of the accurate value without needing
+     * large slow trig functions like ArcTan() or ArcCos().
+     * NOTE! at least one of the X or Y values must be non-zero!
+     * This is the full version, for all 4 quadrants and will generate
+     * the angle in integer degrees from 0-360.
+     * Any values of X and Y are usable including negative values provided
+     * they are between -1456 and 1456 so the 16bit multiply does not overflow.
+     */
     unsigned char negflag;
     unsigned char tempdegree;
     unsigned char comp;
-    unsigned int degree;     // this will hold the result
+    unsigned int degree;     /*this will hold the result*/
     unsigned int ux;
     unsigned int uy;
 
-    // Save the sign flags then remove signs and get XY as unsigned ints
+    /*Save the sign flags then remove signs and get XY as unsigned ints*/
     negflag = 0;
     if(x < 0) {
-        negflag += 0x01;    // x flag bit
-        x = (0 - x);        // is now +
+        negflag += 0x01;    /*x flag bit*/
+        x = (0 - x);        /*is now +*/
     }
-    ux = x;                // copy to unsigned var before multiply
+    ux = x;                /*copy to unsigned var before multiply*/
     if(y < 0) {
-        negflag += 0x02;    // y flag bit
-        y = (0 - y);        // is now +
+        negflag += 0x02;    /*y flag bit*/
+        y = (0 - y);        /*is now +*/
     }
-    uy = y;                // copy to unsigned var before multiply
+    uy = y;                /*copy to unsigned var before multiply*/
 
-    // 1. Calc the scaled "degrees"
+    /*1. Calc the scaled "degrees"*/
     if(ux > uy) {
-        degree = (uy * 45) / ux;   // degree result will be 0-45 range
-        negflag += 0x10;    // octant flag bit
+        degree = (uy * 45) / ux;   /*degree result will be 0-45 range*/
+        negflag += 0x10;    /*octant flag bit*/
     }
     else {
-        degree = (ux * 45) / uy;   // degree result will be 0-45 range
+        degree = (ux * 45) / uy;   /*degree result will be 0-45 range*/
     }
 
-    // 2. Compensate for the 4 degree error curve
+    /*2. Compensate for the 4 degree error curve*/
     comp = 0;
-    tempdegree = degree;    // use an unsigned char for speed!
-    if(tempdegree > 22) {    // if top half of range
+    tempdegree = degree;    /*use an unsigned char for speed!*/
+    if(tempdegree > 22) {    /*if top half of range*/
         if(tempdegree <= 44) comp++;
         if(tempdegree <= 41) comp++;
         if(tempdegree <= 37) comp++;
-        if(tempdegree <= 32) comp++;  // max is 4 degrees compensated
+        if(tempdegree <= 32) comp++;  /*max is 4 degrees compensated*/
     }
-    else {   // else is lower half of range
+    else {   /*else is lower half of range*/
         if(tempdegree >= 2) comp++;
         if(tempdegree >= 6) comp++;
         if(tempdegree >= 10) comp++;
-        if(tempdegree >= 15) comp++;  // max is 4 degrees compensated
+        if(tempdegree >= 15) comp++;  /*max is 4 degrees compensated*/
     }
-    degree += comp;   // degree is now accurate to +/- 1 degree!
+    degree += comp;   /*degree is now accurate to +/- 1 degree!*/
 
-    // Invert degree if it was X>Y octant, makes 0-45 into 90-45
+    /*Invert degree if it was X>Y octant, makes 0-45 into 90-45*/
     if(negflag & 0x10) degree = (90 - degree);
 
-    // 3. Degree is now 0-90 range for this quadrant,
-    // need to invert it for whichever quadrant it was in
-    if(negflag & 0x02) { // if -Y
-        if(negflag & 0x01)   // if -Y -X
+    /*3. Degree is now 0-90 range for this quadrant,*/
+    /*need to invert it for whichever quadrant it was in*/
+    if(negflag & 0x02) { /*if -Y*/
+        if(negflag & 0x01)   /*if -Y -X*/
             degree = (180 + degree);
-        else        // else is -Y +X
+        else        /*else is -Y +X*/
             degree = (180 - degree);
     }
-    else {   // else is +Y
-        if(negflag & 0x01)   // if +Y -X
+    else {   /*else is +Y*/
+        if(negflag & 0x01)   /*if +Y -X*/
             degree = (360 - degree);
     }
     return degree;

--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -258,8 +258,10 @@ static uint32_t lv_text_get_next_word(const char * txt, const lv_font_t * font,
         /*Move pointer "i" backwards*/
         for(; n_move > 0; n_move--) {
             _lv_text_encoded_prev(txt, &i);
-            // TODO: it would be appropriate to update the returned word width here
-            // However, in current usage, this doesn't impact anything.
+            /**
+             * TODO: it would be appropriate to update the returned
+             * word width hereHowever, in current usage, this doesn't impact anything.
+             */
         }
     }
     return i;

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -22,14 +22,14 @@ extern "C" {
  *      DEFINES
  *********************/
 
-// If __UINTPTR_MAX__ or UINTPTR_MAX are available, use them to determine arch size
+/*If __UINTPTR_MAX__ or UINTPTR_MAX are available, use them to determine arch size*/
 #if defined(__UINTPTR_MAX__) && __UINTPTR_MAX__ > 0xFFFFFFFF
 #define LV_ARCH_64
 
 #elif defined(UINTPTR_MAX) && UINTPTR_MAX > 0xFFFFFFFF
 #define LV_ARCH_64
 
-// Otherwise use compiler-dependent means to determine arch size
+/*Otherwise use compiler-dependent means to determine arch size*/
 #elif defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined (__aarch64__)
 #define LV_ARCH_64
 
@@ -77,13 +77,13 @@ typedef uint8_t lv_result_t;
 #endif /*DOXYGEN*/
 
 #if defined(__cplusplus) || __STDC_VERSION__ >= 199901L
-// If c99 or newer,  use the definition of uintptr_t directly from <stdint.h>
+/*If c99 or newer,  use the definition of uintptr_t directly from <stdint.h>*/
 typedef uintptr_t lv_uintptr_t;
 typedef intptr_t lv_intptr_t;
 
 #else
 
-// Otherwise, use the arch size determination
+/*Otherwise, use the arch size determination*/
 #ifdef LV_ARCH_64
 typedef uint64_t lv_uintptr_t;
 typedef int64_t lv_intptr_t;

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -470,7 +470,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     char * buf_p = textarea_txt;
 
     uint32_t cur_shift_left = 0;
-    if(spinbox->range_min < 0) {  // hide sign if there are only positive values
+    if(spinbox->range_min < 0) {  /*hide sign if there are only positive values*/
         /*Add the sign*/
         (*buf_p) = spinbox->value >= 0 ? '+' : '-';
         buf_p++;

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -60,7 +60,7 @@ static void dummy_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t 
 
 void lv_test_assert_fail(void)
 {
-    // Handle error on test
+    /*Handle error on test*/
 }
 
 #endif

--- a/tests/src/test_cases/widgets/test_tabview.c
+++ b/tests/src/test_cases/widgets/test_tabview.c
@@ -157,7 +157,7 @@ void test_tabview_add_several_tabs_no_scroll(void)
     lv_obj_t * label1 = lv_label_create(tab1);
     lv_label_set_text(label1, "Content of the first tab\n");
 
-    // avoid compiler error: unused variable
+    /*avoid compiler error: unused variable*/
     LV_UNUSED(tab2);
     LV_UNUSED(tab3);
 
@@ -174,12 +174,12 @@ void test_tabview_rename_tab(void)
     lv_obj_t * tab2 = lv_tabview_add_tab(tabview, "Tab 2");
     lv_obj_t * tab3 = lv_tabview_add_tab(tabview, "Tab 3");
 
-    // avoid compiler error: unused variable
+    /*avoid compiler error: unused variable*/
     LV_UNUSED(tab1);
     LV_UNUSED(tab2);
     LV_UNUSED(tab3);
 
-    // rename 2nd tab (0-based index)
+    /*rename 2nd tab (0-based index)*/
     lv_tabview_rename_tab(tabview, 1, "2nd Tab");
 
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/tabview_08.png");
@@ -198,7 +198,7 @@ void test_tabview_add_several_tabs_hor(void)
     lv_obj_t * label1 = lv_label_create(tab1);
     lv_label_set_text(label1, "Content of the first tab\n");
 
-    // avoid compiler error: unused variable
+    /*avoid compiler error: unused variable*/
     LV_UNUSED(tab2);
     LV_UNUSED(tab3);
 
@@ -241,7 +241,7 @@ void test_tabview_tab2_selected_event(void)
     lv_obj_t * tab1 = lv_tabview_add_tab(tabview, "Tab 1");
     lv_obj_t * tab2 = lv_tabview_add_tab(tabview, "Tab 2");
 
-    // avoid compiler error: unused variable
+    /*avoid compiler error: unused variable*/
     LV_UNUSED(tab1);
     LV_UNUSED(tab2);
 
@@ -261,7 +261,7 @@ void test_tabview_update_on_external_scroll(void)
     lv_obj_t * tab3 = lv_tabview_add_tab(tabview, "Tab 3");
     lv_obj_t * tab4 = lv_tabview_add_tab(tabview, "Tab 4");
 
-    // avoid compiler error: unused variable
+    /*avoid compiler error: unused variable*/
     LV_UNUSED(tab1);
     LV_UNUSED(tab2);
     LV_UNUSED(tab4);


### PR DESCRIPTION
### Description of the feature or fix

Also add back BASE_DIR config in lv_conf_kconfig.h

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
