### PR TITLE
refactor(draw): use draw buf for label

### DIFF
--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -73,22 +73,21 @@ typedef struct {
 } lv_draw_label_dsc_t;
 
 typedef enum {
+    LV_DRAW_LETTER_BITMAP_FORMAT_INVALID,
     LV_DRAW_LETTER_BITMAP_FORMAT_A8,
     LV_DRAW_LETTER_BITMAP_FORMAT_IMAGE,
     LV_DRAW_LETTER_VECTOR_FORMAT,
 } lv_draw_glyph_bitmap_format_t;
 
 typedef struct {
-    const uint8_t * bitmap;
-    uint8_t * _bitmap_buf_unaligned;
-    uint8_t * bitmap_buf;
-    uint32_t _bitmap_buf_size;
+    void * glyph_data;  /*Depends on `format` field, it could be image source or draw buf of bitmap or vector data.*/
     lv_draw_glyph_bitmap_format_t format;
     const lv_area_t * letter_coords;
     const lv_area_t * bg_coords;
     const lv_font_glyph_dsc_t * g;
     lv_color_t color;
     lv_opa_t opa;
+    lv_draw_buf_t * _draw_buf; /*a shared draw buf for get_bitmap, do not use it directly, use glyph_data instead*/
 } lv_draw_glyph_dsc_t;
 
 /**

--- a/src/draw/nxp/vglite/lv_draw_vglite_label.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_label.c
@@ -84,7 +84,7 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
                                 lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
     if(glyph_draw_dsc) {
-        if(glyph_draw_dsc->bitmap == NULL) {
+        if(glyph_draw_dsc->format == LV_DRAW_LETTER_BITMAP_FORMAT_INVALID) {
 #if LV_USE_FONT_PLACEHOLDER
             /* Draw a placeholder rectangle*/
             lv_draw_border_dsc_t border_draw_dsc;
@@ -107,11 +107,15 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
                 return;
             lv_area_move(&blend_area, -layer->draw_buf_ofs.x, -layer->draw_buf_ofs.y);
 
-            const uint8_t * mask_buf = glyph_draw_dsc->bitmap;
+            const lv_draw_buf_t * draw_buf = glyph_draw_dsc->glyph_data;
+            const uint8_t * mask_buf = draw_buf->data;
             lv_area_t mask_area;
             lv_area_copy(&mask_area, glyph_draw_dsc->letter_coords);
             lv_area_move(&mask_area, -layer->draw_buf_ofs.x, -layer->draw_buf_ofs.y);
 
+            /**
+             * @todo check if we can use draw_buf->header.stride directly.
+             */
             uint32_t mask_stride = lv_draw_buf_width_to_stride(
                                        lv_area_get_width(glyph_draw_dsc->letter_coords),
                                        LV_COLOR_FORMAT_A8);
@@ -142,7 +146,7 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
             img_dsc.angle = 0;
             img_dsc.zoom = LV_ZOOM_NONE;
             img_dsc.opa = glyph_draw_dsc->opa;
