### PR TITLE
chore: move lv_obj_t define to lv_types.h

### DIFF
--- a/docs/others/obj_property.rst
+++ b/docs/others/obj_property.rst
@@ -24,8 +24,8 @@ Two APIs are provided to get/set widget properties. It can be enabled by setting
         };
     } lv_property_t;
 
-    lv_result_t lv_obj_set_property(struct _lv_obj_t * obj, const lv_property_t * value);
-    lv_property_t lv_obj_get_property(struct _lv_obj_t * obj, lv_prop_id_t id);
+    lv_result_t lv_obj_set_property(lv_obj_t * obj, const lv_property_t * value);
+    lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id);
 
 
 Property ID

--- a/docs/overview/draw.rst
+++ b/docs/overview/draw.rst
@@ -267,7 +267,7 @@ documentation.
 
     typedef struct {
         lv_draw_ctx_t * draw_ctx;           /**< Draw context*/
-        const struct _lv_obj_class_t * class_p;     /**< The class that sent the event */
+        const lv_obj_class_t * class_p;     /**< The class that sent the event */
         uint32_t type;                      /**< The type if part being draw. Element of `lv_<name>_draw_part_type_t` */
         lv_area_t * draw_area;              /**< The area of the part being drawn*/
         lv_draw_rect_dsc_t *

--- a/docs/overview/img.rst
+++ b/docs/overview/img.rst
@@ -244,7 +244,7 @@ open/close the PNG files. It should look like this:
     * @param header    image information is set in header parameter
     * @return          LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
     */
-   static lv_result_t decoder_info(struct _lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+   static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
    {
      /*Check whether the type `src` is known by the decoder*/
      if(is_png(src) == false) return LV_RESULT_INVALID;

--- a/env_support/cmake/micropython.cmake
+++ b/env_support/cmake/micropython.cmake
@@ -13,6 +13,6 @@ target_sources(lvgl_interface INTERFACE ${SOURCES})
 # /home/test/build/lv_micropython/ports/rp2/build-PICO/lv_mp.c:29316:16: error:
 # 'lv_style_transition_dsc_t_path_xcb_callback' defined but not used
 # [-Werror=unused-function] 29316 | STATIC int32_t
-# lv_style_transition_dsc_t_path_xcb_callback(const struct _lv_anim_t * arg0) |
+# lv_style_transition_dsc_t_path_xcb_callback(const lv_anim_t * arg0) |
 # ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 target_compile_options(lvgl_interface INTERFACE -Wno-unused-function)

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -476,7 +476,7 @@ def obj_style_get(p):
   if 'section' in p: return
 
   cast = style_get_cast(p['style_type'], p['var_type'])
-  print("static inline " + p['var_type'] + " lv_obj_get_style_" + p['name'].lower() +"(const struct _lv_obj_t * obj, uint32_t part)")
+  print("static inline " + p['var_type'] + " lv_obj_get_style_" + p['name'].lower() +"(const lv_obj_t * obj, uint32_t part)")
   print("{")
   print("    lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_" + p['name'] + ");")
   print("    return " + cast + "v." + p['style_type'] + ";")
@@ -484,7 +484,7 @@ def obj_style_get(p):
   print("")
 
   if 'filtered' in p and p['filtered']:
-    print("static inline " + p['var_type'] + " lv_obj_get_style_" + p['name'].lower() +"_filtered(const struct _lv_obj_t * obj, uint32_t part)")
+    print("static inline " + p['var_type'] + " lv_obj_get_style_" + p['name'].lower() +"_filtered(const lv_obj_t * obj, uint32_t part)")
     print("{")
     print("    lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_" + p['name'] + "));")
     print("    return " + cast + "v." + p['style_type'] + ";")
@@ -528,7 +528,7 @@ def local_style_set_c(p):
 
   cast = style_set_cast(p['style_type'])
   print("")
-  print("void lv_obj_set_style_" + p['name'].lower() + "(struct _lv_obj_t * obj, " + p['var_type'] +" value, lv_style_selector_t selector)")
+  print("void lv_obj_set_style_" + p['name'].lower() + "(lv_obj_t * obj, " + p['var_type'] +" value, lv_style_selector_t selector)")
   print("{")
   print("    lv_style_value_t v = {")
   print("        ." + p['style_type'] +" = " + cast + "value")
@@ -539,7 +539,7 @@ def local_style_set_c(p):
 
 def local_style_set_h(p):
   if 'section' in p: return
-  print("void lv_obj_set_style_" + p['name'].lower() + "(struct _lv_obj_t * obj, " + p['var_type'] +" value, lv_style_selector_t selector);")
+  print("void lv_obj_set_style_" + p['name'].lower() + "(lv_obj_t * obj, " + p['var_type'] +" value, lv_style_selector_t selector);")
 
 
 def style_const_set(p):

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -17,6 +17,7 @@ extern "C" {
 
 #include <stdbool.h>
 
+#include "../misc/lv_types.h"
 #include "../draw/lv_draw.h"
 #if LV_USE_DRAW_SW
 #include "../draw/sw/lv_draw_sw.h"
@@ -48,13 +49,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_display_t;
-struct _lv_group_t;
-struct _my_theme_t;
-struct _lv_indev_t;
-struct _lv_event_t;
-struct _lv_obj_t;
-
 #if LV_USE_SPAN != 0
 struct _snippet_stack;
 #endif
@@ -68,8 +62,8 @@ typedef struct _lv_global_t {
     bool deinit_in_progress;     /**< Can be used e.g. in the LV_EVENT_DELETE to deinit the drivers too */
 
     lv_ll_t disp_ll;
-    struct _lv_display_t * disp_refresh;
-    struct _lv_display_t * disp_default;
+    lv_display_t * disp_refresh;
+    lv_display_t * disp_default;
 
     lv_ll_t style_trans_ll;
     bool style_refresh;
@@ -78,11 +72,11 @@ typedef struct _lv_global_t {
     uint8_t * style_custom_prop_flag_lookup_table;
 
     lv_ll_t group_ll;
-    struct _lv_group_t * group_default;
+    lv_group_t * group_default;
 
     lv_ll_t indev_ll;
-    struct _lv_indev_t * indev_active;
-    struct _lv_obj_t * indev_obj_active;
+    lv_indev_t * indev_active;
+    lv_obj_t * indev_obj_active;
 
     uint32_t layout_count;
     lv_layout_dsc_t * layout_list;
@@ -92,7 +86,7 @@ typedef struct _lv_global_t {
     uint32_t math_rand_seed;
     lv_area_transform_cache_t area_trans_cache;
 
-    struct _lv_event_t * event_header;
+    lv_event_t * event_header;
     uint32_t event_last_register_id;
 
     lv_timer_state_t timer_state;
@@ -125,15 +119,15 @@ typedef struct _lv_global_t {
 #endif
 
 #if LV_USE_THEME_SIMPLE
-    struct _my_theme_t * theme_simple;
+    my_theme_t * theme_simple;
 #endif
 
 #if LV_USE_THEME_DEFAULT
-    struct _my_theme_t * theme_default;
+    my_theme_t * theme_default;
 #endif
 
 #if LV_USE_THEME_MONO
-    struct _my_theme_t * theme_mono;
+    my_theme_t * theme_mono;
 #endif
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN

--- a/src/core/lv_group.h
+++ b/src/core/lv_group.h
@@ -18,8 +18,8 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "../misc/lv_ll.h"
 #include "../misc/lv_types.h"
+#include "../misc/lv_ll.h"
 
 /*********************
  *      DEFINES
@@ -40,29 +40,20 @@ enum _lv_key_t {
     LV_KEY_END       = 3,   /*0x03, ETX*/
 };
 
-#ifdef DOXYGEN
-typedef _lv_key_t lv_key_t;
-#else
-typedef uint8_t lv_key_t;
-#endif /*DOXYGEN*/
-
 /**********************
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-struct _lv_group_t;
-
-typedef void (*lv_group_focus_cb_t)(struct _lv_group_t *);
-typedef void (*lv_group_edge_cb_t)(struct _lv_group_t *, bool);
+typedef void (*lv_group_focus_cb_t)(lv_group_t *);
+typedef void (*lv_group_edge_cb_t)(lv_group_t *, bool);
 
 /**
  * Groups can be used to logically hold objects so that they can be individually focused.
  * They are NOT for laying out objects on a screen (try layouts for that).
  */
-typedef struct _lv_group_t {
+struct _lv_group_t {
     lv_ll_t obj_ll;        /**< Linked list to store the objects in the group*/
-    struct _lv_obj_t ** obj_focus; /**< The object in focus*/
+    lv_obj_t ** obj_focus; /**< The object in focus*/
 
     lv_group_focus_cb_t focus_cb;              /**< A function to call when a new object is focused (optional)*/
     lv_group_edge_cb_t  edge_cb;               /**< A function to call when an edge is reached, no more focus
@@ -77,7 +68,7 @@ typedef struct _lv_group_t {
                                    deletion.*/
     uint8_t wrap : 1;           /**< 1: Focus next/prev can wrap at end of list. 0: Focus next/prev stops at end
                                    of list.*/
-} lv_group_t;
+};
 
 typedef enum {
     LV_GROUP_REFOCUS_POLICY_NEXT = 0,
@@ -129,20 +120,20 @@ lv_group_t * lv_group_get_default(void);
  * @param group     pointer to a group
  * @param obj       pointer to an object to add
  */
-void lv_group_add_obj(lv_group_t * group, struct _lv_obj_t * obj);
+void lv_group_add_obj(lv_group_t * group, lv_obj_t * obj);
 
 /**
  * Swap 2 object in a group. The object must be in the same group
  * @param obj1  pointer to an object
  * @param obj2  pointer to an other object
  */
-void lv_group_swap_obj(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
+void lv_group_swap_obj(lv_obj_t * obj1, lv_obj_t * obj2);
 
 /**
  * Remove an object from its group
  * @param obj       pointer to an object to remove
  */
-void lv_group_remove_obj(struct _lv_obj_t * obj);
+void lv_group_remove_obj(lv_obj_t * obj);
 
 /**
  * Remove all objects from a group
@@ -154,7 +145,7 @@ void lv_group_remove_all_objs(lv_group_t * group);
  * Focus on an object (defocus the current)
  * @param obj       pointer to an object to focus on
  */
-void lv_group_focus_obj(struct _lv_obj_t * obj);
+void lv_group_focus_obj(lv_obj_t * obj);
 
 /**
  * Focus the next object in a group (defocus the current)
@@ -224,7 +215,7 @@ void lv_group_set_wrap(lv_group_t * group, bool en);
  * @param group         pointer to a group
  * @return              pointer to the focused object
  */
-struct _lv_obj_t * lv_group_get_focused(const lv_group_t * group);
+lv_obj_t * lv_group_get_focused(const lv_group_t * group);
 
 /**
  * Get the focus callback function of a group

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -17,12 +17,21 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdbool.h>
-#include "../misc/lv_style.h"
 #include "../misc/lv_types.h"
+#include "../misc/lv_style.h"
 #include "../misc/lv_area.h"
 #include "../misc/lv_color.h"
 #include "../misc/lv_assert.h"
+
+#include "lv_obj_tree.h"
+#include "lv_obj_pos.h"
+#include "lv_obj_scroll.h"
+#include "lv_obj_style.h"
+#include "lv_obj_draw.h"
+#include "lv_obj_class.h"
+#include "lv_obj_event.h"
 #include "lv_obj_property.h"
+#include "lv_group.h"
 
 /*********************
  *      DEFINES
@@ -31,8 +40,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
 
 /**
  * Possible states of a widget.
@@ -56,12 +63,6 @@ enum _lv_state_t {
     LV_STATE_ANY = 0xFFFF,    /**< Special value can be used in some functions to target all states*/
 };
 
-#ifdef DOXYGEN
-typedef _lv_state_t lv_state_t;
-#else
-typedef uint16_t lv_state_t;
-#endif /*DOXYGEN*/
-
 /**
  * The possible parts of widgets.
  * The parts can be considered as the internal building block of the widgets.
@@ -82,12 +83,6 @@ enum _lv_part_t {
 
     LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
 };
-
-#ifdef DOXYGEN
-typedef _lv_part_t lv_part_t;
-#else
-typedef uint32_t lv_part_t;
-#endif /*DOXYGEN*/
 
 /**
  * On/Off features controlling the object's behavior.
@@ -133,12 +128,6 @@ typedef enum {
     LV_OBJ_FLAG_USER_3          = (1L << 29), /**< Custom flag, free to use by user*/
     LV_OBJ_FLAG_USER_4          = (1L << 30), /**< Custom flag, free to use by user*/
 } _lv_obj_flag_t;
-
-#ifdef DOXYGEN
-typedef _lv_obj_flag_t lv_obj_flag_t;
-#else
-typedef uint32_t lv_obj_flag_t;
-#endif /*DOXYGEN*/
 
 #if LV_USE_OBJ_PROPERTY
 enum {
@@ -200,15 +189,6 @@ enum {
 };
 #endif
 
-#include "lv_obj_tree.h"
-#include "lv_obj_pos.h"
-#include "lv_obj_scroll.h"
-#include "lv_obj_style.h"
-#include "lv_obj_draw.h"
-#include "lv_obj_class.h"
-#include "lv_obj_event.h"
-#include "lv_group.h"
-
 /**
  * Make the base object's class publicly available.
  */
@@ -219,7 +199,7 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
  * They are allocated automatically if any elements is set.
  */
 typedef struct {
-    struct _lv_obj_t ** children;   /**< Store the pointer of the children in an array.*/
+    lv_obj_t ** children;   /**< Store the pointer of the children in an array.*/
     lv_group_t * group_p;
     lv_event_list_t event_list;
 
@@ -236,9 +216,9 @@ typedef struct {
     uint16_t layer_type : 2;        /**< Cache the layer type here. Element of @lv_intermediate_layer_type_t */
 } _lv_obj_spec_attr_t;
 
-typedef struct _lv_obj_t {
+struct _lv_obj_t {
     const lv_obj_class_t * class_p;
-    struct _lv_obj_t * parent;
+    lv_obj_t * parent;
     _lv_obj_spec_attr_t * spec_attr;
     _lv_obj_style_t * styles;
 #if LV_OBJ_STYLE_CACHE
@@ -260,7 +240,7 @@ typedef struct _lv_obj_t {
     uint16_t h_layout   : 1;
     uint16_t w_layout   : 1;
     uint16_t is_deleting : 1;
-} lv_obj_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/core/lv_obj_class.h
+++ b/src/core/lv_obj_class.h
@@ -15,8 +15,9 @@ extern "C" {
  *********************/
 #include <stdint.h>
 #include <stdbool.h>
-#include "lv_obj_property.h"
+#include "../misc/lv_types.h"
 #include "../misc/lv_area.h"
+#include "lv_obj_property.h"
 
 /*********************
  *      DEFINES
@@ -25,10 +26,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_obj_class_t;
-struct _lv_event_t;
 
 typedef enum {
     LV_OBJ_CLASS_EDITABLE_INHERIT,      /**< Check the base class. Must have 0 value to let zero initialized class inherit*/
@@ -47,20 +44,19 @@ typedef enum {
     LV_OBJ_CLASS_THEME_INHERITABLE_TRUE,
 } lv_obj_class_theme_inheritable_t;
 
-typedef void (*lv_obj_class_event_cb_t)(struct _lv_obj_class_t * class_p, struct _lv_event_t * e);
+typedef void (*lv_obj_class_event_cb_t)(lv_obj_class_t * class_p, lv_event_t * e);
 /**
  * Describe the common methods of every object.
  * Similar to a C++ class.
  */
-typedef struct _lv_obj_class_t {
-    const struct _lv_obj_class_t * base_class;
+struct _lv_obj_class_t {
+    const lv_obj_class_t * base_class;
     /*class_p is the final class while obj->class_p is the class currently being [de]constructed.*/
-    void (*constructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
-    void (*destructor_cb)(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * obj);
+    void (*constructor_cb)(const lv_obj_class_t * class_p, lv_obj_t * obj);
+    void (*destructor_cb)(const lv_obj_class_t * class_p, lv_obj_t * obj);
 
     /*class_p is the class in which event is being processed.*/
-    void (*event_cb)(const struct _lv_obj_class_t * class_p,
-                     struct _lv_event_t * e);  /**< Widget type specific event function*/
+    void (*event_cb)(const lv_obj_class_t * class_p, lv_event_t * e);  /**< Widget type specific event function*/
 
 #if LV_USE_OBJ_PROPERTY
     uint32_t prop_index_start;
@@ -77,7 +73,7 @@ typedef struct _lv_obj_class_t {
     uint32_t group_def : 2;            /**< Value from ::lv_obj_class_group_def_t*/
     uint32_t instance_size : 16;
     uint32_t theme_inheritable : 1;    /**< Value from ::lv_obj_class_theme_inheritable_t*/
-} lv_obj_class_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -89,15 +85,15 @@ typedef struct _lv_obj_class_t {
  * @param parent    pointer to an object where the new object should be created
  * @return          pointer to the created object
  */
-struct _lv_obj_t * lv_obj_class_create_obj(const struct _lv_obj_class_t * class_p, struct _lv_obj_t * parent);
+lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * parent);
 
-void lv_obj_class_init_obj(struct _lv_obj_t * obj);
+void lv_obj_class_init_obj(lv_obj_t * obj);
 
-void _lv_obj_destruct(struct _lv_obj_t * obj);
+void _lv_obj_destruct(lv_obj_t * obj);
 
-bool lv_obj_is_editable(struct _lv_obj_t * obj);
+bool lv_obj_is_editable(lv_obj_t * obj);
 
-bool lv_obj_is_group_def(struct _lv_obj_t * obj);
+bool lv_obj_is_group_def(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_draw.h
+++ b/src/core/lv_obj_draw.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../misc/lv_types.h"
 #include "../draw/lv_draw.h"
 
 /*********************
@@ -22,9 +23,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_obj_class_t;
 
 typedef enum {
     LV_LAYER_TYPE_NONE,
@@ -46,7 +44,7 @@ typedef enum {
  * @note Only the relevant fields will be set.
  *       E.g. if `border width == 0` the other border properties won't be evaluated.
  */
-void lv_obj_init_draw_rect_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t * draw_dsc);
+void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, uint32_t part, lv_draw_rect_dsc_t * draw_dsc);
 
 /**
  * Initialize a label draw descriptor from an object's styles in its current state
@@ -56,7 +54,7 @@ void lv_obj_init_draw_rect_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_re
  *                  If the `opa` field is set to or the property is equal to `LV_OPA_TRANSP` the rest won't be initialized.
  *                  Should be initialized with `lv_draw_label_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_label_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_label_dsc_t * draw_dsc);
+void lv_obj_init_draw_label_dsc(lv_obj_t * obj, uint32_t part, lv_draw_label_dsc_t * draw_dsc);
 
 /**
  * Initialize an image draw descriptor from an object's styles in its current state
@@ -65,7 +63,7 @@ void lv_obj_init_draw_label_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_l
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_image_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_image_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_image_dsc_t * draw_dsc);
+void lv_obj_init_draw_image_dsc(lv_obj_t * obj, uint32_t part, lv_draw_image_dsc_t * draw_dsc);
 
 /**
  * Initialize a line draw descriptor from an object's styles in its current state
@@ -74,7 +72,7 @@ void lv_obj_init_draw_image_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_i
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_line_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_line_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_line_dsc_t * draw_dsc);
+void lv_obj_init_draw_line_dsc(lv_obj_t * obj, uint32_t part, lv_draw_line_dsc_t * draw_dsc);
 
 /**
  * Initialize an arc draw descriptor from an object's styles in its current state
@@ -83,7 +81,7 @@ void lv_obj_init_draw_line_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_li
  * @param draw_dsc  the descriptor to initialize.
  *                  Should be initialized with `lv_draw_arc_dsc_init(draw_dsc)`.
  */
-void lv_obj_init_draw_arc_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_arc_dsc_t * draw_dsc);
+void lv_obj_init_draw_arc_dsc(lv_obj_t * obj, uint32_t part, lv_draw_arc_dsc_t * draw_dsc);
 
 /**
  * Get the required extra size (around the object's part) to draw shadow, outline, value etc.
@@ -91,23 +89,23 @@ void lv_obj_init_draw_arc_dsc(struct _lv_obj_t * obj, uint32_t part, lv_draw_arc
  * @param part      part of the object
  * @return          the extra size required around the object
  */
-int32_t lv_obj_calculate_ext_draw_size(struct _lv_obj_t * obj, uint32_t part);
+int32_t lv_obj_calculate_ext_draw_size(lv_obj_t * obj, uint32_t part);
 
 /**
  * Send a 'LV_EVENT_REFR_EXT_DRAW_SIZE' Call the ancestor's event handler to the object to refresh the value of the extended draw size.
  * The result will be saved in `obj`.
  * @param obj       pointer to an object
  */
-void lv_obj_refresh_ext_draw_size(struct _lv_obj_t * obj);
+void lv_obj_refresh_ext_draw_size(lv_obj_t * obj);
 
 /**
  * Get the extended draw area of an object.
  * @param obj       pointer to an object
  * @return          the size extended draw area around the real coordinates
  */
-int32_t _lv_obj_get_ext_draw_size(const struct _lv_obj_t * obj);
+int32_t _lv_obj_get_ext_draw_size(const lv_obj_t * obj);
 
-lv_layer_type_t _lv_obj_get_layer_type(const struct _lv_obj_t * obj);
+lv_layer_type_t _lv_obj_get_layer_type(const lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdbool.h>
+#include "../misc/lv_types.h"
 #include "../misc/lv_event.h"
 #include "../indev/lv_indev.h"
 
@@ -24,9 +25,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_obj_class_t;
 
 /**
  * Used as the event parameter of ::LV_EVENT_HIT_TEST to check if an `point` can click the object or not.
@@ -68,7 +66,7 @@ typedef struct {
  * @param param         arbitrary data depending on the widget type and the event. (Usually `NULL`)
  * @return LV_RESULT_OK: `obj` was not deleted in the event; LV_RESULT_INVALID: `obj` was deleted in the event_code
  */
-lv_result_t lv_obj_send_event(struct _lv_obj_t * obj, lv_event_code_t event_code, void * param);
+lv_result_t lv_obj_send_event(lv_obj_t * obj, lv_event_code_t event_code, void * param);
 
 /**
  * Used by the widgets internally to call the ancestor widget types's event handler
@@ -76,7 +74,7 @@ lv_result_t lv_obj_send_event(struct _lv_obj_t * obj, lv_event_code_t event_code
  * @param e         pointer to the event descriptor
  * @return          LV_RESULT_OK: the target object was not deleted in the event; LV_RESULT_INVALID: it was deleted in the event_code
  */
-lv_result_t lv_obj_event_base(const struct _lv_obj_class_t * class_p, lv_event_t * e);
+lv_result_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e);
 
 /**
  * Get the current target of the event. It's the object which event handler being called.
@@ -84,14 +82,14 @@ lv_result_t lv_obj_event_base(const struct _lv_obj_class_t * class_p, lv_event_t
  * @param e     pointer to the event descriptor
  * @return      the target of the event_code
  */
-struct _lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e);
+lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e);
 
 /**
  * Get the object originally targeted by the event. It's the same even if the event is bubbled.
  * @param e     pointer to the event descriptor
  * @return      pointer to the original target of the event_code
  */
-struct _lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
+lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
 
 /**
  * Add an event handler function for an object.
@@ -102,16 +100,16 @@ struct _lv_obj_t * lv_event_get_target_obj(lv_event_t * e);
  * @param event_cb  the new event function
  * @param           user_data custom data data will be available in `event_cb`
  */
-void lv_obj_add_event_cb(struct _lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter,
+void lv_obj_add_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter,
                          void * user_data);
 
-uint32_t lv_obj_get_event_count(struct _lv_obj_t * obj);
+uint32_t lv_obj_get_event_count(lv_obj_t * obj);
 
-lv_event_dsc_t * lv_obj_get_event_dsc(struct _lv_obj_t * obj, uint32_t index);
+lv_event_dsc_t * lv_obj_get_event_dsc(lv_obj_t * obj, uint32_t index);
 
-bool lv_obj_remove_event(struct _lv_obj_t * obj, uint32_t index);
+bool lv_obj_remove_event(lv_obj_t * obj, uint32_t index);
 
-bool lv_obj_remove_event_cb(struct _lv_obj_t * obj, lv_event_cb_t event_cb);
+bool lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb);
 
 /**
  * Remove an event_cb with user_data
@@ -120,7 +118,7 @@ bool lv_obj_remove_event_cb(struct _lv_obj_t * obj, lv_event_cb_t event_cb);
  * @param user_data     user_data
  * @return              the count of the event removed
  */
-uint32_t lv_obj_remove_event_cb_with_user_data(struct _lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data);
+uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data);
 
 /**
  * Get the input device passed as parameter to indev related events.

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -37,7 +37,7 @@ extern "C" {
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_pos(struct _lv_obj_t * obj, int32_t x, int32_t y);
+void lv_obj_set_pos(lv_obj_t * obj, int32_t x, int32_t y);
 
 /**
  * Set the x coordinate of an object
@@ -48,7 +48,7 @@ void lv_obj_set_pos(struct _lv_obj_t * obj, int32_t x, int32_t y);
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_x(struct _lv_obj_t * obj, int32_t x);
+void lv_obj_set_x(lv_obj_t * obj, int32_t x);
 
 /**
  * Set the y coordinate of an object
@@ -59,7 +59,7 @@ void lv_obj_set_x(struct _lv_obj_t * obj, int32_t x);
  * @note            The position is interpreted on the content area of the parent
  * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
  */
-void lv_obj_set_y(struct _lv_obj_t * obj, int32_t y);
+void lv_obj_set_y(lv_obj_t * obj, int32_t y);
 
 /**
  * Set the size of an object.
@@ -72,14 +72,14 @@ void lv_obj_set_y(struct _lv_obj_t * obj, int32_t y);
  *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_size(struct _lv_obj_t * obj, int32_t w, int32_t h);
+void lv_obj_set_size(lv_obj_t * obj, int32_t w, int32_t h);
 
 /**
  * Recalculate the size of the object
  * @param obj       pointer to an object
  * @return          true: the size has been changed
  */
-bool lv_obj_refr_size(struct _lv_obj_t * obj);
+bool lv_obj_refr_size(lv_obj_t * obj);
 
 /**
  * Set the width of an object
@@ -91,7 +91,7 @@ bool lv_obj_refr_size(struct _lv_obj_t * obj);
  *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_width(struct _lv_obj_t * obj, int32_t w);
+void lv_obj_set_width(lv_obj_t * obj, int32_t w);
 
 /**
  * Set the height of an object
@@ -103,54 +103,54 @@ void lv_obj_set_width(struct _lv_obj_t * obj, int32_t w);
  *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
  *                                      x should be in [0..1000]% range
  */
-void lv_obj_set_height(struct _lv_obj_t * obj, int32_t h);
+void lv_obj_set_height(lv_obj_t * obj, int32_t h);
 
 /**
  * Set the width reduced by the left and right padding and the border width.
  * @param obj       pointer to an object
  * @param w         the width without paddings in pixels
  */
-void lv_obj_set_content_width(struct _lv_obj_t * obj, int32_t w);
+void lv_obj_set_content_width(lv_obj_t * obj, int32_t w);
 
 /**
  * Set the height reduced by the top and bottom padding and the border width.
  * @param obj       pointer to an object
  * @param h         the height without paddings in pixels
  */
-void lv_obj_set_content_height(struct _lv_obj_t * obj, int32_t h);
+void lv_obj_set_content_height(lv_obj_t * obj, int32_t h);
 
 /**
  * Set a layout for an object
  * @param obj       pointer to an object
  * @param layout    pointer to a layout descriptor to set
  */
-void lv_obj_set_layout(struct _lv_obj_t * obj, uint32_t layout);
+void lv_obj_set_layout(lv_obj_t * obj, uint32_t layout);
 
 /**
  * Test whether the and object is positioned by a layout or not
  * @param obj       pointer to an object to test
  * @return true:    positioned by a layout; false: not positioned by a layout
  */
-bool lv_obj_is_layout_positioned(const struct _lv_obj_t * obj);
+bool lv_obj_is_layout_positioned(const lv_obj_t * obj);
 
 /**
  * Mark the object for layout update.
  * @param obj      pointer to an object whose children needs to be updated
  */
-void lv_obj_mark_layout_as_dirty(struct _lv_obj_t * obj);
+void lv_obj_mark_layout_as_dirty(lv_obj_t * obj);
 
 /**
  * Update the layout of an object.
  * @param obj      pointer to an object whose children needs to be updated
  */
-void lv_obj_update_layout(const struct _lv_obj_t * obj);
+void lv_obj_update_layout(const lv_obj_t * obj);
 
 /**
  * Change the alignment of an object.
  * @param obj       pointer to an object to align
  * @param align     type of alignment (see 'lv_align_t' enum) `LV_ALIGN_OUT_...` can't be used.
  */
-void lv_obj_set_align(struct _lv_obj_t * obj, lv_align_t align);
+void lv_obj_set_align(lv_obj_t * obj, lv_align_t align);
 
 /**
  * Change the alignment of an object and set new coordinates.
@@ -162,7 +162,7 @@ void lv_obj_set_align(struct _lv_obj_t * obj, lv_align_t align);
  * @param x_ofs     x coordinate offset after alignment
  * @param y_ofs     y coordinate offset after alignment
  */
-void lv_obj_align(struct _lv_obj_t * obj, lv_align_t align, int32_t x_ofs, int32_t y_ofs);
+void lv_obj_align(lv_obj_t * obj, lv_align_t align, int32_t x_ofs, int32_t y_ofs);
 
 /**
  * Align an object to an other object.
@@ -173,7 +173,7 @@ void lv_obj_align(struct _lv_obj_t * obj, lv_align_t align, int32_t x_ofs, int32
  * @param y_ofs     y coordinate offset after alignment
  * @note            if the position or size of `base` changes `obj` needs to be aligned manually again
  */
-void lv_obj_align_to(struct _lv_obj_t * obj, const struct _lv_obj_t * base, lv_align_t align, int32_t x_ofs,
+void lv_obj_align_to(lv_obj_t * obj, const lv_obj_t * base, lv_align_t align, int32_t x_ofs,
                      int32_t y_ofs);
 
 /**
@@ -181,7 +181,7 @@ void lv_obj_align_to(struct _lv_obj_t * obj, const struct _lv_obj_t * base, lv_a
  * @param obj       pointer to an object to align
  * @note            if the parent size changes `obj` needs to be aligned manually again
  */
-static inline void lv_obj_center(struct _lv_obj_t * obj)
+static inline void lv_obj_center(lv_obj_t * obj)
 {
     lv_obj_align(obj, LV_ALIGN_CENTER, 0, 0);
 }
@@ -191,7 +191,7 @@ static inline void lv_obj_center(struct _lv_obj_t * obj)
  * @param obj       pointer to an object
  * @param coords    pointer to an area to store the coordinates
  */
-void lv_obj_get_coords(const struct _lv_obj_t * obj, lv_area_t * coords);
+void lv_obj_get_coords(const lv_obj_t * obj, lv_area_t * coords);
 
 /**
  * Get the x coordinate of object.
@@ -203,7 +203,7 @@ void lv_obj_get_coords(const struct _lv_obj_t * obj, lv_area_t * coords);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-int32_t lv_obj_get_x(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_x(const lv_obj_t * obj);
 
 /**
  * Get the x2 coordinate of object.
@@ -215,7 +215,7 @@ int32_t lv_obj_get_x(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-int32_t lv_obj_get_x2(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_x2(const lv_obj_t * obj);
 
 /**
  * Get the y coordinate of object.
@@ -227,7 +227,7 @@ int32_t lv_obj_get_x2(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-int32_t lv_obj_get_y(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_y(const lv_obj_t * obj);
 
 /**
  * Get the y2 coordinate of object.
@@ -239,21 +239,21 @@ int32_t lv_obj_get_y(const struct _lv_obj_t * obj);
  * @note            Scrolling of the parent doesn't change the returned value.
  * @note            The returned value is always the distance from the parent even if `obj` is positioned by a layout.
  */
-int32_t lv_obj_get_y2(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_y2(const lv_obj_t * obj);
 
 /**
  * Get the actually set x coordinate of object, i.e. the offset form the set alignment
  * @param obj       pointer to an object
  * @return          the set x coordinate
  */
-int32_t lv_obj_get_x_aligned(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_x_aligned(const lv_obj_t * obj);
 
 /**
  * Get the actually set y coordinate of object, i.e. the offset form the set alignment
  * @param obj       pointer to an object
  * @return          the set y coordinate
  */
-int32_t lv_obj_get_y_aligned(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_y_aligned(const lv_obj_t * obj);
 
 /**
  * Get the width of an object
@@ -262,7 +262,7 @@ int32_t lv_obj_get_y_aligned(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the width in pixels
  */
-int32_t lv_obj_get_width(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_width(const lv_obj_t * obj);
 
 /**
  * Get the height of an object
@@ -271,7 +271,7 @@ int32_t lv_obj_get_width(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the height in pixels
  */
-int32_t lv_obj_get_height(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_height(const lv_obj_t * obj);
 
 /**
  * Get the width reduced by the left and right padding and the border width.
@@ -280,7 +280,7 @@ int32_t lv_obj_get_height(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the width which still fits into its parent without causing overflow (making the parent scrollable)
  */
-int32_t lv_obj_get_content_width(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_content_width(const lv_obj_t * obj);
 
 /**
  * Get the height reduced by the top and bottom padding and the border width.
@@ -289,7 +289,7 @@ int32_t lv_obj_get_content_width(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @return          the height which still fits into the parent without causing overflow (making the parent scrollable)
  */
-int32_t lv_obj_get_content_height(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_content_height(const lv_obj_t * obj);
 
 /**
  * Get the area reduced by the paddings and the border width.
@@ -298,7 +298,7 @@ int32_t lv_obj_get_content_height(const struct _lv_obj_t * obj);
  *                  call `lv_obj_update_layout(obj)`.
  * @param area      the area which still fits into the parent without causing overflow (making the parent scrollable)
  */
-void lv_obj_get_content_coords(const struct _lv_obj_t * obj, lv_area_t * area);
+void lv_obj_get_content_coords(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Get the width occupied by the "parts" of the widget. E.g. the width of all columns of a table.
@@ -307,7 +307,7 @@ void lv_obj_get_content_coords(const struct _lv_obj_t * obj, lv_area_t * area);
  * @note            This size independent from the real size of the widget.
  *                  It just tells how large the internal ("virtual") content is.
  */
-int32_t lv_obj_get_self_width(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_self_width(const lv_obj_t * obj);
 
 /**
  * Get the height occupied by the "parts" of the widget. E.g. the height of all rows of a table.
@@ -316,20 +316,20 @@ int32_t lv_obj_get_self_width(const struct _lv_obj_t * obj);
  * @note            This size independent from the real size of the widget.
  *                  It just tells how large the internal ("virtual") content is.
  */
-int32_t lv_obj_get_self_height(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_self_height(const lv_obj_t * obj);
 
 /**
  * Handle if the size of the internal ("virtual") content of an object has changed.
  * @param obj       pointer to an object
  * @return          false: nothing happened; true: refresh happened
  */
-bool lv_obj_refresh_self_size(struct _lv_obj_t * obj);
+bool lv_obj_refresh_self_size(lv_obj_t * obj);
 
-void lv_obj_refr_pos(struct _lv_obj_t * obj);
+void lv_obj_refr_pos(lv_obj_t * obj);
 
-void lv_obj_move_to(struct _lv_obj_t * obj, int32_t x, int32_t y);
+void lv_obj_move_to(lv_obj_t * obj, int32_t x, int32_t y);
 
-void lv_obj_move_children_by(struct _lv_obj_t * obj, int32_t x_diff, int32_t y_diff, bool ignore_floating);
+void lv_obj_move_children_by(lv_obj_t * obj, int32_t x_diff, int32_t y_diff, bool ignore_floating);
 
 /**
  * Transform a point using the angle and zoom style properties of an object
@@ -338,7 +338,7 @@ void lv_obj_move_children_by(struct _lv_obj_t * obj, int32_t x_diff, int32_t y_d
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
+void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
 
 /**
  * Transform an area using the angle and zoom style properties of an object
@@ -347,7 +347,7 @@ void lv_obj_transform_point(const struct _lv_obj_t * obj, lv_point_t * p, bool r
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_get_transformed_area(const struct _lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
+void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
 
 /**
  * Mark an area of an object as invalid.
@@ -355,13 +355,13 @@ void lv_obj_get_transformed_area(const struct _lv_obj_t * obj, lv_area_t * area,
  * @param obj       pointer to an object
  * @param           area the area to redraw
  */
-void lv_obj_invalidate_area(const struct _lv_obj_t * obj, const lv_area_t * area);
+void lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area);
 
 /**
  * Mark the object as invalid to redrawn its area
  * @param obj       pointer to an object
  */
-void lv_obj_invalidate(const struct _lv_obj_t * obj);
+void lv_obj_invalidate(const lv_obj_t * obj);
 
 /**
  * Tell whether an area of an object is visible (even partially) now or not
@@ -369,21 +369,21 @@ void lv_obj_invalidate(const struct _lv_obj_t * obj);
  * @param area      the are to check. The visible part of the area will be written back here.
  * @return true     visible; false not visible (hidden, out of parent, on other screen, etc)
  */
-bool lv_obj_area_is_visible(const struct _lv_obj_t * obj, lv_area_t * area);
+bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Tell whether an object is visible (even partially) now or not
  * @param obj       pointer to an object
  * @return      true: visible; false not visible (hidden, out of parent, on other screen, etc)
  */
-bool lv_obj_is_visible(const struct _lv_obj_t * obj);
+bool lv_obj_is_visible(const lv_obj_t * obj);
 
 /**
  * Set the size of an extended clickable area
  * @param obj       pointer to an object
  * @param size      extended clickable area in all 4 directions [px]
  */
-void lv_obj_set_ext_click_area(struct _lv_obj_t * obj, int32_t size);
+void lv_obj_set_ext_click_area(lv_obj_t * obj, int32_t size);
 
 /**
  * Get the an area where to object can be clicked.
@@ -391,7 +391,7 @@ void lv_obj_set_ext_click_area(struct _lv_obj_t * obj, int32_t size);
  * @param obj       pointer to an object
  * @param area      store the result area here
  */
-void lv_obj_get_click_area(const struct _lv_obj_t * obj, lv_area_t * area);
+void lv_obj_get_click_area(const lv_obj_t * obj, lv_area_t * area);
 
 /**
  * Hit-test an object given a particular point in screen space.
@@ -399,7 +399,7 @@ void lv_obj_get_click_area(const struct _lv_obj_t * obj, lv_area_t * area);
  * @param point     screen-space point (absolute coordinate)
  * @return          true: if the object is considered under the point
  */
-bool lv_obj_hit_test(struct _lv_obj_t * obj, const lv_point_t * point);
+bool lv_obj_hit_test(lv_obj_t * obj, const lv_point_t * point);
 
 /**
  * Clamp a width between min and max width. If the min/max width is in percentage value use the ref_width

--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -20,15 +20,15 @@
  *      TYPEDEFS
  **********************/
 
-typedef void (*lv_property_set_int_t)(struct _lv_obj_t *, int32_t);
-typedef void (*lv_property_set_pointer_t)(struct _lv_obj_t *, const void *);
-typedef void (*lv_property_set_color_t)(struct _lv_obj_t *, lv_color_t);
-typedef lv_result_t (*lv_property_setter_t)(struct _lv_obj_t *, lv_prop_id_t, const lv_property_t *);
+typedef void (*lv_property_set_int_t)(lv_obj_t *, int32_t);
+typedef void (*lv_property_set_pointer_t)(lv_obj_t *, const void *);
+typedef void (*lv_property_set_color_t)(lv_obj_t *, lv_color_t);
+typedef lv_result_t (*lv_property_setter_t)(lv_obj_t *, lv_prop_id_t, const lv_property_t *);
 
-typedef int32_t (*lv_property_get_int_t)(const struct _lv_obj_t *);
-typedef void * (*lv_property_get_pointer_t)(const struct _lv_obj_t *);
-typedef lv_color_t (*lv_property_get_color_t)(const struct _lv_obj_t *);
-typedef lv_result_t (*lv_property_getter_t)(const struct _lv_obj_t *, lv_prop_id_t, lv_property_t *);
+typedef int32_t (*lv_property_get_int_t)(const lv_obj_t *);
+typedef void * (*lv_property_get_pointer_t)(const lv_obj_t *);
+typedef lv_color_t (*lv_property_get_color_t)(const lv_obj_t *);
+typedef lv_result_t (*lv_property_getter_t)(const lv_obj_t *, lv_prop_id_t, lv_property_t *);
 
 /**********************
  *  STATIC PROTOTYPES
@@ -65,7 +65,7 @@ lv_result_t lv_obj_set_property(lv_obj_t * obj, const lv_property_t * value)
     return obj_property(obj, value->id, (lv_property_t *)value, true);
 }
 
-lv_result_t lv_obj_set_properties(struct _lv_obj_t * obj, const lv_property_t * value, uint32_t count)
+lv_result_t lv_obj_set_properties(lv_obj_t * obj, const lv_property_t * value, uint32_t count)
 {
     for(uint32_t i = 0; i < count; i++) {
         lv_result_t result = lv_obj_set_property(obj, &value[i]);

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -34,8 +34,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-
 #define LV_PROPERTY_ID(clz, name, type, index)    LV_PROPERTY_## clz ##_##name = (LV_PROPERTY_## clz ##_START + (index)) | ((type) << 28)
 
 #define LV_PROPERTY_ID_TYPE(id) ((id) >> 28)
@@ -100,9 +98,9 @@ typedef struct {
  * @param value     The property value to set
  * @return          return LV_RESULT_OK if success
  */
-lv_result_t lv_obj_set_property(struct _lv_obj_t * obj, const lv_property_t * value);
+lv_result_t lv_obj_set_property(lv_obj_t * obj, const lv_property_t * value);
 
-lv_result_t lv_obj_set_properties(struct _lv_obj_t * obj, const lv_property_t * value, uint32_t count);
+lv_result_t lv_obj_set_properties(lv_obj_t * obj, const lv_property_t * value, uint32_t count);
 
 /*=====================
  * Getter functions
@@ -115,7 +113,7 @@ lv_result_t lv_obj_set_properties(struct _lv_obj_t * obj, const lv_property_t * 
  * @param value     pointer to a buffer to store the value
  * @return ? to be discussed, LV_RESULT_OK or LV_RESULT_INVALID
  */
-lv_property_t lv_obj_get_property(struct _lv_obj_t * obj, lv_prop_id_t id);
+lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -239,7 +239,7 @@ int32_t lv_obj_get_scroll_right(lv_obj_t * obj)
     return LV_MAX(child_res, self_w);
 }
 
-void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end)
+void lv_obj_get_scroll_end(lv_obj_t * obj, lv_point_t * end)
 {
     lv_anim_t * a;
     a = lv_anim_get(obj, scroll_x_anim);

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -26,7 +26,6 @@ extern "C" {
  **********************/
 
 /*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 /** Scrollbar modes: shows when should the scrollbars be visible*/
 enum _lv_scrollbar_mode_t {
@@ -69,28 +68,28 @@ typedef uint8_t lv_scroll_snap_t;
  * @param obj       pointer to an object
  * @param mode      LV_SCROLL_MODE_ON/OFF/AUTO/ACTIVE
  */
-void lv_obj_set_scrollbar_mode(struct _lv_obj_t * obj, lv_scrollbar_mode_t mode);
+void lv_obj_set_scrollbar_mode(lv_obj_t * obj, lv_scrollbar_mode_t mode);
 
 /**
  * Set the object in which directions can be scrolled
  * @param obj       pointer to an object
  * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
  */
-void lv_obj_set_scroll_dir(struct _lv_obj_t * obj, lv_dir_t dir);
+void lv_obj_set_scroll_dir(lv_obj_t * obj, lv_dir_t dir);
 
 /**
  * Set where to snap the children when scrolling ends horizontally
  * @param obj       pointer to an object
  * @param align     the snap align to set from `lv_scroll_snap_t`
  */
-void lv_obj_set_scroll_snap_x(struct _lv_obj_t * obj, lv_scroll_snap_t align);
+void lv_obj_set_scroll_snap_x(lv_obj_t * obj, lv_scroll_snap_t align);
 
 /**
  * Set where to snap the children when scrolling ends vertically
  * @param obj       pointer to an object
  * @param align     the snap align to set from `lv_scroll_snap_t`
  */
-void lv_obj_set_scroll_snap_y(struct _lv_obj_t * obj, lv_scroll_snap_t align);
+void lv_obj_set_scroll_snap_y(lv_obj_t * obj, lv_scroll_snap_t align);
 
 /*=====================
  * Getter functions
@@ -101,28 +100,28 @@ void lv_obj_set_scroll_snap_y(struct _lv_obj_t * obj, lv_scroll_snap_t align);
  * @param obj       pointer to an object
  * @return          the current scroll mode from `lv_scrollbar_mode_t`
  */
-lv_scrollbar_mode_t lv_obj_get_scrollbar_mode(const struct _lv_obj_t * obj);
+lv_scrollbar_mode_t lv_obj_get_scrollbar_mode(const lv_obj_t * obj);
 
 /**
  * Get the object in which directions can be scrolled
  * @param obj       pointer to an object
  * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
  */
-lv_dir_t lv_obj_get_scroll_dir(const struct _lv_obj_t * obj);
+lv_dir_t lv_obj_get_scroll_dir(const lv_obj_t * obj);
 
 /**
  * Get where to snap the children when scrolling ends horizontally
  * @param obj       pointer to an object
  * @return          the current snap align from `lv_scroll_snap_t`
  */
-lv_scroll_snap_t lv_obj_get_scroll_snap_x(const struct _lv_obj_t * obj);
+lv_scroll_snap_t lv_obj_get_scroll_snap_x(const lv_obj_t * obj);
 
 /**
  * Get where to snap the children when scrolling ends vertically
  * @param  obj      pointer to an object
  * @return          the current snap align from `lv_scroll_snap_t`
  */
-lv_scroll_snap_t lv_obj_get_scroll_snap_y(const struct _lv_obj_t * obj);
+lv_scroll_snap_t lv_obj_get_scroll_snap_y(const lv_obj_t * obj);
 
 /**
  * Get current X scroll position.
@@ -132,7 +131,7 @@ lv_scroll_snap_t lv_obj_get_scroll_snap_y(const struct _lv_obj_t * obj);
  *                  If scrolled return > 0
  *                  If scrolled in (elastic scroll) return < 0
  */
-int32_t lv_obj_get_scroll_x(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_x(const lv_obj_t * obj);
 
 /**
  * Get current Y scroll position.
@@ -142,7 +141,7 @@ int32_t lv_obj_get_scroll_x(const struct _lv_obj_t * obj);
  *                  If scrolled return > 0
  *                  If scrolled inside return < 0
  */
-int32_t lv_obj_get_scroll_y(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_y(const lv_obj_t * obj);
 
 /**
  * Return the height of the area above the object.
@@ -151,7 +150,7 @@ int32_t lv_obj_get_scroll_y(const struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area above the object in pixels
  */
-int32_t lv_obj_get_scroll_top(struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_top(lv_obj_t * obj);
 
 /**
  * Return the height of the area below the object.
@@ -160,7 +159,7 @@ int32_t lv_obj_get_scroll_top(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area below the object in pixels
  */
-int32_t lv_obj_get_scroll_bottom(struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_bottom(lv_obj_t * obj);
 
 /**
  * Return the width of the area on the left the object.
@@ -169,7 +168,7 @@ int32_t lv_obj_get_scroll_bottom(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area on the left the object in pixels
  */
-int32_t lv_obj_get_scroll_left(struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_left(lv_obj_t * obj);
 
 /**
  * Return the width of the area on the right the object.
@@ -178,7 +177,7 @@ int32_t lv_obj_get_scroll_left(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @return          the scrollable area on the right the object in pixels
  */
-int32_t lv_obj_get_scroll_right(struct _lv_obj_t * obj);
+int32_t lv_obj_get_scroll_right(lv_obj_t * obj);
 
 /**
  * Get the X and Y coordinates where the scrolling will end for this object if a scrolling animation is in progress.
@@ -186,7 +185,7 @@ int32_t lv_obj_get_scroll_right(struct _lv_obj_t * obj);
  * @param obj       pointer to an object
  * @param end       pointer to store the result
  */
-void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end);
+void lv_obj_get_scroll_end(lv_obj_t * obj, lv_point_t * end);
 
 /*=====================
  * Other functions
@@ -201,7 +200,7 @@ void lv_obj_get_scroll_end(struct _lv_obj_t  * obj, lv_point_t * end);
  * @note            > 0 value means scroll right/bottom (show the more content on the right/bottom)
  * @note            e.g. dy = -20 means scroll down 20 px
  */
-void lv_obj_scroll_by(struct _lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_by(lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll by a given amount of pixels.
@@ -212,7 +211,7 @@ void lv_obj_scroll_by(struct _lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enab
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  * @note            e.g. dy = -20 means scroll down 20 px
  */
-void lv_obj_scroll_by_bounded(struct _lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t anim_en);
+void lv_obj_scroll_by_bounded(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given coordinate on an object.
@@ -222,7 +221,7 @@ void lv_obj_scroll_by_bounded(struct _lv_obj_t * obj, int32_t dx, int32_t dy, lv
  * @param y         pixels to scroll vertically
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to(struct _lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to(lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given X coordinate on an object.
@@ -231,7 +230,7 @@ void lv_obj_scroll_to(struct _lv_obj_t * obj, int32_t x, int32_t y, lv_anim_enab
  * @param x         pixels to scroll horizontally
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_x(struct _lv_obj_t * obj, int32_t x, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_x(lv_obj_t * obj, int32_t x, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to a given Y coordinate on an object
@@ -240,14 +239,14 @@ void lv_obj_scroll_to_x(struct _lv_obj_t * obj, int32_t x, lv_anim_enable_t anim
  * @param y         pixels to scroll vertically
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_y(struct _lv_obj_t * obj, int32_t y, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_y(lv_obj_t * obj, int32_t y, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to an object until it becomes visible on its parent
  * @param obj       pointer to an object to scroll into view
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_view(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_view(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**
  * Scroll to an object until it becomes visible on its parent.
@@ -256,7 +255,7 @@ void lv_obj_scroll_to_view(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
  * @param obj       pointer to an object to scroll into view
  * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
  */
-void lv_obj_scroll_to_view_recursive(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_scroll_to_view_recursive(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**
  * Low level function to scroll by given x and y coordinates.
@@ -267,21 +266,21 @@ void lv_obj_scroll_to_view_recursive(struct _lv_obj_t * obj, lv_anim_enable_t an
  * @return          `LV_RESULT_INVALID`: to object was deleted in `LV_EVENT_SCROLL`;
  *                  `LV_RESULT_OK`: if the object is still valid
  */
-lv_result_t _lv_obj_scroll_by_raw(struct _lv_obj_t * obj, int32_t x, int32_t y);
+lv_result_t _lv_obj_scroll_by_raw(lv_obj_t * obj, int32_t x, int32_t y);
 
 /**
  * Tell whether an object is being scrolled or not at this moment
  * @param obj   pointer to an object
  * @return      true: `obj` is being scrolled
  */
-bool lv_obj_is_scrolling(const struct _lv_obj_t * obj);
+bool lv_obj_is_scrolling(const lv_obj_t * obj);
 
 /**
  * Check the children of `obj` and scroll `obj` to fulfill the scroll_snap settings
  * @param obj       an object whose children needs to checked and snapped
  * @param anim_en   LV_ANIM_ON/OFF
  */
-void lv_obj_update_snap(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_update_snap(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**
  * Get the area of the scrollbars
@@ -289,20 +288,20 @@ void lv_obj_update_snap(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
  * @param hor   pointer to store the area of the horizontal scrollbar
  * @param ver   pointer to store the area of the vertical  scrollbar
  */
-void lv_obj_get_scrollbar_area(struct _lv_obj_t * obj, lv_area_t * hor, lv_area_t * ver);
+void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor, lv_area_t * ver);
 
 /**
  * Invalidate the area of the scrollbars
  * @param obj       pointer to an object
  */
-void lv_obj_scrollbar_invalidate(struct _lv_obj_t * obj);
+void lv_obj_scrollbar_invalidate(lv_obj_t * obj);
 
 /**
  * Checks if the content is scrolled "in" and adjusts it to a normal position.
  * @param obj       pointer to an object
  * @param anim_en   LV_ANIM_ON/OFF
  */
-void lv_obj_readjust_scroll(struct _lv_obj_t * obj, lv_anim_enable_t anim_en);
+void lv_obj_readjust_scroll(lv_obj_t * obj, lv_anim_enable_t anim_en);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -151,7 +151,7 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     lv_obj_refresh_style(obj, selector, LV_STYLE_PROP_ANY);
 }
 
-bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
+bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
                           lv_style_selector_t selector)
 {
     lv_state_t state = lv_obj_style_get_selector_state(selector);
@@ -250,7 +250,7 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
     }
 }
 
-void lv_obj_remove_style_all(struct _lv_obj_t * obj)
+void lv_obj_remove_style_all(lv_obj_t * obj)
 {
     lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);
 }
@@ -629,7 +629,7 @@ void lv_obj_fade_out(lv_obj_t * obj, uint32_t time, uint32_t delay)
     lv_anim_start(&a);
 }
 
-lv_text_align_t lv_obj_calculate_style_text_align(const struct _lv_obj_t * obj, lv_part_t part, const char * txt)
+lv_text_align_t lv_obj_calculate_style_text_align(const lv_obj_t * obj, lv_part_t part, const char * txt)
 {
     lv_text_align_t align = lv_obj_get_style_text_align(obj, part);
     lv_base_dir_t base_dir = lv_obj_get_style_base_dir(obj, part);

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -26,7 +26,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 /*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 #ifndef LV_OBJ_H
 /// @cond
@@ -88,7 +87,7 @@ void _lv_obj_style_deinit(void);
  * @example         lv_obj_add_style(btn, &style_btn, 0); //Default button style
  * @example         lv_obj_add_style(btn, &btn_red, LV_STATE_PRESSED); //Overwrite only some colors to red when pressed
  */
-void lv_obj_add_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
+void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
  * Replaces a style of an object, preserving the order of the style stack (local styles and transitions are ignored).
@@ -99,7 +98,7 @@ void lv_obj_add_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style
  * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_ANY | LV_STATE_ANY); //Replace a specific style
  * @example lv_obj_replace_style(obj, &yellow_style, &blue_style, LV_PART_MAIN | LV_STATE_PRESSED); //Replace a specific style assigned to the main part when it is pressed
  */
-bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
+bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv_style_t * new_style,
                           lv_style_selector_t selector);
 
 /**
@@ -111,13 +110,13 @@ bool lv_obj_replace_style(struct _lv_obj_t * obj, const lv_style_t * old_style, 
  * @example lv_obj_remove_style(obj, NULL, LV_PART_MAIN | LV_STATE_ANY); //Remove all styles from the main part
  * @example lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY); //Remove all styles
  */
-void lv_obj_remove_style(struct _lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
+void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
  * Remove all styles from an object
  * @param obj       pointer to an object
  */
-void lv_obj_remove_style_all(struct _lv_obj_t * obj);
+void lv_obj_remove_style_all(lv_obj_t * obj);
 
 /**
  * Notify all object if a style is modified
@@ -134,7 +133,7 @@ void lv_obj_report_style_change(lv_style_t * style);
  *                  It is used to optimize what needs to be refreshed.
  *                  `LV_STYLE_PROP_INV` to perform only a style cache update
  */
-void lv_obj_refresh_style(struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
  * Enable or disable automatic style refreshing when a new style is added/removed to/from an object
@@ -153,7 +152,7 @@ void lv_obj_enable_style_refresh(bool en);
  * @return          the value of the property.
  *                  Should be read from the correct field of the `lv_style_value_t` according to the type of the property.
  */
-lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
+lv_style_value_t lv_obj_get_style_prop(const lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
 
 /**
  * Check if an object has a specified style property for a given style selector.
@@ -162,7 +161,7 @@ lv_style_value_t lv_obj_get_style_prop(const struct _lv_obj_t * obj, lv_part_t p
  * @param prop      the property to be checked.
  * @return          true if the object has the specified selector and property, false otherwise.
  */
-bool lv_obj_has_style_prop(const struct _lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop);
+bool lv_obj_has_style_prop(const lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop);
 
 /**
  * Set local style property on an object's part and state.
@@ -171,10 +170,10 @@ bool lv_obj_has_style_prop(const struct _lv_obj_t * obj, lv_style_selector_t sel
  * @param value     value of the property. The correct element should be set according to the type of the property
  * @param selector  OR-ed value of parts and state for which the style should be set
  */
-void lv_obj_set_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t value,
+void lv_obj_set_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t value,
                                  lv_style_selector_t selector);
 
-lv_style_res_t lv_obj_get_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t * value,
+lv_style_res_t lv_obj_get_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_value_t * value,
                                            lv_style_selector_t selector);
 
 /**
@@ -184,12 +183,12 @@ lv_style_res_t lv_obj_get_local_style_prop(struct _lv_obj_t * obj, lv_style_prop
  * @param selector  OR-ed value of parts and state for which the style should be removed
  * @return true     the property was found and removed; false: the property was not found
  */
-bool lv_obj_remove_local_style_prop(struct _lv_obj_t * obj, lv_style_prop_t prop, lv_style_selector_t selector);
+bool lv_obj_remove_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_selector_t selector);
 
 /**
  * Used internally for color filtering
  */
-lv_style_value_t _lv_obj_style_apply_color_filter(const struct _lv_obj_t * obj, uint32_t part, lv_style_value_t v);
+lv_style_value_t _lv_obj_style_apply_color_filter(const lv_obj_t * obj, uint32_t part, lv_style_value_t v);
 
 /**
  * Used internally to create a style transition
@@ -199,7 +198,7 @@ lv_style_value_t _lv_obj_style_apply_color_filter(const struct _lv_obj_t * obj, 
  * @param new_state
  * @param tr
  */
-void _lv_obj_style_create_transition(struct _lv_obj_t * obj, lv_part_t part, lv_state_t prev_state,
+void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t prev_state,
                                      lv_state_t new_state, const _lv_obj_style_transition_dsc_t * tr);
 
 /**
@@ -209,7 +208,7 @@ void _lv_obj_style_create_transition(struct _lv_obj_t * obj, lv_part_t part, lv_
  * @param state2
  * @return
  */
-_lv_style_state_cmp_t _lv_obj_style_state_compare(struct _lv_obj_t * obj, lv_state_t state1, lv_state_t state2);
+_lv_style_state_cmp_t _lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2);
 
 /**
  * Fade in an an object and all its children.
@@ -217,7 +216,7 @@ _lv_style_state_cmp_t _lv_obj_style_state_compare(struct _lv_obj_t * obj, lv_sta
  * @param time      time of fade
  * @param delay     delay to start the animation
  */
-void lv_obj_fade_in(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
+void lv_obj_fade_in(lv_obj_t * obj, uint32_t time, uint32_t delay);
 
 /**
  * Fade out an an object and all its children.
@@ -225,7 +224,7 @@ void lv_obj_fade_in(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
  * @param time      time of fade
  * @param delay     delay to start the animation
  */
-void lv_obj_fade_out(struct _lv_obj_t * obj, uint32_t time, uint32_t delay);
+void lv_obj_fade_out(lv_obj_t * obj, uint32_t time, uint32_t delay);
 
 static inline lv_state_t lv_obj_style_get_selector_state(lv_style_selector_t selector)
 {
@@ -239,7 +238,7 @@ static inline lv_part_t lv_obj_style_get_selector_part(lv_style_selector_t selec
 
 #include "lv_obj_style_gen.h"
 
-static inline void lv_obj_set_style_pad_all(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_all(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_left(obj, value, selector);
     lv_obj_set_style_pad_right(obj, value, selector);
@@ -247,19 +246,19 @@ static inline void lv_obj_set_style_pad_all(struct _lv_obj_t * obj, int32_t valu
     lv_obj_set_style_pad_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_hor(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_hor(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_left(obj, value, selector);
     lv_obj_set_style_pad_right(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_ver(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_ver(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_top(obj, value, selector);
     lv_obj_set_style_pad_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_all(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_all(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_left(obj, value, selector);
     lv_obj_set_style_margin_right(obj, value, selector);
@@ -267,39 +266,39 @@ static inline void lv_obj_set_style_margin_all(struct _lv_obj_t * obj, int32_t v
     lv_obj_set_style_margin_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_hor(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_hor(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_left(obj, value, selector);
     lv_obj_set_style_margin_right(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_margin_ver(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_margin_ver(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_margin_top(obj, value, selector);
     lv_obj_set_style_margin_bottom(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_pad_gap(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+static inline void lv_obj_set_style_pad_gap(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_obj_set_style_pad_row(obj, value, selector);
     lv_obj_set_style_pad_column(obj, value, selector);
 }
 
-static inline void lv_obj_set_style_size(struct _lv_obj_t * obj, int32_t width, int32_t height,
+static inline void lv_obj_set_style_size(lv_obj_t * obj, int32_t width, int32_t height,
                                          lv_style_selector_t selector)
 {
     lv_obj_set_style_width(obj, width, selector);
     lv_obj_set_style_height(obj, height, selector);
 }
 
-static inline void lv_obj_set_style_transform_scale(struct _lv_obj_t * obj, int32_t value,
+static inline void lv_obj_set_style_transform_scale(lv_obj_t * obj, int32_t value,
                                                     lv_style_selector_t selector)
 {
     lv_obj_set_style_transform_scale_x(obj, value, selector);
     lv_obj_set_style_transform_scale_y(obj, value, selector);
 }
 
-static inline int32_t lv_obj_get_style_space_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_space_left(const lv_obj_t * obj, uint32_t part)
 {
     int32_t padding = lv_obj_get_style_pad_left(obj, part);
     int32_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -307,7 +306,7 @@ static inline int32_t lv_obj_get_style_space_left(const struct _lv_obj_t * obj, 
     return (border_side & LV_BORDER_SIDE_LEFT) ? padding + border_width : padding;
 }
 
-static inline int32_t lv_obj_get_style_space_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_space_right(const lv_obj_t * obj, uint32_t part)
 {
     int32_t padding = lv_obj_get_style_pad_right(obj, part);
     int32_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -315,7 +314,7 @@ static inline int32_t lv_obj_get_style_space_right(const struct _lv_obj_t * obj,
     return (border_side & LV_BORDER_SIDE_RIGHT) ? padding + border_width : padding;
 }
 
-static inline int32_t lv_obj_get_style_space_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_space_top(const lv_obj_t * obj, uint32_t part)
 {
     int32_t padding = lv_obj_get_style_pad_top(obj, part);
     int32_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -323,7 +322,7 @@ static inline int32_t lv_obj_get_style_space_top(const struct _lv_obj_t * obj, u
     return (border_side & LV_BORDER_SIDE_TOP) ? padding + border_width : padding;
 }
 
-static inline int32_t lv_obj_get_style_space_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_space_bottom(const lv_obj_t * obj, uint32_t part)
 {
     int32_t padding = lv_obj_get_style_pad_bottom(obj, part);
     int32_t border_width = lv_obj_get_style_border_width(obj, part);
@@ -331,15 +330,15 @@ static inline int32_t lv_obj_get_style_space_bottom(const struct _lv_obj_t * obj
     return (border_side & LV_BORDER_SIDE_BOTTOM) ? padding + border_width : padding;
 }
 
-lv_text_align_t lv_obj_calculate_style_text_align(const struct _lv_obj_t * obj, lv_part_t part, const char * txt);
+lv_text_align_t lv_obj_calculate_style_text_align(const lv_obj_t * obj, lv_part_t part, const char * txt);
 
-static inline int32_t lv_obj_get_style_transform_scale_x_safe(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_scale_x_safe(const lv_obj_t * obj, uint32_t part)
 {
     int16_t zoom = lv_obj_get_style_transform_scale_x(obj, part);
     return zoom != 0 ? zoom : 1;
 }
 
-static inline int32_t lv_obj_get_style_transform_scale_y_safe(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_scale_y_safe(const lv_obj_t * obj, uint32_t part)
 {
     int16_t zoom = lv_obj_get_style_transform_scale_y(obj, part);
     return zoom != 0 ? zoom : 1;
@@ -351,7 +350,7 @@ static inline int32_t lv_obj_get_style_transform_scale_y_safe(const struct _lv_o
  * @param part      the part whose opacity should be get. Non-MAIN parts will consider the `opa` of the MAIN part too
  * @return          the final opacity considering the parents' opacity too
  */
-lv_opa_t lv_obj_get_style_opa_recursive(const struct _lv_obj_t * obj, lv_part_t part);
+lv_opa_t lv_obj_get_style_opa_recursive(const lv_obj_t * obj, lv_part_t part);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_style_gen.c
+++ b/src/core/lv_obj_style_gen.c
@@ -8,7 +8,7 @@
 
 #include "lv_obj.h"
 
-void lv_obj_set_style_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -16,7 +16,7 @@ void lv_obj_set_style_width(struct _lv_obj_t * obj, int32_t value, lv_style_sele
     lv_obj_set_local_style_prop(obj, LV_STYLE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_min_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_min_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -24,7 +24,7 @@ void lv_obj_set_style_min_width(struct _lv_obj_t * obj, int32_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_MIN_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_max_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_max_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -32,7 +32,7 @@ void lv_obj_set_style_max_width(struct _lv_obj_t * obj, int32_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_MAX_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -40,7 +40,7 @@ void lv_obj_set_style_height(struct _lv_obj_t * obj, int32_t value, lv_style_sel
     lv_obj_set_local_style_prop(obj, LV_STYLE_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_min_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_min_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -48,7 +48,7 @@ void lv_obj_set_style_min_height(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_MIN_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_max_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_max_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -56,7 +56,7 @@ void lv_obj_set_style_max_height(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_MAX_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_length(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_length(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -64,7 +64,7 @@ void lv_obj_set_style_length(struct _lv_obj_t * obj, int32_t value, lv_style_sel
     lv_obj_set_local_style_prop(obj, LV_STYLE_LENGTH, v, selector);
 }
 
-void lv_obj_set_style_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -72,7 +72,7 @@ void lv_obj_set_style_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector
     lv_obj_set_local_style_prop(obj, LV_STYLE_X, v, selector);
 }
 
-void lv_obj_set_style_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -80,7 +80,7 @@ void lv_obj_set_style_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector
     lv_obj_set_local_style_prop(obj, LV_STYLE_Y, v, selector);
 }
 
-void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -88,7 +88,7 @@ void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -96,7 +96,7 @@ void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, int32_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -104,7 +104,7 @@ void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, int32_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_HEIGHT, v, selector);
 }
 
-void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_translate_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -112,7 +112,7 @@ void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, int32_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSLATE_X, v, selector);
 }
 
-void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_translate_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -120,7 +120,7 @@ void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, int32_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSLATE_Y, v, selector);
 }
 
-void lv_obj_set_style_transform_scale_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_scale_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -128,7 +128,7 @@ void lv_obj_set_style_transform_scale_x(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_SCALE_X, v, selector);
 }
 
-void lv_obj_set_style_transform_scale_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_scale_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -136,7 +136,7 @@ void lv_obj_set_style_transform_scale_y(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_SCALE_Y, v, selector);
 }
 
-void lv_obj_set_style_transform_rotation(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_rotation(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -144,7 +144,7 @@ void lv_obj_set_style_transform_rotation(struct _lv_obj_t * obj, int32_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_ROTATION, v, selector);
 }
 
-void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -152,7 +152,7 @@ void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_PIVOT_X, v, selector);
 }
 
-void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -160,7 +160,7 @@ void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_PIVOT_Y, v, selector);
 }
 
-void lv_obj_set_style_transform_skew_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_skew_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -168,7 +168,7 @@ void lv_obj_set_style_transform_skew_x(struct _lv_obj_t * obj, int32_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_SKEW_X, v, selector);
 }
 
-void lv_obj_set_style_transform_skew_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_transform_skew_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -176,7 +176,7 @@ void lv_obj_set_style_transform_skew_y(struct _lv_obj_t * obj, int32_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSFORM_SKEW_Y, v, selector);
 }
 
-void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -184,7 +184,7 @@ void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, int32_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_TOP, v, selector);
 }
 
-void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -192,7 +192,7 @@ void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_BOTTOM, v, selector);
 }
 
-void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -200,7 +200,7 @@ void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, int32_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_LEFT, v, selector);
 }
 
-void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -208,7 +208,7 @@ void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, int32_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_RIGHT, v, selector);
 }
 
-void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_row(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -216,7 +216,7 @@ void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, int32_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_ROW, v, selector);
 }
 
-void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_pad_column(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -224,7 +224,7 @@ void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_PAD_COLUMN, v, selector);
 }
 
-void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -232,7 +232,7 @@ void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_TOP, v, selector);
 }
 
-void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -240,7 +240,7 @@ void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, int32_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_BOTTOM, v, selector);
 }
 
-void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -248,7 +248,7 @@ void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, int32_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_LEFT, v, selector);
 }
 
-void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_margin_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -256,7 +256,7 @@ void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, int32_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_MARGIN_RIGHT, v, selector);
 }
 
-void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -264,7 +264,7 @@ void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_COLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -272,7 +272,7 @@ void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -280,7 +280,7 @@ void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_COLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -288,7 +288,7 @@ void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_DIR, v, selector);
 }
 
-void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -296,7 +296,7 @@ void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, int32_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_MAIN_STOP, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -304,7 +304,7 @@ void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, int32_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_STOP, v, selector);
 }
 
-void lv_obj_set_style_bg_main_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_main_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -312,7 +312,7 @@ void lv_obj_set_style_bg_main_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_MAIN_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_grad_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -320,7 +320,7 @@ void lv_obj_set_style_bg_grad_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -328,7 +328,7 @@ void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * valu
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_GRAD, v, selector);
 }
 
-void lv_obj_set_style_bg_image_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -336,7 +336,7 @@ void lv_obj_set_style_bg_image_src(struct _lv_obj_t * obj, const void * value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMAGE_SRC, v, selector);
 }
 
-void lv_obj_set_style_bg_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -344,7 +344,7 @@ void lv_obj_set_style_bg_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMAGE_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_image_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -352,7 +352,7 @@ void lv_obj_set_style_bg_image_recolor(struct _lv_obj_t * obj, lv_color_t value,
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMAGE_RECOLOR, v, selector);
 }
 
-void lv_obj_set_style_bg_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -360,7 +360,7 @@ void lv_obj_set_style_bg_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t valu
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMAGE_RECOLOR_OPA, v, selector);
 }
 
-void lv_obj_set_style_bg_image_tiled(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_bg_image_tiled(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -368,7 +368,7 @@ void lv_obj_set_style_bg_image_tiled(struct _lv_obj_t * obj, bool value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BG_IMAGE_TILED, v, selector);
 }
 
-void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -376,7 +376,7 @@ void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_COLOR, v, selector);
 }
 
-void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -384,7 +384,7 @@ void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_OPA, v, selector);
 }
 
-void lv_obj_set_style_border_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -392,7 +392,7 @@ void lv_obj_set_style_border_width(struct _lv_obj_t * obj, int32_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector)
+void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -400,7 +400,7 @@ void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_SIDE, v, selector);
 }
 
-void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -408,7 +408,7 @@ void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_BORDER_POST, v, selector);
 }
 
-void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -416,7 +416,7 @@ void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, int32_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -424,7 +424,7 @@ void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_COLOR, v, selector);
 }
 
-void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -432,7 +432,7 @@ void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_OPA, v, selector);
 }
 
-void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_outline_pad(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -440,7 +440,7 @@ void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, int32_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_OUTLINE_PAD, v, selector);
 }
 
-void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -448,7 +448,7 @@ void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, int32_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_shadow_offset_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -456,7 +456,7 @@ void lv_obj_set_style_shadow_offset_x(struct _lv_obj_t * obj, int32_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OFFSET_X, v, selector);
 }
 
-void lv_obj_set_style_shadow_offset_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -464,7 +464,7 @@ void lv_obj_set_style_shadow_offset_y(struct _lv_obj_t * obj, int32_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OFFSET_Y, v, selector);
 }
 
-void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_spread(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -472,7 +472,7 @@ void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, int32_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_SPREAD, v, selector);
 }
 
-void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -480,7 +480,7 @@ void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_COLOR, v, selector);
 }
 
-void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -488,7 +488,7 @@ void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_styl
     lv_obj_set_local_style_prop(obj, LV_STYLE_SHADOW_OPA, v, selector);
 }
 
-void lv_obj_set_style_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -496,7 +496,7 @@ void lv_obj_set_style_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMAGE_OPA, v, selector);
 }
 
-void lv_obj_set_style_image_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -504,7 +504,7 @@ void lv_obj_set_style_image_recolor(struct _lv_obj_t * obj, lv_color_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMAGE_RECOLOR, v, selector);
 }
 
-void lv_obj_set_style_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -512,7 +512,7 @@ void lv_obj_set_style_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_IMAGE_RECOLOR_OPA, v, selector);
 }
 
-void lv_obj_set_style_line_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -520,7 +520,7 @@ void lv_obj_set_style_line_width(struct _lv_obj_t * obj, int32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_dash_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -528,7 +528,7 @@ void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, int32_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_DASH_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -536,7 +536,7 @@ void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, int32_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_DASH_GAP, v, selector);
 }
 
-void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -544,7 +544,7 @@ void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_ROUNDED, v, selector);
 }
 
-void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -552,7 +552,7 @@ void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_COLOR, v, selector);
 }
 
-void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -560,7 +560,7 @@ void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_LINE_OPA, v, selector);
 }
 
-void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -568,7 +568,7 @@ void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, int32_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_WIDTH, v, selector);
 }
 
-void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -576,7 +576,7 @@ void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_ROUNDED, v, selector);
 }
 
-void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -584,7 +584,7 @@ void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_COLOR, v, selector);
 }
 
