### PR TITLE
refactor(anim): rename anim time to anim duration

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -493,7 +493,7 @@ static void color_anim(lv_obj_t * obj)
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, color_anim_cb);
     lv_anim_set_values(&a, 0, 100);
-    lv_anim_set_time(&a, 100);      /*New value in each ms*/
+    lv_anim_set_duration(&a, 100);      /*New value in each ms*/
     lv_anim_set_var(&a, obj);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);
@@ -512,7 +512,7 @@ static void arc_anim(lv_obj_t * obj)
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, arc_anim_cb);
     lv_anim_set_values(&a, 0, 100);
-    lv_anim_set_time(&a, t1);
+    lv_anim_set_duration(&a, t1);
     lv_anim_set_playback_time(&a, t2);
     lv_anim_set_var(&a, obj);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
@@ -533,7 +533,7 @@ static void scroll_anim(lv_obj_t * obj, int32_t y_max)
     lv_anim_set_var(&a, obj);
     lv_anim_set_exec_cb(&a, scroll_anim_y_cb);
     lv_anim_set_values(&a, 0, y_max);
-    lv_anim_set_time(&a, t);
+    lv_anim_set_duration(&a, t);
     lv_anim_set_playback_time(&a, t);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);
@@ -554,7 +554,7 @@ static void shake_anim(lv_obj_t * obj, int32_t y_max)
     lv_anim_set_var(&a, obj);
     lv_anim_set_exec_cb(&a, shake_anim_y_cb);
     lv_anim_set_values(&a, 0, y_max);
-    lv_anim_set_time(&a, t1);
+    lv_anim_set_duration(&a, t1);
     lv_anim_set_playback_time(&a, t2);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);

--- a/demos/multilang/lv_demo_multilang.c
+++ b/demos/multilang/lv_demo_multilang.c
@@ -284,7 +284,7 @@ static void scroll_event_cb(lv_event_t * e)
         lv_anim_set_exec_cb(&a, shrink_anim_cb);
         lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
         lv_anim_set_values(&a, 255, 0);
-        lv_anim_set_time(&a, 400);
+        lv_anim_set_duration(&a, 400);
         lv_anim_set_var(&a, cont);
         lv_anim_start(&a);
     }

--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -264,7 +264,7 @@ lv_obj_t * _lv_demo_music_main_create(lv_obj_t * parent)
     for(i = 0; i < BAR_CNT; i++) {
         lv_anim_set_values(&a, LV_HOR_RES, 5);
         lv_anim_set_delay(&a, INTRO_TIME - 200 + rnd_array[i] % 200);
-        lv_anim_set_time(&a, 2500 + rnd_array[i] % 500);
+        lv_anim_set_duration(&a, 2500 + rnd_array[i] % 500);
         lv_anim_set_var(&a, &start_anim_values[i]);
         lv_anim_start(&a);
     }
@@ -278,7 +278,7 @@ lv_obj_t * _lv_demo_music_main_create(lv_obj_t * parent)
 
     lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
     lv_anim_set_var(&a, album_image_obj);
-    lv_anim_set_time(&a, 1000);
+    lv_anim_set_duration(&a, 1000);
     lv_anim_set_delay(&a, INTRO_TIME + 1000);
     lv_anim_set_values(&a, 1, LV_SCALE_NONE);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
@@ -302,7 +302,7 @@ lv_obj_t * _lv_demo_music_main_create(lv_obj_t * parent)
 
     lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
     lv_anim_set_var(&a, logo);
-    lv_anim_set_time(&a, 400);
+    lv_anim_set_duration(&a, 400);
     lv_anim_set_delay(&a, INTRO_TIME + 800);
     lv_anim_set_values(&a, LV_SCALE_NONE, 10);
     lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
@@ -353,7 +353,7 @@ void _lv_demo_music_resume(void)
     lv_anim_set_values(&a, spectrum_i, spectrum_len - 1);
     lv_anim_set_exec_cb(&a, spectrum_anim_cb);
     lv_anim_set_var(&a, spectrum_obj);
-    lv_anim_set_time(&a, ((spectrum_len - spectrum_i) * 1000) / 30);
+    lv_anim_set_duration(&a, ((spectrum_len - spectrum_i) * 1000) / 30);
     lv_anim_set_playback_time(&a, 0);
     lv_anim_set_ready_cb(&a, spectrum_end_cb);
     lv_anim_start(&a);
