### PR TITLE
feat(draw_buf): add ALLOCATED image header flag

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -166,7 +166,7 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
     draw_buf->header.w = w;
     draw_buf->header.h = h;
     draw_buf->header.cf = cf;
-    draw_buf->header.flags = LV_IMAGE_FLAGS_MODIFIABLE;
+    draw_buf->header.flags = LV_IMAGE_FLAGS_MODIFIABLE | LV_IMAGE_FLAGS_ALLOCATED;
     draw_buf->header.stride = stride;
     draw_buf->data = lv_draw_buf_align(buf, cf);
     draw_buf->unaligned_data = buf;
@@ -178,10 +178,14 @@ void lv_draw_buf_destroy(lv_draw_buf_t * buf)
 {
     LV_ASSERT_NULL(buf);
     if(buf == NULL) return;
-    if(buf->header.flags & LV_IMAGE_FLAGS_MODIFIABLE)
-        lv_draw_buf_free(buf->unaligned_data);
 
-    lv_free(buf);
+    if(buf->header.flags & LV_IMAGE_FLAGS_ALLOCATED) {
+        lv_draw_buf_free(buf->unaligned_data);
+        lv_free(buf);
+    }
+    else {
+        LV_LOG_ERROR("draw buffer is not allocated, ignored");
+    }
 }
 
 void * lv_draw_buf_goto_xy(lv_draw_buf_t * buf, uint32_t x, uint32_t y)

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -76,6 +76,11 @@ typedef enum _lv_image_flags_t {
     LV_IMAGE_FLAGS_COMPRESSED       = (1 << 3),
 
     /**
+     * The image is alloced from heap, thus should be freed after use.
+     */
+    LV_IMAGE_FLAGS_ALLOCATED        = (1 << 4),
+
+    /**
      * Flags reserved for user, lvgl won't use these bits.
      */
     LV_IMAGE_FLAGS_USER1            = 0x1000,

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -100,13 +100,13 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
     lv_area_increase(&snapshot_area, ext_size, ext_size);
 
     lv_memzero(buf, buf_size);
-    lv_memzero(dsc, sizeof(lv_image_dsc_t));
     dsc->data = buf;
     dsc->data_size = buf_size_needed;
+    /*Keep header flags unchanged, because we don't know if it's allocated or not.*/
     dsc->header.w = w;
     dsc->header.h = h;
     dsc->header.cf = cf;
-    dsc->header.flags = LV_IMAGE_FLAGS_MODIFIABLE;
+    dsc->header.magic = LV_IMAGE_HEADER_MAGIC;
 
     lv_layer_t layer;
     lv_memzero(&layer, sizeof(layer));


### PR DESCRIPTION


### Description of the feature or fix

For image decoder, the decoded image could be the original image which may stay in flash, thus no need to free. 
For canvas, a static draw buf could be used, thus also no need to free. 

Add the ALLOCATED flag can make it easy to distinguish them. 

While the existing `MODIFIABLE` is only used for modifying image in place

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
