### PR TITLE
chore(cmsis-pack): prepare for v8.3.11

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,10 +36,17 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-09-19" version="8.3.10" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.10.pack">
+    <release date="2023-12-05" version="8.3.11" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.8.3.11.pack">
+      - LVGL 8.3.11
+      - Add LittleFS Library to LVGL8
+      - Backport Tiny TTF to LVGL8
+      - Some minor fixes
+    </release>
+    <release date="2023-09-19" version="8.3.10" url="https://github.com/lvgl/lvgl/raw/9e388055ec0bcad5179461e66d6dac6823129eee/env_support/cmsis-pack/LVGL.lvgl.8.3.10.pack">
       - LVGL 8.3.10
       - Some minor fixes
     </release>
+    
     <release date="2023-08-04" version="8.3.9" url="https://github.com/lvgl/lvgl/raw/bdf5bfb88ce107f16cf9128cf75e61394b3219d0/env_support/cmsis-pack/LVGL.lvgl.8.3.9.pack">
       - LVGL 8.3.10
       - Add snapshot, fragment, imgfont, gridnav, msg and monkey
@@ -303,7 +310,7 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.10">
+        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="8.3.11">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
             <component Cgroup="lvgl" Csub="Essential" >
@@ -436,7 +443,7 @@
                 <file category="sourceC"            name="src/widgets/lv_textarea.c" />
 
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.3" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.0.4" />
                 <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
@@ -721,9 +728,26 @@
                 <file category="sourceC"            name="src/extra/libs/fsdrv/lv_fs_fatfs.c" />
                 <file category="sourceC"            name="src/extra/libs/fsdrv/lv_fs_posix.c" />
                 <file category="sourceC"            name="src/extra/libs/fsdrv/lv_fs_stdio.c" />
+                <file category="sourceC"            name="src/extra/libs/fsdrv/lv_fs_littlefs.c" />
               </files>
 
             </component>
+            
+            <component Cgroup="lvgl" Csub="Libs Tiny TTF"  condition="LVGL-Essential">
+              <description>Add Tiny TTF Library</description>
+              <files>
+                <!-- src/extra/libs/tiny_ttf -->
+                <file category="sourceC"            name="src/extra/libs/tiny_ttf/lv_tiny_ttf.c" />
+              </files>
+              
+              <RTE_Components_h>
+
+/*! \brief enable Tiny TTF Library */
+#define LV_USE_TINY_TTF         1
+              </RTE_Components_h>
+              
+            </component>
+
 
             <component Cgroup="lvgl" Csub="Libs RLOTTIE"  condition="LVGL-Essential">
               <description>Add RLOTTIE support, an extra librbary is required.</description>
@@ -735,7 +759,7 @@
               <RTE_Components_h>
 
 /*! \brief enable RLOTTIE support */
-#define LV_USE_RLOTTIE         1
+#define LV_USE_RLOTTIE          1
               </RTE_Components_h>
 
             </component>
@@ -750,7 +774,7 @@
               <RTE_Components_h>
 
 /*! \brief enable ffmpeg support */
-#define LV_USE_FFMPEG         1
+#define LV_USE_FFMPEG           1
               </RTE_Components_h>
 
             </component>
@@ -765,7 +789,7 @@
               <RTE_Components_h>
 
 /*! \brief enable ffmpeg support */
-#define LV_USE_IME_PINYIN         1
+#define LV_USE_IME_PINYIN       1
               </RTE_Components_h>
 
             </component>
@@ -811,7 +835,7 @@
               <RTE_Components_h>
 
 /*! \brief enable the Grid Navigation support*/
-#define LV_USE_GRIDNAV         1
+#define LV_USE_GRIDNAV          1
               </RTE_Components_h>
 
             </component>
@@ -826,7 +850,7 @@
               <RTE_Components_h>
 
 /*! \brief enable the image font support*/
-#define LV_USE_IMGFONT         1
+#define LV_USE_IMGFONT          1
               </RTE_Components_h>
 
             </component>
@@ -841,7 +865,7 @@
               <RTE_Components_h>
 
 /*! \brief enable the monkey service support*/
-#define LV_USE_MONKEY         1
+#define LV_USE_MONKEY           1
               </RTE_Components_h>
 
             </component>
@@ -856,7 +880,7 @@
               <RTE_Components_h>
 
 /*! \brief enable the message service support*/
-#define LV_USE_MSG         1
+#define LV_USE_MSG              1
               </RTE_Components_h>
 
             </component>
@@ -885,7 +909,7 @@
               <RTE_Components_h>
 
 /*! \brief enable demo:bencharmk */
-#define LV_USE_DEMO_BENCHMARK         1
+#define LV_USE_DEMO_BENCHMAR    1
               </RTE_Components_h>
 
             </component>
@@ -905,7 +929,7 @@
               <RTE_Components_h>
 
 /*! \brief enable demo:widgets support */
