### PR TITLE
fix(cmsis-pack): fix cmsis-pack scripts for v9.0.0

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -20,7 +20,7 @@
 -->
 
 
-<package schemaVersion="1.4" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+<package schemaVersion="1.7.28" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.28/schema/PACK.xsd">
   <vendor>LVGL</vendor>
   <name>lvgl</name>
   <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
@@ -36,20 +36,41 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-     <release date="2023-05-03" version="8.3.7" url="https://github.com/GorgonMeducer/lvgl/raw/a8195160fcb18b522b4a16c230455d48d99a0368/env_support/cmsis-pack/LVGL.lvgl.8.3.7.pack">
-      - LVGL 8.3.7 release
-      - Various fixes
-    </release>
-     <release date="2023-03-03" version="8.3.6" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
-      - LVGL 8.3.6 release
-      - Various fixes
-    </release>
-     <release date="2023-02-26" version="9.0.0-dev" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.9.0.0-dev.pack">
+    <release date="2023-12-10" version="9.0.0-dev" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.9.0.0-dev.pack">
       - LVGL 9.0.0-dev
       - New Driver Architecture
       - Other fixes
-     </release>
-     <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
+    </release>
+    <release date="2023-12-05" version="8.3.11" url="https://github.com/lvgl/lvgl/raw/8194d83226c27c84f12dd51e16f5add9939215a5/env_support/cmsis-pack/LVGL.lvgl.8.3.11.pack">
+      - LVGL 8.3.11
+      - Add LittleFS Library to LVGL8
+      - Backport Tiny TTF to LVGL8
+      - Some minor fixes
+    </release>
+    <release date="2023-09-19" version="8.3.10" url="https://github.com/lvgl/lvgl/raw/9e388055ec0bcad5179461e66d6dac6823129eee/env_support/cmsis-pack/LVGL.lvgl.8.3.10.pack">
+      - LVGL 8.3.10
+      - Some minor fixes
+    </release>
+    <release date="2023-08-04" version="8.3.9" url="https://github.com/lvgl/lvgl/raw/bdf5bfb88ce107f16cf9128cf75e61394b3219d0/env_support/cmsis-pack/LVGL.lvgl.8.3.9.pack">
+      - LVGL 8.3.10
+      - Add snapshot, fragment, imgfont, gridnav, msg and monkey
+      - Other minor fixes
+    </release>
+    <release date="2023-07-04" version="8.3.8" url="https://github.com/lvgl/lvgl/raw/15433d69b9d8ae6aa74f49946874af81a0cc5921/env_support/cmsis-pack/LVGL.lvgl.8.3.8.pack">
+      - LVGL 8.3.8
+      - Add renesas-ra6m3 gpu adaptation
+      - Improve performance and add more features for PXP and VGLite
+      - Minor updates
+    </release>
+    <release date="2023-05-03" version="8.3.7" url="https://github.com/GorgonMeducer/lvgl/raw/a8195160fcb18b522b4a16c230455d48d99a0368/env_support/cmsis-pack/LVGL.lvgl.8.3.7.pack">
+      - LVGL 8.3.7 release
+      - Various fixes
+    </release>
+    <release date="2023-03-03" version="8.3.6" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
+      - LVGL 8.3.6 release
+      - Various fixes
+    </release>
+    <release date="2023-02-06" version="8.3.5" url="https://github.com/lvgl/lvgl/raw/6b0092c0d91b2c7bfded48e04cc7b486ed3a72bd/env_support/cmsis-pack/LVGL.lvgl.8.3.6.pack">
       - LVGL 8.3.5 release
       - Use LVGL version as the cmsis-pack version
       - Fix GPU support for NXP PXP and NXP VGLite
@@ -176,8 +197,6 @@
             <require Cclass="CMSIS" Cgroup="CORE"/>
         </condition>
 
-
-
         <condition id="Cortex-M Arm GCC">
             <description>Compile Cortex-M Processors with GNU Tools for Arm Embedded Processors.</description>
             <require condition="Arm GCC"/>
@@ -202,10 +221,48 @@
             <require condition="CMSIS-CORE"/>
         </condition>
         -->
+        
+        <condition id="GNU Assembler">
+            <accept Tcompiler="ARMCC" Toptions="AC6"/>
+            <accept Tcompiler="ARMCC" Toptions="AC6LTO"/>
+            <accept Tcompiler="GCC"/>
+            <accept Tcompiler="CLANG"/>
+        </condition>
+        
+        <condition id="NEON">
+            <description>Support All Cortex-M based processors</description>
+            <accept  Dcore="Cortex-A8"/>
+            <accept  Dcore="Cortex-A9"/>
+            <accept  Dcore="Cortex-A15"/>
+            <accept  Dcore="Cortex-A17"/>
+            <!--
+            <accept  Dcore="Cortex-A32"/>
+            <accept  Dcore="Cortex-A35"/>
+            -->
+            <accept  Dcore="Cortex-A53"/>
+            <accept  Dcore="Cortex-A57"/>
+            <accept  Dcore="Cortex-A72"/>
+            <accept  Dcore="Cortex-A73"/>
+        </condition>
+        
+        <condition id="Helium GNU Assembler">
+            <require condition="NEON" />
+            <require condition="GNU Assembler" />
+        </condition>
+
+        <condition id="Helium">
+            <description>Support All Cortex-M based processors</description>
+            <!--
+            <accept  Dcore="Cortex-M52"/>
+            -->
+            <accept  Dcore="Cortex-M55"/>
+            <accept  Dcore="Cortex-M85"/>
+            <accept  Dcore="ARMV81MML"/>
+        </condition>
 
         <condition id="LVGL-Essential">
             <description>Require LVGL Essential Service</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
+            <require Cclass="LVGL" Cgroup="Essential"/>
         </condition>
 
         <condition id="Arm-2D">
@@ -215,68 +272,62 @@
 
         <condition id="LVGL-GPU-Arm-2D">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>-->
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>
         </condition>
 
         <condition id="LVGL-GPU-STM32-DMA2D">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>-->
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <!--<deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>-->
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>
         </condition>
 
         <condition id="LVGL-GPU-SWM341-DMA2D">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>-->
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>
+            <!--<deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>-->
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>
         </condition>
 
         <condition id="LVGL-GPU-NXP-PXP">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>-->
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>
+            <!--<deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>-->
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>
         </condition>
 
         <condition id="LVGL-GPU-NXP-VGLite">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>-->
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>
+            <!--<deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>-->
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>
         </condition>
 
         <condition id="LVGL-GPU-GD32-IPA">
             <description>Enable LVGL Arm-2D GPU Support</description>
-            <require Cclass="LVGL" Cgroup="lvgl" Csub="Essential"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU Arm-2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU STM32-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU SWM341-DMA2D"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-PXP"/>
-            <deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU NXP-VGLite"/>
-            <!--<deny Cclass="LVGL" Cgroup="lvgl" Csub="GPU GD32-IPA"/>-->
+            <require Cclass="LVGL" Cgroup="LVGL9" Csub="Essential"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU STM32-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU SWM341-DMA2D"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-PXP"/>
+            <deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU NXP-VGLite"/>
+            <!--<deny Cclass="LVGL" Cgroup="LVGL9" Csub="GPU GD32-IPA"/>-->
         </condition>
 
     </conditions>
@@ -311,68 +362,105 @@
   -->
 
     <components>
-        <bundle Cbundle="LVGL" Cclass="LVGL" Cversion="9.0.0-dev">
+        <bundle Cbundle="LVGL9" Cclass="LVGL" Cversion="9.0.0">
             <description>LVGL (Light and Versatile Graphics Library) is a free and open-source graphics library providing everything you need to create an embedded GUI with easy-to-use graphical elements, beautiful visual effects and a low memory footprint.</description>
             <doc></doc>
-            <component Cgroup="lvgl" Csub="Essential" >
+            <component Cgroup="Essential">
               <description>The Essential services of LVGL (without extra content)</description>
               <files>
+              
+                <!-- src -->
+                <file category="sourceC"            name="src/lv_init.c" />
+                
                 <!-- src/core -->
-                <file category="sourceC"            name="src/core/lv_theme.c" />
-                <file category="sourceC"            name="src/core/lv_indev_scroll.c" />
-                <file category="sourceC"            name="src/core/lv_obj.c" />
-                <file category="sourceC"            name="src/core/lv_refr.c" />
-                <file category="sourceC"            name="src/core/lv_obj_pos.c" />
-                <file category="sourceC"            name="src/core/lv_obj_style_gen.c" />
-                <file category="sourceC"            name="src/core/lv_obj_class.c" />
-                <file category="sourceC"            name="src/core/lv_obj_tree.c" />
-                <file category="sourceC"            name="src/core/lv_indev.c" />
-                <file category="sourceC"            name="src/core/lv_disp.c" />
-                <file category="sourceC"            name="src/core/lv_obj_scroll.c" />
-                <file category="sourceC"            name="src/core/lv_obj_event.c" />
-                <file category="sourceC"            name="src/core/lv_obj_draw.c" />
+                <file category="header"             name="src/core/lv_global.h" />
                 <file category="sourceC"            name="src/core/lv_group.c" />
+                <file category="sourceC"            name="src/core/lv_obj.c" />
+                <file category="sourceC"            name="src/core/lv_obj_class.c" />
+                <file category="sourceC"            name="src/core/lv_obj_draw.c" />
+                <file category="sourceC"            name="src/core/lv_obj_event.c" />
+                <file category="sourceC"            name="src/core/lv_obj_id_builtin.c" />
+                <file category="sourceC"            name="src/core/lv_obj_pos.c" />
+                <file category="sourceC"            name="src/core/lv_obj_property.c" />
+                <file category="sourceC"            name="src/core/lv_obj_scroll.c" />
                 <file category="sourceC"            name="src/core/lv_obj_style.c" />
-
+                <file category="sourceC"            name="src/core/lv_obj_style_gen.c" />
+                <file category="sourceC"            name="src/core/lv_obj_tree.c" />
+                <file category="sourceC"            name="src/core/lv_refr.c" />
+                
+                
+                <!-- src/dev -->
+                <file category="sourceC"            name="src/dev/display/drm/lv_linux_drm.c" />
+                <file category="sourceC"            name="src/dev/display/fb/lv_linux_fbdev.c" />
+                <file category="sourceCpp"          name="src/dev/display/tft_espi/lv_tft_espi.cpp" />
+                <file category="sourceC"            name="src/dev/evdev/lv_evdev.c" />
+                
+                <file category="sourceC"            name="src/dev/nuttx/lv_nuttx_entry.c" />
+                <file category="sourceC"            name="src/dev/nuttx/lv_nuttx_fbdev.c" />
+                <file category="sourceC"            name="src/dev/nuttx/lv_nuttx_lcd.c" />
+                <file category="sourceC"            name="src/dev/nuttx/lv_nuttx_libuv.c" />
+                <file category="sourceC"            name="src/dev/nuttx/lv_nuttx_touchscreen.c" />
+                
+                <file category="sourceC"            name="src/dev/sdl/lv_sdl_keyboard.c" />
+                <file category="sourceC"            name="src/dev/sdl/lv_sdl_mouse.c" />
+                <file category="sourceC"            name="src/dev/sdl/lv_sdl_mousewheel.c" />
+                <file category="sourceC"            name="src/dev/sdl/lv_sdl_window.c" />
+                
+                <file category="sourceC"            name="src/dev/x11/lv_x11_display.c" />
+                <file category="sourceC"            name="src/dev/x11/lv_x11_input.c" />
+                
+                <!-- src/dev -->
+                <file category="sourceC"            name="src/display/lv_display.c" />
+                
 
                 <!-- src/draw -->
-                <file category="sourceC"            name="src/draw/lv_draw_label.c" />
-                <file category="sourceC"            name="src/draw/lv_img_decoder.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_rect.c" />
-
-                <file category="sourceC"            name="src/draw/lv_draw_transform.c" />
-                <file category="sourceC"            name="src/draw/lv_img_buf.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_mask.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_img.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_polygon.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_line.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_letter.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_arc.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_transform.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_blend.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_gradient.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_layer.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_rect.c" />
-                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_dither.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_img.c" />
-                <file category="sourceC"            name="src/draw/lv_img_cache.c" />
-                <file category="sourceC"            name="src/draw/lv_img_cache_builtin.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_line.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_triangle.c" />
                 <file category="sourceC"            name="src/draw/lv_draw.c" />
-                <file category="sourceC"            name="src/draw/lv_draw_layer.c" />
                 <file category="sourceC"            name="src/draw/lv_draw_arc.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_buf.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_image.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_label.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_line.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_mask.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_rect.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_triangle.c" />
+                <file category="sourceC"            name="src/draw/lv_draw_vector.c" />
+                <file category="sourceC"            name="src/draw/lv_image_buf.c" />
+                <file category="sourceC"            name="src/draw/lv_image_decoder.c" />
+                
+                <!-- src/draw/sw -->
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_arc.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_bg_img.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_border.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_box_shadow.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_fill.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_gradient.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_img.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_letter.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_line.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_mask.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_mask_rect.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_transform.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_triangle.c" />
+                <file category="sourceC"            name="src/draw/sw/lv_draw_sw_vector.c" />
+                
+                <!-- src/draw/sw/blend -->
+                <file category="sourceC"            name="src/draw/sw/blend/lv_draw_sw_blend.c" />
+                <file category="sourceC"            name="src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c" />
+                <file category="sourceC"            name="src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c" />
+                <file category="sourceC"            name="src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c" />
+                <file category="sourceAsm"          name="src/draw/sw/blend/neon/lv_blend_neon.S"  condition="Helium GNU Assembler"/>
+                <!--file category="sourceAsm"          name="src/draw/sw/blend/helium/lv_blend_helium.c" condition="Helium" /-->
+                
 
                 <!-- src/font -->
