### PR TITLE
Scaling of Images by Dave2D

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -199,11 +199,11 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
             dyu = (d2_s32)((1 << 1) * lv_trigo_cos((int16_t)angle_low + 90));
         }
 
-        if (LV_SCALE_NONE != draw_dsc->scale_x) {
+        if(LV_SCALE_NONE != draw_dsc->scale_x) {
             dxu = (dxu * LV_SCALE_NONE) / draw_dsc->scale_x;
             dxv = (dxv * LV_SCALE_NONE) / draw_dsc->scale_x;
         }
-        if (LV_SCALE_NONE != draw_dsc->scale_y) {
+        if(LV_SCALE_NONE != draw_dsc->scale_y) {
             dyu = (dyu * LV_SCALE_NONE) / draw_dsc->scale_y;
             dyv = (dyv * LV_SCALE_NONE) / draw_dsc->scale_y;
         }

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -185,11 +185,6 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
         lv_point_transform(&p[2], draw_dsc->rotation, draw_dsc->scale_x, draw_dsc->scale_y, &draw_dsc->pivot, true);
         lv_point_transform(&p[3], draw_dsc->rotation, draw_dsc->scale_x, draw_dsc->scale_y, &draw_dsc->pivot, true);
 
-        int32_t sin_xv = 0; //0 degrees
-        int32_t cos_xu = (1 << 15);
-        int32_t sin_yv = (1 << 15); //90 degress
-        int32_t cos_yu = 0;
-
         int32_t angle_limited = draw_dsc->rotation;
         if(angle_limited > 3600) angle_limited -= 3600;
         if(angle_limited < 0) angle_limited += 3600;
@@ -197,18 +192,23 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
         int32_t angle_low = angle_limited / 10;
 
         if(0 != angle_low) {
-            sin_xv = lv_trigo_sin((int16_t)angle_low);
-            cos_xu = lv_trigo_cos((int16_t)angle_low);
-            sin_yv = lv_trigo_sin((int16_t)angle_low + 90);
-            cos_yu = lv_trigo_cos((int16_t)angle_low + 90);
+            /* LV_TRIGO_SHIFT is 15, so only need to shift by 1 to get 16:16 fixed point */
+            dxv = (d2_s32)((1 << 1) * lv_trigo_sin((int16_t)angle_low));
+            dxu = (d2_s32)((1 << 1) * lv_trigo_cos((int16_t)angle_low));
+            dyv = (d2_s32)((1 << 1) * lv_trigo_sin((int16_t)angle_low + 90));
+            dyu = (d2_s32)((1 << 1) * lv_trigo_cos((int16_t)angle_low + 90));
         }
 
-        /* LV_TRIGO_SHIFT is 15, so only need to shift by 1 to get 16:16 fixed point */
-        dxu = (d2_s32)((1 << 1) *
-                       cos_xu); /* TODO - Need to handle scaling of the texture based on draw_dsc->scale_x, draw_dsc->scale_y, currently no scaling it is 1:1 */
-        dxv = (d2_s32)((1 << 1) * sin_xv);
-        dyu = (d2_s32)((1 << 1) * cos_yu);
-        dyv = (d2_s32)((1 << 1) * sin_yv);
+        if (LV_SCALE_NONE != draw_dsc->scale_x)
+        {
+            dxu = (dxu * LV_SCALE_NONE)/draw_dsc->scale_x;
+            dxv = (dxv * LV_SCALE_NONE)/draw_dsc->scale_x;
+        }
+        if (LV_SCALE_NONE != draw_dsc->scale_y)
+        {
+            dyu = (dyu * LV_SCALE_NONE)/draw_dsc->scale_y;
+            dyv = (dyv * LV_SCALE_NONE)/draw_dsc->scale_y;
+        }
     }
 
     p[0].x += draw_area.x1;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -199,15 +199,13 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
             dyu = (d2_s32)((1 << 1) * lv_trigo_cos((int16_t)angle_low + 90));
         }
 
-        if (LV_SCALE_NONE != draw_dsc->scale_x)
-        {
-            dxu = (dxu * LV_SCALE_NONE)/draw_dsc->scale_x;
-            dxv = (dxv * LV_SCALE_NONE)/draw_dsc->scale_x;
+        if (LV_SCALE_NONE != draw_dsc->scale_x) {
+            dxu = (dxu * LV_SCALE_NONE) / draw_dsc->scale_x;
+            dxv = (dxv * LV_SCALE_NONE) / draw_dsc->scale_x;
         }
-        if (LV_SCALE_NONE != draw_dsc->scale_y)
-        {
-            dyu = (dyu * LV_SCALE_NONE)/draw_dsc->scale_y;
-            dyv = (dyv * LV_SCALE_NONE)/draw_dsc->scale_y;
+        if (LV_SCALE_NONE != draw_dsc->scale_y) {
+            dyu = (dyu * LV_SCALE_NONE) / draw_dsc->scale_y;
+            dyv = (dyv * LV_SCALE_NONE) / draw_dsc->scale_y;
         }
     }
 


### PR DESCRIPTION
### Description of the feature or fix

[Feat] Scaling of Images by Dave2D

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
