### PR TITLE
feat(image): add YUV format enum and adapter yuv for vglite GPU

### DIFF
--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -117,6 +117,24 @@ typedef struct {
 } lv_image_header_t;
 #endif
 
+typedef struct {
+    void * buf;
+    uint32_t stride;            /*Number of bytes in a row*/
+} lv_yuv_plane_t;
+
+typedef union {
+    lv_yuv_plane_t yuv;         /*packed format*/
+    struct {
+        lv_yuv_plane_t y;
+        lv_yuv_plane_t u;
+        lv_yuv_plane_t v;
+    } planar;                   /*planar format with 3 plane*/
+    struct {
+        lv_yuv_plane_t y;
+        lv_yuv_plane_t uv;
+    } semi_planar;              /*planar format with 2 plane*/
+} lv_yuv_buf_t;
+
 /**
  * Struct to describe an image. Both decoded and raw image can share
  * the same struct.

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -312,6 +312,7 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
 
     bool has_alpha = lv_color_format_has_alpha(cf);
     bool is_indexed = LV_COLOR_FORMAT_IS_INDEXED(cf);
+    bool is_yuv = LV_COLOR_FORMAT_IS_YUV(cf);
     bool is_addr_aligned = (image_data == lv_draw_buf_align((void *)image_data, cf)) ? true : false;
 
     uint32_t stride = lv_draw_buf_width_to_stride(width, cf);
@@ -320,10 +321,10 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
     /* When the following conditions are met,
      * there is no need to copy image resource preprocessing.
      */
-    if(is_addr_aligned
-       && is_stride_aligned
-       && !is_indexed
-       && (!has_alpha || (has_alpha && support_blend_normal))) {
+    if((is_addr_aligned
+        && is_stride_aligned
+        && !is_indexed
+        && (!has_alpha || (has_alpha && support_blend_normal))) || is_yuv) {
 
         /*add cache*/
         lv_cache_lock();

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -139,6 +139,22 @@ enum _lv_color_format_t {
     LV_COLOR_FORMAT_A2                = 0x0C,
     LV_COLOR_FORMAT_A4                = 0x0D,
 
+    /* reference to https://wiki.videolan.org/YUV/ */
+    /*YUV planar formats*/
+    LV_COLOR_FORMAT_YUV_START         = 0x20,
+    LV_COLOR_FORMAT_I420              = LV_COLOR_FORMAT_YUV_START,  /*YUV420 planar(3 plane)*/
+    LV_COLOR_FORMAT_I422              = 0x21,  /*YUV422 planar(3 plane)*/
+    LV_COLOR_FORMAT_I444              = 0x22,  /*YUV444 planar(3 plane)*/
+    LV_COLOR_FORMAT_I400              = 0x23,  /*YUV400 no chroma channel*/
+    LV_COLOR_FORMAT_NV21              = 0x24,  /*YUV420 planar(2 plane), UV plane in 'V, U, V, U'*/
+    LV_COLOR_FORMAT_NV12              = 0x25,  /*YUV420 planar(2 plane), UV plane in 'U, V, U, V'*/
+
+    /*YUV packed formats*/
+    LV_COLOR_FORMAT_YUY2              = 0x26,  /*YUV422 packed like 'Y U Y V'*/
+    LV_COLOR_FORMAT_UYVY              = 0x27,  /*YUV422 packed like 'U Y V Y'*/
+
+    LV_COLOR_FORMAT_YUV_END           = LV_COLOR_FORMAT_UYVY,
+
     /*Color formats in which LVGL can render*/
 #if LV_COLOR_DEPTH == 8
     LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_L8,
@@ -162,6 +178,7 @@ typedef uint8_t lv_color_format_t;
 
 #define LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf) ((cf) >= LV_COLOR_FORMAT_A1 && (cf) <= LV_COLOR_FORMAT_A8)
 #define LV_COLOR_FORMAT_IS_INDEXED(cf) ((cf) >= LV_COLOR_FORMAT_I1 && (cf) <= LV_COLOR_FORMAT_I8)
+#define LV_COLOR_FORMAT_IS_YUV(cf)  ((cf) >= LV_COLOR_FORMAT_YUV_START && (cf) <= LV_COLOR_FORMAT_YUV_END)
 #define LV_COLOR_INDEXED_PALETTE_SIZE(cf) ((cf) == LV_COLOR_FORMAT_I1 ? 2 :\
                                            (cf) == LV_COLOR_FORMAT_I2 ? 4 :\
                                            (cf) == LV_COLOR_FORMAT_I4 ? 16 :\


### PR DESCRIPTION
### Description of the feature or fix

Add YUV format for image header.

Support YUV display for vglite GPU

### Checkpoints
- [ x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
