### PR TITLE
perf(gif): reduce lzw decoding time

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1114,8 +1114,8 @@ menu "LVGL configuration"
 			bool "GIF decoder library"
 
 		if LV_USE_GIF
-			config LV_GIF_CACHE_LZW_CODE
-				bool "Use extra 16KB RAM to cache lzw code to accerlate"
+			config LV_GIF_CACHE_DECODE_DATA
+				bool "Use extra 16KB RAM to cache decoded data to accerlate"
 		endif
 
 		config LV_USE_RLE

--- a/Kconfig
+++ b/Kconfig
@@ -1113,6 +1113,11 @@ menu "LVGL configuration"
 		config LV_USE_GIF
 			bool "GIF decoder library"
 
+		if LV_USE_GIF
+			config LV_GIF_CACHE_LZW_CODE
+				bool "Use extra 16KB RAM to cache lzw code to accerlate"
+		endif
+
 		config LV_USE_RLE
 			bool "RLE compressed bin image decoder library"
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -620,7 +620,7 @@
 #define LV_USE_GIF 0
 #if LV_USE_GIF
 /*GIF decoder accelerate*/
-#define LV_GIF_CACHE_LZW_CODE 0
+#define LV_GIF_CACHE_DECODE_DATA 0
 #endif
 
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -618,6 +618,11 @@
 
 /*GIF decoder library*/
 #define LV_USE_GIF 0
+#if LV_USE_GIF
+/*GIF decoder accelerate*/
+#define LV_GIF_CACHE_LZW_CODE 0
+#endif
+
 
 /*Decode bin images to RAM*/
 #define LV_BIN_DECODER_RAM_LOAD 0

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -23,7 +23,7 @@ typedef struct Table {
     Entry * entries;
 } Table;
 
-#if LV_GIF_CACHE_LZW_CODE
+#if LV_GIF_CACHE_DECODE_DATA
 #define LZW_MAXBITS                 12
 #define LZW_TABLE_SIZE              (1 << LZW_MAXBITS)
 #define LZW_CACHE_SIZE              (LZW_TABLE_SIZE * 4)
@@ -113,7 +113,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     /* Aspect Ratio */
     f_gif_read(gif_base, &aspect, 1);
     /* Create gd_GIF Structure. */
-#if LV_GIF_CACHE_LZW_CODE
+#if LV_GIF_CACHE_DECODE_DATA
     gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height + LZW_CACHE_SIZE);
     #else
     gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height);
@@ -134,7 +134,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         memset(gif->frame, gif->bgindex, gif->width * gif->height);
     }
     bgcolor = &gif->palette->colors[gif->bgindex * 3];
-    #if LV_GIF_CACHE_LZW_CODE
+    #if LV_GIF_CACHE_DECODE_DATA
     gif->lzw_cache = gif->frame + width * height;
     #endif
 
@@ -317,7 +317,7 @@ get_key(gd_GIF *gif, int key_size, uint8_t *sub_len, uint8_t *shift, uint8_t *by
     return key;
 }
 
-#if LV_GIF_CACHE_LZW_CODE
+#if LV_GIF_CACHE_DECODE_DATA
 static int
 read_image_data(gd_GIF *gif, int interlace)
 {

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -23,9 +23,11 @@ typedef struct Table {
     Entry * entries;
 } Table;
 
+#if LV_GIF_CACHE_LZW_CODE
 #define LZW_MAXBITS                 12
 #define LZW_TABLE_SIZE              (1 << LZW_MAXBITS)
 #define LZW_CACHE_SIZE              (LZW_TABLE_SIZE * 4)
+#endif
 
 static gd_GIF  * gif_open(gd_GIF * gif);
 static bool f_gif_open(gd_GIF * gif, const void * path, bool is_file);
@@ -111,8 +113,11 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     /* Aspect Ratio */
     f_gif_read(gif_base, &aspect, 1);
     /* Create gd_GIF Structure. */
+#if LV_GIF_CACHE_LZW_CODE
     gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height + LZW_CACHE_SIZE);
-
+    #else
+    gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height);
+    #endif
     if(!gif) goto fail;
     memcpy(gif, gif_base, sizeof(gd_GIF));
     gif->width  = width;
@@ -129,7 +134,9 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         memset(gif->frame, gif->bgindex, gif->width * gif->height);
     }
     bgcolor = &gif->palette->colors[gif->bgindex * 3];
+    #if LV_GIF_CACHE_LZW_CODE
     gif->lzw_cache = gif->frame + width * height;
+    #endif
 
 #ifdef GIFDEC_FILL_BG
     GIFDEC_FILL_BG(gif->canvas, gif->width * gif->height, 1, gif->width * gif->height, bgcolor, 0xff);
@@ -310,6 +317,7 @@ get_key(gd_GIF *gif, int key_size, uint8_t *sub_len, uint8_t *shift, uint8_t *by
     return key;
 }
 
