### PR TITLE
refactor(image): add magic to image header

### DIFF
--- a/examples/libs/gif/lv_example_gif_1.py
+++ b/examples/libs/gif/lv_example_gif_1.py
@@ -11,7 +11,7 @@ fs_driver.fs_register(fs_drv, 'S')
 #
 image_bulb_gif = lv.image_dsc_t(
     {
-        "header": {"always_zero": 0, "w": 0, "h": 0,  "cf": lv.COLOR_FORMAT.RAW},
+        "header": {"w": 0, "h": 0,  "cf": lv.COLOR_FORMAT.RAW},
         "data_size": 0,
         "data": img_bulb_gif_map,
     }

--- a/examples/libs/lodepng/lv_example_lodepng_1.py
+++ b/examples/libs/lodepng/lv_example_lodepng_1.py
@@ -5,7 +5,7 @@ from img_wink_png import img_wink_png_map
 
 image_wink_png = lv.image_dsc_t(
     {
-        "header": {"always_zero": 0, "w": 50, "h": 50,  "cf": lv.COLOR_FORMAT.RAW_ALPHA},
+        "header": {"w": 50, "h": 50,  "cf": lv.COLOR_FORMAT.RAW_ALPHA},
         "data_size": 5158,
         "data": img_wink_png_map,
     }

--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -325,8 +325,8 @@ class LVGLImageHeader:
     @property
     def binary(self) -> bytearray:
         binary = bytearray()
+        binary += uint8_t(0x19)  # magic number for lvgl version 9
         binary += uint8_t(self.cf.value)
-        binary += uint8_t(0)  # 8bits format
         binary += uint16_t(self.flags)  # 16bits flags
 
         binary += uint16_t(self.w)  # 16bits width
@@ -612,6 +612,7 @@ uint8_t {varname}_map[] = {{
 }};
 
 const lv_img_dsc_t {varname} = {{
+  .header.magic = LV_IMAGE_HEADER_MAGIC,
   .header.cf = LV_COLOR_FORMAT_{self.cf.name},
   .header.flags = {flags},
   .header.w = {self.w},

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -40,6 +40,11 @@ extern "C" {
 
 #define _LV_ZOOM_INV_UPSCALE 5
 
+/** Magic number for lvgl image, 9 means lvgl version 9
+ *  It must not be a valid ASCII character nor larger than 0x80. See `lv_image_src_get_type`.
+ */
+#define LV_IMAGE_HEADER_MAGIC (0x19)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -89,12 +94,6 @@ typedef enum {
     LV_IMAGE_COMPRESS_LZ4,
 } lv_image_compress_t;
 
-/**
- * The first 8 bit is very important to distinguish the different source types.
- * For more info see `lv_image_get_src_type()` in lv_img.c
- * On big endian systems the order is reversed so cf and always_zero must be at
- * the end of the struct.
- */
 #if LV_BIG_ENDIAN_SYSTEM
 typedef struct {
     uint32_t reserved_2: 16;    /*Reserved to be used later*/
@@ -102,18 +101,13 @@ typedef struct {
     uint32_t h: 16;
     uint32_t w: 16;
     uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/
-    uint32_t reserved_1: 8;     /*Reserved by LVGL for later use*/
-    uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
-                                  non-printable character*/
-    uint32_t cf : 5;            /*Color format: See `lv_color_format_t`*/
+    uint32_t cf : 8;            /*Color format: See `lv_color_format_t`*/
+    uint32_t magic: 8;          /*Magic number. Must be LV_IMAGE_HEADER_MAGIC*/
 } lv_image_header_t;
 #else
 typedef struct {
-    uint32_t cf : 5;            /*Color format: See `lv_color_format_t`*/
-    uint32_t always_zero : 3;   /*It the upper bits of the first byte. Always zero to look like a
-                                  non-printable character*/
-
-    uint32_t reserved_1: 8;     /*Reserved by LVGL for later use*/
+    uint32_t magic: 8;          /*Magic number. Must be LV_IMAGE_HEADER_MAGIC*/
+    uint32_t cf : 8;            /*Color format: See `lv_color_format_t`*/
     uint32_t flags: 16;         /*Image flags, see `lv_image_flags_t`*/
 
     uint32_t w: 16;

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -123,6 +123,17 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
                 return LV_RESULT_INVALID;
             }
 
+            /**
+             * @todo
+             * This is a temp backward compatibility solution after adding
+             * magic in image header.
+             */
+            if(header->magic != LV_IMAGE_HEADER_MAGIC) {
+                LV_LOG_WARN("Legacy bin image detected: %s", (char *)src);
+                header->cf = header->magic;
+                header->magic = LV_IMAGE_HEADER_MAGIC;
+            }
+
             /*File is always read to buf, thus data can be modified.*/
             header->flags |= LV_IMAGE_FLAGS_MODIFIABLE;
         }


### PR DESCRIPTION


### Description of the feature or fix

Fix #5041
So the cf field is not limited to 5bits, to add more color format options. A workaround is included, so the existing bin images can still work.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
