### PR TITLE
clangd: IWYU pragmas for proper auto-import

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -2,7 +2,7 @@
  * @file lv_global.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_GLOBAL_H
 #define LV_GLOBAL_H

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -2,6 +2,7 @@
  * @file lv_global.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_GLOBAL_H
 #define LV_GLOBAL_H

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -2,7 +2,7 @@
  * @file lv_group.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_GROUP_H
 #define LV_GROUP_H

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -2,6 +2,7 @@
  * @file lv_group.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_GROUP_H
 #define LV_GROUP_H

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -2,7 +2,7 @@
  * @file lv_group.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_GROUP_H
 #define LV_GROUP_H

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -2,7 +2,7 @@
  * @file lv_obj.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_OBJ_H
 #define LV_OBJ_H

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -2,7 +2,7 @@
  * @file lv_obj.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_OBJ_H
 #define LV_OBJ_H

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -2,6 +2,7 @@
  * @file lv_obj.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_OBJ_H
 #define LV_OBJ_H

--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -2,6 +2,7 @@
  * @file lv_refr.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_REFR_H
 #define LV_REFR_H

--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -2,7 +2,7 @@
  * @file lv_refr.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_REFR_H
 #define LV_REFR_H

--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -2,7 +2,7 @@
  * @file lv_refr.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_REFR_H
 #define LV_REFR_H

--- a/src/dev/display/drm/lv_linux_drm.h
+++ b/src/dev/display/drm/lv_linux_drm.h
@@ -2,7 +2,7 @@
  * @file lv_linux_drm_h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LINUX_DRM_H
 #define LV_LINUX_DRM_H

--- a/src/dev/display/drm/lv_linux_drm.h
+++ b/src/dev/display/drm/lv_linux_drm.h
@@ -2,6 +2,7 @@
  * @file lv_linux_drm_h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LINUX_DRM_H
 #define LV_LINUX_DRM_H

--- a/src/dev/display/fb/lv_linux_fbdev.h
+++ b/src/dev/display/fb/lv_linux_fbdev.h
@@ -2,7 +2,7 @@
  * @file lv_linux_fb_dev_h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LINUX_FB_DEV_H
 #define LV_LINUX_FB_DEV_H

--- a/src/dev/display/fb/lv_linux_fbdev.h
+++ b/src/dev/display/fb/lv_linux_fbdev.h
@@ -2,6 +2,7 @@
  * @file lv_linux_fb_dev_h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LINUX_FB_DEV_H
 #define LV_LINUX_FB_DEV_H

--- a/src/dev/evdev/lv_evdev.h
+++ b/src/dev/evdev/lv_evdev.h
@@ -2,7 +2,7 @@
  * @file lv_evdev.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_EVDEV_H
 #define LV_EVDEV_H

--- a/src/dev/evdev/lv_evdev.h
+++ b/src/dev/evdev/lv_evdev.h
@@ -2,6 +2,7 @@
  * @file lv_evdev.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_EVDEV_H
 #define LV_EVDEV_H

