### PR TITLE
chore(image): remove not used frame_id para for decoder

### DIFF
--- a/docs/overview/img.rst
+++ b/docs/overview/img.rst
@@ -335,8 +335,7 @@ manually too. Create an :cpp:type:`lv_image_decoder_dsc_t` variable to describe
 the decoding session and call :cpp:func:`lv_image_decoder_open`.
 
 The ``color`` parameter is used only with ``LV_COLOR_FORMAT_A1/2/4/8``
-images to tell color of the image. ``frame_id`` can be used if the image
-to open is an animation.
+images to tell color of the image.
 
 .. code:: c
 

--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -53,7 +53,6 @@ typedef struct _lv_draw_image_dsc_t {
     lv_opa_t opa;
     lv_blend_mode_t blend_mode : 4;
 
-    int32_t frame_id;
     uint16_t antialias      : 1;
     uint16_t tile           : 1;
     lv_draw_image_sup_t * sup;

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -102,7 +102,6 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     }
 
     dsc->src_type = src_type;
-    if(args) dsc->frame_id = args->frame_id;
 
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         size_t fnlen = lv_strlen(src);

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -59,7 +59,6 @@ struct _lv_cache_entry_t;
  * all field are zero or false.
  */
 typedef struct _lv_image_decoder_args_t {
-    int32_t frame_id;       /*A not use args*/
     bool stride_align;      /*Whether stride should be aligned*/
     bool premultiply;       /*Whether image should be premultiplied or not after decoding*/
     bool no_cache;          /*Whether this image should be kept out of cache*/
@@ -126,9 +125,6 @@ typedef struct _lv_image_decoder_dsc_t {
 
     /**The image source. A file path like "S:my_img.png" or pointer to an `lv_image_dsc_t` variable*/
     const void * src;
-
-    /**Frame of the image, using with animated images*/
-    int32_t frame_id;
 
     /**Type of the source: file or variable. Can be set in `open` function if required*/
     lv_image_src_t src_type;


### PR DESCRIPTION
### Description of the feature or fix

It's introduced in https://github.com/lvgl/lvgl/pull/2197 but never used. Thus remove it unless we have a better use case.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
