### PR TITLE
feat(bin_decoder): post process decoded image to fulfill decoder's args

### DIFF
--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -213,6 +213,11 @@ lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t st
  */
 lv_result_t lv_draw_buf_premultiply(lv_draw_buf_t * draw_buf);
 
+static inline bool lv_draw_buf_has_flag(lv_draw_buf_t * draw_buf, lv_image_flags_t flag)
+{
+    return draw_buf->header.flags & flag;
+}
+
 /**
  * As of now, draw buf share same definition as `lv_image_dsc_t`.
  * And is interchangeable with `lv_image_dsc_t`.

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -182,6 +182,13 @@ void lv_draw_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const l
 lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride);
 
 /**
+ * Duplicate a draw buf with same image size, stride and color format. Copy the image data too.
+ * @param draw_buf  the draw buf to duplicate
+ * @return          the duplicated draw buf on success, NULL if failed
+ */
+lv_draw_buf_t * lv_draw_buf_dup(const lv_draw_buf_t * draw_buf);
+
+/**
  * Destroy a draw buf by free the actual buffer if it's marked as LV_IMAGE_FLAGS_MODIFIABLE in header.
  * Then free the lv_draw_buf_t struct.
  */
@@ -196,6 +203,15 @@ void * lv_draw_buf_goto_xy(lv_draw_buf_t * buf, uint32_t x, uint32_t y);
  * Adjust the stride of a draw buf.
  */
 lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t stride);
+
+/**
+ * Premultiply draw buffer color with alpha channel.
+ * If it's already premultiplied, return directly.
+ * Only color formats with alpha channel will be processed.
+ *
+ * @return LV_RESULT_OK: premultiply success
+ */
+lv_result_t lv_draw_buf_premultiply(lv_draw_buf_t * draw_buf);
 
 /**
  * As of now, draw buf share same definition as `lv_image_dsc_t`.

--- a/src/draw/lv_image_buf.h
+++ b/src/draw/lv_image_buf.h
@@ -76,6 +76,11 @@ typedef enum _lv_image_flags_t {
     LV_IMAGE_FLAGS_COMPRESSED       = (1 << 3),
 
     /**
+     * The image is alloced from heap, thus should be freed after use.
+     */
+    LV_IMAGE_FLAGS_ALLOCATED        = (1 << 4),
+
+    /**
      * Flags reserved for user, lvgl won't use these bits.
      */
     LV_IMAGE_FLAGS_USER1            = 0x1000,

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -115,17 +115,14 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     lv_image_decoder_t * decoder;
     lv_image_decoder_args_t * args_copy = NULL;
 
+    static const lv_image_decoder_args_t def_args = {
+        .stride_align = LV_DRAW_BUF_STRIDE_ALIGN != 1,
+        .premultiply = false,
+        .no_cache = false,
+    };
+
     /*Make a copy of args */