+                <file category="sourceC"            name="src/font/lv_binfont_loader.c" />
                 <file category="sourceC"            name="src/font/lv_font.c" />
                 <file category="sourceC"            name="src/font/lv_font_dejavu_16_persian_hebrew.c" />
                 <file category="sourceC"            name="src/font/lv_font_fmt_txt.c" />
-                <file category="sourceC"            name="src/font/lv_font_loader.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_8.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_10.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_12.c" />
-                <file category="sourceC"            name="src/font/lv_font_montserrat_12_subpx.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_14.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_16.c" />
                 <file category="sourceC"            name="src/font/lv_font_montserrat_18.c" />
@@ -396,118 +484,133 @@
                 <file category="sourceC"            name="src/font/lv_font_unscii_8.c" />
                 <file category="sourceC"            name="src/font/lv_font_unscii_16.c" />
 
-                <!-- src/hal -->
-                <file category="sourceC"            name="src/hal/lv_hal_tick.c" />
 
-                <!-- src/others -->
-                <file category="sourceC"            name="src/others/monkey/lv_monkey.c" />
-                <file category="sourceC"            name="src/others/msg/lv_msg.c" />
-                <file category="sourceC"            name="src/others/ime/lv_ime_pinyin.c" />
-                <file category="sourceC"            name="src/others/fragment/lv_fragment_manager.c" />
-                <file category="sourceC"            name="src/others/fragment/lv_fragment.c" />
-                <file category="sourceC"            name="src/others/snapshot/lv_snapshot.c" />
-                <file category="sourceC"            name="src/others/imgfont/lv_imgfont.c" />
-                <file category="sourceC"            name="src/others/gridnav/lv_gridnav.c" />
-                <file category="sourceC"            name="src/others/sysmon/lv_sysmon.c" />
+                <!-- src/indev -->
+                <file category="sourceC"            name="src/indev/lv_indev.c" />
+                <file category="sourceC"            name="src/indev/lv_indev_scroll.c" />
+                
+                <!-- src/layouts -->
+                <file category="sourceC"            name="src/layouts/lv_layout.c" />
+                <file category="sourceC"            name="src/layouts/flex/lv_flex.c" />
+                <file category="sourceC"            name="src/layouts/grid/lv_grid.c" />
+
 
                 <!-- src/misc-->
-                <file category="sourceC"            name="src/misc/lv_style_gen.c" />
-                <file category="sourceC"            name="src/misc/lv_fs.c" />
-                <file category="sourceC"            name="src/misc/lv_malloc_builtin.c" />
-                <file category="sourceC"            name="src/misc/lv_memcpy_builtin.c" />
+                <file category="sourceC"            name="src/misc/lv_anim.c" />
+                <file category="sourceC"            name="src/misc/lv_anim_timeline.c" />
+                <file category="sourceC"            name="src/misc/lv_area.c" />
+                <file category="sourceC"            name="src/misc/lv_array.c" />
                 <file category="sourceC"            name="src/misc/lv_async.c" />
-                <file category="sourceC"            name="src/misc/lv_txt_ap.c" />
-                <file category="sourceC"            name="src/misc/lv_gc.c" />
-                <file category="sourceC"            name="src/misc/lv_tlsf.c" />
+                <file category="sourceC"            name="src/misc/lv_bidi.c" />
+                <file category="sourceC"            name="src/misc/lv_cache.c" />
+                <file category="sourceC"            name="src/misc/lv_cache_builtin.c" />
+                <file category="sourceC"            name="src/misc/lv_color.c" />
+                <file category="sourceC"            name="src/misc/lv_color_op.c" />
+                <file category="sourceC"            name="src/misc/lv_event.c" />
+                <file category="sourceC"            name="src/misc/lv_fs.c" />
+                <file category="sourceC"            name="src/misc/lv_ll.c" />
                 <file category="sourceC"            name="src/misc/lv_log.c" />
                 <file category="sourceC"            name="src/misc/lv_lru.c" />
-                <file category="sourceC"            name="src/misc/lv_area.c" />
-                <file category="sourceC"            name="src/misc/lv_bidi.c" />
-                <file category="sourceC"            name="src/misc/lv_ll.c" />
-                <file category="sourceC"            name="src/misc/lv_anim_timeline.c" />
+                <file category="sourceC"            name="src/misc/lv_lru_rb.c" />
                 <file category="sourceC"            name="src/misc/lv_math.c" />
-                <file category="sourceC"            name="src/misc/lv_anim.c" />
-                <file category="sourceC"            name="src/misc/lv_txt.c" />
-                <file category="sourceC"            name="src/misc/lv_mem.c" />
-                <file category="sourceC"            name="src/misc/lv_utils.c" />
-                <file category="sourceC"            name="src/misc/lv_timer.c" />
-                <file category="sourceC"            name="src/misc/lv_style.c" />
-                <file category="sourceC"            name="src/misc/lv_color.c" />
-                <file category="sourceC"            name="src/misc/lv_printf.c" />
-                <file category="sourceC"            name="src/misc/lv_event.c" />
+                <file category="sourceC"            name="src/misc/lv_palette.c" />
                 <file category="sourceC"            name="src/misc/lv_profiler_builtin.c" />
+                <file category="sourceC"            name="src/misc/lv_rb.c" />
+                <file category="sourceC"            name="src/misc/lv_style.c" />
+                <file category="sourceC"            name="src/misc/lv_style_gen.c" />
+                <file category="sourceC"            name="src/misc/lv_templ.c" />
+                <file category="sourceC"            name="src/misc/lv_text.c" />
+                <file category="sourceC"            name="src/misc/lv_text_ap.c" />
+                <file category="sourceC"            name="src/misc/lv_timer.c" />
+                <file category="sourceC"            name="src/misc/lv_utils.c" />
 
-                <!-- src/widgets -->
-                <file category="sourceC"            name="src/widgets/spinner/lv_spinner.c" />
-                <file category="sourceC"            name="src/widgets/animimg/lv_animimg.c" />
-                <file category="sourceC"            name="src/widgets/bar/lv_bar.c" />
-                <file category="sourceC"            name="src/widgets/label/lv_label.c" />
-                <file category="sourceC"            name="src/widgets/canvas/lv_canvas.c" />
-                <file category="sourceC"            name="src/widgets/msgbox/lv_msgbox.c" />
-                <file category="sourceC"            name="src/widgets/imgbtn/lv_imgbtn.c" />
-                <file category="sourceC"            name="src/widgets/colorwheel/lv_colorwheel.c" />
-                <file category="sourceC"            name="src/widgets/menu/lv_menu.c" />
-                <file category="sourceC"            name="src/widgets/chart/lv_chart.c" />
-                <file category="sourceC"            name="src/widgets/dropdown/lv_dropdown.c" />
-                <file category="sourceC"            name="src/widgets/arc/lv_arc.c" />
-                <file category="sourceC"            name="src/widgets/table/lv_table.c" />
-                <file category="sourceC"            name="src/widgets/checkbox/lv_checkbox.c" />
-                <file category="sourceC"            name="src/widgets/tabview/lv_tabview.c" />
-                <file category="sourceC"            name="src/widgets/tileview/lv_tileview.c" />
-                <file category="sourceC"            name="src/widgets/objx_templ/lv_objx_templ.c" />
-                <file category="sourceC"            name="src/widgets/keyboard/lv_keyboard.c" />
-                <file category="sourceC"            name="src/widgets/btnmatrix/lv_btnmatrix.c" />
-                <file category="sourceC"            name="src/widgets/switch/lv_switch.c" />
-                <file category="sourceC"            name="src/widgets/calendar/lv_calendar_header_arrow.c" />
-                <file category="sourceC"            name="src/widgets/calendar/lv_calendar.c" />
-                <file category="sourceC"            name="src/widgets/calendar/lv_calendar_header_dropdown.c" />
-                <file category="sourceC"            name="src/widgets/span/lv_span.c" />
-                <file category="sourceC"            name="src/widgets/img/lv_img.c" />
-                <file category="sourceC"            name="src/widgets/meter/lv_meter.c" />
-                <file category="sourceC"            name="src/widgets/win/lv_win.c" />
-                <file category="sourceC"            name="src/widgets/spinbox/lv_spinbox.c" />
-                <file category="sourceC"            name="src/widgets/roller/lv_roller.c" />
-                <file category="sourceC"            name="src/widgets/btn/lv_btn.c" />
-                <file category="sourceC"            name="src/widgets/led/lv_led.c" />
-                <file category="sourceC"            name="src/widgets/textarea/lv_textarea.c" />
-                <file category="sourceC"            name="src/widgets/slider/lv_slider.c" />
-                <file category="sourceC"            name="src/widgets/line/lv_line.c" />
-                <file category="sourceC"            name="src/widgets/list/lv_list.c" />
-                <file category="sourceC"            name="src/libs/fsdrv/lv_fs_posix.c" />
-                <file category="sourceC"            name="src/libs/fsdrv/lv_fs_fatfs.c" />
-                <file category="sourceC"            name="src/libs/fsdrv/lv_fs_stdio.c" />
-                <file category="sourceC"            name="src/libs/fsdrv/lv_fs_win32.c" />
-                <file category="sourceC"            name="src/libs/freetype/lv_freetype.c" />
-                <file category="sourceC"            name="src/libs/ffmpeg/lv_ffmpeg.c" />
-                <file category="sourceC"            name="src/libs/lodepng/lv_lodepng.c" />
-                <file category="sourceC"            name="src/libs/lodepng/lodepng.c" />
-                <file category="sourceC"            name="src/libs/gif/gifdec.c" />
-                <file category="sourceC"            name="src/libs/gif/lv_gif.c" />
-                <file category="sourceC"            name="src/libs/rlottie/lv_rlottie.c" />
-                <file category="sourceC"            name="src/libs/qrcode/lv_qrcode.c" />
-                <file category="sourceC"            name="src/libs/qrcode/qrcodegen.c" />
-                <file category="sourceC"            name="src/libs/tjpgd/tjpgd.c" />
-                <file category="sourceC"            name="src/libs/tjpgd/lv_tjpgd.c" />
-                <file category="sourceC"            name="src/libs/bmp/lv_bmp.c" />
-                <file category="sourceC"            name="src/layouts/grid/lv_grid.c" />
-                <file category="sourceC"            name="src/layouts/flex/lv_flex.c" />
+
+                <!-- src/stdlib-->
+                <file category="sourceC"            name="src/stdlib/lv_mem.c" />
+                <file category="sourceC"            name="src/stdlib/builtin/lv_mem_core_builtin.c" />
+                <file category="sourceC"            name="src/stdlib/builtin/lv_sprintf_builtin.c" />
+                <file category="sourceC"            name="src/stdlib/builtin/lv_string_builtin.c" />
+                <file category="sourceC"            name="src/stdlib/builtin/lv_tlsf.c" />
+                <file category="sourceC"            name="src/stdlib/clib/lv_mem_core_clib.c" />
+                <file category="sourceC"            name="src/stdlib/clib/lv_sprintf_clib.c" />
+                <file category="sourceC"            name="src/stdlib/clib/lv_string_clib.c" />
+                <file category="sourceC"            name="src/stdlib/micropython/lv_mem_core_micropython.c" />
+                <file category="sourceC"            name="src/stdlib/rtthread/lv_mem_core_rtthread.c" />
+                <file category="sourceC"            name="src/stdlib/rtthread/lv_sprintf_rtthread.c" />
+                <file category="sourceC"            name="src/stdlib/rtthread/lv_string_rtthread.c" />
+                
+                
+                <!-- src/themes -->
+                <file category="sourceC"            name="src/themes/lv_theme.c" />
                 <file category="sourceC"            name="src/themes/mono/lv_theme_mono.c" />
                 <file category="sourceC"            name="src/themes/basic/lv_theme_basic.c" />
                 <file category="sourceC"            name="src/themes/default/lv_theme_default.c" />
