### PR TITLE
fix(snapshot): set data_size on returned dsc

### DIFF
--- a/docs/others/snapshot.rst
+++ b/docs/others/snapshot.rst
@@ -47,7 +47,7 @@ Use Existing Buffer
 ~~~~~~~~~~~~~~~~~~~
 
 If the snapshot needs update now and then, or simply caller provides memory, use API
-``lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_image_dsc_t * dsc, void * buf, uint32_t buff_size);``
+``lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_image_dsc_t * dsc, void * buf, uint32_t buf_size);``
 for this case. It's caller's responsibility to alloc/free the memory.
 
 If snapshot is generated successfully, the image descriptor is updated

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -77,11 +77,11 @@ uint32_t lv_snapshot_buf_size_needed(lv_obj_t * obj, lv_color_format_t cf)
  * @param cf        color format for generated image.
  * @param dsc       image descriptor to store the image result.
  * @param buf       the buffer to store image data.
- * @param buff_size provided buffer size in bytes.
+ * @param buf_size  provided buffer size in bytes.
  * @return          LV_RESULT_OK on success, LV_RESULT_INVALID on error.
  */
 lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_image_dsc_t * dsc, void * buf,
-                                    uint32_t buff_size)
+                                    uint32_t buf_size)
 {
     LV_ASSERT_NULL(obj);
     LV_ASSERT_NULL(dsc);
@@ -98,7 +98,8 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
             return LV_RESULT_INVALID;
     }
 
-    if(lv_snapshot_buf_size_needed(obj, cf) > buff_size || buff_size == 0) return LV_RESULT_INVALID;
+    uint32_t buf_size_needed = lv_snapshot_buf_size_needed(obj, cf);
+    if(buf_size_needed == 0 || buf_size < buf_size_needed) return LV_RESULT_INVALID;
 
     LV_ASSERT_MSG(buf == lv_draw_buf_align(buf, cf), "Buffer is not aligned");
 
@@ -113,9 +114,10 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
     lv_obj_get_coords(obj, &snapshot_area);
     lv_area_increase(&snapshot_area, ext_size, ext_size);
 
-    lv_memzero(buf, buff_size);
+    lv_memzero(buf, buf_size);
     lv_memzero(dsc, sizeof(lv_image_dsc_t));
     dsc->data = buf;
+    dsc->data_size = buf_size_needed;
     dsc->header.w = w;
     dsc->header.h = h;
     dsc->header.cf = cf;
@@ -159,10 +161,10 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
 lv_image_dsc_t * lv_snapshot_take(lv_obj_t * obj, lv_color_format_t cf)
 {
     LV_ASSERT_NULL(obj);
-    uint32_t buff_size = lv_snapshot_buf_size_needed(obj, cf);
-    if(buff_size == 0) return NULL;
+    uint32_t buf_size = lv_snapshot_buf_size_needed(obj, cf);
+    if(buf_size == 0) return NULL;
 
-    void * buf = lv_draw_buf_malloc(buff_size, cf);
+    void * buf = lv_draw_buf_malloc(buf_size, cf);
     LV_ASSERT_MALLOC(buf);
     if(buf == NULL) {
         return NULL;
@@ -175,7 +177,7 @@ lv_image_dsc_t * lv_snapshot_take(lv_obj_t * obj, lv_color_format_t cf)
         return NULL;
     }
 
-    if(lv_snapshot_take_to_buf(obj, cf, dsc, buf, buff_size) != LV_RESULT_OK) {
+    if(lv_snapshot_take_to_buf(obj, cf, dsc, buf, buf_size) != LV_RESULT_OK) {
         lv_draw_buf_free(buf);
         lv_free(dsc);
         return NULL;

--- a/src/others/snapshot/lv_snapshot.h
+++ b/src/others/snapshot/lv_snapshot.h
@@ -60,11 +60,11 @@ uint32_t lv_snapshot_buf_size_needed(lv_obj_t * obj, lv_color_format_t cf);
  * @param cf        color format for generated image.
  * @param dsc       image descriptor to store the image result.
  * @param buf       the buffer to store image data.
- * @param buff_size provided buffer size in bytes.
+ * @param buf_size  provided buffer size in bytes.
  * @return          LV_RESULT_OK on success, LV_RESULT_INVALID on error.
  */
 lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_image_dsc_t * dsc, void * buf,
-                                    uint32_t buff_size);
+                                    uint32_t buf_size);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Before, `data_size` would always be 0.

    lv_img_dsc_t * snapshot = lv_snapshot_take(screen, LV_COLOR_FORMAT_RGB888);
    LV_ASSERT(snapshot->data_size > 0); // fail

Also align naming of parameter name and variables (`buf` instead of `buff`, as in function names).