### PR TITLE
refact(draw_buf): hide draw_buf structure members

### DIFF
--- a/demos/render/lv_demo_render.c
+++ b/demos/render/lv_demo_render.c
@@ -755,17 +755,16 @@ static void blend_mode_cb(lv_obj_t * parent)
     /*Make the parent darker for additive blending*/
     lv_obj_set_style_bg_color(parent, lv_color_hex(0x808080), 0);
 
-    static uint8_t buf_rgb565[LV_CANVAS_BUF_SIZE(36, 30, 16, LV_DRAW_BUF_STRIDE_ALIGN)];
-    static uint8_t buf_rgb888[LV_CANVAS_BUF_SIZE(36, 30, 24, LV_DRAW_BUF_STRIDE_ALIGN)];
-    static uint8_t buf_xrgb8888[LV_CANVAS_BUF_SIZE(36, 30, 32, LV_DRAW_BUF_STRIDE_ALIGN)];
-    static uint8_t buf_argb8888[LV_CANVAS_BUF_SIZE(36, 30, 32, LV_DRAW_BUF_STRIDE_ALIGN)];
+    lv_draw_buf_t * buf_rgb565 = lv_draw_buf_create(36, 30, LV_COLOR_FORMAT_RGB565, LV_DRAW_BUF_STRIDE_AUTO, NULL);
+    lv_draw_buf_t * buf_rgb888 = lv_draw_buf_create(36, 30, LV_COLOR_FORMAT_RGB888, LV_DRAW_BUF_STRIDE_AUTO, NULL);
+    lv_draw_buf_t * buf_xrgb8888 = lv_draw_buf_create(36, 30, LV_COLOR_FORMAT_XRGB8888, LV_DRAW_BUF_STRIDE_AUTO, NULL);
+    lv_draw_buf_t * buf_argb8888 = lv_draw_buf_create(36, 30, LV_COLOR_FORMAT_ARGB8888, LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*The canvas will stay in the top left corner to show the original image*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
 
     const char * cf_txt[] = {"RGB565", "RGB888.", "XRGB8888", "ARGB8888"};
-    lv_color_format_t cf_values[] = {LV_COLOR_FORMAT_RGB565, LV_COLOR_FORMAT_RGB888, LV_COLOR_FORMAT_XRGB8888, LV_COLOR_FORMAT_ARGB8888};
-    uint8_t * cf_bufs[] = {buf_rgb565, buf_rgb888, buf_xrgb8888, buf_argb8888};
+    lv_draw_buf_t * cf_bufs[] = {buf_rgb565, buf_rgb888, buf_xrgb8888, buf_argb8888};
     static lv_image_dsc_t image_dscs[4];
 
     const char * mode_txt[] = {"Add.", "Sub.", "Mul."};
@@ -784,7 +783,7 @@ static void blend_mode_cb(lv_obj_t * parent)
         lv_label_set_text(cf_label, cf_txt[cf]);
         lv_obj_set_grid_cell(cf_label, LV_GRID_ALIGN_CENTER, 1 + cf * 2, 2, LV_GRID_ALIGN_CENTER, 0, 1);
 
-        lv_canvas_set_buffer(canvas, cf_bufs[cf], 36, 30, cf_values[cf]);
+        lv_canvas_set_draw_buf(canvas, cf_bufs[cf]);
         create_blend_mode_image_buffer(canvas);
         lv_img_dsc_t * img_src = lv_canvas_get_image(canvas);
         image_dscs[cf] = *img_src;

--- a/demos/vector_graphic/lv_demo_vector_graphic.c
+++ b/demos/vector_graphic/lv_demo_vector_graphic.c
@@ -225,10 +225,10 @@ static void draw_vector(lv_layer_t * layer)
 
 void lv_demo_vector_graphic(void)
 {
-    static uint8_t canvas_buf[LV_CANVAS_BUF_SIZE(WIDTH, HEIGHT, 32, LV_DRAW_BUF_STRIDE_ALIGN)];
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(WIDTH, HEIGHT, LV_COLOR_FORMAT_ARGB8888, LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     lv_obj_t * canvas = lv_canvas_create(lv_scr_act());
-    lv_canvas_set_buffer(canvas, canvas_buf, WIDTH, HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
 
     lv_layer_t layer;
     lv_canvas_init_layer(canvas, &layer);

--- a/examples/widgets/canvas/lv_example_canvas_1.c
+++ b/examples/widgets/canvas/lv_example_canvas_1.c
@@ -27,10 +27,11 @@ void lv_example_canvas_1(void)
     label_dsc.color = lv_palette_main(LV_PALETTE_ORANGE);
     label_dsc.text = "Some text on text canvas";
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf_16bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565);
+    lv_draw_buf_t * draw_buf_16bpp = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565,
+                                                        LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf_16bpp);
+    lv_canvas_set_draw_buf(canvas, draw_buf_16bpp);
     lv_obj_center(canvas);
     lv_canvas_fill_bg(canvas, lv_palette_lighten(LV_PALETTE_GREY, 3), LV_OPA_COVER);
 
@@ -47,10 +48,12 @@ void lv_example_canvas_1(void)
 
     /*Test the rotation. It requires another buffer where the original image is stored.
      *So use previous canvas as image and rotate it to the new canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf_32bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf_32bpp = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                        LV_DRAW_BUF_STRIDE_AUTO, NULL);
+
     /*Create a canvas and initialize its palette*/
     canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf_32bpp);
+    lv_canvas_set_draw_buf(canvas, draw_buf_32bpp);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 
@@ -58,7 +61,7 @@ void lv_example_canvas_1(void)
 
     lv_canvas_init_layer(canvas, &layer);
     lv_image_dsc_t img;
-    lv_draw_buf_to_image(&draw_buf_16bpp, &img);
+    lv_draw_buf_to_image(draw_buf_16bpp, &img);
     lv_draw_image_dsc_t img_dsc;
     lv_draw_image_dsc_init(&img_dsc);
     img_dsc.rotation = 120;

--- a/examples/widgets/canvas/lv_example_canvas_2.c
+++ b/examples/widgets/canvas/lv_example_canvas_2.c
@@ -12,10 +12,11 @@ void lv_example_canvas_2(void)
     lv_obj_set_style_bg_color(lv_screen_active(), lv_palette_lighten(LV_PALETTE_RED, 5), 0);
 
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_obj_center(canvas);
 
     /*Red background (There is no dedicated alpha channel in indexed images so LV_OPA_COVER is ignored)*/

--- a/examples/widgets/canvas/lv_example_canvas_3.c
+++ b/examples/widgets/canvas/lv_example_canvas_3.c
@@ -10,11 +10,12 @@
 void lv_example_canvas_3(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
 
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);

--- a/examples/widgets/canvas/lv_example_canvas_4.c
+++ b/examples/widgets/canvas/lv_example_canvas_4.c
@@ -10,11 +10,12 @@
 void lv_example_canvas_4(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 

--- a/examples/widgets/canvas/lv_example_canvas_5.c
+++ b/examples/widgets/canvas/lv_example_canvas_5.c
@@ -10,11 +10,12 @@
 void lv_example_canvas_5(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 

--- a/examples/widgets/canvas/lv_example_canvas_6.c
+++ b/examples/widgets/canvas/lv_example_canvas_6.c
@@ -10,11 +10,12 @@
 void lv_example_canvas_6(void)
 {
     /*Create a buffer for the canvas*/
-    static uint8_t cbuf[LV_CANVAS_BUF_SIZE(CANVAS_WIDTH, CANVAS_HEIGHT, 32, LV_DRAW_BUF_STRIDE_ALIGN)];
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_buffer(canvas, cbuf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 

--- a/examples/widgets/canvas/lv_example_canvas_7.c
+++ b/examples/widgets/canvas/lv_example_canvas_7.c
@@ -10,11 +10,12 @@
 void lv_example_canvas_7(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 

--- a/examples/widgets/canvas/lv_example_canvas_8.c
+++ b/examples/widgets/canvas/lv_example_canvas_8.c
@@ -12,11 +12,12 @@
 void lv_example_canvas_8(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888,
+                                                  LV_DRAW_BUF_STRIDE_AUTO, NULL);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
     lv_obj_center(canvas);
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -392,10 +392,21 @@ void lv_display_set_draw_buffers(lv_display_t * disp, void * buf1, void * buf2, 
     if(disp == NULL) disp = lv_display_get_default();
     if(disp == NULL) return;
 
-    disp->buf_1 = buf1;
-    disp->buf_2 = buf2;
-    disp->buf_act = buf1;
-    disp->buf_size_in_bytes = buf_size_in_bytes;
+    if(disp->buf_1) {
+        lv_draw_buf_destroy(disp->buf_1);
+        disp->buf_1 = NULL;
+    }
+
+    if(disp->buf_2) {
+        lv_draw_buf_destroy(disp->buf_2);
+        disp->buf_2 = NULL;
+    }
+
+    int32_t height = buf_size_in_bytes / lv_draw_buf_width_to_stride(disp->hor_res, disp->color_format);
+
+    disp->buf_1 = lv_draw_buf_create(disp->hor_res, height, disp->color_format, 0, buf1);
+    disp->buf_2 = lv_draw_buf_create(disp->hor_res, height, disp->color_format, 0, buf2);
+    disp->buf_act = disp->buf_1;
     disp->render_mode = render_mode;
 }
 

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -59,12 +59,11 @@ struct _lv_display_t {
     /*---------------------
      * Buffering
      *--------------------*/
-    uint8_t * buf_1;
-    uint8_t * buf_2;
+    lv_draw_buf_t * buf_1;
+    lv_draw_buf_t * buf_2;
 
     /** Internal, used by the library*/
-    uint8_t * buf_act;
-    uint32_t buf_size_in_bytes;
+    lv_draw_buf_t * buf_act;
 
     /** MANDATORY: Write the internal buffer (draw_buf) to the display. 'lv_display_flush_ready()' has to be
      * called when finished*/

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -175,6 +175,7 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
     /*Remove the finished tasks first*/
     lv_draw_task_t * t_prev = NULL;
     lv_draw_task_t * t = layer->draw_task_head;
+
     while(t) {
         lv_draw_task_t * t_next = t->next;
         if(t->state == LV_DRAW_TASK_STATE_READY) {
@@ -185,15 +186,17 @@ bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
             if(t->type == LV_DRAW_TASK_TYPE_LAYER) {
                 lv_draw_image_dsc_t * draw_image_dsc = t->draw_dsc;
                 lv_layer_t * layer_drawn = (lv_layer_t *)draw_image_dsc->src;
+                lv_color_format_t cf = lv_draw_buf_get_color_format(layer_drawn->buf);
 
                 if(layer_drawn->buf) {
                     int32_t h = lv_area_get_height(&layer_drawn->buf_area);
                     int32_t w = lv_area_get_width(&layer_drawn->buf_area);
-                    uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, layer_drawn->color_format);
+                    uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, cf);
 
                     _draw_info.used_memory_for_layers_kb -= get_layer_size_kb(layer_size_byte);
                     LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
-                    lv_draw_buf_free(layer_drawn->buf_unaligned);
+                    lv_draw_buf_destroy(layer_drawn->buf);
+                    layer_drawn->buf = NULL;
                 }
 
                 /*Remove the layer from  the display's*/
@@ -361,23 +364,17 @@ lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t c
 
 void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
 {
-    int32_t w = lv_area_get_width(&layer->buf_area);
-    uint32_t stride = lv_draw_buf_width_to_stride(w, layer->color_format);
-
     /*If the buffer of the layer is not allocated yet, allocate it now*/
     if(layer->buf == NULL) {
+        int32_t w = lv_area_get_width(&layer->buf_area);
         int32_t h = lv_area_get_height(&layer->buf_area);
-        uint32_t layer_size_byte = h * stride;
-        layer->buf_unaligned = lv_draw_buf_malloc(layer_size_byte, layer->color_format);
-
-        if(layer->buf_unaligned == NULL) {
-            LV_LOG_WARN("Allocating %"LV_PRIu32" bytes of layer buffer failed. Try later", layer_size_byte);
+        layer->buf = lv_draw_buf_create(w, h, layer->color_format, LV_DRAW_BUF_STRIDE_AUTO, NULL);
+        if(layer->buf == NULL) {
+            LV_LOG_WARN("Allocating layer buffer failed. Try later");
             return NULL;
         }
 
-        layer->buf = lv_draw_buf_align(layer->buf_unaligned, layer->color_format);
-
-        _draw_info.used_memory_for_layers_kb += get_layer_size_kb(layer_size_byte);
+        _draw_info.used_memory_for_layers_kb += get_layer_size_kb(lv_draw_buf_get_data_size(layer->buf));
         LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
 
         if(lv_color_format_has_alpha(layer->color_format)) {
@@ -386,26 +383,20 @@ void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
             a.y1 = 0;
             a.x2 = w - 1;
             a.y2 = h - 1;
-            lv_draw_buf_clear(layer->buf, w, h, layer->color_format, &a);
+            lv_draw_buf_clear(layer->buf, &a);
         }
     }
 
     /*Set the stride also for static allocated buffers as well as for new dynamically allocated*/
-    layer->buf_stride = stride;
+    layer->buf_stride = lv_draw_buf_get_stride(layer->buf);
 
     /*Make sure the buffer address is aligned in case of already allocated buffers*/
-    return lv_draw_buf_align(layer->buf, layer->color_format);
+    return lv_draw_buf_get_data(layer->buf);
 }
 
 void * lv_draw_layer_go_to_xy(lv_layer_t * layer, int32_t x, int32_t y)
 {
-    lv_draw_buf_t tmp;
-    tmp.data = layer->buf;
-    tmp.header.stride = layer->buf_stride;
-    tmp.header.cf = layer->color_format;
-    tmp.header.w = lv_area_get_width(&layer->buf_area);
-    tmp.header.h = lv_area_get_height(&layer->buf_area);
-    return lv_draw_buf_goto_xy(&tmp, x, y);
+    return lv_draw_buf_goto_xy(layer->buf, x, y);
 }
 
 /**********************

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -142,19 +142,13 @@ typedef struct _lv_draw_unit_t {
 } lv_draw_unit_t;
 
 typedef struct _lv_layer_t  {
-
-    /** The unaligned buffer where drawing will happen*/
-    void * buf_unaligned;
-
-    /** The aligned buffer, result of lv_draw_buf_align(layer->buf_unaligned)*/
-    void * buf;
-
-    uint32_t buf_stride;
+    /* target draw buffer */
+    lv_draw_buf_t * buf;
 
     /** The absolute coordinates of the buffer */
     lv_area_t buf_area;
 
-    /** The color format of the layer. LV_COLOR_FORMAT_...  */
+    uint32_t buf_stride;
     lv_color_format_t color_format;
 
     /**

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -355,7 +355,7 @@ void lv_draw_label_iterate_characters(lv_draw_unit_t * draw_unit, const lv_draw_
 
         if(pos.y > draw_unit->clip_area->y2) break;
     }
-    lv_draw_buf_free(draw_letter_dsc._bitmap_buf_unaligned);
+    lv_draw_buf_destroy(draw_letter_dsc.buf);
 
     LV_ASSERT_MEM_INTEGRITY();
 }
@@ -398,22 +398,22 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
         return;
     }
 
-    uint32_t bitmap_size = lv_draw_buf_width_to_stride(g.box_w, LV_COLOR_FORMAT_A8) * g.box_h;
-    /*Round up to avoid many allocations if the next buffer is just slightly larger*/
-    bitmap_size = LV_ALIGN_UP(bitmap_size, 64);
-    if(dsc->_bitmap_buf_size < bitmap_size) {
-        lv_draw_buf_free(dsc->_bitmap_buf_unaligned);
-        dsc->_bitmap_buf_unaligned = lv_draw_buf_malloc(bitmap_size, LV_COLOR_FORMAT_A8);
-        LV_ASSERT_MALLOC(dsc->_bitmap_buf_unaligned);
-        dsc->bitmap_buf = lv_draw_buf_align(dsc->_bitmap_buf_unaligned, LV_COLOR_FORMAT_A8);
-        dsc->_bitmap_buf_size = bitmap_size;
-    }
+    // uint32_t bitmap_size = lv_draw_buf_width_to_stride(g.box_w, LV_COLOR_FORMAT_A8) * g.box_h;
+    // /*Round up to avoid many allocations if the next buffer is just slightly larger*/
+    // bitmap_size = LV_ALIGN_UP(bitmap_size, 64);
+    // if(dsc->_bitmap_buf_size < bitmap_size) {
+    //     lv_draw_buf_free(dsc->_bitmap_buf_unaligned);
+    //     dsc->_bitmap_buf_unaligned = lv_draw_buf_malloc(bitmap_size, LV_COLOR_FORMAT_A8);
+    //     LV_ASSERT_MALLOC(dsc->_bitmap_buf_unaligned);
+    //     dsc->bitmap_buf = lv_draw_buf_align(dsc->_bitmap_buf_unaligned, LV_COLOR_FORMAT_A8);
+    //     dsc->_bitmap_buf_size = bitmap_size;
+    // }
 
     if(g.resolved_font) {
-        dsc->bitmap = lv_font_get_glyph_bitmap(g.resolved_font, &g, letter, dsc->bitmap_buf);
+        dsc->buf = lv_font_get_glyph_bitmap(g.resolved_font, &g, letter, NULL);
     }
     else {
-        dsc->bitmap = NULL;
+        dsc->buf = NULL;
     }
     dsc->letter_coords = &letter_coords;
     if(g.bpp == LV_IMGFONT_BPP) dsc->format = LV_DRAW_LETTER_BITMAP_FORMAT_IMAGE;

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -80,10 +80,7 @@ typedef enum {
 } lv_draw_glyph_bitmap_format_t;
 
 typedef struct {
-    const uint8_t * bitmap;
-    uint8_t * _bitmap_buf_unaligned;
-    uint8_t * bitmap_buf;
-    uint32_t _bitmap_buf_size;
+    lv_draw_buf_t * buf;
     lv_draw_glyph_bitmap_format_t format;
     const lv_area_t * letter_coords;
     const lv_area_t * bg_coords;

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -43,7 +43,8 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect_dsc_init(lv_draw_mask_rect_dsc_t * 
 
 LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect(struct _lv_layer_t * layer, const lv_draw_mask_rect_dsc_t * dsc)
 {
-    if(!lv_color_format_has_alpha(layer->color_format)) {
+    lv_color_format_t cf = lv_draw_buf_get_color_format(layer->buf);
+    if(!lv_color_format_has_alpha(cf)) {
         LV_LOG_WARN("Only layers with alpha channel can be masked");
         return;
     }

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -292,9 +292,12 @@ lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_d
     if(decoded == NULL) return NULL; /*No need to adjust*/
 
     lv_image_decoder_args_t * args = &dsc->args;
-    if(args->stride_align && decoded->header.cf != LV_COLOR_FORMAT_RGB565A8) {
-        uint32_t stride_expect = lv_draw_buf_width_to_stride(decoded->header.w, decoded->header.cf);
-        if(decoded->header.stride != stride_expect) {
+    lv_color_format_t cf = lv_draw_buf_get_color_format(decoded);
+    uint32_t w = lv_draw_buf_get_width(decoded);
+    uint32_t stride = lv_draw_buf_get_stride(decoded);
+    if(args->stride_align && cf != LV_COLOR_FORMAT_RGB565A8) {
+        uint32_t stride_expect = lv_draw_buf_width_to_stride(w, cf);
+        if(stride != stride_expect) {
             LV_LOG_WARN("Stride mismatch");
             lv_draw_buf_t * aligned = lv_draw_buf_adjust_stride(decoded, stride_expect);
             if(aligned == NULL) {

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -180,7 +180,7 @@ typedef struct _lv_image_decoder_dsc_t {
  */
 static inline const void * _lv_image_decoder_get_data(const lv_image_decoder_dsc_t * dsc)
 {
-    return dsc->decoded ? dsc->decoded->data : dsc->img_data;
+    return dsc->decoded ? lv_draw_buf_get_data(dsc->decoded) : dsc->img_data;
 }
 
 /**

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -47,7 +47,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
 
     LV_PROFILER_BEGIN;
     lv_layer_t * layer = draw_unit->target_layer;
-    uint32_t layer_stride_byte = lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), layer->color_format);
+    uint32_t layer_stride_byte = layer->buf_stride;
 
     if(blend_dsc->src_buf == NULL) {
         _lv_draw_sw_blend_fill_dsc_t fill_dsc;

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -132,8 +132,8 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
         lv_area_move(&img_area, dsc->center.x - ofs, dsc->center.y - ofs);
         blend_dsc.src_area = &img_area;
         blend_dsc.src_buf = _lv_image_decoder_get_data(&decoder_dsc);
-        blend_dsc.src_color_format = decoder_dsc.decoded->header.cf;
-        blend_dsc.src_stride = decoder_dsc.decoded->header.stride;
+        blend_dsc.src_color_format = lv_draw_buf_get_color_format(decoder_dsc.decoded);
+        blend_dsc.src_stride = lv_draw_buf_get_stride(decoder_dsc.decoded);
     }
 
     lv_opa_t * circle_mask = NULL;

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -62,7 +62,7 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
     img_dsc.header.h = lv_area_get_height(&layer_to_draw->buf_area);
     img_dsc.header.cf = layer_to_draw->color_format;
     img_dsc.header.stride = layer_to_draw->buf_stride;
-    img_dsc.data = layer_to_draw->buf;
+    img_dsc.data = lv_draw_buf_get_data(layer_to_draw->buf);
 
     lv_draw_image_dsc_t new_draw_dsc;
     lv_memcpy(&new_draw_dsc, draw_dsc, sizeof(lv_draw_image_dsc_t));
@@ -181,9 +181,9 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
     cf = LV_COLOR_FORMAT_IS_INDEXED(cf) ? LV_COLOR_FORMAT_ARGB8888 : cf;
 
     if(decoder_dsc->decoded) {
-        src_buf = decoder_dsc->decoded->data;
-        img_stride = decoder_dsc->decoded->header.stride;
-        cf = decoder_dsc->decoded->header.cf;
+        src_buf = lv_draw_buf_get_data(decoder_dsc->decoded);
+        img_stride = lv_draw_buf_get_stride(decoder_dsc->decoded);
+        cf = lv_draw_buf_get_color_format(decoder_dsc->decoded);
     }
 
     lv_memzero(&blend_dsc, sizeof(lv_draw_sw_blend_dsc_t));

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -66,7 +66,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
                                                  lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
     if(glyph_draw_dsc) {
-        if(glyph_draw_dsc->bitmap == NULL) {
+        if(glyph_draw_dsc->buf == NULL) {
 #if LV_USE_FONT_PLACEHOLDER
             /* Draw a placeholder rectangle*/
             lv_draw_border_dsc_t border_draw_dsc;
@@ -84,7 +84,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
             lv_memzero(&blend_dsc, sizeof(blend_dsc));
             blend_dsc.color = glyph_draw_dsc->color;
             blend_dsc.opa = glyph_draw_dsc->opa;
-            blend_dsc.mask_buf = glyph_draw_dsc->bitmap;
+            blend_dsc.mask_buf = lv_draw_buf_get_data(glyph_draw_dsc->buf);
             blend_dsc.mask_area = &mask_area;
             blend_dsc.blend_area = glyph_draw_dsc->letter_coords;
             blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
@@ -99,7 +99,7 @@ LV_ATTRIBUTE_FAST_MEM static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
             img_dsc.scale_x = LV_SCALE_NONE;
             img_dsc.scale_y = LV_SCALE_NONE;
             img_dsc.opa = glyph_draw_dsc->opa;
-            img_dsc.src = glyph_draw_dsc->bitmap;
+            img_dsc.src = (uint8_t *)glyph_draw_dsc->buf;
             lv_draw_sw_image(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
 #endif
         }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -586,7 +586,7 @@ bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_ds
         return false;
     }
 
-    const uint8_t * img_data = decoder_dsc->decoded->data;
+    const uint8_t * img_data = lv_draw_buf_get_data(decoder_dsc->decoded);
 
     if(!img_data) {
         lv_image_decoder_close(decoder_dsc);

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -42,8 +42,8 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                         uint8_t * buf_out)
+const struct _lv_draw_buf_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, lv_font_glyph_dsc_t * g_dsc,
+                                                       uint32_t letter, uint8_t * buf_out)
 {
     LV_ASSERT_NULL(font_p);
     return font_p->get_glyph_bitmap(font_p, g_dsc, letter, buf_out);

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -38,6 +38,7 @@ extern "C" {
  *-----------------*/
 
 struct _lv_font_t;
+struct _lv_draw_buf_t;
 /** Describes the properties of a glyph.*/
 typedef struct {
     const struct _lv_font_t *
@@ -85,7 +86,8 @@ typedef struct _lv_font_t {
     bool (*get_glyph_dsc)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
     /** Get a glyph's bitmap from a font*/
-    const uint8_t * (*get_glyph_bitmap)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t, uint8_t *);
+    const struct _lv_draw_buf_t * (*get_glyph_bitmap)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t,
+                                                      uint8_t *);
 
     /** Release a glyph*/
     void (*release_glyph)(const struct _lv_font_t *, lv_font_glyph_dsc_t *);
@@ -115,8 +117,9 @@ typedef struct _lv_font_t {
  * @param letter        a UNICODE character code
  * @return pointer to the bitmap of the letter
  */
-const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                         uint8_t * buf_out);
+const struct _lv_draw_buf_t * lv_font_get_glyph_bitmap(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                                       uint32_t letter,
+                                                       uint8_t * buf_out);
 
 /**
  * Get the descriptor of a glyph

--- a/src/libs/bmp/lv_bmp.c
+++ b/src/libs/bmp/lv_bmp.c
@@ -199,7 +199,8 @@ static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     if(decoded_area->y1 == LV_COORD_MIN) {
         *decoded_area = *full_area;
         decoded_area->y2 = decoded_area->y1;
-        if(decoded == NULL) decoded = lv_draw_buf_create(lv_area_get_width(full_area), 1, dsc->header.cf, 0);
+        if(decoded == NULL) decoded = lv_draw_buf_create(lv_area_get_width(full_area), 1, dsc->header.cf,
+                                                             LV_DRAW_BUF_STRIDE_AUTO, NULL);
         dsc->decoded = decoded;
     }
     else {

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -198,13 +198,16 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
 
     lv_freetype_cache_node_t * data = lv_cache_entry_get_data(entry);
     data->glyph_dsc = *dsc_out;
-
-    uint32_t stride = lv_draw_buf_width_to_stride(dsc_out->box_w, LV_COLOR_FORMAT_A8);
-    data->draw_buf = lv_draw_buf_create(dsc_out->box_w, dsc_out->box_h, LV_COLOR_FORMAT_A8, stride);
+    data->draw_buf = lv_draw_buf_create(dsc_out->box_w, dsc_out->box_h, LV_COLOR_FORMAT_A8, LV_DRAW_BUF_STRIDE_AUTO, NULL);
+    const uint8_t * src = glyph_bitmap->bitmap.buffer;
+    uint32_t src_stride = dsc_out->box_w;
+    uint8_t * dest = lv_draw_buf_get_data(data->draw_buf);
+    uint32_t dest_stride = lv_draw_buf_get_stride(data->draw_buf);
 
     for(int y = 0; y < dsc_out->box_h; ++y) {
-        lv_memcpy((uint8_t *)(data->draw_buf->data) + y * stride, glyph_bitmap->bitmap.buffer + y * dsc_out->box_w,
-                  dsc_out->box_w);
+        lv_memcpy(dest, src, src_stride);
+        src += src_stride;
+        dest += dest_stride;
     }
 
     dsc_out->entry = NULL;
@@ -235,7 +238,7 @@ static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_f
     g_dsc->entry = entry;
     lv_freetype_cache_node_t * cache_node = lv_cache_entry_get_data(entry);
 
-    return cache_node->draw_buf->data;
+    return lv_draw_buf_get_data(cache_node->draw_buf);
 }
 
 static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)

--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5307,7 +5307,7 @@ static void decodeGeneric(unsigned char ** out, unsigned * w, unsigned * h,
     lodepng_free(idat);
 
     if(!state->error) {
-        lv_draw_buf_t * decoded = lv_draw_buf_create(*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
+        lv_draw_buf_t * decoded = lv_draw_buf_create(*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w, NULL);
         if(decoded) {
             *out = (unsigned char*)decoded;
             outsize = decoded->data_size;

--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -59,7 +59,7 @@ void lv_qrcode_set_size(lv_obj_t * obj, int32_t size)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_draw_buf_t * old_buf = lv_canvas_get_draw_buf(obj);
-    lv_draw_buf_t * new_buf = lv_draw_buf_create(size, size, LV_COLOR_FORMAT_I1, 0);
+    lv_draw_buf_t * new_buf = lv_draw_buf_create(size, size, LV_COLOR_FORMAT_I1, LV_DRAW_BUF_STRIDE_AUTO, NULL);
     if(new_buf == NULL) {
         LV_LOG_ERROR("malloc failed for canvas buffer");
         return;

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -148,10 +148,13 @@ lv_image_dsc_t * lv_snapshot_take(lv_obj_t * obj, lv_color_format_t cf)
     h += ext_size * 2;
     if(w == 0 || h == 0) return NULL;
 
-    lv_draw_buf_t * draw_buf = lv_draw_buf_create(w, h, cf, 0);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create(w, h, cf, LV_DRAW_BUF_STRIDE_AUTO, NULL);
     if(draw_buf == NULL) return NULL;
 
-    if(lv_snapshot_take_to_buf(obj, cf, (lv_image_dsc_t *)draw_buf, draw_buf->data, draw_buf->data_size) != LV_RESULT_OK) {
+    void * buf = lv_draw_buf_get_data(draw_buf);
+    uint32_t buf_size = lv_draw_buf_get_data_size(draw_buf);
+
+    if(lv_snapshot_take_to_buf(obj, cf, (lv_image_dsc_t *)draw_buf, buf, buf_size) != LV_RESULT_OK) {
         lv_draw_buf_destroy(draw_buf);
         return NULL;
     }

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -33,7 +33,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_canvas_class;
 typedef struct {
     lv_image_t img;
     lv_draw_buf_t * draw_buf;
-    lv_draw_buf_t static_buf;
 } lv_canvas_t;
 
 /**********************
@@ -50,21 +49,6 @@ lv_obj_t * lv_canvas_create(lv_obj_t * parent);
 /*=====================
  * Setter functions
  *====================*/
-
-/**
- * Set a buffer for the canvas.
- * Use `lv_canvas_set_draw_buf` instead if you need to set a buffer with alignment requirement.
- * @param buf a buffer where the content of the canvas will be.
- * The required size is (lv_image_color_format_get_px_size(cf) * w) / 8 * h)
- * It can be allocated with `lv_malloc()` or
- * it can be statically allocated array (e.g. static lv_color_t buf[100*50]) or
- * it can be an address in RAM or external SRAM
- * @param canvas pointer to a canvas object
- * @param w width of the canvas
- * @param h height of the canvas
- * @param cf color format. `LV_COLOR_FORMAT...`
- */
-void lv_canvas_set_buffer(lv_obj_t * obj, void * buf, int32_t w, int32_t h, lv_color_format_t cf);
 
 /**
  * Set a draw buffer for the canvas. A draw buffer either can be allocated by `lv_draw_buf_create()`
@@ -107,6 +91,11 @@ void lv_canvas_set_palette(lv_obj_t * canvas, uint8_t id, lv_color32_t c);
 
 lv_draw_buf_t * lv_canvas_get_draw_buf(lv_obj_t * obj);
 
+static inline lv_image_dsc_t * lv_canvas_get_image(lv_obj_t * obj)
+{
+    return (lv_image_dsc_t *)lv_canvas_get_draw_buf(obj);
+}
+
 /**
  * Get a pixel's color and opacity
  * @param obj   pointer to a canvas
@@ -116,38 +105,10 @@ lv_draw_buf_t * lv_canvas_get_draw_buf(lv_obj_t * obj);
  */
 lv_color32_t lv_canvas_get_px(lv_obj_t * obj, int32_t x, int32_t y);
 
-/**
- * Get the image of the canvas as a pointer to an `lv_image_dsc_t` variable.
- * @param canvas    pointer to a canvas object
- * @return          pointer to the image descriptor.
- */
-lv_image_dsc_t * lv_canvas_get_image(lv_obj_t * canvas);
-
-/**
- * Return the pointer for the buffer.
- * It's recommended to use this function instead of the buffer form the
- * return value of lv_canvas_get_image() as is can be aligned
- * @param canvas    pointer to a canvas object
- * @return          pointer to the buffer
- */
-const void * lv_canvas_get_buf(lv_obj_t * canvas);
-
 /*=====================
  * Other functions
  *====================*/
 
-/**
- * Copy a buffer to the canvas
- * @param canvas    pointer to a canvas object
- * @param to_copy   buffer to copy. The color format has to match with the canvas's buffer color
- * format
- * @param x     left side of the destination position
- * @param y     top side of the destination position
- * @param w     width of the buffer to copy
- * @param h     height of the buffer to copy
- */
-void lv_canvas_copy_buf(lv_obj_t * canvas, const void * to_copy, int32_t x, int32_t y, int32_t w,
-                        int32_t h);
 /**
  * Fill the canvas with color
  * @param canvas    pointer to a canvas


### PR DESCRIPTION
### Description of the feature or fix

TO DO:
- [x] Hide draw_buf structure members, standardize life cycle management.
- [x] Add custom draw buffer support.
- [x] Unify the canvas setting draw buffer method to completely solve the problem of buffer release ownership rights.
- [x] `lv_display` uses `lv_draw_buf` to manage buffers.
- [x] `lv_layer` uses `lv_draw_buf` to manage buffers.
- [ ] `lv_font` uses `lv_draw_buf` to manage buffers.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
