### PR TITLE
fix(qrcode): Fix QR code picking a version too big for width

### DIFF
--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -118,13 +118,15 @@ lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_le
     if(qr_size <= 0) return LV_RESULT_INVALID;
     int32_t scale = img_dsc->header.w / qr_size;
     if(scale <= 0) return LV_RESULT_INVALID;
-    int32_t remain = img_dsc->header.w % qr_size;
 
-    /* The qr version is incremented by four point */
-    uint32_t version_extend = remain / (scale << 2);
-    if(version_extend && qr_version < qrcodegen_VERSION_MAX) {
-        qr_version = qr_version + version_extend > qrcodegen_VERSION_MAX ?
-                     qrcodegen_VERSION_MAX : qr_version + version_extend;
+    // Pick the largest QR code that still maintains scale.
+    for(int32_t i = qr_version + 1; i < qrcodegen_VERSION_MAX; i++) {
+        if(qrcodegen_version2size(i) * scale <= img_dsc->header.w) {
+            qr_version = i;
+        }
+        else {
+            break;
+        }
     }
 
     uint8_t * qr0 = lv_malloc(qrcodegen_BUFFER_LEN_FOR_VERSION(qr_version));

--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -119,15 +119,14 @@ lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_le
     int32_t scale = img_dsc->header.w / qr_size;
     if(scale <= 0) return LV_RESULT_INVALID;
 
-    // Pick the largest QR code that still maintains scale.
+    /* Pick the largest QR code that still maintains scale. */
     for(int32_t i = qr_version + 1; i < qrcodegen_VERSION_MAX; i++) {
-        if(qrcodegen_version2size(i) * scale <= img_dsc->header.w) {
-            qr_version = i;
-        }
-        else {
+        if(qrcodegen_version2size(i) * scale > img_dsc->header.w)
             break;
-        }
+
+        qr_version = i;
     }
+    qr_size = qrcodegen_version2size(qr_version);
 
     uint8_t * qr0 = lv_malloc(qrcodegen_BUFFER_LEN_FOR_VERSION(qr_version));
     LV_ASSERT_MALLOC(qr0);


### PR DESCRIPTION
### Description of the feature or fix

The current `lv_qrcode` arbitrarily increases the QR code version based on the formula `uint32_t version_extend = remain / (scale << 2);`.  This is not robust and often will bump the QR code version to one that no longer fits the screen width.

Instead find the largest QR code version that still maintains the scale of the smallest QR code version that can fit all the data.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