@@ -690,12 +690,12 @@ static void track_load(uint32_t id)
     lv_anim_set_var(&a, album_image_obj);
     lv_anim_set_values(&a, lv_obj_get_style_image_opa(album_image_obj, 0), LV_OPA_TRANSP);
     lv_anim_set_exec_cb(&a, album_fade_anim_cb);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_start(&a);
 
     lv_anim_init(&a);
     lv_anim_set_var(&a, album_image_obj);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
 #if LV_DEMO_MUSIC_LANDSCAPE
     if(next) {
@@ -718,7 +718,7 @@ static void track_load(uint32_t id)
 
     lv_anim_set_path_cb(&a, lv_anim_path_linear);
     lv_anim_set_var(&a, album_image_obj);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_values(&a, LV_SCALE_NONE, LV_SCALE_NONE / 2);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
     lv_anim_set_ready_cb(&a, NULL);
@@ -728,7 +728,7 @@ static void track_load(uint32_t id)
 
     lv_anim_set_path_cb(&a, lv_anim_path_overshoot);
     lv_anim_set_var(&a, album_image_obj);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_delay(&a, 100);
     lv_anim_set_values(&a, LV_SCALE_NONE / 4, LV_SCALE_NONE);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
@@ -739,7 +739,7 @@ static void track_load(uint32_t id)
     lv_anim_set_var(&a, album_image_obj);
     lv_anim_set_values(&a, 0, LV_OPA_COVER);
     lv_anim_set_exec_cb(&a, album_fade_anim_cb);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_delay(&a, 100);
     lv_anim_start(&a);
 }

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -122,7 +122,7 @@ static void obj_test_task_cb(lv_timer_t * tmr)
             /*Add an infinite width change animation*/
             lv_anim_init(&a);
             lv_anim_set_var(&a, obj);
-            lv_anim_set_time(&a, LV_DEMO_STRESS_TIME_STEP * 2);
+            lv_anim_set_duration(&a, LV_DEMO_STRESS_TIME_STEP * 2);
             lv_anim_set_exec_cb(&a, set_width_anim);
             lv_anim_set_values(&a, 100, 200);
             lv_anim_set_playback_time(&a, LV_DEMO_STRESS_TIME_STEP * 2);
@@ -199,7 +199,7 @@ static void obj_test_task_cb(lv_timer_t * tmr)
             lv_anim_init(&a);
             lv_anim_set_var(&a, obj);
             lv_anim_set_values(&a, LV_VER_RES, LV_VER_RES - lv_obj_get_height(obj));
-            lv_anim_set_time(&a, LV_DEMO_STRESS_TIME_STEP + 3);
+            lv_anim_set_duration(&a, LV_DEMO_STRESS_TIME_STEP + 3);
             lv_anim_set_exec_cb(&a, set_y_anim);
             lv_anim_start(&a);
 
@@ -226,7 +226,7 @@ static void obj_test_task_cb(lv_timer_t * tmr)
             lv_anim_init(&a);
             lv_anim_set_var(&a, obj);
             lv_anim_set_values(&a, 180, 400);
-            lv_anim_set_time(&a, LV_DEMO_STRESS_TIME_STEP * 2);
+            lv_anim_set_duration(&a, LV_DEMO_STRESS_TIME_STEP * 2);
             lv_anim_set_delay(&a, LV_DEMO_STRESS_TIME_STEP + 25);
             lv_anim_set_playback_time(&a, LV_DEMO_STRESS_TIME_STEP * 5);
             lv_anim_set_repeat_count(&a, 3);
@@ -426,7 +426,7 @@ static void auto_delete(lv_obj_t * obj, uint32_t delay)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, obj);
-    lv_anim_set_time(&a, 0);
+    lv_anim_set_duration(&a, 0);
     lv_anim_set_delay(&a, delay);
     lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
     lv_anim_start(&a);

--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -229,7 +229,7 @@ void lv_demo_widgets_start_slideshow(void)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, scroll_anim_y_cb);
-    lv_anim_set_time(&a, t);
+    lv_anim_set_duration(&a, t);
     lv_anim_set_playback_time(&a, t);
     lv_anim_set_values(&a, 0, v);
     lv_anim_set_var(&a, tab);
@@ -696,7 +696,7 @@ static void analytics_create(lv_obj_t * parent)
 
     lv_anim_set_exec_cb(&a, scale1_indic1_anim_cb);
     lv_anim_set_var(&a, arc);
-    lv_anim_set_time(&a, 4100);
+    lv_anim_set_duration(&a, 4100);
     lv_anim_set_playback_time(&a, 2700);
     lv_anim_start(&a);
 
@@ -712,7 +712,7 @@ static void analytics_create(lv_obj_t * parent)
 
     lv_anim_set_exec_cb(&a, scale1_indic1_anim_cb);
     lv_anim_set_var(&a, arc);
-    lv_anim_set_time(&a, 2600);
+    lv_anim_set_duration(&a, 2600);
     lv_anim_set_playback_time(&a, 3200);
     lv_anim_start(&a);
 
@@ -728,7 +728,7 @@ static void analytics_create(lv_obj_t * parent)
 
     lv_anim_set_exec_cb(&a, scale1_indic1_anim_cb);
     lv_anim_set_var(&a, arc);
-    lv_anim_set_time(&a, 2800);
+    lv_anim_set_duration(&a, 2800);
     lv_anim_set_playback_time(&a, 1800);
     lv_anim_start(&a);
 
@@ -858,7 +858,7 @@ static void analytics_create(lv_obj_t * parent)
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_set_exec_cb(&a, scale3_anim_cb);
     lv_anim_set_var(&a, scale3);
-    lv_anim_set_time(&a, 4100);
+    lv_anim_set_duration(&a, 4100);
     lv_anim_set_playback_time(&a, 800);
     lv_anim_start(&a);
 