--- a/src/dev/nuttx/lv_nuttx_entry.h
+++ b/src/dev/nuttx/lv_nuttx_entry.h
@@ -2,7 +2,7 @@
  * @file lv_nuttx_entry.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 /*********************
  *      INCLUDES

--- a/src/dev/nuttx/lv_nuttx_entry.h
+++ b/src/dev/nuttx/lv_nuttx_entry.h
@@ -2,6 +2,7 @@
  * @file lv_nuttx_entry.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 /*********************
  *      INCLUDES

--- a/src/dev/nuttx/lv_nuttx_fbdev.h
+++ b/src/dev/nuttx/lv_nuttx_fbdev.h
@@ -2,7 +2,7 @@
  * @file lv_nuttx_fbdev_h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_NUTTX_FBDEV_H
 #define LV_NUTTX_FBDEV_H

--- a/src/dev/nuttx/lv_nuttx_fbdev.h
+++ b/src/dev/nuttx/lv_nuttx_fbdev.h
@@ -2,6 +2,7 @@
  * @file lv_nuttx_fbdev_h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_NUTTX_FBDEV_H
 #define LV_NUTTX_FBDEV_H

--- a/src/dev/nuttx/lv_nuttx_lcd.h
+++ b/src/dev/nuttx/lv_nuttx_lcd.h
@@ -2,7 +2,7 @@
  * @file lv_nuttx_lcd.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_NUTTX_LCD_H
 #define LV_NUTTX_LCD_H

--- a/src/dev/nuttx/lv_nuttx_lcd.h
+++ b/src/dev/nuttx/lv_nuttx_lcd.h
@@ -2,6 +2,7 @@
  * @file lv_nuttx_lcd.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_NUTTX_LCD_H
 #define LV_NUTTX_LCD_H

--- a/src/dev/nuttx/lv_nuttx_libuv.h
+++ b/src/dev/nuttx/lv_nuttx_libuv.h
@@ -2,6 +2,7 @@
  * @file lv_nuttx_libuv.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_NUTTX_LIBUV_H
 #define LV_NUTTX_LIBUV_H

--- a/src/dev/nuttx/lv_nuttx_libuv.h
+++ b/src/dev/nuttx/lv_nuttx_libuv.h
@@ -2,7 +2,7 @@
  * @file lv_nuttx_libuv.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_NUTTX_LIBUV_H
 #define LV_NUTTX_LIBUV_H

--- a/src/dev/nuttx/lv_nuttx_touchscreen.h
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.h
@@ -2,7 +2,7 @@
  * @file lv_nuttx_touchscreen.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 /*********************
  *      INCLUDES

--- a/src/dev/nuttx/lv_nuttx_touchscreen.h
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.h
@@ -2,6 +2,7 @@
  * @file lv_nuttx_touchscreen.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 /*********************
  *      INCLUDES

--- a/src/dev/sdl/lv_sdl_keyboard.h
+++ b/src/dev/sdl/lv_sdl_keyboard.h
@@ -2,6 +2,7 @@
  * @file lv_sdl_keyboard.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SDL_KEYBOARD_H
 #define LV_SDL_KEYBOARD_H

--- a/src/dev/sdl/lv_sdl_keyboard.h
+++ b/src/dev/sdl/lv_sdl_keyboard.h
@@ -2,7 +2,7 @@
  * @file lv_sdl_keyboard.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SDL_KEYBOARD_H
 #define LV_SDL_KEYBOARD_H

--- a/src/dev/sdl/lv_sdl_mouse.h
+++ b/src/dev/sdl/lv_sdl_mouse.h
@@ -2,6 +2,7 @@
  * @file Lv_sdl_mouse.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SDL_MOUSE_H
 #define LV_SDL_MOUSE_H

--- a/src/dev/sdl/lv_sdl_mouse.h
+++ b/src/dev/sdl/lv_sdl_mouse.h
@@ -2,7 +2,7 @@
  * @file Lv_sdl_mouse.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SDL_MOUSE_H
 #define LV_SDL_MOUSE_H

--- a/src/dev/sdl/lv_sdl_mousewheel.h
+++ b/src/dev/sdl/lv_sdl_mousewheel.h
@@ -2,6 +2,7 @@
  * @file lv_sdl_mousewheel.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SDL_MOUSEWHEEL_H
 #define LV_SDL_MOUSEWHEEL_H

--- a/src/dev/sdl/lv_sdl_mousewheel.h
+++ b/src/dev/sdl/lv_sdl_mousewheel.h
@@ -2,7 +2,7 @@
  * @file lv_sdl_mousewheel.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SDL_MOUSEWHEEL_H
 #define LV_SDL_MOUSEWHEEL_H

--- a/src/dev/sdl/lv_sdl_window.h
+++ b/src/dev/sdl/lv_sdl_window.h
@@ -2,6 +2,7 @@
  * @file lv_sdl_window.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SDL_DISP_H
 #define LV_SDL_DISP_H

--- a/src/dev/sdl/lv_sdl_window.h
+++ b/src/dev/sdl/lv_sdl_window.h
@@ -2,7 +2,7 @@
  * @file lv_sdl_window.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SDL_DISP_H
 #define LV_SDL_DISP_H

--- a/src/dev/x11/lv_x11.h
+++ b/src/dev/x11/lv_x11.h
@@ -2,7 +2,7 @@
  * @file lv_x11.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_X11_H
 #define LV_X11_H

--- a/src/dev/x11/lv_x11.h
+++ b/src/dev/x11/lv_x11.h
@@ -2,6 +2,7 @@
  * @file lv_x11.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_X11_H
 #define LV_X11_H

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -2,7 +2,7 @@
  * @file lv_disp.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_DISPLAY_H
 #define LV_DISPLAY_H

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -2,6 +2,7 @@
  * @file lv_disp.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_DISPLAY_H
 #define LV_DISPLAY_H

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -2,7 +2,7 @@
  * @file lv_disp.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_DISPLAY_H
 #define LV_DISPLAY_H

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -2,6 +2,7 @@
  * @file lv_draw.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_DRAW_H
 #define LV_DRAW_H

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -2,7 +2,7 @@
  * @file lv_draw.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_DRAW_H
 #define LV_DRAW_H

--- a/src/draw/lv_draw_vector.h
+++ b/src/draw/lv_draw_vector.h
@@ -2,6 +2,7 @@
  * @file lv_draw_vector.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_DRAW_VECTOR_H
 #define LV_DRAW_VECTOR_H

--- a/src/draw/lv_draw_vector.h
+++ b/src/draw/lv_draw_vector.h
@@ -2,7 +2,7 @@
  * @file lv_draw_vector.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_DRAW_VECTOR_H
 #define LV_DRAW_VECTOR_H

--- a/src/font/lv_binfont_loader.h
+++ b/src/font/lv_binfont_loader.h
@@ -2,7 +2,7 @@
  * @file lv_binfont_loader.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FONT_LOADER_H
 #define LV_FONT_LOADER_H

--- a/src/font/lv_binfont_loader.h
+++ b/src/font/lv_binfont_loader.h
@@ -2,7 +2,7 @@
  * @file lv_binfont_loader.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_LOADER_H
 #define LV_FONT_LOADER_H

--- a/src/font/lv_binfont_loader.h
+++ b/src/font/lv_binfont_loader.h
@@ -2,6 +2,7 @@
  * @file lv_binfont_loader.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_LOADER_H
 #define LV_FONT_LOADER_H

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -2,7 +2,7 @@
  * @file lv_font.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FONT_H
 #define LV_FONT_H

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -2,7 +2,7 @@
  * @file lv_font.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_H
 #define LV_FONT_H

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -2,6 +2,7 @@
  * @file lv_font.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_H
 #define LV_FONT_H

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -2,7 +2,7 @@
  * @file lv_font_fmt_txt.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FONT_FMT_TXT_H
 #define LV_FONT_FMT_TXT_H

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -2,6 +2,7 @@
  * @file lv_font_fmt_txt.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_FMT_TXT_H
 #define LV_FONT_FMT_TXT_H

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -2,7 +2,7 @@
  * @file lv_font_fmt_txt.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FONT_FMT_TXT_H
 #define LV_FONT_FMT_TXT_H

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -2,7 +2,7 @@
  * @file lv_indev.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_INDEV_H
 #define LV_INDEV_H

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -2,7 +2,7 @@
  * @file lv_indev.h
  *
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_INDEV_H
 #define LV_INDEV_H

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -2,6 +2,7 @@
  * @file lv_indev.h
  *
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_INDEV_H
 #define LV_INDEV_H

--- a/src/layouts/lv_layout.h
+++ b/src/layouts/lv_layout.h
@@ -2,6 +2,7 @@
  * @file lv_layouts.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LAYOUTS_H
 #define LV_LAYOUTS_H

--- a/src/layouts/lv_layout.h
+++ b/src/layouts/lv_layout.h
@@ -2,7 +2,7 @@
  * @file lv_layouts.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LAYOUTS_H
 #define LV_LAYOUTS_H

--- a/src/libs/barcode/lv_barcode.h
+++ b/src/libs/barcode/lv_barcode.h
@@ -2,6 +2,7 @@
  * @file lv_barcode.c
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BARCODE_H
 #define LV_BARCODE_H

--- a/src/libs/barcode/lv_barcode.h
+++ b/src/libs/barcode/lv_barcode.h
@@ -2,7 +2,7 @@
  * @file lv_barcode.c
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BARCODE_H
 #define LV_BARCODE_H

--- a/src/libs/bin_decoder/lv_bin_decoder.h
+++ b/src/libs/bin_decoder/lv_bin_decoder.h
@@ -2,6 +2,7 @@
  * @file lv_bin_decoder.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BIN_DECODER_H
 #define LV_BIN_DECODER_H

--- a/src/libs/bin_decoder/lv_bin_decoder.h
+++ b/src/libs/bin_decoder/lv_bin_decoder.h
@@ -2,7 +2,7 @@
  * @file lv_bin_decoder.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BIN_DECODER_H
 #define LV_BIN_DECODER_H

--- a/src/libs/bmp/lv_bmp.h
+++ b/src/libs/bmp/lv_bmp.h
@@ -2,7 +2,7 @@
  * @file lv_bmp.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BMP_H
 #define LV_BMP_H

--- a/src/libs/bmp/lv_bmp.h
+++ b/src/libs/bmp/lv_bmp.h
@@ -2,6 +2,7 @@
  * @file lv_bmp.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BMP_H
 #define LV_BMP_H

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -2,7 +2,7 @@
  * @file lv_ffmpeg.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 #ifndef LV_FFMPEG_H
 #define LV_FFMPEG_H
 

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -2,6 +2,7 @@
  * @file lv_ffmpeg.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 #ifndef LV_FFMPEG_H
 #define LV_FFMPEG_H
 

--- a/src/libs/freetype/lv_freetype.h
+++ b/src/libs/freetype/lv_freetype.h
@@ -2,7 +2,7 @@
  * @file lv_freetype.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 #ifndef LV_FREETYPE_H
 #define LV_FREETYPE_H
 

--- a/src/libs/freetype/lv_freetype.h
+++ b/src/libs/freetype/lv_freetype.h
@@ -2,6 +2,7 @@
  * @file lv_freetype.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 #ifndef LV_FREETYPE_H
 #define LV_FREETYPE_H
 

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -2,7 +2,7 @@
  * @file lv_fsdrv.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FSDRV_H
 #define LV_FSDRV_H

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -2,6 +2,7 @@
  * @file lv_fsdrv.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FSDRV_H
 #define LV_FSDRV_H

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.h
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.h
@@ -2,6 +2,7 @@
  * @file lv_libjpeg_turbo.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LIBJPEG_TURBO_H
 #define LV_LIBJPEG_TURBO_H

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.h
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.h
@@ -2,7 +2,7 @@
  * @file lv_libjpeg_turbo.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LIBJPEG_TURBO_H
 #define LV_LIBJPEG_TURBO_H

--- a/src/libs/libpng/lv_libpng.h
+++ b/src/libs/libpng/lv_libpng.h
@@ -2,6 +2,7 @@
  * @file lv_libpng.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LIBPNG_H
 #define LV_LIBPNG_H

--- a/src/libs/libpng/lv_libpng.h
+++ b/src/libs/libpng/lv_libpng.h
@@ -2,7 +2,7 @@
  * @file lv_libpng.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LIBPNG_H
 #define LV_LIBPNG_H

--- a/src/libs/lodepng/lv_lodepng.h
+++ b/src/libs/lodepng/lv_lodepng.h
@@ -2,7 +2,7 @@
  * @file lv_lodepng.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LODEPNG_H
 #define LV_LODEPNG_H

--- a/src/libs/lodepng/lv_lodepng.h
+++ b/src/libs/lodepng/lv_lodepng.h
@@ -2,6 +2,7 @@
  * @file lv_lodepng.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LODEPNG_H
 #define LV_LODEPNG_H

--- a/src/libs/lz4/lz4.h
+++ b/src/libs/lz4/lz4.h
@@ -32,7 +32,7 @@
     - LZ4 homepage : http://www.lz4.org
     - LZ4 source repository : https://github.com/lz4/lz4
 */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #include "../../lv_conf_internal.h"
 #if LV_USE_LZ4_INTERNAL