-            img_dsc.src = glyph_draw_dsc->bitmap;
+            img_dsc.src = glyph_draw_dsc->glyph_data;
             lv_draw_vglite_img(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
 #endif
         }

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
@@ -70,7 +70,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
                 (d2_border)clip_area.y2);
 
     if(glyph_draw_dsc) {
-        if(glyph_draw_dsc->bitmap == NULL) {
+        if(glyph_draw_dsc->format == LV_DRAW_LETTER_BITMAP_FORMAT_INVALID) {
 #if LV_USE_FONT_PLACEHOLDER
             /* Draw a placeholder rectangle*/
             lv_draw_border_dsc_t border_draw_dsc;
@@ -89,7 +89,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
             //            lv_memzero(&blend_dsc, sizeof(blend_dsc));
             //            blend_dsc.color = glyph_draw_dsc->color;
             //            blend_dsc.opa = glyph_draw_dsc->opa;
-            //            blend_dsc.mask_buf = glyph_draw_dsc->bitmap;
+            //            blend_dsc.mask_buf = glyph_draw_dsc->glyph_data;
             //            blend_dsc.mask_area = &mask_area;
             //            blend_dsc.blend_area = glyph_draw_dsc->letter_coords;
             //            blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
@@ -97,10 +97,11 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
 
 #if defined(RENESAS_CORTEX_M85)
 #if (BSP_CFG_DCACHE_ENABLED)
-            d1_cacheblockflush(unit->d2_handle, 0, glyph_draw_dsc->bitmap, glyph_draw_dsc->_bitmap_buf_size);
+            lv_draw_buf_t * draw_buf = glyph_draw_dsc->glyph_data;
+            d1_cacheblockflush(unit->d2_handle, 0, draw_buf->data, draw_buf->data_size);
 #endif
 #endif
-            d2_settexture(unit->d2_handle, (void *)glyph_draw_dsc->bitmap,
+            d2_settexture(unit->d2_handle, (void *)draw_buf->data,
                           (d2_s32)lv_draw_buf_width_to_stride((uint32_t)lv_area_get_width(&letter_coords), LV_COLOR_FORMAT_A8),
                           lv_area_get_width(&letter_coords),  lv_area_get_height(&letter_coords), d2_mode_alpha8);
             d2_settexopparam(unit->d2_handle, d2_cc_red, glyph_draw_dsc->color.red, 0);
@@ -132,7 +133,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
             img_dsc.scale_x = LV_SCALE_NONE;
             img_dsc.scale_y = LV_SCALE_NONE;
             img_dsc.opa = glyph_draw_dsc->opa;
-            img_dsc.src = glyph_draw_dsc->bitmap;
+            img_dsc.src = glyph_draw_dsc->glyph_data;
             //lv_draw_sw_image(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
 #endif
         }

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -149,4 +149,3 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
  **********************/
 
 #endif
-

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -66,7 +66,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
                                                  lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
     if(glyph_draw_dsc) {
-        if(glyph_draw_dsc->bitmap == NULL) {
+        if(glyph_draw_dsc->format == LV_DRAW_LETTER_BITMAP_FORMAT_INVALID) {
 #if LV_USE_FONT_PLACEHOLDER
             /* Draw a placeholder rectangle*/
             lv_draw_border_dsc_t border_draw_dsc;
@@ -84,8 +84,10 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
             lv_memzero(&blend_dsc, sizeof(blend_dsc));
             blend_dsc.color = glyph_draw_dsc->color;
             blend_dsc.opa = glyph_draw_dsc->opa;
-            blend_dsc.mask_buf = glyph_draw_dsc->bitmap;
+            lv_draw_buf_t * draw_buf = glyph_draw_dsc->glyph_data;
+            blend_dsc.mask_buf = draw_buf->data;
             blend_dsc.mask_area = &mask_area;
+            blend_dsc.mask_stride = draw_buf->header.stride;
             blend_dsc.blend_area = glyph_draw_dsc->letter_coords;
             blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
 
@@ -99,7 +101,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
             img_dsc.scale_x = LV_SCALE_NONE;
             img_dsc.scale_y = LV_SCALE_NONE;
             img_dsc.opa = glyph_draw_dsc->opa;
-            img_dsc.src = glyph_draw_dsc->bitmap;
+            img_dsc.src = glyph_draw_dsc->glyph_data;
             lv_draw_sw_image(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
 #endif
         }

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -81,7 +81,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
 {
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
     if(glyph_draw_dsc) {
-        if(glyph_draw_dsc->bitmap == NULL) {
+        if(glyph_draw_dsc->format == LV_DRAW_LETTER_BITMAP_FORMAT_INVALID) {
 #if LV_USE_FONT_PLACEHOLDER
             /* Draw a placeholder rectangle*/
             lv_draw_border_dsc_t border_draw_dsc;
@@ -124,13 +124,7 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
     vg_lite_translate(image_area.x1, image_area.y1, &matrix);
 
     vg_lite_buffer_t src_buf;
-    lv_draw_buf_t draw_buf = { 0 };
-    uint32_t w, h;
-    w = lv_area_get_width(&image_area);
-    h = lv_area_get_height(&image_area);
-    uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_A8);
-    lv_image_header_init(&draw_buf.header, w, h, LV_COLOR_FORMAT_A8, stride, 0);
-    draw_buf.data = (void *)dsc->bitmap;
+    lv_draw_buf_t * draw_buf = dsc->glyph_data;
     lv_vg_lite_buffer_from_draw_buf(&src_buf, &draw_buf);
 
     vg_lite_color_t color;

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -42,11 +42,12 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                         uint8_t * buf_out)
+const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
+                                      lv_draw_buf_t * draw_buf)
 {
+    const lv_font_t * font_p = g_dsc->resolved_font;
     LV_ASSERT_NULL(font_p);
-    return font_p->get_glyph_bitmap(font_p, g_dsc, letter, buf_out);
+    return font_p->get_glyph_bitmap(g_dsc, letter, draw_buf);
 }
 
 bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <stdbool.h>
 
 #include "lv_symbol_def.h"
+#include "../draw/lv_draw_buf.h"
 #include "../misc/lv_area.h"
 #include "../misc/lv_types.h"
 #include "../misc/cache/lv_cache.h"
@@ -29,7 +30,7 @@ extern "C" {
 
 /* imgfont identifier */
 #define LV_IMGFONT_BPP 9
-#define LV_VECFONT_BPP 0
+#define LV_VECFONT_BPP 10
 
 /**********************
  *      TYPEDEFS
@@ -87,7 +88,7 @@ struct _lv_font_t {
     bool (*get_glyph_dsc)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
     /** Get a glyph's bitmap from a font*/
-    const uint8_t * (*get_glyph_bitmap)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t, uint8_t *);
+    const void * (*get_glyph_bitmap)(lv_font_glyph_dsc_t *, uint32_t, lv_draw_buf_t *);
 
     /** Release a glyph*/
     void (*release_glyph)(const lv_font_t *, lv_font_glyph_dsc_t *);
@@ -112,13 +113,13 @@ struct _lv_font_t {
 
 /**
  * Return with the bitmap of a font.
- * @param font_p        pointer to a font
- * @param g_dsc         pass the lv_font_glyph_dsc_t here
+ * @param g_dsc         the glyph descriptor including which font to use etc.
  * @param letter        a UNICODE character code
- * @return pointer to the bitmap of the letter
+ * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
+ * @return pointer to the glyph's data. It can be a draw buffer for bitmap fonts or an image source for imgfonts.
  */
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                         uint8_t * buf_out);
+const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
+                                      lv_draw_buf_t * draw_buf);
 
 /**
  * Get the descriptor of a glyph

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -71,10 +71,11 @@ static const uint8_t opa2_table[4] = {0, 85, 170, 255};
  *   GLOBAL FUNCTIONS
  **********************/
 
-const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                           uint8_t * bitmap_out)
+const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                        lv_draw_buf_t * draw_buf)
 {
-    LV_UNUSED(g_dsc);
+    const lv_font_t * font = g_dsc->resolved_font;
+    uint8_t * bitmap_out = draw_buf->data;
 
     if(unicode_letter == '\t') unicode_letter = ' ';
 
@@ -144,7 +145,7 @@ const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph
                 bitmap_out_tmp += stride;
             }
         }
-        return bitmap_out;
+        return draw_buf;
     }
     /*Handle compressed bitmap*/
     else {
@@ -152,7 +153,7 @@ const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph
         bool prefilter = fdsc->bitmap_format == LV_FONT_FMT_TXT_COMPRESSED;
         decompress(&fdsc->glyph_bitmap[gdsc->bitmap_index], bitmap_out, gdsc->box_w, gdsc->box_h,
                    (uint8_t)fdsc->bpp, prefilter);
-        return bitmap_out;
+        return draw_buf;
 #else /*!LV_USE_FONT_COMPRESSED*/
         LV_LOG_WARN("Compressed fonts is used but LV_USE_FONT_COMPRESSED is not enabled in lv_conf.h");
         return NULL;

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -216,13 +216,13 @@ typedef struct {
 
 /**
  * Used as `get_glyph_bitmap` callback in lvgl's native font format if the font is uncompressed.
- * @param font              pointer to font
- * @param unicode_letter    a unicode letter whose bitmap should be get
- * @param bitmap_out        pointer to an array to store the output A8 bitmap
+ * @param g_dsc         the glyph descriptor including which font to use etc.
+ * @param letter        a UNICODE character code
+ * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
  * @return pointer to an A8 bitmap (not necessarily bitmap_out) or NULL if `unicode_letter` not found
  */
-const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                           uint8_t * bitmap_out);
+const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                        lv_draw_buf_t * draw_buf);
 
 /**
  * Used as `get_glyph_dsc` callback in lvgl's native font format if the font is uncompressed.

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -29,9 +29,9 @@ typedef struct _lv_freetype_image_cache_data_t {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                                    uint32_t unicode_letter,
-                                                    uint8_t * bitmap_out);
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                                 uint32_t unicode_letter,
+                                                 lv_draw_buf_t * draw_buf);
 
 static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void * user_data);
 static void freetype_image_free_cb(lv_freetype_image_cache_data_t * node, void * user_data);
@@ -76,13 +76,13 @@ void lv_freetype_set_cbs_image_font(lv_freetype_font_dsc_t * dsc)
  *   STATIC FUNCTIONS
  **********************/
 
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                                    uint32_t unicode_letter,
-                                                    uint8_t * bitmap_out)
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                                 uint32_t unicode_letter,
+                                                 lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(unicode_letter);
-    LV_UNUSED(bitmap_out);
-
+    LV_UNUSED(draw_buf);
+    const lv_font_t * font = g_dsc->resolved_font;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
@@ -102,7 +102,7 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_f
     g_dsc->entry = entry;
     lv_freetype_image_cache_data_t * cache_node = lv_cache_entry_get_data(entry);
 
-    return cache_node->draw_buf->data;
+    return cache_node->draw_buf;
 }
 
 static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -31,9 +31,9 @@ typedef struct _lv_freetype_outline_node_t {
 static lv_freetype_outline_t outline_create(lv_freetype_context_t * ctx, FT_Face face, FT_UInt glyph_index,
                                             uint32_t size, uint32_t strength);
 static lv_result_t outline_delete(lv_freetype_context_t * ctx, lv_freetype_outline_t outline);
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                                    uint32_t unicode_letter,
-                                                    uint8_t * bitmap_out);
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                                 uint32_t unicode_letter,
+                                                 lv_draw_buf_t * draw_buf);
 static void freetype_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 
 static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, uint32_t unicode_letter);
