### PR TITLE
feat(style): add API to check specific style property is set

### DIFF
--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -156,14 +156,13 @@ void lv_obj_enable_style_refresh(bool en);
 lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
- * Check if the specified style property is explicitly set for a given object and part.
- * @param obj   Pointer to an object.
- * @param part  A part from which the property should be checked.
- * @param prop  The style property to check.
- * @return      LV_STYLE_RES_NOT_FOUND: the property wasn't found.
- *              LV_STYLE_RES_FOUND: the property was fond.
+ * Check if an object has a specified style property for a given style selector.
+ * @param obj       pointer to an object
+ * @param selector  the style selector to be checked, defining the scope of the style to be examined.
+ * @param prop      the property to be checked.
+ * @return          true if the object has the specified selector and property, false otherwise.
  */
-lv_style_res_t lv_obj_style_prop_set_check(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+bool lv_obj_has_style_prop(const struct _lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop);
 
 /**
  * Set local style property on an object's part and state.

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -156,6 +156,16 @@ void lv_obj_enable_style_refresh(bool en);
 lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
+ * Check if the specified style property is explicitly set for a given object and part.
+ * @param obj   Pointer to an object.
+ * @param part  A part from which the property should be checked.
+ * @param prop  The style property to check.
+ * @return      LV_STYLE_RES_NOT_FOUND: the property wasn't found.
+ *              LV_STYLE_RES_FOUND: the property was fond.
+ */
+lv_style_res_t lv_obj_style_prop_set_check(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+
+/**
  * Set local style property on an object's part and state.
  * @param obj       pointer to an object
  * @param prop      the property

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -117,4 +117,27 @@ void test_style_replacement(void)
     lv_style_reset(&style_blue);
 }
 
+void test_style_has_prop(void)
+{
+    lv_style_t style;
+    lv_style_init(&style);
+    lv_style_set_outline_color(&style, lv_color_white());
+
+    /*Create object with style*/
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+
+    TEST_ASSERT_EQUAL(false, lv_obj_has_style_prop(obj, LV_PART_MAIN, LV_STYLE_OUTLINE_COLOR));
+    TEST_ASSERT_EQUAL(false, lv_obj_has_style_prop(obj, LV_PART_MAIN, LV_STYLE_OUTLINE_WIDTH));
+    TEST_ASSERT_EQUAL(false, lv_obj_has_style_prop(obj, LV_PART_INDICATOR, LV_STYLE_OUTLINE_COLOR));
+
+    lv_obj_add_style(obj, &style, LV_PART_MAIN);
+    lv_obj_set_style_outline_width(obj, 2, LV_PART_MAIN);
+
+    TEST_ASSERT_EQUAL(true, lv_obj_has_style_prop(obj, LV_PART_MAIN, LV_STYLE_OUTLINE_COLOR));
+    TEST_ASSERT_EQUAL(true, lv_obj_has_style_prop(obj, LV_PART_MAIN, LV_STYLE_OUTLINE_WIDTH));
+    TEST_ASSERT_EQUAL(false, lv_obj_has_style_prop(obj, LV_PART_INDICATOR, LV_STYLE_OUTLINE_COLOR));
+
+    lv_style_reset(&style);
+}
+
 #endif


### PR DESCRIPTION
### Description of the feature or fix

Gets whether its style is set instead of its default value

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
