### PR TITLE
docs(sjpg): color depth no longer limited to 16 bits

### DIFF
--- a/docs/libs/sjpg.md
+++ b/docs/libs/sjpg.md
@@ -12,7 +12,6 @@ Allow the use of JPG images in LVGL. Besides that it also allows the use of a cu
   - File read from file and c-array are implemented.
   - SJPEG frame fragment cache enables fast fetching of lines if available in cache.
   - By default the sjpg image cache will be image width * 2 * 16 bytes (can be modified)
-  - Currently only 16 bit image format is supported (TODO)
   - Only the required partion of the JPG and SJPG images are decoded, therefore they can't be zoomed or rotated.
 
 ## Usage


### PR DESCRIPTION
Backport part of #4959 to lvgl 8: After lvgl/lv_lib_split_jpg@a2ee0bba87fde13e173b425c77851599ec0ffaba the color depth of the JPG decoder is no longer limited to 16 bit.