### PR TITLE
feat(draw_buf): remove legacy lv_draw_buf_go_to_xy

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -399,8 +399,13 @@ void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
 
 void * lv_draw_layer_go_to_xy(lv_layer_t * layer, int32_t x, int32_t y)
 {
-    return lv_draw_buf_go_to_xy(layer->buf, layer->buf_stride, layer->color_format, x, y);
-
+    lv_draw_buf_t tmp;
+    tmp.data = layer->buf;
+    tmp.header.stride = layer->buf_stride;
+    tmp.header.cf = layer->color_format;
+    tmp.header.w = lv_area_get_width(&layer->buf_area);
+    tmp.header.h = lv_area_get_height(&layer->buf_area);
+    return lv_draw_buf_goto_xy(&tmp, x, y);
 }
 
 /**********************

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -27,9 +27,6 @@ static void * buf_malloc(size_t size, lv_color_format_t color_format);
 static void buf_free(void * buf);
 static void * buf_align(void * buf, lv_color_format_t color_format);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
-static void * buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                           int32_t y);
-
 static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a);
 
 static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
@@ -56,7 +53,6 @@ void _lv_draw_buf_init_handlers(void)
     handlers.align_pointer_cb = buf_align;
     handlers.invalidate_cache_cb = NULL;
     handlers.width_to_stride_cb = width_to_stride;
-    handlers.go_to_xy_cb = buf_go_to_xy;
     handlers.buf_clear_cb = buf_clear;
     handlers.buf_copy_cb = buf_copy;
 }
@@ -92,13 +88,6 @@ void * lv_draw_buf_align(void * data, lv_color_format_t color_format)
 void lv_draw_buf_invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area)
 {
     if(handlers.invalidate_cache_cb) handlers.invalidate_cache_cb(buf, stride, color_format, area);
-}
-
-void * lv_draw_buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                            int32_t y)
-{
-    if(handlers.go_to_xy_cb) return handlers.go_to_xy_cb(buf, stride, color_format, x, y);
-    else return NULL;
 }
 
 void lv_draw_buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)
@@ -247,16 +236,6 @@ static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
     width_byte = w * lv_color_format_get_bpp(color_format);
     width_byte = (width_byte + 7) >> 3; /*Round up*/
     return (width_byte + LV_DRAW_BUF_STRIDE_ALIGN - 1) & ~(LV_DRAW_BUF_STRIDE_ALIGN - 1);
-}
-
-static void * buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                           int32_t y)
-{
-    const uint8_t * buf_tmp = buf;
-    buf_tmp += stride * y;
-    buf_tmp += x * lv_color_format_get_size(color_format);
-
-    return (void *)buf_tmp;
 }
 
 static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -43,9 +43,6 @@ typedef void (*lv_draw_buf_invalidate_cache_cb)(void * buf, uint32_t stride, lv_
 
 typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
 
-typedef void * (*lv_draw_buf_go_to_xy_cb)(const void * buf, uint32_t stride, lv_color_format_t color_format,
-                                          int32_t x, int32_t y);
-
 typedef void (*lv_draw_buf_clear_cb)(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format,
                                      const lv_area_t * a);
 
@@ -60,7 +57,6 @@ typedef struct {
     lv_draw_buf_align_cb align_pointer_cb;
     lv_draw_buf_invalidate_cache_cb invalidate_cache_cb;
     lv_draw_buf_width_to_stride_cb width_to_stride_cb;
-    lv_draw_buf_go_to_xy_cb go_to_xy_cb;
     lv_draw_buf_clear_cb buf_clear_cb;
     lv_draw_buf_copy_cb buf_copy_cb;
 } lv_draw_buf_handlers_t;
@@ -123,18 +119,6 @@ void lv_draw_buf_invalidate_cache(void * buf, uint32_t stride, lv_color_format_t
 uint32_t lv_draw_buf_width_to_stride(uint32_t w, lv_color_format_t color_format);
 
 /**
- * Got to a pixel at X and Y coordinate in a buffer
- * @param buf               pointer to a buffer
- * @param stride            stride of the buffer
- * @param color_format      color format of the buffer
- * @param x                 the target X coordinate
- * @param y                 the target X coordinate
- * @return                  `buf` offset to point to the given X and Y coordinate
- */
-void * lv_draw_buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                            int32_t y);
-
-/**
  * Clear an area on the buffer
  * @param draw_buf          pointer to draw buffer
  * @param w                 width of the buffer
@@ -183,7 +167,6 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
 void lv_draw_buf_destroy(lv_draw_buf_t * buf);
 
 /**
- * @todo, need to replace lv_draw_buf_go_to_xy.
  * Return pointer to the buffer at the given coordinates
  */
 void * lv_draw_buf_goto_xy(lv_draw_buf_t * buf, uint32_t x, uint32_t y);

--- a/src/draw/nxp/vglite/lv_draw_buf_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_buf_vglite.c
@@ -69,7 +69,6 @@ void lv_draw_buf_vglite_init_handlers(void)
     handlers->align_pointer_cb = _align_buf;
     handlers->invalidate_cache_cb = _invalidate_cache;
     handlers->width_to_stride_cb = _width_to_stride;
-    handlers->go_to_xy_cb = _go_to_xy;
     handlers->buf_clear_cb = _vglite_buf_clear;
     handlers->buf_copy_cb = _vglite_buf_copy;
 }
@@ -117,18 +116,6 @@ static uint32_t _width_to_stride(uint32_t w, lv_color_format_t cf)
     uint8_t align_bytes = vglite_get_alignment(cf);
 
     return (width_bytes + align_bytes - 1) & ~(align_bytes - 1);
-}
-
-static void * _go_to_xy(lv_draw_buf_t * draw_buf, int32_t x, int32_t y)
-{
-    uint8_t bits_per_pixel = vglite_get_px_size(draw_buf->color_format);
-    uint32_t stride = lv_draw_buf_get_stride(draw_buf);
-    uint8_t * buf_tmp = lv_draw_buf_get_buf(draw_buf);
-
-    buf_tmp += stride * y;
-    buf_tmp += (x * bits_per_pixel) / 8;
-
-    return buf_tmp;
 }
 
 static void _vglite_buf_clear(lv_draw_buf_t * draw_buf, const lv_area_t * area)

--- a/src/draw/nxp/vglite/lv_draw_vglite_label.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_label.c
@@ -107,10 +107,6 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
                 return;
             lv_area_move(&blend_area, -layer->draw_buf_ofs.x, -layer->draw_buf_ofs.y);
 
-            //void * dest_buf = lv_draw_buf_go_to_xy(&layer->draw_buf,
-            //                                       blend_area.x1 - layer->draw_buf_ofs.x,
-            //                                       blend_area.y1 - layer->draw_buf_ofs.y);
-
             const uint8_t * mask_buf = glyph_draw_dsc->bitmap;
             lv_area_t mask_area;
             lv_area_copy(&mask_area, glyph_draw_dsc->letter_coords);


### PR DESCRIPTION
### Description of the feature or fix

Since we have `stride` parameter now, it no longer needs custom callback to goto (x,y) of buffer.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
