### PR TITLE
chore(image): change not used format field to reserved

### DIFF
--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -96,14 +96,15 @@ typedef enum {
  */
 #if LV_BIG_ENDIAN_SYSTEM
 typedef struct {
-
-    uint32_t h : 11; /*Height of the image map*/
-    uint32_t w : 11; /*Width of the image map*/
-    uint32_t reserved : 2; /*Reserved to be used later*/
-    uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
-                                 non-printable character*/
-    uint32_t cf : 5;          /*Color format: See `lv_color_format_t`*/
-
+    uint32_t reserved_2: 16;    /*Reserved to be used later*/
+    uint32_t stride: 16;        /*Number of bytes in a row*/
+    uint32_t h: 16;
+    uint32_t w: 16;
+    uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/
+    uint32_t reserved_1: 8;     /*Reserved by LVGL for later use*/
+    uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
+                                  non-printable character*/
+    uint32_t cf : 5;            /*Color format: See `lv_color_format_t`*/
 } lv_image_header_t;
 #else
 typedef struct {
@@ -111,13 +112,13 @@ typedef struct {
     uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
                                   non-printable character*/
 
-    uint32_t format: 8;         /*Image format? To be defined by LVGL*/
+    uint32_t reserved_1: 8;     /*Reserved by LVGL for later use*/
     uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/
 
     uint32_t w: 16;
     uint32_t h: 16;
-    uint32_t stride: 16;       /*Number of bytes in a row*/
-    uint32_t reserved_2: 16;   /*Reserved to be used later*/
+    uint32_t stride: 16;        /*Number of bytes in a row*/
+    uint32_t reserved_2: 16;    /*Reserved to be used later*/
 } lv_image_header_t;
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

Since `format` field is not used, let's remove it before releasing v9.
```c
typedef struct {
    uint32_t cf : 5;            /*Color format: See `lv_color_format_t`*/
    uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
                                  non-printable character*/

    uint32_t reserved_1: 8;     /*Reserved by LVGL for later use*/
    uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/

    uint32_t w: 16;
    uint32_t h: 16;
    uint32_t stride: 16;        /*Number of bytes in a row*/
    uint32_t reserved_2: 16;    /*Reserved to be used later*/
} lv_image_header_t;
```

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