@@ -152,11 +152,12 @@ static lv_cache_compare_res_t freetype_glyph_outline_cmp_cb(const lv_freetype_ou
     return node_a->glyph_index > node_b->glyph_index ? 1 : -1;
 }
 
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                                    uint32_t unicode_letter,
-                                                    uint8_t * bitmap_out)
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                                 uint32_t unicode_letter,
+                                                 lv_draw_buf_t * draw_buf)
 {
-    LV_UNUSED(bitmap_out);
+    LV_UNUSED(draw_buf);
+    const lv_font_t * font = g_dsc->resolved_font;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
     lv_cache_entry_t * entry = lv_freetype_outline_lookup(dsc, unicode_letter);

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -65,16 +65,15 @@ typedef struct _tiny_ttf_cache_data_t {
     lv_font_t * font;
     uint32_t unicode;
     uint32_t size;
-
-    uint8_t * buffer;
+    lv_draw_buf_t * draw_buf;
 } tiny_ttf_cache_data_t;
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                  uint32_t unicode_letter_next);
-static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                               uint32_t unicode_letter, uint8_t * bitmap_buf);
+static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                            uint32_t unicode_letter, lv_draw_buf_t * draw_buf);
 static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 static lv_result_t lv_tiny_ttf_create(lv_font_t * out_font, const char * path, const void * data, size_t data_size,
                                       int32_t font_size,
@@ -244,12 +243,11 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     return true; /*true: glyph found; false: glyph was not found*/
 }
 
