### PR TITLE
feat(obj): add obj state property

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -835,6 +835,16 @@ static lv_result_t lv_obj_set_any(lv_obj_t * obj, lv_prop_id_t id, const lv_prop
         else lv_obj_remove_flag(obj, flag);
         return LV_RESULT_OK;
     }
+    else if(id >= LV_PROPERTY_OBJ_STATE_START && id <= LV_PROPERTY_OBJ_STATE_END) {
+        lv_state_t state = 1L << (id - LV_PROPERTY_OBJ_STATE_START);
+        if(id == LV_PROPERTY_OBJ_STATE_ANY) {
+            state = LV_STATE_ANY;
+        }
+
+        if(prop->num) lv_obj_add_state(obj, state);
+        else lv_obj_remove_state(obj, state);
+        return LV_RESULT_OK;
+    }
     else {
         return LV_RESULT_INVALID;
     }
@@ -847,6 +857,17 @@ static lv_result_t lv_obj_get_any(const lv_obj_t * obj, lv_prop_id_t id, lv_prop
         lv_obj_flag_t flag = 1L << (id - LV_PROPERTY_OBJ_FLAG_START);
         prop->id = id;
         prop->num = obj->flags & flag;
+        return LV_RESULT_OK;
+    }
+    else if(id >= LV_PROPERTY_OBJ_STATE_START && id <= LV_PROPERTY_OBJ_STATE_END) {
+        prop->id = id;
+        if(id == LV_PROPERTY_OBJ_STATE_ANY) {
+            prop->num = obj->state;
+        }
+        else {
+            lv_obj_flag_t flag = 1L << (id - LV_PROPERTY_OBJ_STATE_START);
+            prop->num = obj->state & flag;
+        }
         return LV_RESULT_OK;
     }
     else {

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -48,7 +48,6 @@ enum _lv_state_t {
     LV_STATE_PRESSED     =  0x0020,
     LV_STATE_SCROLLED    =  0x0040,
     LV_STATE_DISABLED    =  0x0080,
-
     LV_STATE_USER_1      =  0x1000,
     LV_STATE_USER_2      =  0x2000,
     LV_STATE_USER_3      =  0x4000,
@@ -177,6 +176,23 @@ enum {
     LV_PROPERTY_ID(OBJ, FLAG_USER_4,                LV_PROPERTY_TYPE_INT,       30),
     LV_PROPERTY_ID(OBJ, FLAG_END,                   LV_PROPERTY_TYPE_INT,       30),
 
+    LV_PROPERTY_ID(OBJ, STATE_START,                LV_PROPERTY_TYPE_INT,       31),
+    LV_PROPERTY_ID(OBJ, STATE_CHECKED,              LV_PROPERTY_TYPE_INT,       31),
+    LV_PROPERTY_ID(OBJ, STATE_FOCUSED,              LV_PROPERTY_TYPE_INT,       32),
+    LV_PROPERTY_ID(OBJ, STATE_FOCUS_KEY,            LV_PROPERTY_TYPE_INT,       33),
+    LV_PROPERTY_ID(OBJ, STATE_EDITED,               LV_PROPERTY_TYPE_INT,       34),
+    LV_PROPERTY_ID(OBJ, STATE_HOVERED,              LV_PROPERTY_TYPE_INT,       35),
+    LV_PROPERTY_ID(OBJ, STATE_PRESSED,              LV_PROPERTY_TYPE_INT,       36),
+    LV_PROPERTY_ID(OBJ, STATE_SCROLLED,             LV_PROPERTY_TYPE_INT,       37),
+    LV_PROPERTY_ID(OBJ, STATE_DISABLED,             LV_PROPERTY_TYPE_INT,       38),
+    /*not used bit8-bit11*/
+    LV_PROPERTY_ID(OBJ, STATE_USER_1,               LV_PROPERTY_TYPE_INT,       43),
+    LV_PROPERTY_ID(OBJ, STATE_USER_2,               LV_PROPERTY_TYPE_INT,       44),
+    LV_PROPERTY_ID(OBJ, STATE_USER_3,               LV_PROPERTY_TYPE_INT,       45),
+    LV_PROPERTY_ID(OBJ, STATE_USER_4,               LV_PROPERTY_TYPE_INT,       46),
+    LV_PROPERTY_ID(OBJ, STATE_ANY,                  LV_PROPERTY_TYPE_INT,       47),
+    LV_PROPERTY_ID(OBJ, STATE_END,                  LV_PROPERTY_TYPE_INT,       47),
+
     /*OBJ normal properties*/
     LV_PROPERTY_ID(OBJ, PARENT,                     LV_PROPERTY_TYPE_POINTER,   31),
 
@@ -203,21 +219,21 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
  * They are allocated automatically if any elements is set.
  */
 typedef struct {
-    struct _lv_obj_t ** children;       /**< Store the pointer of the children in an array.*/
+    struct _lv_obj_t ** children;   /**< Store the pointer of the children in an array.*/
     lv_group_t * group_p;
     lv_event_list_t event_list;
 
-    lv_point_t scroll;                  /**< The current X/Y scroll offset*/
+    lv_point_t scroll;              /**< The current X/Y scroll offset*/
 
-    int32_t ext_click_pad;           /**< Extra click padding in all direction*/
-    int32_t ext_draw_size;           /**< EXTend the size in every direction for drawing.*/
+    int32_t ext_click_pad;          /**< Extra click padding in all direction*/
+    int32_t ext_draw_size;          /**< EXTend the size in every direction for drawing.*/
 
-    uint16_t child_cnt;                 /**< Number of children*/
-    lv_scrollbar_mode_t scrollbar_mode : 2; /**< How to display scrollbars*/
-    lv_scroll_snap_t scroll_snap_x : 2;     /**< Where to align the snappable children horizontally*/
-    lv_scroll_snap_t scroll_snap_y : 2;     /**< Where to align the snappable children vertically*/
-    lv_dir_t scroll_dir : 4;                /**< The allowed scroll direction(s)*/
-    uint8_t layer_type : 2;    /**< Cache the layer type here. Element of @lv_intermediate_layer_type_t */
+    uint16_t child_cnt;             /**< Number of children*/
+    uint16_t scrollbar_mode : 2;    /**< How to display scrollbars, see `lv_scrollbar_mode_t`*/
+    uint16_t scroll_snap_x : 2;     /**< Where to align the snappable children horizontally, see `lv_scroll_snap_t`*/
+    uint16_t scroll_snap_y : 2;     /**< Where to align the snappable children vertically*/
+    uint16_t scroll_dir : 4;        /**< The allowed scroll direction(s), see `lv_dir_t`*/
+    uint16_t layer_type : 2;        /**< Cache the layer type here. Element of @lv_intermediate_layer_type_t */
 } _lv_obj_spec_attr_t;
 
 typedef struct _lv_obj_t {

--- a/tests/src/test_cases/widgets/test_obj_property.c
+++ b/tests/src/test_cases/widgets/test_obj_property.c
@@ -154,4 +154,50 @@ void test_obj_property_flag(void)
     }
 }
 
+void test_obj_property_state(void)
+{
+    const struct {
+        uint32_t state;
+        uint32_t id;
+    } states[] = {
+        { LV_STATE_CHECKED,     LV_PROPERTY_OBJ_STATE_CHECKED },
+        { LV_STATE_FOCUSED,     LV_PROPERTY_OBJ_STATE_FOCUSED },
+        { LV_STATE_FOCUS_KEY,   LV_PROPERTY_OBJ_STATE_FOCUS_KEY },
+        { LV_STATE_EDITED,      LV_PROPERTY_OBJ_STATE_EDITED },
+        { LV_STATE_HOVERED,     LV_PROPERTY_OBJ_STATE_HOVERED },
+        { LV_STATE_PRESSED,     LV_PROPERTY_OBJ_STATE_PRESSED },
+        { LV_STATE_SCROLLED,    LV_PROPERTY_OBJ_STATE_SCROLLED },
+        { LV_STATE_DISABLED,    LV_PROPERTY_OBJ_STATE_DISABLED },
+        { LV_STATE_USER_1,      LV_PROPERTY_OBJ_STATE_USER_1 },
+        { LV_STATE_USER_2,      LV_PROPERTY_OBJ_STATE_USER_2 },
+        { LV_STATE_USER_3,      LV_PROPERTY_OBJ_STATE_USER_3 },
+        { LV_STATE_USER_4,      LV_PROPERTY_OBJ_STATE_USER_4 },
+    };
+
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    obj->state = 0;
+    for(unsigned long i = 0; i < sizeof(states) / sizeof(states[0]); i++) {
+        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+        lv_obj_add_state(obj, states[i].state);
+        printf("state: %d, value: %d\n", states[i].state, lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, states[i].id).num);
+
+        lv_obj_remove_state(obj, states[i].state);
+        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+
+        lv_property_t prop = { };
+        prop.id = states[i].id;
+        prop.num = 1;
+        TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_state(obj) & states[i].state);
+
+        prop.id = states[i].id;
+        prop.num = 0;
+        TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_FALSE(lv_obj_get_state(obj) & states[i].state);
+    }
+}
+
 #endif


### PR DESCRIPTION

### Description of the feature or fix

Using same method as obj's flag

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