--- a/src/libs/lz4/lz4.h
+++ b/src/libs/lz4/lz4.h
@@ -32,6 +32,7 @@
     - LZ4 homepage : http://www.lz4.org
     - LZ4 source repository : https://github.com/lz4/lz4
 */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #include "../../lv_conf_internal.h"
 #if LV_USE_LZ4_INTERNAL

--- a/src/libs/qrcode/lv_qrcode.h
+++ b/src/libs/qrcode/lv_qrcode.h
@@ -2,7 +2,7 @@
  * @file lv_qrcode
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_QRCODE_H
 #define LV_QRCODE_H

--- a/src/libs/qrcode/lv_qrcode.h
+++ b/src/libs/qrcode/lv_qrcode.h
@@ -2,6 +2,7 @@
  * @file lv_qrcode
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_QRCODE_H
 #define LV_QRCODE_H

--- a/src/libs/rle/lv_rle_decoder.h
+++ b/src/libs/rle/lv_rle_decoder.h
@@ -2,7 +2,7 @@
  * @file lv_rle_decoder.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_RLE_DECODER_H
 #define LV_RLE_DECODER_H

--- a/src/libs/rle/lv_rle_decoder.h
+++ b/src/libs/rle/lv_rle_decoder.h
@@ -2,6 +2,7 @@
  * @file lv_rle_decoder.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_RLE_DECODER_H
 #define LV_RLE_DECODER_H

