### PR TITLE
fix(vg_lite): fix build break

### DIFF
--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -31,8 +31,6 @@ static void buf_free(void * buf);
 static void * buf_align(void * buf, lv_color_format_t color_format);
 static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
-static void * buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                           int32_t y);
 static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a);
 static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
                      void * src_buf, uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
@@ -59,7 +57,6 @@ void lv_draw_buf_vg_lite_init_handlers(void)
     handlers->align_pointer_cb = buf_align;
     handlers->invalidate_cache_cb = invalidate_cache;
     handlers->width_to_stride_cb = width_to_stride;
-    handlers->go_to_xy_cb = buf_go_to_xy;
     handlers->buf_clear_cb = buf_clear;
     handlers->buf_copy_cb = buf_copy;
 }
@@ -93,16 +90,6 @@ static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t colo
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
     return lv_vg_lite_width_to_stride(w, lv_vg_lite_vg_fmt(color_format));
-}
-
-static void * buf_go_to_xy(const void * buf, uint32_t stride, lv_color_format_t color_format, int32_t x,
-                           int32_t y)
-{
-    const uint8_t * buf_tmp = buf;
-    buf_tmp += stride * y;
-    buf_tmp += x * lv_color_format_get_size(color_format);
-
-    return (void *)buf_tmp;
 }
 
 static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -77,7 +77,7 @@ void lv_draw_vg_lite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t
     }
 #endif /*SUPPORT_OUTLINE_FONT*/
 
-    lv_draw_label_iterate_letters(draw_unit, dsc, coords, draw_letter_cb);
+    lv_draw_label_iterate_characters(draw_unit, dsc, coords, draw_letter_cb);
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

```bash
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘lv_draw_vg_lite_label’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:80:5: warning: implicit declaration of function ‘lv_draw_label_iterate_letters’; did you mean ‘lv_draw_label_iterate_characters’? [-Wimplicit-function-declaration]
   80 |     lv_draw_label_iterate_letters(draw_unit, dsc, coords, draw_letter_cb);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     lv_draw_label_iterate_characters
lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c: In function ‘lv_draw_buf_vg_lite_init_handlers’:
lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c:62:13: error: ‘lv_draw_buf_handlers_t’ {aka ‘struct <anonymous>’} has no member named ‘go_to_xy_cb’
   62 |     handlers->go_to_xy_cb = buf_go_to_xy;
      |             ^~
```

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
