### PR TITLE
chore(cmsis-pack): catch up the latest changes that damaged the script

### DIFF
--- a/env_support/cmsis-pack/LVGL.lvgl.pdsc
+++ b/env_support/cmsis-pack/LVGL.lvgl.pdsc
@@ -36,7 +36,7 @@
   <repository type="git">https://github.com/lvgl/lvgl.git</repository>
 
   <releases>
-    <release date="2023-12-24" version="9.0.0-dev2" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.9.0.0-dev2.pack">
+    <release date="2024-01-02" version="9.0.0-dev3" url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/LVGL.lvgl.9.0.0-dev3.pack">
       - LVGL 9.0.0-dev
       - New Driver Architecture
       - Adds Helium support
@@ -508,8 +508,6 @@
                 <file category="sourceC"            name="src/misc/lv_array.c" />
                 <file category="sourceC"            name="src/misc/lv_async.c" />
                 <file category="sourceC"            name="src/misc/lv_bidi.c" />
-                <file category="sourceC"            name="src/misc/lv_cache.c" />
-                <file category="sourceC"            name="src/misc/lv_cache_builtin.c" />
                 <file category="sourceC"            name="src/misc/lv_color.c" />
                 <file category="sourceC"            name="src/misc/lv_color_op.c" />
                 <file category="sourceC"            name="src/misc/lv_event.c" />
@@ -517,7 +515,6 @@
                 <file category="sourceC"            name="src/misc/lv_ll.c" />
                 <file category="sourceC"            name="src/misc/lv_log.c" />
                 <file category="sourceC"            name="src/misc/lv_lru.c" />
-                <file category="sourceC"            name="src/misc/lv_lru_rb.c" />
                 <file category="sourceC"            name="src/misc/lv_math.c" />
                 <file category="sourceC"            name="src/misc/lv_palette.c" />
                 <file category="sourceC"            name="src/misc/lv_profiler_builtin.c" />
@@ -529,7 +526,12 @@
                 <file category="sourceC"            name="src/misc/lv_text_ap.c" />
                 <file category="sourceC"            name="src/misc/lv_timer.c" />
                 <file category="sourceC"            name="src/misc/lv_utils.c" />
-
+                
+                <!-- src/misc/cache-->
+                <file category="sourceC"            name="src/misc/cache/_lv_cache_lru_rb.c" />
+                <file category="sourceC"            name="src/misc/cache/lv_cache.c" />
+                <file category="sourceC"            name="src/misc/cache/lv_cache_entry.c" />
+                <file category="sourceC"            name="src/misc/cache/lv_image_cache.c" />
 
                 <!-- src/stdlib-->
                 <file category="sourceC"            name="src/stdlib/lv_mem.c" />
@@ -996,7 +998,6 @@
                 <file category="sourceC"    name="src/libs/freetype/lv_freetype.c" />
                 <file category="sourceC"    name="src/libs/freetype/lv_freetype_image.c" />
                 <file category="sourceC"    name="src/libs/freetype/lv_freetype_outline.c" />
-                <file category="sourceC"    name="src/libs/freetype/lv_freetype_sbit.c" />
                 <file category="sourceC"    name="src/libs/freetype/lv_ftsystem.c" />
               </files>
 

--- a/env_support/cmsis-pack/LVGL.pidx
+++ b/env_support/cmsis-pack/LVGL.pidx
@@ -2,8 +2,8 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>LVGL</vendor>
   <url>https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/</url>
-  <timestamp>2023-12-24</timestamp>
+  <timestamp>2024-01-02</timestamp>
   <pindex>
-    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="9.0.0-dev2"/>
+    <pdsc url="https://raw.githubusercontent.com/lvgl/lvgl/master/env_support/cmsis-pack/" vendor="LVGL" name="lvgl" version="9.0.0-dev3"/>
   </pindex>
 </index>


### PR DESCRIPTION
### Description of the feature or fix

Some recent changes forgot to update the cmsis-pack pdsc file. 

### Checkpoints
- [ ] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [ ] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [ ] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [ ] Use typed pointers instead of `void *` pointers
- [ ] Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
- [ ] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [ ] Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [ ] `struct`s should be used via an API and not modified directly via their elements.
- [ ] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [ ] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [ ] Arguments must be named in H files too.
- [ ] To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