+                
+                <!-- src/tick -->
+                <file category="sourceC"            name="src/tick/lv_tick.c" />
+                
+                <!-- src/widgets -->
+                <file category="sourceC"            name="src/widgets/animimage/lv_animimage.c" />
+                <file category="sourceC"            name="src/widgets/arc/lv_arc.c" />
+                <file category="sourceC"            name="src/widgets/bar/lv_bar.c" />
+                <file category="sourceC"            name="src/widgets/button/lv_button.c" />
+                <file category="sourceC"            name="src/widgets/buttonmatrix/lv_buttonmatrix.c" />
+                <file category="sourceC"            name="src/widgets/calendar/lv_calendar.c" />
+                <file category="sourceC"            name="src/widgets/calendar/lv_calendar_header_arrow.c" />
+                <file category="sourceC"            name="src/widgets/calendar/lv_calendar_header_dropdown.c" />
+                <file category="sourceC"            name="src/widgets/canvas/lv_canvas.c" />
+                <file category="sourceC"            name="src/widgets/chart/lv_chart.c" />
+                <file category="sourceC"            name="src/widgets/checkbox/lv_checkbox.c" />
+                <file category="sourceC"            name="src/widgets/dropdown/lv_dropdown.c" />
+                <file category="sourceC"            name="src/widgets/image/lv_image.c" />
+                <file category="sourceC"            name="src/widgets/imgbtn/lv_imgbtn.c" />
+                <file category="sourceC"            name="src/widgets/keyboard/lv_keyboard.c" />
+                <file category="sourceC"            name="src/widgets/label/lv_label.c" />
+                <file category="sourceC"            name="src/widgets/led/lv_led.c" />
+                <file category="sourceC"            name="src/widgets/line/lv_line.c" />
+                <file category="sourceC"            name="src/widgets/list/lv_list.c" />
+                <file category="sourceC"            name="src/widgets/menu/lv_menu.c" />
+                <file category="sourceC"            name="src/widgets/msgbox/lv_msgbox.c" />
+                <file category="sourceC"            name="src/widgets/objx_templ/lv_objx_templ.c" />
+                <file category="sourceC"            name="src/widgets/roller/lv_roller.c" />
+                <file category="sourceC"            name="src/widgets/scale/lv_scale.c" />
+                <file category="sourceC"            name="src/widgets/slider/lv_slider.c" />
+                <file category="sourceC"            name="src/widgets/span/lv_span.c" />
+                <file category="sourceC"            name="src/widgets/spinbox/lv_spinbox.c" />
+                <file category="sourceC"            name="src/widgets/spinner/lv_spinner.c" />
+                <file category="sourceC"            name="src/widgets/switch/lv_switch.c" />
+                <file category="sourceC"            name="src/widgets/table/lv_table.c" />
+                <file category="sourceC"            name="src/widgets/tabview/lv_tabview.c" />
+                <file category="sourceC"            name="src/widgets/textarea/lv_textarea.c" />
+                <file category="sourceC"            name="src/widgets/tileview/lv_tileview.c" />
+                <file category="sourceC"            name="src/widgets/win/lv_win.c" />
 
+                <!-- src/libs -->
+                <file category="sourceC"            name="src/libs/bin_decoder/lv_bin_decoder.c" />
+                <file category="sourceC"            name="src/libs/fsdrv/lv_fs_cbfs.c" />
+                
+                <!-- src/others -->
+                <file category="sourceC"            name="src/others/sysmon/lv_sysmon.c" />
+                
+                <!-- src/demons -->
+                <file category="sourceC"            name="demos/lv_demos.c" />
+                
+                <!-- src/osal -->
+                <file category="sourceC"            name="src/osal/lv_os_none.c"/>
+                
                 <!-- general -->
-                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="1.2.0" />
-                <file category="sourceC"            name="lv_cmsis_pack.c" attr="config" version="1.0.0" />
+                <file category="preIncludeGlobal"   name="lv_conf_cmsis.h" attr="config" version="2.0.2" />
+                <file category="sourceC"            name="lv_cmsis_pack.c" />
                 <file category="header"             name="lvgl.h" />
                 <file category="doc"                name="README.md"/>
 
                 <!-- code template -->
-                <file category="header"       name="examples/porting/lv_port_disp_template.h" attr="template" select="Display port template" version="2.0.0"/>
-                <file category="sourceC"      name="examples/porting/lv_port_disp_template.c" attr="template" select="Display port template" version="2.0.0"/>
-                <file category="header"       name="examples/porting/lv_port_indev_template.h" attr="template" select="Input devices port template" version="2.0.0"/>
-                <file category="sourceC"      name="examples/porting/lv_port_indev_template.c" attr="template" select="Input devices port template" version="2.0.0"/>
-                <file category="header"       name="examples/porting/lv_port_fs_template.h" attr="template" select="File system port template" version="2.0.0"/>
-                <file category="sourceC"      name="examples/porting/lv_port_fs_template.c" attr="template" select="File system port template" version="2.0.0"/>
+                <file category="header"       name="examples/porting/lv_port_disp_template.h" attr="template" select="Display port template" version="2.1.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_disp_template.c" attr="template" select="Display port template" version="2.1.0"/>
+                <file category="header"       name="examples/porting/lv_port_indev_template.h" attr="template" select="Input devices port template" version="2.1.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_indev_template.c" attr="template" select="Input devices port template" version="2.1.0"/>
+                <file category="header"       name="examples/porting/lv_port_fs_template.h" attr="template" select="File system port template" version="2.1.0"/>
+                <file category="sourceC"      name="examples/porting/lv_port_fs_template.c" attr="template" select="File system port template" version="2.1.0"/>
               </files>
 
               <Pre_Include_Global_h>
@@ -524,22 +627,229 @@
                </RTE_Components_h>
 
             </component>
+            
+            <component Cgroup="OS Abstraction Layer" Cvariant="pthreads" condition="LVGL-Essential">
+              <description>Add the support for pthreads</description>
+              <files>
+                <file category="sourceC"      name="src/osal/lv_pthread.c"/>
+              </files>
 
-            <component Cgroup="lvgl" Csub="Porting"  condition="LVGL-Essential">
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS   LV_OS_PTHREAD
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="OS Abstraction Layer" Cvariant="FreeRTOS" condition="LVGL-Essential">
+              <description>Add the support for FreeRTOS</description>
+              <files>
+                <file category="sourceC"      name="src/osal/lv_freertos.c"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS   LV_OS_FREERTOS
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="OS Abstraction Layer" Cvariant="CMSIS-RTOS2" isDefaultVariant="true" condition="LVGL-Essential">
+              <description>Add the support for CMSIS-RTOS2 APIs</description>
+              <files>
+                <file category="sourceC"      name="src/osal/lv_cmsis_rtos2.c"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS   LV_OS_CMSIS_RTOS2
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="OS Abstraction Layer" Cvariant="RT-Thread" condition="LVGL-Essential">
+              <description>Add the support for RT-Thread APIs</description>
+              <files>
+                <file category="sourceC"      name="src/osal/lv_rtthread.c"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS   LV_OS_RTTHREAD
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="OS Abstraction Layer" Cvariant="Windows" condition="LVGL-Essential">
+              <description>Add the support for Windows APIs</description>
+              <files>
+                <file category="sourceC"      name="src/osal/lv_windows.c"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS   LV_OS_WINDOWS
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="OS Abstraction Layer" Cvariant="User Custom" condition="LVGL-Essential">
+              <description>Add a user customized (RT)OS support </description>
+              <files>
+                <file category="sourceC"        name="src/osal/lv_os_custom.c"    attr="config" version="1.0.0"/>
+                <file category="header"         name="src/osal/lv_os_custom.h"     attr="config" version="1.0.0"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*   Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM 
+ */
+#define LV_USE_OS               LV_OS_CUSTOM
+#define LV_OS_CUSTOM_INCLUDE    "lv_os_custom.h"
+
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Porting"  condition="LVGL-Essential">
               <description>Porting Templates</description>
               <files>
-                <file category="header"     name="examples/porting/lv_port_disp_template.h" attr="config" version="1.0.1" />
-                <file category="sourceC"    name="examples/porting/lv_port_disp_template.c" attr="config" version="1.0.1" />
+                <file category="header"     name="examples/porting/lv_port_disp_template.h" attr="config" version="2.1.0" />
+                <file category="sourceC"    name="examples/porting/lv_port_disp_template.c" attr="config" version="2.1.0" />
 
-                <file category="header"     name="examples/porting/lv_port_indev_template.h" attr="config" version="1.0.0" />
-                <file category="sourceC"    name="examples/porting/lv_port_indev_template.c" attr="config" version="1.0.0" />
+                <file category="header"     name="examples/porting/lv_port_indev_template.h" attr="config" version="2.1.0" />
+                <file category="sourceC"    name="examples/porting/lv_port_indev_template.c" attr="config" version="2.1.0" />
 
-                <file category="header"     name="examples/porting/lv_port_fs_template.h" attr="config" version="1.0.0" />
-                <file category="sourceC"    name="examples/porting/lv_port_fs_template.c" attr="config" version="1.0.0" />
+                <file category="header"     name="examples/porting/lv_port_fs_template.h" attr="config" version="2.1.0" />
+                <file category="sourceC"    name="examples/porting/lv_port_fs_template.c" attr="config" version="2.1.0" />
               </files>
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU Arm-2D"  condition="LVGL-GPU-Arm-2D" Cversion="1.2.0">
+
+            <component Cgroup="Acceleration" Csub="GPU NXP-PXP"  condition="LVGL-GPU-NXP-PXP">
+              <description>An hardware acceleration from NXP-PXP</description>
+              <files>
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_buf_pxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_bg_img.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_fill.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_img.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_layer.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_pxp_cfg.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_pxp_osa.c" />
+                <file category="sourceC"      name="src/draw/nxp/pxp/lv_pxp_utils.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable NXP PXP */
+#define LV_USE_DRAW_PXP     1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Acceleration" Csub="GPU NXP-VGLite"  condition="LVGL-GPU-NXP-VGLite">
+              <description>An hardware acceleration from NXP-VGLite</description>
+              <files>
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_buf_vglite.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_arc.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_bg_img.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_border.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_fill.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_img.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_label.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_layer.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_line.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_buf.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_matrix.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_path.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_buf.c" />
+                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_utils.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable NXP VGLite */
+#define LV_USE_DRAW_VGLITE          1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Acceleration" Csub="GPU SDL2" Cversion="2.0.0">
+              <description>Using existing SDL2 APIs for acceleration</description>
+              <files>
+                <file category="sourceC"      name="src/draw/sdl/lv_draw_sdl.c"/>
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable SDL2 acceleration*/
+#define LV_USE_DRAW_SDL 1
+
+              </RTE_Components_h>
+
+            </component>
+
+            <!-- not available yet 
+            <component Cgroup="Acceleration" Csub="GPU Arm-2D"  isDefaultVariant="true" Cversion="2.0.0">
               <description>A 2D image processing library from Arm (i.e. Arm-2D) for All Cortex-M processors including Cortex-M0</description>
               <files>
                 <file category="sourceC"      name="src/draw/arm2d/lv_gpu_arm2d.c" condition="Arm-2D"/>
@@ -554,7 +864,7 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU STM32-DMA2D"  condition="LVGL-GPU-STM32-DMA2D">
+            <component Cgroup="Acceleration" Csub="GPU STM32-DMA2D"  condition="LVGL-GPU-STM32-DMA2D">
               <description>An hardware acceleration from STM32-DMA2D</description>
               <files>
                 <file category="sourceC"      name="src/draw/stm32_dma2d/lv_gpu_stm32_dma2d.c" />
@@ -568,7 +878,7 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU SWM341-DMA2D"  condition="LVGL-GPU-SWM341-DMA2D">
+            <component Cgroup="Acceleration" Csub="GPU SWM341-DMA2D"  condition="LVGL-GPU-SWM341-DMA2D">
               <description>An hardware acceleration from SWM341-DMA2D</description>
               <files>
                 <file category="sourceC"      name="src/draw/swm341_dma2d/lv_gpu_swm341_dma2d.c" />
@@ -582,44 +892,7 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="GPU NXP-PXP"  condition="LVGL-GPU-NXP-PXP">
-              <description>An hardware acceleration from NXP-PXP</description>
-              <files>
-                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp.c" />
-                <file category="sourceC"      name="src/draw/nxp/pxp/lv_draw_pxp_blend.c" />
-                <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp.c" />
-                <file category="sourceC"      name="src/draw/nxp/pxp/lv_gpu_nxp_pxp_osa.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable NXP PXP */
-#define LV_USE_GPU_NXP_PXP          1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="GPU NXP-VGLite"  condition="LVGL-GPU-NXP-VGLite">
-              <description>An hardware acceleration from NXP-VGLite</description>
-              <files>
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_line.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_arc.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_blend.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_draw_vglite_rect.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_buf.c" />
-                <file category="sourceC"      name="src/draw/nxp/vglite/lv_vglite_utils.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable NXP VGLite */
-#define LV_USE_GPU_NXP_VG_LITE          1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="GPU GD32-IPA"  condition="LVGL-GPU-GD32-IPA">
+            <component Cgroup="Acceleration" Csub="GPU GD32-IPA"  condition="LVGL-GPU-GD32-IPA">
               <description>An hardware acceleration from GD32-IPA</description>
               <files>
                 <file category="sourceC"      name="src/draw/gd32_ipa/lv_gpu_gd32_ipa.c" />
@@ -632,51 +905,10 @@
               </RTE_Components_h>
 
             </component>
