### PR TITLE
chore: refactor tiny_ttf file structure

### DIFF
--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -1,9 +1,18 @@
-#include "lv_tiny_ttf.h"
-#if LV_USE_TINY_TTF
-#include <stdio.h>
-#include "../../core/lv_global.h"
+/**
+* @file lv_tiny_ttf.c
+*
+*/
+
+/*********************
+ *      INCLUDES
+ *********************/
 #include "lv_tiny_ttf.h"
 
+#if LV_USE_TINY_TTF
+
+/*********************
+ *      DEFINES
+ *********************/
 #define STB_RECT_PACK_IMPLEMENTATION
 #define STBRP_STATIC
 #define STBTT_STATIC
@@ -14,9 +23,12 @@
 #define STBTT_malloc(x, u) ((void)(u), lv_malloc(x))
 #define STBTT_free(x, u) ((void)(u), lv_free(x))
 
-#define tiny_ttf_cache LV_GLOBAL_DEFAULT()->tiny_ttf_cache
-
 #if LV_TINY_TTF_FILE_SUPPORT != 0
+/* for stream support */
+#define STBTT_STREAM_TYPE ttf_cb_stream_t *
+#define STBTT_STREAM_SEEK(s, x) ttf_cb_stream_seek(s, x);
+#define STBTT_STREAM_READ(s, x, y) ttf_cb_stream_read(s, x, y);
+
 /* a hydra stream that can be in memory or from a file*/
 typedef struct ttf_cb_stream {
     lv_fs_file_t * file;
@@ -25,6 +37,142 @@ typedef struct ttf_cb_stream {
     size_t position;
 } ttf_cb_stream_t;
 
+static void ttf_cb_stream_read(ttf_cb_stream_t * stream, void * data, size_t to_read);
+static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position);
+#endif
+
+#include "stb_rect_pack.h"
+#include "stb_truetype_htcw.h"
+
+#define tiny_ttf_cache LV_GLOBAL_DEFAULT()->tiny_ttf_cache
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef struct ttf_font_desc {
+    lv_fs_file_t file;
+#if LV_TINY_TTF_FILE_SUPPORT != 0
+    ttf_cb_stream_t stream;
+#else
+    const uint8_t * stream;
+#endif
+    stbtt_fontinfo info;
+    float scale;
+    int ascent;
+    int descent;
+} ttf_font_desc_t;
+
+typedef struct _tiny_ttf_cache_data_t {
+    lv_font_t * font;
+    uint32_t unicode;
+    uint32_t size;
+
+    uint8_t * buffer;
+    uint32_t buffer_size;
+} tiny_ttf_cache_data_t;
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
+                                 uint32_t unicode_letter_next);
+static const uint8_t * ttf_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                               uint32_t unicode_letter, uint8_t * bitmap_buf);
+static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
+static lv_result_t lv_tiny_ttf_create(lv_font_t * out_font, const char * path, const void * data, size_t data_size,
+                                      int32_t font_size,
+                                      size_t cache_size);
+
+static bool tiny_ttf_cache_create_cb(tiny_ttf_cache_data_t * node, void * user_data);
+static void tiny_ttf_cache_free_cb(tiny_ttf_cache_data_t * node, void * user_data);
+static lv_cache_compare_res_t tiny_ttf_cache_compare_cb(const tiny_ttf_cache_data_t * lhs,
+                                                        const tiny_ttf_cache_data_t * rhs);
+/**********************
+ *  GLOBAL VARIABLES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+lv_result_t lv_tiny_ttf_create_data_ex(lv_font_t * font, const void * data, size_t data_size, int32_t font_size,
+                                       size_t cache_size)
+{
+    return lv_tiny_ttf_create(font, NULL, data, data_size, font_size, cache_size);
+}
+
+lv_result_t lv_tiny_ttf_create_data(lv_font_t * font, const void * data, size_t data_size, int32_t font_size)
+{
+    return lv_tiny_ttf_create(font, NULL, data, data_size, font_size, 0);
+}
+
+void lv_tiny_ttf_set_size(lv_font_t * font, int32_t font_size)
+{
+    if(font_size <= 0) {
+        LV_LOG_ERROR("invalid font size: %"PRIx32, font_size);
+        return;
+    }
+    ttf_font_desc_t * dsc = (ttf_font_desc_t *)font->dsc;
+    dsc->scale = stbtt_ScaleForMappingEmToPixels(&dsc->info, font_size);
+    int line_gap = 0;
+    stbtt_GetFontVMetrics(&dsc->info, &dsc->ascent, &dsc->descent, &line_gap);
+    font->line_height = (int32_t)(dsc->scale * (dsc->ascent - dsc->descent + line_gap));
+    font->base_line = (int32_t)(dsc->scale * (line_gap - dsc->descent));
+}
+
+void lv_tiny_ttf_destroy(lv_font_t * font)
+{
+    if(font != NULL) {
+        if(font->dsc != NULL) {
+            ttf_font_desc_t * ttf = (ttf_font_desc_t *)font->dsc;
+#if LV_TINY_TTF_FILE_SUPPORT != 0
+            if(ttf->stream.file != NULL) {
+                lv_fs_close(&ttf->file);
+            }
+#endif
+            lv_cache_drop_all(tiny_ttf_cache, (void *)font->dsc);
+            lv_free(ttf);
+            font->dsc = NULL;
+        }
+    }
+}
+
+void lv_tiny_ttf_init(void)
+{
+    lv_cache_ops_t ops = {
+        .compare_cb = (lv_cache_compare_cb_t)tiny_ttf_cache_compare_cb,
+        .create_cb = (lv_cache_create_cb_t)tiny_ttf_cache_create_cb,
+        .free_cb = (lv_cache_free_cb_t)tiny_ttf_cache_free_cb,
+    };
+
+    tiny_ttf_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t), 128, ops);
+}
+
+void lv_tiny_ttf_deinit(void)
+{
+    lv_cache_destroy(tiny_ttf_cache, NULL);
+}
+
+#if LV_TINY_TTF_FILE_SUPPORT != 0
+lv_result_t lv_tiny_ttf_create_file_ex(lv_font_t * font, const char * path, int32_t font_size, size_t cache_size)
+{
+    return lv_tiny_ttf_create(font, path, NULL, 0, font_size, cache_size);
+}
+lv_result_t lv_tiny_ttf_create_file(lv_font_t * font, const char * path, int32_t font_size)
+{
+    return lv_tiny_ttf_create(font, path, NULL, 0, font_size, 0);
+}
+#endif
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#if LV_TINY_TTF_FILE_SUPPORT != 0
 static void ttf_cb_stream_read(ttf_cb_stream_t * stream, void * data, size_t to_read)
 {
     if(stream->file != NULL) {
@@ -53,42 +201,7 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position)
         }
     }
 }
-
-/* for stream support */
-#define STBTT_STREAM_TYPE ttf_cb_stream_t *
-#define STBTT_STREAM_SEEK(s, x) ttf_cb_stream_seek(s, x);
-#define STBTT_STREAM_READ(s, x, y) ttf_cb_stream_read(s, x, y);
 #endif
