### PR TITLE
feat(lv_freetype_image): let the freetype image no longer use the cache that comes with freetype, but use lv cache

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -410,7 +410,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
     }
 
     if(g.resolved_font) {
-        dsc->bitmap = lv_font_get_glyph_bitmap(g.resolved_font, letter, dsc->bitmap_buf);
+        dsc->bitmap = lv_font_get_glyph_bitmap(g.resolved_font, &g, letter, dsc->bitmap_buf);
     }
     else {
         dsc->bitmap = NULL;
@@ -422,5 +422,9 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
     dsc->g = &g;
 
     cb(draw_unit, dsc, NULL, NULL);
+
+    if(font->release_glyph) {
+        font->release_glyph(font, &g);
+    }
     LV_PROFILER_END;
 }

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -42,10 +42,11 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, uint32_t letter, uint8_t * buf_out)
+const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
+                                         uint8_t * buf_out)
 {
     LV_ASSERT_NULL(font_p);
-    return font_p->get_glyph_bitmap(font_p, letter, buf_out);
+    return font_p->get_glyph_bitmap(font_p, g_dsc, letter, buf_out);
 }
 
 bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -111,6 +111,7 @@ typedef struct _lv_font_t {
 /**
  * Return with the bitmap of a font.
  * @param font_p        pointer to a font
+ * @param g_dsc         pass the lv_font_glyph_dsc_t here
  * @param letter        a UNICODE character code
  * @return pointer to the bitmap of the letter
  */

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include "lv_symbol_def.h"
 #include "../misc/lv_area.h"
+#include "../misc/cache/lv_cache.h"
 
 /*********************
  *      DEFINES
@@ -48,6 +49,8 @@ typedef struct {
     int16_t ofs_y;  /**< y offset of the bounding box*/
     uint8_t bpp: 4;  /**< Bit-per-pixel: 1, 2, 4, 8*/
     uint8_t is_placeholder: 1; /** Glyph is missing. But placeholder will still be displayed */
+
+    lv_cache_entry_t * entry;
 } lv_font_glyph_dsc_t;
 
 /** The bitmaps might be upscaled by 3 to achieve subpixel rendering.*/
@@ -82,7 +85,10 @@ typedef struct _lv_font_t {
     bool (*get_glyph_dsc)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
     /** Get a glyph's bitmap from a font*/
-    const uint8_t * (*get_glyph_bitmap)(const struct _lv_font_t *, uint32_t, uint8_t *);
+    const uint8_t * (*get_glyph_bitmap)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t, uint8_t *);
+
+    /** Release a glyph*/
+    void (*release_glyph)(const struct _lv_font_t *, lv_font_glyph_dsc_t *);
 
     /*Pointer to the font in a font pack (must have the same line height)*/
     int32_t line_height;         /**< The real line height where any text fits*/
@@ -108,7 +114,8 @@ typedef struct _lv_font_t {
  * @param letter        a UNICODE character code
  * @return pointer to the bitmap of the letter
  */
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font, uint32_t letter, uint8_t * buf_out);
+const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
+                                         uint8_t * buf_out);
 
 /**
  * Get the descriptor of a glyph

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -71,8 +71,11 @@ static const uint8_t opa2_table[4] = {0, 85, 170, 255};
  *   GLOBAL FUNCTIONS
  **********************/
 