-
-            <component Cgroup="lvgl" Csub="Extra Themes"  condition="LVGL-Essential">
-              <description>Extra Themes, Widgets and Layouts</description>
-              <files>
-
-                <!-- src/themes -->
-                <file category="sourceC"    name="src/themes/default/lv_theme_default.c" />
-                <file category="sourceC"    name="src/themes/basic/lv_theme_basic.c" />
-                <file category="sourceC"    name="src/themes/mono/lv_theme_mono.c" />
-
-                <!-- src/widgets -->
-                <file category="sourceC"    name="src/widgets/animimg/lv_animimg.c" />
-                <file category="sourceC"    name="src/widgets/calendar/lv_calendar.c" />
-                <file category="sourceC"    name="src/widgets/calendar/lv_calendar_header_arrow.c" />
-                <file category="sourceC"    name="src/widgets/calendar/lv_calendar_header_dropdown.c" />
-                <file category="sourceC"    name="src/widgets/chart/lv_chart.c" />
-                <file category="sourceC"    name="src/widgets/colorwheel/lv_colorwheel.c" />
-                <file category="sourceC"    name="src/widgets/imgbtn/lv_imgbtn.c" />
-                <file category="sourceC"    name="src/widgets/keyboard/lv_keyboard.c" />
-                <file category="sourceC"    name="src/widgets/led/lv_led.c" />
-                <file category="sourceC"    name="src/widgets/list/lv_list.c" />
-                <file category="sourceC"    name="src/widgets/menu/lv_menu.c" />
-                <file category="sourceC"    name="src/widgets/meter/lv_meter.c" />
-                <file category="sourceC"    name="src/widgets/msgbox/lv_msgbox.c" />
-                <file category="sourceC"    name="src/widgets/span/lv_span.c" />
-                <file category="sourceC"    name="src/widgets/spinbox/lv_spinbox.c" />
-                <file category="sourceC"    name="src/widgets/spinner/lv_spinner.c" />
-                <file category="sourceC"    name="src/widgets/tabview/lv_tabview.c" />
-                <file category="sourceC"    name="src/widgets/tileview/lv_tileview.c" />
-                <file category="sourceC"    name="src/widgets/win/lv_win.c" />
-
-                <!-- src/layouts -->
-                <file category="sourceC"    name="src/layouts/flex/lv_flex.c" />
-                <file category="sourceC"    name="src/layouts/grid/lv_grid.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief use extra themes, widgets and layouts */
-#define RTE_GRAPHICS_LVGL_USE_EXTRA_THEMES
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="PikaScript Binding" Cversion="0.2.0" condition="LVGL-Essential">
+            -->
+            
+            <!--
+            <component Cgroup="LVGL9" Csub="PikaScript Binding" Cversion="0.2.0" condition="LVGL-Essential">
               <description>Add the binding for PikaScript, an ultra-light-weight python VM.</description>
               <files>
                 <file category="doc"        name="pikascript/README.md"/>
@@ -701,40 +933,10 @@
               </RTE_Components_h>
 
             </component>
+            -->
 
-            <component Cgroup="lvgl" Csub="Libs PNG"  condition="LVGL-Essential">
-              <description>Add PNG support</description>
-              <files>
-                <!-- src/libs/png -->
-                <file category="sourceC"    name="src/libs/lodepng/lodepng.c" />
-                <file category="sourceC"    name="src/libs/lodepng/lv_lodepng.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable PNG support */
-#define LV_USE_LODEPNG          1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Libs BMP"  condition="LVGL-Essential">
-              <description>Add BMP support</description>
-              <files>
-                <!-- src/libs/bmp -->
-                <file category="sourceC"    name="src/libs/bmp/lv_bmp.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable BMP support */
-#define LV_USE_BMP          1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Libs Barcode"  condition="LVGL-Essential">
-              <description>Add BMP support</description>
+            <component Cgroup="Libraries and Others" Csub="Libs Barcode"  condition="LVGL-Essential">
+              <description>Add the Barcode code library</description>
               <files>
                 <!-- src/libs/barcode -->
                 <file category="sourceC"    name="src/libs/barcode/lv_barcode.c" />
@@ -749,15 +951,46 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Libs freetype"  condition="LVGL-Essential">
-              <description>Add freetype support, an extra librbary is required.</description>
+            <component Cgroup="Libraries and Others" Csub="Libs BMP"  condition="LVGL-Essential">
+              <description>Add BMP decoder library</description>
+              <files>
+                <!-- src/libs/bmp -->
+                <file category="sourceC"    name="src/libs/bmp/lv_bmp.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable BMP support */
+#define LV_USE_BMP          1
+              </RTE_Components_h>
+
+            </component>
+
+
+            <component Cgroup="Libraries and Others" Csub="Libs ffmpeg"  condition="LVGL-Essential">
+              <description>Add FFmpeg library for image decoding and playing videos, an extra librbary is required.</description>
+              <files>
+                <!-- src/libs/ffmpeg -->
+                <file category="sourceC"    name="src/libs/ffmpeg/lv_ffmpeg.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable ffmpeg support */
+#define LV_USE_FFMPEG         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs freetype"  condition="LVGL-Essential">
+              <description>Add FreeType library, an extra librbary is required.</description>
               <files>
                 <!-- src/libs/freetype -->
                 <file category="sourceC"    name="src/libs/freetype/lv_freetype.c" />
-                <file category="header"     name="src/libs/freetype/lv_freetype.h" />
+                <file category="sourceC"    name="src/libs/freetype/lv_freetype_image.c" />
+                <file category="sourceC"    name="src/libs/freetype/lv_freetype_outline.c" />
+                <file category="sourceC"    name="src/libs/freetype/lv_freetype_sbit.c" />
                 <file category="sourceC"    name="src/libs/freetype/lv_ftsystem.c" />
-                <file category="header"     name="src/libs/freetype/ftmodule.h" />
-                <file category="header"     name="src/libs/freetype/ftoption.h" />
               </files>
 
               <RTE_Components_h>
@@ -768,7 +1001,85 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Libs GIF"  condition="LVGL-Essential">
+
+            <component Cgroup="Libraries and Others" Csub="Lib Filesystem" Cvariant="FATFS" condition="LVGL-Essential">
+              <description>Add API for FATFS (needs to be added separately). Uses f_open, f_read, etc</description>
+              <files>
+                <!-- src/libs/fsdrv -->
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_fatfs.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable FATFS support */
+#define LV_USE_FS_FATFS         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Lib Filesystem" Cvariant="Memory-Mapped Files" isDefaultVariant="true" condition="LVGL-Essential">
+              <description>Add API for memory-mapped file access.</description>
+              <files>
+                <!-- src/libs/fsdrv -->
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_memfs.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable memory-mapped file access */
+#define LV_USE_FS_MEMFS         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Lib Filesystem" Cvariant="POSIX" condition="LVGL-Essential">
+              <description>Add API for file access via POSIX</description>
+              <files>
+                <!-- src/libs/fsdrv -->
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_posix.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable POSIX file access */
+#define LV_USE_FS_POSIX         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Lib Filesystem" Cvariant="STDIO" condition="LVGL-Essential">
+              <description>Add API for file access via STDIO</description>
+              <files>
+                <!-- src/libs/fsdrv -->
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_stdio.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable STDIO file access */
+#define LV_USE_FS_STDIO         1
+              </RTE_Components_h>
+
+            </component>
+
+            <!--
+            <component Cgroup="Libraries and Others" Csub="Lib Filesystem" Cvariant="WIN32" condition="LVGL-Essential">
+              <description>Add API for file access via STDIO</description>
+              <files>
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_cbfs.c" />
+                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_win32.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable WIN32 file access */
+#define LV_USE_FS_WIN32         1
+              </RTE_Components_h>
+
+            </component>
+            -->
+
+            <component Cgroup="Libraries and Others" Csub="Libs GIF"  condition="LVGL-Essential">
               <description>Add GIF support</description>
               <files>
                 <!-- src/libs/gif -->
@@ -784,7 +1095,87 @@
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Libs RLE"  condition="LVGL-Essential">
+            <component Cgroup="Libraries and Others" Csub="Libs libjpeg-turbo decoder"  condition="LVGL-Essential">
+              <description>Add libjpeg-turbo decoder library</description>
+              <files>
+                <!-- src/libs/libjpeg_turbo -->
+                <file category="sourceC"    name="src/libs/libjpeg_turbo/lv_libjpeg_turbo.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable ibjpeg-turbo decoder */
+#define LV_USE_LIBJPEG_TURBO         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs PNG"  condition="LVGL-Essential">
+              <description>Add PNG decoder(libpng) library</description>
+              <files>
+                <!-- src/libs/png -->
+                <file category="sourceC"    name="src/libs/libpng/lv_libpng.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable PNG decoder(libpng) library */
+#define LV_USE_LIBPNG          1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs LODEPNG"  condition="LVGL-Essential">
+              <description>Add LODEPNG decoder library</description>
+              <files>
+                <!-- src/libs/lodepng -->
+                <file category="sourceC"    name="src/libs/lodepng/lodepng.c" />
+                <file category="sourceC"    name="src/libs/lodepng/lv_lodepng.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable LODEPNG decoder library */
+#define LV_USE_LODEPNG          1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs LZ4"  condition="LVGL-Essential">
+              <description>Add LZ4 compress/decompress lib</description>
+              <files>
+                <!-- src/libs/lz4 -->
+                <file category="sourceC"    name="src/libs/lz4/lz4.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable LZ4 compress/decompress lib */
+#define LV_USE_LZ4              1
+#define LV_USE_LZ4_INTERNAL     1
+#define LV_USE_LZ4_EXTERNAL     0
+              </RTE_Components_h>
+
+            </component>
+            
+            <component Cgroup="Libraries and Others" Csub="Libs QRCode"  condition="LVGL-Essential">
+              <description>Add QR code library</description>
+              <files>
+                <!-- src/libs/qrcode -->
+                <file category="sourceC"    name="src/libs/qrcode/lv_qrcode.c" />
+                <file category="sourceC"    name="src/libs/qrcode/qrcodegen.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable QR code library */
+#define LV_USE_QRCODE         1
+              </RTE_Components_h>
+
+            </component>
+
+
+            <component Cgroup="Libraries and Others" Csub="Libs RLE"  condition="LVGL-Essential">
               <description>Add LVGL's version of RLE compression method support</description>
               <files>
                 <!-- src/libs/rle -->
@@ -797,8 +1188,89 @@
               </RTE_Components_h>
             </component>
 
-            <component Cgroup="lvgl" Csub="Libs sJPG"  condition="LVGL-Essential">
-              <description>Add sJPG support</description>
+            <component Cgroup="Libraries and Others" Csub="Libs RLOTTIE"  condition="LVGL-Essential">
+              <description>Add Rlottie library, an extra librbary is required.</description>
+              <files>
+                <!-- src/libs/rlottie -->
+                <file category="sourceC"    name="src/libs/rlottie/lv_rlottie.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable Rlottie library */
+#define LV_USE_RLOTTIE         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs ThorVG"  condition="LVGL-Essential">
+              <description>Add ThorVG (vector graphics library), an extra librbary is required.</description>
+              <files>
+                <!-- src/libs/thorvg -->
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgAnimation.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgBezier.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgCanvas.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgCapi.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgCompressor.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgFill.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgInitializer.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgLoader.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgMath.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgPaint.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgPicture.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgRawLoader.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgRender.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSaver.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgScene.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgShape.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgStr.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSvgCssStyle.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSvgLoader.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSvgPath.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSvgSceneBuilder.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSvgUtil.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwCanvas.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwFill.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwImage.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwMath.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwMemPool.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwRaster.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwRenderer.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwRle.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwShape.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgSwStroke.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgTaskScheduler.cpp" />
+                <file category="sourceCpp"    name="src/libs/thorvg/tvgXmlParser.cpp" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable ThorVG (vector graphics library) */
+#define LV_USE_VECTOR_GRAPHIC       1
+#define LV_USE_THORVG_INTERNAL      1
+#define LV_USE_THORVG_EXTERNAL      0
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Tiny TTF"  condition="LVGL-Essential">
+              <description>Add Built-in TTF decoder</description>
+              <files>
+                <!-- src/libs/tiny_ttf -->
+                <file category="sourceC"    name="src/libs/tiny_ttf/lv_tiny_ttf.c" />
+                
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable Built-in TTF decoder */
+#define LV_USE_TINY_TTF         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Libs sJPG"  condition="LVGL-Essential">
+              <description>Add JPG + split JPG decoder library. Split JPG is a custom format optimized for embedded systems.</description>
               <files>
                 <!-- src/libs/tjpgd -->
                 <file category="sourceC"    name="src/libs/tjpgd/lv_tjpgd.c" />
@@ -807,85 +1279,14 @@
 
               <RTE_Components_h>
 
-/*! \brief enable sJPG support */
-#define LV_USE_SJPG         1
+/*! \brief enable JPG + split JPG decoder library. */
+#define LV_USE_TJPGD         1
               </RTE_Components_h>
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Libs QRCode"  condition="LVGL-Essential">
-              <description>Add QRCode support</description>
-              <files>
-                <!-- src/libs/qrcode -->
-                <file category="sourceC"    name="src/libs/qrcode/lv_qrcode.c" />
-                <file category="sourceC"    name="src/libs/qrcode/qrcodegen.c" />
-              </files>
 
-              <RTE_Components_h>
-
-/*! \brief enable QRCode support */
-#define LV_USE_QRCODE         1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Libs FileSystem"  condition="LVGL-Essential">
-              <description>Add FileSystem support</description>
-              <files>
-                <!-- src/libs/fsdrv -->
-                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_fatfs.c" />
-                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_posix.c" />
-                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_stdio.c" />
-              </files>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Libs RLOTTIE"  condition="LVGL-Essential">
-              <description>Add RLOTTIE support, an extra librbary is required.</description>
-              <files>
-                <!-- src/libs/rlottie -->
-                <file category="sourceC"    name="src/libs/rlottie/lv_rlottie.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable RLOTTIE support */
-#define LV_USE_RLOTTIE         1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Libs ffmpeg"  condition="LVGL-Essential">
-              <description>Add ffmpeg support, an extra librbary is required.</description>
-              <files>
-                <!-- src/libs/ffmpeg -->
-                <file category="sourceC"    name="src/libs/ffmpeg/lv_ffmpeg.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable ffmpeg support */
-#define LV_USE_FFMPEG         1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="Pinyin"  condition="LVGL-Essential">
-              <description>Add Pinyin input method</description>
-              <files>
-                <!-- src/others/ime -->
-                <file category="sourceC"    name="src/others/ime/lv_ime_pinyin.c" />
-              </files>
-
-              <RTE_Components_h>
-
-/*! \brief enable pinying support */
-#define LV_USE_IME_PINYIN         1
-              </RTE_Components_h>
-
-            </component>
-
-            <component Cgroup="lvgl" Csub="File Explorer"  condition="LVGL-Essential">
+            <component Cgroup="Libraries and Others" Csub="File Explorer"  condition="LVGL-Essential">
               <description>Add a file explorer</description>
               <files>
                 <!-- src/others/file_explorer -->
