### PR TITLE
fix(table): rename shortened function names to full names

### DIFF
--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -294,9 +294,9 @@ static void obj_test_task_cb(lv_timer_t * tmr)
 
             obj = lv_table_create(main_page);
             lv_table_set_cell_value(obj, 0, 0, "0,0");
-            lv_table_set_cell_value_fmt(obj, 3, 0, "%d,%d", 5, 0);
+            lv_table_set_cell_value_format(obj, 3, 0, "%d,%d", 5, 0);
             lv_table_set_row_cnt(obj, 5);
-            lv_table_set_cell_value_fmt(obj, 1, 0, "%s", "1,0");
+            lv_table_set_cell_value_format(obj, 1, 0, "%s", "1,0");
             lv_table_set_cell_value(obj, 1, 3, "1,3");
             break;
 

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -294,9 +294,9 @@ static void obj_test_task_cb(lv_timer_t * tmr)
 
             obj = lv_table_create(main_page);
             lv_table_set_cell_value(obj, 0, 0, "0,0");
-            lv_table_set_cell_value_format(obj, 3, 0, "%d,%d", 5, 0);
+            lv_table_set_cell_value_fmt(obj, 3, 0, "%d,%d", 5, 0);
             lv_table_set_row_cnt(obj, 5);
-            lv_table_set_cell_value_format(obj, 1, 0, "%s", "1,0");
+            lv_table_set_cell_value_fmt(obj, 1, 0, "%s", "1,0");
             lv_table_set_cell_value(obj, 1, 3, "1,3");
             break;
 

--- a/docs/widgets/table.rst
+++ b/docs/widgets/table.rst
@@ -60,7 +60,7 @@ Merge cells
 -----------
 
 Cells can be merged horizontally with
-:cpp:expr:`lv_table_add_cell_control(table, row, col, LV_TABLE_CELL_CTRL_MERGE_RIGHT)`.
+:cpp:expr:`lv_table_add_cell_ctrl(table, row, col, LV_TABLE_CELL_CTRL_MERGE_RIGHT)`.
 To merge more adjacent cells call this function for each cell.
 
 Scroll

--- a/docs/widgets/table.rst
+++ b/docs/widgets/table.rst
@@ -50,7 +50,7 @@ Width and Height
 ----------------
 
 The width of the columns can be set with
