### PR TITLE
refactor(type): move lv_value_precise_t to lv_types.h

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -30,7 +30,25 @@ fout.write(
 #define LV_CONF_INTERNAL_H
 /* clang-format off */
 
-#include "misc/lv_types.h"
+/*Config options*/
+#define LV_OS_NONE          0
+#define LV_OS_PTHREAD       1
+#define LV_OS_FREERTOS      2
+#define LV_OS_CMSIS_RTOS2   3
+#define LV_OS_RTTHREAD      4
+#define LV_OS_WINDOWS       5
+#define LV_OS_CUSTOM        255
+
+#define LV_STDLIB_BUILTIN           0
+#define LV_STDLIB_CLIB              1
+#define LV_STDLIB_MICROPYTHON       2
+#define LV_STDLIB_RTTHREAD          3
+#define LV_STDLIB_CUSTOM            255
+
+#define LV_DRAW_SW_ASM_NONE         0
+#define LV_DRAW_SW_ASM_NEON         1
+#define LV_DRAW_SW_ASM_MVE          2
+#define LV_DRAW_SW_ASM_CUSTOM       255
 
 /* Handle special Kconfig options */
 #ifndef LV_KCONFIG_IGNORE
@@ -155,14 +173,6 @@ LV_EXPORT_CONST_INT(LV_DPI_DEF);
 #endif
 
 #undef _LV_KCONFIG_PRESENT
-
-#ifndef __ASSEMBLY__
-#if LV_USE_FLOAT
-    typedef float lv_value_precise_t;
-#else
-    typedef int32_t lv_value_precise_t;
-#endif
-#endif
 
 /*Set some defines if a dependency is disabled*/
 #if LV_USE_LOG == 0

--- a/src/layouts/lv_layout.h
+++ b/src/layouts/lv_layout.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "../misc/lv_types.h"
 
 /*********************
  *      DEFINES

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -8,7 +8,25 @@
 #define LV_CONF_INTERNAL_H
 /* clang-format off */
 
-#include "misc/lv_types.h"
+/*Config options*/
+#define LV_OS_NONE          0
+#define LV_OS_PTHREAD       1
+#define LV_OS_FREERTOS      2
+#define LV_OS_CMSIS_RTOS2   3
+#define LV_OS_RTTHREAD      4
+#define LV_OS_WINDOWS       5
+#define LV_OS_CUSTOM        255
+
+#define LV_STDLIB_BUILTIN           0
+#define LV_STDLIB_CLIB              1
+#define LV_STDLIB_MICROPYTHON       2
+#define LV_STDLIB_RTTHREAD          3
+#define LV_STDLIB_CUSTOM            255
+
+#define LV_DRAW_SW_ASM_NONE         0
+#define LV_DRAW_SW_ASM_NEON         1
+#define LV_DRAW_SW_ASM_MVE          2
+#define LV_DRAW_SW_ASM_CUSTOM       255
 
 /* Handle special Kconfig options */
 #ifndef LV_KCONFIG_IGNORE
@@ -2943,14 +2961,6 @@ LV_EXPORT_CONST_INT(LV_DPI_DEF);
 #endif
 
 #undef _LV_KCONFIG_PRESENT
-
-#ifndef __ASSEMBLY__
-#if LV_USE_FLOAT
-    typedef float lv_value_precise_t;
-#else
-    typedef int32_t lv_value_precise_t;
-#endif
-#endif
 
 /*Set some defines if a dependency is disabled*/
 #if LV_USE_LOG == 0

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "lv_types.h"
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../lv_conf_internal.h"
 
 #ifndef __ASSEMBLY__
 #include <stdint.h>
@@ -34,25 +35,6 @@ extern "C" {
 #define LV_ARCH_64
 
 #endif
-
-#define LV_OS_NONE          0
-#define LV_OS_PTHREAD       1
-#define LV_OS_FREERTOS      2
-#define LV_OS_CMSIS_RTOS2   3
-#define LV_OS_RTTHREAD      4
-#define LV_OS_WINDOWS       5
-#define LV_OS_CUSTOM        255
-
-#define LV_STDLIB_BUILTIN           0
-#define LV_STDLIB_CLIB              1
-#define LV_STDLIB_MICROPYTHON       2
-#define LV_STDLIB_RTTHREAD          3
-#define LV_STDLIB_CUSTOM            255
-
-#define LV_DRAW_SW_ASM_NONE         0
-#define LV_DRAW_SW_ASM_NEON         1
-#define LV_DRAW_SW_ASM_MVE          2
-#define LV_DRAW_SW_ASM_CUSTOM       255
 
 /**********************
  *      TYPEDEFS
@@ -92,6 +74,12 @@ typedef uint32_t lv_uintptr_t;
 typedef int32_t lv_intptr_t;
 #endif
 
+#endif
+
+#if LV_USE_FLOAT
+typedef float lv_value_precise_t;
+#else
+typedef int32_t lv_value_precise_t;
 #endif
 
 #endif /*__ASSEMBLY__*/


### PR DESCRIPTION


### Description of the feature or fix

`lv_value_precise_t` a lvgl type, thus should be defined in `lv_types.h`.

Make lv_conf_internal.h only responsible for configurations. Remove the include "lv_types.h" from it.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
