### PR TITLE
chore(conf): use EXTERNAL and INTERNAL macro to config libs

### DIFF
--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -648,8 +648,6 @@
 
 /*Enable LZ4 compress/decompress lib*/
 #ifndef LV_USE_LZ4
-#   define LV_USE_LZ4  0
-
 /*Use lvgl built-in LZ4 lib*/
 #   define LV_USE_LZ4_INTERNAL  0
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -710,9 +710,6 @@
 /* Enable ThorVG by assuming that its installed and linked to the project */
 #define LV_USE_THORVG_EXTERNAL 0
 
-/*Enable LZ4 compress/decompress lib*/
-#define LV_USE_LZ4  0
-
 /*Use lvgl built-in LZ4 lib*/
 #define LV_USE_LZ4_INTERNAL  0
 

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -189,6 +189,13 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
+#ifndef LV_USE_LZ4
+    #define LV_USE_LZ4  (LV_USE_LZ4_INTERNAL || LV_USE_LZ4_EXTERNAL)
+#endif
+
+#ifndef LV_USE_THORVG
+    #define LV_USE_THORVG  (LV_USE_LZ4_INTERNAL || LV_USE_LZ4_EXTERNAL)
+#endif
 
 /*If running without lv_conf.h add typedefs with default value*/
 #ifdef LV_CONF_SKIP

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -15,7 +15,7 @@
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
 
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
     #if LV_USE_THORVG_EXTERNAL
         #include <thorvg_capi.h>
     #else
@@ -147,14 +147,14 @@ void lv_draw_sw_init(void)
 #endif
     }
 
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
     tvg_engine_init(TVG_ENGINE_SW, 0);
 #endif
 }
 
 void lv_draw_sw_deinit(void)
 {
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
     tvg_engine_term(TVG_ENGINE_SW);
 #endif
 
@@ -383,7 +383,7 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
             lv_draw_sw_mask_rect((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
             break;
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
         case LV_DRAW_TASK_TYPE_VECTOR:
             lv_draw_sw_vector((lv_draw_unit_t *)u, t->draw_dsc);
             break;

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -162,7 +162,7 @@ void lv_draw_sw_transform(lv_draw_unit_t * draw_unit, const lv_area_t * dest_are
                           int32_t src_w, int32_t src_h, int32_t src_stride,
                           const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t cf, void * dest_buf);
 
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
 /**
  * Draw vector graphics with SW render.
  * @param draw_unit     pointer to a draw unit

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -8,7 +8,7 @@
  *********************/
 #include "lv_draw_sw.h"
 
-#if LV_USE_VECTOR_GRAPHIC && (LV_USE_THORVG_EXTERNAL || LV_USE_THORVG_INTERNAL)
+#if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
 #if LV_USE_THORVG_EXTERNAL
     #include <thorvg_capi.h>
 #else

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2336,15 +2336,6 @@
     #endif
 #endif
 
-/*Enable LZ4 compress/decompress lib*/
-#ifndef LV_USE_LZ4
-    #ifdef CONFIG_LV_USE_LZ4
-        #define LV_USE_LZ4 CONFIG_LV_USE_LZ4
-    #else
-        #define LV_USE_LZ4  0
-    #endif
-#endif
-
 /*Use lvgl built-in LZ4 lib*/
 #ifndef LV_USE_LZ4_INTERNAL
     #ifdef CONFIG_LV_USE_LZ4_INTERNAL
@@ -3194,6 +3185,13 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
+#ifndef LV_USE_LZ4
+    #define LV_USE_LZ4  (LV_USE_LZ4_INTERNAL || LV_USE_LZ4_EXTERNAL)
+#endif
+
+#ifndef LV_USE_THORVG
+    #define LV_USE_THORVG  (LV_USE_LZ4_INTERNAL || LV_USE_LZ4_EXTERNAL)
+#endif
 
 /*If running without lv_conf.h add typedefs with default value*/
 #ifdef LV_CONF_SKIP

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -76,7 +76,6 @@
 #define LV_USE_SYSMON           1
 #define LV_USE_SNAPSHOT         1
 #define LV_USE_THORVG_INTERNAL  1
-#define LV_USE_LZ4              1
 #define LV_USE_LZ4_INTERNAL     1
 #define LV_USE_VECTOR_GRAPHIC   1
 #define LV_USE_PROFILER         1


### PR DESCRIPTION


### Description of the feature or fix

Use lvgl's internal lib by default and switch to external lib if specified.
LZ4 and THORVG have been update.

LV_USE_XXX_INTERNAL is defined automatically in lv_conf_internal.h for internal use only.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