-void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -592,7 +592,7 @@ void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_OPA, v, selector);
 }
 
-void lv_obj_set_style_arc_image_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector)
+void lv_obj_set_style_arc_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -600,7 +600,7 @@ void lv_obj_set_style_arc_image_src(struct _lv_obj_t * obj, const void * value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_ARC_IMAGE_SRC, v, selector);
 }
 
-void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .color = value
@@ -608,7 +608,7 @@ void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_st
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_COLOR, v, selector);
 }
 
-void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -616,7 +616,7 @@ void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_OPA, v, selector);
 }
 
-void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -624,7 +624,7 @@ void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value,
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_FONT, v, selector);
 }
 
-void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_letter_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -632,7 +632,7 @@ void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_LETTER_SPACE, v, selector);
 }
 
-void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_line_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -640,7 +640,7 @@ void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, int32_t value, lv_
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_LINE_SPACE, v, selector);
 }
 
-void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -648,7 +648,7 @@ void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_DECOR, v, selector);
 }
 
-void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -656,7 +656,7 @@ void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_TEXT_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_radius(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -664,7 +664,7 @@ void lv_obj_set_style_radius(struct _lv_obj_t * obj, int32_t value, lv_style_sel
     lv_obj_set_local_style_prop(obj, LV_STYLE_RADIUS, v, selector);
 }
 
-void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector)
+void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -672,7 +672,7 @@ void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_CLIP_CORNER, v, selector);
 }
 
