### PR TITLE
chore(demo): Switch scale animation objects

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -857,7 +857,7 @@ static void analytics_create(lv_obj_t * parent)
     lv_anim_set_values(&a, 10, 60);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_set_exec_cb(&a, scale3_anim_cb);
-    lv_anim_set_var(&a, needle);
+    lv_anim_set_var(&a, scale3);
     lv_anim_set_time(&a, 4100);
     lv_anim_set_playback_time(&a, 800);
     lv_anim_start(&a);
@@ -1615,12 +1615,10 @@ static void scale2_timer_cb(lv_timer_t * timer)
 
 static void scale3_anim_cb(void * var, int32_t v)
 {
-    LV_UNUSED(var);
+    lv_obj_t * needle = lv_obj_get_child(var, 0);
+    lv_scale_set_image_needle_value(var, needle, v);
 
-    lv_obj_t * needle = lv_obj_get_child(scale3, 0);
-    lv_scale_set_image_needle_value(scale3, needle, v);
-
-    lv_obj_t * label = lv_obj_get_child(scale3, 1);
+    lv_obj_t * label = lv_obj_get_child(var, 1);
     lv_label_set_text_fmt(label, "%"LV_PRId32, v);
 }
 

--- a/examples/widgets/scale/lv_example_scale_3.c
+++ b/examples/widgets/scale/lv_example_scale_3.c
@@ -29,7 +29,7 @@ void lv_example_scale_3(void)
     lv_obj_set_style_bg_color(scale_line, lv_palette_lighten(LV_PALETTE_RED, 5), 0);
     lv_obj_set_style_radius(scale_line, LV_RADIUS_CIRCLE, 0);
     lv_obj_set_style_clip_corner(scale_line, true, 0);
-    lv_obj_align(scale_line, LV_ALIGN_LEFT_MID, LV_PCT(5), 0);
+    lv_obj_align(scale_line, LV_ALIGN_LEFT_MID, LV_PCT(2), 0);
 
     lv_scale_set_label_show(scale_line, true);
 
@@ -65,7 +65,7 @@ void lv_example_scale_3(void)
     lv_obj_set_style_bg_color(scale_img, lv_palette_lighten(LV_PALETTE_RED, 5), 0);
     lv_obj_set_style_radius(scale_img, LV_RADIUS_CIRCLE, 0);
     lv_obj_set_style_clip_corner(scale_img, true, 0);
-    lv_obj_align(scale_img, LV_ALIGN_RIGHT_MID, LV_PCT(-5), 0);
+    lv_obj_align(scale_img, LV_ALIGN_RIGHT_MID, LV_PCT(-2), 0);
 
     lv_scale_set_label_show(scale_img, true);
 


### PR DESCRIPTION
### Description of the feature or fix

chore(demo): Switch scale animation objects

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