-:cpp:expr:`lv_table_set_col_width(table, col_id, width)`. The overall width of
+:cpp:expr:`lv_table_set_column_width(table, col_id, width)`. The overall width of
 the Table object will be set to the sum of columns widths.
 
 The height is calculated automatically from the cell styles (font,
@@ -60,7 +60,7 @@ Merge cells
 -----------
 
 Cells can be merged horizontally with
-:cpp:expr:`lv_table_add_cell_ctrl(table, row, col, LV_TABLE_CELL_CTRL_MERGE_RIGHT)`.
+:cpp:expr:`lv_table_add_cell_control(table, row, col, LV_TABLE_CELL_CTRL_MERGE_RIGHT)`.
 To merge more adjacent cells call this function for each cell.
 
 Scroll

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -12,7 +12,7 @@ static void draw_event_cb(lv_event_t * e)
     /*If the cells are drawn...*/
     if(base_dsc->part == LV_PART_ITEMS && draw_task->type == LV_DRAW_TASK_TYPE_FILL) {
         /*Draw the background*/
-        bool chk = lv_table_has_cell_ctrl(obj, base_dsc->id1, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+        bool chk = lv_table_has_cell_control(obj, base_dsc->id1, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
         lv_draw_rect_dsc_t rect_dsc;
         lv_draw_rect_dsc_init(&rect_dsc);
         rect_dsc.bg_color = chk ? lv_theme_get_color_primary(obj) : lv_palette_lighten(LV_PALETTE_GREY, 2);
@@ -49,9 +49,9 @@ static void change_event_cb(lv_event_t * e)
     uint32_t col;
     uint32_t row;
     lv_table_get_selected_cell(obj, &row, &col);
-    bool chk = lv_table_has_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
-    if(chk) lv_table_clear_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
-    else lv_table_add_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    bool chk = lv_table_has_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    if(chk) lv_table_clear_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    else lv_table_add_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
 }
 
 /**
@@ -70,7 +70,7 @@ void lv_example_table_2(void)
     /*Set a smaller height to the table. It'll make it scrollable*/
     lv_obj_set_size(table, LV_SIZE_CONTENT, 200);
 
-    lv_table_set_col_width(table, 0, 150);
+    lv_table_set_column_width(table, 0, 150);
     lv_table_set_row_count(table, ITEM_CNT); /*Not required but avoids a lot of memory reallocation lv_table_set_set_value*/
     lv_table_set_column_count(table, 1);
 
@@ -79,7 +79,7 @@ void lv_example_table_2(void)
 
     uint32_t i;
     for(i = 0; i < ITEM_CNT; i++) {
-        lv_table_set_cell_value_fmt(table, i, 0, "Item %"LV_PRIu32, i + 1);
+        lv_table_set_cell_value_format(table, i, 0, "Item %"LV_PRIu32, i + 1);
     }
 
     lv_obj_align(table, LV_ALIGN_CENTER, 0, -20);

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -12,7 +12,7 @@ static void draw_event_cb(lv_event_t * e)
     /*If the cells are drawn...*/
     if(base_dsc->part == LV_PART_ITEMS && draw_task->type == LV_DRAW_TASK_TYPE_FILL) {
         /*Draw the background*/
-        bool chk = lv_table_has_cell_control(obj, base_dsc->id1, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+        bool chk = lv_table_has_cell_ctrl(obj, base_dsc->id1, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
         lv_draw_rect_dsc_t rect_dsc;
         lv_draw_rect_dsc_init(&rect_dsc);
         rect_dsc.bg_color = chk ? lv_theme_get_color_primary(obj) : lv_palette_lighten(LV_PALETTE_GREY, 2);
@@ -49,9 +49,9 @@ static void change_event_cb(lv_event_t * e)
     uint32_t col;
     uint32_t row;
     lv_table_get_selected_cell(obj, &row, &col);
-    bool chk = lv_table_has_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
-    if(chk) lv_table_clear_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
-    else lv_table_add_cell_control(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    bool chk = lv_table_has_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    if(chk) lv_table_clear_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
+    else lv_table_add_cell_ctrl(obj, row, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
 }
 
 /**
@@ -79,7 +79,7 @@ void lv_example_table_2(void)
 
     uint32_t i;
     for(i = 0; i < ITEM_CNT; i++) {
-        lv_table_set_cell_value_format(table, i, 0, "Item %"LV_PRIu32, i + 1);
+        lv_table_set_cell_value_fmt(table, i, 0, "Item %"LV_PRIu32, i + 1);
     }
 
     lv_obj_align(table, LV_ALIGN_CENTER, 0, -20);

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -228,10 +228,6 @@ static inline void lv_obj_move_background(lv_obj_t * obj)
 #define lv_table_get_row_cnt                lv_table_get_row_count
 #define lv_table_set_col_width              lv_table_set_column_width
 #define lv_table_get_col_width              lv_table_get_column_width
-#define lv_table_set_cell_value_fmt         lv_table_set_cell_value_format
-#define lv_table_add_cell_ctrl              lv_table_add_cell_control
-#define lv_table_clear_cell_ctrl            lv_table_clear_cell_control
-#define lv_table_has_cell_ctrl              lv_table_has_cell_control
 
 #define lv_dropdown_get_option_cnt          lv_dropdown_get_option_count
 

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -226,6 +226,12 @@ static inline void lv_obj_move_background(lv_obj_t * obj)
 #define lv_table_set_row_cnt                lv_table_set_row_count
 #define lv_table_get_col_cnt                lv_table_get_column_count
 #define lv_table_get_row_cnt                lv_table_get_row_count
+#define lv_table_set_col_width              lv_table_set_column_width
+#define lv_table_get_col_width              lv_table_get_column_width
+#define lv_table_set_cell_value_fmt         lv_table_set_cell_value_format
+#define lv_table_add_cell_ctrl              lv_table_add_cell_control
+#define lv_table_clear_cell_ctrl            lv_table_clear_cell_control
+#define lv_table_has_cell_ctrl              lv_table_has_cell_control
 
 #define lv_dropdown_get_option_cnt          lv_dropdown_get_option_count
 

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -538,8 +538,8 @@ static void show_dir(lv_obj_t * obj, const char * path)
         return;
     }
 
-    lv_table_set_cell_value_format(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", ".");
-    lv_table_set_cell_value_format(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", "..");
+    lv_table_set_cell_value_fmt(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", ".");
+    lv_table_set_cell_value_fmt(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", "..");
     lv_table_set_cell_value(explorer->file_table, 0, 1, "0");
     lv_table_set_cell_value(explorer->file_table, 1, 1, "0");
 
@@ -560,15 +560,15 @@ static void show_dir(lv_obj_t * obj, const char * path)
            (is_end_with(fn, ".jpg") == true) || (is_end_with(fn, ".JPG") == true) || \
            (is_end_with(fn, ".bmp") == true) || (is_end_with(fn, ".BMP") == true) || \
            (is_end_with(fn, ".gif") == true) || (is_end_with(fn, ".GIF") == true)) {
-            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_IMAGE "  %s", fn);
+            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_IMAGE "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "1");
         }
         else if((is_end_with(fn, ".mp3") == true) || (is_end_with(fn, ".MP3") == true)) {
-            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_AUDIO "  %s", fn);
+            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_AUDIO "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "2");
         }
         else if((is_end_with(fn, ".mp4") == true) || (is_end_with(fn, ".MP4") == true)) {
-            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_VIDEO "  %s", fn);
+            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_VIDEO "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "3");
         }
         else if((is_end_with(fn, ".") == true) || (is_end_with(fn, "..") == true)) {
@@ -576,11 +576,11 @@ static void show_dir(lv_obj_t * obj, const char * path)
             continue;
         }
         else if(fn[0] == '/') {/*is dir*/
-            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_DIRECTORY "  %s", fn + 1);
+            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_DIRECTORY "  %s", fn + 1);
             lv_table_set_cell_value(explorer->file_table, index, 1, "0");
         }
         else {
-            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_FILE "  %s", fn);
+            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_FILE "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "4");
         }
 

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -321,7 +321,7 @@ static void lv_file_explorer_constructor(const lv_obj_class_t * class_p, lv_obj_
     /*Table showing the contents of the table of contents*/
     explorer->file_table = lv_table_create(explorer->browser_area);
     lv_obj_set_size(explorer->file_table, LV_PCT(100), LV_PCT(86));
-    lv_table_set_col_width(explorer->file_table, 0, LV_PCT(100));
+    lv_table_set_column_width(explorer->file_table, 0, LV_PCT(100));
     lv_table_set_column_count(explorer->file_table, 1);
     lv_obj_add_event_cb(explorer->file_table, browser_file_event_handler, LV_EVENT_ALL, obj);
 
@@ -516,7 +516,7 @@ static void browser_file_event_handler(lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_SIZE_CHANGED) {
-        lv_table_set_col_width(explorer->file_table, 0, lv_obj_get_width(explorer->file_table));
+        lv_table_set_column_width(explorer->file_table, 0, lv_obj_get_width(explorer->file_table));
     }
     else if((code == LV_EVENT_CLICKED) || (code == LV_EVENT_RELEASED)) {
         lv_obj_send_event(obj, LV_EVENT_CLICKED, NULL);
@@ -538,8 +538,8 @@ static void show_dir(lv_obj_t * obj, const char * path)
         return;
     }
 
-    lv_table_set_cell_value_fmt(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", ".");
-    lv_table_set_cell_value_fmt(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", "..");
+    lv_table_set_cell_value_format(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", ".");
+    lv_table_set_cell_value_format(explorer->file_table, index++, 0, LV_SYMBOL_DIRECTORY "  %s", "..");
     lv_table_set_cell_value(explorer->file_table, 0, 1, "0");
     lv_table_set_cell_value(explorer->file_table, 1, 1, "0");
 
@@ -560,15 +560,15 @@ static void show_dir(lv_obj_t * obj, const char * path)
            (is_end_with(fn, ".jpg") == true) || (is_end_with(fn, ".JPG") == true) || \
            (is_end_with(fn, ".bmp") == true) || (is_end_with(fn, ".BMP") == true) || \
            (is_end_with(fn, ".gif") == true) || (is_end_with(fn, ".GIF") == true)) {
-            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_IMAGE "  %s", fn);
+            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_IMAGE "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "1");
         }
         else if((is_end_with(fn, ".mp3") == true) || (is_end_with(fn, ".MP3") == true)) {
-            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_AUDIO "  %s", fn);
+            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_AUDIO "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "2");
         }
         else if((is_end_with(fn, ".mp4") == true) || (is_end_with(fn, ".MP4") == true)) {
-            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_VIDEO "  %s", fn);
+            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_VIDEO "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "3");
         }
         else if((is_end_with(fn, ".") == true) || (is_end_with(fn, "..") == true)) {
@@ -576,11 +576,11 @@ static void show_dir(lv_obj_t * obj, const char * path)
             continue;
         }
         else if(fn[0] == '/') {/*is dir*/
-            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_DIRECTORY "  %s", fn + 1);
+            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_DIRECTORY "  %s", fn + 1);
             lv_table_set_cell_value(explorer->file_table, index, 1, "0");
         }
         else {
-            lv_table_set_cell_value_fmt(explorer->file_table, index, 0, LV_SYMBOL_FILE "  %s", fn);
+            lv_table_set_cell_value_format(explorer->file_table, index, 0, LV_SYMBOL_FILE "  %s", fn);
             lv_table_set_cell_value(explorer->file_table, index, 1, "4");
         }
 

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -120,7 +120,7 @@ void lv_table_set_cell_value(lv_obj_t * obj, uint32_t row, uint32_t col, const c
     refr_cell_size(obj, row, col);
 }
 
-void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt, ...)
+void lv_table_set_cell_value_format(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt, ...)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);
@@ -299,7 +299,7 @@ void lv_table_set_column_count(lv_obj_t * obj, uint32_t col_cnt)
     refr_size_form_row(obj, 0) ;
 }
 
