### PR TITLE
chore(nuttx): use LV_LOG_USER to print driver info

### DIFF
--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -96,7 +96,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         LV_LOG_ERROR("Error: cannot open framebuffer device");
         return -errno;
     }
-    LV_LOG_INFO("The framebuffer device was opened successfully");
+    LV_LOG_USER("The framebuffer device was opened successfully");
 
     if(ioctl(dsc->fd, FBIOGET_VIDEOINFO, (unsigned long)((uintptr_t)&dsc->vinfo)) < 0) {
         LV_LOG_ERROR("ioctl(FBIOGET_VIDEOINFO) failed: %d", errno);
@@ -104,11 +104,11 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         goto errout;
     }
 
-    LV_LOG_INFO("VideoInfo:");
-    LV_LOG_INFO("      fmt: %u", dsc->vinfo.fmt);
-    LV_LOG_INFO("     xres: %u", dsc->vinfo.xres);
-    LV_LOG_INFO("     yres: %u", dsc->vinfo.yres);
-    LV_LOG_INFO("  nplanes: %u", dsc->vinfo.nplanes);
+    LV_LOG_USER("VideoInfo:");
+    LV_LOG_USER("      fmt: %u", dsc->vinfo.fmt);
+    LV_LOG_USER("     xres: %u", dsc->vinfo.xres);
+    LV_LOG_USER("     yres: %u", dsc->vinfo.yres);
+    LV_LOG_USER("  nplanes: %u", dsc->vinfo.nplanes);
 
     if((ret = fbdev_get_pinfo(dsc->fd, &dsc->pinfo)) < 0) {
         goto errout;
@@ -136,7 +136,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
 
-    LV_LOG_INFO("Resolution is set to %dx%d at %ddpi", dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
+    LV_LOG_USER("Resolution is set to %dx%d at %ddpi", dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
     return 0;
 
 errout:
@@ -225,12 +225,12 @@ static int fbdev_get_pinfo(int fd, FAR struct fb_planeinfo_s * pinfo)
         return -errno;
     }
 
-    LV_LOG_INFO("PlaneInfo (plane %d):", pinfo->display);
-    LV_LOG_INFO("    mem: %p", pinfo->fbmem);
-    LV_LOG_INFO("    fblen: %zu", pinfo->fblen);
-    LV_LOG_INFO("   stride: %u", pinfo->stride);
-    LV_LOG_INFO("  display: %u", pinfo->display);
-    LV_LOG_INFO("      bpp: %u", pinfo->bpp);
+    LV_LOG_USER("PlaneInfo (plane %d):", pinfo->display);
+    LV_LOG_USER("    mem: %p", pinfo->fbmem);
+    LV_LOG_USER("    fblen: %zu", pinfo->fblen);
+    LV_LOG_USER("   stride: %u", pinfo->stride);
+    LV_LOG_USER("  display: %u", pinfo->display);
+    LV_LOG_USER("      bpp: %u", pinfo->bpp);
 
     /* Only these pixel depths are supported.  vinfo.fmt is ignored, only
      * certain color formats are supported.
@@ -286,13 +286,13 @@ static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
     if(buf_offset == 0) {
         dsc->mem2_yoffset = dsc->vinfo.yres;
         dsc->mem2 = pinfo.fbmem + dsc->mem2_yoffset * pinfo.stride;
-        LV_LOG_INFO("Use consecutive mem2 = %p, yoffset = %" PRIu32,
+        LV_LOG_USER("Use consecutive mem2 = %p, yoffset = %" LV_PRIu32,
                     dsc->mem2, dsc->mem2_yoffset);
     }
     else {
         dsc->mem2_yoffset = buf_offset / dsc->pinfo.stride;
         dsc->mem2 = pinfo.fbmem;
-        LV_LOG_INFO("Use non-consecutive mem2 = %p, yoffset = %" PRIu32,
+        LV_LOG_USER("Use non-consecutive mem2 = %p, yoffset = %" LV_PRIu32,
                     dsc->mem2, dsc->mem2_yoffset);
     }
 
@@ -313,7 +313,7 @@ static void display_release_cb(lv_event_t * e)
         }
         lv_free(dsc);
     }
-    LV_LOG_INFO("Done");
+    LV_LOG_USER("Done");
 }
 
 #endif /*LV_USE_NUTTX*/

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -73,14 +73,14 @@ lv_display_t * lv_nuttx_lcd_create(const char * dev_path)
 
     LV_ASSERT_NULL(dev_path);
 
-    LV_LOG_INFO("lcd %s opening", dev_path);
+    LV_LOG_USER("lcd %s opening", dev_path);
     fd = open(dev_path, 0);
     if(fd < 0) {
         perror("Error: cannot open lcd device");
         return NULL;
     }
 
-    LV_LOG_INFO("lcd %s open success", dev_path);
+    LV_LOG_USER("lcd %s open success", dev_path);
 
     ret = ioctl(fd, LCDDEVIO_GETVIDEOINFO,
                 (unsigned long)((uintptr_t)&vinfo));
@@ -230,7 +230,7 @@ static void display_release_cb(lv_event_t * e)
             dsc->fd = -1;
         }
         lv_free(dsc);
-        LV_LOG_INFO("Done");
+        LV_LOG_USER("Done");
     }
 }
 #endif /*LV_USE_NUTTX_LCD*/