@@ -899,37 +1300,124 @@
               </RTE_Components_h>
 
             </component>
-
-            <component Cgroup="lvgl" Csub="Tiny TTF"  condition="LVGL-Essential">
-              <description>Add the Tiny TTF support</description>
+            
+            <component Cgroup="Libraries and Others" Csub="Fragment"  condition="LVGL-Essential">
+              <description>Add the Fragment service</description>
               <files>
-                <!-- src/libs/tiny_ttf -->
-                <file category="sourceC"    name="src/libs/tiny_ttf/lv_tiny_ttf.c" />
-                <!-- src/libs/fsdrv -->
-                <file category="sourceC"    name="src/libs/fsdrv/lv_fs_cbfs.c" />
+                <!-- src/others/fragment -->
+                <file category="sourceC"            name="src/others/fragment/lv_fragment.c" />
+                <file category="sourceC"            name="src/others/fragment/lv_fragment_manager.c" />
               </files>
 
               <RTE_Components_h>
 
-/*! \brief enable tiny ttf support */
-#define LV_USE_TINY_TTF         1
+/*! \brief enable lv_obj fragment */
+#define LV_USE_FRAGMENT         1
+              </RTE_Components_h>
+
+            </component>
+            
+            <component Cgroup="Libraries and Others" Csub="Grid Navigation"  condition="LVGL-Essential">
+              <description>Add the Grid Navigation service</description>
+              <files>
+                <!-- src/others/gridnav -->
+                <file category="sourceC"            name="src/others/gridnav/lv_gridnav.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Grid Navigation support*/
+#define LV_USE_GRIDNAV          1
               </RTE_Components_h>
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Benchmark"  condition="LVGL-Essential">
+            <component Cgroup="Libraries and Others" Csub="IME Pinyin"  condition="LVGL-Essential">
+              <description>Add Pinyin input method</description>
+              <files>
+                <!-- src/others/ime -->
+                <file category="sourceC"            name="src/others/ime/lv_ime_pinyin.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief Pinyin input method */
+#define LV_USE_IME_PINYIN       1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Image Font"  condition="LVGL-Essential">
+              <description>Add Support for using images as font in label or span widgets</description>
+              <files>
+                <!-- src/others/imgfont -->
+                <file category="sourceC"            name="src/others/imgfont/lv_imgfont.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT          1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Monkey"  condition="LVGL-Essential">
+              <description>Add the Monkey test service</description>
+              <files>
+                <!-- src/others/monkey -->
+                <file category="sourceC"            name="src/others/monkey/lv_monkey.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable Monkey test*/
+#define LV_USE_MONKEY           1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Observer"  condition="LVGL-Essential">
+              <description>Add an observer pattern implementation</description>
+              <files>
+                <!-- src/others/observer -->
+                <file category="sourceC"            name="src/others/observer/lv_observer.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable an observer pattern implementation*/
+#define LV_USE_OBSERVER         1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Libraries and Others" Csub="Snapshot"  condition="LVGL-Essential">
+              <description>Add the API to take snapshot for object</description>
+              <files>
+                <!-- src/others/snapshot -->
+                <file category="sourceC"            name="src/others/snapshot/lv_snapshot.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable API to take snapshot for object */
+#define LV_USE_SNAPSHOT         1
+              </RTE_Components_h>
+
+            </component>
+
+
+            <component Cgroup="Demos" Csub="Benchmark"  condition="LVGL-Essential">
               <description>Add the official benchmark.</description>
               <files>
                 <!-- demos/benchmark -->
                 <file category="sourceC"    name="demos/benchmark/lv_demo_benchmark.c" />
-                <file category="header"     name="demos/benchmark/lv_demo_benchmark.h" />
 
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_alpha256.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_argb.c" />
-                <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_chroma_keyed.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_indexed16.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_rgb.c" />
-                <file category="sourceC"    name="demos/benchmark/assets/img_benchmark_cogwheel_rgb565a8.c" />
 
                 <file category="sourceC"    name="demos/benchmark/assets/lv_font_benchmark_montserrat_12_compr_az.c.c" />
                 <file category="sourceC"    name="demos/benchmark/assets/lv_font_benchmark_montserrat_16_compr_az.c.c" />
@@ -941,27 +1429,271 @@
               <RTE_Components_h>
 
 /*! \brief enable demo:bencharmk */
-#define LV_USE_DEMO_BENCHMARK         1
+#define LV_USE_DEMO_BENCHMARK           1
               </RTE_Components_h>
 
             </component>
 
-            <component Cgroup="lvgl" Csub="Demo:Widgets"  condition="LVGL-Essential">
+            <component Cgroup="Demos" Csub="Flex Layout" condition="LVGL-Essential">
+              <description>Add the Flex layout demo</description>
+              <files>
+                <!-- demos/flex_layout -->
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_ctrl_pad.c" />
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_flex_loader.c" />
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_main.c" />
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_view.c" />
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_view_child_node.c" />
+                <file category="sourceC"    name="demos/flex_layout/lv_demo_flex_layout_view_ctrl_pad.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Flex layout demo */
+#define LV_USE_DEMO_FLEX_LAYOUT         1
+              </RTE_Components_h>
+
+            </component>
+ 
+             <component Cgroup="Demos" Csub="Keypad Encoder" condition="LVGL-Essential">
+              <description>Add the demonstrate the usage of encoder and keyboard</description>
+              <files>
+                <!-- demos/keypad_encoder -->
+                <file category="sourceC"    name="demos/keypad_encoder/lv_demo_keypad_encoder.c" />
+                <file category="doc"        name="demos/keypad_encoder/README.md" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the demonstrate the usage of encoder and keyboard */
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER  1
+              </RTE_Components_h>
+
+            </component>
+ 
+ 
+              <component Cgroup="Demos" Csub="Multi-Language" condition="LVGL-Essential">
+              <description>Add the Smart-phone like multi-language demo.</description>
+              <files>
+                <!-- demos/multilang -->
+                <file category="sourceC"    name="demos/multilang/lv_demo_multilang.c" />
+                <file category="sourceC"    name="demos/multilang/assets/img_multilang_like.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_1.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_2.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_3.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_4.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_5.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_6.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_7.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_8.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_9.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_10.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_11.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_12.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_13.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_14.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_15.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_16.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_17.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_18.c" />
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_19.c" />
+
+
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_22.c" />
+
+                <file category="sourceC"    name="demos/multilang/assets/avatars/img_multilang_avatar_25.c" />
+                
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_artist_palette.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_books.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_camera_with_flash.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_cat_face.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_deciduous_tree.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_dog_face.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_earth_globe_europe_africa.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_flexed_biceps.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_movie_camera.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_red_heart.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_rocket.c" />
+                <file category="sourceC"    name="demos/multilang/assets/emojis/img_emoji_soccer_ball.c" />
+                
+                <file category="sourceC"    name="demos/multilang/assets/fonts/font_multilang_large.c" />
+                <file category="sourceC"    name="demos/multilang/assets/fonts/font_multilang_small.c" />
+
+                
+                <file category="doc"        name="demos/multilang/README.md" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Smart-phone like multi-language demo */
+#define LV_USE_DEMO_MULTILANG           1
+              </RTE_Components_h>
+
+            </component>
+ 
+              <component Cgroup="Demos" Csub="Music Player" condition="LVGL-Essential">
+              <description>Add the music player demo</description>
+              <files>
+                <!-- demos/music -->
+                <file category="sourceC"    name="demos/music/lv_demo_music.c" />
+                <file category="sourceC"    name="demos/music/lv_demo_music_list.c" />
+                <file category="sourceC"    name="demos/music/lv_demo_music_main.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_wave_top_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_wave_top.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_wave_bottom_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_wave_bottom.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_slider_knob_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_slider_knob.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_logo.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_list_border_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_list_border.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_4_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_4.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_3_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_3.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_2_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_2.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_1_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_icon_1.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_3_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_3.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_2_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_2.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_1_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_cover_1.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_corner_right_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_corner_right.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_corner_left_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_corner_left.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_rnd_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_rnd.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_prev_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_prev.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_play_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_play.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_pause_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_pause.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_next_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_next.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_loop_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_loop.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_list_play_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_list_play.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_list_pause_large.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_list_pause.c" />
+                <file category="sourceC"    name="demos/music/assets/img_lv_demo_music_btn_corner_large.c" />
+                
+                <file category="doc"        name="demos/music/README.md" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the music player demo */
+#define LV_USE_DEMO_MUSIC               1
+              </RTE_Components_h>
+
+            </component>
+ 
+             <component Cgroup="Demos" Csub="Scroll" condition="LVGL-Essential">
+              <description>Add the demonstration for scroll settings</description>
+              <files>
+                <!-- demos/scroll -->
+                <file category="sourceC"    name="demos/scroll/lv_demo_scroll.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the demonstration for scroll settings */
+#define LV_USE_DEMO_SCROLL              1
+              </RTE_Components_h>
+
+            </component>
+
+             <component Cgroup="Demos" Csub="Stress Test" condition="LVGL-Essential">
+              <description>Add the Stress test for LVGL</description>
+              <files>
+                <!-- demos/stress -->
+                <file category="sourceC"    name="demos/stress/lv_demo_stress.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Stress test for LVGL */
+#define LV_USE_DEMO_STRESS              1
+              </RTE_Components_h>
+
+            </component>
+            
+             <component Cgroup="Demos" Csub="Widget Transform" condition="LVGL-Essential">
+              <description>Add the Widget transformation demo</description>
+              <files>
+                <!-- demos/transform -->
+                <file category="sourceC"    name="demos/transform/lv_demo_transform.c" />
+                <file category="sourceC"    name="demos/transform/assets/img_transform_avatar_15.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Widget transformation demo */
+#define LV_USE_DEMO_TRANSFORM           1
+              </RTE_Components_h>
+
+            </component>
+ 
+              <component Cgroup="Demos" Csub="Vector Graphic" condition="LVGL-Essential">
+              <description>Add the Vector graphic demo</description>
+              <files>
+                <!-- demos/vector_graphic -->
+                <file category="sourceC"    name="demos/vector_graphic/lv_demo_vector_graphic.c" />
+                <file category="sourceC"    name="demos/vector_graphic/assets/img_demo_vector_avatar.c" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief enable the Vector graphic demo */
+#define LV_USE_DEMO_VECTOR_GRAPHIC      1
+              </RTE_Components_h>
+
+            </component>
+
+            <component Cgroup="Demos" Csub="Widgets" condition="LVGL-Essential">
               <description>Add the demo:widgets</description>
               <files>
                 <!-- demos/widgets -->
                 <file category="sourceC"    name="demos/widgets/lv_demo_widgets.c" />
-                <file category="header"     name="demos/widgets/lv_demo_widgets.h" />
 
                 <file category="sourceC"    name="demos/widgets/assets/img_clothes.c" />
                 <file category="sourceC"    name="demos/widgets/assets/img_demo_widgets_avatar.c" />
+                <file category="sourceC"    name="demos/widgets/assets/img_demo_widgets_needle.c" />
                 <file category="sourceC"    name="demos/widgets/assets/img_lvgl_logo.c" />
               </files>
 
               <RTE_Components_h>
 
 /*! \brief enable demo:widgets support */
-#define LV_USE_DEMO_WIDGETS         1
+#define LV_USE_DEMO_WIDGETS             1
+              </RTE_Components_h>
+
+            </component>
+            
+            <component Cgroup="Demos" Csub="Render Test" condition="LVGL-Essential">
+              <description>Add the Render test for each primitives. Requires at least 480x272 display</description>
+              <files>
+                <!-- demos/render -->
+                <file category="sourceC"    name="demos/render/lv_demo_render.c" />
+
+                <file category="sourceC"    name="demos/render/assets/img_render_arc_bg.c" />
+                <file category="sourceC"    name="demos/render/assets/img_render_lvgl_logo_argb8888.c" />
+                <file category="sourceC"    name="demos/render/assets/img_render_lvgl_logo_rgb565.c" />
+                <file category="sourceC"    name="demos/render/assets/img_render_lvgl_logo_rgb888.c" />
+                <file category="sourceC"    name="demos/render/assets/img_render_lvgl_logo_xrgb8888.c" />
+                
+                <file category="doc"        name="demos/render/README.md" />
+              </files>
+
+              <RTE_Components_h>
+
+/*! \brief add Render test for each primitives */
+#define LV_USE_DEMO_RENDER              1
               </RTE_Components_h>
 
             </component>

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2023-03-03T12:22:00</timestamp>
+  <timestamp>2023-12-10</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="8.3.7"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="9.0.0-dev"/>
   </pindex>
 </index>