-#define LV_USE_DEMO_WIDGETS         1
+#define LV_USE_DEMO_WIDGETS     1
               </RTE_Components_h>
 
             </component>

--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -909,7 +909,7 @@
               <RTE_Components_h>
 
 /*! \brief enable demo:bencharmk */
-#define LV_USE_DEMO_BENCHMAR    1
+#define LV_USE_DEMO_BENCHMARK    1
               </RTE_Components_h>
 
             </component>

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2023-09-19</timestamp>
+  <timestamp>2023-12-09</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.10"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/release/v8.3/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.11"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -46,12 +46,33 @@ remove the misleading guide above this code segment.
    - LV_USE_GPU_SWM341_DMA2D
    - LV_USE_GPU_ARM2D
    - LV_USE_IME_PINYIN
+   - LV_USE_PNG
+   - LV_USE_BMP
+   - LV_USE_SJPG
+   - LV_USE_GIF
+   - LV_USE_QRCODE
+   - LV_USE_FREETYPE
+   - LV_USE_TINY_TTF
+   - LV_USE_RLOTTIE
+   - LV_USE_FFMPEG
+   - LV_USE_SNAPSHOT
+   - LV_USE_MONKEY
+   - LV_USE_GRIDNAV
+   - LV_USE_FRAGMENT
+   - LV_USE_IMGFONT
+   - LV_USE_MSG
+   - LV_USE_IME_PINYIN
 5. Update macro `LV_ATTRIBUTE_MEM_ALIGN` and `LV_ATTRIBUTE_MEM_ALIGN_SIZE`  to force a WORD alignment.
 ```c
 #define LV_ATTRIBUTE_MEM_ALIGN_SIZE     4
 #define LV_ATTRIBUTE_MEM_ALIGN          __attribute__((aligned(4)))
 ```
 Update macro `LV_MEM_SIZE` to `(64*1024U)`.
+
+Update macro `LV_FONT_MONTSERRAT_12` to `1`.
+
+Update macro `LV_FONT_MONTSERRAT_12` to `1`.
+
 6. Update Theme related macros:
 
 ```c
@@ -89,25 +110,41 @@ Update macro `LV_MEM_SIZE` to `(64*1024U)`.
     #define LV_TICK_CUSTOM 1
     #if LV_TICK_CUSTOM
         extern uint32_t SystemCoreClock;
-        #define LV_TICK_CUSTOM_INCLUDE             "perf_counter.h"
-
-        #if __PER_COUNTER_VER__ < 10902ul
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR    ((uint32_t)get_system_ticks() / (SystemCoreClock / 1000ul))
-        #else
-            #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
-        #endif
+        #define LV_TICK_CUSTOM_INCLUDE          "perf_counter.h"
+        #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
     #endif   /*LV_TICK_CUSTOM*/
 #else
     #define LV_TICK_CUSTOM 0
     #if LV_TICK_CUSTOM
         #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
         #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+    /*If using lvgl as ESP32 component*/
+    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
+    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
     #endif   /*LV_TICK_CUSTOM*/
 #endif       /*__PERF_COUNTER__*/
 ```
-9. Thoroughly remove the `DEMO USAGE` section.
-10. Thoroughly remove the '3rd party libraries' section.
-10. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
+
+
+9. Remove all content in `DEMO USAGE` section but keep the following:
+
+```c
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#if LV_USE_DEMO_WIDGETS
+	#define LV_DEMO_WIDGETS_SLIDESHOW 0
+#endif
+
+/*Benchmark your system*/
+#if LV_USE_DEMO_BENCHMARK
+/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
+	#define LV_DEMO_BENCHMARK_RGB565A8 1
+#endif
+```
+
+
+
+10. Thoroughly remove the `3rd party libraries` section.
+11. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
 
 
 

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.10
+ * Configuration file for v8.3.11
  */
 
 /* clang-format off */
@@ -76,6 +76,7 @@
 /*Input device read period in milliseconds*/
 #define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
 
+
 /*Use a custom tick source that tells the elapsed time in milliseconds.
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
 #ifdef __PERF_COUNTER__
@@ -90,11 +91,12 @@
     #if LV_TICK_CUSTOM
         #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
         #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-        /*If using lvgl as ESP32 component*/
-        // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-        // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
+    /*If using lvgl as ESP32 component*/
+    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
+    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
     #endif   /*LV_TICK_CUSTOM*/
 #endif       /*__PERF_COUNTER__*/
+
 
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
@@ -178,11 +180,19 @@
  * GPU
  *-----------*/
 
+
 /*Use STM32's DMA2D (aka Chrom Art) GPU*/
 #if LV_USE_GPU_STM32_DMA2D
     /*Must be defined to include path of CMSIS header of target processor
     e.g. "stm32f7xx.h" or "stm32f4xx.h"*/
     #define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
