### PR TITLE
docs(image): fix expression formatting, and correct names

### DIFF
--- a/docs/overview/img.rst
+++ b/docs/overview/img.rst
@@ -162,7 +162,7 @@ The simplest way to use an image in LVGL is to display it with an
    lv_image_set_src(icon, "S:my_icon.bin");
 
 If the image was converted with the online converter, you should use
-:cpp:expr:`LV_IMG_DECLARE(my_icon_dsc)` to declare the image in the file where
+:cpp:expr:`LV_IMAGE_DECLARE(my_icon_dsc)` to declare the image in the file where
 you want to use it.
 
 Image decoder

--- a/docs/widgets/image.rst
+++ b/docs/widgets/image.rst
@@ -1,4 +1,4 @@
-Image (lv_img)
+Image (lv_image)
 ==============
 
 Overview
@@ -34,7 +34,7 @@ To set the source of an image, use :cpp:expr:`lv_image_set_src(img, src)`.
 To generate a pixel array from a PNG, JPG or BMP image, use the `Online image converter tool <https://lvgl.io/tools/imageconverter>`__
 and set the converted image with its pointer  :cpp:expr:`lv_image_set_src(img1, &converted_img_var)`
 To make the variable visible in the C file, you need to declare it with
-:cpp:expr:`LV_IMG_DECLARE(converted_img_var)`.
+:cpp:expr:`LV_IMAGE_DECLARE(converted_img_var)`.
 
 To use external files, you also need to convert the image files using
 the online converter tool but now you should select the binary output
@@ -152,23 +152,23 @@ It means the the widget will be sized automatically according to the image sourc
 If the widget's width or height is set the smaller value the ``align`` property tells
 how to align the image source inside the widget. The alignment set any of these:
 
-- :cpp:expr`LV_IMAGE_ALIGN_DEFAULT` Meaning top left
-- :cpp:expr`LV_IMAGE_ALIGN_TOP_LEFT`
-- :cpp:expr`LV_IMAGE_ALIGN_TOP_MID`
-- :cpp:expr`LV_IMAGE_ALIGN_TOP_RIGHT`
-- :cpp:expr`LV_IMAGE_ALIGN_BOTTOM_LEFT`
-- :cpp:expr`LV_IMAGE_ALIGN_BOTTOM_MID`
-- :cpp:expr`LV_IMAGE_ALIGN_BOTTOM_RIGHT`
-- :cpp:expr`LV_IMAGE_ALIGN_LEFT_MID`
-- :cpp:expr`LV_IMAGE_ALIGN_RIGHT_MID`
-- :cpp:expr`LV_IMAGE_ALIGN_CENTER`
+- :cpp:expr:`LV_IMAGE_ALIGN_DEFAULT` Meaning top left
+- :cpp:expr:`LV_IMAGE_ALIGN_TOP_LEFT`
+- :cpp:expr:`LV_IMAGE_ALIGN_TOP_MID`
+- :cpp:expr:`LV_IMAGE_ALIGN_TOP_RIGHT`
+- :cpp:expr:`LV_IMAGE_ALIGN_BOTTOM_LEFT`
+- :cpp:expr:`LV_IMAGE_ALIGN_BOTTOM_MID`
+- :cpp:expr:`LV_IMAGE_ALIGN_BOTTOM_RIGHT`
+- :cpp:expr:`LV_IMAGE_ALIGN_LEFT_MID`
+- :cpp:expr:`LV_IMAGE_ALIGN_RIGHT_MID`
+- :cpp:expr:`LV_IMAGE_ALIGN_CENTER`
 
-The ``offset`` value is applied after the image source is aligned. For example setting an ``y=-10`` and :cpp:expr`LV_IMAGE_ALIGN_CENTER`
+The ``offset`` value is applied after the image source is aligned. For example setting an ``y=-10`` and :cpp:expr:`LV_IMAGE_ALIGN_CENTER`
 will move the image source up a little bit from the center of the widget.
 
 Or to automatically scale or tile the image
-- :cpp:expr`LV_IMAGE_ALIGN_STRETCH` Set X and Y scale to fill the widget's area
-- :cpp:expr`LV_IMAGE_ALIGN_TILE` Tile the image to will the widget area. Offset is applied to shift the tiling.
+- :cpp:expr:`LV_IMAGE_ALIGN_STRETCH` Set X and Y scale to fill the widget's area
+- :cpp:expr:`LV_IMAGE_ALIGN_TILE` Tile the image to will the widget area. Offset is applied to shift the tiling.
 
 The alignment can be set by :cpp:func:`lv_image_set_align(image, align)`
 


### PR DESCRIPTION
### Description of the feature or fix

Fix image documentation:
- fix expression formatting
- correct names

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