--- a/env_support/cmsis-pack/README.md
+++ b/env_support/cmsis-pack/README.md
@@ -34,127 +34,63 @@ remove the misleading guide above this code segment.
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
-#include <stdint.h>
 #include "RTE_Components.h"
 ...
 ```
+4. Remove macro definitions for
 
-4. Update `LV_STDIO_INCLUDE` and `LV_STRING_INCLUDE`
-
-   ```c
-   #define LV_STDLIB_INCLUDE <stdlib.h>
-   #define LV_STDIO_INCLUDE  <stdio.h>
-   #define LV_STRING_INCLUDE <string.h>
-   ```
-
-
-
-5. Remove macro definitions for
-
-   - LV_USE_GPU_STM32_DMA2D
-   - LV_USE_GPU_NXP_PXP
-   - LV_USE_GPU_NXP_VG_LITE
-   - LV_USE_GPU_SWM341_DMA2D
-   - LV_USE_GPU_GD32_IPA
-   - LV_USE_GPU_ARM2D
    - LV_USE_DEMO_WIDGETS
    - LV_USE_DEMO_BENCHMARK
    - LV_USE_IME_PINYIN
+   - LV_USE_OS
    - LV_USE_FILE_EXPLORER
+   - LV_USE_DEMO_WIDGETS
+   - LV_USE_DEMO_KEYPAD_AND_ENCODER
+   - LV_USE_DEMO_BENCHMARK
+   - LV_USE_DEMO_RENDER
+   - LV_USE_DEMO_STRESS
+   - LV_USE_DEMO_MUSIC
+   - LV_USE_DEMO_FLEX_LAYOUT
+   - LV_USE_DEMO_MULTILANG
+   - LV_USE_DEMO_TRANSFORM
+   - LV_USE_DEMO_SCROLL
+   - LV_USE_DEMO_VECTOR_GRAPHIC
+   - LV_USE_DRAW_VGLITE
+   - LV_USE_DRAW_PXP
+   - LV_USE_DRAW_SDL
+   - LV_USE_SNAPSHOT
+   - LV_USE_MONKEY
+   - LV_USE_GRIDNAV
+   - LV_USE_FRAGMENT
+   - LV_USE_IMGFONT
+   - LV_USE_OBSERVER
+5. Update `LV_LOG_PRINTF` to `1` and `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER`
 
-6. Update `LV_LOG_PRINTF` to `1` and `LV_LOG_LEVEL` to `LV_LOG_LEVEL_USER`
 
-7. Update `LV_DEMO_BENCHMARK_RGB565A8` to `1`
+6. Set `LV_FONT_MONTSERRAT_12` and `LV_FONT_MONTSERRAT_16` to `1` (So Widgets and Benchmark can be compiled correctly, this is for improving the out of box experience.)
 
-8. Set `LV_FONT_MONTSERRAT_12` and `LV_FONT_MONTSERRAT_16` to `1` (So Widgets and Benchmark can be compiled correctly, this is for improving the out of box experience.)
 
-9. Update macro `LV_ATTRIBUTE_MEM_ALIGN` and `LV_ATTRIBUTE_MEM_ALIGN_SIZE`  to force a WORD alignment.
+7. Update macro `LV_ATTRIBUTE_MEM_ALIGN` and `LV_ATTRIBUTE_MEM_ALIGN_SIZE`  to force a WORD alignment.
 ```c
 #define LV_ATTRIBUTE_MEM_ALIGN_SIZE     4
+#define LV_DRAW_BUF_STRIDE_ALIGN		4
 #define LV_ATTRIBUTE_MEM_ALIGN          __attribute__((aligned(4)))
 ```
-Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
+Make sure `LV_MEM_SIZE` is no less than `(256*1024U)`.
 
-
-
-6. Update Theme related macros:
-
-```c
-#ifdef RTE_GRAPHICS_LVGL_USE_EXTRA_THEMES
-    /*A simple, impressive and very complete theme*/
-    #define LV_USE_THEME_DEFAULT 1
-    #if LV_USE_THEME_DEFAULT
-
-        /*0: Light mode; 1: Dark mode*/
-        #define LV_THEME_DEFAULT_DARK 0
-
-        /*1: Enable grow on press*/
-        #define LV_THEME_DEFAULT_GROW 1
-
-        /*Default transition time in [ms]*/
-        #define LV_THEME_DEFAULT_TRANSITION_TIME 80
-    #endif /*LV_USE_THEME_DEFAULT*/
-
-    /*A very simple theme that is a good starting point for a custom theme*/
-    #define LV_USE_THEME_BASIC 1
-
-    /*A theme designed for monochrome displays*/
-    #define LV_USE_THEME_MONO 1
-#else
-    #define LV_USE_THEME_DEFAULT    0
-    #define LV_USE_THEME_BASIC      0
-    #define LV_USE_THEME_MONO       0
-#endif
-```
-7. Update `LV_TICK_CUSTOM` related macros:
-```c
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#ifdef __PERF_COUNTER__
-    #define LV_TICK_CUSTOM 1
-    #if LV_TICK_CUSTOM
-        extern uint32_t SystemCoreClock;
-        #define LV_TICK_CUSTOM_INCLUDE          "perf_counter.h"
-        #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
-    #endif   /*LV_TICK_CUSTOM*/
-#else
-    #define LV_TICK_CUSTOM 0
-    #if LV_TICK_CUSTOM
-        #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-        #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-        /*If using lvgl as ESP32 component*/
-        // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-        // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
-    #endif   /*LV_TICK_CUSTOM*/
-#endif       /*__PERF_COUNTER__*/
-```
-9. Thoroughly remove the `DEMO USAGE` section and add following code:
-
-   ```c
-   /*Show some widget. It might be required to increase `LV_MEM_SIZE` */
-   #if LV_USE_DEMO_WIDGETS
-       #define LV_DEMO_WIDGETS_SLIDESHOW 0
-   #endif
-
-   /*Benchmark your system*/
-   #if LV_USE_DEMO_BENCHMARK
-       /*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
-       #define LV_DEMO_BENCHMARK_RGB565A8 0
-   #endif
-   ```
-
-
-
-10. Remove following macro definitions in the `3rd party libraries` section:
+8. Remove following macro definitions in the `3rd party libraries` section:
 
     - \#define LV_USE_FS_STDIO 0
     - \#define LV_USE_FS_POSIX 0
     - \#define LV_USE_FS_WIN32 0
     - \#define LV_USE_FS_FATFS 0
+    - #define LV_USE_FS_MEMFS 0
     - \#define LV_USE_LODEPNG 0
+    - #define LV_USE_LIBPNG 0
     - \#define LV_USE_BMP 0
     - \#define LV_USE_RLE 0
-    - \#define LV_USE_SJPG 0
+    - #define LV_USE_TJPGD 0
+    - #define LV_USE_LIBJPEG_TURBO 0
     - \#define LV_USE_GIF 0
     - \#define LV_USE_BARCODE 0
     - \#define LV_USE_QRCODE 0
@@ -163,21 +99,38 @@ Make sure `LV_MEM_SIZE` is no less than `(64*1024U)`.
     - \#define LV_USE_RLOTTIE 0
     - \#define LV_USE_FFMPEG 0
 
-11. Remove unsupported devices from the `DEVICES` section
+9. update the definition of following macros: `LV_USE_VECTOR_GRAPHIC`, `LV_USE_THORVE_INTERNAL` and `LV_USE_THORVE_EXTERNAL` as 
 
-    - LV_USE_SDL
+    ```c
+    /*Enable Vector Graphic APIs*/
+    #ifndef LV_USE_VECTOR_GRAPHIC
+    #   define LV_USE_VECTOR_GRAPHIC  0
+    
+    /* Enable ThorVG (vector graphics library) from the src/libs folder */
+    #   define LV_USE_THORVG_INTERNAL 0
+    
+    /* Enable ThorVG by assuming that its installed and linked to the project */
+    #   define LV_USE_THORVG_EXTERNAL 0
+    #endif
+    ```
 
-    - LV_USE_X11
+10. update the definition of following macros: `LV_USE_LZ4`, `LV_USE_LZ4_INTERNAL` and `LV_USE_LZ4_EXTERNAL` as 
 
-    - LV_USE_LINUX_FBDEV
+    ```c
+    /*Enable LZ4 compress/decompress lib*/
+    #ifndef LV_USE_LZ4
+    #   define LV_USE_LZ4  0
+    
+    /*Use lvgl built-in LZ4 lib*/
+    #   define LV_USE_LZ4_INTERNAL  0
+    
+    /*Use external LZ4 library*/
+    #   define LV_USE_LZ4_EXTERNAL  0
+    #endif
+    ```
 
-    - LV_USE_NUTTX_FBDEV
 
-    - LV_USE_LINUX_DRM
-
-    - LV_USE_TFT_ESPI
-
-12. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
+11. rename '**lv_conf_template.h**' to '**lv_conf_cmsis.h**'.
 
 
 

--- a/env_support/cmsis-pack/gen_pack.sh
+++ b/env_support/cmsis-pack/gen_pack.sh
@@ -44,7 +44,6 @@ PACK_BUILD=build/
 # alternative: specify directory names to be added to pack base directory
 PACK_DIRS="
   ../../src
-  ../../docs
   ../../demos
   ../../env_support/pikascript
 "
@@ -193,6 +192,15 @@ rm -rf PackName.txt
 # echo apply patches...
 # rm -rf $PACK_BUILD/demos/lv_demos.h
 # cp -f ./lv_demos.h $PACK_BUILD/demos/
+
+echo delete files...
+find $PACK_BUILD/demos/ -type f -name "*.png" -delete
+find $PACK_BUILD/demos/ -type f -name "*.gif" -delete
+find $PACK_BUILD/demos/ -type f -name "*.gif" -delete
+find $PACK_BUILD/demos/ -type f -name "*.ttf" -delete
+find $PACK_BUILD/demos/ -type f -name "*.otf" -delete
+find $PACK_BUILD/demos/ -type f -name "*.jpg" -delete
+find $PACK_BUILD/demos/ -type f -name "*.fnt" -delete
 
 # Archiving
 # $ZIP a $PACKNAME

--- a/env_support/cmsis-pack/gen_pack.sh
+++ b/env_support/cmsis-pack/gen_pack.sh
@@ -138,10 +138,6 @@ fi
 mkdir -p ${PACK_BUILD}/examples
 mkdir -p ${PACK_BUILD}/examples/porting
 
-# Copy files into build base directory: $PACK_BUILD
-# pdsc file is mandatory in base directory:
-cp -f  ./$PACK_VENDOR.$PACK_NAME.pdsc ${PACK_BUILD}
-cp -f ../../examples/porting/* ${PACK_BUILD}/examples/porting
 
 
 # directories
@@ -161,6 +157,12 @@ for f in $PACK_BASE_FILES
 do
   cp -f  "$f" $PACK_BUILD/
 done
+
+# Copy files into build base directory: $PACK_BUILD
+# pdsc file is mandatory in base directory:
+cp -f  ./$PACK_VENDOR.$PACK_NAME.pdsc ${PACK_BUILD}
+cp -f ../../examples/porting/* ${PACK_BUILD}/examples/porting
+cp -f ./lv_os_custom.* ${PACK_BUILD}/src/osal
 
 mv "${PACK_BUILD}/lv_cmsis_pack.txt" "${PACK_BUILD}/lv_cmsis_pack.c"
 
@@ -187,12 +189,6 @@ fi
 
 PACKNAME=`cat PackName.txt`
 rm -rf PackName.txt
-
-echo remove unrequired files and folders...
-rm -rf $PACK_BUILD/demos/keypad_encoder
-rm -rf $PACK_BUILD/demos/music
-rm -rf $PACK_BUILD/demos/stress
-rm -rf $PACK_BUILD/demos/widgets/screenshot1.gif
 
 # echo apply patches...
 # rm -rf $PACK_BUILD/demos/lv_demos.h

--- a/env_support/cmsis-pack/lv_cmsis_pack.txt
+++ b/env_support/cmsis-pack/lv_cmsis_pack.txt
@@ -27,9 +27,18 @@
 #include "RTE_Components.h"
 #include <time.h>
 
- /*********************
+#if defined(__PERF_COUNTER__) && __PERF_COUNTER__
+#   include "perf_counter.h"
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+#include "lv_global.h"
+
+/*********************
  *      DEFINES
  *********************/
+#define state LV_GLOBAL_DEFAULT()->tick_state
 
  /**********************
  *      TYPEDEFS
@@ -102,12 +111,35 @@
  * time() which is not included in the MicroLib 
  */
 #if defined(__IS_COMPILER_ARM_COMPILER__) && __IS_COMPILER_ARM_COMPILER__
-#	if defined(__MICROLIB)
+#   if defined(__MICROLIB)
 __attribute__((weak))
 _ARMABI time_t time(time_t * time)
 {
     return (time_t)(-1);
 }
-#	endif
+#   endif
+
+
+
+#   if defined(__PERF_COUNTER__) && __PERF_COUNTER__
+/**
+ * Get the elapsed milliseconds since start up from perf_counter
+ * @return the elapsed milliseconds
+ */
+uint32_t $Sub$$lv_tick_get(void)
+{
+    lv_tick_state_t * state_p = &state;
+    
+    if (state_p->tick_get_cb){
+        return state_p->tick_get_cb();
+    }
+
+    return (uint32_t)get_system_ms();
+}
+
+#   endif
+
 #endif
+
+
 

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -9,27 +9,34 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
-#include <stdint.h>
 #include "RTE_Components.h"
 
 /*====================
    COLOR SETTINGS
  *====================*/
 
-/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 24 (RGB888), 32 (ARGB8888)*/
+/*Color depth: 8 (A8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
 #define LV_COLOR_DEPTH 16
-
-#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)
 
 /*=========================
    STDLIB WRAPPER SETTINGS
  *=========================*/
 
-/*Enable and configure the built-in memory manager*/
-#define LV_USE_BUILTIN_MALLOC 1
-#if LV_USE_BUILTIN_MALLOC
+/* Possible values
+ * - LV_STDLIB_BUILTIN:     LVGL's built in implementation
+ * - LV_STDLIB_CLIB:        Standard C functions, like malloc, strlen, etc
+ * - LV_STDLIB_MICROPYTHON: MicroPython implementation
+ * - LV_STDLIB_RTTHREAD:    RT-Thread implementation
+ * - LV_STDLIB_CUSTOM:      Implement the functions externally
+ */
+#define LV_USE_STDLIB_MALLOC    LV_STDLIB_BUILTIN
+#define LV_USE_STDLIB_STRING    LV_STDLIB_BUILTIN
+#define LV_USE_STDLIB_SPRINTF   LV_STDLIB_BUILTIN
+
+
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
     /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (128U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (256 * 1024U)          /*[bytes]*/
 
     /*Size of the memory expand for `lv_malloc()` in bytes*/
     #define LV_MEM_POOL_EXPAND_SIZE 0
@@ -41,35 +48,7 @@
         #undef LV_MEM_POOL_INCLUDE
         #undef LV_MEM_POOL_ALLOC
     #endif
-#endif  /*LV_USE_BUILTIN_MALLOC*/
-
-/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin, lv_strcpy_builtin*/
-#define LV_USE_BUILTIN_MEMCPY 1
-
-/*Enable and configure the built-in (v)snprintf */
-#define LV_USE_BUILTIN_SNPRINTF 1
-#if LV_USE_BUILTIN_SNPRINTF
-    #define LV_SPRINTF_USE_FLOAT 0
-#endif  /*LV_USE_BUILTIN_SNPRINTF*/
-
-#define LV_STDLIB_INCLUDE <stdlib.h>
-#define LV_STDIO_INCLUDE  <stdio.h>
-#define LV_STRING_INCLUDE <string.h>
-#define LV_MALLOC       lv_malloc_builtin
-#define LV_REALLOC      lv_realloc_builtin
-#define LV_FREE         lv_free_builtin
-#define LV_MEMSET       lv_memset_builtin
-#define LV_MEMCPY       lv_memcpy_builtin
-#define LV_SNPRINTF     lv_snprintf_builtin
-#define LV_VSNPRINTF    lv_vsnprintf_builtin
-#define LV_STRLEN       lv_strlen_builtin
-#define LV_STRNCPY      lv_strncpy_builtin
-#define LV_STRCPY       lv_strcpy_builtin
-
-#define "../misc/lv_color.h" <stdint.h>
-#define LV_COLOR_MIX      lv_color_mix
-#define LV_COLOR_PREMULT      lv_color_premult
-#define LV_COLOR_MIX_PREMULT      lv_color_mix_premult
+#endif  /*LV_USE_MALLOC == LV_STDLIB_BUILTIN*/
 
 /*====================
    HAL SETTINGS
@@ -78,44 +57,26 @@
 /*Default display refresh, input device read and animation step period.*/
 #define LV_DEF_REFR_PERIOD  33      /*[ms]*/
 
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#ifdef __PERF_COUNTER__
-    #define LV_TICK_CUSTOM 1
-    #if LV_TICK_CUSTOM
-        extern uint32_t SystemCoreClock;
-        #define LV_TICK_CUSTOM_INCLUDE          "perf_counter.h"
-        #define LV_TICK_CUSTOM_SYS_TIME_EXPR    get_system_ms()
-    #endif   /*LV_TICK_CUSTOM*/
-#else
-    #define LV_TICK_CUSTOM 0
-    #if LV_TICK_CUSTOM
-        #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-        #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-        /*If using lvgl as ESP32 component*/
-        // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-        // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
-    #endif   /*LV_TICK_CUSTOM*/
-#endif       /*__PERF_COUNTER__*/
-
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #define LV_DPI_DEF 130     /*[px/inch]*/
 
 /*========================
- * DRAW CONFIGURATION
+ * RENDERING CONFIGURATION
  *========================*/
 
-/*Enable the built in mask engine.
- *Required to draw shadow, rounded corners, circles, arc, skew lines, or any other masks*/
-#define LV_USE_DRAW_MASKS 1
+/*Align the stride of all layers and images to this bytes*/
+#define LV_DRAW_BUF_STRIDE_ALIGN                4
 
-#define LV_USE_DRAW_SW  1
-#if LV_USE_DRAW_SW
+/*Align the start address of draw_buf addresses to this bytes*/
+#define LV_DRAW_BUF_ALIGN                       4
 
-    /*Enable complex draw engine.
-     *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
-    #define LV_DRAW_SW_COMPLEX 1
+#define LV_USE_DRAW_SW 1
+#if LV_USE_DRAW_SW == 1
+    /* Set the number of draw unit.
+     * > 1 requires an operating system enabled in `LV_USE_OS`
+     * > 1 means multiply threads will render the screen in parallel */
+    #define LV_DRAW_SW_DRAW_UNIT_CNT    1
 
     /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
      * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
@@ -125,71 +86,37 @@
     /*The target buffer size for simple layer chunks.*/
     #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)   /*[bytes]*/
 
-    /*Used if `LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.*/
-    #define LV_DRAW_SW_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)    /*[bytes]*/
+    /* 0: use a simple renderer capable of drawing only simple rectangles with gradient, images, texts, and straight lines only
+     * 1: use a complex renderer capable of drawing rounded corners, shadow, skew lines, and arcs too */
+    #define LV_DRAW_SW_COMPLEX          1
 
