### PR TITLE
fix(sdl): fix memory leak and double free

### DIFF
--- a/src/dev/sdl/lv_sdl_keyboard.c
+++ b/src/dev/sdl/lv_sdl_keyboard.c
@@ -57,8 +57,7 @@ lv_indev_t * lv_sdl_keyboard_create(void)
     lv_indev_set_type(indev, LV_INDEV_TYPE_KEYPAD);
     lv_indev_set_read_cb(indev, sdl_keyboard_read);
     lv_indev_set_driver_data(indev, dsc);
-
-    lv_timer_delete(lv_indev_get_read_timer(indev));
+    lv_indev_delete_read_timer(indev);
     lv_indev_add_event_cb(indev, release_indev_cb, LV_EVENT_DELETE, indev);
 
     return indev;

--- a/src/dev/sdl/lv_sdl_mouse.c
+++ b/src/dev/sdl/lv_sdl_mouse.c
@@ -58,7 +58,7 @@ lv_indev_t * lv_sdl_mouse_create(void)
     lv_indev_set_read_cb(indev, sdl_mouse_read);
     lv_indev_set_driver_data(indev, dsc);
 
-    lv_timer_delete(lv_indev_get_read_timer(indev));
+    lv_indev_delete_read_timer(indev);
     lv_indev_add_event_cb(indev, release_indev_cb, LV_EVENT_DELETE, indev);
 
     return indev;

--- a/src/dev/sdl/lv_sdl_mousewheel.c
+++ b/src/dev/sdl/lv_sdl_mousewheel.c
@@ -53,7 +53,7 @@ lv_indev_t * lv_sdl_mousewheel_create(void)
     lv_indev_set_read_cb(indev, sdl_mousewheel_read);
     lv_indev_set_driver_data(indev, dsc);
 
-    lv_timer_delete(lv_indev_get_read_timer(indev));
+    lv_indev_delete_read_timer(indev);
     lv_indev_add_event_cb(indev, release_indev_cb, LV_EVENT_DELETE, indev);
 
     return indev;

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -12,6 +12,7 @@
 #include "../../core/lv_refr.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
+#include "../../lv_init.h"
 
 #define SDL_MAIN_HANDLED /*To fix SDL's "undefined reference to WinMain" issue*/
 #include LV_SDL_INCLUDE_PATH
@@ -173,6 +174,7 @@ void lv_sdl_quit()
     if(inited) {
         SDL_Quit();
         lv_timer_delete(event_handler_timer);
+        event_handler_timer = NULL;
         inited = false;
     }
 }
@@ -254,7 +256,7 @@ static void sdl_event_handler(lv_timer_t * t)
         }
         if(event.type == SDL_QUIT) {
             SDL_Quit();
-            lv_timer_delete(event_handler_timer);
+            lv_deinit();
             inited = false;
 #if LV_SDL_DIRECT_EXIT
             exit(0);
@@ -373,7 +375,8 @@ static void release_disp_cb(lv_event_t * e)
     SDL_DestroyTexture(dsc->texture);
     SDL_DestroyRenderer(dsc->renderer);
     SDL_DestroyWindow(dsc->window);
-
+    if(dsc->fb1) lv_free(dsc->fb1);
+    if(dsc->fb2) lv_free(dsc->fb2);
     lv_free(dsc);
     lv_display_set_driver_data(disp, NULL);
 }


### PR DESCRIPTION
### Description of the feature or fix

Use https://github.com/lvgl/lv_port_pc_eclipse/pull/134 to check simulator.

```bash
==509406==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1536000 byte(s) in 1 object(s) allocated from:
    #0 0x7ff9bea92c3e in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:163
    #1 0x55922d55e41a in texture_resize ../lvgl/src/dev/sdl/lv_sdl_window.c:318
    #2 0x55922d55e2ed in window_create ../lvgl/src/dev/sdl/lv_sdl_window.c:292
    #3 0x55922d55ddb9 in lv_sdl_window_create ../lvgl/src/dev/sdl/lv_sdl_window.c:106
    #4 0x55922d5474da in hal_init ../main.c:486
    #5 0x55922d54747d in main ../main.c:401
    #6 0x7ff9bdc4b082 in __libc_start_main ../csu/libc-start.c:308
```
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
