### PR TITLE
feat(freetype): refactoring freetype to make glyph dsc independent

### DIFF
--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -50,7 +50,8 @@ typedef struct {
     uint8_t bpp: 4;  /**< Bit-per-pixel: 1, 2, 4, 8*/
     uint8_t is_placeholder: 1; /** Glyph is missing. But placeholder will still be displayed */
 
-    lv_cache_entry_t * entry;
+    uint32_t glyph_index; /**< The index of the glyph in the font file. Used by the font cache*/
+    lv_cache_entry_t * entry; /**< The cache entry of the glyph draw data. Used by the font cache*/
 } lv_font_glyph_dsc_t;
 
 /** The bitmaps might be upscaled by 3 to achieve subpixel rendering.*/

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -157,6 +157,8 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint32_t size, lv_fre
     font->underline_position = FT_F26DOT6_TO_INT(FT_MulFix(scale, ft_size->face->underline_position));
     font->underline_thickness = thickness < 1 ? 1 : thickness;
 
+    lv_freetype_on_glyph_cache_create(dsc);
+
     return font;
 }
 

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -171,6 +171,7 @@ void lv_freetype_font_delete(lv_font_t * font)
 
     lv_freetype_on_font_delete(dsc);
     lv_freetype_drop_face_id(dsc->context, dsc->face_id);
+    lv_freetype_on_glyph_cache_delete(dsc);
 
     /* invalidate magic number */
     lv_memzero(dsc, sizeof(lv_freetype_font_dsc_t));

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -157,8 +157,6 @@ lv_font_t * lv_freetype_font_create(const char * pathname, uint32_t size, lv_fre
     font->underline_position = FT_F26DOT6_TO_INT(FT_MulFix(scale, ft_size->face->underline_position));
     font->underline_thickness = thickness < 1 ? 1 : thickness;
 
-    lv_freetype_on_glyph_cache_create(dsc);
-
     return font;
 }
 
@@ -171,7 +169,6 @@ void lv_freetype_font_delete(lv_font_t * font)
 
     lv_freetype_on_font_delete(dsc);
     lv_freetype_drop_face_id(dsc->context, dsc->face_id);
-    lv_freetype_on_glyph_cache_delete(dsc);
 
     /* invalidate magic number */
     lv_memzero(dsc, sizeof(lv_freetype_font_dsc_t));

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -46,7 +46,7 @@ static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-lv_cache_t * lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc)
+lv_cache_t * lv_freetype_glyph_cache_create(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
@@ -70,7 +70,7 @@ lv_cache_t * lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc)
     return cache;
 }
 
-void lv_freetype_on_glyph_cache_delete(lv_cache_t * cache)
+void lv_freetype_glyph_cache_delete(lv_cache_t * cache)
 {
     lv_cache_destroy(cache, NULL);
 }

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -68,6 +68,13 @@ bool lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc)
     return true;
 }
 
+bool lv_freetype_on_glyph_cache_delete(lv_freetype_font_dsc_t * dsc)
+{
+    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
+    lv_cache_destroy(dsc->context->glyph_cache, NULL);
+    return true;
+}
+
 static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
                                       uint32_t unicode_letter_next)
 {

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -12,6 +12,8 @@
 /*********************
  *      DEFINES
  *********************/
+#if LV_USE_FREETYPE
+
 #define LV_FREETYPE_GLYPH_DSC_CACHE_SIZE (LV_FREETYPE_CACHE_FT_OUTLINES * 2)
 /**********************
  *      TYPEDEFS
@@ -179,3 +181,4 @@ static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_
     }
     return 0;
 }
+#endif

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -153,12 +153,24 @@ static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void
 
     FT_GlyphSlot glyph = ft_size->face->glyph;
 
+#if LV_FREETYPE_CACHE_TYPE == LV_FREETYPE_CACHE_TYPE_OUTLINE
     dsc_out->adv_w = FT_F26DOT6_TO_INT(glyph->metrics.horiAdvance);
     dsc_out->box_h = FT_F26DOT6_TO_INT(glyph->metrics.height);          /*Height of the bitmap in [px]*/
     dsc_out->box_w = FT_F26DOT6_TO_INT(glyph->metrics.width);           /*Width of the bitmap in [px]*/
     dsc_out->ofs_x = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingX);    /*X offset of the bitmap in [pf]*/
     dsc_out->ofs_y = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingY -
                                        glyph->metrics.height);          /*Y offset of the bitmap measured from the as line*/
