### PR TITLE
chore(docs): fix some outdated information

### DIFF
--- a/docs/overview/coord.rst
+++ b/docs/overview/coord.rst
@@ -440,9 +440,13 @@ the given layout.
 Built-in layout
 ---------------
 
-LVGL comes with two very powerful layouts: - Flexbox - Grid
+LVGL comes with two very powerful layouts:
+
+* Flexbox: arrange objects into rows or columns, with support for wrapping and expanding items.
+* Grid: arrange objects into fixed positions in 2D table.
 
 Both are heavily inspired by the CSS layouts with the same name.
+Layouts are described in detail in their own section of documentation.
 
 Flags
 -----

--- a/docs/overview/disp.rst
+++ b/docs/overview/disp.rst
@@ -78,8 +78,7 @@ types are `Base object </widgets/obj>`__ and `Image </widgets/img>`__
 (to create a wallpaper).
 
 To create a screen, use
-``lv_obj_t * scr = lv_<type>_create(NULL, copy)``. ``copy`` can be an
-existing screen copied into the new screen.
+``lv_obj_t * scr = lv_<type>_create(NULL)``. `NULL` indicates no parent.
 
 To load a screen, use :cpp:expr:`lv_screen_load(scr)`. To get the active screen,
 use :cpp:expr:`lv_screen_active()`. These functions work on the default display. If

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -98,7 +98,7 @@ struct _lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
  * Used by the user to react on event which happens with the object.
  * An object can have multiple event handler. They will be called in the same order as they were added.
  * @param obj       pointer to an object
- * @param filter    and event code (e.g. `LV_EVENT_CLICKED`) on which the event should be called. `LV_EVENT_ALL` can be sued the receive all the events.
+ * @param filter    an event code (e.g. `LV_EVENT_CLICKED`) on which the event should be called. `LV_EVENT_ALL` can be used to receive all the events.
  * @param event_cb  the new event function
  * @param           user_data custom data data will be available in `event_cb`
  */

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -69,7 +69,7 @@ void lv_obj_set_y(struct _lv_obj_t * obj, int32_t y);
  * @note            possible values are:
  *                  pixel               simple set the size accordingly
  *                  LV_SIZE_CONTENT     set the size to involve all children in the given direction
- *                  LV_SIZE_PCT(x)     to set size in percentage of the parent's content area size (the size without paddings).
+ *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
 void lv_obj_set_size(struct _lv_obj_t * obj, int32_t w, int32_t h);


### PR DESCRIPTION
Just a few small fixes to documentation that I stumbled upon.
No functional changes.

As an aside, is it intentional that [https://docs.lvgl.io/latest/](https://docs.lvgl.io/latest/en/html/intro/index.html) is v7.11.0-dev and not the latest version? Most google hits for lvgl end up there, and I was confused for a moment until I noticed the version number in sidebar, as I only looked at the URL.

Oh, and happy new year to the very cool library!