### PR TITLE
fix(observer): fail when observing an invalid subject

### DIFF
--- a/src/others/observer/lv_observer.c
+++ b/src/others/observer/lv_observer.c
@@ -273,6 +273,11 @@ lv_observer_t * lv_subject_add_observer(lv_subject_t * subject, lv_observer_cb_t
 lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_cb_t cb, lv_obj_t * obj,
                                             void * user_data)
 {
+    LV_ASSERT_NULL(subject);
+    if(subject->type == LV_SUBJECT_TYPE_INVALID) {
+        LV_LOG_WARN("Subject not initialized yet");
+        return NULL;
+    }
     lv_observer_t * observer = _lv_ll_ins_tail(&(subject->subs_ll));
     LV_ASSERT_MALLOC(observer);
     if(observer == NULL) return NULL;
@@ -297,6 +302,11 @@ lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_
 lv_observer_t * lv_subject_add_observer_with_target(lv_subject_t * subject, lv_observer_cb_t cb, void * target,
                                                     void * user_data)
 {
+    LV_ASSERT_NULL(subject);
+    if(subject->type == LV_SUBJECT_TYPE_INVALID) {
+        LV_LOG_WARN("Subject not initialized yet");
+        return NULL;
+    }
     lv_observer_t * observer = _lv_ll_ins_tail(&(subject->subs_ll));
     LV_ASSERT_MALLOC(observer);
     if(observer == NULL) return NULL;
@@ -330,6 +340,11 @@ void lv_observer_remove(lv_observer_t * observer)
 
 void lv_subject_remove_all_obj(lv_subject_t * subject, lv_obj_t * obj)
 {
+    LV_ASSERT_NULL(subject);
+    if(subject->type == LV_SUBJECT_TYPE_INVALID) {
+        LV_LOG_WARN("Subject not initialized yet");
+        return;
+    }
     while(lv_obj_remove_event_cb(obj, unsubscribe_on_delete_cb));
     while(lv_obj_remove_event_cb(obj, btn_value_changed_event_cb));
     while(lv_obj_remove_event_cb(obj, arc_value_changed_event_cb));

--- a/src/others/observer/lv_observer.h
+++ b/src/others/observer/lv_observer.h
@@ -28,12 +28,13 @@ extern "C" {
 struct _lv_observer_t;
 
 typedef enum {
-    LV_SUBJECT_TYPE_NONE =      0,
-    LV_SUBJECT_TYPE_INT =       1,   /**< an int32_t*/
-    LV_SUBJECT_TYPE_POINTER =   2,   /**< a void pointer*/
-    LV_SUBJECT_TYPE_COLOR   =   3,   /**< an lv_color_t*/
-    LV_SUBJECT_TYPE_GROUP  =    4,   /**< an array of subjects*/
-    LV_SUBJECT_TYPE_STRING  =   5,   /**< a char pointer*/
+    LV_SUBJECT_TYPE_INVALID =   0,   /**< indicates subject not initialized yet*/
+    LV_SUBJECT_TYPE_NONE =      1,   /**< a null value like None or NILt*/
+    LV_SUBJECT_TYPE_INT =       2,   /**< an int32_t*/
+    LV_SUBJECT_TYPE_POINTER =   3,   /**< a void pointer*/
+    LV_SUBJECT_TYPE_COLOR   =   4,   /**< an lv_color_t*/
+    LV_SUBJECT_TYPE_GROUP  =    5,   /**< an array of subjects*/
+    LV_SUBJECT_TYPE_STRING  =   6,   /**< a char pointer*/
 } lv_subject_type_t;
 
 /**

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -41,6 +41,10 @@ void test_observer_add_remove(void)
     lv_subject_set_int(&subject, 15);
     TEST_ASSERT_EQUAL(15, lv_subject_get_int(&subject));
     TEST_ASSERT_EQUAL(10, current_v);   /*The observer cb is not called*/
+
+    static lv_subject_t uninitialized_subject;
+    observer = lv_subject_add_observer(&uninitialized_subject, observer_int, NULL);
+    TEST_ASSERT_EQUAL_PTR(NULL, observer);   /*The observer must be NULL*/
 }
 
 void test_observer_int(void)


### PR DESCRIPTION
### Description of the feature or fix

observing a subject which has not been initialized yet results in a hang
this change detects that scenario and fails the observer initialisation


### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