@@ -1127,7 +1127,7 @@ static void color_changer_event_cb(lv_event_t * e)
             lv_anim_set_var(&a, color_cont);
             lv_anim_set_exec_cb(&a, color_changer_anim_cb);
             lv_anim_set_values(&a, 0, 256);
-            lv_anim_set_time(&a, 200);
+            lv_anim_set_duration(&a, 200);
             lv_anim_start(&a);
         }
         else {
@@ -1136,7 +1136,7 @@ static void color_changer_event_cb(lv_event_t * e)
             lv_anim_set_var(&a, color_cont);
             lv_anim_set_exec_cb(&a, color_changer_anim_cb);
             lv_anim_set_values(&a, 256, 0);
-            lv_anim_set_time(&a, 200);
+            lv_anim_set_duration(&a, 200);
             lv_anim_start(&a);
         }
     }
@@ -1154,7 +1154,7 @@ static void color_event_cb(lv_event_t * e)
             lv_anim_set_var(&a, color_cont);
             lv_anim_set_exec_cb(&a, color_changer_anim_cb);
             lv_anim_set_values(&a, 0, 256);
-            lv_anim_set_time(&a, 200);
+            lv_anim_set_duration(&a, 200);
             lv_anim_start(&a);
         }
     }
@@ -1656,7 +1656,7 @@ static void slideshow_anim_ready_cb(lv_anim_t * a_old)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, scroll_anim_y_cb);
-    lv_anim_set_time(&a, t);
+    lv_anim_set_duration(&a, t);
     lv_anim_set_playback_time(&a, t);
     lv_anim_set_values(&a, 0, v);
     lv_anim_set_var(&a, tab);

--- a/docs/overview/anim.rst
+++ b/docs/overview/anim.rst
@@ -41,7 +41,7 @@ and configured with ``lv_anim_set_...()`` functions.
    lv_anim_set_var(&a, obj);
 
    /*Length of the animation [ms]*/
-   lv_anim_set_time(&a, duration);
+   lv_anim_set_duration(&a, duration);
 
    /*Set start and end values. E.g. 0, 150*/
    lv_anim_set_values(&a, start, end);

--- a/examples/anim/lv_example_anim_1.c
+++ b/examples/anim/lv_example_anim_1.c
@@ -16,7 +16,7 @@ static void sw_event_cb(lv_event_t * e)
         lv_anim_init(&a);
         lv_anim_set_var(&a, label);
         lv_anim_set_values(&a, lv_obj_get_x(label), 100);
-        lv_anim_set_time(&a, 500);
+        lv_anim_set_duration(&a, 500);
         lv_anim_set_exec_cb(&a, anim_x_cb);
         lv_anim_set_path_cb(&a, lv_anim_path_overshoot);
         lv_anim_start(&a);
@@ -26,7 +26,7 @@ static void sw_event_cb(lv_event_t * e)
         lv_anim_init(&a);
         lv_anim_set_var(&a, label);
         lv_anim_set_values(&a, lv_obj_get_x(label), -lv_obj_get_width(label));
-        lv_anim_set_time(&a, 500);
+        lv_anim_set_duration(&a, 500);
         lv_anim_set_exec_cb(&a, anim_x_cb);
         lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
         lv_anim_start(&a);

--- a/examples/anim/lv_example_anim_2.c
+++ b/examples/anim/lv_example_anim_2.c
@@ -27,7 +27,7 @@ void lv_example_anim_2(void)
     lv_anim_init(&a);
     lv_anim_set_var(&a, obj);
     lv_anim_set_values(&a, 10, 50);
-    lv_anim_set_time(&a, 1000);
+    lv_anim_set_duration(&a, 1000);
     lv_anim_set_playback_delay(&a, 100);
     lv_anim_set_playback_time(&a, 300);
     lv_anim_set_repeat_delay(&a, 500);

--- a/examples/anim/lv_example_anim_3.c
+++ b/examples/anim/lv_example_anim_3.c
@@ -55,7 +55,7 @@ void lv_example_anim_3(void)
     int32_t end = lv_obj_get_style_width(cont, LV_PART_MAIN) -
                   lv_obj_get_style_width(ginfo.anim_obj, LV_PART_MAIN) - 10;
     lv_anim_set_values(&ginfo.a, 5, end);
-    lv_anim_set_time(&ginfo.a, 2000);
+    lv_anim_set_duration(&ginfo.a, 2000);
     lv_anim_set_exec_cb(&ginfo.a, anim_x_cb);
     lv_anim_set_path_cb(&ginfo.a, anim_path_bezier3_cb);
 

--- a/examples/anim/lv_example_anim_timeline_1.c
+++ b/examples/anim/lv_example_anim_timeline_1.c
@@ -29,7 +29,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a1, 0, obj_width);
     lv_anim_set_custom_exec_cb(&a1, set_width);
     lv_anim_set_path_cb(&a1, lv_anim_path_overshoot);
-    lv_anim_set_time(&a1, 300);
+    lv_anim_set_duration(&a1, 300);
 
     lv_anim_t a2;
     lv_anim_init(&a2);