+#if LV_GIF_CACHE_LZW_CODE
 static int
 read_image_data(gd_GIF *gif, int interlace)
 {
@@ -450,6 +458,147 @@ read_image_data(gd_GIF *gif, int interlace)
     f_gif_seek(gif, end, LV_FS_SEEK_SET);
     return ret;
 }
+#else
+static Table *
+new_table(int key_size)
+{
+    int key;
+    int init_bulk = MAX(1 << (key_size + 1), 0x100);
+    Table * table = lv_malloc(sizeof(*table) + sizeof(Entry) * init_bulk);
+    if(table) {
+        table->bulk = init_bulk;
+        table->nentries = (1 << key_size) + 2;
+        table->entries = (Entry *) &table[1];
+        for(key = 0; key < (1 << key_size); key++)
+            table->entries[key] = (Entry) {
+            1, 0xFFF, key
+        };
+    }
+    return table;
+}
+
+/* Add table entry. Return value:
+ *  0 on success
+ *  +1 if key size must be incremented after this addition
+ *  -1 if could not realloc table */
+static int
+add_entry(Table ** tablep, uint16_t length, uint16_t prefix, uint8_t suffix)
+{
+    Table * table = *tablep;
+    if(table->nentries == table->bulk) {
+        table->bulk *= 2;
+        table = lv_realloc(table, sizeof(*table) + sizeof(Entry) * table->bulk);
+        if(!table) return -1;
+        table->entries = (Entry *) &table[1];
+        *tablep = table;
+    }
+    table->entries[table->nentries] = (Entry) {
+        length, prefix, suffix
+    };
+    table->nentries++;
+    if((table->nentries & (table->nentries - 1)) == 0)
+        return 1;
+    return 0;
+}
+
+/* Compute output index of y-th input line, in frame of height h. */
+static int
+interlaced_line_index(int h, int y)
+{
+    int p; /* number of lines in current pass */
+
+    p = (h - 1) / 8 + 1;
+    if(y < p)  /* pass 1 */
+        return y * 8;
+    y -= p;
+    p = (h - 5) / 8 + 1;
+    if(y < p)  /* pass 2 */
+        return y * 8 + 4;
+    y -= p;
+    p = (h - 3) / 4 + 1;
+    if(y < p)  /* pass 3 */
+        return y * 4 + 2;
+    y -= p;
+    /* pass 4 */
+    return y * 2 + 1;
+}
+
+/* Decompress image pixels.
+ * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table). */
+static int
+read_image_data(gd_GIF * gif, int interlace)
+{
+    uint8_t sub_len, shift, byte;
+    int init_key_size, key_size, table_is_full = 0;
+    int frm_off, frm_size, str_len = 0, i, p, x, y;
+    uint16_t key, clear, stop;
+    int ret;
+    Table * table;
+    Entry entry = {0};
+    size_t start, end;
+
+    f_gif_read(gif, &byte, 1);
+    key_size = (int) byte;
+    start = f_gif_seek(gif, 0, LV_FS_SEEK_CUR);
+    discard_sub_blocks(gif);
+    end = f_gif_seek(gif, 0, LV_FS_SEEK_CUR);
+    f_gif_seek(gif, start, LV_FS_SEEK_SET);
+    clear = 1 << key_size;
+    stop = clear + 1;
+    table = new_table(key_size);
+    key_size++;
+    init_key_size = key_size;
+    sub_len = shift = 0;
+    key = get_key(gif, key_size, &sub_len, &shift, &byte); /* clear code */
+    frm_off = 0;
+    ret = 0;
+    frm_size = gif->fw * gif->fh;
+    while(frm_off < frm_size) {
+        if(key == clear) {
+            key_size = init_key_size;
+            table->nentries = (1 << (key_size - 1)) + 2;
+            table_is_full = 0;
+        }
+        else if(!table_is_full) {
+            ret = add_entry(&table, str_len + 1, key, entry.suffix);
+            if(ret == -1) {
+                lv_free(table);
+                return -1;
+            }
+            if(table->nentries == 0x1000) {
+                ret = 0;
+                table_is_full = 1;
+            }
+        }
+        key = get_key(gif, key_size, &sub_len, &shift, &byte);
+        if(key == clear) continue;
+        if(key == stop || key == 0x1000) break;
+        if(ret == 1) key_size++;
+        entry = table->entries[key];
+        str_len = entry.length;
+        for(i = 0; i < str_len; i++) {
+            p = frm_off + entry.length - 1;
+            x = p % gif->fw;
+            y = p / gif->fw;
+            if(interlace)
+                y = interlaced_line_index((int) gif->fh, y);
+            gif->frame[(gif->fy + y) * gif->width + gif->fx + x] = entry.suffix;
+            if(entry.prefix == 0xFFF)
+                break;
+            else
+                entry = table->entries[entry.prefix];
+        }
+        frm_off += str_len;
+        if(key < table->nentries - 1 && !table_is_full)
+            table->entries[table->nentries - 1].suffix = entry.suffix;
+    }
+    lv_free(table);
+    if(key == stop) f_gif_read(gif, &sub_len, 1);  /* Must be zero! */
+    f_gif_seek(gif, end, LV_FS_SEEK_SET);
+    return 0;
+}
+
+#endif
 
 /* Read image.
  * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table). */