-    /*Allow buffering some shadow calculation.
-    *LV_DRAW_SW_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
-    *Caching has LV_DRAW_SW_SHADOW_CACHE_SIZE^2 RAM cost*/
-    #define LV_DRAW_SW_SHADOW_CACHE_SIZE 0
+    #if LV_DRAW_SW_COMPLEX == 1
+        /*Allow buffering some shadow calculation.
+        *LV_DRAW_SW_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+        *Caching has LV_DRAW_SW_SHADOW_CACHE_SIZE^2 RAM cost*/
+        #define LV_DRAW_SW_SHADOW_CACHE_SIZE 0
 
-    /* Set number of maximally cached circle data.
-    * The circumference of 1/4 circle are saved for anti-aliasing
-    * radius * 4 bytes are used per circle (the most often used radiuses are saved)
-    * 0: to disable caching */
-    #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
-
-    /*Default gradient buffer size.
-     *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
-     *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
-     *If the cache is too small the map will be allocated only while it's required for the drawing.
-     *0 mean no caching.*/
-    #define LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE 0
-
-    /*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
-     *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
-     *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
-    #define LV_DRAW_SW_GRADIENT_DITHER 0
-    #if LV_DRAW_SW_GRADIENT_DITHER
-        /*Add support for error diffusion dithering.
-         *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
-         *The increase in memory consumption is (24 bits * object's width)*/
-        #define LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION 0
+        /* Set number of maximally cached circle data.
+        * The circumference of 1/4 circle are saved for anti-aliasing
+        * radius * 4 bytes are used per circle (the most often used radiuses are saved)
+        * 0: to disable caching */
+        #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
     #endif
 
-    /*Enable subpixel rendering*/
-    #define LV_DRAW_SW_FONT_SUBPX 0
-    #if LV_DRAW_SW_FONT_SUBPX
-        /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
-        #define LV_DRAW_SW_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+    #define  LV_USE_DRAW_SW_ASM     LV_DRAW_SW_ASM_NONE
+
+    #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_CUSTOM
+        #define  LV_DRAW_SW_ASM_CUSTOM_INCLUDE ""
     #endif
 #endif
 
-/*=====================
- * GPU CONFIGURATION
- *=====================*/
 
+/*=================
+ * OPERATING SYSTEM
+ *=================*/
 
-/*Use STM32's DMA2D (aka Chrom Art) GPU*/
-#if LV_USE_GPU_STM32_DMA2D
-    /*Must be defined to include path of CMSIS header of target processor
-    e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
-    #define LV_GPU_DMA2D_CMSIS_INCLUDE
-#endif
-
-/*Use NXP's PXP GPU iMX RTxxx platforms*/
-#if LV_USE_GPU_NXP_PXP
-    /*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
-    *   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
-    *   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
-    *0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
-    */
-    #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
-#endif
-
-/*Use SWM341's DMA2D GPU*/
-#if LV_USE_GPU_SWM341_DMA2D
-    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
+#if LV_USE_OS == LV_OS_CUSTOM
+    #define LV_OS_CUSTOM_INCLUDE <stdint.h>
 #endif
 
 /*=======================
@@ -221,6 +148,10 @@
      *0: Disable print timestamp*/
     #define LV_LOG_USE_TIMESTAMP 1
 
+    /*1: Print file and line number of the log;
+     *0: Do not print file and line number of the log*/
+    #define LV_LOG_USE_FILE_LINE 1
+
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1
     #define LV_LOG_TRACE_TIMER      1
@@ -230,7 +161,6 @@
     #define LV_LOG_TRACE_OBJ_CREATE 1
     #define LV_LOG_TRACE_LAYOUT     1
     #define LV_LOG_TRACE_ANIM       1
-    #define LV_LOG_TRACE_MSG        1
     #define LV_LOG_TRACE_CACHE      1
 
 #endif  /*LV_USE_LOG*/
@@ -252,8 +182,23 @@
 #define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
 
 /*-------------
- * Others
+ * Debug
  *-----------*/
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*1: Draw a red overlay for ARGB layers and a green overlay for RGB layers*/
+#define LV_USE_LAYER_DEBUG 0
+
+/*1: Draw overlays with different colors for each draw_unit's tasks.
+ *Also add the index number of the draw unit on white background.
+ *For layers add the index number of the draw unit on black background.*/
+#define LV_USE_PARALLEL_DRAW_DEBUG 0
+
+/*------------------
+ * STATUS MONITORING
+ *------------------*/
 
 /*1: Show CPU usage and FPS count
  * Requires `LV_USE_SYSMON = 1`*/
@@ -273,35 +218,45 @@
     #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
 #endif
 
-/*1: Draw random colored rectangles over the redrawn areas*/
-#define LV_USE_REFR_DEBUG 0
+/*-------------
+ * Others
+ *-----------*/
 
 /*Maximum buffer size to allocate for rotation.
  *Only used if software rotation is enabled in the display driver.*/
 #define LV_DISPLAY_ROT_MAX_BUF (10*1024)
 
-/*Garbage Collector settings
- *Used if lvgl is bound to higher level language and the memory is managed by that language*/
-#define LV_ENABLE_GC 0
-#if LV_ENABLE_GC != 0
-    #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
-#endif /*LV_ENABLE_GC*/
+#define LV_ENABLE_GLOBAL_CUSTOM 0
+#if LV_ENABLE_GLOBAL_CUSTOM
+    /*Header to include for the custom 'lv_global' function"*/
+    #define LV_GLOBAL_CUSTOM_INCLUDE <stdint.h>
+#endif
 
-/*Default image cache size. Image caching keeps some images opened.
- *If only the built-in image formats are used there is no real advantage of caching.
- *With other image decoders (e.g. PNG or JPG) caching save the continuous open/decode of images.
- *However the opened images consume additional RAM.
- *0: to disable caching*/
-#define LV_IMAGE_CACHE_DEF_SIZE 0
-
+/*Default cache size in bytes.
+ *Used by image decoders such as `lv_lodepng` to keep the decoded image in the memory.
+ *Data larger than the size of the cache also can be allocated but
+ *will be dropped immediately after usage.*/
+#define LV_CACHE_DEF_SIZE       0
 
 /*Number of stops allowed per gradient. Increase this to allow more stops.
  *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
-#define LV_GRADIENT_MAX_STOPS 2
+#define LV_GRADIENT_MAX_STOPS   2
 
 /* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
  * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
-#define LV_COLOR_MIX_ROUND_OFS 0
+#define LV_COLOR_MIX_ROUND_OFS  0
+
+/* Add 2 x 32 bit variables to each lv_obj_t to speed up getting style properties */
+#define LV_OBJ_STYLE_CACHE      0
+
+/* Add `id` field to `lv_obj_t` */
+#define LV_USE_OBJ_ID           0
+
+/* Use lvgl builtin method for obj ID */
+#define LV_USE_OBJ_ID_BUILTIN   0
+
+/*Use obj property set/get API*/
+#define LV_USE_OBJ_PROPERTY 0
 
 /*=====================
  *  COMPILER SETTINGS
@@ -335,10 +290,15 @@
 /*Place performance critical functions into a faster memory (e.g RAM)*/
 #define LV_ATTRIBUTE_FAST_MEM
 
-
 /*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
  *should also appear on LVGL binding API such as Micropython.*/
 #define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Prefix all global extern data with this*/
+#define LV_ATTRIBUTE_EXTERN_DATA
+
+/* Use `float` as `lv_value_precise_t` */
+#define LV_USE_FLOAT            0
 
 /*==================
  *   FONT USAGE
@@ -369,7 +329,6 @@
 #define LV_FONT_MONTSERRAT_48 0
 
 /*Demonstrate special features*/
-#define LV_FONT_MONTSERRAT_12_SUBPX      0
 #define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
 #define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
 #define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
@@ -424,9 +383,6 @@
  *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
 #define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
 
-/*The control character to use for signalling text recoloring.*/
-#define LV_TXT_COLOR_CMD "#"
-
 /*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
  *The direction will be processed according to the Unicode Bidirectional Algorithm:
  *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
@@ -448,6 +404,8 @@
  *================*/
 
 /*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+
+#define LV_WIDGETS_HAS_DEFAULT_VALUE  1
 
 #define LV_USE_ANIMIMG    1
 
@@ -491,6 +449,7 @@
 #if LV_USE_LABEL
     #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
     #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+    #define LV_LABEL_WAIT_CHAR_COUNT 3  /*The count of wait chart*/
 #endif
 
 #define LV_USE_LED        1
