### PR TITLE
feat(profiler): add some profiler points and default header for perfetto ui

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -292,6 +292,7 @@ void lv_obj_update_layout(const lv_obj_t * obj)
         LV_LOG_TRACE("Already running, returning");
         return;
     }
+    LV_PROFILER_BEGIN;
     update_layout_mutex = true;
 
     lv_obj_t * scr = lv_obj_get_screen(obj);
@@ -304,6 +305,7 @@ void lv_obj_update_layout(const lv_obj_t * obj)
     }
 
     update_layout_mutex = false;
+    LV_PROFILER_END;
 }
 
 void lv_obj_set_align(lv_obj_t * obj, lv_align_t align)

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -435,6 +435,7 @@ refr_finish:
  */
 static void lv_refr_join_area(void)
 {
+    LV_PROFILER_BEGIN;
     uint32_t join_from;
     uint32_t join_in;
     lv_area_t joined_area;
@@ -465,6 +466,7 @@ static void lv_refr_join_area(void)
             }
         }
     }
+    LV_PROFILER_END;
 }
 
 /**
@@ -481,6 +483,7 @@ static void refr_sync_areas(void)
     /*Do not sync if no sync areas*/
     if(_lv_ll_is_empty(&disp_refr->sync_areas)) return;
 
+    LV_PROFILER_BEGIN;
     /*With double buffered direct mode synchronize the rendered areas to the other buffer*/
     /*We need to wait for ready here to not mess up the active screen*/
     wait_for_flushing(disp_refr);
@@ -542,6 +545,7 @@ static void refr_sync_areas(void)
 
     /*Clear sync areas*/
     _lv_ll_clear(&disp_refr->sync_areas);
+    LV_PROFILER_END;
 }
 
 /**
@@ -589,6 +593,7 @@ static void refr_invalid_areas(void)
  */
 static void refr_area(const lv_area_t * area_p)
 {
+    LV_PROFILER_BEGIN;
     lv_layer_t * layer = disp_refr->layer_head;
     layer->buf = disp_refr->buf_act;
 
@@ -614,6 +619,7 @@ static void refr_area(const lv_area_t * area_p)
             layer->_clip_area = *area_p;
             refr_area_part(layer);
         }
+        LV_PROFILER_END;
         return;
     }
 
@@ -658,10 +664,12 @@ static void refr_area(const lv_area_t * area_p)
         disp_refr->last_part = 1;
         refr_area_part(layer);
     }
+    LV_PROFILER_END;
 }
 
 static void refr_area_part(lv_layer_t * layer)
 {
+    LV_PROFILER_BEGIN;
     disp_refr->refreshed_area = layer->_clip_area;
 
     /* In single buffered mode wait here until the buffer is freed.
@@ -716,6 +724,7 @@ static void refr_area_part(lv_layer_t * layer)
     refr_obj_and_children(layer, lv_display_get_layer_sys(disp_refr));
 
     draw_buf_flush(disp_refr);
+    LV_PROFILER_END;
 }
 
 /**
@@ -772,6 +781,7 @@ static void refr_obj_and_children(lv_layer_t * layer, lv_obj_t * top_obj)
     if(top_obj == NULL) top_obj = lv_display_get_screen_active(disp_refr);
     if(top_obj == NULL) return;  /*Shouldn't happen*/
 
+    LV_PROFILER_BEGIN;
     /*Refresh the top object and its children*/
     refr_obj(layer, top_obj);
 
@@ -808,6 +818,7 @@ static void refr_obj_and_children(lv_layer_t * layer, lv_obj_t * top_obj)
         /*Go a level deeper*/
         parent = lv_obj_get_parent(parent);
     }
+    LV_PROFILER_END;
 }
 
 static lv_result_t layer_get_area(lv_layer_t * layer, lv_obj_t * obj, lv_layer_type_t layer_type,

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -107,6 +107,7 @@ lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords)
 
 void lv_draw_finalize_task_creation(lv_layer_t * layer, lv_draw_task_t * t)
 {
+    LV_PROFILER_BEGIN;
     lv_draw_dsc_base_t * base_dsc = t->draw_dsc;
     base_dsc->layer = layer;
 
@@ -145,6 +146,7 @@ void lv_draw_finalize_task_creation(lv_layer_t * layer, lv_draw_task_t * t)
             u = u->next;
         }
     }
+    LV_PROFILER_END;
 }
 
 void lv_draw_dispatch(void)
@@ -169,6 +171,7 @@ void lv_draw_dispatch(void)
 
 bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
 {
+    LV_PROFILER_BEGIN;
     /*Remove the finished tasks first*/
     lv_draw_task_t * t_prev = NULL;
     lv_draw_task_t * t = layer->draw_task_head;
@@ -255,6 +258,7 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
         }
     }
 
+    LV_PROFILER_END;
     return render_running;
 }
 

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -76,6 +76,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_layer_t * layer, const lv_draw_label
         return;
     }
 
+    LV_PROFILER_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
@@ -89,6 +90,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_label(lv_layer_t * layer, const lv_draw_label
     }
 
     lv_draw_finalize_task_creation(layer, t);
+    LV_PROFILER_END;
 }
 
 LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(lv_layer_t * layer, lv_draw_label_dsc_t * dsc,
@@ -101,6 +103,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(lv_layer_t * layer, lv_draw_label_dsc_
     }
 
     if(_lv_text_is_marker(unicode_letter)) return;
+
+    LV_PROFILER_BEGIN;
 
     lv_font_glyph_dsc_t g;
     lv_font_get_glyph_dsc(dsc->font, &g, unicode_letter, 0);
@@ -126,6 +130,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_letter(lv_layer_t * layer, lv_draw_label_dsc_
     dsc->text_local = 1;
 
     lv_draw_label(layer, dsc, &a);
+    LV_PROFILER_END;
 }
 
 void lv_draw_label_iterate_letters(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -45,6 +45,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
     lv_area_t blend_area;
     if(!_lv_area_intersect(&blend_area, blend_dsc->blend_area, draw_unit->clip_area)) return;
 
+    LV_PROFILER_BEGIN;
     lv_layer_t * layer = draw_unit->target_layer;
     uint32_t layer_stride_byte = lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), layer->color_format);
 
