### PR TITLE
scale: Update ticks length with length style property

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -737,7 +737,7 @@ static void analytics_create(lv_obj_t * parent)
     lv_scale_set_angle_range(scale2, 360);
     lv_scale_set_text_src(scale2, scale2_text);
     lv_scale_set_total_tick_count(scale2, 11);
-    lv_scale_set_major_tick_length(scale2, 30);
+    lv_obj_set_style_length(scale2, 30, LV_PART_INDICATOR);
     lv_scale_set_major_tick_every(scale2, 1);
     arc = lv_arc_create(scale2);
     lv_obj_set_size(arc, lv_pct(100), lv_pct(100));
@@ -780,8 +780,8 @@ static void analytics_create(lv_obj_t * parent)
     lv_scale_set_range(scale3, 10, 60);
     lv_scale_set_total_tick_count(scale3, 21);
     lv_scale_set_major_tick_every(scale3, 4);
-    lv_scale_set_minor_tick_length(scale3, 10);
-    lv_scale_set_major_tick_length(scale3, 20);
+    lv_obj_set_style_length(scale3, 10, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale3, 20, LV_PART_INDICATOR);
     lv_scale_set_angle_range(scale3, 225);
     lv_scale_set_rotation(scale3, 135);
 

--- a/docs/widgets/scale.rst
+++ b/docs/widgets/scale.rst
@@ -30,7 +30,9 @@ Configure ticks
 
 Set the number of total ticks with :cpp:expr:`lv_scale_set_total_tick_count(scale, total_tick_count)` and then configure the major tick being every Nth ticks with :cpp:expr:`lv_scale_set_major_tick_every(scale, nth_tick)`.
 
-Labels on major ticks can be configured with :cpp:expr:`lv_scale_set_label_show(scale, show_label)`, set `show_label` to true if labels should be drawn, :cpp:expr:`false` to hide them. If instead of a numerical value in the major ticks a text is required they can be set with :cpp:expr:`lv_scale_set_text_src(scale, custom_labels)` using NULL as the last element, i.e. :cpp:expr:`static char * custom_labels[3] = {"One", "Two", NULL};`
+Labels on major ticks can be configured with :cpp:expr:`lv_scale_set_label_show(scale, show_label)`, set `show_label` to true if labels should be drawn, :cpp:expr:`false` to hide them. If instead of a numerical value in the major ticks a text is required they can be set with :cpp:expr:`lv_scale_set_text_src(scale, custom_labels)` using NULL as the last element, i.e. :cpp:expr:`static char * custom_labels[3] = {"One", "Two", NULL};`.
+
+The length of the ticks can be configured with the length style property on the :cpp:enumerator: `LV_PART_INDICATOR` for major ticks and :cpp:enumerator: `LV_PART_ITEMS` for minor ticks, for example with local style: :cpp:expr:`lv_obj_set_style_length(scale, 5, LV_PART_INDICATOR);` for major ticks and :cpp:expr:`lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);` for minor ticks.
 
 Sections
 --------

--- a/examples/widgets/scale/lv_example_scale_1.c
+++ b/examples/widgets/scale/lv_example_scale_1.c
@@ -16,8 +16,8 @@ void lv_example_scale_1(void)
     lv_scale_set_total_tick_count(scale, 31);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 10, 40);
 }
 

--- a/examples/widgets/scale/lv_example_scale_2.c
+++ b/examples/widgets/scale/lv_example_scale_2.c
@@ -15,8 +15,8 @@ void lv_example_scale_2(void)
     lv_scale_set_total_tick_count(scale, 21);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
     lv_scale_set_range(scale, 0, 100);
 
     static const char * custom_labels[] = {"0 °C", "25 °C", "50 °C", "75 °C", "100 °C", NULL};

--- a/examples/widgets/scale/lv_example_scale_3.c
+++ b/examples/widgets/scale/lv_example_scale_3.c
@@ -36,8 +36,8 @@ void lv_example_scale_3(void)
     lv_scale_set_total_tick_count(scale_line, 31);
     lv_scale_set_major_tick_every(scale_line, 5);
 
-    lv_scale_set_major_tick_length(scale_line, 10);
-    lv_scale_set_minor_tick_length(scale_line, 5);
+    lv_obj_set_style_length(scale_line, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale_line, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale_line, 10, 40);
 
     lv_scale_set_angle_range(scale_line, 270);
@@ -73,8 +73,8 @@ void lv_example_scale_3(void)
     lv_scale_set_total_tick_count(scale_img, 31);
     lv_scale_set_major_tick_every(scale_img, 5);
 
-    lv_scale_set_major_tick_length(scale_img, 10);
-    lv_scale_set_minor_tick_length(scale_img, 5);
+    lv_obj_set_style_length(scale_img, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale_img, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale_img, 10, 40);
 
     lv_scale_set_angle_range(scale_img, 270);