--- a/src/libs/rlottie/lv_rlottie.h
+++ b/src/libs/rlottie/lv_rlottie.h
@@ -2,7 +2,7 @@
  * @file lv_rlottie.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_RLOTTIE_H
 #define LV_RLOTTIE_H

--- a/src/libs/rlottie/lv_rlottie.h
+++ b/src/libs/rlottie/lv_rlottie.h
@@ -2,6 +2,7 @@
  * @file lv_rlottie.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_RLOTTIE_H
 #define LV_RLOTTIE_H

--- a/src/libs/tiny_ttf/lv_tiny_ttf.h
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.h
@@ -2,6 +2,7 @@
  * @file lv_templ.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TINY_TTF_H
 #define LV_TINY_TTF_H

--- a/src/libs/tiny_ttf/lv_tiny_ttf.h
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.h
@@ -2,7 +2,7 @@
  * @file lv_templ.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TINY_TTF_H
 #define LV_TINY_TTF_H

--- a/src/libs/tjpgd/lv_tjpgd.h
+++ b/src/libs/tjpgd/lv_tjpgd.h
@@ -2,6 +2,7 @@
  * @file lv_tjpgd.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TJPGD_H
 #define LV_TJPGD_H

--- a/src/libs/tjpgd/lv_tjpgd.h
+++ b/src/libs/tjpgd/lv_tjpgd.h
@@ -2,7 +2,7 @@
  * @file lv_tjpgd.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TJPGD_H
 #define LV_TJPGD_H

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -2,6 +2,7 @@
  * @file lv_api_map.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_API_MAP_H
 #define LV_API_MAP_H

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -2,7 +2,7 @@
  * @file lv_api_map.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_API_MAP_H
 #define LV_API_MAP_H

--- a/src/lv_init.h
+++ b/src/lv_init.h
@@ -3,7 +3,7 @@
  *
  */
 
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_INIT_H
 #define LV_INIT_H

--- a/src/lv_init.h
+++ b/src/lv_init.h
@@ -3,6 +3,8 @@
  *
  */
 
+// IWYU pragma: private, include <lvgl/lvgl.h">
+
 #ifndef LV_INIT_H
 #define LV_INIT_H
 

--- a/src/misc/lv_anim_timeline.h
+++ b/src/misc/lv_anim_timeline.h
@@ -2,6 +2,7 @@
  * @file lv_anim_timeline.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ANIM_TIMELINE_H
 #define LV_ANIM_TIMELINE_H

