### PR TITLE
refactor(drawbuf): eliminate clear/copy buffer callbacks

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -27,11 +27,6 @@ static void * buf_malloc(size_t size, lv_color_format_t color_format);
 static void buf_free(void * buf);
 static void * buf_align(void * buf, lv_color_format_t color_format);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
-static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a);
-
-static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
-                     void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
-                     lv_color_format_t color_format);
 
 /**********************
  *  STATIC VARIABLES
@@ -53,8 +48,6 @@ void _lv_draw_buf_init_handlers(void)
     handlers.align_pointer_cb = buf_align;
     handlers.invalidate_cache_cb = NULL;
     handlers.width_to_stride_cb = width_to_stride;
-    handlers.buf_clear_cb = buf_clear;
-    handlers.buf_copy_cb = buf_copy;
 }
 
 lv_draw_buf_handlers_t * lv_draw_buf_get_handlers(void)
@@ -92,16 +85,53 @@ void lv_draw_buf_invalidate_cache(void * buf, uint32_t stride, lv_color_format_t
 
 void lv_draw_buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)
 {
-    if(handlers.buf_clear_cb) handlers.buf_clear_cb(buf, w, h, color_format, a);
+    LV_UNUSED(h);
+
+    uint8_t px_size = lv_color_format_get_size(color_format);
+    uint32_t stride = lv_draw_buf_width_to_stride(w, color_format);
+    uint8_t * bufc =  buf;
+
+    /*Got the first pixel of each buffer*/
+    bufc += stride * a->y1;
+    bufc += a->x1 * px_size;
+
+    uint32_t line_length = lv_area_get_width(a) * px_size;
+    int32_t y;
+    for(y = a->y1; y <= a->y2; y++) {
+        lv_memzero(bufc, line_length);
+        bufc += stride;
+    }
+
 }
 
 void lv_draw_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
                       void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
                       lv_color_format_t color_format)
 {
-    if(handlers.buf_copy_cb) handlers.buf_copy_cb(dest_buf, dest_w, dest_h, dest_area_to_copy,
-                                                      src_buf, src_w, src_h, src_area_to_copy,
-                                                      color_format);
+    LV_UNUSED(dest_h);
+    LV_UNUSED(src_h);
+
+    uint8_t px_size = lv_color_format_get_size(color_format);
+    uint8_t * dest_bufc =  dest_buf;
+    uint8_t * src_bufc =  src_buf;
+
+    uint32_t dest_stride = lv_draw_buf_width_to_stride(dest_w, color_format);
+    uint32_t src_stride = lv_draw_buf_width_to_stride(src_w, color_format);
+
+    /*Got the first pixel of each buffer*/
+    dest_bufc += dest_stride * dest_area_to_copy->y1;
+    dest_bufc += dest_area_to_copy->x1 * px_size;
+
+    src_bufc += src_stride * src_area_to_copy->y1;
+    src_bufc += src_area_to_copy->x1 * px_size;
+
+    uint32_t line_length = lv_area_get_width(dest_area_to_copy) * px_size;
+    int32_t y;
+    for(y = dest_area_to_copy->y1; y <= dest_area_to_copy->y2; y++) {
+        lv_memcpy(dest_bufc, src_bufc, line_length);
+        dest_bufc += dest_stride;
+        src_bufc += src_stride;
+    }
 }
 
 lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride)
@@ -236,56 +266,4 @@ static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
     width_byte = w * lv_color_format_get_bpp(color_format);
     width_byte = (width_byte + 7) >> 3; /*Round up*/
     return (width_byte + LV_DRAW_BUF_STRIDE_ALIGN - 1) & ~(LV_DRAW_BUF_STRIDE_ALIGN - 1);