-static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
-                                               uint32_t unicode_letter, uint8_t * bitmap_buf)
+static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
+                                            uint32_t unicode_letter, lv_draw_buf_t * draw_buf)
 {
-    LV_UNUSED(g_dsc);
-    LV_UNUSED(bitmap_buf);
-
+    LV_UNUSED(draw_buf);
+    const lv_font_t * font = g_dsc->resolved_font;
     tiny_ttf_cache_data_t search_key = {
         .font = (lv_font_t *)font,
         .unicode = unicode_letter,
@@ -265,7 +263,7 @@ static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_g
 
     g_dsc->entry = entry;
     tiny_ttf_cache_data_t * cached_data = lv_cache_entry_get_data(entry);
-    return cached_data->buffer;
+    return cached_data->draw_buf;
 }
 
 static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)
@@ -351,27 +349,29 @@ static bool tiny_ttf_cache_create_cb(tiny_ttf_cache_data_t * node, void * user_d
     int w, h;
     w = x2 - x1 + 1;
     h = y2 - y1 + 1;
-    uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_A8);
-    size_t szb = h * stride;
-
-    uint8_t * buffer = lv_draw_buf_malloc(szb, LV_COLOR_FORMAT_A8);
-    if(NULL == buffer) {
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(w, h, LV_COLOR_FORMAT_A8, 0);
+    if(NULL == draw_buf) {
         LV_LOG_ERROR("tiny_ttf: out of memory\n");
         return false;
     }
 
-    memset(buffer, 0, szb);
-    stbtt_MakeGlyphBitmap(info, buffer, w, h, stride, dsc->scale, dsc->scale, g1);
+    lv_image_header_t * header = &draw_buf->header;
+    uint32_t stride = header->stride;
 
-    node->buffer = buffer;
+    /**
+     * @todo use `lv_draw_buf_clear` instead.
+     */
+    memset(draw_buf->data, 0, h * stride);
+    stbtt_MakeGlyphBitmap(info, draw_buf->data, w, h, stride, dsc->scale, dsc->scale, g1);
 
+    node->draw_buf = draw_buf;
     return true;
 }
 static void tiny_ttf_cache_free_cb(tiny_ttf_cache_data_t * node, void * user_data)
 {
     LV_UNUSED(user_data);
 
-    lv_draw_buf_free(node->buffer);
+    lv_draw_buf_destroy(node->draw_buf);
 }
 static lv_cache_compare_res_t tiny_ttf_cache_compare_cb(const tiny_ttf_cache_data_t * lhs,
                                                         const tiny_ttf_cache_data_t * rhs)

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -26,8 +26,8 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
-                                                uint8_t * bitmap_buf);
+static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
+                                             lv_draw_buf_t * draw_buf);
 static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
                                   uint32_t unicode, uint32_t unicode_next);
 