--- a/src/misc/lv_anim_timeline.h
+++ b/src/misc/lv_anim_timeline.h
@@ -2,7 +2,7 @@
  * @file lv_anim_timeline.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ANIM_TIMELINE_H
 #define LV_ANIM_TIMELINE_H

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -2,6 +2,7 @@
  * @file lv_array.h
  * Array. The elements are dynamically allocated by the 'lv_mem' module.
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ARRAY_H
 #define LV_ARRAY_H

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -2,7 +2,7 @@
  * @file lv_array.h
  * Array. The elements are dynamically allocated by the 'lv_mem' module.
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ARRAY_H
 #define LV_ARRAY_H

--- a/src/misc/lv_async.h
+++ b/src/misc/lv_async.h
@@ -2,7 +2,7 @@
  * @file lv_async.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ASYNC_H
 #define LV_ASYNC_H

--- a/src/misc/lv_async.h
+++ b/src/misc/lv_async.h
@@ -2,6 +2,7 @@
  * @file lv_async.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ASYNC_H
 #define LV_ASYNC_H

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -2,7 +2,7 @@
  * @file lv_log.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LOG_H
 #define LV_LOG_H

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -2,6 +2,7 @@
  * @file lv_log.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LOG_H
 #define LV_LOG_H

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -2,6 +2,7 @@
  * @file lv_math.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_MATH_H
 #define LV_MATH_H

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -2,7 +2,7 @@
  * @file lv_math.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_MATH_H
 #define LV_MATH_H

--- a/src/misc/lv_profiler_builtin.h
+++ b/src/misc/lv_profiler_builtin.h
@@ -2,6 +2,7 @@
  * @file lv_profiler_builtin.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_PROFILER_BUILTIN_H
 #define LV_PROFILER_BUILTIN_H

--- a/src/misc/lv_profiler_builtin.h
+++ b/src/misc/lv_profiler_builtin.h
@@ -2,7 +2,7 @@
  * @file lv_profiler_builtin.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_PROFILER_BUILTIN_H
 #define LV_PROFILER_BUILTIN_H

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -1,6 +1,7 @@
 /**
  * @file lv_timer.h
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TIMER_H
 #define LV_TIMER_H

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -1,7 +1,7 @@
 /**
  * @file lv_timer.h
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TIMER_H
 #define LV_TIMER_H

--- a/src/others/file_explorer/lv_file_explorer.h
+++ b/src/others/file_explorer/lv_file_explorer.h
@@ -2,6 +2,7 @@
  * @file lv_file_explorer.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FILE_EXPLORER_H
 #define LV_FILE_EXPLORER_H

--- a/src/others/file_explorer/lv_file_explorer.h
+++ b/src/others/file_explorer/lv_file_explorer.h
@@ -2,7 +2,7 @@
  * @file lv_file_explorer.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FILE_EXPLORER_H
 #define LV_FILE_EXPLORER_H

--- a/src/others/fragment/lv_fragment.h
+++ b/src/others/fragment/lv_fragment.h
@@ -2,7 +2,7 @@
  * Public header for Fragment
  * @file lv_fragment.h
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_FRAGMENT_H
 #define LV_FRAGMENT_H

--- a/src/others/fragment/lv_fragment.h
+++ b/src/others/fragment/lv_fragment.h
@@ -2,6 +2,7 @@
  * Public header for Fragment
  * @file lv_fragment.h
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_FRAGMENT_H
 #define LV_FRAGMENT_H

--- a/src/others/gridnav/lv_gridnav.h
+++ b/src/others/gridnav/lv_gridnav.h
@@ -2,7 +2,7 @@
  * @file lv_templ.c
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 /*********************
  *      INCLUDES

--- a/src/others/gridnav/lv_gridnav.h
+++ b/src/others/gridnav/lv_gridnav.h
@@ -2,6 +2,7 @@
  * @file lv_templ.c
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 /*********************
  *      INCLUDES

--- a/src/others/ime/lv_ime_pinyin.h
+++ b/src/others/ime/lv_ime_pinyin.h
@@ -2,6 +2,7 @@
  * @file lv_ime_pinyin.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 #ifndef LV_IME_PINYIN_H
 #define LV_IME_PINYIN_H
 

--- a/src/others/ime/lv_ime_pinyin.h
+++ b/src/others/ime/lv_ime_pinyin.h
@@ -2,7 +2,7 @@
  * @file lv_ime_pinyin.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 #ifndef LV_IME_PINYIN_H
 #define LV_IME_PINYIN_H
 

--- a/src/others/imgfont/lv_imgfont.h
+++ b/src/others/imgfont/lv_imgfont.h
@@ -2,7 +2,7 @@
  * @file lv_imgfont.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_IMGFONT_H
 #define LV_IMGFONT_H

--- a/src/others/imgfont/lv_imgfont.h
+++ b/src/others/imgfont/lv_imgfont.h
@@ -2,6 +2,7 @@
  * @file lv_imgfont.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_IMGFONT_H
 #define LV_IMGFONT_H

--- a/src/others/monkey/lv_monkey.h
+++ b/src/others/monkey/lv_monkey.h
@@ -2,6 +2,7 @@
  * @file lv_monkey.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 #ifndef LV_MONKEY_H
 #define LV_MONKEY_H
 

--- a/src/others/monkey/lv_monkey.h
+++ b/src/others/monkey/lv_monkey.h
@@ -2,7 +2,7 @@
  * @file lv_monkey.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 #ifndef LV_MONKEY_H
 #define LV_MONKEY_H
 

--- a/src/others/observer/lv_observer.h
+++ b/src/others/observer/lv_observer.h
@@ -2,7 +2,7 @@
  * @file lv_observer.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_OBSERVER_H
 #define LV_OBSERVER_H

--- a/src/others/observer/lv_observer.h
+++ b/src/others/observer/lv_observer.h
@@ -2,6 +2,7 @@
  * @file lv_observer.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_OBSERVER_H
 #define LV_OBSERVER_H

--- a/src/others/snapshot/lv_snapshot.h
+++ b/src/others/snapshot/lv_snapshot.h
@@ -2,6 +2,7 @@
  * @file lv_snapshot.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SNAPSHOT_H
 #define LV_SNAPSHOT_H

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -2,7 +2,7 @@
  * @file lv_sysmon.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SYSMON_H
 #define LV_SYSMON_H

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -2,6 +2,7 @@
  * @file lv_sysmon.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SYSMON_H
 #define LV_SYSMON_H

--- a/src/stdlib/lv_mem.h
+++ b/src/stdlib/lv_mem.h
@@ -2,7 +2,7 @@
  * @file lv_mem.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_MEM_H
 #define LV_MEM_H

--- a/src/stdlib/lv_mem.h
+++ b/src/stdlib/lv_mem.h
@@ -2,6 +2,7 @@
  * @file lv_mem.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_MEM_H
 #define LV_MEM_H

--- a/src/stdlib/lv_sprintf.h
+++ b/src/stdlib/lv_sprintf.h
@@ -2,6 +2,7 @@
  * lv_snprintf.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef _LV_SPRINTF_H_
 #define _LV_SPRINTF_H_

--- a/src/stdlib/lv_sprintf.h
+++ b/src/stdlib/lv_sprintf.h
@@ -2,7 +2,7 @@
  * lv_snprintf.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef _LV_SPRINTF_H_
 #define _LV_SPRINTF_H_

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -2,6 +2,7 @@
  * @file lv_stringn.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_STRING_H
 #define LV_STRING_H

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -2,7 +2,7 @@
  * @file lv_stringn.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_STRING_H
 #define LV_STRING_H

--- a/src/themes/lv_theme.h
+++ b/src/themes/lv_theme.h
@@ -2,7 +2,7 @@
  *@file lv_theme.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_THEME_H
 #define LV_THEME_H

--- a/src/themes/lv_theme.h
+++ b/src/themes/lv_theme.h
@@ -2,6 +2,7 @@
  *@file lv_theme.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_THEME_H
 #define LV_THEME_H

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -2,7 +2,7 @@
  * @file lv_hal_tick.h
  * Provide access to the system tick with 1 millisecond resolution
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_HAL_TICK_H
 #define LV_HAL_TICK_H

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -2,7 +2,7 @@
  * @file lv_hal_tick.h
  * Provide access to the system tick with 1 millisecond resolution
  */
- // IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_HAL_TICK_H
 #define LV_HAL_TICK_H

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -2,6 +2,7 @@
  * @file lv_hal_tick.h
  * Provide access to the system tick with 1 millisecond resolution
  */
+ // IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_HAL_TICK_H
 #define LV_HAL_TICK_H

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -2,7 +2,7 @@
  * @file lv_animimg.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ANIM_IMAGE_H
 #define LV_ANIM_IMAGE_H

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -2,6 +2,7 @@
  * @file lv_animimg.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ANIM_IMAGE_H
 #define LV_ANIM_IMAGE_H

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -2,7 +2,7 @@
  * @file lv_arc.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ARC_H
 #define LV_ARC_H

--- a/src/widgets/arc/lv_arc.h
+++ b/src/widgets/arc/lv_arc.h
@@ -2,6 +2,7 @@
  * @file lv_arc.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ARC_H
 #define LV_ARC_H

--- a/src/widgets/bar/lv_bar.h
+++ b/src/widgets/bar/lv_bar.h
@@ -2,6 +2,7 @@
  * @file lv_bar.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BAR_H
 #define LV_BAR_H

--- a/src/widgets/bar/lv_bar.h
+++ b/src/widgets/bar/lv_bar.h
@@ -2,7 +2,7 @@
  * @file lv_bar.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BAR_H
 #define LV_BAR_H

--- a/src/widgets/button/lv_button.h
+++ b/src/widgets/button/lv_button.h
@@ -2,6 +2,7 @@
  * @file lv_btn.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BUTTON_H
 #define LV_BUTTON_H