--- a/src/dev/nuttx/lv_nuttx_libuv.c
+++ b/src/dev/nuttx/lv_nuttx_libuv.c
@@ -112,7 +112,7 @@ void lv_nuttx_uv_deinit(void ** data)
 
     lv_free(uv_ctx);
     *data = NULL;
-    LV_LOG_INFO("Done");
+    LV_LOG_USER("Done");
 }
 
 /**********************
@@ -136,7 +136,7 @@ static void lv_nuttx_uv_timer_cb(uv_timer_t * handle)
         sleep_ms = 1;
     }
 
-    LV_LOG_TRACE("sleep_ms = %" PRIu32, sleep_ms);
+    LV_LOG_TRACE("sleep_ms = %" LV_PRIu32, sleep_ms);
     uv_timer_start(handle, lv_nuttx_uv_timer_cb, sleep_ms, 0);
 }
 
@@ -165,7 +165,7 @@ static void lv_nuttx_uv_timer_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
 {
     lv_timer_handler_set_resume_cb(NULL, NULL);
     uv_close((uv_handle_t *)&uv_ctx->uv_timer, NULL);
-    LV_LOG_INFO("Done");
+    LV_LOG_USER("Done");
 }
 
 static void lv_nuttx_uv_disp_poll_cb(uv_poll_t * handle, int status, int events)
@@ -202,7 +202,7 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_fb_ctx_t * f
     fb_ctx->fd = (uintptr_t)lv_display_get_user_data(disp);
 
     if(fb_ctx->fd <= 0) {
-        LV_LOG_INFO("skip uv fb init.");
+        LV_LOG_USER("skip uv fb init.");
         return 0;
     }
 
@@ -220,7 +220,7 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_fb_ctx_t * f
     uv_poll_init(loop, &fb_ctx->fb_poll, fb_ctx->fd);
     uv_poll_start(&fb_ctx->fb_poll, UV_WRITABLE, lv_nuttx_uv_disp_poll_cb);
 
-    LV_LOG_INFO("lvgl fb loop start OK");
+    LV_LOG_USER("lvgl fb loop start OK");
 
     /* Register for the invalidate area event */
 
@@ -236,7 +236,7 @@ static void lv_nuttx_uv_fb_deinit(lv_nuttx_uv_fb_ctx_t * fb_ctx)
     if(fb_ctx->fd > 0) {
         uv_close((uv_handle_t *)&fb_ctx->fb_poll, NULL);
     }
-    LV_LOG_INFO("Done");
+    LV_LOG_USER("Done");
 }
 
 static void lv_nuttx_uv_input_poll_cb(uv_poll_t * handle, int status, int events)
@@ -259,7 +259,7 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_input_ctx
     lv_indev_t * indev = uv_info->indev;
 
     if(indev == NULL) {
-        LV_LOG_INFO("skip uv input init.");
+        LV_LOG_USER("skip uv input init.");
         return 0;
     }
 
@@ -285,7 +285,7 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_input_ctx
     uv_poll_init(loop, &input_ctx->input_poll, input_ctx->fd);
     uv_poll_start(&input_ctx->input_poll, UV_READABLE, lv_nuttx_uv_input_poll_cb);
 
-    LV_LOG_INFO("lvgl input loop start OK");
+    LV_LOG_USER("lvgl input loop start OK");
 
     return 0;
 }
@@ -295,7 +295,7 @@ static void lv_nuttx_uv_input_deinit(lv_nuttx_uv_input_ctx_t * input_ctx)
     if(input_ctx->fd > 0) {
         uv_close((uv_handle_t *)&input_ctx->input_poll, NULL);
     }
-    LV_LOG_INFO("Done");
+    LV_LOG_USER("Done");
 }
 
 #endif /*LV_USE_NUTTX_LIBUV*/

--- a/src/dev/nuttx/lv_nuttx_touchscreen.c
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.c
@@ -62,14 +62,14 @@ lv_indev_t * lv_nuttx_touchscreen_create(const char * dev_path)
     int fd;
 
     LV_ASSERT_NULL(dev_path);
-    LV_LOG_INFO("touchscreen %s opening", dev_path);
+    LV_LOG_USER("touchscreen %s opening", dev_path);
     fd = open(dev_path, O_RDONLY | O_NONBLOCK);
     if(fd < 0) {
         perror("Error: cannot open touchscreen device");
         return NULL;
     }
 
-    LV_LOG_INFO("touchscreen %s open success", dev_path);
+    LV_LOG_USER("touchscreen %s open success", dev_path);
 
     indev = touchscreen_init(fd);
 
@@ -133,7 +133,7 @@ static void touchscreen_delete_cb(lv_event_t * e)
             touchscreen->fd = -1;
         }
         lv_free(touchscreen);
-        LV_LOG_INFO("done");
+        LV_LOG_USER("done");
     }
 }
 


### PR DESCRIPTION
### Description of the feature or fix

It is convenient to confirm whether the parameters reported by the driver in different products are correct.

cc @bjsylvia 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