@@ -87,7 +88,10 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         }
     }
     else {
-        if(!_lv_area_intersect(&blend_area, &blend_area, blend_dsc->src_area)) return;
+        if(!_lv_area_intersect(&blend_area, &blend_area, blend_dsc->src_area)) {
+            LV_PROFILER_END;
+            return;
+        }
 
         _lv_draw_sw_blend_image_dsc_t image_dsc;
         image_dsc.dest_w = lv_area_get_width(&blend_area);
@@ -137,6 +141,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
                 break;
         }
     }
+    LV_PROFILER_END;
 }
 
 /**********************

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -214,17 +214,27 @@ static int32_t evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 
 static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 {
+    LV_PROFILER_BEGIN;
     lv_draw_sw_unit_t * draw_sw_unit = (lv_draw_sw_unit_t *) draw_unit;
 
     /*Return immediately if it's busy with draw task*/
-    if(draw_sw_unit->task_act) return 0;
+    if(draw_sw_unit->task_act) {
+        LV_PROFILER_END;
+        return 0;
+    }
 
     lv_draw_task_t * t = NULL;
     t = lv_draw_get_next_available_task(layer, NULL, DRAW_UNIT_ID_SW);
-    if(t == NULL) return -1;
+    if(t == NULL) {
+        LV_PROFILER_END;
+        return -1;
+    }
 
     void * buf = lv_draw_layer_alloc_buf(layer);
-    if(buf == NULL) return -1;
+    if(buf == NULL) {
+        LV_PROFILER_END;
+        return -1;
+    }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_sw_unit->base_unit.target_layer = layer;
@@ -237,6 +247,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 #else
     execute_drawing_unit(draw_sw_unit);
 #endif
+    LV_PROFILER_END;
     return 1;
 }
 
@@ -272,6 +283,7 @@ static void render_thread_cb(void * ptr)
 
 static void execute_drawing(lv_draw_sw_unit_t * u)
 {
+    LV_PROFILER_BEGIN;
     /*Render the draw task*/
     lv_draw_task_t * t = u->task_act;
     switch(t->type) {
@@ -360,7 +372,7 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         lv_draw_sw_label((lv_draw_unit_t *)u, &label_dsc, &txt_area);
     }
 #endif
-
+    LV_PROFILER_END;
 }
 
 static void rotate90_argb8888(const uint32_t * src, uint32_t * dst, int32_t srcWidth, int32_t srcHeight,

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -53,7 +53,9 @@ void lv_draw_sw_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * ds
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
+    LV_PROFILER_BEGIN;
     lv_draw_label_iterate_letters(draw_unit, dsc, coords, draw_letter_cb);
+    LV_PROFILER_END;
 }
 
 /**********************
@@ -106,7 +108,6 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
     if(fill_draw_dsc && fill_area) {
         lv_draw_sw_fill(draw_unit, fill_draw_dsc, fill_area);
     }
-
 }
 
 #endif /*LV_USE_DRAW_SW*/

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -66,6 +66,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_
     is_common = _lv_area_intersect(&clip_line, &clip_line, draw_unit->clip_area);
     if(!is_common) return;
 
+    LV_PROFILER_BEGIN;
     if(dsc->p1.y == dsc->p2.y) draw_line_hor(draw_unit, dsc);
     else if(dsc->p1.x == dsc->p2.x) draw_line_ver(draw_unit, dsc);
     else draw_line_skew(draw_unit, dsc);
@@ -97,6 +98,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_
             lv_draw_sw_fill(draw_unit, &cir_dsc, &cir_area);
         }
     }
+    LV_PROFILER_END;
 }
 
 /**********************
@@ -250,7 +252,6 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_ver(lv_draw_unit_t * draw_unit, cons
 
 LV_ATTRIBUTE_FAST_MEM static void draw_line_skew(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
 {
-
 #if LV_DRAW_SW_COMPLEX
     /*Keep the great y in p1*/
     lv_point_t p1;

--- a/src/misc/lv_profiler_builtin.c
+++ b/src/misc/lv_profiler_builtin.c
@@ -87,6 +87,12 @@ void lv_profiler_builtin_init(const lv_profiler_builtin_config_t * config)
     profiler_ctx.item_num = num;
     profiler_ctx.config = *config;
 
+    if(profiler_ctx.config.flush_cb) {
+        /* add profiler header for perfetto */
+        profiler_ctx.config.flush_cb("# tracer: nop\n");
+        profiler_ctx.config.flush_cb("#\n");
+    }
+
     LV_LOG_INFO("init OK, item_num = %d", (int)num);
 }
 
@@ -113,7 +119,7 @@ void lv_profiler_builtin_flush(void)
         uint32_t sec = item->tick / tick_per_sec;
         uint32_t usec = (item->tick % tick_per_sec) * (LV_PROFILER_TICK_PER_SEC_MAX / tick_per_sec);
         lv_snprintf(buf, sizeof(buf),
-                    "LVGL-1 [0] %" LV_PRIu32 ".%06" LV_PRIu32 ": tracing_mark_write: %c|1|%s\n",
+                    "   LVGL-1 [0] %" LV_PRIu32 ".%06" LV_PRIu32 ": tracing_mark_write: %c|1|%s\n",
                     sec,
                     usec,
                     item->tag,


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