--- a/src/widgets/button/lv_button.h
+++ b/src/widgets/button/lv_button.h
@@ -2,7 +2,7 @@
  * @file lv_btn.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BUTTON_H
 #define LV_BUTTON_H

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.h
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.h
@@ -2,7 +2,7 @@
  * @file lv_btnmatrix.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_BUTTONMATRIX_H
 #define LV_BUTTONMATRIX_H

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.h
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.h
@@ -2,6 +2,7 @@
  * @file lv_btnmatrix.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_BUTTONMATRIX_H
 #define LV_BUTTONMATRIX_H

--- a/src/widgets/calendar/lv_calendar.h
+++ b/src/widgets/calendar/lv_calendar.h
@@ -2,7 +2,7 @@
  * @file lv_calendar.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_CALENDAR_H
 #define LV_CALENDAR_H

--- a/src/widgets/calendar/lv_calendar.h
+++ b/src/widgets/calendar/lv_calendar.h
@@ -2,6 +2,7 @@
  * @file lv_calendar.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_CALENDAR_H
 #define LV_CALENDAR_H

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -2,6 +2,7 @@
  * @file lv_canvas.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_CANVAS_H
 #define LV_CANVAS_H

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -2,7 +2,7 @@
  * @file lv_canvas.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_CANVAS_H
 #define LV_CANVAS_H

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -2,6 +2,7 @@
  * @file lv_chart.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_CHART_H
 #define LV_CHART_H

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -2,7 +2,7 @@
  * @file lv_chart.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_CHART_H
 #define LV_CHART_H

--- a/src/widgets/checkbox/lv_checkbox.h
+++ b/src/widgets/checkbox/lv_checkbox.h
@@ -2,7 +2,7 @@
  * @file lv_cb.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_CHECKBOX_H
 #define LV_CHECKBOX_H

--- a/src/widgets/checkbox/lv_checkbox.h
+++ b/src/widgets/checkbox/lv_checkbox.h
@@ -2,6 +2,7 @@
  * @file lv_cb.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_CHECKBOX_H
 #define LV_CHECKBOX_H

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -2,7 +2,7 @@
  * @file lv_dropdown.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_DROPDOWN_H
 #define LV_DROPDOWN_H

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -2,6 +2,7 @@
  * @file lv_dropdown.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_DROPDOWN_H
 #define LV_DROPDOWN_H

--- a/src/widgets/image/lv_image.h
+++ b/src/widgets/image/lv_image.h
@@ -2,6 +2,7 @@
  * @file lv_img.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_IMAGE_H
 #define LV_IMAGE_H

--- a/src/widgets/imgbtn/lv_imgbtn.h
+++ b/src/widgets/imgbtn/lv_imgbtn.h
@@ -2,6 +2,7 @@
  * @file lv_imgbtn.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_IMGBTN_H
 #define LV_IMGBTN_H

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -2,6 +2,7 @@
  * @file lv_keyboard.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_KEYBOARD_H
 #define LV_KEYBOARD_H

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -2,6 +2,7 @@
  * @file lv_label.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LABEL_H
 #define LV_LABEL_H

--- a/src/widgets/led/lv_led.h
+++ b/src/widgets/led/lv_led.h
@@ -2,7 +2,7 @@
  * @file lv_led.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LED_H
 #define LV_LED_H

--- a/src/widgets/led/lv_led.h
+++ b/src/widgets/led/lv_led.h
@@ -2,6 +2,7 @@
  * @file lv_led.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LED_H
 #define LV_LED_H

--- a/src/widgets/line/lv_line.h
+++ b/src/widgets/line/lv_line.h
@@ -2,7 +2,7 @@
  * @file lv_line.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LINE_H
 #define LV_LINE_H

--- a/src/widgets/line/lv_line.h
+++ b/src/widgets/line/lv_line.h
@@ -2,6 +2,7 @@
  * @file lv_line.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LINE_H
 #define LV_LINE_H

--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -2,7 +2,7 @@
  * @file lv_win.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_LIST_H
 #define LV_LIST_H

--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -2,6 +2,7 @@
  * @file lv_win.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_LIST_H
 #define LV_LIST_H

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -2,6 +2,7 @@
  * @file lv_menu.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_MENU_H
 #define LV_MENU_H

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -2,7 +2,7 @@
  * @file lv_menu.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_MENU_H
 #define LV_MENU_H

--- a/src/widgets/msgbox/lv_msgbox.h
+++ b/src/widgets/msgbox/lv_msgbox.h
@@ -2,7 +2,7 @@
  * @file lv_mbox.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_MSGBOX_H
 #define LV_MSGBOX_H

--- a/src/widgets/msgbox/lv_msgbox.h
+++ b/src/widgets/msgbox/lv_msgbox.h
@@ -2,6 +2,7 @@
  * @file lv_mbox.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_MSGBOX_H
 #define LV_MSGBOX_H

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -2,7 +2,7 @@
  * @file lv_roller.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_ROLLER_H
 #define LV_ROLLER_H

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -2,6 +2,7 @@
  * @file lv_roller.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_ROLLER_H
 #define LV_ROLLER_H

--- a/src/widgets/scale/lv_scale.h
+++ b/src/widgets/scale/lv_scale.h
@@ -2,6 +2,7 @@
  * @file lv_scale.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SCALE_H
 #define LV_SCALE_H

