### PR TITLE
refact(anim_timeline): refact anim timeline design

### DIFF
--- a/docs/overview/anim.rst
+++ b/docs/overview/anim.rst
@@ -147,6 +147,9 @@ timeline.
 
 It supports forward and backward playback of the entire animation group,
 using :cpp:expr:`lv_anim_timeline_set_reverse(at, reverse)`.
+Note that if you want to play in reverse from the end of the timeline,
+you need to call :cpp:expr:`lv_anim_timeline_set_progress(at, LV_ANIM_TIMELINE_PROGRESS_MAX)`
+after adding all animations and before starting to play.
 
 Call :cpp:expr:`lv_anim_timeline_stop(at)` to stop the animation timeline.
 
@@ -159,8 +162,9 @@ duration of the entire animation timeline.
 Call :cpp:expr:`lv_anim_timeline_get_reverse(at)` function to get whether to
 reverse the animation timeline.
 
-Call :cpp:expr:`lv_anim_timeline_delete(at)` function to delete the animation
-timeline.
+Call :cpp:expr:`lv_anim_timeline_delete(at)` function to delete the animation timeline.
+**Note**: If you need to delete an object during animation, be sure to delete the
+anim timeline before deleting the object. Otherwise, the program may crash or behave abnormally.
 
 .. image:: /misc/anim-timeline.png
 

--- a/examples/anim/lv_example_anim_timeline_1.c
+++ b/examples/anim/lv_example_anim_timeline_1.c
@@ -1,12 +1,6 @@
 #include "../lv_examples.h"
 #if LV_USE_FLEX && LV_BUILD_EXAMPLES
 
-static lv_anim_timeline_t * anim_timeline = NULL;
-
-static lv_obj_t * obj1 = NULL;
-static lv_obj_t * obj2 = NULL;
-static lv_obj_t * obj3 = NULL;
-
 static const int32_t obj_width = 90;
 static const int32_t obj_height = 70;
 
@@ -20,9 +14,98 @@ static void set_height(lv_anim_t * var, int32_t v)
     lv_obj_set_height(var->var, v);
 }
 