-const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, uint32_t unicode_letter, uint8_t * bitmap_out)
+const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                           uint8_t * bitmap_out)
 {
+    LV_UNUSED(g_dsc);
+
     if(unicode_letter == '\t') unicode_letter = ' ';
 
     lv_font_fmt_txt_dsc_t * fdsc = (lv_font_fmt_txt_dsc_t *)font->dsc;

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -221,7 +221,8 @@ typedef struct {
  * @param bitmap_out        pointer to an array to store the output A8 bitmap
  * @return pointer to an A8 bitmap (not necessarily bitmap_out) or NULL if `unicode_letter` not found
  */
-const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, uint32_t unicode_letter, uint8_t * bitmap_out);
+const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                           uint8_t * bitmap_out);
 
 /**
  * Used as `get_glyph_dsc` callback in lvgl's native font format if the font is uncompressed.

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -203,7 +203,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     data->draw_buf = lv_draw_buf_create(dsc_out->box_w, dsc_out->box_h, LV_COLOR_FORMAT_A8, stride);
 
     for(int y = 0; y < dsc_out->box_h; ++y) {
-        lv_memcpy(data->draw_buf->data + y * stride, glyph_bitmap->bitmap.buffer + y * dsc_out->box_w,
+        lv_memcpy((uint8_t *)(data->draw_buf->data) + y * stride, glyph_bitmap->bitmap.buffer + y * dsc_out->box_w,
                   dsc_out->box_w);
     }
 

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -20,11 +20,15 @@
  **********************/
 
 struct _lv_freetype_cache_context_t {
-    FTC_ImageCache image_cache;
+    lv_cache_t * cache;
 };
 
 struct _lv_freetype_cache_node_t {
-    FT_Glyph image_glyph;
+    FT_UInt unicode;
+    uint32_t size;
+
+    lv_font_glyph_dsc_t glyph_dsc;
+    lv_draw_buf_t * draw_buf;
 };
 
 /**********************
@@ -36,9 +40,15 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
                                       uint32_t unicode_letter,
                                       uint32_t unicode_letter_next);
 
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t unicode_letter,
+static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                                    uint32_t unicode_letter,
                                                     uint8_t * bitmap_out);
 
+static void freetype_image_free_cb(lv_freetype_cache_node_t * node, void * user_data);
+static lv_cache_compare_res_t freetype_image_compare_cb(const lv_freetype_cache_node_t * lhs,
+                                                        const lv_freetype_cache_node_t * rhs);
+
+static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -57,9 +67,16 @@ lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_conte
     LV_ASSERT_MALLOC(cache_ctx);
     lv_memzero(cache_ctx, sizeof(lv_freetype_cache_context_t));
 
-    FT_Error error = FTC_ImageCache_New(ctx->cache_manager, &cache_ctx->image_cache);
-    if(error) {
-        FT_ERROR_MSG("FTC_ImageCache_New", error);
+    lv_cache_ops_t ops = {
+        .compare_cb = (lv_cache_compare_cb_t)freetype_image_compare_cb,
+        .create_cb = NULL,
+        .free_cb = (lv_cache_free_cb_t)freetype_image_free_cb,
+    };
+
+    cache_ctx->cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_cache_node_t),
+                                       LV_FREETYPE_CACHE_FT_OUTLINES, ops);
+    if(cache_ctx->cache == NULL) {
+        LV_LOG_ERROR("lv_cache_create failed");
         lv_free(cache_ctx);
         return NULL;
     }
@@ -70,26 +87,22 @@ lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_conte
 void lv_freetype_cache_context_delete(lv_freetype_cache_context_t * cache_ctx)
 {
     LV_ASSERT_NULL(cache_ctx);
+    lv_cache_destroy(cache_ctx->cache, NULL);
     lv_free(cache_ctx);
 }
 
 bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    lv_freetype_cache_node_t * cache_node = lv_malloc(sizeof(lv_freetype_cache_node_t));
-    LV_ASSERT_MALLOC(cache_node);
-    lv_memzero(cache_node, sizeof(lv_freetype_cache_context_t));
-    dsc->cache_node = cache_node;
     dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
     dsc->font.get_glyph_bitmap = freetype_get_glyph_bitmap_cb;
+    dsc->font.release_glyph = freetype_image_release_cb;
     return true;
 }
 
 void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    LV_ASSERT_NULL(dsc->cache_node);
-    lv_free(dsc->cache_node);
 }
 
 /**********************
@@ -126,31 +139,44 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
     FT_UInt glyph_index = FTC_CMapCache_Lookup(dsc->context->cmap_cache, dsc->face_id, charmap_index, unicode_letter);
     dsc_out->is_placeholder = glyph_index == 0;
 
+    lv_freetype_cache_node_t search_key = {
+        .unicode = unicode_letter,
+        .size = dsc->size,
+    };
+
+    lv_cache_entry_t * entry = lv_cache_acquire(dsc->context->cache_context->cache, &search_key, NULL);
+    if(entry != NULL) {
+        lv_freetype_cache_node_t * data = lv_cache_entry_get_data(entry);
+        dsc_out->entry = NULL;
+        *dsc_out = data->glyph_dsc;
+        lv_cache_release(dsc->context->cache_context->cache, entry, NULL);
+        return true;
+    }
+
     if(dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) {
         lv_freetype_italic_transform(face);
     }
 
-    FTC_ImageTypeRec desc_type;
-    desc_type.face_id = dsc->face_id;
-    desc_type.flags = FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL;
-    desc_type.height = dsc->size;
-    desc_type.width = dsc->size;
-
-    error = FTC_ImageCache_Lookup(dsc->context->cache_context->image_cache,
-                                  &desc_type,
-                                  glyph_index,
-                                  &dsc->cache_node->image_glyph,
-                                  NULL);
+    FT_Set_Pixel_Sizes(face, 0, dsc->size);
+    error = FT_Load_Glyph(face, glyph_index,  FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL);
     if(error) {
-        FT_ERROR_MSG("ImageCache_Lookup", error);
+        FT_ERROR_MSG("FT_Load_Glyph", error);
         return false;
     }
-    if(dsc->cache_node->image_glyph->format != FT_GLYPH_FORMAT_BITMAP) {
-        LV_LOG_WARN("glyph format(%d) != FT_GLYPH_FORMAT_BITMAP", dsc->cache_node->image_glyph->format);
+    error = FT_Render_Glyph(face->glyph, FT_RENDER_MODE_NORMAL);
+    if(error) {
+        FT_ERROR_MSG("FT_Render_Glyph", error);
         return false;
     }
 
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)dsc->cache_node->image_glyph;
+    FT_Glyph glyph;
+    error = FT_Get_Glyph(face->glyph, &glyph);
+    if(error) {
+        FT_ERROR_MSG("FT_Get_Glyph", error);
+        return false;
+    }
+
+    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)glyph;
 
     dsc_out->adv_w = FT_F16DOT16_TO_INT(glyph_bitmap->root.advance.x);
     dsc_out->box_h = glyph_bitmap->bitmap.rows;         /*Height of the bitmap in [px]*/