+#elif LV_FREETYPE_CACHE_TYPE == LV_FREETYPE_CACHE_TYPE_BITMAP
+    FT_Bitmap * glyph_bitmap = &ft_size->face->glyph->bitmap;
+
+    dsc_out->adv_w = FT_F26DOT6_TO_INT(glyph->advance.x);        /*Width of the glyph in [pf]*/
+    dsc_out->box_h = glyph_bitmap->rows;                         /*Height of the bitmap in [px]*/
+    dsc_out->box_w = glyph_bitmap->width;                        /*Width of the bitmap in [px]*/
+    dsc_out->ofs_x = glyph->bitmap_left;                         /*X offset of the bitmap in [pf]*/
+    dsc_out->ofs_y = glyph->bitmap_top -
+                     dsc_out->box_h;                             /*Y offset of the bitmap measured from the as line*/
+#endif
+
     dsc_out->bpp = 8; /*Bit per pixel: 1/2/4/8*/
     dsc_out->is_placeholder = glyph_index == 0;
     dsc_out->glyph_index = glyph_index;

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -1,0 +1,174 @@
+/**
+ * @file lv_freetype_glyph.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_freetype_private.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+#define LV_FREETYPE_GLYPH_DSC_CACHE_SIZE (LV_FREETYPE_CACHE_FT_OUTLINES * 2)
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef struct _lv_freetype_glyph_cache_data_t {
+    uint32_t unicode;
+    uint32_t size;
+
+    lv_font_glyph_dsc_t glyph_dsc;
+} lv_freetype_glyph_cache_data_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                      uint32_t unicode_letter_next);
+
+static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
+static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
+static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_cache_data_t * lhs,
+                                                        const lv_freetype_glyph_cache_data_t * rhs);
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+bool lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc)
+{
+    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
+
+    lv_cache_ops_t ops = {
+        .create_cb = (lv_cache_create_cb_t)freetype_glyph_create_cb,
+        .free_cb = (lv_cache_free_cb_t)freetype_glyph_free_cb,
+        .compare_cb = (lv_cache_compare_cb_t)freetype_glyph_compare_cb,
+    };
+
+    dsc->context->glyph_cache = lv_cache_create(&lv_cache_class_lru_rb_count
+                                                , sizeof(lv_freetype_glyph_cache_data_t),
+                                                LV_FREETYPE_GLYPH_DSC_CACHE_SIZE,
+                                                ops
+                                               );
+    if(dsc->context->glyph_cache == NULL) {
+        LV_LOG_ERROR("lv_cache_create failed");
+        return false;
+    }
+
+    dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
+    return true;
+}
+
+static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                      uint32_t unicode_letter_next)
+{
+    LV_ASSERT_NULL(font);
+    LV_ASSERT_NULL(g_dsc);
+
+    if(unicode_letter < 0x20) {
+        g_dsc->adv_w = 0;
+        g_dsc->box_h = 0;
+        g_dsc->box_w = 0;
+        g_dsc->ofs_x = 0;
+        g_dsc->ofs_y = 0;
+        g_dsc->bpp = 0;
+        return true;
+    }
+
+    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
+    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
+
+    lv_freetype_glyph_cache_data_t search_key = {
+        .unicode = unicode_letter,
+        .size = dsc->size,
+    };
+
+    lv_cache_entry_t * entry = lv_cache_acquire_or_create(dsc->context->glyph_cache, &search_key, dsc);
+    if(entry == NULL) {
+        LV_LOG_ERROR("glyph lookup failed for unicode = %u", unicode_letter);
+        return false;
+    }
+    lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);
+    *g_dsc = data->glyph_dsc;
+
+    if((dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) && (unicode_letter_next == '\0')) {
+        g_dsc->adv_w = g_dsc->box_w + g_dsc->ofs_x;
+    }
+
+    g_dsc->entry = NULL;
+
+    lv_cache_release(dsc->context->glyph_cache, entry, NULL);
+    return true;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/*-----------------
+ * Cache Callbacks
+ *----------------*/
+
+static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void * user_data)
+{
+    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)user_data;
+
+    FT_Error error;
+
+    FT_Size ft_size = lv_freetype_lookup_size(dsc);
+    if(!ft_size) {
+        return false;
+    }
+
+    lv_font_glyph_dsc_t * dsc_out = &data->glyph_dsc;
+
+    FT_Face face = ft_size->face;
+    FT_UInt charmap_index = FT_Get_Charmap_Index(face->charmap);
+    FT_UInt glyph_index = FTC_CMapCache_Lookup(dsc->context->cmap_cache, dsc->face_id, charmap_index, data->unicode);
+
+    FT_Set_Pixel_Sizes(face, 0, dsc->size);
+    error = FT_Load_Glyph(face, glyph_index,  FT_LOAD_COMPUTE_METRICS | FT_LOAD_NO_BITMAP);
+    if(error) {
+        FT_ERROR_MSG("FT_Load_Glyph", error);
+        return false;
+    }
+
+    FT_GlyphSlot glyph = ft_size->face->glyph;
+
+    dsc_out->adv_w = FT_F26DOT6_TO_INT(glyph->metrics.horiAdvance);
+    dsc_out->box_h = FT_F26DOT6_TO_INT(glyph->metrics.height);          /*Height of the bitmap in [px]*/
+    dsc_out->box_w = FT_F26DOT6_TO_INT(glyph->metrics.width);           /*Width of the bitmap in [px]*/
+    dsc_out->ofs_x = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingX);    /*X offset of the bitmap in [pf]*/
+    dsc_out->ofs_y = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingY -
+                                       glyph->metrics.height);          /*Y offset of the bitmap measured from the as line*/
+    dsc_out->bpp = 8; /*Bit per pixel: 1/2/4/8*/
+    dsc_out->is_placeholder = glyph_index == 0;
+    dsc_out->glyph_index = glyph_index;
+
+    return true;
+}
+static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void * user_data)
+{
+    LV_UNUSED(data);
+    LV_UNUSED(user_data);
+}
+static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_cache_data_t * lhs,
+                                                        const lv_freetype_glyph_cache_data_t * rhs)
+{
+    if(lhs->unicode != rhs->unicode) {
+        return lhs->unicode > rhs->unicode ? 1 : -1;
+    }
+    if(lhs->size != rhs->size) {
+        return lhs->size > rhs->size ? 1 : -1;
+    }
+    return 0;
+}

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -111,8 +111,6 @@ bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc)
 void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-
