### PR TITLE
feat(tool): add compressed binary image support to C-array

### DIFF
--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -579,14 +579,12 @@ class LVGLImage:
 
         varname = path.basename(filename).split('.')[0]
         varname = varname.replace("-", "_")
-        varname += f"_{self.cf.name.lower()}"
-        if self.stride != (self.w * self.cf.bpp + 7) // 8:
-            varname += f"_stride{self.stride}"
-        if compress is not CompressMethod.NONE:
-            varname += f"_{compress.name}"
+        varname = varname.replace(".", "_")
 
-        flags = 0
-        flags |= 0x08 if compress != CompressMethod.NONE else 0
+        flags = "0"
+        if compress is not CompressMethod.NONE:
+            flags += " | LV_IMAGE_FLAGS_COMPRESSED"
+
         compressed = LVGLCompressData(self.cf, compress, self.data)
 
         header = f'''
@@ -615,7 +613,7 @@ uint8_t {varname}_map[] = {{
 
 const lv_img_dsc_t {varname} = {{
   .header.cf = LV_COLOR_FORMAT_{self.cf.name},
-  .header.flags = {hex(flags)},
+  .header.flags = {flags},
   .header.w = {self.w},
   .header.h = {self.h},
   .header.stride = {self.stride},
@@ -1145,6 +1143,7 @@ def test():
     img = LVGLImage().from_png(f, cf=ColorFormat.RGB888, background=0xFF_FF_00)
     img.adjust_stride(align=16)
     img.to_bin("output/cogwheel.RGB888.bin")
+    img.to_c_array("output/cogwheel-abc.c")  # file name is used as c var name
     img.to_png("output/cogwheel.RGB888.png.png")  # convert back to png
 
 

--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     raise ImportError("Need pypng package, do `pip3 install pypng`")
 
-
 try:
     import lz4.block
 except ImportError:
@@ -395,16 +394,11 @@ class LVGLImage:
                  h: int = 0,
                  data: bytes = b'') -> None:
         self.stride = 0  # default no valid stride value
-        self.compress = CompressMethod.NONE
         self.set_data(cf, w, h, data)
 
     def __repr__(self) -> str:
         return (f"'LVGL image {self.w}x{self.h}, {self.cf.name},"
                 f" (12+{self.data_len})Byte'")
-
-    def set_compress(self, method: CompressMethod):
-        # only do compression when return binary data
-        self.compress = method
 
     def adjust_stride(self, stride: int = 0, align: int = 1):
         '''
@@ -487,26 +481,6 @@ class LVGLImage:
         return p
 
     @property
-    def binary(self) -> bytearray:
-        '''
-        Return binary of this image including correct lvgl image header and
-        raw data
-        '''
-        bin = bytearray()
-        flags = 0
-        flags |= 0x08 if self.compress != CompressMethod.NONE else 0
-
-        header = LVGLImageHeader(self.cf,
-                                 self.w,
-                                 self.h,
-                                 self.stride,
-                                 flags=flags)
-        bin += header.binary
-        compress = LVGLCompressData(self.cf, self.compress, self.data)
-        bin += compress.compressed
-        return bin
-
-    @property
     def header(self) -> bytearray:
         return LVGLImageHeader(self.cf, self.w, self.h)
 
@@ -570,7 +544,9 @@ class LVGLImage:
             logging.info(f"mkdir of {dir} for {filename}")
             os.makedirs(dir)
 
-    def to_bin(self, filename: str):
+    def to_bin(self,
+               filename: str,
+               compress: CompressMethod = CompressMethod.NONE):
         '''
         Write this image to file, filename should be ended with '.bin'
         '''
@@ -578,11 +554,26 @@ class LVGLImage:
         self._check_dir(filename)
 
         with open(filename, "wb+") as f:
-            f.write(self.binary)
+            bin = bytearray()
+            flags = 0
+            flags |= 0x08 if compress != CompressMethod.NONE else 0
+
+            header = LVGLImageHeader(self.cf,
+                                     self.w,
+                                     self.h,
+                                     self.stride,
+                                     flags=flags)
+            bin += header.binary
+            compressed = LVGLCompressData(self.cf, compress, self.data)
+            bin += compressed.compressed
+
+            f.write(bin)
 
         return self
 