-static void anim_timeline_create(void)
+static void set_slider_value(lv_anim_t * var, int32_t v)
 {
-    /* obj1 */
+    lv_slider_set_value(var->var, v, LV_ANIM_OFF);
+}
+
+static void btn_start_event_handler(lv_event_t * e)
+{
+    lv_obj_t * btn = lv_event_get_current_target_obj(e);
+    lv_anim_timeline_t * anim_timeline = lv_event_get_user_data(e);
+
+    bool reverse = lv_obj_has_state(btn, LV_STATE_CHECKED);
+    lv_anim_timeline_set_reverse(anim_timeline, reverse);
+    lv_anim_timeline_start(anim_timeline);
+}
+
+static void btn_pause_event_handler(lv_event_t * e)
+{
+    lv_anim_timeline_t * anim_timeline = lv_event_get_user_data(e);
+    lv_anim_timeline_pause(anim_timeline);
+}
+
+static void slider_prg_event_handler(lv_event_t * e)
+{
+    lv_obj_t * slider = lv_event_get_current_target_obj(e);
+    lv_anim_timeline_t * anim_timeline = lv_event_get_user_data(e);
+    int32_t progress = lv_slider_get_value(slider);
+    lv_anim_timeline_set_progress(anim_timeline, progress);
+}
+
+/**
+ * Create an animation timeline
+ */
+void lv_example_anim_timeline_1(void)
+{
+    /* Create anim timeline */
+    lv_anim_timeline_t * anim_timeline = lv_anim_timeline_create();
+
+    lv_obj_t * par = lv_screen_active();
+    lv_obj_set_flex_flow(par, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(par, LV_FLEX_ALIGN_SPACE_AROUND, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    /* create btn_start */
+    lv_obj_t * btn_start = lv_button_create(par);
+    lv_obj_add_event_cb(btn_start, btn_start_event_handler, LV_EVENT_VALUE_CHANGED, anim_timeline);
+    lv_obj_add_flag(btn_start, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    lv_obj_add_flag(btn_start, LV_OBJ_FLAG_CHECKABLE);
+    lv_obj_align(btn_start, LV_ALIGN_TOP_MID, -100, 20);
+
+    lv_obj_t * label_start = lv_label_create(btn_start);
+    lv_label_set_text(label_start, "Start");
+    lv_obj_center(label_start);
+
+    /* create btn_pause */
+    lv_obj_t * btn_pause = lv_button_create(par);
+    lv_obj_add_event_cb(btn_pause, btn_pause_event_handler, LV_EVENT_CLICKED, anim_timeline);
+    lv_obj_add_flag(btn_pause, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    lv_obj_align(btn_pause, LV_ALIGN_TOP_MID, 100, 20);
+
+    lv_obj_t * label_pause = lv_label_create(btn_pause);
+    lv_label_set_text(label_pause, "Pause");
+    lv_obj_center(label_pause);
+
+    /* create slider_prg */
+    lv_obj_t * slider_prg = lv_slider_create(par);
+    lv_obj_add_event_cb(slider_prg, slider_prg_event_handler, LV_EVENT_VALUE_CHANGED, anim_timeline);
+    lv_obj_add_flag(slider_prg, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    lv_obj_align(slider_prg, LV_ALIGN_BOTTOM_MID, 0, -20);
+    lv_slider_set_range(slider_prg, 0, LV_ANIM_TIMELINE_PROGRESS_MAX);
+
+    /* create 3 objects */
+    lv_obj_t * obj1 = lv_obj_create(par);
+    lv_obj_set_size(obj1, obj_width, obj_height);
+    lv_obj_set_scrollbar_mode(obj1, LV_SCROLLBAR_MODE_OFF);
+
+    lv_obj_t * obj2 = lv_obj_create(par);
+    lv_obj_set_size(obj2, obj_width, obj_height);
+    lv_obj_set_scrollbar_mode(obj2, LV_SCROLLBAR_MODE_OFF);
+
+    lv_obj_t * obj3 = lv_obj_create(par);
+    lv_obj_set_size(obj3, obj_width, obj_height);
+    lv_obj_set_scrollbar_mode(obj3, LV_SCROLLBAR_MODE_OFF);
+
+    /* anim-slider */
+    lv_anim_t a_slider;
+    lv_anim_init(&a_slider);
+    lv_anim_set_var(&a_slider, slider_prg);
+    lv_anim_set_values(&a_slider, 0, LV_ANIM_TIMELINE_PROGRESS_MAX);
+    lv_anim_set_custom_exec_cb(&a_slider, set_slider_value);
+    lv_anim_set_path_cb(&a_slider, lv_anim_path_linear);
+    lv_anim_set_duration(&a_slider, 700);
+
+    /* anim-obj1 */
     lv_anim_t a1;
     lv_anim_init(&a1);
     lv_anim_set_var(&a1, obj1);
@@ -39,7 +122,7 @@ static void anim_timeline_create(void)
     lv_anim_set_path_cb(&a2, lv_anim_path_ease_out);
     lv_anim_set_duration(&a2, 300);
 
-    /* obj2 */
+    /* anim-obj2 */
     lv_anim_t a3;
     lv_anim_init(&a3);
     lv_anim_set_var(&a3, obj2);
@@ -56,7 +139,7 @@ static void anim_timeline_create(void)
     lv_anim_set_path_cb(&a4, lv_anim_path_ease_out);
     lv_anim_set_duration(&a4, 300);
 
-    /* obj3 */
+    /* anim-obj3 */
     lv_anim_t a5;
     lv_anim_init(&a5);
     lv_anim_set_var(&a5, obj3);
@@ -73,119 +156,16 @@ static void anim_timeline_create(void)
     lv_anim_set_path_cb(&a6, lv_anim_path_ease_out);
     lv_anim_set_duration(&a6, 300);
 
-    /* Create anim timeline */
-    anim_timeline = lv_anim_timeline_create();
+    /* add animations to timeline */
+    lv_anim_timeline_add(anim_timeline, 0, &a_slider);
     lv_anim_timeline_add(anim_timeline, 0, &a1);
     lv_anim_timeline_add(anim_timeline, 0, &a2);
     lv_anim_timeline_add(anim_timeline, 200, &a3);
     lv_anim_timeline_add(anim_timeline, 200, &a4);
     lv_anim_timeline_add(anim_timeline, 400, &a5);
     lv_anim_timeline_add(anim_timeline, 400, &a6);
-}
 
-static void btn_start_event_handler(lv_event_t * e)
-{
-    lv_obj_t * btn = lv_event_get_target(e);
-
-    if(!anim_timeline) {
-        anim_timeline_create();
-    }
-
-    bool reverse = lv_obj_has_state(btn, LV_STATE_CHECKED);
-    lv_anim_timeline_set_reverse(anim_timeline, reverse);
-    lv_anim_timeline_start(anim_timeline);
-}
-
-static void btn_delete_event_handler(lv_event_t * e)
-{
-    LV_UNUSED(e);
-    if(anim_timeline) {
-        lv_anim_timeline_delete(anim_timeline);
-        anim_timeline = NULL;
-    }
-}
-
-static void btn_stop_event_handler(lv_event_t * e)
-{
-    LV_UNUSED(e);
-    if(anim_timeline) {
-        lv_anim_timeline_stop(anim_timeline);
-    }
-}
-
-static void slider_prg_event_handler(lv_event_t * e)
-{
-    lv_obj_t * slider = lv_event_get_target(e);
-
-    if(!anim_timeline) {
-        anim_timeline_create();
-    }
-
-    int32_t progress = lv_slider_get_value(slider);
-    lv_anim_timeline_set_progress(anim_timeline, progress);
-}
-
-/**
- * Create an animation timeline
- */
-void lv_example_anim_timeline_1(void)
-{
-    lv_obj_t * par = lv_screen_active();
-    lv_obj_set_flex_flow(par, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(par, LV_FLEX_ALIGN_SPACE_AROUND, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-
-    /* create btn_start */
-    lv_obj_t * btn_start = lv_button_create(par);
-    lv_obj_add_event_cb(btn_start, btn_start_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_obj_add_flag(btn_start, LV_OBJ_FLAG_IGNORE_LAYOUT);
-    lv_obj_add_flag(btn_start, LV_OBJ_FLAG_CHECKABLE);
-    lv_obj_align(btn_start, LV_ALIGN_TOP_MID, -100, 20);
-
-    lv_obj_t * label_start = lv_label_create(btn_start);
-    lv_label_set_text(label_start, "Start");
-    lv_obj_center(label_start);
-
-    /* create btn_del */
-    lv_obj_t * btn_del = lv_button_create(par);
-    lv_obj_add_event_cb(btn_del, btn_delete_event_handler, LV_EVENT_CLICKED, NULL);
-    lv_obj_add_flag(btn_del, LV_OBJ_FLAG_IGNORE_LAYOUT);
-    lv_obj_align(btn_del, LV_ALIGN_TOP_MID, 0, 20);
-
-    lv_obj_t * label_del = lv_label_create(btn_del);
-    lv_label_set_text(label_del, "Delete");
-    lv_obj_center(label_del);
-
-    /* create btn_stop */
-    lv_obj_t * btn_stop = lv_button_create(par);
-    lv_obj_add_event_cb(btn_stop, btn_stop_event_handler, LV_EVENT_CLICKED, NULL);
-    lv_obj_add_flag(btn_stop, LV_OBJ_FLAG_IGNORE_LAYOUT);
-    lv_obj_align(btn_stop, LV_ALIGN_TOP_MID, 100, 20);
-
-    lv_obj_t * label_stop = lv_label_create(btn_stop);
-    lv_label_set_text(label_stop, "Stop");
-    lv_obj_center(label_stop);
-
-    /* create slider_prg */
-    lv_obj_t * slider_prg = lv_slider_create(par);
-    lv_obj_add_event_cb(slider_prg, slider_prg_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_obj_add_flag(slider_prg, LV_OBJ_FLAG_IGNORE_LAYOUT);
-    lv_obj_align(slider_prg, LV_ALIGN_BOTTOM_MID, 0, -20);
-    lv_slider_set_range(slider_prg, 0, 65535);
-
-    /* create 3 objects */
-    obj1 = lv_obj_create(par);
-    lv_obj_set_size(obj1, obj_width, obj_height);
-    lv_obj_set_scrollbar_mode(obj1, LV_SCROLLBAR_MODE_OFF);
-
-    obj2 = lv_obj_create(par);
-    lv_obj_set_size(obj2, obj_width, obj_height);
-    lv_obj_set_scrollbar_mode(obj2, LV_SCROLLBAR_MODE_OFF);
-
-    obj3 = lv_obj_create(par);
-    lv_obj_set_size(obj3, obj_width, obj_height);
-    lv_obj_set_scrollbar_mode(obj3, LV_SCROLLBAR_MODE_OFF);
-
-    anim_timeline_create();
+    lv_anim_timeline_set_progress(anim_timeline, LV_ANIM_TIMELINE_PROGRESS_MAX);
 }
 
 #endif

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -181,6 +181,11 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
         }
+        else if(act_time > start_time + a->duration) {
+            value = a->end_value;
+            if(a->exec_cb) a->exec_cb(a->var, value);
+            if(a->custom_exec_cb) a->custom_exec_cb(a, value);
+        }
     }
 }
 

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -175,6 +175,12 @@ bool lv_anim_timeline_get_reverse(lv_anim_timeline_t * at)
     return at->reverse;
 }
 
+uint16_t lv_anim_timeline_get_progress(lv_anim_timeline_t * at)
+{
+    LV_ASSERT_NULL(at);
+    return at->progress;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/lv_anim_timeline.h
+++ b/src/misc/lv_anim_timeline.h
@@ -19,22 +19,13 @@ extern "C" {
  *      DEFINES
  *********************/
 
+#define LV_ANIM_TIMELINE_PROGRESS_MAX 0xFFFF
+
 /**********************
  *      TYPEDEFS
  **********************/
 
-/*Data of anim_timeline_dsc*/
-typedef struct {
-    lv_anim_t anim;
-    uint32_t start_time;
-} lv_anim_timeline_dsc_t;
-
-/*Data of anim_timeline*/
-typedef struct {
-    lv_anim_timeline_dsc_t * anim_dsc;  /**< Dynamically allocated anim dsc array*/
-    uint32_t anim_dsc_cnt;              /**< The length of anim dsc array*/
-    bool reverse;                       /**< Reverse playback*/
-} lv_anim_timeline_t;
+typedef struct _lv_anim_timeline_t lv_anim_timeline_t;
 
 /**********************
 * GLOBAL PROTOTYPES
@@ -58,7 +49,7 @@ void lv_anim_timeline_delete(lv_anim_timeline_t * at);
  * @param start_time    the time the animation started on the timeline, note that start_time will override the value of delay.
  * @param a             pointer to an animation.
  */
-void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, lv_anim_t * a);
+void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, const lv_anim_t * a);
 
 /**
  * Start the animation timeline.
@@ -68,10 +59,10 @@ void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, lv_anim_
 uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at);
 
 /**
- * Stop the animation timeline.
+ * Pause the animation timeline.
  * @param at    pointer to the animation timeline.
  */
-void lv_anim_timeline_stop(lv_anim_timeline_t * at);
+void lv_anim_timeline_pause(lv_anim_timeline_t * at);
 
 /**
  * Set the playback direction of the animation timeline.
@@ -100,6 +91,13 @@ uint32_t lv_anim_timeline_get_playtime(lv_anim_timeline_t * at);
  * @return return true if it is reverse playback.
  */
 bool lv_anim_timeline_get_reverse(lv_anim_timeline_t * at);
+
+/**
+ * Get the progress of the animation timeline.
+ * @param at    pointer to the animation timeline.
+ * @return return value 0~65535 to map 0~100% animation progress.
+ */
+uint16_t lv_anim_timeline_get_progress(lv_anim_timeline_t * at);
 
 /**********************
  *      MACROS

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -272,7 +272,7 @@ void test_anim_timeline_reverse(void)
     lv_anim_set_duration(&a1, 1500);
     lv_anim_timeline_add(anim_timeline, 2000, &a1);
 
-    lv_anim_timeline_set_reverse(anim_timeline, true);
+    lv_anim_timeline_set_progress(anim_timeline, LV_ANIM_TIMELINE_PROGRESS_MAX);
     lv_anim_timeline_start(anim_timeline);    /*0 (3500)*/
 
     lv_refr_now(NULL);

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -202,11 +202,11 @@ void test_anim_timeline_start(void)
     lv_test_wait(100);  /*1100*/
     TEST_ASSERT_EQUAL(100, lv_obj_get_x(obj));
 
-    /*Nothing should change it*/
+    /*Should change it*/
     lv_obj_set_x(obj, 10);
 
     lv_test_wait(100);  /*1200*/
-    TEST_ASSERT_EQUAL(10, lv_obj_get_x(obj));
+    TEST_ASSERT_EQUAL(100, lv_obj_get_x(obj));
 
     lv_test_wait(300);  /*1500*/
     TEST_ASSERT_EQUAL(200, lv_obj_get_x(obj));
@@ -282,23 +282,23 @@ void test_anim_timeline_reverse(void)
     TEST_ASSERT_EQUAL(500, lv_obj_get_x(obj));
 
     lv_test_wait(201);                   /*1200 (2300)*/
-    TEST_ASSERT_EQUAL(280, lv_obj_get_x(obj));
+    TEST_ASSERT_EQUAL(459, lv_obj_get_x(obj));
 
     lv_test_wait(300);                   /*1500 (2000)*/
-    TEST_ASSERT_EQUAL(250, lv_obj_get_x(obj));
+    TEST_ASSERT_EQUAL(400, lv_obj_get_x(obj));
 
     lv_test_wait(500);                    /*2000 (1500)*/
     TEST_ASSERT_EQUAL(200, lv_obj_get_x(obj));
 
     /*There is a gap*/
     lv_test_wait(100);                    /*2100 (1400)*/
-    TEST_ASSERT_EQUAL(200, lv_obj_get_x(obj));
+    TEST_ASSERT_EQUAL(100, lv_obj_get_x(obj));
 
-    /*Nothing should change it*/
+    /*Should change it*/
     lv_obj_set_x(obj, 10);
 
     lv_test_wait(100);                    /*2200 (1300)*/
-    TEST_ASSERT_EQUAL(10, lv_obj_get_x(obj));
+    TEST_ASSERT_EQUAL(100, lv_obj_get_x(obj));
 
     lv_test_wait(300);                    /*2500 (1000)*/
     TEST_ASSERT_EQUAL(100, lv_obj_get_x(obj));


### PR DESCRIPTION
### Description of the feature or fix

1. Hide the `lv_anim_timeline_t` data structure
2. Rename `lv_anim_timeline_stop` -> `lv_anim_timeline_pause`
3. Use a single anim to control the overall animation progress instead of independent anim
4. Add progress record, you can pause and resume animation from any time
5. Remove all global variables of the anim timeline example and add slider linkage

https://github.com/lvgl/lvgl/assets/26767803/34630f43-2dd6-4e5e-8324-bb817e8aa547

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