-}
-
-static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)
-{
-
-    LV_UNUSED(h);
-
-    uint8_t px_size = lv_color_format_get_size(color_format);
-    uint32_t stride = lv_draw_buf_width_to_stride(w, color_format);
-    uint8_t * bufc =  buf;
-
-    /*Got the first pixel of each buffer*/
-    bufc += stride * a->y1;
-    bufc += a->x1 * px_size;
-
-    uint32_t line_length = lv_area_get_width(a) * px_size;
-    int32_t y;
-    for(y = a->y1; y <= a->y2; y++) {
-        lv_memzero(bufc, line_length);
-        bufc += stride;
-    }
-
-}
-
-static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
-                     void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
-                     lv_color_format_t color_format)
-{
-    LV_UNUSED(dest_h);
-    LV_UNUSED(src_h);
-
-    uint8_t px_size = lv_color_format_get_size(color_format);
-    uint8_t * dest_bufc =  dest_buf;
-    uint8_t * src_bufc =  src_buf;
-
-    uint32_t dest_stride = lv_draw_buf_width_to_stride(dest_w, color_format);
-    uint32_t src_stride = lv_draw_buf_width_to_stride(src_w, color_format);
-
-    /*Got the first pixel of each buffer*/
-    dest_bufc += dest_stride * dest_area_to_copy->y1;
-    dest_bufc += dest_area_to_copy->x1 * px_size;
-
-    src_bufc += src_stride * src_area_to_copy->y1;
-    src_bufc += src_area_to_copy->x1 * px_size;
-
-    uint32_t line_length = lv_area_get_width(dest_area_to_copy) * px_size;
-    int32_t y;
-    for(y = dest_area_to_copy->y1; y <= dest_area_to_copy->y2; y++) {
-        lv_memcpy(dest_bufc, src_bufc, line_length);
-        dest_bufc += dest_stride;
-        src_bufc += src_stride;
-    }
 }

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -74,22 +74,12 @@ typedef void (*lv_draw_buf_invalidate_cache_cb)(void * buf, uint32_t stride, lv_
 
 typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
 
-typedef void (*lv_draw_buf_clear_cb)(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format,
-                                     const lv_area_t * a);
-
-typedef void (*lv_draw_buf_copy_cb)(void * dest_buf, uint32_t dest_w, uint32_t dest_h,
-                                    const lv_area_t * dest_area_to_copy,
-                                    void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
-                                    lv_color_format_t color_format);
-
 typedef struct {
     lv_draw_buf_malloc_cb buf_malloc_cb;
     lv_draw_buf_free_cb buf_free_cb;
     lv_draw_buf_align_cb align_pointer_cb;
     lv_draw_buf_invalidate_cache_cb invalidate_cache_cb;
     lv_draw_buf_width_to_stride_cb width_to_stride_cb;
-    lv_draw_buf_clear_cb buf_clear_cb;
-    lv_draw_buf_copy_cb buf_copy_cb;
 } lv_draw_buf_handlers_t;
 
 /**********************

--- a/src/draw/nxp/pxp/lv_draw_buf_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_buf_pxp.c
@@ -35,9 +35,6 @@
 
 static void _invalidate_cache(lv_draw_buf_t * draw_buf, const char * area);
 
-static void _pxp_buf_copy(void * dest_buf, uint32_t dest_stride, const lv_area_t * dest_area,
-                          void * src_buf, uint32_t src_stride, const lv_area_t * src_area, lv_color_format_t cf);
-
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -55,7 +52,6 @@ void lv_draw_buf_pxp_init_handlers(void)
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
 
     handlers->invalidate_cache_cb = _invalidate_cache;
-    handlers->buf_copy_cb = _pxp_buf_copy;
 }
 
 /**********************
@@ -69,6 +65,12 @@ static void _invalidate_cache(lv_draw_buf_t * draw_buf, const char * area)
 
     DEMO_CleanInvalidateCache();
 }
+
+#if 0
+/**
+ * @todo
+ * LVGL needs to use hardware acceleration for buf_copy and do not affect GPU rendering.
+ */
 
 void _pxp_buf_copy(void * dest_buf, uint32_t dest_stride, const lv_area_t * dest_area,
                    void * src_buf, uint32_t src_stride, const lv_area_t * src_area,
@@ -94,5 +96,6 @@ void _pxp_buf_copy(void * dest_buf, uint32_t dest_stride, const lv_area_t * dest
 
     lv_pxp_run();
 }
+#endif
 
 #endif /*LV_USE_DRAW_PXP*/

--- a/src/draw/nxp/vglite/lv_draw_buf_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_buf_vglite.c
@@ -44,11 +44,6 @@ static uint32_t _width_to_stride(uint32_t w, lv_color_format_t cf);
 
 static void * _go_to_xy(lv_draw_buf_t * draw_buf, int32_t x, int32_t y);
 
-static void _vglite_buf_clear(lv_draw_buf_t * draw_buf, const lv_area_t * area);
-
-static void _vglite_buf_copy(void * dest_buf, uint32_t dest_stride, const lv_area_t * dest_area,
-                             void * src_buf, uint32_t src_stride, const lv_area_t * src_area, lv_color_format_t cf);
-
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -69,8 +64,6 @@ void lv_draw_buf_vglite_init_handlers(void)
     handlers->align_pointer_cb = _align_buf;
     handlers->invalidate_cache_cb = _invalidate_cache;
     handlers->width_to_stride_cb = _width_to_stride;
-    handlers->buf_clear_cb = _vglite_buf_clear;
-    handlers->buf_copy_cb = _vglite_buf_copy;
 }
 
 /**********************
@@ -117,6 +110,12 @@ static uint32_t _width_to_stride(uint32_t w, lv_color_format_t cf)
 
     return (width_bytes + align_bytes - 1) & ~(align_bytes - 1);
 }
+
+/**
+ * @todo
+ * LVGL needs to use hardware acceleration for buf_copy and do not affect GPU rendering.
+ */
+#if 0
 
 static void _vglite_buf_clear(lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
@@ -176,5 +175,6 @@ static void _vglite_buf_copy(void * dest_buf, uint32_t dest_stride, const lv_are
     /* Disable scissor. */
     vglite_disable_scissor();
 }
+#endif
 
 #endif /*LV_USE_DRAW_VGLITE*/

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -34,9 +34,6 @@ static void _dave2d_buf_invalidate_cache_cb(void * buf, uint32_t stride, lv_colo
 #endif
 #endif
 
-static  void _dave2d_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area,
-                              void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area, lv_color_format_t color_format);
-
 static int32_t _dave2d_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 
 static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
@@ -122,7 +119,6 @@ static void lv_draw_buf_dave2d_init_handlers(void)
     handlers->invalidate_cache_cb = _dave2d_buf_invalidate_cache_cb;
 #endif
 #endif
-    handlers->buf_copy_cb        = _dave2d_buf_copy;
 }
 
 #if defined(RENESAS_CORTEX_M85)
@@ -148,6 +144,11 @@ static void _dave2d_buf_invalidate_cache_cb(void * buf, uint32_t stride, lv_colo
 #endif
 #endif
 
+/**
+ * @todo
+ * LVGL needs to use hardware acceleration for buf_copy and do not affect GPU rendering.
+ */
+#if 0
 static void _dave2d_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area,
                              void * src_buf,  uint32_t src_w, uint32_t src_h, const lv_area_t * src_area, lv_color_format_t color_format)
 {
@@ -230,6 +231,7 @@ static void _dave2d_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, 
 #endif
 
 }
+#endif
 
 #define USE_D2 (1)
 

--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -31,10 +31,6 @@ static void buf_free(void * buf);
 static void * buf_align(void * buf, lv_color_format_t color_format);
 static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
-static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a);
-static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
-                     void * src_buf, uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
-                     lv_color_format_t color_format);
 
 /**********************
  *  STATIC VARIABLES
@@ -57,8 +53,6 @@ void lv_draw_buf_vg_lite_init_handlers(void)
     handlers->align_pointer_cb = buf_align;
     handlers->invalidate_cache_cb = invalidate_cache;
     handlers->width_to_stride_cb = width_to_stride;
-    handlers->buf_clear_cb = buf_clear;
-    handlers->buf_copy_cb = buf_copy;
 }
 
 /**********************
@@ -90,95 +84,6 @@ static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t colo
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
     return lv_vg_lite_width_to_stride(w, lv_vg_lite_vg_fmt(color_format));
-}
-
-static void buf_clear(void * buf, uint32_t w, uint32_t h, lv_color_format_t color_format, const lv_area_t * a)
-{
-#if 0
-    if(LV_VG_LITE_IS_ALIGNED(buf, LV_VG_LITE_BUF_ALIGN)) {
-        /* finish outstanding buffers */
-        LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
-
-        vg_lite_buffer_t dest_buf;
-        LV_ASSERT(lv_vg_lite_buffer_init(&dest_buf, buf, w, h, lv_vg_lite_vg_fmt(color_format), false));
-        LV_VG_LITE_ASSERT_DEST_BUFFER(&dest_buf);
-
-        vg_lite_rectangle_t rect;
-        lv_vg_lite_rect(&rect, a);
-        LV_VG_LITE_CHECK_ERROR(vg_lite_clear(&dest_buf, &rect, 0));
-        LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
-        return;
-    }
-#endif
-
-    uint8_t px_size = lv_color_format_get_size(color_format);
-    uint32_t stride = lv_draw_buf_width_to_stride(w, color_format);
-    uint8_t * bufc = buf;
-
-    /*Got the first pixel of each buffer*/
-    bufc += stride * a->y1;
-    bufc += a->x1 * px_size;
-
-    uint32_t line_length = lv_area_get_width(a) * px_size;
-    int32_t y;
-    for(y = a->y1; y <= a->y2; y++) {
-        lv_memzero(bufc, line_length);
-        bufc += stride;
-    }
-}
-
-static void buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const lv_area_t * dest_area_to_copy,
-                     void * src_buf, uint32_t src_w, uint32_t src_h, const lv_area_t * src_area_to_copy,
-                     lv_color_format_t color_format)
-{
-#if 0
-    if(LV_VG_LITE_IS_ALIGNED(dest_buf, LV_VG_LITE_BUF_ALIGN)
-       && LV_VG_LITE_IS_ALIGNED(src_buf, LV_VG_LITE_BUF_ALIGN)) {
-        vg_lite_buffer_t dest;
-        LV_ASSERT(lv_vg_lite_buffer_init(&dest, dest_buf, dest_w, dest_h, lv_vg_lite_vg_fmt(color_format), false));
-        LV_VG_LITE_ASSERT_DEST_BUFFER(&dest);
-
-        vg_lite_buffer_t src;
-        LV_ASSERT(lv_vg_lite_buffer_init(&src, src_buf, src_w, src_h, lv_vg_lite_vg_fmt(color_format), false));
-        LV_VG_LITE_ASSERT_SRC_BUFFER(&src);
-
-        vg_lite_rectangle_t src_rect;
-        lv_vg_lite_rect(&src_rect, src_area_to_copy);
-
-        vg_lite_matrix_t matrix;
-        vg_lite_identity(&matrix);
-
-        LV_VG_LITE_CHECK_ERROR(vg_lite_blit_rect(&dest, &src,
-                                                 &src_rect,
-                                                 &matrix,
-                                                 VG_LITE_BLEND_NONE, 0,
-                                                 VG_LITE_FILTER_POINT));
-        LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
-        return;
-    }
-#endif
-
-    uint8_t px_size = lv_color_format_get_size(color_format);
-    uint8_t * dest_bufc = dest_buf;
-    uint8_t * src_bufc = src_buf;
-
-    uint32_t dest_stride = lv_draw_buf_width_to_stride(dest_w, color_format);
-    uint32_t src_stride = lv_draw_buf_width_to_stride(src_w, color_format);
-
-    /*Got the first pixel of each buffer*/
-    dest_bufc += dest_stride * dest_area_to_copy->y1;
-    dest_bufc += dest_area_to_copy->x1 * px_size;
-
-    src_bufc += src_stride * src_area_to_copy->y1;
-    src_bufc += src_area_to_copy->x1 * px_size;
-
-    uint32_t line_length = lv_area_get_width(dest_area_to_copy) * px_size;
-    int32_t y;
-    for(y = dest_area_to_copy->y1; y <= dest_area_to_copy->y2; y++) {
-        lv_memcpy(dest_bufc, src_bufc, line_length);
-        dest_bufc += dest_stride;
-        src_bufc += src_stride;
-    }
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/


### PR DESCRIPTION
### Description of the feature or fix

Potential hardware conflicts can occur when the clear/copy API is invoked concurrently with the renderer. To fully leverage all hardware capabilities, an alternative approach is required.

Fix #5037
### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
