### PR TITLE
chore: fix build warning using LV_UNUSED

### DIFF
--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -79,6 +79,10 @@ static void * buf_align(void * buf, lv_color_format_t color_format)
 
 static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area)
 {
+    LV_UNUSED(buf);
+    LV_UNUSED(stride);
+    LV_UNUSED(color_format);
+    LV_UNUSED(area);
 }
 
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)

--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -204,6 +204,8 @@ void lv_vg_lite_path_get_bonding_box(lv_vg_lite_path_t * path,
 
 static void path_bounds_iter_cb(void * user_data, uint8_t op_code, const float * data, uint32_t len)
 {
+    LV_UNUSED(op_code);
+
     if(len == 0) {
         return;
     }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -251,6 +251,8 @@ const char * lv_vg_lite_vlc_op_string(uint8_t vlc_op)
 
 static void path_data_print_cb(void * user_data, uint8_t op_code, const float * data, uint32_t len)
 {
+    LV_UNUSED(user_data);
+
     LV_LOG("%s, ", lv_vg_lite_vlc_op_string(op_code));
     for(uint32_t i = 0; i < len; i++) {
         LV_LOG("%0.2f, ", data[i]);

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -63,6 +63,8 @@ static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_
 
 lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_context_t * ctx)
 {
+    LV_UNUSED(ctx);
+
     lv_freetype_cache_context_t * cache_ctx = lv_malloc(sizeof(lv_freetype_cache_context_t));
     LV_ASSERT_MALLOC(cache_ctx);
     lv_memzero(cache_ctx, sizeof(lv_freetype_cache_context_t));


### PR DESCRIPTION
### Description of the feature or fix

fix build warning using LV_UNUSED

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