--- a/examples/widgets/scale/lv_example_scale_4.c
+++ b/examples/widgets/scale/lv_example_scale_4.c
@@ -15,8 +15,8 @@ void lv_example_scale_4(void)
     lv_scale_set_total_tick_count(scale, 21);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 0, 100);
 
     static const char * custom_labels[] = {"0 °C", "25 °C", "50 °C", "75 °C", "100 °C", NULL};

--- a/examples/widgets/scale/lv_example_scale_5.c
+++ b/examples/widgets/scale/lv_example_scale_5.c
@@ -13,8 +13,8 @@ void lv_example_scale_5(void)
     lv_scale_set_total_tick_count(scale, 10);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 25, 35);
 
     static const char * custom_labels[3] = {"One", "Two", NULL};

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -130,26 +130,6 @@ void lv_scale_set_major_tick_every(lv_obj_t * obj, uint32_t major_tick_every)
     lv_obj_invalidate(obj);
 }
 
-void lv_scale_set_major_tick_length(lv_obj_t * obj, uint32_t major_len)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-    lv_scale_t * scale = (lv_scale_t *)obj;
-
-    scale->major_len = major_len;
-
-    lv_obj_invalidate(obj);
-}
-
-void lv_scale_set_minor_tick_length(lv_obj_t * obj, uint32_t minor_len)
-{
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-    lv_scale_t * scale = (lv_scale_t *)obj;
-
-    scale->minor_len = minor_len;
-
-    lv_obj_invalidate(obj);
-}
-
 void lv_scale_set_label_show(lv_obj_t * obj, bool show_label)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -424,8 +404,6 @@ static void lv_scale_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     scale->rotation = LV_SCALE_DEFAULT_ROTATION;
     scale->range_min = 0U;
     scale->range_max = 100U;
-    scale->major_len = 10U;
-    scale->minor_len = 5u;
     scale->last_tick_width = 0U;
     scale->first_tick_width = 0U;
     scale->post_draw = false;
@@ -514,6 +492,8 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
     lv_draw_line_dsc_t main_line_dsc;
     lv_draw_line_dsc_init(&main_line_dsc);
     lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &main_line_dsc);