@@ -84,12 +84,11 @@ void lv_imgfont_destroy(lv_font_t * font)
  *   STATIC FUNCTIONS
  **********************/
 
-static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
-                                                uint8_t * bitmap_buf)
+static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
+                                             lv_draw_buf_t * draw_buf)
 {
-    LV_UNUSED(bitmap_buf);
-    LV_ASSERT_NULL(font);
-    LV_UNUSED(g_dsc);
+    LV_UNUSED(draw_buf);
+    const lv_font_t * font = g_dsc->resolved_font;
 
     imgfont_dsc_t * dsc = (imgfont_dsc_t *)font->dsc;
     int32_t offset_y = 0;

--- a/tests/src/test_cases/libs/test_freetype.c
+++ b/tests/src/test_cases/libs/test_freetype.c
@@ -483,7 +483,7 @@ void test_freetype_outline_rendering_test(void)
     lv_font_get_glyph_dsc(font_italic, &g, 0x9F98, '\0');
 
     const lv_ll_t * outline_data;
-    outline_data = (lv_ll_t *)lv_font_get_glyph_bitmap(font_italic, &g, 0x9F98, NULL);
+    outline_data = (lv_ll_t *)lv_font_get_glyph_bitmap(&g, 0x9F98, NULL);
 
     uint32_t i = 0;
     lv_freetype_outline_event_param_t * param;


### PR DESCRIPTION
### Description of the feature or fix

Add API to reshape existing draw buf. This is normally used when a shared draw buf is used for multiple times. The data_size field will be checked to make sure new shape will fit in.

Use draw buf for label
This is part of removing dependency for API lv_draw_buf_malloc as mentioned in #4868

Please do not squash the two commits.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