--- a/src/libs/gif/gifdec.h
+++ b/src/libs/gif/gifdec.h
@@ -43,7 +43,9 @@ typedef struct _gd_GIF {
     uint16_t fx, fy, fw, fh;
     uint8_t bgindex;
     uint8_t * canvas, * frame;
+    #if LV_GIF_CACHE_LZW_CODE
     uint8_t *lzw_cache;
+    #endif
 } gd_GIF;
 
 gd_GIF * gd_open_gif_file(const char * fname);

--- a/src/libs/gif/gifdec.h
+++ b/src/libs/gif/gifdec.h
@@ -43,7 +43,7 @@ typedef struct _gd_GIF {
     uint16_t fx, fy, fw, fh;
     uint8_t bgindex;
     uint8_t * canvas, * frame;
-    #if LV_GIF_CACHE_LZW_CODE
+    #if LV_GIF_CACHE_DECODE_DATA
     uint8_t *lzw_cache;
     #endif
 } gd_GIF;

--- a/src/libs/gif/gifdec.h
+++ b/src/libs/gif/gifdec.h
@@ -43,6 +43,7 @@ typedef struct _gd_GIF {
     uint16_t fx, fy, fw, fh;
     uint8_t bgindex;
     uint8_t * canvas, * frame;
+    uint8_t *lzw_cache;
 } gd_GIF;
 
 gd_GIF * gd_open_gif_file(const char * fname);

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2054,7 +2054,7 @@
         #define LV_USE_GIF 0
     #endif
 #endif
-
+#if LV_USE_GIF
 /*GIF decoder accelerate*/
 #ifndef LV_GIF_CACHE_LZW_CODE
     #ifdef CONFIG_LV_GIF_CACHE_LZW_CODE
@@ -2063,6 +2063,8 @@
         #define LV_GIF_CACHE_LZW_CODE 0
     #endif
 #endif
+#endif
+
 
 /*Decode bin images to RAM*/
 #ifndef LV_BIN_DECODER_RAM_LOAD

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2056,11 +2056,11 @@
 #endif
 #if LV_USE_GIF
 /*GIF decoder accelerate*/
-#ifndef LV_GIF_CACHE_LZW_CODE
-    #ifdef CONFIG_LV_GIF_CACHE_LZW_CODE
-        #define LV_GIF_CACHE_LZW_CODE CONFIG_LV_GIF_CACHE_LZW_CODE
+#ifndef LV_GIF_CACHE_DECODE_DATA
+    #ifdef CONFIG_LV_GIF_CACHE_DECODE_DATA
+        #define LV_GIF_CACHE_DECODE_DATA CONFIG_LV_GIF_CACHE_DECODE_DATA
     #else
-        #define LV_GIF_CACHE_LZW_CODE 0
+        #define LV_GIF_CACHE_DECODE_DATA 0
     #endif
 #endif
 #endif

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2055,6 +2055,15 @@
     #endif
 #endif
 
+/*GIF decoder accelerate*/
+#ifndef LV_GIF_CACHE_LZW_CODE
+    #ifdef CONFIG_LV_GIF_CACHE_LZW_CODE
+        #define LV_GIF_CACHE_LZW_CODE CONFIG_LV_GIF_CACHE_LZW_CODE
+    #else
+        #define LV_GIF_CACHE_LZW_CODE 0
+    #endif
+#endif
+
 /*Decode bin images to RAM*/
 #ifndef LV_BIN_DECODER_RAM_LOAD
     #ifdef CONFIG_LV_BIN_DECODER_RAM_LOAD


### PR DESCRIPTION
### Reduce lzw decoding time

In order to improve the frame rate of gif, I did some tests. And I found `read_image_data` cost time too much when showing some gifs, like below.

![cats](https://github.com/lvgl/lvgl/assets/32351888/7298670a-f1ea-46c2-a01a-d9296e3abb70)

Its frame rate should be 50fps, but every calling of `read_image_data` cost 33ms about which reduce its frame rate to 22fps about. So I modify the code in `read_image_data` with reference to the method in [ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/gifdec.c) . 
After using the optimization method, the time spent on `read_image_data` was reduced from 33ms to about 23ms, and the frame rate of gif was increased to 27fps.

**Platform**
Arm cortex M55 @ 200MHZ

In order to avoid time-consuming file operations, I read all the gif data into memory to test this optimization.

Before:
![image](https://github.com/lvgl/lvgl/assets/32351888/dceb544d-8460-4f93-8d3e-e101fb6ac017)

After:
![image](https://github.com/lvgl/lvgl/assets/32351888/56e5105e-5659-4820-abb4-6b90fef9322b)


### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