@@ -164,10 +190,31 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
         dsc_out->adv_w = dsc_out->box_w + dsc_out->ofs_x;
     }
 
+    entry = lv_cache_add(dsc->context->cache_context->cache, &search_key, NULL);
+    if(entry == NULL) {
+        LV_LOG_WARN("lv_cache_add failed");
+        return false;
+    }
+
+    lv_freetype_cache_node_t * data = lv_cache_entry_get_data(entry);
+    data->glyph_dsc = *dsc_out;
+
+    uint32_t stride = lv_draw_buf_width_to_stride(dsc_out->box_w, LV_COLOR_FORMAT_A8);
+    data->draw_buf = lv_draw_buf_create(dsc_out->box_w, dsc_out->box_h, LV_COLOR_FORMAT_A8, stride);
+
+    for(int y = 0; y < dsc_out->box_h; ++y) {
+        lv_memcpy(data->draw_buf->data + y * stride, glyph_bitmap->bitmap.buffer + y * dsc_out->box_w,
+                  dsc_out->box_w);
+    }
+
+    dsc_out->entry = NULL;
+
+    lv_cache_release(dsc->context->cache_context->cache, entry, NULL);
     return true;
 }
 
-static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t unicode_letter,
+static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                                    uint32_t unicode_letter,
                                                     uint8_t * bitmap_out)
 {
     LV_UNUSED(unicode_letter);
@@ -176,8 +223,43 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, uint
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
-    FT_BitmapGlyph glyph_bitmap = (FT_BitmapGlyph)dsc->cache_node->image_glyph;
-    return (const uint8_t *)glyph_bitmap->bitmap.buffer;
+    lv_cache_t * cache = dsc->context->cache_context->cache;
+
+    lv_freetype_cache_node_t search_key = {
+        .unicode = unicode_letter,
+        .size = dsc->size
+    };
+
+    lv_cache_entry_t * entry = lv_cache_acquire(cache, &search_key, NULL);
+
+    g_dsc->entry = entry;
+    lv_freetype_cache_node_t * cache_node = lv_cache_entry_get_data(entry);
+
+    return cache_node->draw_buf->data;
 }
 
+static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)
+{
+    LV_ASSERT_NULL(font);
+    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
+    lv_cache_release(dsc->context->cache_context->cache, g_dsc->entry, NULL);
+    g_dsc->entry = NULL;
+}
+
+static void freetype_image_free_cb(lv_freetype_cache_node_t * data, void * user_data)
+{
+    LV_UNUSED(user_data);
+    lv_draw_buf_destroy(data->draw_buf);
+}
+static lv_cache_compare_res_t freetype_image_compare_cb(const lv_freetype_cache_node_t * lhs,
+                                                        const lv_freetype_cache_node_t * rhs)
+{
+    if(lhs->unicode != rhs->unicode) {
+        return lhs->unicode > rhs->unicode ? 1 : -1;
+    }
+    if(lhs->size != rhs->size) {
+        return lhs->size > rhs->size ? 1 : -1;
+    }
+    return 0;
+}
 #endif

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -77,7 +77,6 @@ typedef struct _lv_freetype_font_dsc_t {
     uint32_t size;
     lv_freetype_font_style_t style;
     lv_freetype_context_t * context;
-    lv_freetype_cache_node_t * cache_node;
     FTC_FaceID face_id;
 } lv_freetype_font_dsc_t;
 

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -135,8 +135,10 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     return true; /*true: glyph found; false: glyph was not found*/
 }
 
-static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t unicode_letter, uint8_t * bitmap_buf)
+static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                               uint32_t unicode_letter, uint8_t * bitmap_buf)
 {
+    LV_UNUSED(g_dsc);
     LV_UNUSED(bitmap_buf);
 
     tiny_ttf_cache_data_t search_key = {

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -26,7 +26,8 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, uint32_t unicode, uint8_t * bitmap_buf);
+static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
+                                                uint8_t * bitmap_buf);
 static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
                                   uint32_t unicode, uint32_t unicode_next);
 
@@ -83,10 +84,13 @@ void lv_imgfont_destroy(lv_font_t * font)
  *   STATIC FUNCTIONS
  **********************/
 
-static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, uint32_t unicode, uint8_t * bitmap_buf)
+static const uint8_t * imgfont_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
+                                                uint8_t * bitmap_buf)
 {
     LV_UNUSED(bitmap_buf);
     LV_ASSERT_NULL(font);
+    LV_UNUSED(g_dsc);
+
     imgfont_dsc_t * dsc = (imgfont_dsc_t *)font->dsc;
     int32_t offset_y = 0;
     const void * img_src = dsc->path_cb(dsc->font, unicode, 0, &offset_y, dsc->user_data);


### PR DESCRIPTION
### Description of the feature or fix

let the freetype image no longer use the cache that comes with freetype, but use lv cache

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
