### PR TITLE
chore: fix warning

### DIFF
--- a/src/dev/display/drm/lv_linux_drm.c
+++ b/src/dev/display/drm/lv_linux_drm.c
@@ -162,7 +162,8 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
         lv_display_set_dpi(disp, DIV_ROUND_UP(hor_res * 25400, width * 1000));
     }
 
-    LV_LOG_INFO("Resolution is set to %dx%d at %ddpi", hor_res, ver_res, lv_display_get_dpi(disp));
+    LV_LOG_INFO("Resolution is set to %" LV_PRId32 "x%" LV_PRId32 " at %" LV_PRId32 "dpi",
+                hor_res, ver_res, lv_display_get_dpi(disp));
 }
 
 /**********************

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -211,7 +211,8 @@ void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         lv_display_set_dpi(disp, DIV_ROUND_UP(hor_res * 254, width * 10));
     }
 
-    LV_LOG_INFO("Resolution is set to %dx%d at %ddpi", hor_res, ver_res, lv_display_get_dpi(disp));
+    LV_LOG_INFO("Resolution is set to %" LV_PRId32 "x%" LV_PRId32 " at %" LV_PRId32 "dpi",
+                hor_res, ver_res, lv_display_get_dpi(disp));
 }
 
 /**********************

--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -136,7 +136,8 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
 
-    LV_LOG_USER("Resolution is set to %dx%d at %ddpi", dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
+    LV_LOG_USER("Resolution is set to %dx%d at %" LV_PRId32 "dpi",
+                dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
     return 0;
 
 errout:

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -770,7 +770,7 @@ static lv_result_t decode_compressed(lv_image_decoder_t * decoder, lv_image_deco
     uint32_t rn;
     uint32_t len;
     uint32_t compressed_len;
-    uint8_t * file_buf;
+    uint8_t * file_buf = NULL;
     decoder_data_t * decoder_data = get_decoder_data(dsc);
     lv_result_t res;
     lv_image_compressed_t * compressed = &decoder_data->compressed;


### PR DESCRIPTION
### Description of the feature or fix

```
lvgl/lvgl/src/dev/nuttx/../../display/../misc/lv_assert.h:17,
                 from lvgl/lvgl/src/dev/nuttx/../../display/../misc/lv_color.h:17,
                 from lvgl/lvgl/src/dev/nuttx/../../display/lv_display.h:18,
                 from lvgl/lvgl/src/dev/nuttx/lv_nuttx_fbdev.h:17,
                 from lvgl/lvgl/src/dev/nuttx/lv_nuttx_fbdev.c:9:
lvgl/lvgl/src/dev/nuttx/lv_nuttx_fbdev.c: In function 'lv_nuttx_fbdev_set_file':
lvgl/lvgl/src/dev/nuttx/lv_nuttx_fbdev.c:139:17: warning: format '%d' expects argument of type 'int', but argument 8 has type 'int32_t' {aka 'long int'} [-Wformat=]
  139 |     LV_LOG_USER("Resolution is set to %dx%d at %ddpi", dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    ~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                          |
      |                                                                                          int32_t {aka long int}
lvgl/lvgl/src/dev/nuttx/../../display/../misc/lv_log.h:132:97: note: in definition of macro 'LV_LOG_USER'
  132 | #    define LV_LOG_USER(...) _lv_log_add(LV_LOG_LEVEL_USER, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
      |                                                                                                 ^~~~~~~~~~~
lvgl/lvgl/src/dev/nuttx/lv_nuttx_fbdev.c:139:49: note: format string is defined here
  139 |     LV_LOG_USER("Resolution is set to %dx%d at %ddpi", dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
      |                                                ~^
      |                                                 |
      |                                                 int
      |                                                %ld
lvgl/lvgl/src/libs/bin_decoder/lv_bin_decoder.c:845:17: warning: 'file_buf' may be used uninitialized in this function [-Wmaybe-uninitialized]
  845 |     if(is_file) lv_free(file_buf);
      |                 ^~~~~~~~~~~~~~~~~
```


### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