-void lv_table_set_col_width(lv_obj_t * obj, uint32_t col_id, int32_t w)
+void lv_table_set_column_width(lv_obj_t * obj, uint32_t col_id, int32_t w)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -312,7 +312,7 @@ void lv_table_set_col_width(lv_obj_t * obj, uint32_t col_id, int32_t w)
     refr_size_form_row(obj, 0);
 }
 
-void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -337,7 +337,7 @@ void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table
     table->cell_data[cell]->ctrl |= ctrl;
 }
 
-void lv_table_clear_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+void lv_table_clear_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -427,7 +427,7 @@ uint32_t lv_table_get_column_count(lv_obj_t * obj)
     return table->col_cnt;
 }
 
-int32_t lv_table_get_col_width(lv_obj_t * obj, uint32_t col)
+int32_t lv_table_get_column_width(lv_obj_t * obj, uint32_t col)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -441,7 +441,7 @@ int32_t lv_table_get_col_width(lv_obj_t * obj, uint32_t col)
     return table->col_w[col];
 }
 
-bool lv_table_has_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+bool lv_table_has_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -120,7 +120,7 @@ void lv_table_set_cell_value(lv_obj_t * obj, uint32_t row, uint32_t col, const c
     refr_cell_size(obj, row, col);
 }
 