-    lv_cache_destroy(dsc->context->glyph_cache, NULL);
 }
 
 /**********************

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -108,7 +108,7 @@ bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc)
 
     cache_node->image_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_image_cache_data_t),
                                               LV_FREETYPE_CACHE_FT_OUTLINES, ops);
-    cache_node->glyph_cache = lv_freetype_on_glyph_cache_create(dsc);
+    cache_node->glyph_cache = lv_freetype_glyph_cache_create(dsc);
     if(cache_node->image_cache == NULL || cache_node->glyph_cache == NULL) {
         LV_LOG_ERROR("lv_cache_create failed");
         return NULL;
@@ -123,7 +123,7 @@ void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
     lv_cache_destroy(dsc->cache_node->image_cache, NULL);
-    lv_freetype_on_glyph_cache_delete(dsc->cache_node->glyph_cache);
+    lv_freetype_glyph_cache_delete(dsc->cache_node->glyph_cache);
     lv_free(dsc->cache_node);
 }
 

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -111,6 +111,8 @@ bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc)
 void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
+
+    lv_cache_destroy(dsc->context->glyph_cache, NULL);
 }
 
 /**********************

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -17,8 +17,6 @@
 
 #define LV_FREETYPE_OUTLINE_REF_SIZE_DEF 128
 
-#define LV_FREETYPE_GLYPH_DSC_CACHE_SIZE (LV_FREETYPE_CACHE_FT_OUTLINES * 2)
-
 #if LV_FREETYPE_CACHE_FT_OUTLINES <= 0
     #error "LV_FREETYPE_CACHE_FT_OUTLINES must be greater than 0"
 #endif
@@ -34,12 +32,6 @@ struct _lv_freetype_cache_context_t {
     void * user_data;
 };
 
-typedef struct _lv_freetype_glyph_dsc_node_t {
-    FT_UInt glyph_index;
-    uint32_t size;
-    lv_font_glyph_dsc_t glyph_dsc;
-} lv_freetype_glyph_dsc_node_t;
-
 struct _lv_freetype_cache_node_t {
     lv_freetype_cache_context_t * cache_context;
 
@@ -51,10 +43,6 @@ struct _lv_freetype_cache_node_t {
     /*glyph outline cache*/
     lv_cache_t * glyph_outline_cache;
     int outline_cnt;
