### PR TITLE
feat(draw_buf): add API to do alpha premultiply for draw buf

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -230,6 +230,69 @@ lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t st
     return dst;
 }
 
+lv_result_t lv_draw_buf_premultiply(lv_draw_buf_t * draw_buf)
+{
+    LV_ASSERT_NULL(draw_buf);
+    if(draw_buf == NULL) return LV_RESULT_INVALID;
+
+    if(draw_buf->header.flags & LV_IMAGE_FLAGS_PREMULTIPLIED) return LV_RESULT_INVALID;
+    if((draw_buf->header.flags & LV_IMAGE_FLAGS_MODIFIABLE) == 0) {
+        LV_LOG_WARN("draw buf is not modifiable: 0x%04x", draw_buf->header.flags);
+        return LV_RESULT_INVALID;
+    }
+
+    /*Premultiply color with alpha, do case by case by judging color format*/
+    lv_color_format_t cf = draw_buf->header.cf;
+    if(LV_COLOR_FORMAT_IS_INDEXED(cf)) {
+        int size = LV_COLOR_INDEXED_PALETTE_SIZE(cf);
+        lv_color32_t * palette = (lv_color32_t *)draw_buf->data;
+        for(int i = 0; i < size; i++) {
+            lv_color_premultiply(&palette[i]);
+        }
+    }
+    else if(cf == LV_COLOR_FORMAT_ARGB8888) {
+        uint32_t h = draw_buf->header.h;
+        uint32_t w = draw_buf->header.w;
+        uint32_t stride = draw_buf->header.stride;
+        uint8_t * line = (uint8_t *)draw_buf->data;
+        for(uint32_t y = 0; y < h; y++) {
+            lv_color32_t * pixel = (lv_color32_t *)line;
+            for(uint32_t x = 0; x < w; x++) {
+                lv_color_premultiply(pixel);
+                pixel++;
+            }
+            line += stride;
+        }
+    }
+    else if(cf == LV_COLOR_FORMAT_RGB565A8) {
+        uint32_t h = draw_buf->header.h;
+        uint32_t w = draw_buf->header.w;
+        uint32_t stride = draw_buf->header.stride;
+        uint32_t alpha_stride = stride / 2;
+        uint8_t * line = (uint8_t *)draw_buf->data;
+        lv_opa_t * alpha = (lv_opa_t *)(line + stride * h);
+        for(uint32_t y = 0; y < h; y++) {
+            lv_color16_t * pixel = (lv_color16_t *)line;
+            for(uint32_t x = 0; x < w; x++) {
+                lv_color16_premultiply(pixel, alpha[x]);
+                pixel++;
+            }
+            line += stride;
+            alpha += alpha_stride;
+        }
+    }
+    else if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf)) {
+        /*Pass*/
+    }
+    else {
+        LV_LOG_WARN("draw buf has no alpha, cf: %d", cf);
+    }
+
+    draw_buf->header.flags |= LV_IMAGE_FLAGS_PREMULTIPLIED;
+
+    return LV_RESULT_OK;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -198,6 +198,15 @@ void * lv_draw_buf_goto_xy(lv_draw_buf_t * buf, uint32_t x, uint32_t y);
 lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t stride);
 
 /**
+ * Premultiply draw buffer color with alpha channel.
+ * If it's already premultiplied, return directly.
+ * Only color formats with alpha channel will be processed.
+ *
+ * @return LV_RESULT_OK: premultiply success
+ */
+lv_result_t lv_draw_buf_premultiply(lv_draw_buf_t * draw_buf);
+
+/**
  * As of now, draw buf share same definition as `lv_image_dsc_t`.
  * And is interchangeable with `lv_image_dsc_t`.
  */

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -407,6 +407,20 @@ static inline lv_color_t lv_color_black(void)
     return lv_color_make(0x00, 0x00, 0x00);
 }
 
+static inline void lv_color_premultiply(lv_color32_t * c)
+{
+    c->red = LV_OPA_MIX2(c->red, c->alpha);
+    c->green = LV_OPA_MIX2(c->green, c->alpha);
+    c->blue = LV_OPA_MIX2(c->blue, c->alpha);
+}
+
+static inline void lv_color16_premultiply(lv_color16_t * c, lv_opa_t a)
+{
+    c->red = LV_OPA_MIX2(c->red, a);
+    c->green = LV_OPA_MIX2(c->green, a);
+    c->blue = LV_OPA_MIX2(c->blue, a);
+}
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

This API will be used in decoder to fulfill decoder args when `premultiply` is set.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
