### PR TITLE
feat(draw_buf): add draw_buf init API

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -135,6 +135,27 @@ void lv_draw_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const l
     }
 }
 
+lv_result_t lv_draw_buf_init(lv_draw_buf_t * draw_buf, uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride,
+                             void * data, uint32_t data_size)
+{
+    LV_ASSERT_NULL(draw_buf);
+    if(draw_buf == NULL) return LV_RESULT_INVALID;
+
+    lv_memzero(draw_buf, sizeof(lv_draw_buf_t));
+    if(stride == 0) stride = lv_draw_buf_width_to_stride(w, cf);
+    if(stride * h > data_size) {
+        LV_LOG_WARN("Data size too small, required: %" LV_PRId32 ", provided: %" LV_PRId32, stride * h,
+                    data_size);
+        return LV_RESULT_INVALID;
+    }
+
+    lv_image_header_init(&draw_buf->header, w, h, cf, stride, 0);
+    draw_buf->data = lv_draw_buf_align(data, cf);
+    draw_buf->unaligned_data = data;
+    draw_buf->data_size = data_size;
+    return LV_RESULT_OK;
+}
+
 lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride)
 {
     lv_draw_buf_t * draw_buf = lv_malloc_zeroed(sizeof(lv_draw_buf_t));

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -174,12 +174,26 @@ void lv_draw_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, const l
  * that meets specified requirements.
  *
  * @param w         the buffer width in pixels
- * @param h
+ * @param h         the buffer height in pixels
  * @param cf        the color format for image
  * @param stride    the stride in bytes for image. Use 0 for automatic calculation based on
  *                  w, cf, and global stride alignment configuration.
  */
 lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride);
+
+/**
+ * Initialize a draw buf with the given buffer and parameters.
+ * @param draw_buf  the draw buf to initialize
+ * @param w         the buffer width in pixels
+ * @param h         the buffer height in pixels
+ * @param cf        the color format
+ * @param stride    the stride in bytes. Use 0 for automatic calculation
+ * @param data      the buffer used for drawing. Unaligned `data` will be aligned internally
+ * @param data_size the size of the buffer in bytes
+ * @return          return LV_RESULT_OK on success, LV_RESULT_INVALID otherwise
+ */
+lv_result_t lv_draw_buf_init(lv_draw_buf_t * draw_buf, uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride,
+                             void * data, uint32_t data_size);
 
 /**
  * Duplicate a draw buf with same image size, stride and color format. Copy the image data too.

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -219,10 +219,8 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
 
         lv_draw_buf_t * draw_buf = lv_malloc_zeroed(sizeof(lv_draw_buf_t));
         LV_ASSERT_MALLOC(draw_buf);
-        lv_image_header_init(&draw_buf->header, width, height, cf, stride, LV_VG_LITE_IMAGE_NO_CACHE);
+        lv_draw_buf_init(draw_buf, width, height, cf, stride, (void *)image_data, LV_VG_LITE_IMAGE_NO_CACHE);
         dsc->decoded = draw_buf;
-        draw_buf->data = (void *)image_data;
-        draw_buf->unaligned_data = (void *)image_data;
         return LV_RESULT_OK;
     }
 

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -70,11 +70,7 @@ void lv_canvas_set_buffer(lv_obj_t * obj, void * buf, int32_t w, int32_t h, lv_c
 
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
-    lv_memzero(&canvas->static_buf, sizeof(canvas->static_buf));
-    lv_image_header_init(&canvas->static_buf.header, w, h, cf, stride, 0);
-    canvas->static_buf.data_size = stride * h;
-    canvas->static_buf.data = lv_draw_buf_align(buf, cf);
-    canvas->static_buf.unaligned_data = buf;
+    lv_draw_buf_init(&canvas->static_buf, w, h, cf, stride, buf, stride * h);
     canvas->draw_buf = &canvas->static_buf;
 
     const void * src = lv_image_get_src(obj);


### PR DESCRIPTION

### Description of the feature or fix

It's useful to convert existing memory to draw buffer to match other APIs. Init a draw buf means the memory comes from user, and user should take care of it instead of calling draw_buf_destroy.

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