@@ -506,6 +465,8 @@
 #define LV_USE_MSGBOX     1
 
 #define LV_USE_ROLLER     1   /*Requires: lv_label*/
+
+#define LV_USE_SCALE      1
 
 #define LV_USE_SLIDER     1   /*Requires: lv_bar*/
 
@@ -538,31 +499,25 @@
  * THEMES
  *==================*/
 
-#ifdef RTE_GRAPHICS_LVGL_USE_EXTRA_THEMES
-    /*A simple, impressive and very complete theme*/
-    #define LV_USE_THEME_DEFAULT 1
-    #if LV_USE_THEME_DEFAULT
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
 
-        /*0: Light mode; 1: Dark mode*/
-        #define LV_THEME_DEFAULT_DARK 0
+    /*0: Light mode; 1: Dark mode*/
+    #define LV_THEME_DEFAULT_DARK 0
 
-        /*1: Enable grow on press*/
-        #define LV_THEME_DEFAULT_GROW 1
+    /*1: Enable grow on press*/
+    #define LV_THEME_DEFAULT_GROW 1
 
-        /*Default transition time in [ms]*/
-        #define LV_THEME_DEFAULT_TRANSITION_TIME 80
-    #endif /*LV_USE_THEME_DEFAULT*/
+    /*Default transition time in [ms]*/
+    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
 
-    /*A very simple theme that is a good starting point for a custom theme*/
-    #define LV_USE_THEME_BASIC 1
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_BASIC 1
 
-    /*A theme designed for monochrome displays*/
-    #define LV_USE_THEME_MONO 1
-#else
-    #define LV_USE_THEME_DEFAULT    0
-    #define LV_USE_THEME_BASIC      0
-    #define LV_USE_THEME_MONO       0
-#endif
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
 
 /*==================
  * LAYOUTS
@@ -607,24 +562,42 @@
     #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
 #endif
 
+/*API for memory-mapped file access. */
+#if LV_USE_FS_MEMFS
+    #define LV_FS_MEMFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#endif
+
+
+/*GIF decoder library*/
+#if LV_USE_GIF
+/*GIF decoder accelerate*/
+#define LV_GIF_CACHE_DECODE_DATA 0
+#endif
+
+
+/*Decode bin images to RAM*/
+#define LV_BIN_DECODER_RAM_LOAD 0
+
 
 /*FreeType library*/
 #if LV_USE_FREETYPE
-    /*Memory used by FreeType to cache characters [bytes]*/
-    #define LV_FREETYPE_CACHE_SIZE (64 * 1024)
+    /*Memory used by FreeType to cache characters in kilobytes*/
+    #define LV_FREETYPE_CACHE_SIZE 768
 
     /*Let FreeType to use LVGL memory and file porting*/
     #define LV_FREETYPE_USE_LVGL_PORT 0
 
-    /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
-    /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
-    /* if font size >= 256, must be configured as image cache */
-    #define LV_FREETYPE_SBIT_CACHE 0
+    /*FreeType cache type:
+     * LV_FREETYPE_CACHE_TYPE_IMAGE    - Image cache
+     * LV_FREETYPE_CACHE_TYPE_SBIT     - Sbit cache
+     * LV_FREETYPE_CACHE_TYPE_OUTLINE  - Outline cache*/
+    #define LV_FREETYPE_CACHE_TYPE LV_FREETYPE_CACHE_TYPE_IMAGE
 
     /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
     /* (0:use system defaults) */
-    #define LV_FREETYPE_CACHE_FT_FACES 4
-    #define LV_FREETYPE_CACHE_FT_SIZES 4
+    #define LV_FREETYPE_CACHE_FT_FACES 8
+    #define LV_FREETYPE_CACHE_FT_SIZES 8
+    #define LV_FREETYPE_CACHE_FT_OUTLINES 256
 #endif
 
 /* Built-in TTF decoder */
@@ -633,6 +606,28 @@
     #define LV_TINY_TTF_FILE_SUPPORT 0
 #endif
 
+
+/*Enable Vector Graphic APIs*/
+#ifndef LV_USE_VECTOR_GRAPHIC
+#   define LV_USE_VECTOR_GRAPHIC  0
+
+/* Enable ThorVG (vector graphics library) from the src/libs folder */
+#   define LV_USE_THORVG_INTERNAL 0
+
+/* Enable ThorVG by assuming that its installed and linked to the project */
+#   define LV_USE_THORVG_EXTERNAL 0
+#endif
+
+/*Enable LZ4 compress/decompress lib*/
+#ifndef LV_USE_LZ4
+#   define LV_USE_LZ4  0
+
+/*Use lvgl built-in LZ4 lib*/
+#   define LV_USE_LZ4_INTERNAL  0
+
+/*Use external LZ4 library*/
+#   define LV_USE_LZ4_EXTERNAL  0
+#endif
 
 /*FFmpeg library for image decoding and playing videos
  *Supports all major image formats so do not enable other image decoder with it*/
@@ -645,11 +640,9 @@
  * OTHERS
  *==================*/
 
-/*1: Enable API to take snapshot for object*/
-#define LV_USE_SNAPSHOT 0
 
 /*1: Enable system monitor component*/
-#define LV_USE_SYSMON 0
+#define LV_USE_SYSMON   (LV_USE_MEM_MONITOR | LV_USE_PERF_MONITOR)
 
 /*1: Enable the runtime performance profiler*/
 #define LV_USE_PROFILER 0
@@ -665,23 +658,20 @@
     #define LV_PROFILER_INCLUDE "lvgl/src/misc/lv_profiler_builtin.h"
 
     /*Profiler start point function*/
-    #define LV_PROFILER_BEGIN   LV_PROFILER_BUILTIN_BEGIN
+    #define LV_PROFILER_BEGIN    LV_PROFILER_BUILTIN_BEGIN
 
     /*Profiler end point function*/
-    #define LV_PROFILER_END     LV_PROFILER_BUILTIN_END
+    #define LV_PROFILER_END      LV_PROFILER_BUILTIN_END
+
+    /*Profiler start point function with custom tag*/
+    #define LV_PROFILER_BEGIN_TAG LV_PROFILER_BUILTIN_BEGIN_TAG
+
+    /*Profiler end point function with custom tag*/
+    #define LV_PROFILER_END_TAG   LV_PROFILER_BUILTIN_END_TAG
 #endif
 
-/*1: Enable Monkey test*/
-#define LV_USE_MONKEY 0
-
-/*1: Enable grid navigation*/
-#define LV_USE_GRIDNAV 0
-
-/*1: Enable lv_obj fragment*/
-#define LV_USE_FRAGMENT 0
 
 /*1: Support using images as font in label or span widgets */
-#define LV_USE_IMGFONT 0
 #if LV_USE_IMGFONT
     /*Imgfont image file path maximum length*/
     #define LV_IMGFONT_PATH_MAX_LEN 64
@@ -689,6 +679,7 @@
     /*1: Use img cache to buffer header information*/
     #define LV_IMGFONT_USE_IMAGE_CACHE_HEADER 0
 #endif
+
 
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/
@@ -704,7 +695,7 @@
     #define LV_IME_PINYIN_USE_K9_MODE      1
     #if LV_IME_PINYIN_USE_K9_MODE == 1
         #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
-    #endif // LV_IME_PINYIN_USE_K9_MODE
+    #endif /*LV_IME_PINYIN_USE_K9_MODE*/
 #endif
 
 /*1: Enable file explorer*/
@@ -722,17 +713,64 @@
  *==================*/
 
 /*Use SDL to open window on PC and handle mouse and keyboard*/
+#define LV_USE_SDL              0
 #if LV_USE_SDL
     #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
-    #define LV_SDL_PARTIAL_MODE    0    /*Recommended only to emulate a setup with a display controller*/
-    #define LV_SDL_FULLSCREEN      0
-    #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL widows are closed*/
+    #define LV_SDL_RENDER_MODE     LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
+    #define LV_SDL_BUF_COUNT       1    /*1 or 2*/
+    #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
+    #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
+#endif
+
+/*Use X11 to open window on Linux desktop and handle mouse and keyboard*/
+#define LV_USE_X11              0
+#if LV_USE_X11
+    #define LV_X11_DIRECT_EXIT         1  /*Exit the application when all X11 windows have been closed*/
+    #define LV_X11_DOUBLE_BUFFER       1  /*Use double buffers for endering*/
+    /*select only 1 of the following render modes (LV_X11_RENDER_MODE_PARTIAL preferred!)*/
+    #define LV_X11_RENDER_MODE_PARTIAL 1  /*Partial render mode (preferred)*/
+    #define LV_X11_RENDER_MODE_DIRECT  0  /*direct render mode*/
+    #define LV_X11_RENDER_MODE_FULL    0  /*Full render mode*/
 #endif
 
 /*Driver for /dev/fb*/
+#define LV_USE_LINUX_FBDEV      0
 #if LV_USE_LINUX_FBDEV
-    #define LV_LINUX_FBDEV_BSD  0
+    #define LV_LINUX_FBDEV_BSD           0
+    #define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_PARTIAL
+    #define LV_LINUX_FBDEV_BUFFER_COUNT  0
+    #define LV_LINUX_FBDEV_BUFFER_SIZE   60
 #endif
+
+/*Use Nuttx to open window and handle touchscreen*/
+#define LV_USE_NUTTX    0
+
+#if LV_USE_NUTTX
+    #define LV_USE_NUTTX_LIBUV    0
+
+    /*Use Nuttx custom init API to open window and handle touchscreen*/
+    #define LV_USE_NUTTX_CUSTOM_INIT    0
+
+    /*Driver for /dev/lcd*/
+    #define LV_USE_NUTTX_LCD      0
+    #if LV_USE_NUTTX_LCD
+        #define LV_NUTTX_LCD_BUFFER_COUNT    0
+        #define LV_NUTTX_LCD_BUFFER_SIZE     60
+    #endif
+
+    /*Driver for /dev/input*/
+    #define LV_USE_NUTTX_TOUCHSCREEN    0
+
+#endif
+
+/*Driver for /dev/dri/card*/
+#define LV_USE_LINUX_DRM        0
+
+/*Interface for TFT_eSPI*/
+#define LV_USE_TFT_ESPI         0
+
+/*Driver for evdev input devices*/
+#define LV_USE_EVDEV    0
 
 /*==================
 * EXAMPLES
@@ -750,10 +788,13 @@
     #define LV_DEMO_WIDGETS_SLIDESHOW 0
 #endif
 
-/*Benchmark your system*/
-#if LV_USE_DEMO_BENCHMARK
-    /*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
-    #define LV_DEMO_BENCHMARK_RGB565A8 1
+/*Music player demo*/
+#if LV_USE_DEMO_MUSIC
+    #define LV_DEMO_MUSIC_SQUARE    0
+    #define LV_DEMO_MUSIC_LANDSCAPE 0
+    #define LV_DEMO_MUSIC_ROUND     0
+    #define LV_DEMO_MUSIC_LARGE     0
+    #define LV_DEMO_MUSIC_AUTO_PLAY 0
 #endif
 
 /*--END OF LV_CONF_H--*/

--- a/env_support/cmsis-pack/lv_os_custom.c
+++ b/env_support/cmsis-pack/lv_os_custom.c
@@ -1,0 +1,120 @@
+/**
+ * @file lv_os_custom.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_os.h"
+
+#if LV_USE_OS == LV_OS_CUSTOM
+#include "../misc/lv_types.h"
+#include "../misc/lv_assert.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+lv_result_t lv_thread_init(lv_thread_t * thread, lv_thread_prio_t prio, void (*callback)(void *), size_t stack_size,
+                           void * user_data)
+{
+    LV_UNUSED(thread);
+    LV_UNUSED(callback);
+    LV_UNUSED(prio);
+    LV_UNUSED(stack_size);
+    LV_UNUSED(user_data);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+lv_result_t lv_thread_delete(lv_thread_t * thread)
+{
+    LV_UNUSED(thread);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+lv_result_t lv_mutex_init(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_mutex_lock(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_mutex_lock_isr(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_mutex_unlock(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_mutex_delete(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_thread_sync_init(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+lv_result_t lv_thread_sync_wait(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+lv_result_t lv_thread_sync_signal(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+lv_result_t lv_thread_sync_delete(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    LV_ASSERT(0);
+    return LV_RESULT_INVALID;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_OS == LV_OS_CUSTOM*/

--- a/env_support/cmsis-pack/lv_os_custom.h
+++ b/env_support/cmsis-pack/lv_os_custom.h
@@ -1,0 +1,43 @@
+/**
+ * @file lv_os_custom.h
+ *
+ */
+
+#ifndef LV_OS_CUSTOM_H
+#define LV_OS_CUSTOM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#if LV_USE_OS == LV_OS_CUSTOM
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef int lv_mutex_t;
+typedef int lv_thread_t;
+typedef int lv_thread_sync_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_OS == LV_OS_CUSTOM*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_OS_CUSTOM_H*/


### PR DESCRIPTION
### Description of the feature or fix

- Update cmsis-pack script for the LVGL9 
    * Restructure
    * Adds all examples and demos
    * Adds all components
    * Update documents

![image](https://github.com/lvgl/lvgl/assets/13148491/f53f92df-3ddb-4729-910f-61b85adfaa67)

Validated with the latest MDK and Arm Compiler 6.21



### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
