### PR TITLE
fix(table): set row count to zero

### DIFF
--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -218,7 +218,7 @@ void lv_table_set_row_count(lv_obj_t * obj, uint32_t row_cnt)
         uint32_t new_cell_cnt = table->col_cnt * table->row_cnt;
         uint32_t i;
         for(i = new_cell_cnt; i < old_cell_cnt; i++) {
-            if(table->cell_data[i]->user_data) {
+            if(table->cell_data[i] && table->cell_data[i]->user_data) {
                 lv_free(table->cell_data[i]->user_data);
                 table->cell_data[i]->user_data = NULL;
             }

--- a/tests/src/test_cases/widgets/test_table.c
+++ b/tests/src/test_cases/widgets/test_table.c
@@ -17,6 +17,13 @@ void tearDown(void)
     lv_obj_clean(lv_screen_active());
 }
 
+void test_table_should_set_row_count_to_zero(void)
+{
+    lv_table_set_row_count(table, 0);
+
+    TEST_ASSERT_EQUAL_UINT32(0, lv_table_get_row_count(table));
+}
+
 void test_table_should_return_assigned_cell_value(void)
 {
     uint16_t row = 0;


### PR DESCRIPTION
### Description of the feature or fix

Fix bug when setting table row count to zero.

This simple line produced memory violation exception:
`lv_table_set_row_count(table, 0);`

Exception:
```
/home/pg/src/pg_lvgl/src/widgets/table/lv_table.c:221:35: runtime error: member access within null pointer of type 'struct lv_table_cell_t'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==31669==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x558b59e03fbf bp 0x7ffc03c921f0 sp 0x7ffc03c921a0 T0)
==31669==The signal is caused by a READ memory access.
==31669==Hint: address points to the zero page.
    #0 0x558b59e03fbe in lv_table_set_row_count /home/pg/src/pg_lvgl/src/widgets/table/lv_table.c:221
    #1 0x558b59b88216 in test_table_should_set_row_count_to_zero /home/pg/src/pg_lvgl/tests/src/test_cases/widgets/test_table.c:22
    #2 0x558b59b8abec in run_test /home/pg/src/pg_lvgl/tests/build_test_sysheap/test_table_Runner.c:80
    #3 0x558b59b8ad4c in main /home/pg/src/pg_lvgl/tests/build_test_sysheap/test_table_Runner.c:97
    #4 0x7f8f57599082 in __libc_start_main ../csu/libc-start.c:308
    #5 0x558b59b879fd in _start (/home/pg/src/pg_lvgl/tests/build_test_sysheap/test_table+0x9fa9fd)
```

(there was no such a bug in LVGL v8.x)

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