@@ -37,7 +37,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a2, 0, obj_height);
     lv_anim_set_custom_exec_cb(&a2, set_height);
     lv_anim_set_path_cb(&a2, lv_anim_path_ease_out);
-    lv_anim_set_time(&a2, 300);
+    lv_anim_set_duration(&a2, 300);
 
     /* obj2 */
     lv_anim_t a3;
@@ -46,7 +46,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a3, 0, obj_width);
     lv_anim_set_custom_exec_cb(&a3, set_width);
     lv_anim_set_path_cb(&a3, lv_anim_path_overshoot);
-    lv_anim_set_time(&a3, 300);
+    lv_anim_set_duration(&a3, 300);
 
     lv_anim_t a4;
     lv_anim_init(&a4);
@@ -54,7 +54,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a4, 0, obj_height);
     lv_anim_set_custom_exec_cb(&a4, set_height);
     lv_anim_set_path_cb(&a4, lv_anim_path_ease_out);
-    lv_anim_set_time(&a4, 300);
+    lv_anim_set_duration(&a4, 300);
 
     /* obj3 */
     lv_anim_t a5;
@@ -63,7 +63,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a5, 0, obj_width);
     lv_anim_set_custom_exec_cb(&a5, set_width);
     lv_anim_set_path_cb(&a5, lv_anim_path_overshoot);
-    lv_anim_set_time(&a5, 300);
+    lv_anim_set_duration(&a5, 300);
 
     lv_anim_t a6;
     lv_anim_init(&a6);
@@ -71,7 +71,7 @@ static void anim_timeline_create(void)
     lv_anim_set_values(&a6, 0, obj_height);
     lv_anim_set_custom_exec_cb(&a6, set_height);
     lv_anim_set_path_cb(&a6, lv_anim_path_ease_out);
-    lv_anim_set_time(&a6, 300);
+    lv_anim_set_duration(&a6, 300);
 
     /* Create anim timeline */
     anim_timeline = lv_anim_timeline_create();

--- a/examples/layouts/flex/lv_example_flex_5.c
+++ b/examples/layouts/flex/lv_example_flex_5.c
@@ -38,12 +38,12 @@ void lv_example_flex_5(void)
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     lv_anim_set_exec_cb(&a, row_gap_anim);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_playback_time(&a, 500);
     lv_anim_start(&a);
 
     lv_anim_set_exec_cb(&a, column_gap_anim);
-    lv_anim_set_time(&a, 3000);
+    lv_anim_set_duration(&a, 3000);
     lv_anim_set_playback_time(&a, 3000);
     lv_anim_start(&a);
 }

--- a/examples/layouts/grid/lv_example_grid_5.c
+++ b/examples/layouts/grid/lv_example_grid_5.c
@@ -49,12 +49,12 @@ void lv_example_grid_5(void)
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     lv_anim_set_exec_cb(&a, row_gap_anim);
-    lv_anim_set_time(&a, 500);
+    lv_anim_set_duration(&a, 500);
     lv_anim_set_playback_time(&a, 500);
     lv_anim_start(&a);
 
     lv_anim_set_exec_cb(&a, column_gap_anim);
-    lv_anim_set_time(&a, 3000);
+    lv_anim_set_duration(&a, 3000);
     lv_anim_set_playback_time(&a, 3000);
     lv_anim_start(&a);
 }

--- a/examples/others/observer/lv_example_observer_4.c
+++ b/examples/others/observer/lv_example_observer_4.c
@@ -83,7 +83,7 @@ static void cont_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
     /*Animate out the previous content*/
     lv_anim_t a;
     lv_anim_init(&a);
-    lv_anim_set_time(&a, 300);
+    lv_anim_set_duration(&a, 300);
     lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
     lv_anim_set_exec_cb(&a, anim_set_x_cb);
     lv_anim_set_get_value_cb(&a, anim_get_x_cb);
@@ -194,7 +194,7 @@ static void indicator_observer_cb(lv_observer_t * observer, lv_subject_t * subje
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, anim_set_x_cb);
-    lv_anim_set_time(&a, 300);
+    lv_anim_set_duration(&a, 300);
     lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
     lv_anim_set_var(&a, indicator);
     lv_anim_set_values(&a, lv_obj_get_x(indicator), lv_obj_get_x(btn_act));

--- a/examples/widgets/arc/lv_example_arc_2.c
+++ b/examples/widgets/arc/lv_example_arc_2.c
@@ -24,7 +24,7 @@ void lv_example_arc_2(void)
     lv_anim_init(&a);
     lv_anim_set_var(&a, arc);
     lv_anim_set_exec_cb(&a, set_angle);
-    lv_anim_set_time(&a, 1000);
+    lv_anim_set_duration(&a, 1000);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);    /*Just for the demo*/
     lv_anim_set_repeat_delay(&a, 500);
     lv_anim_set_values(&a, 0, 100);