-    def to_c_array(self, filename: str):
+    def to_c_array(self,
+                   filename: str,
+                   compress: CompressMethod = CompressMethod.NONE):
         self._check_ext(filename, ".c")
         self._check_dir(filename)
 
@@ -591,6 +582,12 @@ class LVGLImage:
         varname += f"_{self.cf.name.lower()}"
         if self.stride != (self.w * self.cf.bpp + 7) // 8:
             varname += f"_stride{self.stride}"
+        if compress is not CompressMethod.NONE:
+            varname += f"_{compress.name}"
+
+        flags = 0
+        flags |= 0x08 if compress != CompressMethod.NONE else 0
+        compressed = LVGLCompressData(self.cf, compress, self.data)
 
         header = f'''
 #if defined(LV_LVGL_H_INCLUDE_SIMPLE)
@@ -608,7 +605,8 @@ class LVGLImage:
 #define LV_ATTRIBUTE_IMG_DUST
 #endif
 
-const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMG_DUST
+static const
+LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMG_DUST
 uint8_t {varname}_map[] = {{
 '''
 
@@ -617,10 +615,11 @@ uint8_t {varname}_map[] = {{
 
 const lv_img_dsc_t {varname} = {{
   .header.cf = LV_COLOR_FORMAT_{self.cf.name},
+  .header.flags = {hex(flags)},
   .header.w = {self.w},
   .header.h = {self.h},
   .header.stride = {self.stride},
-  .data_size = {len(self.data)},
+  .data_size = {len(compressed.compressed)},
   .data = {varname}_map,
 }};
 
@@ -636,12 +635,16 @@ const lv_img_dsc_t {varname} = {{
         with open(filename, "w+") as f:
             f.write(header)
 
-            # write palette separately
-            ncolors = self.cf.ncolors
-            if ncolors:
-                write_binary(f, self.data[:ncolors * 4], 16)
+            if compress is not CompressMethod.NONE:
+                write_binary(f, compressed.compressed, 16)
+            else:
+                # write palette separately
+                ncolors = self.cf.ncolors
+                if ncolors:
+                    write_binary(f, self.data[:ncolors * 4], 16)
 
-            write_binary(f, self.data[ncolors * 4:], self.stride)
+                write_binary(f, self.data[ncolors * 4:], self.stride)
+
             f.write(ending)
 
         return self
@@ -1032,13 +1035,11 @@ class PNGConverter:
     def convert(self):
         output = []
         for f in self.files:
-
             if self.ofmt == OutputFormat.RLE_FILE:
                 rle = RLEImage().from_png(f,
                                           self.cf,
                                           background=self.background)
                 rle.adjust_stride(align=self.align)
-                rle.set_compress(self.compress)
                 output.append((f, rle))
                 rle.to_rle(self._replace_ext(f, ".rle"))
             else:
@@ -1046,12 +1047,13 @@ class PNGConverter:
                                            self.cf,
                                            background=self.background)
                 img.adjust_stride(align=self.align)
-                img.set_compress(self.compress)
                 output.append((f, img))
                 if self.ofmt == OutputFormat.BIN_FILE:
-                    img.to_bin(self._replace_ext(f, ".bin"))
+                    img.to_bin(self._replace_ext(f, ".bin"),
+                               compress=self.compress)
                 elif self.ofmt == OutputFormat.C_ARRAY:
-                    img.to_c_array(self._replace_ext(f, ".c"))
+                    img.to_c_array(self._replace_ext(f, ".c"),
+                                   compress=self.compress)
                 elif self.ofmt == OutputFormat.PNG_FILE:
                     img.to_png(self._replace_ext(f, ".png"))
 
@@ -1142,7 +1144,6 @@ def test():
     f = "pngs/cogwheel.RGB565A8.png"
     img = LVGLImage().from_png(f, cf=ColorFormat.RGB888, background=0xFF_FF_00)
     img.adjust_stride(align=16)
-    img.set_compress(CompressMethod.RLE)
     img.to_bin("output/cogwheel.RGB888.bin")
     img.to_png("output/cogwheel.RGB888.png.png")  # convert back to png
 


### PR DESCRIPTION
### Description of the feature or fix

This PR enables PNG to compressed C-array conversion. 

Key updates include:
  - move `compress` parameter to `to_bin` method, since it's only used in lvgl binary image
  - C-array map data is now static
  - compression method is appended to C-array variable name, preventing naming conflicts.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
