### PR TITLE
lvgl:add lv_display_remove_event_cb_with_user_data

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -139,6 +139,25 @@ bool lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
     return false;
 }
 
+uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data)
+{
+    LV_ASSERT_NULL(obj);
+
+    uint32_t event_cnt = lv_obj_get_event_count(obj);
+    uint32_t removed_count = 0;
+    int32_t i;
+
+    for(i = event_cnt - 1; i >= 0; i--) {
+        lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
+        if(dsc && dsc->cb == event_cb && dsc->user_data == user_data) {
+            lv_obj_remove_event(obj, i);
+            removed_count ++;
+        }
+    }
+
+    return removed_count;
+}
+
 lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e)
 {
     return lv_event_get_current_target(e);

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -114,6 +114,15 @@ bool lv_obj_remove_event(struct _lv_obj_t * obj, uint32_t index);
 bool lv_obj_remove_event_cb(struct _lv_obj_t * obj, lv_event_cb_t event_cb);
 
 /**
+ * Remove an event_cb with user_data
+ * @param obj           pointer to a obj
+ * @param event_cb      the event_cb of the event to remove
+ * @param user_data     user_data
+ * @return              the count of the event removed
+ */
+uint32_t lv_obj_remove_event_cb_with_user_data(struct _lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data);
+
+/**
  * Get the input device passed as parameter to indev related events.
  * @param e     pointer to an event
  * @return      the indev that triggered the event or NULL if called on a not indev related event

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -699,6 +699,25 @@ bool lv_display_delete_event(lv_display_t * disp, uint32_t index)
     return lv_event_remove(&disp->event_list, index);
 }
 
+uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event_cb_t event_cb, void * user_data)
+{
+    LV_ASSERT_NULL(disp);
+
+    uint32_t event_cnt = lv_display_get_event_count(disp);
+    uint32_t removed_count = 0;
+    int32_t i;
+
+    for(i = event_cnt - 1; i >= 0; i--) {
+        lv_event_dsc_t * dsc = lv_display_get_event_dsc(disp, i);
+        if(dsc && dsc->cb == event_cb && dsc->user_data == user_data) {
+            lv_display_delete_event(disp, i);
+            removed_count ++;
+        }
+    }
+
+    return removed_count;
+}
+
 lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, void * param)
 {
 

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -453,6 +453,15 @@ lv_event_dsc_t * lv_display_get_event_dsc(lv_display_t * disp, uint32_t index);
 bool lv_display_delete_event(lv_display_t * disp, uint32_t index);
 
 /**
+ * Remove an event_cb with user_data
+ * @param disp          pointer to a display
+ * @param event_cb      the event_cb of the event to remove
+ * @param user_data     user_data
+ * @return              the count of the event removed
+ */
+uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event_cb_t event_cb, void * user_data);
+
+/**
  * Send an event to a display
  * @param disp          pointer to a display
  * @param code          an event code. LV_EVENT_...

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -557,6 +557,25 @@ bool lv_indev_remove_event(lv_indev_t * indev, uint32_t index)
     return lv_event_remove(&indev->event_list, index);
 }
 
+uint32_t lv_indev_remove_event_cb_with_user_data(lv_indev_t * indev, lv_event_cb_t event_cb, void * user_data)
+{
+    LV_ASSERT_NULL(indev);
+
+    uint32_t event_cnt = lv_indev_get_event_count(indev);
+    uint32_t removed_count = 0;
+    int32_t i;
+
+    for(i = event_cnt - 1; i >= 0; i--) {
+        lv_event_dsc_t * dsc = lv_indev_get_event_dsc(indev, i);
+        if(dsc && dsc->cb == event_cb && dsc->user_data == user_data) {
+            lv_indev_remove_event(indev, i);
+            removed_count ++;
+        }
+    }
+
+    return removed_count;
+}
+
 lv_result_t lv_indev_send_event(lv_indev_t * indev, lv_event_code_t code, void * param)
 {
 

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -289,6 +289,15 @@ lv_event_dsc_t * lv_indev_get_event_dsc(lv_indev_t * indev, uint32_t index);
 bool lv_indev_remove_event(lv_indev_t * indev, uint32_t index);
 
 /**
+ * Remove an event_cb with user_data
+ * @param indev         pointer to a indev
+ * @param event_cb      the event_cb of the event to remove
+ * @param user_data     user_data
+ * @return              the count of the event removed
+ */
+uint32_t lv_indev_remove_event_cb_with_user_data(lv_indev_t * indev, lv_event_cb_t event_cb, void * user_data);
+
+/**
  * Send an event to an indev
  * @param indev         pointer to an indev
  * @param code          an event code. LV_EVENT_...


### PR DESCRIPTION
### Description of the feature or fix

Add lv_display_remove_event_cb_with_user_data becuase in many cases we don’t know the index corresponding to the event.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