-void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -680,7 +680,7 @@ void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selec
     lv_obj_set_local_style_prop(obj, LV_STYLE_OPA, v, selector);
 }
 
-void lv_obj_set_style_opa_layered(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_opa_layered(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -688,7 +688,7 @@ void lv_obj_set_style_opa_layered(struct _lv_obj_t * obj, lv_opa_t value, lv_sty
     lv_obj_set_local_style_prop(obj, LV_STYLE_OPA_LAYERED, v, selector);
 }
 
-void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_filter_dsc_t * value,
+void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc_t * value,
                                        lv_style_selector_t selector)
 {
     lv_style_value_t v = {
@@ -697,7 +697,7 @@ void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_fi
     lv_obj_set_local_style_prop(obj, LV_STYLE_COLOR_FILTER_DSC, v, selector);
 }
 
-void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
+void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -705,7 +705,7 @@ void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_COLOR_FILTER_OPA, v, selector);
 }
 
-void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -713,7 +713,7 @@ void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_ANIM, v, selector);
 }
 
-void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_anim_time(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -721,7 +721,7 @@ void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style
     lv_obj_set_local_style_prop(obj, LV_STYLE_ANIM_TIME, v, selector);
 }
 
-void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transition_dsc_t * value,
+void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t * value,
                                  lv_style_selector_t selector)
 {
     lv_style_value_t v = {
@@ -730,7 +730,7 @@ void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transiti
     lv_obj_set_local_style_prop(obj, LV_STYLE_TRANSITION, v, selector);
 }
 
-void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector)
+void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -738,7 +738,7 @@ void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, 
     lv_obj_set_local_style_prop(obj, LV_STYLE_BLEND_MODE, v, selector);
 }
 
