### PR TITLE
feat(png): use draw_buf for decoded image

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -154,6 +154,7 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
 
         dsc->error_msg = NULL;
         dsc->img_data  = NULL;
+        dsc->decoded  = NULL;
         dsc->cache_entry = NULL;
         dsc->user_data = NULL;
         dsc->time_to_open = 0;

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -16,7 +16,7 @@ extern "C" {
 #include "../lv_conf_internal.h"
 
 #include <stdint.h>
-#include "lv_image_buf.h"
+#include "lv_draw_buf.h"
 #include "../misc/lv_fs.h"
 #include "../misc/lv_types.h"
 #include "../misc/lv_area.h"
@@ -136,6 +136,8 @@ typedef struct _lv_image_decoder_dsc_t {
      *  MUST be set in `open` function*/
     const uint8_t * img_data;
 
+    const lv_draw_buf_t * decoded;    /*A draw buffer to described decoded image.*/
+
     const lv_color32_t * palette;
     uint32_t palette_size;
 
@@ -157,6 +159,14 @@ typedef struct _lv_image_decoder_dsc_t {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+/**
+ * @todo remove it when all decoder migrates to new draw buf interface.
+ */
+static inline const void * _lv_image_decoder_get_data(const lv_image_decoder_dsc_t * dsc)
+{
+    return dsc->decoded ? dsc->decoded->data : dsc->img_data;
+}
 
 /**
  * Initialize the image decoder module

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -131,7 +131,7 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
         int32_t ofs = decoder_dsc.header.w / 2;
         lv_area_move(&img_area, dsc->center.x - ofs, dsc->center.y - ofs);
         blend_dsc.src_area = &img_area;
-        blend_dsc.src_buf = decoder_dsc.img_data;
+        blend_dsc.src_buf = _lv_image_decoder_get_data(&decoder_dsc);
         blend_dsc.src_color_format = decoder_dsc.header.cf;
         blend_dsc.src_stride = decoder_dsc.header.stride;
     }

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -253,7 +253,7 @@ static void img_decode_and_draw(lv_draw_unit_t * draw_unit, const lv_draw_image_
     sup.palette_size = decoder_dsc->palette_size;
 
     /*The whole image is available, just draw it*/
-    if(decoder_dsc->img_data) {
+    if(decoder_dsc->decoded || decoder_dsc->img_data) {
         img_draw_core(draw_unit, draw_dsc, decoder_dsc, &sup, img_area, clipped_img_area);
     }
     /*Draw in smaller pieces*/
@@ -298,7 +298,13 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
     uint32_t img_stride = header->stride;
     lv_color_format_t cf = header->cf;
 
-    cf = LV_COLOR_FORMAT_IS_INDEXED(cf) ? LV_COLOR_FORMAT_ARGB8888 : cf,
+    cf = LV_COLOR_FORMAT_IS_INDEXED(cf) ? LV_COLOR_FORMAT_ARGB8888 : cf;
+
+    if(decoder_dsc->decoded) {
+        src_buf = decoder_dsc->decoded->data;
+        img_stride = decoder_dsc->decoded->header.stride;
+        cf = decoder_dsc->decoded->header.cf;
+    }
 
     lv_memzero(&blend_dsc, sizeof(lv_draw_sw_blend_dsc_t));
     blend_dsc.opa = draw_dsc->opa;

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -297,13 +297,13 @@ static void _set_paint_fill_pattern(Tvg_Paint * obj, Tvg_Canvas * canvas, const 
         return;
     }
 
-    if(!decoder_dsc.img_data) {
+    if(!decoder_dsc.decoded && !decoder_dsc.img_data) {
         lv_image_decoder_close(&decoder_dsc);
         LV_LOG_ERROR("Image not ready");
         return;
     }
 
-    const uint8_t * src_buf = decoder_dsc.img_data;
+    const uint8_t * src_buf = _lv_image_decoder_get_data(&decoder_dsc);
     const lv_image_header_t * header = &decoder_dsc.header;
     lv_color_format_t cf = header->cf;
 

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -36,7 +36,7 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, 
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
                                 const lv_image_decoder_args_t * args);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
-static const void * decode_jpeg_file(const char * filename, size_t * size);
+static lv_draw_buf_t * decode_jpeg_file(const char * filename);
 static bool get_jpeg_size(const char * filename, uint32_t * width, uint32_t * height);
 static void error_exit(j_common_ptr cinfo);
 static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc);
@@ -161,11 +161,15 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         const char * fn = dsc->src;
         size_t decoded_size = 0;
         uint32_t t = lv_tick_get();
-        const void * decoded_img = decode_jpeg_file(fn, &decoded_size);
+        lv_draw_buf_t * decoded = decode_jpeg_file(fn);
+        if(decoded == NULL){
+            LV_LOG_WARN("decode jpeg file failed");
+            return LV_RESULT_INVALID;
+        }
         t = lv_tick_elaps(t);
 
         lv_cache_lock();
-        lv_cache_entry_t * cache = lv_cache_add(decoded_img, decoded_size, decoder->cache_data_type,
+        lv_cache_entry_t * cache = lv_cache_add(decoded, decoded_size, decoder->cache_data_type,
                                                 decoded_size);
         if(cache == NULL) {
             lv_cache_unlock();
@@ -183,7 +187,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             cache->src = dsc->src;
         }
 
-        dsc->img_data = lv_cache_get_data(cache);
+        dsc->decoded = lv_cache_get_data(cache);
         dsc->cache_entry = cache;
 
         lv_cache_unlock();
@@ -212,7 +216,7 @@ static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc)
 
         lv_cache_entry_t * cache = lv_cache_find_by_src(NULL, fn, LV_CACHE_SRC_TYPE_PATH);
         if(cache) {
-            dsc->img_data = lv_cache_get_data(cache);
+            dsc->decoded = lv_cache_get_data(cache);
             dsc->cache_entry = cache;     /*Save the cache to release it in decoder_close*/
             lv_cache_unlock();
             return LV_RESULT_OK;
@@ -278,7 +282,7 @@ failed:
     return data;
 }
 
-static const void * decode_jpeg_file(const char * filename, size_t * size)
+static lv_draw_buf_t * decode_jpeg_file(const char * filename)
 {
     /* This struct contains the JPEG decompression parameters and pointers to
      * working space (which is allocated as needed by the JPEG library).
@@ -370,17 +374,16 @@ static const void * decode_jpeg_file(const char * filename, size_t * size)
      * In this example, we need to make an output work buffer of the right size.
      */
     /* JSAMPLEs per row in output buffer */
+    lv_draw_buf_t * decoded;
     row_stride = cinfo.output_width * cinfo.output_components;
     /* Make a one-row-high sample array that will go away when done with image */
     buffer = (*cinfo.mem->alloc_sarray)
              ((j_common_ptr) &cinfo, JPOOL_IMAGE, row_stride, 1);
 
-    size_t output_buffer_size = cinfo.output_width * cinfo.output_height * JPEG_PIXEL_SIZE;
-    output_buffer = lv_draw_buf_malloc(output_buffer_size, LV_COLOR_FORMAT_RGB888);
-    if(output_buffer) {
-        uint8_t * cur_pos = output_buffer;
+    decoded = lv_draw_buf_create(cinfo.output_width, cinfo.output_height, LV_COLOR_FORMAT_RGB888, 0);
+    if(decoded != NULL) {
+        uint8_t * cur_pos = decoded->data;
         size_t stride = cinfo.output_width * JPEG_PIXEL_SIZE;
-        if(size) *size = output_buffer_size;
 
         /* while (scan lines remain to be read) */
         /* jpeg_read_scanlines(...); */
@@ -397,7 +400,7 @@ static const void * decode_jpeg_file(const char * filename, size_t * size)
 
             /* Assume put_scanline_someplace wants a pointer and sample count. */
             lv_memcpy(cur_pos, buffer[0], stride);
-            cur_pos += stride;
+            cur_pos += decoded->header.stride;
         }
     }
 
@@ -426,7 +429,7 @@ static const void * decode_jpeg_file(const char * filename, size_t * size)
     */
 
     /* And we're done! */
-    return output_buffer;
+    return decoded;
 }
 
 static bool get_jpeg_size(const char * filename, uint32_t * width, uint32_t * height)
@@ -482,7 +485,7 @@ static void error_exit(j_common_ptr cinfo)
 static void cache_invalidate_cb(lv_cache_entry_t * entry)
 {
     if(entry->src_type == LV_CACHE_SRC_TYPE_PATH) lv_free((void *)entry->src);
-    lv_free((void *)entry->data);
+    lv_draw_buf_destroy((lv_draw_buf_t *)entry->data);
 }
 
 #endif /*LV_USE_LIBJPEG_TURBO*/

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -162,7 +162,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         size_t decoded_size = 0;
         uint32_t t = lv_tick_get();
         lv_draw_buf_t * decoded = decode_jpeg_file(fn);
-        if(decoded == NULL){
+        if(decoded == NULL) {
             LV_LOG_WARN("decode jpeg file failed");
             return LV_RESULT_INVALID;
         }

--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5307,13 +5307,17 @@ static void decodeGeneric(unsigned char ** out, unsigned * w, unsigned * h,
     lodepng_free(idat);
 
     if(!state->error) {
-        outsize = lodepng_get_raw_size(*w, *h, &state->info_png.color);
-        *out = (unsigned char *)lv_draw_buf_malloc(outsize, LV_COLOR_FORMAT_ARGB8888);
-        if(!*out) state->error = 83; /*alloc fail*/
+        lv_draw_buf_t * decoded = lv_draw_buf_create(*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
+        if(decoded) {
+            *out = (unsigned char*)decoded;
+            outsize = decoded->data_size;
+        }
+        else state->error = 83; /*alloc fail*/
     }
     if(!state->error) {
-        lodepng_memset(*out, 0, outsize);
-        state->error = postProcessScanlines(*out, scanlines, *w, *h, &state->info_png);
+        lv_draw_buf_t * decoded = (lv_draw_buf_t *)*out;
+        lodepng_memset(decoded->data, 0, outsize);
+        state->error = postProcessScanlines(decoded->data, scanlines, *w, *h, &state->info_png);
     }
     lodepng_free(scanlines);
 }


### PR DESCRIPTION
### Description of the feature or fix

Use draw buffer for decoded image.

Continue of https://github.com/lvgl/lvgl/pull/4833, https://github.com/lvgl/lvgl/pull/4934

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