+
+/*Enable RA6M3 G2D GPU*/
+#if LV_USE_GPU_RA6M3_G2D
+    /*include path of target processor
+    e.g. "hal_data.h"*/
+    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
 #endif
 
 /*Use SWM341's DMA2D GPU*/
@@ -200,22 +210,6 @@
     #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
 #endif
 
-#if LV_USE_GPU_RA6M3_G2D
-    /*include path of target processor
-    e.g. "hal_data.h"*/
-    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
-#endif
-
-/*Use SDL renderer API*/
-#define LV_USE_GPU_SDL 0
-#if LV_USE_GPU_SDL
-    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
-    /*Texture cache size, 8MB by default*/
-    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
-    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
-    #define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
-#endif
-
 /*-------------
  * Logging
  *-----------*/
@@ -231,11 +225,11 @@
     *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
     *LV_LOG_LEVEL_USER        Only logs added by the user
     *LV_LOG_LEVEL_NONE        Do not log anything*/
-    #define LV_LOG_LEVEL LV_LOG_LEVEL_USER
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
 
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
-    #define LV_LOG_PRINTF 1
+    #define LV_LOG_PRINTF 0
 
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1
@@ -588,7 +582,6 @@
     #define LV_USE_THEME_BASIC      0
     #define LV_USE_THEME_MONO       0
 #endif
-
 /*-----------
  * Layouts
  *----------*/
@@ -599,27 +592,85 @@
 /*A layout similar to Grid in CSS.*/
 #define LV_USE_GRID 1
 
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+    #define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_POSIX_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+    #define LV_FS_WIN32_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS 0
+#if LV_USE_FS_FATFS
+    #define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for LittleFS (library needs to be added separately). Uses lfs_file_open, lfs_file_read, etc*/
+#define LV_USE_FS_LITTLEFS 0
+#if LV_USE_FS_LITTLEFS
+    #define LV_FS_LITTLEFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_LITTLEFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+
+
+/*FreeType library*/
+#if LV_USE_FREETYPE
+    /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+    #define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+    #if LV_FREETYPE_CACHE_SIZE >= 0
+        /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+        /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+        /* if font size >= 256, must be configured as image cache */
+        #define LV_FREETYPE_SBIT_CACHE 0
+        /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+        /* (0:use system defaults) */
+        #define LV_FREETYPE_CACHE_FT_FACES 0
+        #define LV_FREETYPE_CACHE_FT_SIZES 0
+    #endif
+#endif
+
+/*Tiny TTF library*/
+#if LV_USE_TINY_TTF
+    /*Load TTF data from files*/
+    #define LV_TINY_TTF_FILE_SUPPORT 0
+#endif
+
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#if LV_USE_FFMPEG
+    /*Dump input information to stderr*/
+    #define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
 /*-----------
  * Others
  *----------*/
-
-/*1: Enable API to take snapshot for object*/
-#define LV_USE_SNAPSHOT 0
-
-/*1: Enable Monkey test*/
-#define LV_USE_MONKEY 0
-
-/*1: Enable grid navigation*/
-#define LV_USE_GRIDNAV 0
-
-/*1: Enable lv_obj fragment*/
-#define LV_USE_FRAGMENT 0
-
-/*1: Support using images as font in label or span widgets */
-#define LV_USE_IMGFONT 0
-
-/*1: Enable a published subscriber based messaging system */
-#define LV_USE_MSG 0
 
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/
@@ -645,6 +696,20 @@
 /*Enable the examples to be built with the library*/
 #define LV_BUILD_EXAMPLES 1
 
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#if LV_USE_DEMO_WIDGETS
+    #define LV_DEMO_WIDGETS_SLIDESHOW 0
+#endif
+
+/*Benchmark your system*/
+#if LV_USE_DEMO_BENCHMARK
+/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
+    #define LV_DEMO_BENCHMARK_RGB565A8 1
+#endif
 
 /*--END OF LV_CONF_H--*/
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "lvgl",
-	"version": "8.3.10",
+	"version": "8.3.11",
 	"keywords": "graphics, gui, embedded, tft, lvgl",
 	"description": "Graphics library to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint. It offers anti-aliasing, opacity, and animations using only one frame buffer.",
 	"repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=lvgl
-version=8.3.10
+version=8.3.11
 author=kisvegabor
 maintainer=kisvegabor,embeddedt,pete-pjb
 sentence=Full-featured Graphics Library for Embedded Systems

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.9
+ * Configuration file for v8.3.11
  */
 
 /*

--- a/lvgl.h
+++ b/lvgl.h
@@ -15,7 +15,7 @@ extern "C" {
  ***************************/
 #define LVGL_VERSION_MAJOR 8
 #define LVGL_VERSION_MINOR 3
-#define LVGL_VERSION_PATCH 10
+#define LVGL_VERSION_PATCH 11
 #define LVGL_VERSION_INFO ""
 
 /*********************


### PR DESCRIPTION
### Description of the feature or fix

Prepare for maintenance release v8.3.11

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