--- a/examples/widgets/bar/lv_example_bar_3.c
+++ b/examples/widgets/bar/lv_example_bar_3.c
@@ -28,7 +28,7 @@ void lv_example_bar_3(void)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, set_temp);
-    lv_anim_set_time(&a, 3000);
+    lv_anim_set_duration(&a, 3000);
     lv_anim_set_playback_time(&a, 3000);
     lv_anim_set_var(&a, bar);
     lv_anim_set_values(&a, -20, 40);

--- a/examples/widgets/bar/lv_example_bar_6.c
+++ b/examples/widgets/bar/lv_example_bar_6.c
@@ -61,7 +61,7 @@ void lv_example_bar_6(void)
     lv_anim_set_var(&a, bar);
     lv_anim_set_values(&a, 0, 100);
     lv_anim_set_exec_cb(&a, set_value);
-    lv_anim_set_time(&a, 4000);
+    lv_anim_set_duration(&a, 4000);
     lv_anim_set_playback_time(&a, 4000);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);

--- a/examples/widgets/img/lv_example_img_3.c
+++ b/examples/widgets/img/lv_example_img_3.c
@@ -29,7 +29,7 @@ void lv_example_image_3(void)
     lv_anim_set_var(&a, img);
     lv_anim_set_exec_cb(&a, set_angle);
     lv_anim_set_values(&a, 0, 3600);
-    lv_anim_set_time(&a, 5000);
+    lv_anim_set_duration(&a, 5000);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);
 

--- a/examples/widgets/img/lv_example_img_4.c
+++ b/examples/widgets/img/lv_example_img_4.c
@@ -31,7 +31,7 @@ void lv_example_image_4(void)
     lv_anim_set_var(&a, img);
     lv_anim_set_exec_cb(&a, ofs_y_anim);
     lv_anim_set_values(&a, 0, 100);
-    lv_anim_set_time(&a, 3000);
+    lv_anim_set_duration(&a, 3000);
     lv_anim_set_playback_time(&a, 500);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
     lv_anim_start(&a);

--- a/examples/widgets/scale/lv_example_scale_3.c
+++ b/examples/widgets/scale/lv_example_scale_3.c
@@ -51,7 +51,7 @@ void lv_example_scale_3(void)
     lv_anim_init(&anim_scale_line);
     lv_anim_set_var(&anim_scale_line, scale_line);
     lv_anim_set_exec_cb(&anim_scale_line, set_needle_line_value);
-    lv_anim_set_time(&anim_scale_line, 1000);
+    lv_anim_set_duration(&anim_scale_line, 1000);
     lv_anim_set_repeat_count(&anim_scale_line, LV_ANIM_REPEAT_INFINITE);
     lv_anim_set_playback_time(&anim_scale_line, 1000);
     lv_anim_set_values(&anim_scale_line, 10, 40);
@@ -88,7 +88,7 @@ void lv_example_scale_3(void)
     lv_anim_init(&anim_scale_img);
     lv_anim_set_var(&anim_scale_img, scale_img);
     lv_anim_set_exec_cb(&anim_scale_img, set_needle_img_value);
