### PR TITLE
fix(gif):fix wrong position of pointers in interlace mode

### DIFF
--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -326,7 +326,8 @@ read_image_data(gd_GIF *gif, int interlace)
     int key_size;
     int y, pass, linesize;
     uint8_t *ptr = NULL;
-    uint8_t *ptr_init = NULL;
+    uint8_t *ptr_row_start = NULL;
+    uint8_t *ptr_base = NULL;
     size_t start, end;
     uint16_t key, clear_code, stop_code, curr_code;
     int frm_off, frm_size,curr_size,top_slot,new_codes,slot;
@@ -351,8 +352,9 @@ read_image_data(gd_GIF *gif, int interlace)
     f_gif_seek(gif, start, LV_FS_SEEK_SET);
 
     linesize = gif->width;
-    ptr_init = &gif->frame[gif->fy * linesize + gif->fx];
-    ptr = ptr_init;
+    ptr_base = &gif->frame[gif->fy * linesize + gif->fx];
+    ptr_row_start = ptr_base;
+    ptr = ptr_row_start;
     sub_len = shift = 0;
     /* decoder */
     pass = 0;
@@ -376,34 +378,34 @@ read_image_data(gd_GIF *gif, int interlace)
             *ptr++ = *(--sp);
             frm_off += 1;
             /* read one line */
-            if ((ptr - ptr_init) == gif->fw) {
+            if ((ptr - ptr_row_start) == gif->fw) {
                 if (interlace) {
                     switch(pass) {
                     case 0:
                     case 1:
                         y += 8;
-                        ptr_init += linesize * 8;
+                        ptr_row_start += linesize * 8;
                         break;
                     case 2:
                         y += 4;
-                        ptr_init += linesize * 4;
+                        ptr_row_start += linesize * 4;
                         break;
                     case 3:
                         y += 2;
-                        ptr_init += linesize * 2;
+                        ptr_row_start += linesize * 2;
                         break;
                     default:
                         break;
                     }
                     while (y >= gif->fh) {
                         y  = 4 >> pass;
-                        ptr_init = ptr_init + linesize * y;
+                        ptr_row_start = ptr_base + linesize * y;
                         pass++;
                     }
                 } else {
-                    ptr_init += linesize;
+                    ptr_row_start += linesize;
                 }
-                ptr = ptr_init;
+                ptr = ptr_row_start;
             }
         }
 


### PR DESCRIPTION
### Fix wrong position of pointer if gif image is interlace mode

Gif image's interlace mode like this:
![image](https://github.com/lvgl/lvgl/assets/32351888/f466a327-43d5-4eac-80dd-ecf2a5bb41f8)


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
