### PR TITLE
feat(property): add PRECISE type property value

### DIFF
--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -25,9 +25,10 @@ extern "C" {
 /*All possible property value types*/
 #define LV_PROPERTY_TYPE_INVALID        0   /*Use default 0 as invalid to detect program outliers*/
 #define LV_PROPERTY_TYPE_INT            1   /*int32_t type*/
-#define LV_PROPERTY_TYPE_COLOR          2   /*ARGB8888 type*/
-#define LV_PROPERTY_TYPE_POINTER        3   /*void * pointer*/
-#define LV_PROPERTY_TYPE_IMGSRC         4   /*Special pointer for image*/
+#define LV_PROPERTY_TYPE_PRECISE        2   /*lv_value_precise_t, int32_t or float depending on LV_USE_FLOAT*/
+#define LV_PROPERTY_TYPE_COLOR          3   /*ARGB8888 type*/
+#define LV_PROPERTY_TYPE_POINTER        4   /*void * pointer*/
+#define LV_PROPERTY_TYPE_IMGSRC         5   /*Special pointer for image*/
 
 /**********************
  *      TYPEDEFS
@@ -72,6 +73,7 @@ typedef struct {
         int32_t num;                /**< Number integer number (opacity, enums, booleans or "normal" numbers)*/
         const void * ptr;           /**< Constant pointers  (font, cone text, etc)*/
         lv_color_t color;           /**< Colors*/
+        lv_value_precise_t precise; /**< float or int for precise value*/
         lv_style_value_t _style;    /**< A place holder for style value which is same as property value.*/
     };
 } lv_property_t;


### PR DESCRIPTION
### Description of the feature or fix

As discussed in https://github.com/lvgl/lvgl/pull/4579#pullrequestreview-1678154358
Add precise type for property value.

It's already used by `lv_arc` widget.

```c
void lv_arc_set_start_angle(lv_obj_t * obj, lv_value_precise_t start);
lv_value_precise_t lv_arc_get_angle_start(lv_obj_t * obj);
```
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
