### PR TITLE
chore: change API name for lv_rb and lv_lru_rb

### DIFF
--- a/src/misc/lv_lru_rb.h
+++ b/src/misc/lv_lru_rb.h
@@ -29,7 +29,7 @@ struct _lv_lru_rb_t;
 typedef struct _lv_lru_rb_t lv_lru_rb_t;
 
 typedef int8_t lv_lru_rb_compare_res_t;
-typedef bool (*lv_lru_rb_alloc_cb_t)(void * node, void * user_data);
+typedef bool (*lv_lru_rb_create_cb_t)(void * node, void * user_data);
 typedef void (*lv_lru_rb_free_cb_t)(void * node, void * user_data);
 typedef lv_lru_rb_compare_res_t (*lv_lru_rb_compare_cb_t)(const void * a, const void * b);
 
@@ -37,17 +37,17 @@ typedef lv_lru_rb_compare_res_t (*lv_lru_rb_compare_cb_t)(const void * a, const 
  * GLOBAL PROTOTYPES
  **********************/
 lv_lru_rb_t * lv_lru_rb_create(size_t node_size, size_t max_size, lv_lru_rb_compare_cb_t compare_cb,
-                               lv_lru_rb_alloc_cb_t alloc_cb, lv_lru_rb_free_cb_t free_cb);
+                               lv_lru_rb_create_cb_t create_cb, lv_lru_rb_free_cb_t free_cb);
 void lv_lru_rb_destroy(lv_lru_rb_t * lru, void * user_data);
-void * lv_lru_rb_get(lv_lru_rb_t * lru, const void * key, void * user_data);
-void lv_lru_rb_reset(lv_lru_rb_t * lru, const void * key, void * user_data);
-void lv_lru_rb_clear(lv_lru_rb_t * lru, void * user_data);
+void * lv_lru_rb_get_or_create(lv_lru_rb_t * lru, const void * key, void * user_data);
+void lv_lru_rb_drop(lv_lru_rb_t * lru, const void * key, void * user_data);
+void lv_lru_rb_drop_all(lv_lru_rb_t * lru, void * user_data);
 void lv_lru_rb_set_max_size(lv_lru_rb_t * lru, size_t max_size, void * user_data);
 size_t lv_lru_rb_get_max_size(lv_lru_rb_t * lru, void * user_data);
 size_t lv_lru_rb_get_size(lv_lru_rb_t * lru, void * user_data);
 size_t lv_lru_rb_get_free_size(lv_lru_rb_t * lru, void * user_data);
 void lv_lru_rb_set_compare_cb(lv_lru_rb_t * lru, lv_lru_rb_compare_cb_t compare_cb, void * user_data);
-void lv_lru_rb_set_alloc_cb(lv_lru_rb_t * lru, lv_lru_rb_alloc_cb_t alloc_cb, void * user_data);
+void lv_lru_rb_set_create_cb(lv_lru_rb_t * lru, lv_lru_rb_create_cb_t create_cb, void * user_data);
 void lv_lru_rb_set_free_cb(lv_lru_rb_t * lru, lv_lru_rb_free_cb_t free_cb, void * user_data);
 /*************************
  *    GLOBAL VARIABLES

--- a/src/misc/lv_rb.c
+++ b/src/misc/lv_rb.c
@@ -126,18 +126,18 @@ lv_rb_node_t * lv_rb_find(lv_rb_t * tree, const void * key)
     return NULL;
 }
 
-bool lv_rb_remove(lv_rb_t * tree, const void * key)
+void * lv_rb_remove(lv_rb_t * tree, const void * key)
 {
     LV_ASSERT_NULL(tree);
     if(tree == NULL) {
-        return false;
+        return NULL;
     }
 
     lv_rb_node_t * node = lv_rb_find(tree, key);
     LV_ASSERT_NULL(node);
     if(node == NULL) {
         LV_LOG_WARN("rb delete %d not found", (int)(uintptr_t)key);
-        return false;
+        return NULL;
     }
 
     lv_rb_node_t * child = NULL;
@@ -185,9 +185,9 @@ bool lv_rb_remove(lv_rb_t * tree, const void * key)
             rb_delete_color(tree, child, parent);
         }
 
-        lv_free(node->data);
+        void * data = node->data;
         lv_free(node);
-        return true;
+        return data;
     }
 
     child = node->right != NULL ? node->right : node->left;
@@ -214,9 +214,24 @@ bool lv_rb_remove(lv_rb_t * tree, const void * key)
         rb_delete_color(tree, child, parent);
     }
 
-    lv_free(node->data);
+    void * data = node->data;
     lv_free(node);
-    return true;
+    return data;
+}
+
+bool lv_rb_drop(lv_rb_t * tree, const void * key)
+{
+    LV_ASSERT_NULL(tree);
+    if(tree == NULL) {
+        return NULL;
+    }
+
+    void * data = lv_rb_remove(tree, key);
+    if(data) {
+        lv_free(data);
+        return true;
+    }
+    return false;
 }
 
 void lv_rb_destroy(lv_rb_t * tree)

--- a/src/misc/lv_rb.h
+++ b/src/misc/lv_rb.h
@@ -55,7 +55,8 @@ typedef struct {
 bool lv_rb_init(lv_rb_t * tree, lv_rb_compare_t compare, size_t node_size);
 lv_rb_node_t * lv_rb_insert(lv_rb_t * tree, void * key);
 lv_rb_node_t * lv_rb_find(lv_rb_t * tree, const void * key);
-bool lv_rb_remove(lv_rb_t * tree, const void * key);
+void * lv_rb_remove(lv_rb_t * tree, const void * key);
+bool lv_rb_drop(lv_rb_t * tree, const void * key);
 lv_rb_node_t * lv_rb_minimum(lv_rb_t * node);
 lv_rb_node_t * lv_rb_maximum(lv_rb_t * node);
 lv_rb_node_t * lv_rb_minimum_from(lv_rb_node_t * node);


### PR DESCRIPTION
### Description of the feature or fix

change API name for lv_rb and lv_lru_rb

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
