### PR TITLE
Fix dashed horizontal line rendering.

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -1064,9 +1064,9 @@ static void color_event_cb(lv_event_t * e)
         lv_palette_t * palette_primary = lv_event_get_user_data(e);
         lv_palette_t palette_secondary = (*palette_primary) + 3; /*Use another palette as secondary*/
         if(palette_secondary >= _LV_PALETTE_LAST) palette_secondary = 0;
-
+#if LV_USE_THEME_DEFAULT
         lv_theme_default_init(NULL, lv_palette_main(*palette_primary), lv_palette_main(palette_secondary), LV_THEME_DEFAULT_DARK, font_normal);
-
+#endif
         lv_color_t color = lv_palette_main(*palette_primary);
         lv_style_set_text_color(&style_icon, color);
         lv_chart_set_series_color(chart1, ser1, color);

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -389,12 +389,6 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
         i->proc.types.keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
     }
 
-    lv_group_t * g = i->group;
-    if(g == NULL) return;
-
-    indev_obj_act = lv_group_get_focused(g);
-    if(indev_obj_act == NULL) return;
-
     /*Save the last key to compare it with the current latter on RELEASE*/
     uint32_t prev_key = i->proc.types.keypad.last_key;
 
@@ -407,6 +401,12 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
      *for the next time*/
     uint32_t prev_state             = i->proc.types.keypad.last_state;
     i->proc.types.keypad.last_state = data->state;
+
+    lv_group_t * g = i->group;
+    if(g == NULL) return;
+
+    indev_obj_act = lv_group_get_focused(g);
+    if(indev_obj_act == NULL) return;
 
     /*Key press happened*/
     if(data->state == LV_INDEV_STATE_PRESSED && prev_state == LV_INDEV_STATE_RELEASED) {

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -968,7 +968,7 @@ static void indev_proc_release(_lv_indev_proc_t * proc)
  */
 static void indev_proc_reset_query_handler(lv_indev_t * indev)
 {
-    if(indev->proc.reset_query) {
+    if(indev && indev->proc.reset_query) {
         indev->proc.types.pointer.act_obj           = NULL;
         indev->proc.types.pointer.last_obj          = NULL;
         indev->proc.types.pointer.scroll_obj          = NULL;

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -783,7 +783,7 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
     }
     else if(code == LV_EVENT_FOCUSED) {
         if(lv_obj_has_flag(obj, LV_OBJ_FLAG_SCROLL_ON_FOCUS)) {
-            lv_obj_scroll_to_view_recursive(obj, LV_ANIM_ON);
+            lv_obj_scroll_to_view_recursive(obj, LV_ANIM_OFF);
         }
 
         bool editing = false;

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -746,7 +746,7 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
         x_scroll = left_diff;
         /*Do not let scrolling in*/
         lv_coord_t sl = lv_obj_get_scroll_left(parent);
-        if(sl + x_scroll > 0) x_scroll = 0;
+        if(sl - x_scroll < 0) x_scroll = 0;
     }
     else if(right_diff > 0) {
         x_scroll = -right_diff;

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -658,7 +658,10 @@ static void scroll_by_raw(lv_obj_t * obj, lv_coord_t x, lv_coord_t y)
     obj->spec_attr->scroll.y += y;
 
     lv_obj_move_children_by(obj, x, y, true);
-    lv_res_t res = lv_event_send(obj, LV_EVENT_SCROLL, NULL);
+    lv_point_t p;
+    p.x = x;
+    p.y = y;
+    lv_res_t res = lv_event_send(obj, LV_EVENT_SCROLL, &p);
     if(res != LV_RES_OK) return;
     lv_obj_invalidate(obj);
 }

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -168,8 +168,8 @@ LV_ATTRIBUTE_FAST_MEM static void draw_line_hor(struct _lv_draw_ctx_t * draw_ctx
                     lv_coord_t dash_cnt = dash_start;
                     lv_coord_t i;
                     for(i = 0; i < blend_area_w; i++, dash_cnt++) {
-                        if(dash_cnt <= dsc->dash_width) {
-                            int16_t diff = dsc->dash_width - dash_cnt;
+                        if(dash_cnt < dsc->dash_width) {
+                            int16_t diff = dsc->dash_width - dash_cnt - 1;
                             i += diff;
                             dash_cnt += diff;
                         }

--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -47,6 +47,7 @@ uint32_t lv_snapshot_buf_size_needed(lv_obj_t * obj, lv_img_cf_t cf)
 {
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR_ALPHA:
+        case LV_IMG_CF_TRUE_COLOR:
         case LV_IMG_CF_ALPHA_1BIT:
         case LV_IMG_CF_ALPHA_2BIT:
         case LV_IMG_CF_ALPHA_4BIT:
@@ -86,6 +87,7 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
 
     switch(cf) {
         case LV_IMG_CF_TRUE_COLOR_ALPHA:
+        case LV_IMG_CF_TRUE_COLOR:
         case LV_IMG_CF_ALPHA_1BIT:
         case LV_IMG_CF_ALPHA_2BIT:
         case LV_IMG_CF_ALPHA_4BIT:


### PR DESCRIPTION
### Description of the feature or fix

The dash_width and dash_gap properties for horizontal line drawing do not work as intended. Setting both value to 1 results in a solid line instead of a dotted line.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
