### PR TITLE
chore: fix warning in SDL draw unit

### DIFF
--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -213,7 +213,6 @@ static lv_cache_entry_t * draw_to_texture(lv_draw_sdl_unit_t * u)
                     return NULL;
                 }
 
-                lv_display_t * disp = _lv_refr_get_disp_refreshing();
                 SDL_Renderer * renderer = lv_sdl_window_get_renderer(disp);
                 texture = SDL_CreateTextureFromSurface(renderer, surface);
                 break;
@@ -302,7 +301,6 @@ static void draw_from_cached_texture(lv_draw_sdl_unit_t * u)
 
     cache_data_t data_to_find;
     data_to_find.draw_dsc = (lv_draw_dsc_base_t *)t->draw_dsc;
-    lv_draw_dsc_base_t * base_dsc = t->draw_dsc;
 
     data_to_find.w = lv_area_get_width(&t->area);
     data_to_find.h = lv_area_get_height(&t->area);


### PR DESCRIPTION

### Description of the feature or fix

```
../lvgl/src/draw/sdl/lv_draw_sdl.c: In function ‘draw_to_texture’: ../lvgl/src/draw/sdl/lv_draw_sdl.c:216:32: warning: declaration of ‘disp’ shadows a previous local [-Wshadow]
  216 |                 lv_display_t * disp = _lv_refr_get_disp_refreshing();
      |                                ^~~~
../lvgl/src/draw/sdl/lv_draw_sdl.c:166:20: note: shadowed declaration is here
  166 |     lv_display_t * disp = _lv_refr_get_disp_refreshing();
      |                    ^~~~
../lvgl/src/draw/sdl/lv_draw_sdl.c: In function ‘draw_from_cached_texture’:
../lvgl/src/draw/sdl/lv_draw_sdl.c:305:26: warning: unused variable ‘base_dsc’ [-Wunused-variable]
  305 |     lv_draw_dsc_base_t * base_dsc = t->draw_dsc;
      |                          ^~~~~~~~

```
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