-void lv_table_set_cell_value_format(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt, ...)
+void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt, ...)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);
@@ -312,7 +312,7 @@ void lv_table_set_column_width(lv_obj_t * obj, uint32_t col_id, int32_t w)
     refr_size_form_row(obj, 0);
 }
 
-void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -337,7 +337,7 @@ void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_ta
     table->cell_data[cell]->ctrl |= ctrl;
 }
 
-void lv_table_clear_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+void lv_table_clear_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -441,7 +441,7 @@ int32_t lv_table_get_column_width(lv_obj_t * obj, uint32_t col)
     return table->col_w[col];
 }
 
-bool lv_table_has_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
+bool lv_table_has_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 

--- a/src/widgets/table/lv_table.h
+++ b/src/widgets/table/lv_table.h
@@ -102,7 +102,7 @@ void lv_table_set_cell_value(lv_obj_t * obj, uint32_t row, uint32_t col, const c
  * @param fmt           `printf`-like format
  * @note                New roes/columns are added automatically if required
  */
-void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt,
+void lv_table_set_cell_value_format(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt,
                                  ...) LV_FORMAT_ATTRIBUTE(4, 5);
 
 /**
@@ -125,7 +125,7 @@ void lv_table_set_column_count(lv_obj_t * obj, uint32_t col_cnt);
  * @param col_id    id of the column [0 .. LV_TABLE_COL_MAX -1]
  * @param w         width of the column
  */
-void lv_table_set_col_width(lv_obj_t * obj, uint32_t col_id, int32_t w);
+void lv_table_set_column_width(lv_obj_t * obj, uint32_t col_id, int32_t w);
 
 /**
  * Add control bits to the cell.
@@ -134,7 +134,7 @@ void lv_table_set_col_width(lv_obj_t * obj, uint32_t col_id, int32_t w);
  * @param col       id of the column [0 .. col_cnt -1]
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  */
-void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Clear control bits of the cell.
@@ -143,7 +143,7 @@ void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table
  * @param col       id of the column [0 .. col_cnt -1]
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  */
-void lv_table_clear_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+void lv_table_clear_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Add custom user data to the cell.
@@ -190,7 +190,7 @@ uint32_t lv_table_get_column_count(lv_obj_t * obj);
  * @param col       id of the column [0 .. LV_TABLE_COL_MAX -1]
  * @return          width of the column
  */
-int32_t lv_table_get_col_width(lv_obj_t * obj, uint32_t col);
+int32_t lv_table_get_column_width(lv_obj_t * obj, uint32_t col);
 
 /**
  * Get whether a cell has the control bits
@@ -200,7 +200,7 @@ int32_t lv_table_get_col_width(lv_obj_t * obj, uint32_t col);
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  * @return          true: all control bits are set; false: not all control bits are set
  */
-bool lv_table_has_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+bool lv_table_has_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Get the selected cell (pressed and or focused)

--- a/src/widgets/table/lv_table.h
+++ b/src/widgets/table/lv_table.h
@@ -103,7 +103,7 @@ void lv_table_set_cell_value(lv_obj_t * obj, uint32_t row, uint32_t col, const c
  * @note                New roes/columns are added automatically if required
  */
 void lv_table_set_cell_value_format(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt,
-                                 ...) LV_FORMAT_ATTRIBUTE(4, 5);
+                                    ...) LV_FORMAT_ATTRIBUTE(4, 5);
 
 /**
  * Set the number of rows

--- a/src/widgets/table/lv_table.h
+++ b/src/widgets/table/lv_table.h
@@ -102,8 +102,8 @@ void lv_table_set_cell_value(lv_obj_t * obj, uint32_t row, uint32_t col, const c
  * @param fmt           `printf`-like format
  * @note                New roes/columns are added automatically if required
  */
-void lv_table_set_cell_value_format(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt,
-                                    ...) LV_FORMAT_ATTRIBUTE(4, 5);
+void lv_table_set_cell_value_fmt(lv_obj_t * obj, uint32_t row, uint32_t col, const char * fmt,
+                                 ...) LV_FORMAT_ATTRIBUTE(4, 5);
 
 /**
  * Set the number of rows
@@ -134,7 +134,7 @@ void lv_table_set_column_width(lv_obj_t * obj, uint32_t col_id, int32_t w);
  * @param col       id of the column [0 .. col_cnt -1]
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  */
-void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+void lv_table_add_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Clear control bits of the cell.
@@ -143,7 +143,7 @@ void lv_table_add_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_ta
  * @param col       id of the column [0 .. col_cnt -1]
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  */
-void lv_table_clear_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+void lv_table_clear_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Add custom user data to the cell.
@@ -200,7 +200,7 @@ int32_t lv_table_get_column_width(lv_obj_t * obj, uint32_t col);
  * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
  * @return          true: all control bits are set; false: not all control bits are set
  */
-bool lv_table_has_cell_control(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
+bool lv_table_has_cell_ctrl(lv_obj_t * obj, uint32_t row, uint32_t col, lv_table_cell_ctrl_t ctrl);
 
 /**
  * Get the selected cell (pressed and or focused)

--- a/tests/src/test_cases/widgets/test_table.c
+++ b/tests/src/test_cases/widgets/test_table.c
@@ -35,7 +35,7 @@ void test_table_should_grow_columns_automatically_when_setting_formatted_cell_va
     TEST_ASSERT_EQUAL_UINT16(1, original_column_count);
 
     /* Table currently only has a cell at 0,0 (row, column) */
-    lv_table_set_cell_value_format(table, 0, 1, "LVGL %s", "Rocks!");
+    lv_table_set_cell_value_fmt(table, 0, 1, "LVGL %s", "Rocks!");
 
     /* Table now should have cells at 0,0 and 0,1, so 2 columns */
     uint16_t expected_column_count = original_column_count + 1;
@@ -46,12 +46,12 @@ void test_table_should_identify_cell_with_ctrl(void)
 {
     bool has_ctrl = false;
 
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
 
     TEST_ASSERT_FALSE(has_ctrl);
 
-    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_TRUE(has_ctrl);
 }
 
@@ -59,12 +59,12 @@ void test_table_should_clear_selected_cell_ctrl(void)
 {
     bool has_ctrl = false;
 
-    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_TRUE(has_ctrl);
 
-    lv_table_clear_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_clear_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_FALSE(has_ctrl);
 }
 
@@ -72,13 +72,13 @@ void test_table_should_keep_not_selected_cell_ctrl(void)
 {
     bool has_ctrl = false;
 
-    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT | LV_TABLE_CELL_CTRL_TEXT_CROP);
+    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT | LV_TABLE_CELL_CTRL_TEXT_CROP);
 
-    lv_table_clear_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_clear_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_FALSE(has_ctrl);
 
-    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_TEXT_CROP);
+    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_TEXT_CROP);
     TEST_ASSERT_TRUE(has_ctrl);
 }
 
