### PR TITLE
chore(vg_lite): use draw buffer for internal logic

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -89,13 +89,15 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
 
     lv_layer_t * layer = u->base_unit.target_layer;
 
-    lv_vg_lite_buffer_init(
-        &u->target_buffer,
-        layer->buf,
-        lv_area_get_width(&layer->buf_area),
-        lv_area_get_height(&layer->buf_area),
-        lv_vg_lite_vg_fmt(layer->color_format),
-        false);
+    lv_draw_buf_t draw_buf = { 0 };
+    uint32_t w, h, stride;
+    w = lv_area_get_width(&layer->buf_area);
+    h = lv_area_get_height(&layer->buf_area);
+    stride = lv_draw_buf_width_to_stride(w, layer->color_format);
+
+    lv_image_header_init(&draw_buf.header, w, h, layer->color_format, stride, 0);
+    draw_buf.data = layer->buf;
+    lv_vg_lite_buffer_from_draw_buf(&u->target_buffer, &draw_buf);
 
     vg_lite_identity(&u->global_matrix);
     vg_lite_translate(-layer->buf_area.x1, -layer->buf_area.y1, &u->global_matrix);

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -134,13 +134,14 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
     vg_lite_translate(image_area.x1, image_area.y1, &matrix);
 
     vg_lite_buffer_t src_buf;
-    lv_vg_lite_buffer_init(
-        &src_buf,
-        dsc->bitmap,
-        lv_vg_lite_width_align(lv_area_get_width(&image_area)),
-        lv_area_get_height(&image_area),
-        VG_LITE_A8,
-        false);
+    lv_draw_buf_t draw_buf = { 0 };
+    uint32_t w, h;
+    w = lv_area_get_width(&image_area);
+    h = lv_area_get_height(&image_area);
+    uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_A8);
+    lv_image_header_init(&draw_buf.header, w, h, LV_COLOR_FORMAT_A8, stride, 0);
+    draw_buf.data = (void *)dsc->bitmap;
+    lv_vg_lite_buffer_from_draw_buf(&src_buf, &draw_buf);
 
     vg_lite_color_t color;
     color = lv_vg_lite_color(dsc->color, dsc->opa, true);

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -492,7 +492,7 @@ uint32_t lv_vg_lite_width_align(uint32_t w)
     return w;
 }
 
-bool lv_vg_lite_buffer_init(
+void lv_vg_lite_buffer_init(
     vg_lite_buffer_t * buffer,
     const void * ptr,
     int32_t width,
@@ -537,8 +537,24 @@ bool lv_vg_lite_buffer_init(
         buffer->memory = (void *)ptr;
         buffer->address = (uintptr_t)ptr;
     }
+}
 
-    return true;
+void lv_vg_lite_buffer_from_draw_buf(vg_lite_buffer_t * buffer, const lv_draw_buf_t * draw_buf)
+{
+    LV_ASSERT_NULL(buffer);
+    LV_ASSERT_NULL(draw_buf);
+
+    const void * ptr = draw_buf->data;
+    int32_t width = draw_buf->header.w;
+    int32_t height = draw_buf->header.h;
+    vg_lite_buffer_format_t format = lv_vg_lite_vg_fmt(draw_buf->header.cf);
+
+    if(LV_COLOR_FORMAT_IS_INDEXED(draw_buf->header.cf))
+        ptr += LV_COLOR_INDEXED_PALETTE_SIZE(draw_buf->header.cf) * 4;
+
+    width = lv_vg_lite_width_align(width);
+
+    lv_vg_lite_buffer_init(buffer, ptr, width, height, format, false);
 }
 
 void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, const lv_draw_image_dsc_t * dsc)
@@ -588,40 +604,25 @@ bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_ds
         return false;
     }
 
-    const uint8_t * img_data = decoder_dsc->decoded->data;
-
-    if(!img_data) {
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    if(decoded == NULL || decoded->data == NULL) {
         lv_image_decoder_close(decoder_dsc);
         LV_LOG_ERROR("image data is NULL");
         return false;
     }
 
-    if(!lv_vg_lite_is_src_cf_supported(decoder_dsc->header.cf)) {
+    if(!lv_vg_lite_is_src_cf_supported(decoded->header.cf)) {
         lv_image_decoder_close(decoder_dsc);
-        LV_LOG_ERROR("unsupported color format: %d", decoder_dsc->header.cf);
+        LV_LOG_ERROR("unsupported color format: %d", decoded->header.cf);
         return false;
     }
 
-    vg_lite_buffer_format_t fmt = lv_vg_lite_vg_fmt(decoder_dsc->header.cf);
-
-    uint32_t palette_size = lv_vg_lite_get_palette_size(fmt);
-    uint32_t image_offset = 0;
-    if(palette_size) {
-        LV_VG_LITE_CHECK_ERROR(vg_lite_set_CLUT(palette_size, (uint32_t *)img_data));
-        image_offset = LV_VG_LITE_ALIGN(palette_size * sizeof(uint32_t), LV_VG_LITE_BUF_ALIGN);
+    if(LV_COLOR_FORMAT_IS_INDEXED(decoded->header.cf)) {
+        uint32_t palette_size = LV_COLOR_INDEXED_PALETTE_SIZE(decoded->header.cf);
+        LV_VG_LITE_CHECK_ERROR(vg_lite_set_CLUT(palette_size, (uint32_t *)decoded->data));
     }
 
-    uint32_t width = lv_vg_lite_width_align(decoder_dsc->header.w);
-    img_data += image_offset;
-
-    LV_ASSERT(lv_vg_lite_buffer_init(
-                  buffer,
-                  img_data,
-                  width,
-                  decoder_dsc->header.h,
-                  fmt,
-                  false));
-
+    lv_vg_lite_buffer_from_draw_buf(buffer, decoded);
     return true;
 }
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -106,13 +106,15 @@ uint32_t lv_vg_lite_width_to_stride(uint32_t w, vg_lite_buffer_format_t color_fo
 
 uint32_t lv_vg_lite_width_align(uint32_t w);
 
-bool lv_vg_lite_buffer_init(
+void lv_vg_lite_buffer_init(
     vg_lite_buffer_t * buffer,
     const void * ptr,
     int32_t width,
     int32_t height,
     vg_lite_buffer_format_t format,
     bool tiled);
+
+void lv_vg_lite_buffer_from_draw_buf(vg_lite_buffer_t * buffer, const lv_draw_buf_t * draw_buf);
 
 void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, const lv_draw_image_dsc_t * dsc);
 


### PR DESCRIPTION

### Description of the feature or fix

Initialize a vg-lite buffer from draw buffer.
Currently, the `tiled` is not available. We can extend the image flags to include it to indicate if memory is tiled or linear.

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