-    lv_anim_set_time(&anim_scale_img, 1000);
+    lv_anim_set_duration(&anim_scale_img, 1000);
     lv_anim_set_repeat_count(&anim_scale_img, LV_ANIM_REPEAT_INFINITE);
     lv_anim_set_playback_time(&anim_scale_img, 1000);
     lv_anim_set_values(&anim_scale_img, 10, 40);

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -314,7 +314,7 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         if(dx) {
             uint32_t t = lv_anim_speed_clamped((lv_display_get_horizontal_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
                                                SCROLL_ANIM_TIME_MAX);
-            lv_anim_set_time(&a, t);
+            lv_anim_set_duration(&a, t);
             int32_t sx = lv_obj_get_scroll_x(obj);
             lv_anim_set_values(&a, -sx, -sx + dx);
             lv_anim_set_exec_cb(&a, scroll_x_anim);
@@ -329,7 +329,7 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         if(dy) {
             uint32_t t = lv_anim_speed_clamped((lv_display_get_vertical_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
                                                SCROLL_ANIM_TIME_MAX);
-            lv_anim_set_time(&a, t);
+            lv_anim_set_duration(&a, t);
             int32_t sy = lv_obj_get_scroll_y(obj);
             lv_anim_set_values(&a, -sy, -sy + dy);
             lv_anim_set_exec_cb(&a,  scroll_y_anim);

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -562,7 +562,7 @@ void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t 
     lv_anim_set_start_cb(&a, trans_anim_start_cb);
     lv_anim_set_ready_cb(&a, trans_anim_ready_cb);
     lv_anim_set_values(&a, 0x00, 0xFF);
-    lv_anim_set_time(&a, tr_dsc->time);
+    lv_anim_set_duration(&a, tr_dsc->time);
     lv_anim_set_delay(&a, tr_dsc->delay);
     lv_anim_set_path_cb(&a, tr_dsc->path_cb);
     lv_anim_set_early_apply(&a, false);
@@ -650,7 +650,7 @@ void lv_obj_fade_in(lv_obj_t * obj, uint32_t time, uint32_t delay)
     lv_anim_set_values(&a, 0, LV_OPA_COVER);
     lv_anim_set_exec_cb(&a, fade_anim_cb);
     lv_anim_set_ready_cb(&a, fade_in_anim_ready);
-    lv_anim_set_time(&a, time);
+    lv_anim_set_duration(&a, time);
     lv_anim_set_delay(&a, delay);
     lv_anim_start(&a);
 }
@@ -662,7 +662,7 @@ void lv_obj_fade_out(lv_obj_t * obj, uint32_t time, uint32_t delay)
     lv_anim_set_var(&a, obj);
     lv_anim_set_values(&a, lv_obj_get_style_opa(obj, 0), LV_OPA_TRANSP);
     lv_anim_set_exec_cb(&a, fade_anim_cb);
-    lv_anim_set_time(&a, time);
+    lv_anim_set_duration(&a, time);
     lv_anim_set_delay(&a, delay);
     lv_anim_start(&a);
 }

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -124,7 +124,7 @@ void lv_obj_delete_delayed(lv_obj_t * obj, uint32_t delay_ms)
     lv_anim_init(&a);
     lv_anim_set_var(&a, obj);
     lv_anim_set_exec_cb(&a, NULL);
-    lv_anim_set_time(&a, 1);
+    lv_anim_set_duration(&a, 1);
     lv_anim_set_delay(&a, delay_ms);
     lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
     lv_anim_start(&a);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -577,13 +577,13 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
     lv_anim_set_var(&a_new, new_scr);
     lv_anim_set_start_cb(&a_new, scr_load_anim_start);
     lv_anim_set_ready_cb(&a_new, scr_anim_ready);
-    lv_anim_set_time(&a_new, time);
+    lv_anim_set_duration(&a_new, time);
     lv_anim_set_delay(&a_new, delay);
 
     lv_anim_t a_old;
     lv_anim_init(&a_old);
     lv_anim_set_var(&a_old, d->act_scr);
-    lv_anim_set_time(&a_old, time);
+    lv_anim_set_duration(&a_old, time);
     lv_anim_set_delay(&a_old, delay);
 
     switch(anim_type) {

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1527,7 +1527,7 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
         if(indev->scroll_throw_anim) {
             /*hacky*/
             LV_LOG_INFO("stop animation");
-            lv_anim_set_time(indev->scroll_throw_anim, 0);
+            lv_anim_set_duration(indev->scroll_throw_anim, 0);
         }
     }
 }
@@ -1546,7 +1546,7 @@ static void indev_scroll_throw_anim_start(lv_indev_t * indev)
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, indev);
-    lv_anim_set_time(&a, 1024);
+    lv_anim_set_duration(&a, 1024);
     lv_anim_set_values(&a, 0, 1024);
     lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
     lv_anim_set_ready_cb(&a, indev_scroll_throw_anim_ready_cb);

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -218,9 +218,17 @@ static inline void lv_anim_set_exec_cb(lv_anim_t * a, lv_anim_exec_xcb_t exec_cb
  * @param a         pointer to an initialized `lv_anim_t` variable
  * @param duration  duration of the animation in milliseconds
  */
-static inline void lv_anim_set_time(lv_anim_t * a, uint32_t duration)
+static inline void lv_anim_set_duration(lv_anim_t * a, uint32_t duration)
 {
     a->duration = duration;
+}
+
+/**
+ * Legacy `lv_anim_set_time` API will be removed soon, use `lv_anim_set_duration` instead.
+ */
+static inline void lv_anim_set_time(lv_anim_t * a, uint32_t duration)
+{
+    lv_anim_set_duration(a, duration);
 }
 
 /**

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -90,7 +90,7 @@ void lv_animimg_set_duration(lv_obj_t * obj, uint32_t duration)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
-    lv_anim_set_time(&animimg->anim, duration);
+    lv_anim_set_duration(&animimg->anim, duration);
     lv_anim_set_playback_delay(&animimg->anim, duration);
 }
 
@@ -150,7 +150,7 @@ static void lv_animimg_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     /*initial animation*/
     lv_anim_init(&animimg->anim);
     lv_anim_set_var(&animimg->anim, obj);
-    lv_anim_set_time(&animimg->anim, 30);
+    lv_anim_set_duration(&animimg->anim, 30);
     lv_anim_set_exec_cb(&animimg->anim, (lv_anim_exec_xcb_t)index_change);
     lv_anim_set_values(&animimg->anim, 0, 1);
     lv_anim_set_repeat_count(&animimg->anim, LV_ANIM_REPEAT_INFINITE);

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -572,7 +572,7 @@ static void lv_bar_set_value_with_anim(lv_obj_t * obj, int32_t new_value, int32_
         lv_anim_set_exec_cb(&a, lv_bar_anim);
         lv_anim_set_values(&a, LV_BAR_ANIM_STATE_START, LV_BAR_ANIM_STATE_END);
         lv_anim_set_ready_cb(&a, lv_bar_anim_ready);
-        lv_anim_set_time(&a, lv_obj_get_style_anim_time(obj, LV_PART_MAIN));
+        lv_anim_set_duration(&a, lv_obj_get_style_anim_time(obj, LV_PART_MAIN));
         lv_anim_start(&a);
     }
 }

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -914,7 +914,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
                 }
             }
 