-void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_selector_t selector)
+void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -746,7 +746,7 @@ void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_se
     lv_obj_set_local_style_prop(obj, LV_STYLE_LAYOUT, v, selector);
 }
 
-void lv_obj_set_style_base_dir(struct _lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector)
+void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -754,7 +754,7 @@ void lv_obj_set_style_base_dir(struct _lv_obj_t * obj, lv_base_dir_t value, lv_s
     lv_obj_set_local_style_prop(obj, LV_STYLE_BASE_DIR, v, selector);
 }
 
-void lv_obj_set_style_flex_flow(struct _lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector)
+void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -762,7 +762,7 @@ void lv_obj_set_style_flex_flow(struct _lv_obj_t * obj, lv_flex_flow_t value, lv
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_FLOW, v, selector);
 }
 
-void lv_obj_set_style_flex_main_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -770,7 +770,7 @@ void lv_obj_set_style_flex_main_place(struct _lv_obj_t * obj, lv_flex_align_t va
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_MAIN_PLACE, v, selector);
 }
 
-void lv_obj_set_style_flex_cross_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_flex_cross_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -778,7 +778,7 @@ void lv_obj_set_style_flex_cross_place(struct _lv_obj_t * obj, lv_flex_align_t v
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_CROSS_PLACE, v, selector);
 }
 
-void lv_obj_set_style_flex_track_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_flex_track_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -786,7 +786,7 @@ void lv_obj_set_style_flex_track_place(struct _lv_obj_t * obj, lv_flex_align_t v
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_TRACK_PLACE, v, selector);
 }
 
-void lv_obj_set_style_flex_grow(struct _lv_obj_t * obj, uint8_t value, lv_style_selector_t selector)
+void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -794,7 +794,7 @@ void lv_obj_set_style_flex_grow(struct _lv_obj_t * obj, uint8_t value, lv_style_
     lv_obj_set_local_style_prop(obj, LV_STYLE_FLEX_GROW, v, selector);
 }
 
