### PR TITLE
chore: fix warning when log disable

### DIFF
--- a/examples/others/observer/lv_example_observer_2.c
+++ b/examples/others/observer/lv_example_observer_2.c
@@ -30,6 +30,7 @@ static void engine_state_observer_cb(lv_observer_t * observer, lv_subject_t * su
     LV_UNUSED(observer);
 
     int32_t v = lv_subject_get_int(subject);
+    LV_UNUSED(v);
     /*In a real application set/clear a pin here*/
     LV_LOG_USER("Engine state: %d", v);
 }

--- a/examples/widgets/msgbox/lv_example_msgbox_1.c
+++ b/examples/widgets/msgbox/lv_example_msgbox_1.c
@@ -5,6 +5,7 @@ static void event_cb(lv_event_t * e)
 {
     lv_obj_t * btn = lv_event_get_target(e);
     lv_obj_t * label = lv_obj_get_child(btn, 0);
+    LV_UNUSED(label);
     LV_LOG_USER("Button %s clicked", lv_label_get_text(label));
 }
 

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -120,7 +120,7 @@ typedef struct _lv_global_t {
     lv_log_print_g_cb_t custom_log_print_cb;
 #endif
 
-#if LV_LOG_USE_TIMESTAMP
+#if LV_USE_LOG && LV_LOG_USE_TIMESTAMP
     uint32_t log_last_log_time;
 #endif
 

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -926,6 +926,7 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
 
     uint8_t * img_data;
     uint32_t input_len = compressed->compressed_size;
+    LV_UNUSED(input_len);
     uint32_t out_len = compressed->decompressed_size;
 
     lv_draw_buf_t * decompressed = lv_draw_buf_create(dsc->header.w, dsc->header.h, dsc->header.cf,


### PR DESCRIPTION
### Description of the feature or fix

```bash
lvgl/examples/widgets/textarea/../../../src/core/lv_global.h:123:5: warning: "LV_LOG_USE_TIMESTAMP" is not defined, evaluates to 0 [-Wundef]
  123 | #if LV_LOG_USE_TIMESTAMP
      |     ^~~~~~~~~~~~~~~~~~~~

lvgl/src/libs/bin_decoder/lv_bin_decoder.c: In function ‘decompress_image’:
lvgl/src/libs/bin_decoder/lv_bin_decoder.c:928:14: warning: unused variable ‘input_len’ [-Wunused-variable]
  928 |     uint32_t input_len = compressed->compressed_size;
      |              ^~~~~~~~~

lvgl/examples/others/observer/lv_example_observer_2.c: In function ‘engine_state_observer_cb’:
lvgl/examples/others/observer/lv_example_observer_2.c:32:13: warning: unused variable ‘v’ [-Wunused-variable]
   32 |     int32_t v = lv_subject_get_int(subject);
      |             ^

lvgl/examples/widgets/msgbox/lv_example_msgbox_1.c: In function ‘event_cb’:
lvgl/examples/widgets/msgbox/lv_example_msgbox_1.c:7:16: warning: unused variable ‘label’ [-Wunused-variable]
    7 |     lv_obj_t * label = lv_obj_get_child(btn, 0);
      |                ^~~~~
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
