### PR TITLE
fix(vector): change draw rectangle rx, ry to float type.

### DIFF
--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -295,7 +295,7 @@ void lv_vector_path_close(lv_vector_path_t * path)
     LV_ARRAY_APPEND_VALUE(&path->ops, op);
 }
 
-void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect, int32_t rx, int32_t ry)
+void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect, float rx, float ry)
 {
     float x = rect->x1;
     float y = rect->y1;
@@ -305,8 +305,8 @@ void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect,
     float hw = w * 0.5f;
     float hh = h * 0.5f;
 
-    if(rx > hw) rx = (int32_t)hw;
-    if(ry > hh) ry = (int32_t)hh;
+    if(rx > hw) rx = hw;
+    if(ry > hh) ry = hh;
 
     if(rx == 0 && ry == 0) {
         lv_fpoint_t pt = {x, y};
@@ -319,7 +319,7 @@ void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect,
         lv_vector_path_line_to(path, &pt);
         lv_vector_path_close(path);
     }
-    else if(rx == (int32_t)hw && ry == (int32_t)hh) {
+    else if(rx == hw && ry == hh) {
         lv_fpoint_t pt = {x + w * 0.5f, y + h * 0.5f};
         lv_vector_path_append_circle(path, &pt, rx, ry);
     }
@@ -383,7 +383,7 @@ void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect,
     }
 }
 
-void lv_vector_path_append_circle(lv_vector_path_t * path, const lv_fpoint_t * c, int32_t rx, int32_t ry)
+void lv_vector_path_append_circle(lv_vector_path_t * path, const lv_fpoint_t * c, float rx, float ry)
 {
     float krx = rx * 0.552284f;
     float kry = ry * 0.552284f;

--- a/src/draw/lv_draw_vector.h
+++ b/src/draw/lv_draw_vector.h
@@ -276,7 +276,7 @@ void lv_vector_path_close(lv_vector_path_t * path);
  * @param rx                the horizontal radius for rounded rectangle
  * @param ry                the vertical radius for rounded rectangle
  */
-void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect, int32_t rx, int32_t ry);
+void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect, float rx, float ry);
 
 /**
  * Add a circle to the path
@@ -285,7 +285,7 @@ void lv_vector_path_append_rect(lv_vector_path_t * path, const lv_area_t * rect,
  * @param rx                the horizontal radius for circle
  * @param ry                the vertical radius for circle
  */
-void lv_vector_path_append_circle(lv_vector_path_t * path, const lv_fpoint_t * c, int32_t rx, int32_t ry);
+void lv_vector_path_append_circle(lv_vector_path_t * path, const lv_fpoint_t * c, float rx, float ry);
 
 /**
  * Add an sub path to the path


### PR DESCRIPTION
### fix vector api rectangle rx, ry to float type

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