-
-#include "stb_rect_pack.h"
-#include "stb_truetype_htcw.h"
-
-typedef struct ttf_font_desc {
-    lv_fs_file_t file;
-#if LV_TINY_TTF_FILE_SUPPORT != 0
-    ttf_cb_stream_t stream;
-#else
-    const uint8_t * stream;
-#endif
-    stbtt_fontinfo info;
-    float scale;
-    int ascent;
-    int descent;
-} ttf_font_desc_t;
-
-typedef struct _tiny_ttf_cache_data_t {
-    lv_font_t * font;
-    uint32_t unicode;
-    uint32_t size;
-
-    uint8_t * buffer;
-    uint32_t buffer_size;
-} tiny_ttf_cache_data_t;
-
-static bool tiny_ttf_cache_create_cb(tiny_ttf_cache_data_t * node, void * user_data);
-static void tiny_ttf_cache_free_cb(tiny_ttf_cache_data_t * node, void * user_data);
-static lv_cache_compare_res_t tiny_ttf_cache_compare_cb(const tiny_ttf_cache_data_t * lhs,
-                                                        const tiny_ttf_cache_data_t * rhs);
 
 static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                  uint32_t unicode_letter_next)
@@ -220,70 +333,10 @@ static lv_result_t lv_tiny_ttf_create(lv_font_t * out_font, const char * path, c
     lv_tiny_ttf_set_size(out_font, font_size);
     return LV_RESULT_OK;
 }
