### PR TITLE
nuttx:lv_display_set_color_format LV_COLOR_FORMAT_NATIVE_WITH_ALPHA

### DIFF
--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -76,6 +76,10 @@ lv_display_t * lv_nuttx_fbdev_create(void)
         return NULL;
     }
     dsc->fd = -1;
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_NATIVE_WITH_ALPHA);
+    if(lv_color_format_has_alpha(disp->color_format)) {
+        lv_obj_remove_style_all(disp->act_scr);
+    }
     lv_display_set_driver_data(disp, dsc);
     lv_display_add_event_cb(disp, display_release_cb, LV_EVENT_DELETE, disp);
     lv_display_set_flush_cb(disp, flush_cb);
@@ -122,6 +126,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         ret = -errno;
         goto errout;
     }
+    memset(dsc->mem, 0, dsc->pinfo.fblen);
 
     /* double buffer mode */
 


### PR DESCRIPTION

### Description of the feature or fix

set lv_display color_format LV_COLOR_FORMAT_NATIVE_WITH_ALPHA

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
