### PR TITLE
fix(barcode): use draw buffer to set canvas to meet align requirement 

### DIFF
--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -53,6 +53,7 @@ lv_obj_t * lv_canvas_create(lv_obj_t * parent);
 
 /**
  * Set a buffer for the canvas.
+ * Use `lv_canvas_set_draw_buf` instead if you need to set a buffer with alignment requirement.
  * @param buf a buffer where the content of the canvas will be.
  * The required size is (lv_image_color_format_get_px_size(cf) * w) / 8 * h)
  * It can be allocated with `lv_malloc()` or
@@ -65,6 +66,13 @@ lv_obj_t * lv_canvas_create(lv_obj_t * parent);
  */
 void lv_canvas_set_buffer(lv_obj_t * obj, void * buf, int32_t w, int32_t h, lv_color_format_t cf);
 
+/**
+ * Set a draw buffer for the canvas. A draw buffer either can be allocated by `lv_draw_buf_create()`
+ * or defined statically by `LV_DRAW_BUF_DEFINE`. When buffer start address and stride has alignment
+ * requirement, it's recommended to use `lv_draw_buf_create`.
+ * @param obj       pointer to a canvas object
+ * @param draw_buf  pointer to a draw buffer
+ */
 void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf);
 
 /**


### PR DESCRIPTION
### Description of the feature or fix

Continue of #5012 #5022 
Only with draw buffer interface, the start address and stride alignment can meet requirement.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
