### PR TITLE
feat(lv_rb): add drop_node and remove_node api

### DIFF
--- a/src/misc/lv_rb.c
+++ b/src/misc/lv_rb.c
@@ -126,20 +126,8 @@ lv_rb_node_t * lv_rb_find(lv_rb_t * tree, const void * key)
     return NULL;
 }
 
-void * lv_rb_remove(lv_rb_t * tree, const void * key)
+void * lv_rb_remove_node(lv_rb_t * tree, lv_rb_node_t * node)
 {
-    LV_ASSERT_NULL(tree);
-    if(tree == NULL) {
-        return NULL;
-    }
-
-    lv_rb_node_t * node = lv_rb_find(tree, key);
-    LV_ASSERT_NULL(node);
-    if(node == NULL) {
-        LV_LOG_WARN("rb delete %d not found", (int)(uintptr_t)key);
-        return NULL;
-    }
-
     lv_rb_node_t * child = NULL;
     lv_rb_node_t * parent = NULL;
     lv_rb_color_t color = LV_RB_COLOR_BLACK;
@@ -217,6 +205,38 @@ void * lv_rb_remove(lv_rb_t * tree, const void * key)
     void * data = node->data;
     lv_free(node);
     return data;
+}
+
+void * lv_rb_remove(lv_rb_t * tree, const void * key)
+{
+    LV_ASSERT_NULL(tree);
+    if(tree == NULL) {
+        return NULL;
+    }
+
+    lv_rb_node_t * node = lv_rb_find(tree, key);
+    LV_ASSERT_NULL(node);
+    if(node == NULL) {
+        LV_LOG_WARN("rb delete %d not found", (int)(uintptr_t)key);
+        return NULL;
+    }
+
+    return lv_rb_remove_node(tree, node);
+}
+
+bool lv_rb_drop_node(lv_rb_t * tree, lv_rb_node_t * node)
+{
+    LV_ASSERT_NULL(tree);
+    if(tree == NULL) {
+        return false;
+    }
+
+    void * data = lv_rb_remove_node(tree, node);
+    if(data) {
+        lv_free(data);
+        return true;
+    }
+    return false;
 }
 
 bool lv_rb_drop(lv_rb_t * tree, const void * key)

--- a/src/misc/lv_rb.h
+++ b/src/misc/lv_rb.h
@@ -55,7 +55,9 @@ typedef struct {
 bool lv_rb_init(lv_rb_t * tree, lv_rb_compare_t compare, size_t node_size);
 lv_rb_node_t * lv_rb_insert(lv_rb_t * tree, void * key);
 lv_rb_node_t * lv_rb_find(lv_rb_t * tree, const void * key);
+void * lv_rb_remove_node(lv_rb_t * tree, lv_rb_node_t * node);
 void * lv_rb_remove(lv_rb_t * tree, const void * key);
+bool lv_rb_drop_node(lv_rb_t * tree, lv_rb_node_t * node);
 bool lv_rb_drop(lv_rb_t * tree, const void * key);
 lv_rb_node_t * lv_rb_minimum(lv_rb_t * node);
 lv_rb_node_t * lv_rb_maximum(lv_rb_t * node);


### PR DESCRIPTION
### Description of the feature or fix

add drop_node and remove_node api for directly removing or dropping a node for lv_rb_node entity without `find`

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
