### PR TITLE
chore(test): only do rotation test when image loaded to RAM

### DIFF
--- a/tests/src/test_cases/draw/test_image_formats.c
+++ b/tests/src/test_cases/draw/test_image_formats.c
@@ -69,6 +69,7 @@ void test_image_built_in_decode(void)
 
 void test_image_built_in_decode_rotate(void)
 {
+#if LV_BIN_DECODER_RAM_LOAD
     LV_IMAGE_DECLARE(test_image_cogwheel_i4);
     LV_IMAGE_DECLARE(test_image_cogwheel_a8);
     LV_IMAGE_DECLARE(test_image_cogwheel_rgb565);
@@ -95,6 +96,7 @@ void test_image_built_in_decode_rotate(void)
     img_create("binARGB8888", "A:src/test_files/binimages/cogwheel.ARGB8888.bin", true, false);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("draw/image_format_rotated.png");
+#endif
 }
 
 void test_image_built_in_decode_recolor(void)
@@ -129,6 +131,7 @@ void test_image_built_in_decode_recolor(void)
 
 void test_image_built_in_decode_rotate_and_recolor(void)
 {
+#if LV_BIN_DECODER_RAM_LOAD
     LV_IMAGE_DECLARE(test_image_cogwheel_i4);
     LV_IMAGE_DECLARE(test_image_cogwheel_a8);
     LV_IMAGE_DECLARE(test_image_cogwheel_rgb565);
@@ -155,11 +158,12 @@ void test_image_built_in_decode_rotate_and_recolor(void)
     img_create("binARGB8888", "A:src/test_files/binimages/cogwheel.ARGB8888.bin", true, true);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("draw/image_format_rotate_and_recolor.png");
+#endif
 }
 
 void test_image_rle_compressed_decode(void)
 {
-#if LV_USE_RLE
+#if LV_USE_RLE && LV_BIN_DECODER_RAM_LOAD
     img_create("rleA1", "A:src/test_files/rle_compressed/cogwheel.A1.bin", false, false);
     img_create("rleA2", "A:src/test_files/rle_compressed/cogwheel.A2.bin", false, false);
     img_create("rleA4", "A:src/test_files/rle_compressed/cogwheel.A4.bin", false, false);
@@ -180,7 +184,7 @@ void test_image_rle_compressed_decode(void)
 
 void test_image_rle_compressed_decode_rotate(void)
 {
-#if LV_USE_RLE
+#if LV_USE_RLE && LV_BIN_DECODER_RAM_LOAD
     img_create("rleA1", "A:src/test_files/rle_compressed/cogwheel.A1.bin", true, false);
     img_create("rleA2", "A:src/test_files/rle_compressed/cogwheel.A2.bin", true, false);
     img_create("rleA4", "A:src/test_files/rle_compressed/cogwheel.A4.bin", true, false);
@@ -201,7 +205,7 @@ void test_image_rle_compressed_decode_rotate(void)
 
 void test_image_rle_compressed_decode_rotate_recolor(void)
 {
-#if LV_USE_RLE
+#if LV_USE_RLE && LV_BIN_DECODER_RAM_LOAD
     img_create("rleA1", "A:src/test_files/rle_compressed/cogwheel.A1.bin", true, true);
     img_create("rleA2", "A:src/test_files/rle_compressed/cogwheel.A2.bin", true, true);
     img_create("rleA4", "A:src/test_files/rle_compressed/cogwheel.A4.bin", true, true);
@@ -222,7 +226,7 @@ void test_image_rle_compressed_decode_rotate_recolor(void)
 
 void test_image_lz4_compressed_decode(void)
 {
-#if LV_USE_LZ4
+#if LV_USE_LZ4 && LV_BIN_DECODER_RAM_LOAD
     img_create("lz4A1", "A:src/test_files/lz4_compressed/cogwheel.A1.bin", false, false);
     img_create("lz4A2", "A:src/test_files/lz4_compressed/cogwheel.A2.bin", false, false);
     img_create("lz4A4", "A:src/test_files/lz4_compressed/cogwheel.A4.bin", false, false);
@@ -243,7 +247,7 @@ void test_image_lz4_compressed_decode(void)
 
 void test_image_lz4_compressed_decode_rotate(void)
 {
-#if LV_USE_LZ4
+#if LV_USE_LZ4 && LV_BIN_DECODER_RAM_LOAD
     img_create("lz4A1", "A:src/test_files/lz4_compressed/cogwheel.A1.bin", true, false);
     img_create("lz4A2", "A:src/test_files/lz4_compressed/cogwheel.A2.bin", true, false);
     img_create("lz4A4", "A:src/test_files/lz4_compressed/cogwheel.A4.bin", true, false);
@@ -264,7 +268,7 @@ void test_image_lz4_compressed_decode_rotate(void)
 
 void test_image_lz4_compressed_decode_rotate_recolor(void)
 {
-#if LV_USE_LZ4
+#if LV_USE_LZ4 && LV_BIN_DECODER_RAM_LOAD
     img_create("lz4A1", "A:src/test_files/lz4_compressed/cogwheel.A1.bin", true, true);
     img_create("lz4A2", "A:src/test_files/lz4_compressed/cogwheel.A2.bin", true, true);
     img_create("lz4A4", "A:src/test_files/lz4_compressed/cogwheel.A4.bin", true, true);


### PR DESCRIPTION
### Description of the feature or fix

This is required for CI to use `LV_BIN_DECODER_RAM_LOAD=0`

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
