### PR TITLE
feat(indev) Add crown support to pointer input device

### DIFF
--- a/demos/render/lv_demo_render.c
+++ b/demos/render/lv_demo_render.c
@@ -214,6 +214,7 @@ static lv_obj_t * box_shadow_obj_create(lv_obj_t * parent, int32_t col, int32_t 
     lv_obj_t * obj = lv_obj_create(parent);
     lv_obj_remove_style_all(obj);
     lv_obj_set_style_bg_opa(obj, LV_OPA_20, 0);
+    lv_obj_set_style_bg_color(obj, lv_color_black(), 0);
     lv_obj_set_style_shadow_color(obj, lv_color_hex3(0xf00), 0);
     lv_obj_set_style_opa(obj, opa_saved, 0);
     lv_obj_set_size(obj, DEF_WIDTH - 20, DEF_HEIGHT - 5);
@@ -452,6 +453,7 @@ static lv_obj_t * arc_obj_create(lv_obj_t * parent, int32_t col, int32_t row, in
     lv_obj_t * obj = lv_arc_create(parent);
     lv_obj_remove_style_all(obj);
     lv_obj_set_style_arc_width(obj, w, 0);
+    lv_obj_set_style_arc_color(obj, lv_color_white(), 0);
     lv_obj_set_style_opa(obj, opa_saved, 0);
     lv_arc_set_bg_angles(obj, start, end);
     lv_obj_set_size(obj, DEF_HEIGHT, DEF_HEIGHT);

--- a/docs/overview/style-props.md
+++ b/docs/overview/style-props.md
@@ -1,0 +1,1033 @@
+# Style properties
+
+## Size and position
+Properties related to size, position, alignment and layout of the objects.
+
+### width
+Sets the width of object. Pixel, percentage and `LV_SIZE_CONTENT` values can be used. Percentage values are relative to the width of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> Widget dependent</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### min_width
+Sets a minimal width. Pixel and percentage values can be used. Percentage values are relative to the width of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### max_width
+Sets a maximal width. Pixel and percentage values can be used. Percentage values are relative to the width of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> LV_COORD_MAX</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### height
+Sets the height of object. Pixel, percentage and `LV_SIZE_CONTENT` can be used. Percentage values are relative to the height of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> Widget dependent</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### min_height
+Sets a minimal height. Pixel and percentage values can be used. Percentage values are relative to the width of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### max_height
+Sets a maximal height. Pixel and percentage values can be used. Percentage values are relative to the height of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> LV_COORD_MAX</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### length
+Its meaning depends on the type of the widget. For example in case of lv_scale it means the length of the ticks.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### x
+Set the X coordinate of the object considering the set `align`. Pixel and percentage values can be used. Percentage values are relative to the width of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### y
+Set the Y coordinate of the object considering the set `align`. Pixel and percentage values can be used. Percentage values are relative to the height of the parent's content area.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### align
+Set the alignment which tells from which point of the parent the X and Y coordinates should be interpreted. The possible values are: `LV_ALIGN_DEFAULT`, `LV_ALIGN_TOP_LEFT/MID/RIGHT`, `LV_ALIGN_BOTTOM_LEFT/MID/RIGHT`, `LV_ALIGN_LEFT/RIGHT_MID`, `LV_ALIGN_CENTER`. `LV_ALIGN_DEFAULT` means `LV_ALIGN_TOP_LEFT` with LTR base direction and `LV_ALIGN_TOP_RIGHT` with RTL base direction.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_ALIGN_DEFAULT`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### transform_width
+Make the object wider on both sides with this value. Pixel and percentage (with `lv_pct(x)`) values can be used. Percentage values are relative to the object's width.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### transform_height
+Make the object higher on both sides with this value. Pixel and percentage (with `lv_pct(x)`) values can be used. Percentage values are relative to the object's height.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### translate_x
+Move the object with this value in X direction. Applied after layouts, aligns and other positioning. Pixel and percentage (with `lv_pct(x)`) values can be used. Percentage values are relative to the object's width.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### translate_y
+Move the object with this value in Y direction. Applied after layouts, aligns and other positioning. Pixel and percentage (with `lv_pct(x)`) values can be used. Percentage values are relative to the object's height.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### transform_scale_x
+Zoom an objects horizontally. The value 256 (or `LV_SCALE_NONE`) means normal size, 128 half size, 512 double size, and so on
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### transform_scale_y
+Zoom an objects vertically. The value 256 (or `LV_SCALE_NONE`) means normal size, 128 half size, 512 double size, and so on
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### transform_rotation
+Rotate an objects. The value is interpreted in 0.1 degree units. E.g. 450 means 45 deg.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### transform_pivot_x
+Set the pivot point's X coordinate for transformations. Relative to the object's top left corner'
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### transform_pivot_y
+Set the pivot point's Y coordinate for transformations. Relative to the object's top left corner'
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### transform_skew_x
+Skew an object horizontally. The value is interpreted in 0.1 degree units. E.g. 450 means 45 deg.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### transform_skew_y
+Skew an object vertically. The value is interpreted in 0.1 degree units. E.g. 450 means 45 deg.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+## Padding
+Properties to describe spacing between the parent's sides and the children and among the children. Very similar to the padding properties in HTML.
+
+### pad_top
+Sets the padding on the top. It makes the content area smaller in this direction.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### pad_bottom
+Sets the padding on the bottom. It makes the content area smaller in this direction.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### pad_left
+Sets the padding on the left. It makes the content area smaller in this direction.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### pad_right
+Sets the padding on the right. It makes the content area smaller in this direction.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### pad_row
+Sets the padding between the rows. Used by the layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### pad_column
+Sets the padding between the columns. Used by the layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Margin
+Properties to describe spacing around an object. Very similar to the margin properties in HTML.
+
+### margin_top
+Sets the margin on the top. The object will keep this space from its siblings in layouts. 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### margin_bottom
+Sets the margin on the bottom. The object will keep this space from its siblings in layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### margin_left
+Sets the margin on the left. The object will keep this space from its siblings in layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### margin_right
+Sets the margin on the right. The object will keep this space from its siblings in layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Background
+Properties to describe the background color and image of the objects.
+
+### bg_color
+Set the background color of the object.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0xffffff`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_opa
+Set the opacity of the background. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_TRANSP`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_grad_color
+Set the gradient color of the background. Used only if `grad_dir` is not `LV_GRAD_DIR_NONE`
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_grad_dir
+Set the direction of the gradient of the background. The possible values are `LV_GRAD_DIR_NONE/HOR/VER`.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRAD_DIR_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_main_stop
+Set the point from which the background color should start for gradients. 0 means to top/left side, 255 the bottom/right side, 128 the center, and so on
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_grad_stop
+Set the point from which the background's gradient color should start. 0 means to top/left side, 255 the bottom/right side, 128 the center, and so on
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 255</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_main_opa
+Set the opacity of the first gradient color
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 255</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_grad_opa
+Set the opacity of the second gradient color
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 255</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_grad
+Set the gradient definition. The pointed instance must exist while the object is alive. NULL to disable. It wraps `BG_GRAD_COLOR`, `BG_GRAD_DIR`, `BG_MAIN_STOP` and `BG_GRAD_STOP` into one descriptor and allows creating gradients with more colors too. If it's set other gradient related properties will be ignored'
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_image_src
+Set a background image. Can be a pointer to `lv_image_dsc_t`, a path to a file or an `LV_SYMBOL_...`
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### bg_image_opa
+Set the opacity of the background image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_image_recolor
+Set a color to mix to the background image.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_image_recolor_opa
+Set the intensity of background image recoloring. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means no mixing, 255, `LV_OPA_100` or `LV_OPA_COVER` means full recoloring, other values or LV_OPA_10, LV_OPA_20, etc are interpreted proportionally.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_TRANSP`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bg_image_tiled
+If enabled the background image will be tiled. The possible values are `true` or `false`.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Border
+Properties to describe the borders
+
+### border_color
+Set the color of the border
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### border_opa
+Set the opacity of the border. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### border_width
+Set the width of the border. Only pixel values can be used.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### border_side
+Set only which side(s) the border should be drawn. The possible values are `LV_BORDER_SIDE_NONE/TOP/BOTTOM/LEFT/RIGHT/INTERNAL`. OR-ed values can be used as well, e.g. `LV_BORDER_SIDE_TOP | LV_BORDER_SIDE_LEFT`.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BORDER_SIDE_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### border_post
+Sets whether the border should be drawn before or after the children are drawn. `true`: after children, `false`: before children
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Outline
+Properties to describe the outline. It's like a border but drawn outside of the rectangles.
+
+### outline_width
+Set the width of the outline in pixels. 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### outline_color
+Set the color of the outline.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### outline_opa
+Set the opacity of the outline. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### outline_pad
+Set the padding of the outline, i.e. the gap between object and the outline.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+## Shadow
+Properties to describe the shadow drawn under the rectangles.
+
+### shadow_width
+Set the width of the shadow in pixels. The value should be >= 0.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### shadow_offset_x
+Set an offset on the shadow in pixels in X direction. 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### shadow_offset_y
+Set an offset on the shadow in pixels in Y direction. 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### shadow_spread
+Make the shadow calculation to use a larger or smaller rectangle as base. The value can be in pixel to make the area larger/smaller
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### shadow_color
+Set the color of the shadow
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### shadow_opa
+Set the opacity of the shadow. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+## Image
+Properties to describe the images
+
+### image_opa
+Set the opacity of an image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### image_recolor
+Set color to mixt to the image.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### image_recolor_opa
+Set the intensity of the color mixing. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Line
+Properties to describe line-like objects
+
+### line_width
+Set the width of the lines in pixel.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### line_dash_width
+Set the width of dashes in pixel. Note that dash works only on horizontal and vertical lines
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### line_dash_gap
+Set the gap between dashes in pixel. Note that dash works only on horizontal and vertical lines
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### line_rounded
+Make the end points of the lines rounded. `true`: rounded, `false`: perpendicular line ending 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### line_color
+Set the color of the lines.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### line_opa
+Set the opacity of the lines.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Arc
+TODO
+
+### arc_width
+Set the width (thickness) of the arcs in pixel.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> Yes</li>
+</ul>
+
+### arc_rounded
+Make the end points of the arcs rounded. `true`: rounded, `false`: perpendicular line ending 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### arc_color
+Set the color of the arc.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### arc_opa
+Set the opacity of the arcs.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### arc_image_src
+Set an image from which the arc will be masked out. It's useful to display complex effects on the arcs. Can be a pointer to `lv_image_dsc_t` or a path to a file
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Text
+Properties to describe the properties of text. All these properties are inherited.
+
+### text_color
+Sets the color of the text.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_opa
+Set the opacity of the text. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_font
+Set the font of the text (a pointer `lv_font_t *`). 
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FONT_DEFAULT`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_letter_space
+Set the letter space in pixels
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_line_space
+Set the line space in pixels.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_decor
+Set decoration for the text. The possible values are `LV_TEXT_DECOR_NONE/UNDERLINE/STRIKETHROUGH`. OR-ed values can be used as well.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_TEXT_DECOR_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### text_align
+Set how to align the lines of the text. Note that it doesn't align the object itself, only the lines inside the object. The possible values are `LV_TEXT_ALIGN_LEFT/CENTER/RIGHT/AUTO`. `LV_TEXT_ALIGN_AUTO` detect the text base direction and uses left or right alignment accordingly
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_TEXT_ALIGN_AUTO`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Miscellaneous
+Mixed properties for various purposes.
+
+### radius
+Set the radius on every corner. The value is interpreted in pixel (>= 0) or `LV_RADIUS_CIRCLE` for max. radius
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### clip_corner
+Enable to clip the overflowed content on the rounded corner. Can be `true` or `false`.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### opa
+Scale down all opacity values of the object by this factor. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### opa_layered
+First draw the object on the layer, then scale down layer opacity factor. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 255, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### color_filter_dsc
+Mix a color to all colors of the object.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### color_filter_opa
+The intensity of mixing of color filter.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_TRANSP`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### anim
+The animation template for the object's animation. Should be a pointer to `lv_anim_t`. The animation parameters are widget specific, e.g. animation time could be the E.g. blink time of the cursor on the text area or scroll time of a roller. See the widgets' documentation to learn more.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### anim_duration
+The animation duration in milliseconds. Its meaning is widget specific. E.g. blink time of the cursor on the text area or scroll time of a roller. See the widgets' documentation to learn more.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### transition
+An initialized `lv_style_transition_dsc_t` to describe a transition.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### blend_mode
+Describes how to blend the colors to the background. The possible values are `LV_BLEND_MODE_NORMAL/ADDITIVE/SUBTRACTIVE/MULTIPLY`
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BLEND_MODE_NORMAL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### layout
+Set the layout if the object. The children will be repositioned and resized according to the policies set for the layout. For the possible values see the documentation of the layouts.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### base_dir
+Set the base direction of the object. The possible values are `LV_BIDI_DIR_LTR/RTL/AUTO`.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BASE_DIR_AUTO`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### bitmap_mask_src
+If set a layer will be created for the widget and the layer will be masked with this A8 bitmap mask.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### rotary_sensitivity
+Adjust the sensitivity for rotary encoders in 1/256 unit. It means, 128: slow down the rotary to half, 512: speeds up to double, 256: no change
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `256`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Flex
+Flex layout properties.
+
+### flex_flow
+Defines in which direct the flex layout should arrange the children
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FLEX_FLOW_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### flex_main_place
+Defines how to align the children in the direction of flex flow
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FLEX_ALIGN_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### flex_cross_place
+Defines how to align the children perpendicular to the direction of flex flow
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FLEX_ALIGN_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### flex_track_place
+Defines how to align the tracks of the flow
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FLEX_ALIGN_NONE`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### flex_grow
+Defines how mayn space to take proprtionally the free space of the object's trach
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_FLEX_ALIGN_ROW`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+## Grid
+Grid layout properties.
+
+### grid_column_dsc_array
+An array to describe the columns of the grid. Should be LV_GRID_TEMPLATE_LAST terminated
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_column_align
+Defines how to distribute the columns
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_row_dsc_array
+An array to describe the rows of the grid. Should be LV_GRID_TEMPLATE_LAST terminated
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `NULL`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_row_align
+Defines how to distribute the rows.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_column_pos
+Set the column in which the object should be placed
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_x_align
+Set how to align the object horizontally.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_column_span
+Set how many columns the object should span. Needs to be >= 1
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_row_pos
+Set the row in which the object should be placed
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_y_align
+Set how to align the object vertically.
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>
+
+### grid_cell_row_span
+Set how many rows the object should span. Needs to be >= 1
+<ul>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_GRID_ALIGN_START`</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+</ul>

--- a/docs/overview/style-props.rst
+++ b/docs/overview/style-props.rst
@@ -1378,6 +1378,20 @@ If set a layer will be created for the widget and the layer will be masked with 
   <li style='display:inline-block; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
   </ul>
 
+rotary_sensitivity
+~~~~~~~~~~~~~~~~~~
+
+Adjust the sensitivity for rotary encoders in 1/256 unit. It means, 128: slow down the rotary to half, 512: speeds up to double, 256: no change
+
+.. raw:: html
+
+  <ul>
+  <li style='display:inline-block; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `256`</li>
+  <li style='display:inline-block; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
+  <li style='display:inline-block; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> No</li>
+  <li style='display:inline-block; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
+  </ul>
+
 Flex
 ----
 

--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -51,7 +51,40 @@ category.
      }
    }
 
+
+Mouse cursor
+~~~~~~~~~~~~
+
 To set a mouse cursor use :cpp:expr:`lv_indev_set_cursor(indev, &img_cursor)`.
+
+Crown behavior
+~~~~~~~~~~~~~~
+
+The "Crown" is a rotary device typically found on smart watches.
+
+When the user clicks somewhere and after that turns the rotary
+the last clicked widget will be either scrolled or it's value will be incremented/decremented
+(e.g. in case of a slider).
+
+As this behavior is tightly related to the last clicked widget, the crown support is
+an extension of the pointer input device.  Just set ``data->diff`` to the number of
+turned steps and LVGL will automatically send :cpp:enum:`LV_EVENT_ROTARY` or scroll the widget based on the
+``editable`` flag in the widget's class. Non-editable widgets are scrolled and for editable widgets the event is sent.
+
+To get the steps in an event callback use :cpp:func:`int32_t diff = lv_event_get_rotary_diff(e)`
+
+The rotary sensitivity can be adjusted on 2 levels:
+
+1. In the input device by the `indev->rotary_sensitvity` element (1/256 unit)
+2. By the `rotary_sensitivity` style property in the widget (1/256 unit)
+
+The final diff is calculated like this:
+
+``diff_final = diff_in * (indev_sensitivity / 256) +  (widget_sensitivity / 256); ``
+
+For example, if both the indev and widget sensitivity is set to 128 (0.5), the input diff. will be
+multiplied by 0.25 (divided by 4). The value of the widget will be incremented by this value or
+the widget will be scrolled this amount of pixels.
 
 Keypad or keyboard
 ------------------

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -853,12 +853,12 @@
 /*Use SDL to open window on PC and handle mouse and keyboard*/
 #define LV_USE_SDL              0
 #if LV_USE_SDL
-    #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
-    #define LV_SDL_RENDER_MODE     LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
-    #define LV_SDL_BUF_COUNT       1    /*1 or 2*/
-    #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
-    #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
-    #define LV_SDL_MOUSEWHEEL_MODE 0    /*0: Encoder, 1: Watch crown*/
+    #define LV_SDL_INCLUDE_PATH     <SDL2/SDL.h>
+    #define LV_SDL_RENDER_MODE      LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
+    #define LV_SDL_BUF_COUNT        1    /*1 or 2*/
+    #define LV_SDL_FULLSCREEN       0    /*1: Make the window full screen by default*/
+    #define LV_SDL_DIRECT_EXIT      1    /*1: Exit the application when all SDL windows are closed*/
+    #define LV_SDL_MOUSEWHEEL_MODE  LV_SDL_MOUSEWHEEL_MODE_ENCODER  /*LV_SDL_MOUSEWHEEL_MODE_ENCODER/CROWN*/
 #endif
 
 /*Use X11 to open window on Linux desktop and handle mouse and keyboard*/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -858,6 +858,7 @@
     #define LV_SDL_BUF_COUNT       1    /*1 or 2*/
     #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
     #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
+    #define LV_SDL_MOUSEWHEEL_MODE 0    /*0: Encoder, 1: Watch crown*/
 #endif
 
 /*Use X11 to open window on Linux desktop and handle mouse and keyboard*/

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -394,7 +394,7 @@ props = [
  'dsc': "If set a layer will be created for the widget and the layer will be masked with this A8 bitmap mask."},
 
 {'name': 'ROTARY_SENSITIVITY',
- 'style_type': 'num',   'var_type': 'uint32_t', 'default':'`256`', 'inherited': 0, 'layout': 0, 'ext_draw': 0,
+ 'style_type': 'num',   'var_type': 'uint32_t', 'default':'`256`', 'inherited': 1, 'layout': 0, 'ext_draw': 0,
  'dsc': "Adjust the sensitivity for rotary encoders in 1/256 unit. It means, 128: slow down the rotary to half, 512: speeds up to double, 256: no change"},
 
 {'section': 'Flex', 'dsc':'Flex layout properties.',  'guard':'LV_USE_FLEX'},

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -393,6 +393,10 @@ props = [
  'style_type': 'ptr',   'var_type': 'const lv_image_dsc_t *', 'default':'`NULL`', 'inherited': 0, 'layout': 0, 'ext_draw': 0,
  'dsc': "If set a layer will be created for the widget and the layer will be masked with this A8 bitmap mask."},
 
+{'name': 'ROTARY_SENSITIVITY',
+ 'style_type': 'num',   'var_type': 'uint32_t', 'default':'`256`', 'inherited': 0, 'layout': 0, 'ext_draw': 0,
+ 'dsc': "Adjust the sensitivity for rotary encoders in 1/256 unit. It means, 128: slow down the rotary to half, 512: speeds up to double, 256: no change"},
+
 {'section': 'Flex', 'dsc':'Flex layout properties.',  'guard':'LV_USE_FLEX'},
 
 

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -242,6 +242,19 @@ uint32_t lv_event_get_key(lv_event_t * e)
     }
 }
 
+int32_t lv_event_get_rotary_diff(lv_event_t * e)
+{
+    if(e->code == LV_EVENT_ROTARY) {
+        int32_t * r = lv_event_get_param(e);
+        if(r) return *r;
+        else return 0;
+    }
+    else {
+        LV_LOG_WARN("Not interpreted with this event code");
+        return 0;
+    }
+}
+
 lv_anim_t * lv_event_get_scroll_anim(lv_event_t * e)
 {
     if(e->code == LV_EVENT_SCROLL_BEGIN) {

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -152,6 +152,13 @@ const lv_area_t * lv_event_get_old_size(lv_event_t * e);
 uint32_t lv_event_get_key(lv_event_t * e);
 
 /**
+ * Get the signed rotary encoder diff. passed as parameter to an event. Can be used in `LV_EVENT_ROTARY`
+ * @param e     pointer to an event
+ * @return      the triggering key or NULL if called on an unrelated event
+ */
+int32_t lv_event_get_rotary_diff(lv_event_t * e);
+
+/**
  * Get the animation descriptor of a scrolling. Can be used in `LV_EVENT_SCROLL_BEGIN`
  * @param e     pointer to an event
  * @return      the animation that will scroll the object. (can be modified as required)

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -320,70 +320,6 @@ void lv_obj_enable_style_refresh(bool en)
     style_refr = en;
 }
 
-static inline lv_style_value_t lv_style_prop_get_default_inlined(lv_style_prop_t prop)
-{
-    const lv_color_t black = LV_COLOR_MAKE(0x00, 0x00, 0x00);
-    const lv_color_t white = LV_COLOR_MAKE(0xff, 0xff, 0xff);
-    switch(prop) {
-        case LV_STYLE_TRANSFORM_SCALE_X:
-        case LV_STYLE_TRANSFORM_SCALE_Y:
-            return (lv_style_value_t) {
-                .num = LV_SCALE_NONE
-            };
-        case LV_STYLE_BG_COLOR:
-            return (lv_style_value_t) {
-                .color = black
-            };
-        case LV_STYLE_BG_GRAD_COLOR:
-        case LV_STYLE_BORDER_COLOR:
-        case LV_STYLE_SHADOW_COLOR:
-        case LV_STYLE_OUTLINE_COLOR:
-        case LV_STYLE_ARC_COLOR:
-        case LV_STYLE_LINE_COLOR:
-        case LV_STYLE_TEXT_COLOR:
-        case LV_STYLE_IMAGE_RECOLOR:
-            return (lv_style_value_t) {
-                .color = white
-            };
-        case LV_STYLE_OPA:
-        case LV_STYLE_OPA_LAYERED:
-        case LV_STYLE_BORDER_OPA:
-        case LV_STYLE_TEXT_OPA:
-        case LV_STYLE_IMAGE_OPA:
-        case LV_STYLE_BG_GRAD_OPA:
-        case LV_STYLE_BG_MAIN_OPA:
-        case LV_STYLE_BG_IMAGE_OPA:
-        case LV_STYLE_OUTLINE_OPA:
-        case LV_STYLE_SHADOW_OPA:
-        case LV_STYLE_LINE_OPA:
-        case LV_STYLE_ARC_OPA:
-            return (lv_style_value_t) {
-                .num = LV_OPA_COVER
-            };
-        case LV_STYLE_BG_GRAD_STOP:
-            return (lv_style_value_t) {
-                .num = 255
-            };
-        case LV_STYLE_BORDER_SIDE:
-            return (lv_style_value_t) {
-                .num = LV_BORDER_SIDE_FULL
-            };
-        case LV_STYLE_TEXT_FONT:
-            return (lv_style_value_t) {
-                .ptr = LV_FONT_DEFAULT
-            };
-        case LV_STYLE_MAX_WIDTH:
-        case LV_STYLE_MAX_HEIGHT:
-            return (lv_style_value_t) {
-                .num = LV_COORD_MAX
-            };
-        default:
-            return (lv_style_value_t) {
-                .ptr = 0
-            };
-    }
-}
-
 lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
 {
     LV_ASSERT_NULL(obj)
@@ -395,7 +331,7 @@ lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_
     found = get_selector_style_prop(obj, selector, prop, &value_act);
     if(found == LV_STYLE_RES_FOUND) return value_act;
 
-    return lv_style_prop_get_default_inlined(prop);
+    return lv_style_prop_get_default(prop);
 }
 
 bool lv_obj_has_style_prop(const lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop)

--- a/src/core/lv_obj_style_gen.c
+++ b/src/core/lv_obj_style_gen.c
@@ -762,6 +762,14 @@ void lv_obj_set_style_bitmap_mask_src(lv_obj_t * obj, const lv_image_dsc_t * val
     };
     lv_obj_set_local_style_prop(obj, LV_STYLE_BITMAP_MASK_SRC, v, selector);
 }
+
+void lv_obj_set_style_rotary_sensitivity(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_obj_set_local_style_prop(obj, LV_STYLE_ROTARY_SENSITIVITY, v, selector);
+}
 #if LV_USE_FLEX
 
 void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector)

--- a/src/core/lv_obj_style_gen.h
+++ b/src/core/lv_obj_style_gen.h
@@ -644,6 +644,12 @@ static inline const lv_image_dsc_t * lv_obj_get_style_bitmap_mask_src(const lv_o
     return (const lv_image_dsc_t *)v.ptr;
 }
 
+static inline uint32_t lv_obj_get_style_rotary_sensitivity(const lv_obj_t * obj, uint32_t part)
+{
+    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ROTARY_SENSITIVITY);
+    return (uint32_t)v.num;
+}
+
 #if LV_USE_FLEX
 static inline lv_flex_flow_t lv_obj_get_style_flex_flow(const lv_obj_t * obj, uint32_t part)
 {
@@ -835,6 +841,7 @@ void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style
 void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
 void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);
 void lv_obj_set_style_bitmap_mask_src(lv_obj_t * obj, const lv_image_dsc_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_rotary_sensitivity(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
 #if LV_USE_FLEX
     void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector);
     void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);

--- a/src/drivers/sdl/lv_sdl_mouse.c
+++ b/src/drivers/sdl/lv_sdl_mouse.c
@@ -35,6 +35,9 @@ typedef struct {
     int16_t last_x;
     int16_t last_y;
     bool left_button_down;
+#if LV_SDL_MOUSEWHEEL_MODE == 1
+    int32_t diff;
+#endif
 } lv_sdl_mouse_t;
 
 /**********************
@@ -76,6 +79,10 @@ static void sdl_mouse_read(lv_indev_t * indev, lv_indev_data_t * data)
     data->point.x = dsc->last_x;
     data->point.y = dsc->last_y;
     data->state = dsc->left_button_down ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+#if LV_SDL_MOUSEWHEEL_MODE == 1
+    data->enc_diff = dsc->diff;
+    dsc->diff = 0;
+#endif
 }
 
 static void release_indev_cb(lv_event_t * e)
@@ -101,7 +108,11 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
         case SDL_MOUSEMOTION:
             win_id = event->motion.windowID;
             break;
-
+#if LV_SDL_MOUSEWHEEL_MODE == 1
+        case SDL_MOUSEWHEEL:
+            win_id = event->wheel.windowID;
+            break;
+#endif
         case SDL_FINGERUP:
         case SDL_FINGERDOWN:
         case SDL_FINGERMOTION:
@@ -174,8 +185,19 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
             indev_dev->last_x = (int16_t)((float)hor_res * event->tfinger.x / zoom);
             indev_dev->last_y = (int16_t)((float)ver_res * event->tfinger.y / zoom);
             break;
+        case SDL_MOUSEWHEEL:
+#if LV_SDL_MOUSEWHEEL_MODE == 1
+#ifdef __EMSCRIPTEN__
+            /*Escripten scales it wrong*/
+            if(event->wheel.y < 0) dsc->diff++;
+            if(event->wheel.y > 0) dsc->diff--;
+#else
+            indev_dev->diff = -event->wheel.y;
+#endif  /*LV_SDL_MOUSEWHEEL_MODE*/
+#endif /*LV_SDL_MOUSEWHEEL_MODE == 1*/
+            break;
     }
-    lv_indev_read(indev);
+    //    lv_indev_read(indev);
 }
 
 #endif /*LV_USE_SDL*/

--- a/src/drivers/sdl/lv_sdl_mouse.c
+++ b/src/drivers/sdl/lv_sdl_mouse.c
@@ -197,7 +197,7 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
 #endif /*LV_SDL_MOUSEWHEEL_MODE == 1*/
             break;
     }
-    //    lv_indev_read(indev);
+    lv_indev_read(indev);
 }
 
 #endif /*LV_USE_SDL*/

--- a/src/drivers/sdl/lv_sdl_mouse.c
+++ b/src/drivers/sdl/lv_sdl_mouse.c
@@ -35,7 +35,7 @@ typedef struct {
     int16_t last_x;
     int16_t last_y;
     bool left_button_down;
-#if LV_SDL_MOUSEWHEEL_MODE == 1
+#if LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_CROWN
     int32_t diff;
 #endif
 } lv_sdl_mouse_t;
@@ -79,7 +79,7 @@ static void sdl_mouse_read(lv_indev_t * indev, lv_indev_data_t * data)
     data->point.x = dsc->last_x;
     data->point.y = dsc->last_y;
     data->state = dsc->left_button_down ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
-#if LV_SDL_MOUSEWHEEL_MODE == 1
+#if LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_CROWN
     data->enc_diff = dsc->diff;
     dsc->diff = 0;
 #endif
@@ -108,7 +108,7 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
         case SDL_MOUSEMOTION:
             win_id = event->motion.windowID;
             break;
-#if LV_SDL_MOUSEWHEEL_MODE == 1
+#if LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_CROWN
         case SDL_MOUSEWHEEL:
             win_id = event->wheel.windowID;
             break;
@@ -186,7 +186,7 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
             indev_dev->last_y = (int16_t)((float)ver_res * event->tfinger.y / zoom);
             break;
         case SDL_MOUSEWHEEL:
-#if LV_SDL_MOUSEWHEEL_MODE == 1
+#if LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_CROWN
 #ifdef __EMSCRIPTEN__
             /*Escripten scales it wrong*/
             if(event->wheel.y < 0) dsc->diff++;
@@ -194,7 +194,7 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
 #else
             indev_dev->diff = -event->wheel.y;
 #endif  /*__EMSCRIPTEN__*/
-#endif /*LV_SDL_MOUSEWHEEL_MODE == 1*/
+#endif /*LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_CROWN*/
             break;
     }
     lv_indev_read(indev);

--- a/src/drivers/sdl/lv_sdl_mouse.c
+++ b/src/drivers/sdl/lv_sdl_mouse.c
@@ -193,7 +193,7 @@ void _lv_sdl_mouse_handler(SDL_Event * event)
             if(event->wheel.y > 0) dsc->diff--;
 #else
             indev_dev->diff = -event->wheel.y;
-#endif  /*LV_SDL_MOUSEWHEEL_MODE*/
+#endif  /*__EMSCRIPTEN__*/
 #endif /*LV_SDL_MOUSEWHEEL_MODE == 1*/
             break;
     }

--- a/src/drivers/sdl/lv_sdl_mousewheel.c
+++ b/src/drivers/sdl/lv_sdl_mousewheel.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_sdl_mousewheel.h"
-#if LV_USE_SDL
+#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == 0
 
 #include "../../core/lv_group.h"
 #include "../../indev/lv_indev_private.h"

--- a/src/drivers/sdl/lv_sdl_mousewheel.c
+++ b/src/drivers/sdl/lv_sdl_mousewheel.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_sdl_mousewheel.h"
-#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == 0
+#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_ENCODER
 
 #include "../../core/lv_group.h"
 #include "../../indev/lv_indev_private.h"

--- a/src/drivers/sdl/lv_sdl_mousewheel.h
+++ b/src/drivers/sdl/lv_sdl_mousewheel.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "lv_sdl_window.h"
-#if LV_USE_SDL
+#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == 0
 
 /*********************
  *      DEFINES

--- a/src/drivers/sdl/lv_sdl_mousewheel.h
+++ b/src/drivers/sdl/lv_sdl_mousewheel.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "lv_sdl_window.h"
-#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == 0
+#if LV_USE_SDL && LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_ENCODER
 
 /*********************
  *      DEFINES

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -253,7 +253,9 @@ static void sdl_event_handler(lv_timer_t * t)
     SDL_Event event;
     while(SDL_PollEvent(&event)) {
         _lv_sdl_mouse_handler(&event);
+#if LV_SDL_MOUSEWHEEL_MODE == 0
         _lv_sdl_mousewheel_handler(&event);
+#endif
         _lv_sdl_keyboard_handler(&event);
 
         if(event.type == SDL_WINDOWEVENT) {

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -253,7 +253,7 @@ static void sdl_event_handler(lv_timer_t * t)
     SDL_Event event;
     while(SDL_PollEvent(&event)) {
         _lv_sdl_mouse_handler(&event);
-#if LV_SDL_MOUSEWHEEL_MODE == 0
+#if LV_SDL_MOUSEWHEEL_MODE == LV_SDL_MOUSEWHEEL_MODE_ENCODER
         _lv_sdl_mousewheel_handler(&event);
 #endif
         _lv_sdl_keyboard_handler(&event);

--- a/src/drivers/sdl/lv_sdl_window.h
+++ b/src/drivers/sdl/lv_sdl_window.h
@@ -23,6 +23,10 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/* Possible values of LV_SDL_MOUSEWHEEL_MODE */
+#define LV_SDL_MOUSEWHEEL_MODE_ENCODER  0  /* The mousewheel emulates an encoder input device*/
+#define LV_SDL_MOUSEWHEEL_MODE_CROWN    1  /* The mousewheel emulates a smart watch crown*/
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -49,7 +49,6 @@
 /**< Rotary diff count will be multiples by this value when scrolling to get scroll throw size*/
 #define LV_INDEV_DEF_ROTARY_SCROLL_SENSITVITY      LV_DPI_DEF / 4
 
-
 #if LV_INDEV_DEF_SCROLL_THROW <= 0
     #warning "LV_INDEV_DEF_SCROLL_THROW must be greater than 0"
 #endif
@@ -681,7 +680,6 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     else {
         indev_proc_release(i);
     }
-
 
     i->pointer.last_point.x = i->pointer.act_point.x;
     i->pointer.last_point.y = i->pointer.act_point.y;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1335,22 +1335,22 @@ static void indev_proc_pointer_diff(lv_indev_t * indev)
     if(editable) {
         uint32_t indev_sensitivity = indev->rotary_sensitvity;
         uint32_t obj_sensitivity = lv_obj_get_style_rotary_sensitivity(indev_obj_act, 0);
-        int32_t diff = (uint32_t)((uint32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
+        int32_t diff = (int32_t)((int32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
         send_event(LV_EVENT_ROTARY, &diff);
     }
     else {
 
         int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
         indev->pointer.vect.y = vect;
-
+        indev->pointer.act_obj = obj;
         lv_obj_t * scroll_obj = lv_indev_find_scroll_obj(indev);
+        if(scroll_obj == NULL) return;
         uint32_t indev_sensitivity = indev->rotary_sensitvity;
         uint32_t obj_sensitivity = lv_obj_get_style_rotary_sensitivity(scroll_obj, 0);
-        int32_t diff = (uint32_t)((uint32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
+        int32_t diff = (int32_t)((int32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
 
         indev->pointer.scroll_throw_vect.y = diff;
         indev->pointer.scroll_throw_vect_ori.y = diff;
-        indev->pointer.act_obj = obj;
         _lv_indev_scroll_handler(indev);
     }
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -64,6 +64,7 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data);
 static void indev_proc_press(lv_indev_t * indev);
 static void indev_proc_release(lv_indev_t * indev);
+static void indev_proc_pointer_diff(lv_indev_t * indev);
 static lv_obj_t * pointer_search_obj(lv_display_t * disp, lv_point_t * p);
 static void indev_proc_reset_query_handler(lv_indev_t * indev);
 static void indev_click_focus(lv_indev_t * indev);
@@ -75,6 +76,7 @@ static lv_result_t send_event(lv_event_code_t code, void * param);
 
 static void indev_scroll_throw_anim_start(lv_indev_t * indev);
 static void indev_scroll_throw_anim_cb(void * var, int32_t v);
+<<<<<<< HEAD
 static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim);
 static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
 {
@@ -84,6 +86,8 @@ static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
         indev->scroll_throw_anim = NULL;
     }
 }
+=======
+>>>>>>> 80ddb6b88 (add crown support)
 
 /**********************
  *  STATIC VARIABLES
@@ -660,6 +664,7 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 
     i->pointer.act_point.x = data->point.x;
     i->pointer.act_point.y = data->point.y;
+    i->pointer.diff = data->enc_diff;
 
     if(i->state == LV_INDEV_STATE_PRESSED) {
         indev_proc_press(i);
@@ -668,8 +673,11 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
         indev_proc_release(i);
     }
 
+    indev_proc_pointer_diff(i);
+
     i->pointer.last_point.x = i->pointer.act_point.x;
     i->pointer.last_point.y = i->pointer.act_point.y;
+
 }
 
 /**
@@ -1117,8 +1125,9 @@ static void indev_proc_press(lv_indev_t * indev)
     if(new_obj_searched && indev->pointer.last_obj) {
 
         /*Attempt to stop scroll throw animation firstly*/
-        if(!indev->scroll_throw_anim || !lv_anim_delete(indev, indev_scroll_throw_anim_cb)) {
-            indev_scroll_throw_anim_reset(indev);
+        if(indev->scroll_throw_anim) {
+            lv_anim_delete(indev, indev_scroll_throw_anim_cb);
+            indev->scroll_throw_anim = NULL;
         }
 
         _lv_indev_scroll_throw_handler(indev);
@@ -1300,7 +1309,6 @@ static void indev_proc_release(lv_indev_t * indev)
                 lv_point_transform(&indev->pointer.scroll_throw_vect_ori, angle, scale_x, scale_y, &pivot, false);
             }
         }
-
     }
 
     if(scroll_obj) {
@@ -1310,6 +1318,37 @@ static void indev_proc_release(lv_indev_t * indev)
 
         if(indev_reset_check(indev)) return;
     }
+}
+
+static void indev_proc_pointer_diff(lv_indev_t * indev)
+{
+    lv_obj_t * obj = indev->pointer.last_pressed;
+    if(obj == NULL) return;
+    if(indev->pointer.diff == 0) return;
+
+    indev_obj_act = obj;
+
+    bool interactive = lv_obj_is_group_def(obj);
+
+    if(interactive) {
+        uint32_t k = indev->pointer.diff < 0 ? LV_KEY_LEFT : LV_KEY_RIGHT;
+        uint32_t cnt = LV_ABS(indev->pointer.diff);
+        while(cnt) {
+            send_event(LV_EVENT_KEY, &k);
+            cnt--;
+        }
+    }
+    else {
+        int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
+        int32_t throw = indev->pointer.diff > 0 ? LV_VER_RES / 8 : -LV_VER_RES / 8;
+        indev->pointer.vect.y = vect;
+        indev->pointer.scroll_throw_vect.y = throw;
+        indev->pointer.scroll_throw_vect_ori.y = throw;
+        indev->pointer.act_obj = obj;
+        _lv_indev_scroll_handler(indev);
+        _lv_indev_scroll_throw_handler(indev);
+    }
+
 }
 
 static lv_obj_t * pointer_search_obj(lv_display_t * disp, lv_point_t * p)
@@ -1563,10 +1602,15 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
         if(indev->scroll_throw_anim) {
             LV_LOG_INFO("stop animation");
             lv_anim_delete(indev, indev_scroll_throw_anim_cb);
+<<<<<<< HEAD
+=======
+            indev->scroll_throw_anim = NULL;
+>>>>>>> 80ddb6b88 (add crown support)
         }
     }
 }
 
+<<<<<<< HEAD
 static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim)
 {
     if(anim) {
@@ -1574,6 +1618,8 @@ static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim)
     }
 }
 
+=======
+>>>>>>> 80ddb6b88 (add crown support)
 static void indev_scroll_throw_anim_start(lv_indev_t * indev)
 {
     LV_ASSERT_NULL(indev);
@@ -1584,8 +1630,11 @@ static void indev_scroll_throw_anim_start(lv_indev_t * indev)
     lv_anim_set_duration(&a, 1024);
     lv_anim_set_values(&a, 0, 1024);
     lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
+<<<<<<< HEAD
     lv_anim_set_completed_cb(&a, indev_scroll_throw_anim_completed_cb);
     lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_completed_cb);
+=======
+>>>>>>> 80ddb6b88 (add crown support)
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     indev->scroll_throw_anim = lv_anim_start(&a);

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -76,7 +76,6 @@ static lv_result_t send_event(lv_event_code_t code, void * param);
 
 static void indev_scroll_throw_anim_start(lv_indev_t * indev);
 static void indev_scroll_throw_anim_cb(void * var, int32_t v);
-<<<<<<< HEAD
 static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim);
 static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
 {
@@ -86,8 +85,6 @@ static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
         indev->scroll_throw_anim = NULL;
     }
 }
-=======
->>>>>>> 80ddb6b88 (add crown support)
 
 /**********************
  *  STATIC VARIABLES
@@ -1602,15 +1599,10 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
         if(indev->scroll_throw_anim) {
             LV_LOG_INFO("stop animation");
             lv_anim_delete(indev, indev_scroll_throw_anim_cb);
-<<<<<<< HEAD
-=======
-            indev->scroll_throw_anim = NULL;
->>>>>>> 80ddb6b88 (add crown support)
         }
     }
 }
 
-<<<<<<< HEAD
 static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim)
 {
     if(anim) {
@@ -1618,8 +1610,6 @@ static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim)
     }
 }
 
-=======
->>>>>>> 80ddb6b88 (add crown support)
 static void indev_scroll_throw_anim_start(lv_indev_t * indev)
 {
     LV_ASSERT_NULL(indev);
@@ -1630,11 +1620,8 @@ static void indev_scroll_throw_anim_start(lv_indev_t * indev)
     lv_anim_set_duration(&a, 1024);
     lv_anim_set_values(&a, 0, 1024);
     lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
-<<<<<<< HEAD
     lv_anim_set_completed_cb(&a, indev_scroll_throw_anim_completed_cb);
     lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_completed_cb);
-=======
->>>>>>> 80ddb6b88 (add crown support)
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     indev->scroll_throw_anim = lv_anim_start(&a);

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1339,16 +1339,16 @@ static void indev_proc_pointer_diff(lv_indev_t * indev)
     bool editable = lv_obj_is_editable(obj);
 
     if(editable) {
-    	int32_t sensitivity = indev->rotary_adjust_divider;
+        int32_t sensitivity = indev->rotary_adjust_divider;
         int32_t diff = indev->pointer.diff / sensitivity;
-		send_event(LV_EVENT_ROTARY, &diff);
+        send_event(LV_EVENT_ROTARY, &diff);
     }
     else {
 
-    	int32_t sensitivity = indev->rotary_scroll_sensitvity;
-    	int32_t throw = indev->pointer.diff * sensitivity;
+        int32_t sensitivity = indev->rotary_scroll_sensitvity;
+        int32_t throw = indev->pointer.diff * sensitivity;
 
-    	int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
+        int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
         indev->pointer.vect.y = vect;
         indev->pointer.scroll_throw_vect.y = throw;
         indev->pointer.scroll_throw_vect_ori.y = throw;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -43,6 +43,13 @@
 /*Gesture min velocity at release before swipe (pixels)*/
 #define LV_INDEV_DEF_GESTURE_MIN_VELOCITY 3
 
+/**< Rotary diff count will be divided by this value when widgets are adjusted*/
+#define LV_INDEV_DEF_ROTARY_ADJUST_DIVIDER         1
+
+/**< Rotary diff count will be multiples by this value when scrolling to get scroll throw size*/
+#define LV_INDEV_DEF_ROTARY_SCROLL_SENSITVITY      LV_DPI_DEF
+
+
 #if LV_INDEV_DEF_SCROLL_THROW <= 0
     #warning "LV_INDEV_DEF_SCROLL_THROW must be greater than 0"
 #endif
@@ -1328,19 +1335,19 @@ static void indev_proc_pointer_diff(lv_indev_t * indev)
     bool interactive = lv_obj_is_group_def(obj);
 
     if(interactive) {
-        uint32_t k = indev->pointer.diff < 0 ? LV_KEY_LEFT : LV_KEY_RIGHT;
-        uint32_t cnt = LV_ABS(indev->pointer.diff);
-        while(cnt) {
-            send_event(LV_EVENT_KEY, &k);
-            cnt--;
-        }
+    	int32_t sensitivity = indev->rotary_adjust_divider;
+        int32_t diff = indev->pointer.diff / sensitivity;
+		send_event(LV_EVENT_ROTARY, &diff);
     }
     else {
-        int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
-        int32_t throw = indev->pointer.diff > 0 ? LV_VER_RES / 8 : -LV_VER_RES / 8;
+
+    	int32_t sensitivity = indev->rotary_scroll_sensitvity;
+    	int32_t diff = indev->pointer.diff * sensitivity;
+
+    	int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
         indev->pointer.vect.y = vect;
-        indev->pointer.scroll_throw_vect.y = throw;
-        indev->pointer.scroll_throw_vect_ori.y = throw;
+        indev->pointer.scroll_throw_vect.y = sensitivity;
+        indev->pointer.scroll_throw_vect_ori.y = sensitivity;
         indev->pointer.act_obj = obj;
         _lv_indev_scroll_handler(indev);
         _lv_indev_scroll_throw_handler(indev);

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -43,7 +43,7 @@
 /*Gesture min velocity at release before swipe (pixels)*/
 #define LV_INDEV_DEF_GESTURE_MIN_VELOCITY 3
 
-/**< Rotary diff count will be multipled by this and divided by 256 */
+/**< Rotary diff count will be multiplied by this and divided by 256 */
 #define LV_INDEV_DEF_ROTARY_SENSITIVITY         256
 
 #if LV_INDEV_DEF_SCROLL_THROW <= 0
@@ -1587,7 +1587,8 @@ static lv_result_t send_event(lv_event_code_t code, void * param)
        code == LV_EVENT_CLICKED ||
        code == LV_EVENT_RELEASED ||
        code == LV_EVENT_LONG_PRESSED ||
-       code == LV_EVENT_LONG_PRESSED_REPEAT) {
+       code == LV_EVENT_LONG_PRESSED_REPEAT ||
+       code == LV_EVENT_ROTARY) {
         lv_indev_send_event(indev_act, code, indev_obj_act);
         if(indev_reset_check(indev_act)) return LV_RESULT_INVALID;
     }

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -115,8 +115,8 @@ struct _lv_indev_t {
 /**
  * Find a scrollable object based on the current scroll vector in the indev.
  * In handles scroll propagation to the parent if needed, and scroll directions too.
- * @param indev		pointer to an indev
- * @return			the found scrollable object or NULL if not found.
+ * @param indev     pointer to an indev
+ * @return          the found scrollable object or NULL if not found.
  */
 lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev);
 

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -69,6 +69,12 @@ struct _lv_indev_t {
     /**< Repeated trigger period in long press [ms]*/
     uint16_t long_press_repeat_time;
 
+    /**< Rotary diff count will be divided by this value when widgets are adjusted*/
+    int32_t rotary_adjust_divider;
+
+    /**< Rotary diff count will be multiples by this value when scrolling to get scroll throw size*/
+    int32_t rotary_scroll_sensitvity;
+
     struct {
         /*Pointer and button data*/
         lv_point_t act_point; /**< Current point of input device.*/

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -84,6 +84,7 @@ struct _lv_indev_t {
         lv_obj_t * last_pressed; /*The lastly pressed object*/
         lv_area_t scroll_area;
         lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
+        int32_t diff;
 
         /*Flags*/
         lv_dir_t scroll_dir : 4;
@@ -100,10 +101,10 @@ struct _lv_indev_t {
     lv_group_t * group;   /**< Keypad destination group*/
     const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed
                                       here by the buttons*/
-
     lv_event_list_t event_list;
     lv_anim_t * scroll_throw_anim;
 };
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -69,11 +69,8 @@ struct _lv_indev_t {
     /**< Repeated trigger period in long press [ms]*/
     uint16_t long_press_repeat_time;
 
-    /**< Rotary diff count will be divided by this value when widgets are adjusted*/
-    int32_t rotary_adjust_divider;
-
-    /**< Rotary diff count will be multiples by this value when scrolling to get scroll throw size*/
-    int32_t rotary_scroll_sensitvity;
+    /**< Rotary diff count will be multiplied by this value and divided by 256*/
+    int32_t rotary_sensitvity;
 
     struct {
         /*Pointer and button data*/
@@ -114,6 +111,14 @@ struct _lv_indev_t {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+/**
+ * Find a scrollable object based on the current scroll vector in the indev.
+ * In handles scroll propagation to the parent if needed, and scroll directions too.
+ * @param indev		pointer to an indev
+ * @return			the found scrollable object or NULL if not found.
+ */
+lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev);
 
 /**********************
  *      MACROS

--- a/src/indev/lv_indev_scroll.c
+++ b/src/indev/lv_indev_scroll.c
@@ -22,7 +22,6 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_obj_t * find_scroll_obj(lv_indev_t * indev);
 static void init_scroll_limits(lv_indev_t * indev);
 static int32_t find_snap_point_x(const lv_obj_t * obj, int32_t min, int32_t max, int32_t ofs);
 static int32_t find_snap_point_y(const lv_obj_t * obj, int32_t min, int32_t max, int32_t ofs);
@@ -51,7 +50,7 @@ void _lv_indev_scroll_handler(lv_indev_t * indev)
     lv_obj_t * scroll_obj = indev->pointer.scroll_obj;
     /*If there is no scroll object yet try to find one*/
     if(scroll_obj == NULL) {
-        scroll_obj = find_scroll_obj(indev);
+        scroll_obj = lv_indev_find_scroll_obj(indev);
         if(scroll_obj == NULL) return;
 
         init_scroll_limits(indev);
@@ -254,11 +253,7 @@ void lv_indev_scroll_get_snap_dist(lv_obj_t * obj, lv_point_t * p)
     p->y = find_snap_point_y(obj, obj->coords.y1, obj->coords.y2, 0);
 }
 
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static lv_obj_t * find_scroll_obj(lv_indev_t * indev)
+lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
 {
     lv_obj_t * obj_candidate = NULL;
     lv_dir_t dir_candidate = LV_DIR_NONE;
@@ -388,6 +383,10 @@ static lv_obj_t * find_scroll_obj(lv_indev_t * indev)
 
     return obj_candidate;
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
 
 static void init_scroll_limits(lv_indev_t * indev)
 {

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2774,6 +2774,13 @@
             #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
         #endif
     #endif
+    #ifndef LV_SDL_MOUSEWHEEL_MODE
+        #ifdef CONFIG_LV_SDL_MOUSEWHEEL_MODE
+            #define LV_SDL_MOUSEWHEEL_MODE CONFIG_LV_SDL_MOUSEWHEEL_MODE
+        #else
+            #define LV_SDL_MOUSEWHEEL_MODE 0    /*0: Encoder, 1: Watch crown*/
+        #endif
+    #endif
 #endif
 
 /*Use X11 to open window on Linux desktop and handle mouse and keyboard*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2735,14 +2735,14 @@
         #ifdef CONFIG_LV_SDL_INCLUDE_PATH
             #define LV_SDL_INCLUDE_PATH CONFIG_LV_SDL_INCLUDE_PATH
         #else
-            #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
+            #define LV_SDL_INCLUDE_PATH     <SDL2/SDL.h>
         #endif
     #endif
     #ifndef LV_SDL_RENDER_MODE
         #ifdef CONFIG_LV_SDL_RENDER_MODE
             #define LV_SDL_RENDER_MODE CONFIG_LV_SDL_RENDER_MODE
         #else
-            #define LV_SDL_RENDER_MODE     LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
+            #define LV_SDL_RENDER_MODE      LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
         #endif
     #endif
     #ifndef LV_SDL_BUF_COUNT
@@ -2753,14 +2753,14 @@
                 #define LV_SDL_BUF_COUNT 0
             #endif
         #else
-            #define LV_SDL_BUF_COUNT       1    /*1 or 2*/
+            #define LV_SDL_BUF_COUNT        1    /*1 or 2*/
         #endif
     #endif
     #ifndef LV_SDL_FULLSCREEN
         #ifdef CONFIG_LV_SDL_FULLSCREEN
             #define LV_SDL_FULLSCREEN CONFIG_LV_SDL_FULLSCREEN
         #else
-            #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
+            #define LV_SDL_FULLSCREEN       0    /*1: Make the window full screen by default*/
         #endif
     #endif
     #ifndef LV_SDL_DIRECT_EXIT
@@ -2771,14 +2771,14 @@
                 #define LV_SDL_DIRECT_EXIT 0
             #endif
         #else
-            #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
+            #define LV_SDL_DIRECT_EXIT      1    /*1: Exit the application when all SDL windows are closed*/
         #endif
     #endif
     #ifndef LV_SDL_MOUSEWHEEL_MODE
         #ifdef CONFIG_LV_SDL_MOUSEWHEEL_MODE
             #define LV_SDL_MOUSEWHEEL_MODE CONFIG_LV_SDL_MOUSEWHEEL_MODE
         #else
-            #define LV_SDL_MOUSEWHEEL_MODE 0    /*0: Encoder, 1: Watch crown*/
+            #define LV_SDL_MOUSEWHEEL_MODE  LV_SDL_MOUSEWHEEL_MODE_ENCODER  /*LV_SDL_MOUSEWHEEL_MODE_ENCODER/CROWN*/
         #endif
     #endif
 #endif

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -57,6 +57,7 @@ typedef enum {
     LV_EVENT_SCROLL,              /**< Scrolling*/
     LV_EVENT_GESTURE,             /**< A gesture is detected. Get the gesture with `lv_indev_get_gesture_dir(lv_indev_active());` */
     LV_EVENT_KEY,                 /**< A key is sent to the object. Get the key with `lv_indev_get_key(lv_indev_active());`*/
+    LV_EVENT_ROTARY,              /**< An encoder or wheel was rotated. Get the rotation count with `lv_indev_get_diff(lv_indev_active());`*/
     LV_EVENT_FOCUSED,             /**< The object is focused*/
     LV_EVENT_DEFOCUSED,           /**< The object is defocused*/
     LV_EVENT_LEAVE,               /**< The object is defocused but still selected*/

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -57,7 +57,7 @@ typedef enum {
     LV_EVENT_SCROLL,              /**< Scrolling*/
     LV_EVENT_GESTURE,             /**< A gesture is detected. Get the gesture with `lv_indev_get_gesture_dir(lv_indev_active());` */
     LV_EVENT_KEY,                 /**< A key is sent to the object. Get the key with `lv_indev_get_key(lv_indev_active());`*/
-    LV_EVENT_ROTARY,              /**< An encoder or wheel was rotated. Get the rotation count with `lv_indev_get_diff(lv_indev_active());`*/
+    LV_EVENT_ROTARY,              /**< An encoder or wheel was rotated. Get the rotation count with `lv_event_get_rotary_diff(e);`*/
     LV_EVENT_FOCUSED,             /**< The object is focused*/
     LV_EVENT_DEFOCUSED,           /**< The object is defocused*/
     LV_EVENT_LEAVE,               /**< The object is defocused but still selected*/

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -406,9 +406,10 @@ lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
             return (lv_style_value_t) {
                 .num = LV_COORD_MAX
             };
+        case LV_STYLE_ROTARY_SENSITIVITY:
         default:
             return (lv_style_value_t) {
-                .ptr = 0
+                .num = 256
             };
     }
 }

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -411,9 +411,9 @@ lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
                 .num = 256
             };
         default:
-        	return (lv_style_value_t) {
-        		.ptr = NULL
-        	};
+            return (lv_style_value_t) {
+                .ptr = NULL
+            };
     }
 }
 

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -407,10 +407,13 @@ lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
                 .num = LV_COORD_MAX
             };
         case LV_STYLE_ROTARY_SENSITIVITY:
-        default:
             return (lv_style_value_t) {
                 .num = 256
             };
+        default:
+        	return (lv_style_value_t) {
+        		.ptr = NULL
+        	};
     }
 }
 

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -298,8 +298,8 @@ enum _lv_style_prop_t {
     LV_STYLE_TRANSFORM_PIVOT_Y      = 112,
     LV_STYLE_TRANSFORM_SKEW_X       = 113,
     LV_STYLE_TRANSFORM_SKEW_Y       = 114,
-
     LV_STYLE_BITMAP_MASK_SRC        = 115,
+    LV_STYLE_ROTARY_SENSITIVITY     = 116,
 
 #if LV_USE_FLEX
     LV_STYLE_FLEX_FLOW              = 125,

--- a/src/misc/lv_style_gen.c
+++ b/src/misc/lv_style_gen.c
@@ -6,9 +6,7 @@
  **********************************************************************
  */
 
-
 #include "lv_style.h"
-
 
 void lv_style_set_width(lv_style_t * style, int32_t value)
 {
@@ -961,7 +959,6 @@ void lv_style_set_rotary_sensitivity(lv_style_t * style, uint32_t value)
 const lv_style_prop_t _lv_style_const_prop_id_ROTARY_SENSITIVITY = LV_STYLE_ROTARY_SENSITIVITY;
 #if LV_USE_FLEX
 
-
 void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value)
 {
     lv_style_value_t v = {
@@ -1014,7 +1011,6 @@ const lv_style_prop_t _lv_style_const_prop_id_FLEX_GROW = LV_STYLE_FLEX_GROW;
 #endif /*LV_USE_FLEX*/
 
 #if LV_USE_GRID
-
 
 void lv_style_set_grid_column_dsc_array(lv_style_t * style, const int32_t * value)
 {
@@ -1116,4 +1112,3 @@ void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value)
 
 const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN = LV_STYLE_GRID_CELL_ROW_SPAN;
 #endif /*LV_USE_GRID*/
-

--- a/src/misc/lv_style_gen.c
+++ b/src/misc/lv_style_gen.c
@@ -6,7 +6,9 @@
  **********************************************************************
  */
 
+
 #include "lv_style.h"
+
 
 void lv_style_set_width(lv_style_t * style, int32_t value)
 {
@@ -1112,3 +1114,4 @@ void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value)
 
 const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN = LV_STYLE_GRID_CELL_ROW_SPAN;
 #endif /*LV_USE_GRID*/
+

--- a/src/misc/lv_style_gen.c
+++ b/src/misc/lv_style_gen.c
@@ -949,7 +949,18 @@ void lv_style_set_bitmap_mask_src(lv_style_t * style, const lv_image_dsc_t * val
 }
 
 const lv_style_prop_t _lv_style_const_prop_id_BITMAP_MASK_SRC = LV_STYLE_BITMAP_MASK_SRC;
+
+void lv_style_set_rotary_sensitivity(lv_style_t * style, uint32_t value)
+{
+    lv_style_value_t v = {
+        .num = (int32_t)value
+    };
+    lv_style_set_prop(style, LV_STYLE_ROTARY_SENSITIVITY, v);
+}
+
+const lv_style_prop_t _lv_style_const_prop_id_ROTARY_SENSITIVITY = LV_STYLE_ROTARY_SENSITIVITY;
 #if LV_USE_FLEX
+
 
 void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value)
 {
@@ -1003,6 +1014,7 @@ const lv_style_prop_t _lv_style_const_prop_id_FLEX_GROW = LV_STYLE_FLEX_GROW;
 #endif /*LV_USE_FLEX*/
 
 #if LV_USE_GRID
+
 
 void lv_style_set_grid_column_dsc_array(lv_style_t * style, const int32_t * value)
 {

--- a/src/misc/lv_style_gen.h
+++ b/src/misc/lv_style_gen.h
@@ -198,7 +198,10 @@ void lv_style_set_base_dir(lv_style_t * style, lv_base_dir_t value);
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BASE_DIR;
 void lv_style_set_bitmap_mask_src(lv_style_t * style, const lv_image_dsc_t * value);
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BITMAP_MASK_SRC;
+void lv_style_set_rotary_sensitivity(lv_style_t * style, uint32_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_ROTARY_SENSITIVITY;
 #if LV_USE_FLEX
+<<<<<<< HEAD
     void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value);
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_FLOW;
     void lv_style_set_flex_main_place(lv_style_t * style, lv_flex_align_t value);
@@ -232,6 +235,43 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BI
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_Y_ALIGN;
     void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value);
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN;
+=======
+
+void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_FLOW;
+void lv_style_set_flex_main_place(lv_style_t * style, lv_flex_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_MAIN_PLACE;
+void lv_style_set_flex_cross_place(lv_style_t * style, lv_flex_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_CROSS_PLACE;
+void lv_style_set_flex_track_place(lv_style_t * style, lv_flex_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_TRACK_PLACE;
+void lv_style_set_flex_grow(lv_style_t * style, uint8_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_GROW;
+#endif /*LV_USE_FLEX*/
+
+#if LV_USE_GRID
+
+void lv_style_set_grid_column_dsc_array(lv_style_t * style, const int32_t * value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_COLUMN_DSC_ARRAY;
+void lv_style_set_grid_column_align(lv_style_t * style, lv_grid_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_COLUMN_ALIGN;
+void lv_style_set_grid_row_dsc_array(lv_style_t * style, const int32_t * value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_ROW_DSC_ARRAY;
+void lv_style_set_grid_row_align(lv_style_t * style, lv_grid_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_ROW_ALIGN;
+void lv_style_set_grid_cell_column_pos(lv_style_t * style, int32_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_COLUMN_POS;
+void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_grid_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_X_ALIGN;
+void lv_style_set_grid_cell_column_span(lv_style_t * style, int32_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_COLUMN_SPAN;
+void lv_style_set_grid_cell_row_pos(lv_style_t * style, int32_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_POS;
+void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_grid_align_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_Y_ALIGN;
+void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value);
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN;
+>>>>>>> 6e905817b (add LV_STYLE_ROTARY_SENSITIVITY)
 #endif /*LV_USE_GRID*/
 
 
@@ -704,7 +744,13 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BI
     { \
         .prop_ptr = &_lv_style_const_prop_id_BITMAP_MASK_SRC, .value = { .ptr = val } \
     }
+
+#define LV_STYLE_CONST_ROTARY_SENSITIVITY(val) \
+    { \
+        .prop_ptr = &_lv_style_const_prop_id_ROTARY_SENSITIVITY, .value = { .num = (int32_t)val } \
+    }
 #if LV_USE_FLEX
+
 
 #define LV_STYLE_CONST_FLEX_FLOW(val) \
     { \
@@ -733,6 +779,7 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BI
 #endif /*LV_USE_FLEX*/
 
 #if LV_USE_GRID
+
 
 #define LV_STYLE_CONST_GRID_COLUMN_DSC_ARRAY(val) \
     { \

--- a/src/misc/lv_style_gen.h
+++ b/src/misc/lv_style_gen.h
@@ -201,7 +201,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_BI
 void lv_style_set_rotary_sensitivity(lv_style_t * style, uint32_t value);
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_ROTARY_SENSITIVITY;
 #if LV_USE_FLEX
-<<<<<<< HEAD
     void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value);
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_FLOW;
     void lv_style_set_flex_main_place(lv_style_t * style, lv_flex_align_t value);
@@ -235,43 +234,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_RO
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_Y_ALIGN;
     void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value);
     LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN;
-=======
-
-void lv_style_set_flex_flow(lv_style_t * style, lv_flex_flow_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_FLOW;
-void lv_style_set_flex_main_place(lv_style_t * style, lv_flex_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_MAIN_PLACE;
-void lv_style_set_flex_cross_place(lv_style_t * style, lv_flex_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_CROSS_PLACE;
-void lv_style_set_flex_track_place(lv_style_t * style, lv_flex_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_TRACK_PLACE;
-void lv_style_set_flex_grow(lv_style_t * style, uint8_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_FLEX_GROW;
-#endif /*LV_USE_FLEX*/
-
-#if LV_USE_GRID
-
-void lv_style_set_grid_column_dsc_array(lv_style_t * style, const int32_t * value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_COLUMN_DSC_ARRAY;
-void lv_style_set_grid_column_align(lv_style_t * style, lv_grid_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_COLUMN_ALIGN;
-void lv_style_set_grid_row_dsc_array(lv_style_t * style, const int32_t * value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_ROW_DSC_ARRAY;
-void lv_style_set_grid_row_align(lv_style_t * style, lv_grid_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_ROW_ALIGN;
-void lv_style_set_grid_cell_column_pos(lv_style_t * style, int32_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_COLUMN_POS;
-void lv_style_set_grid_cell_x_align(lv_style_t * style, lv_grid_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_X_ALIGN;
-void lv_style_set_grid_cell_column_span(lv_style_t * style, int32_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_COLUMN_SPAN;
-void lv_style_set_grid_cell_row_pos(lv_style_t * style, int32_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_POS;
-void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_grid_align_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_Y_ALIGN;
-void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value);
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GRID_CELL_ROW_SPAN;
->>>>>>> 6e905817b (add LV_STYLE_ROTARY_SENSITIVITY)
 #endif /*LV_USE_GRID*/
 
 
@@ -751,7 +713,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GR
     }
 #if LV_USE_FLEX
 
-
 #define LV_STYLE_CONST_FLEX_FLOW(val) \
     { \
         .prop_ptr = &_lv_style_const_prop_id_FLEX_FLOW, .value = { .num = (int32_t)val } \
@@ -779,7 +740,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t _lv_style_const_prop_id_GR
 #endif /*LV_USE_FLEX*/
 
 #if LV_USE_GRID
-
 
 #define LV_STYLE_CONST_GRID_COLUMN_DSC_ARRAY(val) \
     { \

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -263,6 +263,7 @@ static void style_init(my_theme_t * theme)
     lv_style_set_text_font(&theme->styles.scr, theme->base.font_normal);
     lv_style_set_pad_row(&theme->styles.scr, PAD_SMALL);
     lv_style_set_pad_column(&theme->styles.scr, PAD_SMALL);
+    lv_style_set_rotary_sensitivity(&theme->styles.scr, theme->disp_dpi / 4);
 
     style_init_reset(&theme->styles.card);
     lv_style_set_radius(&theme->styles.card, RADIUS_DEFAULT);
@@ -277,6 +278,7 @@ static void style_init(my_theme_t * theme)
     lv_style_set_pad_column(&theme->styles.card, PAD_SMALL);
     lv_style_set_line_color(&theme->styles.card, lv_palette_main(LV_PALETTE_GREY));
     lv_style_set_line_width(&theme->styles.card, _LV_DPX_CALC(theme->disp_dpi, 1));
+    lv_style_set_rotary_sensitivity(&theme->styles.card, theme->disp_dpi / 4);
 
     style_init_reset(&theme->styles.outline_primary);
     lv_style_set_outline_color(&theme->styles.outline_primary, theme->base.color_primary);

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -75,6 +75,7 @@ typedef struct {
     lv_style_t circle;
     lv_style_t no_radius;
     lv_style_t clip_corner;
+    lv_style_t rotary_scroll;
 #if LV_THEME_DEFAULT_GROW
     lv_style_t grow;
 #endif
@@ -263,7 +264,7 @@ static void style_init(my_theme_t * theme)
     lv_style_set_text_font(&theme->styles.scr, theme->base.font_normal);
     lv_style_set_pad_row(&theme->styles.scr, PAD_SMALL);
     lv_style_set_pad_column(&theme->styles.scr, PAD_SMALL);
-    lv_style_set_rotary_sensitivity(&theme->styles.scr, theme->disp_dpi / 4);
+    lv_style_set_rotary_sensitivity(&theme->styles.scr, theme->disp_dpi / 4 * 256);
 
     style_init_reset(&theme->styles.card);
     lv_style_set_radius(&theme->styles.card, RADIUS_DEFAULT);
@@ -278,7 +279,6 @@ static void style_init(my_theme_t * theme)
     lv_style_set_pad_column(&theme->styles.card, PAD_SMALL);
     lv_style_set_line_color(&theme->styles.card, lv_palette_main(LV_PALETTE_GREY));
     lv_style_set_line_width(&theme->styles.card, _LV_DPX_CALC(theme->disp_dpi, 1));
-    lv_style_set_rotary_sensitivity(&theme->styles.card, theme->disp_dpi / 4);
 
     style_init_reset(&theme->styles.outline_primary);
     lv_style_set_outline_color(&theme->styles.outline_primary, theme->base.color_primary);
@@ -387,6 +387,9 @@ static void style_init(my_theme_t * theme)
 
     style_init_reset(&theme->styles.no_radius);
     lv_style_set_radius(&theme->styles.no_radius, 0);
+
+    style_init_reset(&theme->styles.rotary_scroll);
+    lv_style_set_rotary_sensitivity(&theme->styles.rotary_scroll, theme->disp_dpi / 4 * 256);
 
 #if LV_THEME_DEFAULT_GROW
     style_init_reset(&theme->styles.grow);
@@ -737,7 +740,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         lv_obj_t * parent = lv_obj_get_parent(obj);
         /*Tabview content area*/
         if(parent && lv_obj_check_type(parent, &lv_tabview_class) && lv_obj_get_index(obj) == 1) {
-            return;
+        	return;
         }
         /*Tabview button container*/
         else if(lv_obj_check_type(parent, &lv_tabview_class) && lv_obj_get_index(obj) == 0) {
@@ -749,6 +752,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         /*Tabview pages*/
         else if(parent && lv_obj_check_type(lv_obj_get_parent(parent), &lv_tabview_class)) {
             lv_obj_add_style(obj, &theme->styles.pad_normal, 0);
+            lv_obj_add_style(obj, &theme->styles.rotary_scroll, 0);
             lv_obj_add_style(obj, &theme->styles.scrollbar, LV_PART_SCROLLBAR);
             lv_obj_add_style(obj, &theme->styles.scrollbar_scrolled, LV_PART_SCROLLBAR | LV_STATE_SCROLLED);
             return;

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -740,7 +740,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         lv_obj_t * parent = lv_obj_get_parent(obj);
         /*Tabview content area*/
         if(parent && lv_obj_check_type(parent, &lv_tabview_class) && lv_obj_get_index(obj) == 1) {
-        	return;
+            return;
         }
         /*Tabview button container*/
         else if(lv_obj_check_type(parent, &lv_tabview_class) && lv_obj_get_index(obj) == 0) {

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -605,7 +605,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_KEY) {
         uint32_t c = lv_event_get_key(e);
 
-        int16_t old_value = arc->value;
+        int32_t old_value = arc->value;
         if(c == LV_KEY_RIGHT || c == LV_KEY_UP) {
             lv_arc_set_value(obj, lv_arc_get_value(obj) + 1);
         }
@@ -613,6 +613,16 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
             lv_arc_set_value(obj, lv_arc_get_value(obj) - 1);
         }
 
+        if(old_value != arc->value) {
+            res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
+            if(res != LV_RESULT_OK) return;
+        }
+    }
+    else if(code == LV_EVENT_ROTARY) {
+        int32_t r = lv_event_get_rotary_diff(e);
+
+        int32_t old_value = arc->value;
+		lv_arc_set_value(obj, lv_arc_get_value(obj) + r);
         if(old_value != arc->value) {
             res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
             if(res != LV_RESULT_OK) return;

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -622,7 +622,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
         int32_t r = lv_event_get_rotary_diff(e);
 
         int32_t old_value = arc->value;
-		lv_arc_set_value(obj, lv_arc_get_value(obj) + r);
+        lv_arc_set_value(obj, lv_arc_get_value(obj) + r);
         if(old_value != arc->value) {
             res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
             if(res != LV_RESULT_OK) return;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -739,16 +739,17 @@ static void lv_dropdown_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_ROTARY) {
-		if(!lv_dropdown_is_open(obj)) {
-			lv_dropdown_open(obj);
-		} else {
-			int32_t r = lv_event_get_rotary_diff(e);
-			int32_t new_id = dropdown->sel_opt_id + r;
-			new_id = LV_CLAMP(0, new_id, (int32_t)dropdown->option_cnt - 1);
+        if(!lv_dropdown_is_open(obj)) {
+            lv_dropdown_open(obj);
+        }
+        else {
+            int32_t r = lv_event_get_rotary_diff(e);
+            int32_t new_id = dropdown->sel_opt_id + r;
+            new_id = LV_CLAMP(0, new_id, (int32_t)dropdown->option_cnt - 1);
 
-			dropdown->sel_opt_id = new_id;
-			position_to_selected(obj);
-		}
+            dropdown->sel_opt_id = new_id;
+            position_to_selected(obj);
+        }
     }
     else if(code == LV_EVENT_DRAW_MAIN) {
         draw_main(e);

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -738,6 +738,18 @@ static void lv_dropdown_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
         }
     }
+    else if(code == LV_EVENT_ROTARY) {
+		if(!lv_dropdown_is_open(obj)) {
+			lv_dropdown_open(obj);
+		} else {
+			int32_t r = lv_event_get_rotary_diff(e);
+			int32_t new_id = dropdown->sel_opt_id + r;
+			new_id = LV_CLAMP(0, new_id, (int32_t)dropdown->option_cnt - 1);
+
+			dropdown->sel_opt_id = new_id;
+			position_to_selected(obj);
+		}
+    }
     else if(code == LV_EVENT_DRAW_MAIN) {
         draw_main(e);
     }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -380,15 +380,15 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
         }
     }
-	else if(code == LV_EVENT_ROTARY) {
-		int32_t r = lv_event_get_rotary_diff(e);
-		int32_t new_id = roller->sel_opt_id + r;
-		new_id = LV_CLAMP(0, new_id, (int32_t)roller->option_cnt - 1);
-		if((int32_t)roller->sel_opt_id != new_id) {
-			uint32_t ori_id = roller->sel_opt_id_ori; /*lv_roller_set_selected will overwrite this*/
-			lv_roller_set_selected(obj, new_id, LV_ANIM_ON);
-			roller->sel_opt_id_ori = ori_id;
-		}
+    else if(code == LV_EVENT_ROTARY) {
+        int32_t r = lv_event_get_rotary_diff(e);
+        int32_t new_id = roller->sel_opt_id + r;
+        new_id = LV_CLAMP(0, new_id, (int32_t)roller->option_cnt - 1);
+        if((int32_t)roller->sel_opt_id != new_id) {
+            uint32_t ori_id = roller->sel_opt_id_ori; /*lv_roller_set_selected will overwrite this*/
+            lv_roller_set_selected(obj, new_id, LV_ANIM_ON);
+            roller->sel_opt_id_ori = ori_id;
+        }
     }
     else if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         lv_obj_t * label = get_label(obj);

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -380,6 +380,16 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
         }
     }
+	else if(code == LV_EVENT_ROTARY) {
+		int32_t r = lv_event_get_rotary_diff(e);
+		int32_t new_id = roller->sel_opt_id + r;
+		new_id = LV_CLAMP(0, new_id, (int32_t)roller->option_cnt - 1);
+		if((int32_t)roller->sel_opt_id != new_id) {
+			uint32_t ori_id = roller->sel_opt_id_ori; /*lv_roller_set_selected will overwrite this*/
+			lv_roller_set_selected(obj, new_id, LV_ANIM_ON);
+			roller->sel_opt_id_ori = ori_id;
+		}
+    }
     else if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         lv_obj_t * label = get_label(obj);
         lv_obj_refresh_ext_draw_size(label);

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -225,10 +225,10 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(res != LV_RESULT_OK) return;
     }
     else if(code == LV_EVENT_ROTARY) {
-    	int32_t r = lv_event_get_rotary_diff(e);
+        int32_t r = lv_event_get_rotary_diff(e);
 
-		if(!slider->left_knob_focus) lv_slider_set_value(obj, lv_slider_get_value(obj) + r, LV_ANIM_ON);
-		else lv_slider_set_left_value(obj, lv_slider_get_left_value(obj) + 1, LV_ANIM_ON);
+        if(!slider->left_knob_focus) lv_slider_set_value(obj, lv_slider_get_value(obj) + r, LV_ANIM_ON);
+        else lv_slider_set_left_value(obj, lv_slider_get_left_value(obj) + 1, LV_ANIM_ON);
 
         res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
         if(res != LV_RESULT_OK) return;

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -224,6 +224,15 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
         if(res != LV_RESULT_OK) return;
     }
+    else if(code == LV_EVENT_ROTARY) {
+    	int32_t r = lv_event_get_rotary_diff(e);
+
+		if(!slider->left_knob_focus) lv_slider_set_value(obj, lv_slider_get_value(obj) + r, LV_ANIM_ON);
+		else lv_slider_set_left_value(obj, lv_slider_get_left_value(obj) + 1, LV_ANIM_ON);
+
+        res = lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
+        if(res != LV_RESULT_OK) return;
+    }
     else if(code == LV_EVENT_DRAW_MAIN) {
         draw_knob(e);
     }

--- a/tests/src/test_cases/widgets/test_image.c
+++ b/tests/src/test_cases/widgets/test_image.c
@@ -21,6 +21,7 @@ static lv_obj_t * img_create(void)
     lv_obj_t * img = lv_image_create(lv_screen_active());
     lv_image_set_src(img, &test_img_lvgl_logo_png);
     lv_obj_set_style_bg_opa(img, LV_OPA_20, 0);
+    lv_obj_set_style_bg_color(img, lv_color_hex(0x000000), 0);
     lv_obj_set_style_shadow_width(img, 10, 0);
     lv_obj_set_style_shadow_color(img, lv_color_hex(0xff0000), 0);
     return img;


### PR DESCRIPTION
### Description of the feature or fix

It nicely integrates the the typical watch crown features with the pointer input device. To test it with SDL change `LV_SDL_MOUSEWHEEL_MODE` to `1`.

cc @XuNeo @bjsylvia 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
