### PR TITLE
feat(nuttx): get fd by lv_xxx_get_driver_data

### DIFF
--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -32,13 +32,14 @@
  **********************/
 
 typedef struct {
+    /* fd should be defined at the beginning */
+    int fd;
     struct fb_videoinfo_s vinfo;
     struct fb_planeinfo_s pinfo;
 
     void * mem;
     void * mem2;
     uint32_t mem2_yoffset;
-    int fd;
 } lv_nuttx_fb_t;
 
 /**********************
@@ -132,7 +133,6 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
 
     lv_display_set_draw_buffers(disp, dsc->mem, dsc->mem2,
                                 (dsc->pinfo.stride * dsc->vinfo.yres), LV_DISP_RENDER_MODE_DIRECT);
-    lv_display_set_user_data(disp, (void *)(uintptr_t)(dsc->fd));
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
 

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -34,6 +34,7 @@
  **********************/
 
 typedef struct {
+    /* fd should be defined at the beginning */
     int fd;
     lv_display_t * disp;
     struct lcddev_area_s area;
@@ -201,7 +202,6 @@ static lv_display_t * lcd_init(int fd, int hor_res, int ver_res)
     lv_display_add_event_cb(lcd->disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, lcd);
     lv_display_add_event_cb(lcd->disp, display_release_cb, LV_EVENT_DELETE, lcd->disp);
     lv_display_set_driver_data(lcd->disp, lcd);
-    lv_display_set_user_data(lcd->disp, (void *)(uintptr_t)fd);
 
     return lcd->disp;
 }

--- a/src/dev/nuttx/lv_nuttx_libuv.c
+++ b/src/dev/nuttx/lv_nuttx_libuv.c
@@ -199,7 +199,7 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_fb_ctx_t * f
     LV_ASSERT_NULL(disp);
     LV_ASSERT_NULL(loop);
 
-    fb_ctx->fd = (uintptr_t)lv_display_get_user_data(disp);
+    fb_ctx->fd = *(int *)lv_display_get_driver_data(disp);
 
     if(fb_ctx->fd <= 0) {
         LV_LOG_USER("skip uv fb init.");
@@ -271,7 +271,7 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_input_ctx
         return -EINVAL;
     }
 
-    input_ctx->fd = (uintptr_t)lv_indev_get_user_data(indev);
+    input_ctx->fd = *(int *)lv_indev_get_driver_data(indev);
     if(input_ctx->fd <= 0) {
         return 0;
     }

--- a/src/dev/nuttx/lv_nuttx_touchscreen.c
+++ b/src/dev/nuttx/lv_nuttx_touchscreen.c
@@ -32,6 +32,7 @@
  **********************/
 
 typedef struct {
+    /* fd should be defined at the beginning */
     int fd;
     lv_indev_state_t last_state;
     lv_indev_t * indev_drv;
@@ -155,7 +156,6 @@ static lv_indev_t * touchscreen_init(int fd)
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
     lv_indev_set_read_cb(indev, touchscreen_read);
     lv_indev_set_driver_data(indev, touchscreen);
-    lv_indev_set_user_data(indev, (void *)(uintptr_t)fd);
     lv_indev_add_event_cb(indev, touchscreen_delete_cb, LV_EVENT_DELETE, indev);
     return indev;
 }


### PR DESCRIPTION
keep the user_data for the user to use.

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
