### PR TITLE
fix(decoder): fix potential mem leak in image decoder

### DIFF
--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -172,6 +172,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                                                 decoded->data_size);
         if(cache == NULL) {
             lv_cache_unlock();
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
 

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -159,7 +159,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     /*If it's a JPEG file...*/
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * fn = dsc->src;
-        size_t decoded_size = 0;
         uint32_t t = lv_tick_get();
         lv_draw_buf_t * decoded = decode_jpeg_file(fn);
         if(decoded == NULL) {
@@ -169,8 +168,8 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         t = lv_tick_elaps(t);
 
         lv_cache_lock();
-        lv_cache_entry_t * cache = lv_cache_add(decoded, decoded_size, decoder->cache_data_type,
-                                                decoded_size);
+        lv_cache_entry_t * cache = lv_cache_add(decoded, decoded->data_size, decoder->cache_data_type,
+                                                decoded->data_size);
         if(cache == NULL) {
             lv_cache_unlock();
             return LV_RESULT_INVALID;

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -162,6 +162,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_cache_entry_t * cache = lv_cache_add(decoded, 0, decoder->cache_data_type, decoded->data_size);
         if(cache == NULL) {
             lv_cache_unlock();
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
 


### PR DESCRIPTION
### Description of the feature or fix

fix potential mem leak in image decoder

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