--- a/src/widgets/scale/lv_scale.h
+++ b/src/widgets/scale/lv_scale.h
@@ -2,7 +2,7 @@
  * @file lv_scale.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SCALE_H
 #define LV_SCALE_H

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -2,7 +2,7 @@
  * @file lv_slider.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SLIDER_H
 #define LV_SLIDER_H

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -2,6 +2,7 @@
  * @file lv_slider.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SLIDER_H
 #define LV_SLIDER_H

--- a/src/widgets/span/lv_span.h
+++ b/src/widgets/span/lv_span.h
@@ -2,7 +2,7 @@
  * @file lv_span.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SPAN_H
 #define LV_SPAN_H

--- a/src/widgets/span/lv_span.h
+++ b/src/widgets/span/lv_span.h
@@ -2,6 +2,7 @@
  * @file lv_span.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SPAN_H
 #define LV_SPAN_H

--- a/src/widgets/spinbox/lv_spinbox.h
+++ b/src/widgets/spinbox/lv_spinbox.h
@@ -2,7 +2,7 @@
  * @file lv_spinbox.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SPINBOX_H
 #define LV_SPINBOX_H

--- a/src/widgets/spinbox/lv_spinbox.h
+++ b/src/widgets/spinbox/lv_spinbox.h
@@ -2,6 +2,7 @@
  * @file lv_spinbox.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SPINBOX_H
 #define LV_SPINBOX_H

--- a/src/widgets/spinner/lv_spinner.h
+++ b/src/widgets/spinner/lv_spinner.h
@@ -2,6 +2,7 @@
  * @file lv_spinner.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SPINNER_H
 #define LV_SPINNER_H

--- a/src/widgets/spinner/lv_spinner.h
+++ b/src/widgets/spinner/lv_spinner.h
@@ -2,7 +2,7 @@
  * @file lv_spinner.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SPINNER_H
 #define LV_SPINNER_H

--- a/src/widgets/switch/lv_switch.h
+++ b/src/widgets/switch/lv_switch.h
@@ -2,7 +2,7 @@
  * @file lv_switch.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_SWITCH_H
 #define LV_SWITCH_H

--- a/src/widgets/switch/lv_switch.h
+++ b/src/widgets/switch/lv_switch.h
@@ -2,6 +2,7 @@
  * @file lv_switch.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_SWITCH_H
 #define LV_SWITCH_H

--- a/src/widgets/table/lv_table.h
+++ b/src/widgets/table/lv_table.h
@@ -2,6 +2,7 @@
  * @file lv_table.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TABLE_H
 #define LV_TABLE_H

--- a/src/widgets/table/lv_table.h
+++ b/src/widgets/table/lv_table.h
@@ -2,7 +2,7 @@
  * @file lv_table.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TABLE_H
 #define LV_TABLE_H

--- a/src/widgets/tabview/lv_tabview.h
+++ b/src/widgets/tabview/lv_tabview.h
@@ -2,6 +2,7 @@
  * @file lv_templ.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TABVIEW_H
 #define LV_TABVIEW_H

--- a/src/widgets/tabview/lv_tabview.h
+++ b/src/widgets/tabview/lv_tabview.h
@@ -2,7 +2,7 @@
  * @file lv_templ.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TABVIEW_H
 #define LV_TABVIEW_H

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -2,7 +2,7 @@
  * @file lv_textarea.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TEXTAREA_H
 #define LV_TEXTAREA_H

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -2,6 +2,7 @@
  * @file lv_textarea.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TEXTAREA_H
 #define LV_TEXTAREA_H

--- a/src/widgets/tileview/lv_tileview.h
+++ b/src/widgets/tileview/lv_tileview.h
@@ -2,6 +2,7 @@
  * @file lv_tileview.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_TILEVIEW_H
 #define LV_TILEVIEW_H

--- a/src/widgets/tileview/lv_tileview.h
+++ b/src/widgets/tileview/lv_tileview.h
@@ -2,7 +2,7 @@
  * @file lv_tileview.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_TILEVIEW_H
 #define LV_TILEVIEW_H

--- a/src/widgets/win/lv_win.h
+++ b/src/widgets/win/lv_win.h
@@ -2,7 +2,7 @@
  * @file lv_win.h
  *
  */
-// IWYU pragma: private, include <lvgl/lvgl.h">
+// IWYU pragma: private, include <lvgl/lvgl.h>
 
 #ifndef LV_WIN_H
 #define LV_WIN_H

--- a/src/widgets/win/lv_win.h
+++ b/src/widgets/win/lv_win.h
@@ -2,6 +2,7 @@
  * @file lv_win.h
  *
  */
+// IWYU pragma: private, include <lvgl/lvgl.h">
 
 #ifndef LV_WIN_H
 #define LV_WIN_H


### PR DESCRIPTION
### Description of the feature or fix

This PR adds `// IWYU pragma: private, include <lvgl/lvgl.h">` statements all over internal header files that are re-exported by `lvgl.h`. This allows `clangd` to properly auto-import a correct, `<lvgl/lvgl.h>` header, instead of an internal one.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [x] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