@@ -174,25 +174,25 @@ void test_table_rendering(void)
     lv_table_set_column_width(table, 1, 60);
     lv_table_set_column_width(table, 2, 100);
 
-    lv_table_add_cell_control(table, 0, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 0, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     lv_table_set_cell_value(table, 0, 1, "2 cells are merged");
 
-    lv_table_add_cell_control(table, 1, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_control(table, 1, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_control(table, 1, 2, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_control(table, 1, 3, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 1, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 1, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 1, 2, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_ctrl(table, 1, 3, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     lv_table_set_cell_value(table, 1, 0, "5 cells are merged");
 
     uint32_t i;
     for(i = 0; i < 5; i++) {
-        lv_table_set_cell_value_format(table, 3, i, "%d", i);
+        lv_table_set_cell_value_fmt(table, 3, i, "%d", i);
     }
 
-    lv_table_set_cell_value_format(table, 2, 3, "Multi\nline text");
-    lv_table_set_cell_value_format(table, 2, 4, "Very long text wrapped automatically");
+    lv_table_set_cell_value_fmt(table, 2, 3, "Multi\nline text");
+    lv_table_set_cell_value_fmt(table, 2, 4, "Very long text wrapped automatically");
 
-    lv_table_add_cell_control(table, 4, 3, LV_TABLE_CELL_CTRL_TEXT_CROP);
-    lv_table_set_cell_value_format(table, 4, 3, "crop crop crop crop crop crop crop crop ");
+    lv_table_add_cell_ctrl(table, 4, 3, LV_TABLE_CELL_CTRL_TEXT_CROP);
+    lv_table_set_cell_value_fmt(table, 4, 3, "crop crop crop crop crop crop crop crop ");
 
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/table_1.png");
 }

--- a/tests/src/test_cases/widgets/test_table.c
+++ b/tests/src/test_cases/widgets/test_table.c
@@ -35,7 +35,7 @@ void test_table_should_grow_columns_automatically_when_setting_formatted_cell_va
     TEST_ASSERT_EQUAL_UINT16(1, original_column_count);
 
     /* Table currently only has a cell at 0,0 (row, column) */
-    lv_table_set_cell_value_fmt(table, 0, 1, "LVGL %s", "Rocks!");
+    lv_table_set_cell_value_format(table, 0, 1, "LVGL %s", "Rocks!");
 
     /* Table now should have cells at 0,0 and 0,1, so 2 columns */
     uint16_t expected_column_count = original_column_count + 1;
@@ -46,12 +46,12 @@ void test_table_should_identify_cell_with_ctrl(void)
 {
     bool has_ctrl = false;
 
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
 
     TEST_ASSERT_FALSE(has_ctrl);
 
-    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_TRUE(has_ctrl);
 }
 
@@ -59,12 +59,12 @@ void test_table_should_clear_selected_cell_ctrl(void)
 {
     bool has_ctrl = false;
 
-    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_TRUE(has_ctrl);
 
-    lv_table_clear_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_clear_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_FALSE(has_ctrl);
 }
 
@@ -72,13 +72,13 @@ void test_table_should_keep_not_selected_cell_ctrl(void)
 {
     bool has_ctrl = false;
 
-    lv_table_add_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT | LV_TABLE_CELL_CTRL_TEXT_CROP);
+    lv_table_add_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT | LV_TABLE_CELL_CTRL_TEXT_CROP);
 
-    lv_table_clear_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_clear_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     TEST_ASSERT_FALSE(has_ctrl);
 
-    has_ctrl = lv_table_has_cell_ctrl(table, 0, 0, LV_TABLE_CELL_CTRL_TEXT_CROP);
+    has_ctrl = lv_table_has_cell_control(table, 0, 0, LV_TABLE_CELL_CTRL_TEXT_CROP);
     TEST_ASSERT_TRUE(has_ctrl);
 }
 
@@ -109,7 +109,7 @@ void test_table_should_wrap_long_texts(void)
     const char * long_text = "Testing automatic text wrap with a very long text";
     const char * small_text = "Hi";
 
-    lv_table_set_col_width(table, 0, 50);
+    lv_table_set_column_width(table, 0, 50);
 
     lv_table_set_cell_value(table, 0, 0, small_text);
     int32_t row_height = table_ptr->row_h[0];
@@ -171,28 +171,28 @@ void test_table_rendering(void)
     lv_obj_set_style_border_width(table, 5, LV_PART_ITEMS);
     lv_table_set_column_count(table, 5);
     lv_table_set_row_count(table, 5);
-    lv_table_set_col_width(table, 1, 60);
-    lv_table_set_col_width(table, 2, 100);
+    lv_table_set_column_width(table, 1, 60);
+    lv_table_set_column_width(table, 2, 100);
 
-    lv_table_add_cell_ctrl(table, 0, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 0, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     lv_table_set_cell_value(table, 0, 1, "2 cells are merged");
 
-    lv_table_add_cell_ctrl(table, 1, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_ctrl(table, 1, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_ctrl(table, 1, 2, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-    lv_table_add_cell_ctrl(table, 1, 3, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 1, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 1, 1, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 1, 2, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+    lv_table_add_cell_control(table, 1, 3, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
     lv_table_set_cell_value(table, 1, 0, "5 cells are merged");
 
     uint32_t i;
     for(i = 0; i < 5; i++) {
-        lv_table_set_cell_value_fmt(table, 3, i, "%d", i);
+        lv_table_set_cell_value_format(table, 3, i, "%d", i);
     }
 
-    lv_table_set_cell_value_fmt(table, 2, 3, "Multi\nline text");
-    lv_table_set_cell_value_fmt(table, 2, 4, "Very long text wrapped automatically");
+    lv_table_set_cell_value_format(table, 2, 3, "Multi\nline text");
+    lv_table_set_cell_value_format(table, 2, 4, "Very long text wrapped automatically");
 
-    lv_table_add_cell_ctrl(table, 4, 3, LV_TABLE_CELL_CTRL_TEXT_CROP);
-    lv_table_set_cell_value_fmt(table, 4, 3, "crop crop crop crop crop crop crop crop ");
+    lv_table_add_cell_control(table, 4, 3, LV_TABLE_CELL_CTRL_TEXT_CROP);
+    lv_table_set_cell_value_format(table, 4, 3, "crop crop crop crop crop crop crop crop ");
 
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/table_1.png");
 }


### PR DESCRIPTION
### Description of the feature or fix

Rename table widget shortened function names to full names:
- `lv_table_set_col_width` -> `lv_table_set_column_width`
- `lv_table_get_col_width` -> `lv_table_get_column_width`

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