-
-    /*glyph size cache*/
-    lv_cache_t * glyph_dsc_cache;
-    int dsc_cnt;
 };
 
 typedef struct _lv_freetype_outline_node_t {
@@ -69,8 +57,6 @@ typedef struct _lv_freetype_outline_node_t {
 static lv_freetype_outline_t outline_create(lv_freetype_context_t * ctx, FT_Face face, FT_UInt glyph_index,
                                             uint32_t size, uint32_t strength);
 static lv_result_t outline_delete(lv_freetype_cache_context_t * cache_context, lv_freetype_outline_t outline);
-static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
-                                      uint32_t unicode_letter_next);
 static const uint8_t * freetype_get_glyph_bitmap_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
                                                     uint32_t unicode_letter,
                                                     uint8_t * bitmap_out);
@@ -86,12 +72,6 @@ static bool freetype_glyph_outline_create_cb(lv_freetype_outline_node_t * node, 
 static void freetype_glyph_outline_free_cb(lv_freetype_outline_node_t * node, lv_freetype_font_dsc_t * dsc);
 static lv_cache_compare_res_t freetype_glyph_outline_cmp_cb(const lv_freetype_outline_node_t * node_a,
                                                             const lv_freetype_outline_node_t * node_b);
-
-/*glyph dsc cache lru callbacks*/
-static bool freetype_glyph_dsc_create_cb(lv_freetype_glyph_dsc_node_t * glyph_dsc_node, lv_freetype_font_dsc_t * dsc);
-static void freetype_glyph_dsc_free_cb(lv_freetype_glyph_dsc_node_t * glyph_dsc_node, lv_freetype_font_dsc_t * dsc);
-static lv_cache_compare_res_t freetype_glyph_dsc_cmp_cb(const lv_freetype_glyph_dsc_node_t * node_a,
-                                                        const lv_freetype_glyph_dsc_node_t * node_b);
 
 /**********************
  *  STATIC VARIABLES
@@ -143,7 +123,6 @@ bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
     dsc->cache_node = lv_freetype_cache_node_lookup(dsc->context, lv_freetype_get_pathname(dsc->face_id), dsc->style);
-    dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
     dsc->font.get_glyph_bitmap = freetype_get_glyph_bitmap_cb;
     dsc->font.release_glyph = freetype_release_glyph_cb;
     return true;
@@ -269,20 +248,12 @@ static lv_freetype_cache_node_t * lv_freetype_cache_node_lookup(lv_freetype_cont
     cache->ref_cnt = 1;
     cache->cache_context = cache_context;
 
-    lv_cache_ops_t glyph_dsc_cache_ops = {
-        .create_cb = (lv_cache_create_cb_t)freetype_glyph_dsc_create_cb,
-        .free_cb = (lv_cache_free_cb_t)freetype_glyph_dsc_free_cb,
-        .compare_cb = (lv_cache_compare_cb_t)freetype_glyph_dsc_cmp_cb,
-    };
     lv_cache_ops_t glyph_outline_cache_ops = {
         .create_cb = (lv_cache_create_cb_t)freetype_glyph_outline_create_cb,
         .free_cb = (lv_cache_free_cb_t)freetype_glyph_outline_free_cb,
         .compare_cb = (lv_cache_compare_cb_t)freetype_glyph_outline_cmp_cb,
     };
 
-    cache->glyph_dsc_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_glyph_dsc_node_t),
-                                             LV_FREETYPE_GLYPH_DSC_CACHE_SIZE,
-                                             glyph_dsc_cache_ops);
     cache->glyph_outline_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_outline_node_t),
                                                  LV_FREETYPE_CACHE_FT_OUTLINES,
                                                  glyph_outline_cache_ops);
@@ -315,110 +286,8 @@ static void lv_freetype_cache_node_drop(lv_freetype_font_dsc_t * dsc)
     lv_ll_t * cache_ll = &cache_node->cache_context->cache_ll;
     _lv_ll_remove(cache_ll, cache_node);
 
-    lv_cache_destroy(cache_node->glyph_dsc_cache, dsc);
     lv_cache_destroy(cache_node->glyph_outline_cache, dsc);
     lv_free(cache_node);
-}
-
-/*-------------------
- *  GLYPH DSC CACHE
- *------------------*/
-
-static bool freetype_glyph_dsc_create_cb(lv_freetype_glyph_dsc_node_t * glyph_dsc_node, lv_freetype_font_dsc_t * dsc)
-{
-    lv_font_glyph_dsc_t * dsc_out = &glyph_dsc_node->glyph_dsc;
-
-    FT_UInt glyph_index = glyph_dsc_node->glyph_index;
-    /* cache miss, load dsc */
-    FT_Size ft_size = lv_freetype_lookup_size(dsc);
-    if(!ft_size) {
-        return false;
-    }
-
-    FT_Error error = FT_Load_Glyph(ft_size->face, glyph_index, FT_LOAD_COMPUTE_METRICS | FT_LOAD_NO_BITMAP);
-    if(error) {
-        FT_ERROR_MSG("FT_Load_Glyph", error);
-        return false;
-    }
-
-    LV_LOG_INFO("glyph_index = %u, cnt = %d", glyph_index, ++dsc->cache_node->dsc_cnt);
-
-    FT_GlyphSlot glyph = ft_size->face->glyph;
-
-    dsc_out->adv_w = FT_F26DOT6_TO_INT(glyph->metrics.horiAdvance);
-    dsc_out->box_h = FT_F26DOT6_TO_INT(glyph->metrics.height);          /*Height of the bitmap in [px]*/
-    dsc_out->box_w = FT_F26DOT6_TO_INT(glyph->metrics.width);           /*Width of the bitmap in [px]*/
-    dsc_out->ofs_x = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingX);    /*X offset of the bitmap in [pf]*/
-    dsc_out->ofs_y = FT_F26DOT6_TO_INT(glyph->metrics.horiBearingY -
-                                       glyph->metrics.height);          /*Y offset of the bitmap measured from the as line*/
-    dsc_out->bpp = 8; /*Bit per pixel: 1/2/4/8*/
-    dsc_out->is_placeholder = glyph_index == 0;
-
-    return true;
-}
-
-static void freetype_glyph_dsc_free_cb(lv_freetype_glyph_dsc_node_t * glyph_dsc_node, lv_freetype_font_dsc_t * dsc)
-{
-    LV_UNUSED(glyph_dsc_node);
-    LV_UNUSED(dsc);
-    LV_LOG_INFO("cnt = %d", --dsc->cache_node->dsc_cnt);
-}
-
-static lv_cache_compare_res_t freetype_glyph_dsc_cmp_cb(const lv_freetype_glyph_dsc_node_t * node_a,
-                                                        const lv_freetype_glyph_dsc_node_t * node_b)
-{
-    if(node_a->glyph_index != node_b->glyph_index)
-        return (node_a->glyph_index > node_b->glyph_index) ? 1 : -1;
-
-    if(node_a->size != node_b->size)
-        return (node_a->size > node_b->size) ? 1 : -1;
-
-    return 0;
-}
-
-static bool freetype_get_glyph_dsc_cb(const lv_font_t * font,
-                                      lv_font_glyph_dsc_t * dsc_out,
-                                      uint32_t unicode_letter,
-                                      uint32_t unicode_letter_next)
-{
-    LV_ASSERT_NULL(font);
-    LV_ASSERT_NULL(dsc_out);
-
-    if(unicode_letter < 0x20) {
-        dsc_out->adv_w = 0;
-        dsc_out->box_h = 0;
-        dsc_out->box_w = 0;
-        dsc_out->ofs_x = 0;
-        dsc_out->ofs_y = 0;
-        dsc_out->bpp = 0;
-        return true;
-    }
-
-    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
-    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-
-    lv_freetype_cache_node_t * cache_node = dsc->cache_node;
-
-    FT_UInt charmap_index = FT_Get_Charmap_Index(cache_node->face->charmap);
-    FT_UInt glyph_index = FTC_CMapCache_Lookup(dsc->context->cmap_cache, dsc->face_id, charmap_index, unicode_letter);
-
-    lv_freetype_glyph_dsc_node_t tmp_node;
-    tmp_node.glyph_index = glyph_index;
-    tmp_node.size = dsc->size;
-
-    lv_cache_entry_t * entry = lv_cache_acquire_or_create(cache_node->glyph_dsc_cache, &tmp_node, dsc);
-    if(entry == NULL) {
-        return false;
-    }
-    lv_freetype_glyph_dsc_node_t * new_node = lv_cache_entry_get_data(entry);
-    *dsc_out = new_node->glyph_dsc;
-
-    if((dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) && (unicode_letter_next == '\0')) {
-        dsc_out->adv_w = dsc_out->box_w + dsc_out->ofs_x;
-    }
-    lv_cache_release(cache_node->glyph_dsc_cache, entry, NULL);
-
-    return true;
 }
 
 /*-------------------

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -105,9 +105,9 @@ lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_conte
 
 void lv_freetype_cache_context_delete(lv_freetype_cache_context_t * cache_ctx);
 
-lv_cache_t * lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
+lv_cache_t * lv_freetype_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
 
-void lv_freetype_on_glyph_cache_delete(lv_cache_t * cache);
+void lv_freetype_glyph_cache_delete(lv_cache_t * cache);
 
 bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc);
 

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -69,6 +69,8 @@ typedef struct _lv_freetype_context_t {
     FTC_CMapCache cmap_cache;
     lv_freetype_cache_context_t * cache_context;
     lv_ll_t face_id_ll;
+
+    lv_cache_t * glyph_cache;
 } lv_freetype_context_t;
 
 typedef struct _lv_freetype_font_dsc_t {
@@ -104,6 +106,8 @@ FT_Size lv_freetype_lookup_size(const lv_freetype_font_dsc_t * dsc);
 lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_context_t * ctx);
 
 void lv_freetype_cache_context_delete(lv_freetype_cache_context_t * cache_ctx);
+
+bool lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
 
 bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc);
 

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -109,6 +109,8 @@ void lv_freetype_cache_context_delete(lv_freetype_cache_context_t * cache_ctx);
 
 bool lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
 
+bool lv_freetype_on_glyph_cache_delete(lv_freetype_font_dsc_t * dsc);
+
 bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc);
 
 void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc);

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -69,8 +69,6 @@ typedef struct _lv_freetype_context_t {
     FTC_CMapCache cmap_cache;
     lv_freetype_cache_context_t * cache_context;
     lv_ll_t face_id_ll;
-
-    lv_cache_t * glyph_cache;
 } lv_freetype_context_t;
 
 typedef struct _lv_freetype_font_dsc_t {
@@ -107,9 +105,9 @@ lv_freetype_cache_context_t * lv_freetype_cache_context_create(lv_freetype_conte
 
 void lv_freetype_cache_context_delete(lv_freetype_cache_context_t * cache_ctx);
 
-bool lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
+lv_cache_t * lv_freetype_on_glyph_cache_create(lv_freetype_font_dsc_t * dsc);
 
-bool lv_freetype_on_glyph_cache_delete(lv_freetype_font_dsc_t * dsc);
+void lv_freetype_on_glyph_cache_delete(lv_cache_t * cache);
 
 bool lv_freetype_on_font_create(lv_freetype_font_dsc_t * dsc);
 
@@ -118,6 +116,8 @@ void lv_freetype_on_font_delete(lv_freetype_font_dsc_t * dsc);
 void lv_freetype_italic_transform(FT_Face face);
 
 const char * lv_freetype_get_pathname(FTC_FaceID face_id);
+
+lv_cache_t * lv_freetype_get_glyph_cache(const lv_freetype_font_dsc_t * dsc);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

Refactoring freetype to make glyph dsc independent

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