-            lv_anim_set_time(&a, anim_time);
+            lv_anim_set_duration(&a, anim_time);
             lv_anim_set_playback_time(&a, a.duration);
 
             /*If a template animation exists, overwrite some property*/
@@ -953,7 +953,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
                 }
             }
 
-            lv_anim_set_time(&a, anim_time);
+            lv_anim_set_duration(&a, anim_time);
             lv_anim_set_playback_time(&a, a.duration);
 
             /*If a template animation exists, overwrite some property*/
@@ -1000,7 +1000,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
             lv_anim_set_values(&a, 0, -size.x - lv_font_get_glyph_width(font, ' ', ' ') * LV_LABEL_WAIT_CHAR_COUNT);
 #endif
             lv_anim_set_exec_cb(&a, set_ofs_x_anim);
-            lv_anim_set_time(&a, anim_time);
+            lv_anim_set_duration(&a, anim_time);
 
             lv_anim_t * anim_cur = lv_anim_get(obj, set_ofs_x_anim);
             int32_t act_time = anim_cur ? anim_cur->act_time : 0;
@@ -1026,7 +1026,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
         if(size.y > lv_area_get_height(&txt_coords) && hor_anim == false) {
             lv_anim_set_values(&a, 0, -size.y - (lv_font_get_line_height(font)));
             lv_anim_set_exec_cb(&a, set_ofs_y_anim);
-            lv_anim_set_time(&a, anim_time);
+            lv_anim_set_duration(&a, anim_time);
 
             lv_anim_t * anim_cur = lv_anim_get(obj, set_ofs_y_anim);
             int32_t act_time = anim_cur ? anim_cur->act_time : 0;

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -660,7 +660,7 @@ static void refr_position(lv_obj_t * obj, lv_anim_enable_t anim_en)
         lv_anim_set_var(&a, label);
         lv_anim_set_exec_cb(&a, set_y_anim);
         lv_anim_set_values(&a, lv_obj_get_y(label), new_y);
-        lv_anim_set_time(&a, anim_time);
+        lv_anim_set_duration(&a, anim_time);
         lv_anim_set_ready_cb(&a, scroll_anim_ready_cb);
         lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
         lv_anim_start(&a);

--- a/src/widgets/spinner/lv_spinner.c
+++ b/src/widgets/spinner/lv_spinner.c
@@ -61,7 +61,7 @@ void lv_spinner_set_anim_params(lv_obj_t * obj, uint32_t t, uint32_t angle)
     lv_anim_set_var(&a, obj);
     lv_anim_set_exec_cb(&a, arc_anim_end_angle);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
-    lv_anim_set_time(&a, t);
+    lv_anim_set_duration(&a, t);
     lv_anim_set_values(&a, angle, 360 + angle);
     lv_anim_start(&a);
 

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -256,7 +256,7 @@ static void lv_switch_trigger_anim(lv_obj_t * obj)
         lv_anim_set_exec_cb(&a, lv_switch_anim_exec_cb);
         lv_anim_set_values(&a, anim_start, anim_end);
         lv_anim_set_ready_cb(&a, lv_switch_anim_ready);
-        lv_anim_set_time(&a, anim_dur);
+        lv_anim_set_duration(&a, anim_dur);
         lv_anim_start(&a);
     }
 }

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -1049,7 +1049,7 @@ static void start_cursor_blink(lv_obj_t * obj)
         lv_anim_init(&a);
         lv_anim_set_var(&a, ta);
         lv_anim_set_exec_cb(&a, cursor_blink_anim_cb);
-        lv_anim_set_time(&a, blink_time);
+        lv_anim_set_duration(&a, blink_time);
         lv_anim_set_playback_time(&a, blink_time);
         lv_anim_set_values(&a, 1, 0);
         lv_anim_set_path_cb(&a, lv_anim_path_step);
@@ -1362,7 +1362,7 @@ static void auto_hide_characters(lv_obj_t * obj)
         lv_anim_init(&a);
         lv_anim_set_var(&a, ta);
         lv_anim_set_exec_cb(&a, pwd_char_hider_anim);
-        lv_anim_set_time(&a, ta->pwd_show_time);
+        lv_anim_set_duration(&a, ta->pwd_show_time);
         lv_anim_set_values(&a, 0, 1);
         lv_anim_set_path_cb(&a, lv_anim_path_step);
         lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);

--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -36,7 +36,7 @@ void test_anim_delete(void)
     lv_anim_set_var(&a, &var);
     lv_anim_set_values(&a, 0, 100);
     lv_anim_set_exec_cb(&a, exec_cb);
-    lv_anim_set_time(&a, 100);
+    lv_anim_set_duration(&a, 100);
     lv_anim_start(&a);
 
     lv_test_wait(20);
@@ -68,7 +68,7 @@ void test_anim_delete_custom(void)
     lv_anim_set_var(&a, &var);
     lv_anim_set_values(&a, 0, 100);
     lv_anim_set_custom_exec_cb(&a, custom_exec_cb);