+
+    const int32_t major_len = lv_obj_get_style_length(obj, LV_PART_INDICATOR);
 
     if((LV_SCALE_MODE_VERTICAL_LEFT == scale->mode || LV_SCALE_MODE_VERTICAL_RIGHT == scale->mode)
        || (LV_SCALE_MODE_HORIZONTAL_BOTTOM == scale->mode || LV_SCALE_MODE_HORIZONTAL_TOP == scale->mode)) {
@@ -666,10 +646,10 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
 
                 uint32_t radius_text = 0;
                 if(LV_SCALE_MODE_ROUND_INNER == scale->mode) {
-                    radius_text = (radius_edge - scale->major_len) - (label_gap + label_dsc.letter_space);
+                    radius_text = (radius_edge - major_len) - (label_gap + label_dsc.letter_space);
                 }
                 else if(LV_SCALE_MODE_ROUND_OUTER == scale->mode) {
-                    radius_text = (radius_edge + scale->major_len) + (label_gap + label_dsc.letter_space);
+                    radius_text = (radius_edge + major_len) + (label_gap + label_dsc.letter_space);
                 }
                 else { /* Nothing to do */ }
 
@@ -914,10 +894,10 @@ static void scale_get_tick_points(lv_obj_t * obj, const uint32_t tick_idx, bool 
     int32_t major_len = 0;
 
     if(is_major_tick) {
-        major_len = scale->major_len;
+        major_len = lv_obj_get_style_length(obj, LV_PART_INDICATOR);
     }
     else {
-        minor_len = scale->minor_len;
+        minor_len = lv_obj_get_style_length(obj, LV_PART_ITEMS);
     }
 
     if((LV_SCALE_MODE_VERTICAL_LEFT == scale->mode || LV_SCALE_MODE_VERTICAL_RIGHT == scale->mode)

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -22,6 +22,8 @@
 #define LV_SCALE_LABEL_TXT_LEN          (20U)
 #define LV_SCALE_DEFAULT_ANGLE_RANGE    ((uint32_t) 270U)
 #define LV_SCALE_DEFAULT_ROTATION       ((int32_t) 135U)
+#define LV_SCALE_TICK_IDX_DEFAULT_ID    ((uint32_t) 255U)
+#define LV_SCALE_DEFAULT_LABEL_GAP      ((uint32_t) 15U)
 
 /**********************
  *      TYPEDEFS
@@ -295,8 +297,8 @@ lv_scale_section_t * lv_scale_add_section(lv_obj_t * obj)
     section->items_style = NULL;
     section->minor_range = 0U;
     section->major_range = 0U;
-    section->first_tick_idx_in_section = 255U;
-    section->last_tick_idx_in_section = 255U;
+    section->first_tick_idx_in_section = LV_SCALE_TICK_IDX_DEFAULT_ID;
+    section->last_tick_idx_in_section = LV_SCALE_TICK_IDX_DEFAULT_ID;
     section->first_tick_idx_is_major = 0U;
     section->last_tick_idx_is_major = 0U;
     section->first_tick_in_section_width = 0U;
@@ -587,7 +589,7 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
         /* Major tick */
         major_tick_dsc.raw_end = 0;
 
-        uint32_t label_gap = 15U; /* TODO: Add to style properties */
+        uint32_t label_gap = LV_SCALE_DEFAULT_LABEL_GAP; /* TODO: Add to style properties */
         uint32_t tick_idx = 0;
         uint32_t major_tick_idx = 0;
         for(tick_idx = 0; tick_idx < scale->total_tick_count; tick_idx++) {
@@ -1270,7 +1272,7 @@ static void scale_find_section_tick_idx(lv_obj_t * obj)
         lv_scale_section_t * section;
         _LV_LL_READ_BACK(&scale->section_ll, section) {
             if(section->minor_range <= tick_value && section->major_range >= tick_value) {
-                if(section->first_tick_idx_in_section == 255) {
+                if(LV_SCALE_TICK_IDX_DEFAULT_ID == section->first_tick_idx_in_section) {
                     section->first_tick_idx_in_section = tick_idx;
                     section->first_tick_idx_is_major = is_major_tick;
                 }

--- a/src/widgets/scale/lv_scale.h
+++ b/src/widgets/scale/lv_scale.h
@@ -206,7 +206,7 @@ lv_scale_section_t * lv_scale_add_section(lv_obj_t * obj);
 
 /**
  * Set the range for the given scale section
- * @param obj           pointer to a scale section object
+ * @param section       pointer to a scale section object
  * @param minor_range   section new minor range
  * @param major_range   section new major range
  */
@@ -214,7 +214,7 @@ void lv_scale_section_set_range(lv_scale_section_t * section, int32_t minor_rang
 
 /**
  * Set the style of the part for the given scale section
- * @param obj       pointer to a scale section object
+ * @param section   pointer to a scale section object
  * @param part      the part for the section, e.g. LV_PART_INDICATOR
  * @param section_part_style Pointer to the section part style
  */

--- a/src/widgets/scale/lv_scale.h
+++ b/src/widgets/scale/lv_scale.h
@@ -76,8 +76,6 @@ typedef struct {
     lv_ll_t section_ll;     /**< Linked list for the sections (stores lv_scale_section_t)*/
     const char ** txt_src;
     lv_scale_mode_t mode;
-    uint32_t major_len;
-    uint32_t minor_len;
     int32_t range_min;
     int32_t range_max;
     uint32_t total_tick_count   : 15;
@@ -141,20 +139,6 @@ void lv_scale_set_major_tick_every(lv_obj_t * obj, uint32_t major_tick_every);
  * @param show_label    true/false to enable tick label
  */
 void lv_scale_set_label_show(lv_obj_t * obj, bool show_label);
-
-/**
- * Sets major tick length
- * @param obj           pointer the scale object
- * @param major_len     major tick length
- */
-void lv_scale_set_major_tick_length(lv_obj_t * obj, uint32_t major_len);
-
-/**
- * Sets major tick length
- * @param obj           pointer the scale object
- * @param minor_len     minor tick length
- */
-void lv_scale_set_minor_tick_length(lv_obj_t * obj, uint32_t minor_len);
 
 /**
  * Set the minimal and maximal values on a scale

--- a/tests/src/test_cases/widgets/test_scale.c
+++ b/tests/src/test_cases/widgets/test_scale.c
@@ -27,8 +27,8 @@ void test_scale_render_example_1(void)
     lv_scale_set_total_tick_count(scale, 31);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 10, 40);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("scale_1.png");
@@ -46,8 +46,8 @@ void test_scale_render_example_2(void)
     lv_scale_set_total_tick_count(scale, 21);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 0, 100);
 
     static const char * custom_labels[] = {"0 °C", "25 °C", "50 °C", "75 °C", "100 °C", NULL};
@@ -135,8 +135,8 @@ void test_scale_render_example_3(void)
     lv_scale_set_total_tick_count(scale, 11);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 10, 40);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("scale_3.png");
@@ -154,8 +154,8 @@ void test_scale_render_example_4(void)
     lv_scale_set_total_tick_count(scale, 21);
     lv_scale_set_major_tick_every(scale, 5);
 
-    lv_scale_set_major_tick_length(scale, 10);
-    lv_scale_set_minor_tick_length(scale, 5);
+    lv_obj_set_style_length(scale, 5, LV_PART_ITEMS);
+    lv_obj_set_style_length(scale, 10, LV_PART_INDICATOR);
     lv_scale_set_range(scale, 0, 100);
 
     static const char * custom_labels[] = {"0 °C", "25 °C", "50 °C", "75 °C", "100 °C", NULL};


### PR DESCRIPTION
### Description of the feature or fix

Update ticks length with length style property. Related to #5099 

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [x] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
