### PR TITLE
lvgl:add vsync_poll

### DIFF
--- a/src/dev/nuttx/lv_nuttx_libuv.c
+++ b/src/dev/nuttx/lv_nuttx_libuv.c
@@ -28,6 +28,7 @@ typedef struct {
     int fd;
     bool polling;
     uv_poll_t fb_poll;
+    uv_poll_t vsync_poll;
 } lv_nuttx_uv_fb_ctx_t;
 
 typedef struct {
@@ -49,6 +50,7 @@ static void lv_nuttx_uv_timer_cb(uv_timer_t * handle);
 static int  lv_nuttx_uv_timer_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_ctx);
 static void lv_nuttx_uv_timer_deinit(lv_nuttx_uv_ctx_t * uv_ctx);
 
+static void lv_nuttx_uv_vsync_poll_cb(uv_poll_t * handle, int status, int events);
 static void lv_nuttx_uv_disp_poll_cb(uv_poll_t * handle, int status, int events);
 static void lv_nuttx_uv_disp_refr_req_cb(lv_event_t * e);
 static int  lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_fb_ctx_t * fb_ctx);
@@ -168,6 +170,20 @@ static void lv_nuttx_uv_timer_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
     LV_LOG_USER("Done");
 }
 
+static void lv_nuttx_uv_vsync_poll_cb(uv_poll_t * handle, int status, int events)
+{
+    LV_UNUSED(handle);
+    LV_UNUSED(status);
+    LV_UNUSED(events);
+
+    lv_display_t * d;
+    d = lv_display_get_next(NULL);
+    while(d) {
+        lv_display_send_event(d, LV_EVENT_VSYNC, NULL);
+        d = lv_display_get_next(d);
+    }
+}
+
 static void lv_nuttx_uv_disp_poll_cb(uv_poll_t * handle, int status, int events)
 {
     lv_nuttx_uv_fb_ctx_t * fb_ctx = (lv_nuttx_uv_fb_ctx_t *)(handle->data);
@@ -220,6 +236,10 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_fb_ctx_t * f
     uv_poll_init(loop, &fb_ctx->fb_poll, fb_ctx->fd);
     uv_poll_start(&fb_ctx->fb_poll, UV_WRITABLE, lv_nuttx_uv_disp_poll_cb);
 
+    fb_ctx->vsync_poll.data = fb_ctx;
+    uv_poll_init(loop, &fb_ctx->vsync_poll, fb_ctx->fd);
+    uv_poll_start(&fb_ctx->vsync_poll, UV_PRIORITIZED, lv_nuttx_uv_vsync_poll_cb);
+
     LV_LOG_USER("lvgl fb loop start OK");
 
     /* Register for the invalidate area event */
@@ -235,6 +255,7 @@ static void lv_nuttx_uv_fb_deinit(lv_nuttx_uv_fb_ctx_t * fb_ctx)
 
     if(fb_ctx->fd > 0) {
         uv_close((uv_handle_t *)&fb_ctx->fb_poll, NULL);
+        uv_close((uv_handle_t *)&fb_ctx->vsync_poll, NULL);
     }
     LV_LOG_USER("Done");
 }

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -106,6 +106,8 @@ typedef enum {
     LV_EVENT_FLUSH_START,
     LV_EVENT_FLUSH_FINISH,
 
+    LV_EVENT_VSYNC,
+
     _LV_EVENT_LAST,               /** Number of default events*/
 
     LV_EVENT_PREPROCESS = 0x80,   /** This is a flag that can be set with an event so it's processed


### PR DESCRIPTION
### Description of the feature or fix

add vsync poll to get the time of vysnc.

### Checkpoints
- [x ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