-    lv_anim_set_time(&a, 100);
+    lv_anim_set_duration(&a, 100);
     lv_anim_start(&a);
 
     lv_test_wait(20);

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -32,7 +32,7 @@ void test_anim_timeline_progress_1(void)
     lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
     lv_anim_set_var(&a1, obj);
     lv_anim_set_values(&a1, 0, 700);
-    lv_anim_set_time(&a1, 1000);
+    lv_anim_set_duration(&a1, 1000);
 
     anim_timeline = lv_anim_timeline_create();
     TEST_ASSERT_NOT_NULL(anim_timeline);
@@ -90,14 +90,14 @@ void test_anim_timeline_progress_2(void)
     lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
     lv_anim_set_var(&a1, obj);
     lv_anim_set_values(&a1, 0, 700);
-    lv_anim_set_time(&a1, 1000);
+    lv_anim_set_duration(&a1, 1000);
 
     lv_anim_t a2;
     lv_anim_init(&a2);
     lv_anim_set_exec_cb(&a2, (lv_anim_exec_xcb_t)lv_obj_set_y);
     lv_anim_set_var(&a2, obj);
     lv_anim_set_values(&a2, 0, 300);
-    lv_anim_set_time(&a2, 1000);
+    lv_anim_set_duration(&a2, 1000);
 
     /*
      *   |------X------|
@@ -167,17 +167,17 @@ void test_anim_timeline_start(void)
     lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
     lv_anim_set_var(&a1, obj);
     lv_anim_set_values(&a1, 50, 100);
-    lv_anim_set_time(&a1, 800);
+    lv_anim_set_duration(&a1, 800);
     lv_anim_set_early_apply(&a1, false);
     lv_anim_timeline_add(anim_timeline, 200, &a1);
 
     lv_anim_set_values(&a1, 200, 300);
-    lv_anim_set_time(&a1, 1000);
+    lv_anim_set_duration(&a1, 1000);
     lv_anim_timeline_add(anim_timeline, 1500, &a1);
 
     /*Overlap with the previous*/
     lv_anim_set_values(&a1, 400, 700);
-    lv_anim_set_time(&a1, 1500);
+    lv_anim_set_duration(&a1, 1500);
     lv_anim_timeline_add(anim_timeline, 2000, &a1);
 
     lv_anim_timeline_start(anim_timeline);
@@ -259,17 +259,17 @@ void test_anim_timeline_reverse(void)
     lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
     lv_anim_set_var(&a1, obj);
     lv_anim_set_values(&a1, 50, 100);
-    lv_anim_set_time(&a1, 800);
+    lv_anim_set_duration(&a1, 800);
     lv_anim_set_early_apply(&a1, false);
     lv_anim_timeline_add(anim_timeline, 200, &a1);
 
     lv_anim_set_values(&a1, 200, 300);
-    lv_anim_set_time(&a1, 1000);
+    lv_anim_set_duration(&a1, 1000);
     lv_anim_timeline_add(anim_timeline, 1500, &a1);
 
     /*Overlap with the previous*/
     lv_anim_set_values(&a1, 400, 700);
-    lv_anim_set_time(&a1, 1500);
+    lv_anim_set_duration(&a1, 1500);
     lv_anim_timeline_add(anim_timeline, 2000, &a1);
 
     lv_anim_timeline_set_reverse(anim_timeline, true);

--- a/tests/src/test_cases/test_bindings.c
+++ b/tests/src/test_cases/test_bindings.c
@@ -137,7 +137,7 @@ static void create_ui(void)
             lv_anim_set_var(&a, btn);
             lv_anim_set_values(&a, LV_OPA_COVER, LV_OPA_50);
             lv_anim_set_exec_cb(&a, opa_anim_cb);   /*Pass a callback*/
-            lv_anim_set_time(&a, 300);
+            lv_anim_set_duration(&a, 300);
             lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
             lv_anim_start(&a);
         }
@@ -158,7 +158,7 @@ static void create_ui(void)
             lv_anim_set_var(&a, btn);
             lv_anim_set_values(&a, LV_OPA_COVER, LV_OPA_50);
             lv_anim_set_exec_cb(&a, opa_anim_cb);   /*Pass a callback*/
-            lv_anim_set_time(&a, 300);
+            lv_anim_set_duration(&a, 300);
             lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
             lv_anim_start(&a);
         }

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -27,7 +27,7 @@ void test_gradient_vertical_misalignment(void)
     lv_anim_init(&a);
     lv_anim_set_var(&a, obj);
     lv_anim_set_exec_cb(&a, obj_set_height_helper);
-    lv_anim_set_time(&a, 1000);
+    lv_anim_set_duration(&a, 1000);
     lv_anim_set_playback_time(&a, 1000);
     lv_anim_set_repeat_count(&a, 100);
     lv_anim_set_values(&a, 0, 300);


### PR DESCRIPTION
### Description of the feature or fix

A macro is defined for backward compatibility. 

```c

/**
 * Legacy `lv_anim_set_time` API will be removed soon, use `lv_anim_set_duration` instead.
 */
#define lv_anim_set_time lv_anim_set_duration

```

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