-    if(args) {
-        args_copy = lv_malloc(sizeof(lv_image_decoder_args_t));
-        LV_ASSERT_MALLOC(args_copy);
-        if(args_copy == NULL) {
-            LV_LOG_WARN("Out of memory");
-            return LV_RESULT_INVALID;
-        }
-        lv_memcpy(args_copy, args, sizeof(lv_image_decoder_args_t));
-        dsc->args = args_copy;
-    }
+    dsc->args = args ? *args : def_args;
 
     _LV_LL_READ(img_decoder_ll_p, decoder) {
         /*Info and Open callbacks are required*/
@@ -174,7 +171,6 @@ void lv_image_decoder_close(lv_image_decoder_dsc_t * dsc)
 {
     if(dsc->decoder) {
         if(dsc->decoder->close_cb) dsc->decoder->close_cb(dsc->decoder, dsc);
-        if(dsc->args) lv_free(dsc->args);
 
         if(dsc->src_type == LV_IMAGE_SRC_FILE) {
             lv_free((void *)dsc->src);

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -268,6 +268,15 @@ void lv_image_decoder_set_get_area_cb(lv_image_decoder_t * decoder, lv_image_dec
  */
 void lv_image_decoder_set_close_cb(lv_image_decoder_t * decoder, lv_image_decoder_close_f_t close_cb);
 
+/**
+ * Check the decoded image, make any modification if decoder `args` requires.
+ * @note A new draw buf will be allocated if provided `decoded` is not modifiable or stride mismatch etc.
+ * @param dsc       pointer to a decoder descriptor
+ * @param decoded   pointer to a decoded image to post process to meet dsc->args requirement.
+ * @return          post processed draw buffer, when it differs with `decoded`, it's newly allocated.
+ */
+lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_draw_buf_t * decoded);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -121,7 +121,7 @@ typedef struct _lv_image_decoder_dsc_t {
     lv_image_decoder_t * decoder;
 
     /*A copy of parameters of how this image is decoded*/
-    lv_image_decoder_args_t * args;
+    lv_image_decoder_args_t args;
 
     /**The image source. A file path like "S:my_img.png" or pointer to an `lv_image_dsc_t` variable*/
     const void * src;

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -132,8 +132,8 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
         lv_area_move(&img_area, dsc->center.x - ofs, dsc->center.y - ofs);
         blend_dsc.src_area = &img_area;
         blend_dsc.src_buf = _lv_image_decoder_get_data(&decoder_dsc);
-        blend_dsc.src_color_format = decoder_dsc.header.cf;
-        blend_dsc.src_stride = decoder_dsc.header.stride;
+        blend_dsc.src_color_format = decoder_dsc.decoded->header.cf;
+        blend_dsc.src_stride = decoder_dsc.decoded->header.stride;
     }
 
     lv_opa_t * circle_mask = NULL;

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -291,7 +291,8 @@ static void _set_paint_fill_pattern(Tvg_Paint * obj, Tvg_Canvas * canvas, const 
                                     const lv_matrix_t * m)
 {
     lv_image_decoder_dsc_t decoder_dsc;
-    lv_result_t res = lv_image_decoder_open(&decoder_dsc, p->src, NULL);
+    lv_image_decoder_args_t args = { 0 };
+    lv_result_t res = lv_image_decoder_open(&decoder_dsc, p->src, &args);
     if(res != LV_RESULT_OK) {
         LV_LOG_ERROR("Failed to open image");
         return;

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -160,7 +160,9 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, 
     }
 
     /*For backward compatibility, all images are not premultiplied for now.*/
-    header->flags &= ~LV_IMAGE_FLAGS_PREMULTIPLIED;
+    if(header->magic != LV_IMAGE_HEADER_MAGIC) {
+        header->flags &= ~LV_IMAGE_FLAGS_PREMULTIPLIED;
+    }
 
     return LV_RESULT_OK;
 }
@@ -276,24 +278,6 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 decoded->header.stride = dsc->header.stride;
             }
 
-            /**
-             * @todo need to convert c-array image stride if not match
-             *
-             * lv_draw_buf_create(); //create new draw buf that meets requirement
-             * lv_draw_buf_copy(); //copy from c-array image to new draw buf
-             */
-            uint32_t stride_expect = lv_draw_buf_width_to_stride(dsc->header.w, dsc->header.cf);
-            if(dsc->header.stride != stride_expect) {
-                LV_LOG_WARN("Stride mismatch");
-#if 0
-                /**
-                 * @fixme ignore for now
-                 */
-                free_decoder_data(dsc);
-                return LV_RESULT_INVALID;
-#endif
-            }
-
             res = LV_RESULT_OK;
         }
     }
@@ -304,6 +288,22 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     }
 
     if(dsc->decoded == NULL) return LV_RESULT_OK; /*Need to read via get_area_cb*/
+
+    lv_draw_buf_t * decoded = (lv_draw_buf_t *)dsc->decoded;
+    lv_draw_buf_t * adjusted = lv_image_decoder_post_process(dsc, decoded);
+    if(adjusted == NULL) {
+        free_decoder_data(dsc);
+        return LV_RESULT_INVALID;
+    }
+
+    /*The adjusted draw buffer is newly allocated.*/
+    if(adjusted != decoded) {
+        free_decoder_data(dsc);
+        decoder_data_t * decoder_data = get_decoder_data(dsc);
+        decoder_data->decoded = adjusted; /*Now this new buffer need to be free'd on decoder close*/
+    }
+
+    dsc->decoded = adjusted;
 
     /*Add it to cache*/
     t = lv_tick_elaps(t);

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -407,6 +407,20 @@ static inline lv_color_t lv_color_black(void)
     return lv_color_make(0x00, 0x00, 0x00);
 }
 
+static inline void lv_color_premultiply(lv_color32_t * c)
+{
+    c->red = LV_OPA_MIX2(c->red, c->alpha);
+    c->green = LV_OPA_MIX2(c->green, c->alpha);
+    c->blue = LV_OPA_MIX2(c->blue, c->alpha);
+}
+
+static inline void lv_color16_premultiply(lv_color16_t * c, lv_opa_t a)
+{
+    c->red = LV_OPA_MIX2(c->red, a);
+    c->green = LV_OPA_MIX2(c->green, a);
+    c->blue = LV_OPA_MIX2(c->blue, a);
+}
+
 /**********************
  *      MACROS
  **********************/

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -100,13 +100,13 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
     lv_area_increase(&snapshot_area, ext_size, ext_size);
 
     lv_memzero(buf, buf_size);
-    lv_memzero(dsc, sizeof(lv_image_dsc_t));
     dsc->data = buf;
     dsc->data_size = buf_size_needed;
+    /*Keep header flags unchanged, because we don't know if it's allocated or not.*/
     dsc->header.w = w;
     dsc->header.h = h;
     dsc->header.cf = cf;
-    dsc->header.flags = LV_IMAGE_FLAGS_MODIFIABLE;
+    dsc->header.magic = LV_IMAGE_HEADER_MAGIC;
 
     lv_layer_t layer;
     lv_memzero(&layer, sizeof(layer));


### PR DESCRIPTION
### Description of the feature or fix

Check and adjust if decoded image should be pre-mulitplied and stride aligned.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