-#if LV_TINY_TTF_FILE_SUPPORT != 0
-lv_result_t lv_tiny_ttf_create_file_ex(lv_font_t * font, const char * path, int32_t font_size, size_t cache_size)
-{
-    return lv_tiny_ttf_create(font, path, NULL, 0, font_size, cache_size);
-}
-lv_result_t lv_tiny_ttf_create_file(lv_font_t * font, const char * path, int32_t font_size)
-{
-    return lv_tiny_ttf_create(font, path, NULL, 0, font_size, 0);
-}
-#endif
-lv_result_t lv_tiny_ttf_create_data_ex(lv_font_t * font, const void * data, size_t data_size, int32_t font_size,
-                                       size_t cache_size)
-{
-    return lv_tiny_ttf_create(font, NULL, data, data_size, font_size, cache_size);
-}
-lv_result_t lv_tiny_ttf_create_data(lv_font_t * font, const void * data, size_t data_size, int32_t font_size)
-{
-    return lv_tiny_ttf_create(font, NULL, data, data_size, font_size, 0);
-}
-void lv_tiny_ttf_set_size(lv_font_t * font, int32_t font_size)
-{
-    if(font_size <= 0) {
-        LV_LOG_ERROR("invalid font size: %"PRIx32, font_size);
-        return;
-    }
-    ttf_font_desc_t * dsc = (ttf_font_desc_t *)font->dsc;
-    dsc->scale = stbtt_ScaleForMappingEmToPixels(&dsc->info, font_size);
-    int line_gap = 0;
-    stbtt_GetFontVMetrics(&dsc->info, &dsc->ascent, &dsc->descent, &line_gap);
-    font->line_height = (int32_t)(dsc->scale * (dsc->ascent - dsc->descent + line_gap));
-    font->base_line = (int32_t)(dsc->scale * (line_gap - dsc->descent));
-}
-void lv_tiny_ttf_destroy(lv_font_t * font)
-{
-    if(font != NULL) {
-        if(font->dsc != NULL) {
-            ttf_font_desc_t * ttf = (ttf_font_desc_t *)font->dsc;
-#if LV_TINY_TTF_FILE_SUPPORT != 0
-            if(ttf->stream.file != NULL) {
-                lv_fs_close(&ttf->file);
-            }
-#endif
-            lv_cache_drop_all(tiny_ttf_cache, (void *)font->dsc);
-            lv_free(ttf);
-            font->dsc = NULL;
-        }
-    }
-}
 
-void lv_tiny_ttf_init(void)
-{
-    lv_cache_ops_t ops = {
-        .compare_cb = (lv_cache_compare_cb_t)tiny_ttf_cache_compare_cb,
-        .create_cb = (lv_cache_create_cb_t)tiny_ttf_cache_create_cb,
-        .free_cb = (lv_cache_free_cb_t)tiny_ttf_cache_free_cb,
-    };
-
-    tiny_ttf_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t), 128, ops);
-}
-
-void lv_tiny_ttf_deinit(void)
-{
-    lv_cache_destroy(tiny_ttf_cache, NULL);
-}
+/*-----------------
+ * Cache Callbacks
+ *----------------*/
 
 static bool tiny_ttf_cache_create_cb(tiny_ttf_cache_data_t * node, void * user_data)
 {

--- a/src/libs/tiny_ttf/lv_tiny_ttf.h
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_templ.h
+ * @file lv_tiny_ttf.h
  *
  */
 


### PR DESCRIPTION
### Description of the feature or fix

refactor tiny_ttf file structure

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
