### PR TITLE
chore: rename _unaligned to avoid MSVC compile issue

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -139,7 +139,7 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
     draw_buf->header.flags = LV_IMAGE_FLAGS_MODIFIABLE;
     draw_buf->header.stride = stride;
     draw_buf->data = lv_draw_buf_align(buf, cf);
-    draw_buf->_unaligned = buf;
+    draw_buf->unaligned_data = buf;
     draw_buf->data_size = size;
     return draw_buf;
 }
@@ -149,7 +149,7 @@ void lv_draw_buf_destroy(lv_draw_buf_t * buf)
     LV_ASSERT_NULL(buf);
     if(buf == NULL) return;
     if(buf->header.flags & LV_IMAGE_FLAGS_MODIFIABLE)
-        lv_draw_buf_free(buf->_unaligned);
+        lv_draw_buf_free(buf->unaligned_data);
 
     lv_free(buf);
 }

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -29,7 +29,7 @@ typedef struct {
     lv_image_header_t header;
     uint32_t data_size;     /*Total buf size in bytes*/
     void * data;
-    void * _unaligned;      /*Unaligned address of data*/
+    void * unaligned_data;  /*Unaligned address of `data`, used internally by lvgl*/
 } lv_draw_buf_t;
 
 /**
@@ -60,7 +60,7 @@ typedef struct {
                                             }, \
                                   .data_size = sizeof(buf_##name), \
                                   .data = buf_##name, \
-                                  ._unaligned = buf_##name, \
+                                  .unaligned_data = buf_##name, \
                                 }
 
 typedef void * (*lv_draw_buf_malloc_cb)(size_t size, lv_color_format_t color_format);

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -74,7 +74,7 @@ void lv_canvas_set_buffer(lv_obj_t * obj, void * buf, int32_t w, int32_t h, lv_c
     lv_image_header_init(&canvas->static_buf.header, w, h, cf, stride, 0);
     canvas->static_buf.data_size = stride * h;
     canvas->static_buf.data = lv_draw_buf_align(buf, cf);
-    canvas->static_buf._unaligned = buf;
+    canvas->static_buf.unaligned_data = buf;
     canvas->draw_buf = &canvas->static_buf;
 
     const void * src = lv_image_get_src(obj);
@@ -243,7 +243,7 @@ const void * lv_canvas_get_buf(lv_obj_t * obj)
 
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     if(canvas->draw_buf)
-        return canvas->draw_buf->_unaligned;
+        return canvas->draw_buf->unaligned_data;
 
     return NULL;
 }


### PR DESCRIPTION
### Description of the feature or fix

Fix #5027

Need to take care of #5022 before proceeding renaming.
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