-void lv_obj_set_style_grid_column_dsc_array(struct _lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_column_dsc_array(lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -802,7 +802,7 @@ void lv_obj_set_style_grid_column_dsc_array(struct _lv_obj_t * obj, const int32_
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_COLUMN_DSC_ARRAY, v, selector);
 }
 
-void lv_obj_set_style_grid_column_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_column_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -810,7 +810,7 @@ void lv_obj_set_style_grid_column_align(struct _lv_obj_t * obj, lv_grid_align_t 
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_COLUMN_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_grid_row_dsc_array(struct _lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_row_dsc_array(lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .ptr = value
@@ -818,7 +818,7 @@ void lv_obj_set_style_grid_row_dsc_array(struct _lv_obj_t * obj, const int32_t *
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_ROW_DSC_ARRAY, v, selector);
 }
 
-void lv_obj_set_style_grid_row_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_row_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -826,7 +826,7 @@ void lv_obj_set_style_grid_row_align(struct _lv_obj_t * obj, lv_grid_align_t val
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_ROW_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_column_pos(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_column_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -834,7 +834,7 @@ void lv_obj_set_style_grid_cell_column_pos(struct _lv_obj_t * obj, int32_t value
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_COLUMN_POS, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_x_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -842,7 +842,7 @@ void lv_obj_set_style_grid_cell_x_align(struct _lv_obj_t * obj, lv_grid_align_t 
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_X_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_column_span(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_column_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -850,7 +850,7 @@ void lv_obj_set_style_grid_cell_column_span(struct _lv_obj_t * obj, int32_t valu
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_COLUMN_SPAN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_row_pos(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_row_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -858,7 +858,7 @@ void lv_obj_set_style_grid_cell_row_pos(struct _lv_obj_t * obj, int32_t value, l
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_ROW_POS, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_y_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value
@@ -866,7 +866,7 @@ void lv_obj_set_style_grid_cell_y_align(struct _lv_obj_t * obj, lv_grid_align_t 
     lv_obj_set_local_style_prop(obj, LV_STYLE_GRID_CELL_Y_ALIGN, v, selector);
 }
 
-void lv_obj_set_style_grid_cell_row_span(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
+void lv_obj_set_style_grid_cell_row_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)
 {
     lv_style_value_t v = {
         .num = (int32_t)value

--- a/src/core/lv_obj_style_gen.h
+++ b/src/core/lv_obj_style_gen.h
@@ -13,831 +13,831 @@
 #include "../misc/lv_style.h"
 #include "../core/lv_obj_style.h"
 
-static inline int32_t lv_obj_get_style_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_min_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_min_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MIN_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_max_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_max_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MAX_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_HEIGHT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_min_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_min_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MIN_HEIGHT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_max_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_max_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MAX_HEIGHT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_length(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_length(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LENGTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_Y);
     return (int32_t)v.num;
 }
 
-static inline lv_align_t lv_obj_get_style_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_align_t lv_obj_get_style_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ALIGN);
     return (lv_align_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_height(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_height(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_HEIGHT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_translate_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_translate_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSLATE_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_translate_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_translate_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSLATE_Y);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_scale_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_scale_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_SCALE_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_scale_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_scale_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_SCALE_Y);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_rotation(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_rotation(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_ROTATION);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_pivot_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_pivot_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_PIVOT_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_pivot_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_pivot_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_PIVOT_Y);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_skew_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_skew_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_SKEW_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_transform_skew_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_transform_skew_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSFORM_SKEW_Y);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_top(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_TOP);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_bottom(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_BOTTOM);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_left(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_LEFT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_right(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_RIGHT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_row(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_row(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_ROW);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_pad_column(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_pad_column(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_PAD_COLUMN);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_margin_top(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_margin_top(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_TOP);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_margin_bottom(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_margin_bottom(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_BOTTOM);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_margin_left(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_margin_left(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_LEFT);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_margin_right(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_margin_right(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_MARGIN_RIGHT);
     return (int32_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_BG_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_grad_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_grad_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_grad_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_grad_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_BG_GRAD_COLOR));
     return v.color;
 }
 
-static inline lv_grad_dir_t lv_obj_get_style_bg_grad_dir(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grad_dir_t lv_obj_get_style_bg_grad_dir(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_DIR);
     return (lv_grad_dir_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_bg_main_stop(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_bg_main_stop(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_MAIN_STOP);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_bg_grad_stop(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_bg_grad_stop(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_STOP);
     return (int32_t)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_main_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_main_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_MAIN_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_grad_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_grad_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_grad_dsc_t * lv_obj_get_style_bg_grad(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_grad_dsc_t * lv_obj_get_style_bg_grad(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_GRAD);
     return (const lv_grad_dsc_t *)v.ptr;
 }
 
-static inline const void * lv_obj_get_style_bg_image_src(const struct _lv_obj_t * obj, uint32_t part)
+static inline const void * lv_obj_get_style_bg_image_src(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMAGE_SRC);
     return (const void *)v.ptr;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_image_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_image_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMAGE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_image_recolor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_image_recolor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMAGE_RECOLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_bg_image_recolor_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_bg_image_recolor_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_BG_IMAGE_RECOLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_bg_image_recolor_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_bg_image_recolor_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMAGE_RECOLOR_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline bool lv_obj_get_style_bg_image_tiled(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_bg_image_tiled(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BG_IMAGE_TILED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_border_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_border_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_border_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_border_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_BORDER_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_border_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_border_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_border_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_border_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline lv_border_side_t lv_obj_get_style_border_side(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_border_side_t lv_obj_get_style_border_side(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_SIDE);
     return (lv_border_side_t)v.num;
 }
 
-static inline bool lv_obj_get_style_border_post(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_border_post(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BORDER_POST);
     return (bool)v.num;
 }
 
-static inline int32_t lv_obj_get_style_outline_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_outline_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_outline_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_outline_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_outline_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_outline_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_OUTLINE_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_outline_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_outline_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_outline_pad(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_outline_pad(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OUTLINE_PAD);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_shadow_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_shadow_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_shadow_offset_x(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_shadow_offset_x(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OFFSET_X);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_shadow_offset_y(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_shadow_offset_y(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OFFSET_Y);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_shadow_spread(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_shadow_spread(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_SPREAD);
     return (int32_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_shadow_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_shadow_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_shadow_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_shadow_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_SHADOW_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_shadow_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_shadow_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_SHADOW_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_image_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_image_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMAGE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_image_recolor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_image_recolor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMAGE_RECOLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_image_recolor_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_image_recolor_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part,
                                                                                            LV_STYLE_IMAGE_RECOLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_image_recolor_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_image_recolor_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_IMAGE_RECOLOR_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_line_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_line_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_line_dash_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_line_dash_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_DASH_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_line_dash_gap(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_line_dash_gap(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_DASH_GAP);
     return (int32_t)v.num;
 }
 
-static inline bool lv_obj_get_style_line_rounded(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_line_rounded(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_ROUNDED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_line_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_line_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_line_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_line_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_line_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_line_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LINE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_arc_width(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_arc_width(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_WIDTH);
     return (int32_t)v.num;
 }
 
-static inline bool lv_obj_get_style_arc_rounded(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_arc_rounded(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_ROUNDED);
     return (bool)v.num;
 }
 
-static inline lv_color_t lv_obj_get_style_arc_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_arc_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_arc_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_arc_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_arc_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_arc_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const void * lv_obj_get_style_arc_image_src(const struct _lv_obj_t * obj, uint32_t part)
+static inline const void * lv_obj_get_style_arc_image_src(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ARC_IMAGE_SRC);
     return (const void *)v.ptr;
 }
 
-static inline lv_color_t lv_obj_get_style_text_color(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_text_color(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_COLOR);
     return v.color;
 }
 
-static inline lv_color_t lv_obj_get_style_text_color_filtered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_color_t lv_obj_get_style_text_color_filtered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = _lv_obj_style_apply_color_filter(obj, part, lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_COLOR));
     return v.color;
 }
 
-static inline lv_opa_t lv_obj_get_style_text_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_text_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_font_t * lv_obj_get_style_text_font(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_font_t * lv_obj_get_style_text_font(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_FONT);
     return (const lv_font_t *)v.ptr;
 }
 
-static inline int32_t lv_obj_get_style_text_letter_space(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_text_letter_space(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_LETTER_SPACE);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_text_line_space(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_text_line_space(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_LINE_SPACE);
     return (int32_t)v.num;
 }
 
-static inline lv_text_decor_t lv_obj_get_style_text_decor(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_text_decor_t lv_obj_get_style_text_decor(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_DECOR);
     return (lv_text_decor_t)v.num;
 }
 
-static inline lv_text_align_t lv_obj_get_style_text_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_text_align_t lv_obj_get_style_text_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TEXT_ALIGN);
     return (lv_text_align_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_radius(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_radius(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_RADIUS);
     return (int32_t)v.num;
 }
 
-static inline bool lv_obj_get_style_clip_corner(const struct _lv_obj_t * obj, uint32_t part)
+static inline bool lv_obj_get_style_clip_corner(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_CLIP_CORNER);
     return (bool)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline lv_opa_t lv_obj_get_style_opa_layered(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_opa_layered(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_OPA_LAYERED);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_color_filter_dsc_t * lv_obj_get_style_color_filter_dsc(const struct _lv_obj_t * obj,
+static inline const lv_color_filter_dsc_t * lv_obj_get_style_color_filter_dsc(const lv_obj_t * obj,
                                                                               uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_COLOR_FILTER_DSC);
     return (const lv_color_filter_dsc_t *)v.ptr;
 }
 
-static inline lv_opa_t lv_obj_get_style_color_filter_opa(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_opa_t lv_obj_get_style_color_filter_opa(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_COLOR_FILTER_OPA);
     return (lv_opa_t)v.num;
 }
 
-static inline const lv_anim_t * lv_obj_get_style_anim(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_anim_t * lv_obj_get_style_anim(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ANIM);
     return (const lv_anim_t *)v.ptr;
 }
 
-static inline uint32_t lv_obj_get_style_anim_time(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint32_t lv_obj_get_style_anim_time(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_ANIM_TIME);
     return (uint32_t)v.num;
 }
 
-static inline const lv_style_transition_dsc_t * lv_obj_get_style_transition(const struct _lv_obj_t * obj, uint32_t part)
+static inline const lv_style_transition_dsc_t * lv_obj_get_style_transition(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_TRANSITION);
     return (const lv_style_transition_dsc_t *)v.ptr;
 }
 
-static inline lv_blend_mode_t lv_obj_get_style_blend_mode(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_blend_mode_t lv_obj_get_style_blend_mode(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BLEND_MODE);
     return (lv_blend_mode_t)v.num;
 }
 
-static inline uint16_t lv_obj_get_style_layout(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint16_t lv_obj_get_style_layout(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_LAYOUT);
     return (uint16_t)v.num;
 }
 
-static inline lv_base_dir_t lv_obj_get_style_base_dir(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_base_dir_t lv_obj_get_style_base_dir(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_BASE_DIR);
     return (lv_base_dir_t)v.num;
 }
 
-static inline lv_flex_flow_t lv_obj_get_style_flex_flow(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_flex_flow_t lv_obj_get_style_flex_flow(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_FLOW);
     return (lv_flex_flow_t)v.num;
 }
 
-static inline lv_flex_align_t lv_obj_get_style_flex_main_place(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_flex_align_t lv_obj_get_style_flex_main_place(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_MAIN_PLACE);
     return (lv_flex_align_t)v.num;
 }
 
-static inline lv_flex_align_t lv_obj_get_style_flex_cross_place(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_flex_align_t lv_obj_get_style_flex_cross_place(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_CROSS_PLACE);
     return (lv_flex_align_t)v.num;
 }
 
-static inline lv_flex_align_t lv_obj_get_style_flex_track_place(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_flex_align_t lv_obj_get_style_flex_track_place(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_TRACK_PLACE);
     return (lv_flex_align_t)v.num;
 }
 
-static inline uint8_t lv_obj_get_style_flex_grow(const struct _lv_obj_t * obj, uint32_t part)
+static inline uint8_t lv_obj_get_style_flex_grow(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_FLEX_GROW);
     return (uint8_t)v.num;
 }
 
-static inline const int32_t * lv_obj_get_style_grid_column_dsc_array(const struct _lv_obj_t * obj, uint32_t part)
+static inline const int32_t * lv_obj_get_style_grid_column_dsc_array(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_COLUMN_DSC_ARRAY);
     return (const int32_t *)v.ptr;
 }
 
-static inline lv_grid_align_t lv_obj_get_style_grid_column_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_column_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_COLUMN_ALIGN);
     return (lv_grid_align_t)v.num;
 }
 
-static inline const int32_t * lv_obj_get_style_grid_row_dsc_array(const struct _lv_obj_t * obj, uint32_t part)
+static inline const int32_t * lv_obj_get_style_grid_row_dsc_array(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_ROW_DSC_ARRAY);
     return (const int32_t *)v.ptr;
 }
 
-static inline lv_grid_align_t lv_obj_get_style_grid_row_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_row_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_ROW_ALIGN);
     return (lv_grid_align_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_grid_cell_column_pos(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_grid_cell_column_pos(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_COLUMN_POS);
     return (int32_t)v.num;
 }
 
-static inline lv_grid_align_t lv_obj_get_style_grid_cell_x_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_cell_x_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_X_ALIGN);
     return (lv_grid_align_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_grid_cell_column_span(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_grid_cell_column_span(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_COLUMN_SPAN);
     return (int32_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_grid_cell_row_pos(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_grid_cell_row_pos(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_ROW_POS);
     return (int32_t)v.num;
 }
 
-static inline lv_grid_align_t lv_obj_get_style_grid_cell_y_align(const struct _lv_obj_t * obj, uint32_t part)
+static inline lv_grid_align_t lv_obj_get_style_grid_cell_y_align(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_Y_ALIGN);
     return (lv_grid_align_t)v.num;
 }
 
-static inline int32_t lv_obj_get_style_grid_cell_row_span(const struct _lv_obj_t * obj, uint32_t part)
+static inline int32_t lv_obj_get_style_grid_cell_row_span(const lv_obj_t * obj, uint32_t part)
 {
     lv_style_value_t v = lv_obj_get_style_prop(obj, part, LV_STYLE_GRID_CELL_ROW_SPAN);
     return (int32_t)v.num;
 }
 
-void lv_obj_set_style_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_min_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_max_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_min_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_max_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_length(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_align(struct _lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_height(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_translate_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_translate_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_scale_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_scale_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_rotation(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_pivot_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_pivot_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_skew_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transform_skew_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_top(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_bottom(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_left(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_right(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_row(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_pad_column(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_top(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_bottom(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_left(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_margin_right(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_dir(struct _lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_main_stop(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_stop(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_main_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_grad(struct _lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_image_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_image_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_bg_image_tiled(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_border_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_side(struct _lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector);
-void lv_obj_set_style_border_post(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_outline_pad(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_offset_x(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_offset_y(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_spread(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_shadow_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_image_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_image_recolor(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_image_recolor_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_dash_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_dash_gap(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_line_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_line_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_width(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_rounded(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_arc_image_src(struct _lv_obj_t * obj, const void * value, lv_style_selector_t selector);
-void lv_obj_set_style_text_color(struct _lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_font(struct _lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_text_letter_space(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_line_space(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_decor(struct _lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector);
-void lv_obj_set_style_text_align(struct _lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_radius(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_clip_corner(struct _lv_obj_t * obj, bool value, lv_style_selector_t selector);
-void lv_obj_set_style_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_opa_layered(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_color_filter_dsc(struct _lv_obj_t * obj, const lv_color_filter_dsc_t * value,
+void lv_obj_set_style_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_min_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_max_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_min_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_max_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_length(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_translate_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_translate_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_scale_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_scale_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_rotation(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_skew_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transform_skew_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_row(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_pad_column(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_margin_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_main_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_bg_image_tiled(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector);
+void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_outline_pad(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_spread(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_dash_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_arc_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
+void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_text_letter_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_line_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector);
+void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_t selector);
+void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_opa_layered(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc_t * value,
                                        lv_style_selector_t selector);
-void lv_obj_set_style_color_filter_opa(struct _lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
-void lv_obj_set_style_anim(struct _lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_anim_time(struct _lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_transition(struct _lv_obj_t * obj, const lv_style_transition_dsc_t * value,
+void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
+void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_anim_time(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t * value,
                                  lv_style_selector_t selector);
-void lv_obj_set_style_blend_mode(struct _lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector);
-void lv_obj_set_style_layout(struct _lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
-void lv_obj_set_style_base_dir(struct _lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);
-void lv_obj_set_style_flex_flow(struct _lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector);
-void lv_obj_set_style_flex_main_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_flex_cross_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_flex_track_place(struct _lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_flex_grow(struct _lv_obj_t * obj, uint8_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_column_dsc_array(struct _lv_obj_t * obj, const int32_t * value,
+void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector);
+void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
+void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_cross_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_track_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_column_dsc_array(lv_obj_t * obj, const int32_t * value,
                                             lv_style_selector_t selector);
-void lv_obj_set_style_grid_column_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_row_dsc_array(struct _lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_row_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_column_pos(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_x_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_column_span(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_row_pos(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_y_align(struct _lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
-void lv_obj_set_style_grid_cell_row_span(struct _lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_column_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_row_dsc_array(lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_row_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_column_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_column_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_row_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
+void lv_obj_set_style_grid_cell_row_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
 #endif /* LV_OBJ_STYLE_GEN_H */

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include <stddef.h>
 #include <stdbool.h>
+#include "../misc/lv_types.h"
 #include "../misc/lv_anim.h"
 #include "../display/lv_display.h"
 
@@ -26,17 +27,13 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-struct _lv_display_t;
-struct _lv_obj_class_t;
-
 typedef enum {
     LV_OBJ_TREE_WALK_NEXT,
     LV_OBJ_TREE_WALK_SKIP_CHILDREN,
     LV_OBJ_TREE_WALK_END,
 } lv_obj_tree_walk_res_t;
 
-typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(struct _lv_obj_t *, void *);
+typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(lv_obj_t *, void *);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -48,7 +45,7 @@ typedef lv_obj_tree_walk_res_t (*lv_obj_tree_walk_cb_t)(struct _lv_obj_t *, void
  * Send `LV_EVENT_DELETED` to deleted objects.
  * @param obj       pointer to an object
  */
-void lv_obj_delete(struct _lv_obj_t * obj);
+void lv_obj_delete(lv_obj_t * obj);
 
 /**
  * Delete all children of an object.
@@ -56,14 +53,14 @@ void lv_obj_delete(struct _lv_obj_t * obj);
  * Send `LV_EVENT_DELETED` to deleted objects.
  * @param obj       pointer to an object
  */
-void lv_obj_clean(struct _lv_obj_t * obj);
+void lv_obj_clean(lv_obj_t * obj);
 
 /**
  * Delete an object after some delay
  * @param obj       pointer to an object
  * @param delay_ms  time to wait before delete in milliseconds
  */
-void lv_obj_delete_delayed(struct _lv_obj_t * obj, uint32_t delay_ms);
+void lv_obj_delete_delayed(lv_obj_t * obj, uint32_t delay_ms);
 
 /**
  * A function to be easily used in animation ready callback to delete an object when the animation is ready
@@ -77,7 +74,7 @@ void lv_obj_delete_anim_ready_cb(lv_anim_t * a);
  * @param obj       object to delete
  * @see lv_async_call
  */
-void lv_obj_delete_async(struct _lv_obj_t * obj);
+void lv_obj_delete_async(lv_obj_t * obj);
 
 /**
  * Move the parent of an object. The relative coordinates will be kept.
@@ -85,7 +82,7 @@ void lv_obj_delete_async(struct _lv_obj_t * obj);
  * @param obj       pointer to an object whose parent needs to be changed
  * @param parent pointer to the new parent
  */
-void lv_obj_set_parent(struct _lv_obj_t * obj, struct _lv_obj_t * parent);
+void lv_obj_set_parent(lv_obj_t * obj, lv_obj_t * parent);
 
 /**
  * Swap the positions of two objects.
@@ -93,7 +90,7 @@ void lv_obj_set_parent(struct _lv_obj_t * obj, struct _lv_obj_t * parent);
  * @param obj1  pointer to the first object
  * @param obj2  pointer to the second object
  */
-void lv_obj_swap(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
+void lv_obj_swap(lv_obj_t * obj1, lv_obj_t * obj2);
 
 /**
  * moves the object to the given index in its parent.
@@ -103,28 +100,28 @@ void lv_obj_swap(struct _lv_obj_t * obj1, struct _lv_obj_t * obj2);
  * @note to move to the background: lv_obj_move_to_index(obj, 0)
  * @note to move forward (up): lv_obj_move_to_index(obj, lv_obj_get_index(obj) - 1)
  */
-void lv_obj_move_to_index(struct _lv_obj_t * obj, int32_t index);
+void lv_obj_move_to_index(lv_obj_t * obj, int32_t index);
 
 /**
  * Get the screen of an object
  * @param obj       pointer to an object
  * @return          pointer to the object's screen
  */
-struct _lv_obj_t * lv_obj_get_screen(const struct _lv_obj_t * obj);
+lv_obj_t * lv_obj_get_screen(const lv_obj_t * obj);
 
 /**
  * Get the display of the object
  * @param obj       pointer to an object
  * @return          pointer to the object's display
  */
-struct _lv_display_t * lv_obj_get_disp(const struct _lv_obj_t * obj);
+lv_display_t * lv_obj_get_disp(const lv_obj_t * obj);
 
 /**
  * Get the parent of an object
  * @param obj       pointer to an object
  * @return          the parent of the object. (NULL if `obj` was a screen)
  */
-struct _lv_obj_t * lv_obj_get_parent(const struct _lv_obj_t * obj);
+lv_obj_t * lv_obj_get_parent(const lv_obj_t * obj);
 
 /**
  * Get the child of an object by the child's index.
@@ -137,7 +134,7 @@ struct _lv_obj_t * lv_obj_get_parent(const struct _lv_obj_t * obj);
  *                  -2: the second youngest
  * @return          pointer to the child or NULL if the index was invalid
  */
-struct _lv_obj_t * lv_obj_get_child(const struct _lv_obj_t * obj, int32_t idx);
+lv_obj_t * lv_obj_get_child(const lv_obj_t * obj, int32_t idx);
 
 /**
  * Get the child of an object by the child's index. Consider the children only with a given type.
@@ -151,8 +148,8 @@ struct _lv_obj_t * lv_obj_get_child(const struct _lv_obj_t * obj, int32_t idx);
  * @param class_p   the type of the children to check
  * @return          pointer to the child or NULL if the index was invalid
  */
-struct _lv_obj_t * lv_obj_get_child_by_type(const struct _lv_obj_t * obj, int32_t idx,
-                                            const struct _lv_obj_class_t * class_p);
+lv_obj_t * lv_obj_get_child_by_type(const lv_obj_t * obj, int32_t idx,
+                                    const lv_obj_class_t * class_p);
 
 /**
  * Return a sibling of an object
@@ -165,7 +162,7 @@ struct _lv_obj_t * lv_obj_get_child_by_type(const struct _lv_obj_t * obj, int32_
  *                  etc
  * @return          pointer to the requested sibling  or NULL if there is no such sibling
  */
-struct _lv_obj_t * lv_obj_get_sibling(const struct _lv_obj_t * obj, int32_t idx);
+lv_obj_t * lv_obj_get_sibling(const lv_obj_t * obj, int32_t idx);
 
 /**
  * Return a sibling of an object. Consider the siblings only with a given type.
@@ -179,15 +176,15 @@ struct _lv_obj_t * lv_obj_get_sibling(const struct _lv_obj_t * obj, int32_t idx)
  * @param class_p   the type of the children to check
  * @return          pointer to the requested sibling  or NULL if there is no such sibling
  */
-struct _lv_obj_t * lv_obj_get_sibling_by_type(const struct _lv_obj_t * obj, int32_t idx,
-                                              const struct _lv_obj_class_t * class_p);
+lv_obj_t * lv_obj_get_sibling_by_type(const lv_obj_t * obj, int32_t idx,
+                                      const lv_obj_class_t * class_p);
 
 /**
  * Get the number of children
  * @param obj       pointer to an object
  * @return          the number of children
  */
-uint32_t lv_obj_get_child_count(const struct _lv_obj_t * obj);
+uint32_t lv_obj_get_child_count(const lv_obj_t * obj);
 
 /**
  * Get the number of children having a given type.
@@ -196,7 +193,7 @@ uint32_t lv_obj_get_child_count(const struct _lv_obj_t * obj);
  * @return          the number of children
  */
 
-uint32_t lv_obj_get_child_count_by_type(const struct _lv_obj_t * obj, const struct _lv_obj_class_t * class_p);
+uint32_t lv_obj_get_child_count_by_type(const lv_obj_t * obj, const lv_obj_class_t * class_p);
 
 /**
  * Get the index of a child.
@@ -205,7 +202,7 @@ uint32_t lv_obj_get_child_count_by_type(const struct _lv_obj_t * obj, const stru
  *                  E.g. 0: the oldest (firstly created child).
  *                  (-1 if child could not be found or no parent exists)
  */
-int32_t lv_obj_get_index(const struct _lv_obj_t * obj);
+int32_t lv_obj_get_index(const lv_obj_t * obj);
 
 /**
  * Get the index of a child. Consider the children only with a given type.
@@ -215,7 +212,7 @@ int32_t lv_obj_get_index(const struct _lv_obj_t * obj);
  *                  E.g. 0: the oldest (firstly created child with the given class).
  *                  (-1 if child could not be found or no parent exists)
  */
-int32_t lv_obj_get_index_by_type(const struct _lv_obj_t * obj, const struct _lv_obj_class_t * class_p);
+int32_t lv_obj_get_index_by_type(const lv_obj_t * obj, const lv_obj_class_t * class_p);
 
 /**
  * Iterate through all children of any object.
@@ -223,13 +220,13 @@ int32_t lv_obj_get_index_by_type(const struct _lv_obj_t * obj, const struct _lv_
  * @param cb            call this callback on the objects
  * @param user_data     pointer to any user related data (will be passed to `cb`)
  */
-void lv_obj_tree_walk(struct _lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void * user_data);
+void lv_obj_tree_walk(lv_obj_t * start_obj, lv_obj_tree_walk_cb_t cb, void * user_data);
 
 /**
  * Iterate through all children of any object and print their ID.
  * @param start_obj     start integrating from this object
  */
-void lv_obj_dump_tree(struct _lv_obj_t * start_ob);
+void lv_obj_dump_tree(lv_obj_t * start_ob);
 
 /**********************
  *      MACROS

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../misc/lv_types.h"
 #include "../misc/lv_timer.h"
 #include "../misc/lv_event.h"
 #include "../misc/lv_color.h"
@@ -29,11 +30,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_obj_t;
-struct _lv_theme_t;
-struct _lv_display_t;
-typedef struct _lv_display_t lv_display_t;
 
 typedef enum {
     LV_DISPLAY_ROTATION_0 = 0,
@@ -82,8 +78,8 @@ typedef enum {
     LV_SCR_LOAD_ANIM_OUT_BOTTOM,
 } lv_screen_load_anim_t;
 
-typedef void (*lv_display_flush_cb_t)(struct _lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
-typedef void (*lv_display_flush_wait_cb_t)(struct _lv_display_t * disp);
+typedef void (*lv_display_flush_cb_t)(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
+typedef void (*lv_display_flush_wait_cb_t)(lv_display_t * disp);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -322,7 +318,7 @@ bool lv_display_is_double_buffered(lv_display_t * disp);
  *                  (NULL to use the default screen)
  * @return          pointer to the active screen object (loaded by 'lv_screen_load()')
  */
-struct _lv_obj_t * lv_display_get_screen_active(lv_display_t * disp);
+lv_obj_t * lv_display_get_screen_active(lv_display_t * disp);
 
 /**
  * Return with a pointer to the previous screen. Only used during screen transitions.
@@ -330,27 +326,27 @@ struct _lv_obj_t * lv_display_get_screen_active(lv_display_t * disp);
  *                  (NULL to use the default screen)
  * @return          pointer to the previous screen object or NULL if not used now
  */
-struct _lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp);
+lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp);
 
 /**
  * Make a screen active
  * @param scr       pointer to a screen
  */
-void lv_display_load_scr(struct _lv_obj_t * scr);
+void lv_display_load_scr(lv_obj_t * scr);
 
 /**
  * Return the top layer. The top layer is the same on all screens and it is above the normal screen layer.
  * @param disp      pointer to display which top layer should be get. (NULL to use the default screen)
  * @return          pointer to the top layer object
  */
-struct _lv_obj_t * lv_display_get_layer_top(lv_display_t * disp);
+lv_obj_t * lv_display_get_layer_top(lv_display_t * disp);
 
 /**
  * Return the sys. layer. The system layer is the same on all screen and it is above the normal screen and the top layer.
  * @param disp      pointer to display which sys. layer should be retrieved. (NULL to use the default screen)
  * @return          pointer to the sys layer object
  */
-struct _lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp);
+lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp);
 
 /**
  * Return the bottom layer. The bottom layer is the same on all screen and it is under the normal screen layer.
@@ -358,7 +354,7 @@ struct _lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp);
  * @param disp      pointer to display (NULL to use the default screen)
  * @return          pointer to the bottom layer object
  */
-struct _lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp);
+lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp);
 
 /**
  * Switch screen with animation
@@ -368,14 +364,14 @@ struct _lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp);
  * @param delay     delay before the transition
  * @param auto_del  true: automatically delete the old screen
  */
-void lv_screen_load_anim(struct _lv_obj_t * scr, lv_screen_load_anim_t anim_type, uint32_t time, uint32_t delay,
+void lv_screen_load_anim(lv_obj_t * scr, lv_screen_load_anim_t anim_type, uint32_t time, uint32_t delay,
                          bool auto_del);
 
 /**
  * Get the active screen of the default display
  * @return          pointer to the active screen
  */
-static inline struct _lv_obj_t * lv_screen_active(void)
+static inline lv_obj_t * lv_screen_active(void)
 {
     return lv_display_get_screen_active(lv_display_get_default());
 }
@@ -384,7 +380,7 @@ static inline struct _lv_obj_t * lv_screen_active(void)
  * Get the top layer  of the default display
  * @return          pointer to the top layer
  */
-static inline struct _lv_obj_t * lv_layer_top(void)
+static inline lv_obj_t * lv_layer_top(void)
 {
     return lv_display_get_layer_top(lv_display_get_default());
 }
@@ -393,7 +389,7 @@ static inline struct _lv_obj_t * lv_layer_top(void)
  * Get the system layer  of the default display
  * @return          pointer to the sys layer
  */
-static inline struct _lv_obj_t * lv_layer_sys(void)
+static inline lv_obj_t * lv_layer_sys(void)
 {
     return lv_display_get_layer_sys(lv_display_get_default());
 }
@@ -402,7 +398,7 @@ static inline struct _lv_obj_t * lv_layer_sys(void)
  * Get the bottom layer  of the default display
  * @return          pointer to the bottom layer
  */
-static inline struct _lv_obj_t * lv_layer_bottom(void)
+static inline lv_obj_t * lv_layer_bottom(void)
 {
     return lv_display_get_layer_bottom(lv_display_get_default());
 }
@@ -411,7 +407,7 @@ static inline struct _lv_obj_t * lv_layer_bottom(void)
  * Load a screen on the default display
  * @param scr       pointer to a screen
  */
-static inline void lv_screen_load(struct _lv_obj_t * scr)
+static inline void lv_screen_load(lv_obj_t * scr)
 {
     lv_display_load_scr(scr);
 }
@@ -475,14 +471,14 @@ lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, voi
  * @param disp      pointer to a display
  * @param th        pointer to a theme
  */
-void lv_display_set_theme(lv_display_t * disp, struct _lv_theme_t * th);
+void lv_display_set_theme(lv_display_t * disp, lv_theme_t * th);
 
 /**
  * Get the theme of a display
  * @param disp      pointer to a display
  * @return          the display's theme (can be NULL)
  */
-struct _lv_theme_t * lv_display_get_theme(lv_display_t * disp);
+lv_theme_t * lv_display_get_theme(lv_display_t * disp);
 
 /**
  * Get elapsed time since last user activity on a display (e.g. click)

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../misc/lv_types.h"
 #include "../core/lv_obj.h"
 #include "../draw/lv_draw.h"
 #include "lv_display.h"
@@ -27,8 +28,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_display_t;
 
 struct _lv_display_t {
 
@@ -105,21 +104,21 @@ struct _lv_display_t {
      * Layer
      *--------------------*/
     lv_layer_t * layer_head;
-    void (*layer_init)(struct _lv_display_t * disp, lv_layer_t * layer);
-    void (*layer_deinit)(struct _lv_display_t * disp, lv_layer_t * layer);
+    void (*layer_init)(lv_display_t * disp, lv_layer_t * layer);
+    void (*layer_deinit)(lv_display_t * disp, lv_layer_t * layer);
 
     /*---------------------
      * Screens
      *--------------------*/
 
     /** Screens of the display*/
-    struct _lv_obj_t ** screens;    /**< Array of screen objects.*/
-    struct _lv_obj_t * act_scr;     /**< Currently active screen on this display*/
-    struct _lv_obj_t * prev_scr;    /**< Previous screen. Used during screen animations*/
-    struct _lv_obj_t * scr_to_load; /**< The screen prepared to load in lv_screen_load_anim*/
-    struct _lv_obj_t * bottom_layer;    /**< @see lv_display_get_layer_bottom*/
-    struct _lv_obj_t * top_layer;       /**< @see lv_display_get_layer_top*/
-    struct _lv_obj_t * sys_layer;       /**< @see lv_display_get_layer_sys*/
+    lv_obj_t ** screens;    /**< Array of screen objects.*/
+    lv_obj_t * act_scr;     /**< Currently active screen on this display*/
+    lv_obj_t * prev_scr;    /**< Previous screen. Used during screen animations*/
+    lv_obj_t * scr_to_load; /**< The screen prepared to load in lv_screen_load_anim*/
+    lv_obj_t * bottom_layer;    /**< @see lv_display_get_layer_bottom*/
+    lv_obj_t * top_layer;       /**< @see lv_display_get_layer_top*/
+    lv_obj_t * sys_layer;       /**< @see lv_display_get_layer_sys*/
     uint32_t screen_cnt;
     uint8_t draw_prev_over_act  : 1;/** 1: Draw previous screen over active screen*/
     uint8_t del_prev  : 1; /** 1: Automatically delete the previous screen when the screen load animation is ready*/
@@ -138,7 +137,7 @@ struct _lv_display_t {
     uint32_t rotation  : 2; /**< Element of  @lv_display_rotation_t*/
 
     /**< The theme assigned to the screen*/
-    struct _lv_theme_t * theme;
+    lv_theme_t * theme;
 
     /** A timer which periodically checks the dirty areas and refreshes them*/
     lv_timer_t * refr_timer;

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -169,7 +169,7 @@ void lv_draw_dispatch(void)
     LV_PROFILER_END;
 }
 
-bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer)
+bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
 {
     LV_PROFILER_BEGIN;
     /*Remove the finished tasks first*/

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 
+#include "../misc/lv_types.h"
 #include "../misc/lv_style.h"
 #include "../misc/lv_text.h"
 #include "../misc/lv_profiler.h"
@@ -30,9 +31,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
-struct _lv_draw_image_dsc_t;
-struct _lv_display_t;
 
 typedef enum {
     LV_DRAW_TASK_TYPE_FILL,
@@ -56,8 +54,8 @@ typedef enum {
     LV_DRAW_TASK_STATE_READY,
 } lv_draw_task_state_t;
 
-typedef struct _lv_draw_task_t {
-    struct _lv_draw_task_t * next;
+struct _lv_draw_task_t {
+    lv_draw_task_t * next;
 
     lv_draw_task_type_t type;
 
@@ -93,19 +91,19 @@ typedef struct _lv_draw_task_t {
      */
     uint8_t preference_score;
 
-} lv_draw_task_t;
+};
 
 typedef struct {
     void * user_data;
 } lv_draw_mask_t;
 
-typedef struct _lv_draw_unit_t {
-    struct _lv_draw_unit_t * next;
+struct _lv_draw_unit_t {
+    lv_draw_unit_t * next;
 
     /**
      * The target_layer on which drawing should happen
      */
-    struct _lv_layer_t * target_layer;
+    lv_layer_t * target_layer;
 
     const lv_area_t * clip_area;
 
@@ -123,7 +121,7 @@ typedef struct _lv_draw_unit_t {
      *                              It signals that LVGL should call the dispatcher later again
      *                              to let draw unit try to start the rendering again.
      */
-    int32_t (*dispatch_cb)(struct _lv_draw_unit_t * draw_unit, struct _lv_layer_t * layer);
+    int32_t (*dispatch_cb)(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
 
     /**
      *
@@ -131,17 +129,17 @@ typedef struct _lv_draw_unit_t {
      * @param task
      * @return
      */
-    int32_t (*evaluate_cb)(struct _lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
+    int32_t (*evaluate_cb)(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 
     /**
      * Called to delete draw unit.
      * @param draw_unit
      * @return
      */
-    int32_t (*delete_cb)(struct _lv_draw_unit_t * draw_unit);
-} lv_draw_unit_t;
+    int32_t (*delete_cb)(lv_draw_unit_t * draw_unit);
+};
 
-typedef struct _lv_layer_t  {
+struct _lv_layer_t  {
 
     /** The unaligned buffer where drawing will happen*/
     void * buf_unaligned;
@@ -170,14 +168,14 @@ typedef struct _lv_layer_t  {
     /** Linked list of draw tasks */
     lv_draw_task_t * draw_task_head;
 
-    struct _lv_layer_t * parent;
-    struct _lv_layer_t * next;
+    lv_layer_t * parent;
+    lv_layer_t * next;
     bool all_tasks_added;
     void * user_data;
-} lv_layer_t;
+};
 
 typedef struct {
-    struct _lv_obj_t * obj;
+    lv_obj_t * obj;
     uint32_t part;
     uint32_t id1;
     uint32_t id2;
@@ -248,7 +246,7 @@ void lv_draw_dispatch(void);
  * @param layer     pointer to a layer
  * @return          at least one draw task is being rendered (maybe it was taken earlier)
  */
-bool lv_draw_dispatch_layer(struct _lv_display_t * disp, lv_layer_t * layer);
+bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer);
 
 /**
  * Wait for a new dispatch request.

--- a/src/draw/lv_draw_arc.h
+++ b/src/draw/lv_draw_arc.h
@@ -40,8 +40,6 @@ typedef struct {
     uint8_t rounded : 1;
 } lv_draw_arc_dsc_t;
 
-struct _lv_layer_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -57,7 +55,7 @@ void lv_draw_arc_dsc_init(lv_draw_arc_dsc_t * dsc);
  * @param layer         pointer to a layer
  * @param dsc           pointer to an initialized draw descriptor variable
  */
-void lv_draw_arc(struct _lv_layer_t * layer, const lv_draw_arc_dsc_t * dsc);
+void lv_draw_arc(lv_layer_t * layer, const lv_draw_arc_dsc_t * dsc);
 
 /**
  * Get an area the should be invalidated when the arcs angle changed between start_angle and end_ange

--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -72,7 +72,6 @@ typedef struct _lv_draw_image_dsc_t {
 typedef void (*lv_draw_image_core_cb)(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
                                       const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                                       const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
-struct _lv_layer_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -90,7 +89,7 @@ void lv_draw_image_dsc_init(lv_draw_image_dsc_t * dsc);
  * @param dsc           pointer to an initialized draw descriptor
  * @param coords        the coordinates of the image
  */
-void lv_draw_image(struct _lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Create a draw task to blend a layer to an other layer
@@ -98,7 +97,7 @@ void lv_draw_image(struct _lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, 
  * @param dsc           pointer to an initialized draw descriptor
  * @param coords        the coordinates of the layer
  */
-void lv_draw_layer(struct _lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_layer(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Get the type of an image source

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -28,8 +28,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_layer_t;
-
 /** Store some info to speed up drawing of very large texts
  * It takes a lot of time to get the first visible character because
  * all the previous characters needs to be checked to calculate the positions.

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -43,7 +43,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc)
     dsc->color = lv_color_black();
 }
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_line(struct _lv_layer_t * layer, const lv_draw_line_dsc_t * dsc)
+LV_ATTRIBUTE_FAST_MEM void lv_draw_line(lv_layer_t * layer, const lv_draw_line_dsc_t * dsc)
 {
     LV_PROFILER_BEGIN;
     lv_area_t a;

--- a/src/draw/lv_draw_line.h
+++ b/src/draw/lv_draw_line.h
@@ -41,8 +41,6 @@ typedef struct {
     uint8_t raw_end     : 1;    /*Do not bother with perpendicular line ending if it's not visible for any reason*/
 } lv_draw_line_dsc_t;
 
-struct _lv_layer_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -58,7 +56,7 @@ void lv_draw_line_dsc_init(lv_draw_line_dsc_t * dsc);
  * @param layer     pointer to a layer
  * @param dsc       pointer to an initialized `lv_draw_line_dsc_t` variable
  */
-void lv_draw_line(struct _lv_layer_t * layer, const lv_draw_line_dsc_t * dsc);
+void lv_draw_line(lv_layer_t * layer, const lv_draw_line_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -41,7 +41,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect_dsc_init(lv_draw_mask_rect_dsc_t * 
     lv_memzero(dsc, sizeof(lv_draw_mask_rect_dsc_t));
 }
 
-LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect(struct _lv_layer_t * layer, const lv_draw_mask_rect_dsc_t * dsc)
+LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect(lv_layer_t * layer, const lv_draw_mask_rect_dsc_t * dsc)
 {
     if(!lv_color_format_has_alpha(layer->color_format)) {
         LV_LOG_WARN("Only layers with alpha channel can be masked");

--- a/src/draw/lv_draw_mask.h
+++ b/src/draw/lv_draw_mask.h
@@ -32,8 +32,6 @@ typedef struct {
     int32_t radius;
 } lv_draw_mask_rect_dsc_t;
 
-struct _lv_layer_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -49,7 +47,7 @@ LV_ATTRIBUTE_FAST_MEM void lv_draw_mask_rect_dsc_init(lv_draw_mask_rect_dsc_t * 
  * @param layer     pointer to a layer
  * @param dsc       pointer to a draw descriptor
  */
-void lv_draw_mask_rect(struct _lv_layer_t * layer, const lv_draw_mask_rect_dsc_t * dsc);
+void lv_draw_mask_rect(lv_layer_t * layer, const lv_draw_mask_rect_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/lv_draw_rect.h
+++ b/src/draw/lv_draw_rect.h
@@ -140,7 +140,7 @@ void lv_draw_box_shadow_dsc_init(lv_draw_box_shadow_dsc_t * dsc);
  * @param dsc           pointer to an initialized draw descriptor variable
  * @param coords        the coordinates of the rectangle
  */
-void lv_draw_rect(struct _lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords);
 
 /**********************
  *      MACROS

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -49,7 +49,7 @@ void lv_draw_triangle_dsc_init(lv_draw_triangle_dsc_t * dsc)
     LV_PROFILER_END;
 }
 
-void lv_draw_triangle(struct _lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
 {
     LV_PROFILER_BEGIN;
     lv_area_t a;

--- a/src/draw/lv_draw_triangle.h
+++ b/src/draw/lv_draw_triangle.h
@@ -47,7 +47,7 @@ void lv_draw_triangle_dsc_init(lv_draw_triangle_dsc_t * draw_dsc);
  * @param layer     pointer to a layer
  * @param dsc       pointer to an initialized `lv_draw_triangle_dsc_t` variable
  */
-void lv_draw_triangle(struct _lv_layer_t * layer, const lv_draw_triangle_dsc_t * draw_dsc);
+void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * draw_dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -47,8 +47,7 @@ typedef uint8_t lv_image_src_t;
 
 /*Decoder function definitions*/
 struct _lv_image_decoder_dsc_t;
-struct _lv_image_decoder_t;
-struct _lv_cache_entry_t;
+typedef struct _lv_image_decoder_dsc_t lv_image_decoder_dsc_t;
 
 /**
  * Image decoder args.
@@ -73,7 +72,7 @@ typedef struct _lv_image_decoder_args_t {
  * @param header store the info here
  * @return LV_RESULT_OK: info written correctly; LV_RESULT_INVALID: failed
  */
-typedef lv_result_t (*lv_image_decoder_info_f_t)(struct _lv_image_decoder_t * decoder, const void * src,
+typedef lv_result_t (*lv_image_decoder_info_f_t)(lv_image_decoder_t * decoder, const void * src,
                                                  lv_image_header_t * header);
 
 /**
@@ -82,8 +81,8 @@ typedef lv_result_t (*lv_image_decoder_info_f_t)(struct _lv_image_decoder_t * de
  * @param dsc pointer to decoder descriptor. `src`, `color` are already initialized in it.
  * @param args arguments of how to decode the image. see `lv_image_decoder_args_t`.
  */
-typedef lv_result_t (*lv_image_decoder_open_f_t)(struct _lv_image_decoder_t * decoder,
-                                                 struct _lv_image_decoder_dsc_t * dsc,
+typedef lv_result_t (*lv_image_decoder_open_f_t)(lv_image_decoder_t * decoder,
+                                                 lv_image_decoder_dsc_t * dsc,
                                                  const lv_image_decoder_args_t * args);
 
 /**
@@ -97,8 +96,8 @@ typedef lv_result_t (*lv_image_decoder_open_f_t)(struct _lv_image_decoder_t * de
  * @param buf a buffer to store the decoded pixels
  * @return LV_RESULT_OK: ok; LV_RESULT_INVALID: failed
  */
-typedef lv_result_t (*lv_image_decoder_get_area_cb_t)(struct _lv_image_decoder_t * decoder,
-                                                      struct _lv_image_decoder_dsc_t * dsc,
+typedef lv_result_t (*lv_image_decoder_get_area_cb_t)(lv_image_decoder_t * decoder,
+                                                      lv_image_decoder_dsc_t * dsc,
                                                       const lv_area_t * full_area, lv_area_t * decoded_area);
 
 /**
@@ -106,9 +105,9 @@ typedef lv_result_t (*lv_image_decoder_get_area_cb_t)(struct _lv_image_decoder_t
  * @param decoder pointer to the decoder the function associated with
  * @param dsc pointer to decoder descriptor
  */
-typedef void (*lv_image_decoder_close_f_t)(struct _lv_image_decoder_t * decoder, struct _lv_image_decoder_dsc_t * dsc);
+typedef void (*lv_image_decoder_close_f_t)(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 
-typedef struct _lv_image_decoder_t {
+struct _lv_image_decoder_t {
     lv_image_decoder_info_f_t info_cb;
     lv_image_decoder_open_f_t open_cb;
     lv_image_decoder_get_area_cb_t get_area_cb;
@@ -116,7 +115,7 @@ typedef struct _lv_image_decoder_t {
 
     lv_cache_free_cb_t cache_free_cb;
     void * user_data;
-} lv_image_decoder_t;
+};
 
 typedef struct _lv_image_decoder_cache_data_t {
     lv_cache_slot_size_t slot;
@@ -130,7 +129,7 @@ typedef struct _lv_image_decoder_cache_data_t {
 } lv_image_cache_data_t;
 
 /**Describe an image decoding session. Stores data about the decoding*/
-typedef struct _lv_image_decoder_dsc_t {
+struct _lv_image_decoder_dsc_t {
     /**The decoder which was able to open the image source*/
     lv_image_decoder_t * decoder;
 
@@ -168,7 +167,7 @@ typedef struct _lv_image_decoder_dsc_t {
 
     /**Store any custom data here is required*/
     void * user_data;
-} lv_image_decoder_dsc_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/draw/nxp/pxp/lv_draw_pxp.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp.h
@@ -37,7 +37,7 @@ typedef lv_layer_t lv_pxp_layer_t;
 
 typedef struct {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
 #if LV_USE_OS
     lv_thread_sync_t sync;
     lv_thread_t thread;

--- a/src/draw/nxp/vglite/lv_draw_vglite.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite.h
@@ -50,7 +50,7 @@ extern "C" {
 
 typedef struct {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
 #if LV_USE_OS
     lv_thread_sync_t sync;
     lv_thread_t thread;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -403,7 +403,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
         dave2d_execute_dlist_and_flush();
     }
 
-    struct _lv_draw_task_t ** p_new_list_entry;
+    lv_draw_task_t ** p_new_list_entry;
     p_new_list_entry = _lv_ll_ins_tail(&_ll_Dave2D_Tasks);
     *p_new_list_entry = t;
 #endif
@@ -598,8 +598,8 @@ void dave2d_execute_dlist_and_flush(void)
 #endif
 
     d2_s32     result;
-    struct _lv_draw_task_t ** p_list_entry;
-    struct _lv_draw_task_t * p_list_entry1;
+    lv_draw_task_t ** p_list_entry;
+    lv_draw_task_t * p_list_entry1;
 
     // Execute render operations
     result = d2_executerenderbuffer(_d2_handle, _renderbuffer, 0);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -26,7 +26,7 @@ extern "C" {
 
 typedef struct {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
 #if LV_USE_OS
     lv_thread_sync_t sync;
     lv_thread_t thread;

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -33,7 +33,7 @@ extern "C" {
 
 typedef struct {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
     uint32_t texture_cache_data_type;
     lv_cache_t * texture_cache;
 } lv_draw_sdl_unit_t;

--- a/src/draw/sw/blend/lv_draw_sw_blend.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend.h
@@ -44,8 +44,6 @@ typedef struct {
     lv_blend_mode_t blend_mode;     /**< E.g. LV_BLEND_MODE_ADDITIVE*/
 } lv_draw_sw_blend_dsc_t;
 
-struct _lv_draw_unit_t;
-
 typedef struct {
     void * dest_buf;
     int32_t dest_w;
@@ -80,7 +78,7 @@ typedef struct {
  * @param draw_unit     pointer to a draw unit
  * @param dsc           pointer to an initialized blend descriptor
  */
-void lv_draw_sw_blend(struct _lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t * dsc);
+void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -33,7 +33,7 @@ extern "C" {
 
 typedef struct {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
 #if LV_USE_OS
     lv_thread_sync_t sync;
     lv_thread_t thread;

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -31,7 +31,7 @@ extern "C" {
 
 typedef struct _lv_draw_vg_lite_unit_t {
     lv_draw_unit_t base_unit;
-    struct _lv_draw_task_t * task_act;
+    lv_draw_task_t * task_act;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;
     lv_ll_t path_free_ll;

--- a/src/draw/vg_lite/lv_vg_lite_path.h
+++ b/src/draw/vg_lite/lv_vg_lite_path.h
@@ -23,7 +23,7 @@ extern "C" {
  *********************/
 
 typedef struct _lv_vg_lite_path_t lv_vg_lite_path_t;
-struct _lv_draw_vg_lite_unit_t;
+typedef struct _lv_draw_vg_lite_unit_t lv_draw_vg_lite_unit_t;
 
 typedef void (*lv_vg_lite_path_iter_cb_t)(void * user_data, uint8_t op_code, const float * data, uint32_t len);
 
@@ -35,17 +35,17 @@ typedef void (*lv_vg_lite_path_iter_cb_t)(void * user_data, uint8_t op_code, con
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_vg_lite_path_init(struct _lv_draw_vg_lite_unit_t * unit);
+void lv_vg_lite_path_init(lv_draw_vg_lite_unit_t * unit);
 
-void lv_vg_lite_path_deinit(struct _lv_draw_vg_lite_unit_t * unit);
+void lv_vg_lite_path_deinit(lv_draw_vg_lite_unit_t * unit);
 
 lv_vg_lite_path_t * lv_vg_lite_path_create(vg_lite_format_t data_format);
 
 void lv_vg_lite_path_destroy(lv_vg_lite_path_t * path);
 
-lv_vg_lite_path_t * lv_vg_lite_path_get(struct _lv_draw_vg_lite_unit_t * unit, vg_lite_format_t data_format);
+lv_vg_lite_path_t * lv_vg_lite_path_get(lv_draw_vg_lite_unit_t * unit, vg_lite_format_t data_format);
 
-void lv_vg_lite_path_drop(struct _lv_draw_vg_lite_unit_t * unit, lv_vg_lite_path_t * path);
+void lv_vg_lite_path_drop(lv_draw_vg_lite_unit_t * unit, lv_vg_lite_path_t * path);
 
 void lv_vg_lite_path_reset(lv_vg_lite_path_t * path, vg_lite_format_t data_format);
 

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -37,11 +37,10 @@ extern "C" {
  * General types
  *-----------------*/
 
-struct _lv_font_t;
 /** Describes the properties of a glyph.*/
 typedef struct {
-    const struct _lv_font_t *
-        resolved_font; /**< Pointer to a font where the glyph was actually found after handling fallbacks*/
+    const lv_font_t *
+    resolved_font; /**< Pointer to a font where the glyph was actually found after handling fallbacks*/
     uint16_t adv_w; /**< The glyph needs this space. Draw the next glyph after this width.*/
     uint16_t box_w; /**< Width of the glyph's bounding box*/
     uint16_t box_h; /**< Height of the glyph's bounding box*/
@@ -83,13 +82,13 @@ typedef uint8_t lv_font_kerning_t;
 /** Describe the properties of a font*/
 typedef struct _lv_font_t {
     /** Get a glyph's descriptor from a font*/
-    bool (*get_glyph_dsc)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
+    bool (*get_glyph_dsc)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
     /** Get a glyph's bitmap from a font*/
-    const uint8_t * (*get_glyph_bitmap)(const struct _lv_font_t *, lv_font_glyph_dsc_t *, uint32_t, uint8_t *);
+    const uint8_t * (*get_glyph_bitmap)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t, uint8_t *);
 
     /** Release a glyph*/
-    void (*release_glyph)(const struct _lv_font_t *, lv_font_glyph_dsc_t *);
+    void (*release_glyph)(const lv_font_t *, lv_font_glyph_dsc_t *);
 
     /*Pointer to the font in a font pack (must have the same line height)*/
     int32_t line_height;         /**< The real line height where any text fits*/
@@ -101,7 +100,7 @@ typedef struct _lv_font_t {
     int8_t underline_thickness;     /**< Thickness of the underline*/
 
     const void * dsc;               /**< Store implementation specific or run_time data or caching here*/
-    const struct _lv_font_t * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
+    const lv_font_t * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
     void * user_data;               /**< Custom user data for font.*/
 } lv_font_t;
 

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -25,12 +25,6 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-struct _lv_obj_t;
-struct _lv_display_t;
-struct _lv_group_t;
-struct _lv_indev_t;
-struct _lv_display_t;
-typedef struct _lv_indev_t lv_indev_t;
 
 /** Possible input device types*/
 typedef enum {
@@ -63,7 +57,7 @@ typedef struct {
     bool continue_reading;  /**< If set to true, the read callback is invoked again*/
 } lv_indev_data_t;
 
-typedef void (*lv_indev_read_cb_t)(struct _lv_indev_t * indev, lv_indev_data_t * data);
+typedef void (*lv_indev_read_cb_t)(lv_indev_t * indev, lv_indev_data_t * data);
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -137,9 +131,9 @@ lv_indev_state_t lv_indev_get_state(const lv_indev_t * indev);
 
 lv_group_t * lv_indev_get_group(const lv_indev_t * indev);
 
-struct _lv_display_t * lv_indev_get_disp(const lv_indev_t * indev);
+lv_display_t * lv_indev_get_disp(const lv_indev_t * indev);
 
-void lv_indev_set_disp(lv_indev_t * indev, struct _lv_display_t * disp);
+void lv_indev_set_disp(lv_indev_t * indev, lv_display_t * disp);
 
 void * lv_indev_get_user_data(const lv_indev_t * indev);
 
@@ -150,7 +144,7 @@ void * lv_indev_get_driver_data(const lv_indev_t * indev);
  * @param indev pointer to an input device to reset or NULL to reset all of them
  * @param obj pointer to an object which triggers the reset.
  */
-void lv_indev_reset(lv_indev_t * indev, struct _lv_obj_t * obj);
+void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj);
 
 /**
  * Reset the long press state of an input device
@@ -163,7 +157,7 @@ void lv_indev_reset_long_press(lv_indev_t * indev);
  * @param indev pointer to an input device
  * @param cur_obj pointer to an object to be used as cursor
  */
-void lv_indev_set_cursor(lv_indev_t * indev, struct _lv_obj_t * cur_obj);
+void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj);
 
 /**
  * Set a destination group for a keypad input device (for LV_INDEV_TYPE_KEYPAD)
@@ -216,7 +210,7 @@ lv_dir_t lv_indev_get_scroll_dir(const lv_indev_t * indev);
  * @param indev pointer to an input device
  * @return pointer to the currently scrolled object or NULL if no scrolling by this indev
  */
-struct _lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev);
+lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev);
 
 /**
  * Get the movement vector of an input device (for LV_INDEV_TYPE_POINTER and
@@ -236,7 +230,7 @@ void lv_indev_wait_release(lv_indev_t * indev);
  * Gets a pointer to the currently active object in the currently processed input device.
  * @return pointer to currently active object or NULL if no active object
  */
-struct _lv_obj_t * lv_indev_get_active_obj(void);
+lv_obj_t * lv_indev_get_active_obj(void);
 
 /**
  * Get a pointer to the indev read timer to
@@ -259,7 +253,7 @@ void lv_indev_set_mode(lv_indev_t * indev, lv_indev_mode_t mode);
  * @param point pointer to a point for searching the most top child
  * @return pointer to the found object or NULL if there was no suitable object
  */
-struct _lv_obj_t * lv_indev_search_obj(struct _lv_obj_t * obj, lv_point_t * point);
+lv_obj_t * lv_indev_search_obj(lv_obj_t * obj, lv_point_t * point);
 
 /**
  * Add an event handler to the indev

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -23,9 +23,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_indev_t;
-struct _lv_event_t;
-
 struct _lv_indev_t {
     /**< Input device type*/
     lv_indev_type_t type;
@@ -49,7 +46,7 @@ struct _lv_indev_t {
     void * user_data;
 
     /**< Pointer to the assigned display*/
-    struct _lv_display_t * disp;
+    lv_display_t * disp;
 
     /**< Timer to periodically read the input device*/
     lv_timer_t * read_timer;
@@ -81,10 +78,10 @@ struct _lv_indev_t {
         lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
         lv_point_t scroll_throw_vect;
         lv_point_t scroll_throw_vect_ori;
-        struct _lv_obj_t * act_obj;      /*The object being pressed*/
-        struct _lv_obj_t * last_obj;     /*The last object which was pressed*/
-        struct _lv_obj_t * scroll_obj;   /*The object being scrolled*/
-        struct _lv_obj_t * last_pressed; /*The lastly pressed object*/
+        lv_obj_t * act_obj;      /*The object being pressed*/
+        lv_obj_t * last_obj;     /*The last object which was pressed*/
+        lv_obj_t * scroll_obj;   /*The object being scrolled*/
+        lv_obj_t * last_pressed; /*The lastly pressed object*/
         lv_area_t scroll_area;
         lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
 
@@ -99,8 +96,8 @@ struct _lv_indev_t {
         uint32_t last_key;
     } keypad;
 
-    struct _lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
-    struct _lv_group_t * group;    /**< Keypad destination group*/
+    lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
+    lv_group_t * group;   /**< Keypad destination group*/
     const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed
                                       here by the buttons*/
 

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -322,7 +322,7 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
     int32_t (*area_get_main_size)(const lv_area_t *) = (f->row ? lv_area_get_width : lv_area_get_height);
     int32_t (*area_get_cross_size)(const lv_area_t *) = (!f->row ? lv_area_get_width : lv_area_get_height);
 
-    typedef int32_t (*margin_func_t)(const struct _lv_obj_t *, uint32_t);
+    typedef int32_t (*margin_func_t)(const lv_obj_t *, uint32_t);
     margin_func_t get_margin_main_start = (f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);
     margin_func_t get_margin_main_end = (f->row ? lv_obj_get_style_margin_right : lv_obj_get_style_margin_bottom);
     margin_func_t get_margin_cross_start = (!f->row ? lv_obj_get_style_margin_left : lv_obj_get_style_margin_top);

--- a/src/layouts/flex/lv_flex.h
+++ b/src/layouts/flex/lv_flex.h
@@ -31,7 +31,6 @@ extern "C" {
  **********************/
 
 /*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 typedef enum {
     LV_FLEX_ALIGN_START,
@@ -72,7 +71,7 @@ void lv_flex_init(void);
  * @param obj pointer to an object. The parent must have flex layout else nothing will happen.
  * @param flow an element of `lv_flex_flow_t`.
  */
-void lv_obj_set_flex_flow(struct _lv_obj_t * obj, lv_flex_flow_t flow);
+void lv_obj_set_flex_flow(lv_obj_t * obj, lv_flex_flow_t flow);
 
 /**
  * Set how to place (where to align) the items and tracks
@@ -81,7 +80,7 @@ void lv_obj_set_flex_flow(struct _lv_obj_t * obj, lv_flex_flow_t flow);
  * @param cross_place where to place the item in their track on the cross axis. `LV_FLEX_ALIGN_START/END/CENTER`
  * @param track_cross_place where to place the tracks in the cross direction. Any value of `lv_flex_align_t`.
  */
-void lv_obj_set_flex_align(struct _lv_obj_t * obj, lv_flex_align_t main_place, lv_flex_align_t cross_place,
+void lv_obj_set_flex_align(lv_obj_t * obj, lv_flex_align_t main_place, lv_flex_align_t cross_place,
                            lv_flex_align_t track_cross_place);
 
 /**
@@ -89,7 +88,7 @@ void lv_obj_set_flex_align(struct _lv_obj_t * obj, lv_flex_align_t main_place, l
  * @param obj pointer to an object. The parent must have flex layout else nothing will happen.
  * @param grow a value to set how much free space to take proportionally to other growing items.
  */
-void lv_obj_set_flex_grow(struct _lv_obj_t * obj, uint8_t grow);
+void lv_obj_set_flex_grow(lv_obj_t * obj, uint8_t grow);
 
 /**********************
  *      MACROS

--- a/src/layouts/grid/lv_grid.h
+++ b/src/layouts/grid/lv_grid.h
@@ -39,7 +39,6 @@ LV_EXPORT_CONST_INT(LV_GRID_TEMPLATE_LAST);
  **********************/
 
 /*Can't include lv_obj.h because it includes this header file*/
-struct _lv_obj_t;
 
 typedef enum {
     LV_GRID_ALIGN_START,
@@ -61,9 +60,9 @@ typedef enum {
 
 void lv_grid_init(void);
 
-void lv_obj_set_grid_dsc_array(struct _lv_obj_t * obj, const int32_t col_dsc[], const int32_t row_dsc[]);
+void lv_obj_set_grid_dsc_array(lv_obj_t * obj, const int32_t col_dsc[], const int32_t row_dsc[]);
 
-void lv_obj_set_grid_align(struct _lv_obj_t * obj, lv_grid_align_t column_align, lv_grid_align_t row_align);
+void lv_obj_set_grid_align(lv_obj_t * obj, lv_grid_align_t column_align, lv_grid_align_t row_align);
 
 /**
  * Set the cell of an object. The object's parent needs to have grid layout, else nothing will happen
@@ -75,7 +74,7 @@ void lv_obj_set_grid_align(struct _lv_obj_t * obj, lv_grid_align_t column_align,
  * @param row_pos row ID
  * @param row_span number of rows to take (>= 1)
  */
-void lv_obj_set_grid_cell(struct _lv_obj_t * obj, lv_grid_align_t column_align, int32_t col_pos, int32_t col_span,
+void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t column_align, int32_t col_pos, int32_t col_span,
                           lv_grid_align_t row_align, int32_t row_pos, int32_t row_span);
 
 /**

--- a/src/layouts/lv_layout.h
+++ b/src/layouts/lv_layout.h
@@ -24,9 +24,7 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_obj_t;
-
-typedef void (*lv_layout_update_cb_t)(struct _lv_obj_t *, void * user_data);
+typedef void (*lv_layout_update_cb_t)(lv_obj_t *, void * user_data);
 typedef struct {
     lv_layout_update_cb_t cb;
     void * user_data;
@@ -66,7 +64,7 @@ uint32_t lv_layout_register(lv_layout_update_cb_t cb, void * user_data);
  * Update the layout of a widget
  * @param obj   pointer to a widget
  */
-void _lv_layout_apply(struct _lv_obj_t * obj);
+void _lv_layout_apply(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -24,7 +24,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(struct _lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
                                 const lv_image_decoder_args_t * args);
 static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
@@ -77,7 +77,7 @@ void lv_lodepng_deinit(void)
  * @param header    image information is set in header parameter
  * @return          LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
  */
-static lv_result_t decoder_info(struct _lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
 {
     (void) decoder; /*Unused*/
     lv_image_src_t src_type = lv_image_src_get_type(src);          /*Get the source type*/

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -165,7 +165,7 @@ lv_anim_t * lv_anim_get(void * var, lv_anim_exec_xcb_t exec_cb)
     return NULL;
 }
 
-struct _lv_timer_t * lv_anim_get_timer(void)
+lv_timer_t * lv_anim_get_timer(void)
 {
     return state.timer;
 }

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
+#include "lv_types.h"
 #include "lv_math.h"
 #include "lv_timer.h"
 #include "lv_ll.h"
@@ -88,18 +89,15 @@ typedef enum {
     LV_ANIM_ON,
 } lv_anim_enable_t;
 
-struct _lv_anim_t;
-struct _lv_timer_t;
-
 typedef struct {
     bool anim_list_changed;
     bool anim_run_round;
-    struct _lv_timer_t * timer;
+    lv_timer_t * timer;
     lv_ll_t anim_ll;
 } lv_anim_state_t;
 
 /** Get the current value during an animation*/
-typedef int32_t (*lv_anim_path_cb_t)(const struct _lv_anim_t *);
+typedef int32_t (*lv_anim_path_cb_t)(const lv_anim_t *);
 
 /** Generic prototype of "animator" functions.
  * First parameter is the variable to animate.
@@ -111,19 +109,19 @@ typedef void (*lv_anim_exec_xcb_t)(void *, int32_t);
 
 /** Same as `lv_anim_exec_xcb_t` but receives `lv_anim_t *` as the first parameter.
  * It's more consistent but less convenient. Might be used by binding generator functions.*/
-typedef void (*lv_anim_custom_exec_cb_t)(struct _lv_anim_t *, int32_t);
+typedef void (*lv_anim_custom_exec_cb_t)(lv_anim_t *, int32_t);
 
 /** Callback to call when the animation is ready*/
-typedef void (*lv_anim_ready_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_ready_cb_t)(lv_anim_t *);
 
 /** Callback to call when the animation really stars (considering `delay`)*/
-typedef void (*lv_anim_start_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_start_cb_t)(lv_anim_t *);
 
 /** Callback used when the animation values are relative to get the current value*/
-typedef int32_t (*lv_anim_get_value_cb_t)(struct _lv_anim_t *);
+typedef int32_t (*lv_anim_get_value_cb_t)(lv_anim_t *);
 
 /** Callback used when the animation is deleted*/
-typedef void (*lv_anim_deleted_cb_t)(struct _lv_anim_t *);
+typedef void (*lv_anim_deleted_cb_t)(lv_anim_t *);
 
 typedef struct _lv_anim_bezier3_para_t {
     int16_t x1;
@@ -133,7 +131,7 @@ typedef struct _lv_anim_bezier3_para_t {
 } lv_anim_bezier3_para_t; /**< Parameter used when path is custom_bezier*/
 
 /** Describes an animation*/
-typedef struct _lv_anim_t {
+struct _lv_anim_t {
     void * var;                                 /**<Variable to animate*/
     lv_anim_exec_xcb_t exec_cb;                 /**< Function to execute to animate*/
     lv_anim_custom_exec_cb_t custom_exec_cb;/**< Function to execute to animate,
@@ -164,7 +162,7 @@ typedef struct _lv_anim_t {
     uint8_t playback_now : 1; /**< Play back is in progress*/
     uint8_t run_round : 1;    /**< Indicates the animation has run in this round*/
     uint8_t start_cb_called : 1;    /**< Indicates that the `start_cb` was already called*/
-} lv_anim_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -484,7 +482,7 @@ lv_anim_t * lv_anim_get(void * var, lv_anim_exec_xcb_t exec_cb);
  * Get global animation refresher timer.
  * @return pointer to the animation refresher timer.
  */
-struct _lv_timer_t * lv_anim_get_timer(void);
+lv_timer_t * lv_anim_get_timer(void);
 
 /**
  * Delete an animation by getting the animated variable from `a`.

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -25,9 +25,8 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-struct _lv_event_t;
 
-typedef void (*lv_event_cb_t)(struct _lv_event_t * e);
+typedef void (*lv_event_cb_t)(lv_event_t * e);
 
 typedef struct {
     lv_event_cb_t cb;
@@ -126,7 +125,7 @@ typedef struct _lv_event_t {
     lv_event_code_t code;
     void * user_data;
     void * param;
-    struct _lv_event_t * prev;
+    lv_event_t * prev;
     uint8_t deleted : 1;
     uint8_t stop_processing : 1;
     uint8_t stop_bubbling : 1;

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -78,24 +78,26 @@ typedef enum {
     LV_FS_SEEK_END = 0x02,      /**< Set the position from the end of the file*/
 } lv_fs_whence_t;
 
-typedef struct _lv_fs_drv_t {
+struct _lv_fs_drv_t;
+typedef struct _lv_fs_drv_t lv_fs_drv_t;
+struct _lv_fs_drv_t {
     char letter;
     uint32_t cache_size;
-    bool (*ready_cb)(struct _lv_fs_drv_t * drv);
+    bool (*ready_cb)(lv_fs_drv_t * drv);
 
-    void * (*open_cb)(struct _lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
-    lv_fs_res_t (*close_cb)(struct _lv_fs_drv_t * drv, void * file_p);
-    lv_fs_res_t (*read_cb)(struct _lv_fs_drv_t * drv, void * file_p, void * buf, uint32_t btr, uint32_t * br);
-    lv_fs_res_t (*write_cb)(struct _lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw);
-    lv_fs_res_t (*seek_cb)(struct _lv_fs_drv_t * drv, void * file_p, uint32_t pos, lv_fs_whence_t whence);
-    lv_fs_res_t (*tell_cb)(struct _lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p);
+    void * (*open_cb)(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
+    lv_fs_res_t (*close_cb)(lv_fs_drv_t * drv, void * file_p);
+    lv_fs_res_t (*read_cb)(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_t btr, uint32_t * br);
+    lv_fs_res_t (*write_cb)(lv_fs_drv_t * drv, void * file_p, const void * buf, uint32_t btw, uint32_t * bw);
+    lv_fs_res_t (*seek_cb)(lv_fs_drv_t * drv, void * file_p, uint32_t pos, lv_fs_whence_t whence);
+    lv_fs_res_t (*tell_cb)(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p);
 
-    void * (*dir_open_cb)(struct _lv_fs_drv_t * drv, const char * path);
-    lv_fs_res_t (*dir_read_cb)(struct _lv_fs_drv_t * drv, void * rddir_p, char * fn);
-    lv_fs_res_t (*dir_close_cb)(struct _lv_fs_drv_t * drv, void * rddir_p);
+    void * (*dir_open_cb)(lv_fs_drv_t * drv, const char * path);
+    lv_fs_res_t (*dir_read_cb)(lv_fs_drv_t * drv, void * rddir_p, char * fn);
+    lv_fs_res_t (*dir_close_cb)(lv_fs_drv_t * drv, void * rddir_p);
 
     void * user_data; /**< Custom file user data*/
-} lv_fs_drv_t;
+};
 
 typedef struct {
     uint32_t start;

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -14,6 +14,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 #include "../tick/lv_tick.h"
+#include "lv_types.h"
 #include "lv_ll.h"
 
 #include <stdint.h>
@@ -32,12 +33,10 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_timer_t;
-
 /**
  * Timers execute this type of functions.
  */
-typedef void (*lv_timer_cb_t)(struct _lv_timer_t *);
+typedef void (*lv_timer_cb_t)(lv_timer_t *);
 
 /**
  * Timer handler resume this type of function.
@@ -47,7 +46,7 @@ typedef void (*lv_timer_handler_resume_cb_t)(void * data);
 /**
  * Descriptor of a lv_timer
  */
-typedef struct _lv_timer_t {
+struct _lv_timer_t {
     uint32_t period; /**< How often the timer should run*/
     uint32_t last_run; /**< Last time the timer ran*/
     lv_timer_cb_t timer_cb; /**< Timer function*/
@@ -55,7 +54,7 @@ typedef struct _lv_timer_t {
     int32_t repeat_count; /**< 1: One time;  -1 : infinity;  n>0: residual times*/
     uint32_t paused : 1;
     uint32_t auto_delete : 1;
-} lv_timer_t;
+};
 
 typedef struct {
     lv_ll_t timer_ll; /*Linked list to store the lv_timers*/

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -82,6 +82,70 @@ typedef float lv_value_precise_t;
 typedef int32_t lv_value_precise_t;
 #endif
 
+/**
+ * Typedefs from various lvgl modules.
+ * They are defined here to avoid circular dependencies.
+ */
+
+struct _lv_obj_t;
+typedef struct _lv_obj_t lv_obj_t;
+
+#ifdef DOXYGEN
+typedef _lv_state_t lv_state_t;
+typedef _lv_part_t lv_part_t;
+typedef _lv_obj_flag_t lv_obj_flag_t;
+#else
+typedef uint16_t lv_state_t;
+typedef uint32_t lv_part_t;
+typedef uint32_t lv_obj_flag_t;
+#endif /*DOXYGEN*/
+
+struct _lv_obj_class_t;
+typedef struct _lv_obj_class_t lv_obj_class_t;
+
+struct _lv_group_t;
+typedef struct _lv_group_t lv_group_t;
+
+#ifdef DOXYGEN
+typedef _lv_key_t lv_key_t;
+#else
+typedef uint8_t lv_key_t;
+#endif /*DOXYGEN*/
+
+struct _lv_display_t;
+typedef struct _lv_display_t lv_display_t;
+
+struct _lv_layer_t;
+typedef struct _lv_layer_t lv_layer_t;
+struct _lv_draw_unit_t;
+typedef struct _lv_draw_unit_t lv_draw_unit_t;
+struct _lv_draw_task_t;
+typedef struct _lv_draw_task_t lv_draw_task_t;
+
+struct _lv_indev_t;
+typedef struct _lv_indev_t lv_indev_t;
+
+struct _lv_event_t;
+typedef struct _lv_event_t lv_event_t;
+
+struct _lv_timer_t;
+typedef struct _lv_timer_t lv_timer_t;
+
+struct _lv_theme_t;
+typedef struct _lv_theme_t lv_theme_t;
+
+struct _lv_anim_t;
+typedef struct _lv_anim_t lv_anim_t;
+
+struct _lv_font_t;
+typedef struct _lv_font_t lv_font_t;
+
+struct _my_theme_t;
+typedef struct _my_theme_t my_theme_t;
+
+struct _lv_image_decoder_t;
+typedef struct _lv_image_decoder_t lv_image_decoder_t;
+
 #endif /*__ASSEMBLY__*/
 
 /**********************

--- a/src/others/observer/lv_observer.h
+++ b/src/others/observer/lv_observer.h
@@ -26,6 +26,7 @@ extern "C" {
  **********************/
 
 struct _lv_observer_t;
+typedef struct _lv_observer_t lv_observer_t;
 
 typedef enum {
     LV_SUBJECT_TYPE_INVALID =   0,   /**< indicates subject not initialized yet*/
@@ -64,19 +65,19 @@ typedef struct {
   * @param observer     pointer to the observer of the callback
   * @param subject      pointer to the subject of the observer
   */
-typedef void (*lv_observer_cb_t)(struct _lv_observer_t * observer, lv_subject_t * subject);
+typedef void (*lv_observer_cb_t)(lv_observer_t * observer, lv_subject_t * subject);
 
 /**
  * The observer object: a descriptor returned when subscribing LVGL widgets to subjects
  */
-typedef struct _lv_observer_t {
+struct _lv_observer_t {
     lv_subject_t * subject;             /**< The observed value */
     lv_observer_cb_t cb;                /**< Callback that should be called when the value changes*/
     void * target;                      /**< A target for the observer, e.g. a widget or style*/
     void * user_data;                   /**< Additional parameter supplied when subscribing*/
     uint32_t auto_free_user_data : 1;   /**< Automatically free user data when the observer is removed */
     uint32_t notified : 1;              /**< Mark if this observer was already notified*/
-} lv_observer_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -158,7 +158,7 @@ typedef enum {
     DISP_LARGE = 1,
 } disp_size_t;
 
-typedef struct _my_theme_t {
+struct _my_theme_t {
     lv_theme_t base;
     disp_size_t disp_size;
     int32_t disp_dpi;
@@ -176,7 +176,7 @@ typedef struct _my_theme_t {
     lv_style_transition_dsc_t trans_delayed;
     lv_style_transition_dsc_t trans_normal;
 #endif
-} my_theme_t;
+};
 
 /**********************
  *  STATIC PROTOTYPES
@@ -209,7 +209,7 @@ static lv_color_t grey_filter_cb(const lv_color_filter_dsc_t * f, lv_color_t col
     else return lv_color_mix(lv_palette_lighten(LV_PALETTE_GREY, 2), color, opa);
 }
 
-static void style_init(struct _my_theme_t * theme)
+static void style_init(my_theme_t * theme)
 {
 #if TRANSITION_TIME
     static const lv_style_prop_t trans_props[] = {
@@ -660,7 +660,7 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
         theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     lv_display_t * new_disp = disp == NULL ? lv_display_get_default() : disp;
     int32_t new_dpi = lv_display_get_dpi(new_disp);
@@ -704,7 +704,7 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
 
 void lv_theme_default_deinit(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme) {
         if(theme->inited) {
             lv_style_t * theme_styles = (lv_style_t *)(&(theme->styles));
@@ -730,7 +730,7 @@ lv_theme_t * lv_theme_default_get(void)
 
 bool lv_theme_default_is_inited(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme == NULL) return false;
     return theme->inited;
 }
@@ -739,7 +739,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 {
     LV_UNUSED(th);
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     if(lv_obj_get_parent(obj) == NULL) {
         lv_obj_add_style(obj, &theme->styles.scr, 0);

--- a/src/themes/lv_theme.h
+++ b/src/themes/lv_theme.h
@@ -23,23 +23,20 @@ extern "C" {
  *    TYPEDEFS
  **********************/
 
-struct _lv_theme_t;
-struct _lv_display_t;
+typedef void (*lv_theme_apply_cb_t)(lv_theme_t *, lv_obj_t *);
 
-typedef void (*lv_theme_apply_cb_t)(struct _lv_theme_t *, lv_obj_t *);
-
-typedef struct _lv_theme_t {
+struct _lv_theme_t {
     lv_theme_apply_cb_t apply_cb;
-    struct _lv_theme_t * parent;    /**< Apply the current theme's style on top of this theme.*/
+    lv_theme_t * parent;   /**< Apply the current theme's style on top of this theme.*/
     void * user_data;
-    struct _lv_display_t * disp;
+    lv_display_t * disp;
     lv_color_t color_primary;
     lv_color_t color_secondary;
     const lv_font_t * font_small;
     const lv_font_t * font_normal;
     const lv_font_t * font_large;
     uint32_t flags;                 /*Any custom flag used by the theme*/
-} lv_theme_t;
+};
 
 /**********************
  *  GLOBAL PROTOTYPES

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -55,11 +55,11 @@ typedef struct {
 #endif
 } my_theme_styles_t;
 
-typedef struct _my_theme_t {
+struct _my_theme_t {
     lv_theme_t base;
     my_theme_styles_t styles;
     bool inited;
-} my_theme_t;
+};
 
 /**********************
  *  STATIC PROTOTYPES
@@ -79,7 +79,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj);
  *   STATIC FUNCTIONS
  **********************/
 
-static void style_init(struct _my_theme_t * theme, bool dark_bg, const lv_font_t * font)
+static void style_init(my_theme_t * theme, bool dark_bg, const lv_font_t * font)
 {
     style_init_reset(&theme->styles.scrollbar);
     lv_style_set_bg_opa(&theme->styles.scrollbar, LV_OPA_COVER);
@@ -178,14 +178,14 @@ static void style_init(struct _my_theme_t * theme, bool dark_bg, const lv_font_t
 
 bool lv_theme_mono_is_inited(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme == NULL) return false;
     return theme->inited;
 }
 
 void lv_theme_mono_deinit(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme) {
         if(theme->inited) {
             lv_style_t * theme_styles = (lv_style_t *)(&(theme->styles));
@@ -208,7 +208,7 @@ lv_theme_t * lv_theme_mono_init(lv_display_t * disp, bool dark_bg, const lv_font
         theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     theme->base.disp = disp;
     theme->base.font_small = LV_FONT_DEFAULT;
@@ -229,7 +229,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 {
     LV_UNUSED(th);
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     if(lv_obj_get_parent(obj) == NULL) {
         lv_obj_add_style(obj, &theme->styles.scr, 0);

--- a/src/themes/simple/lv_theme_simple.c
+++ b/src/themes/simple/lv_theme_simple.c
@@ -45,11 +45,11 @@ typedef struct {
 #endif
 } my_theme_styles_t;
 
-typedef struct _my_theme_t {
+struct _my_theme_t {
     lv_theme_t base;
     my_theme_styles_t styles;
     bool inited;
-} my_theme_t;
+};
 
 /**********************
  *  STATIC PROTOTYPES
@@ -69,7 +69,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj);
  *   STATIC FUNCTIONS
  **********************/
 
-static void style_init(struct _my_theme_t * theme)
+static void style_init(my_theme_t * theme)
 {
     style_init_reset(&theme->styles.scrollbar);
     lv_style_set_bg_opa(&theme->styles.scrollbar, LV_OPA_COVER);
@@ -139,7 +139,7 @@ static void style_init(struct _my_theme_t * theme)
 
 bool lv_theme_simple_is_inited(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme == NULL) return false;
     return theme->inited;
 }
@@ -155,7 +155,7 @@ lv_theme_t * lv_theme_simple_get(void)
 
 void lv_theme_simple_deinit(void)
 {
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
     if(theme) {
         if(theme->inited) {
             lv_style_t * theme_styles = (lv_style_t *)(&(theme->styles));
@@ -178,7 +178,7 @@ lv_theme_t * lv_theme_simple_init(lv_display_t * disp)
         theme_def  = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     theme->base.disp = disp;
     theme->base.font_small = LV_FONT_DEFAULT;
@@ -201,7 +201,7 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 {
     LV_UNUSED(th);
 
-    struct _my_theme_t * theme = theme_def;
+    my_theme_t * theme = theme_def;
 
     if(lv_obj_get_parent(obj) == NULL) {
         lv_obj_add_style(obj, &theme->styles.scr, 0);


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Continue of #4380. 
Micropython should now has no complain, and it's also reasonable to move `lvgl` defined types to `lv_types.h`.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
