### PR TITLE
fix(gpu-arm2d): fix a blending issue in blend-normal-with-mask-and-opa

### DIFF
--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -878,10 +878,10 @@ static bool LV_ATTRIBUTE_FAST_MEM arm_2d_copy_normal(lv_color_t * dest_buf,
         /*Handle opa and mask values too*/
         else {
             __arm_2d_impl_gray8_colour_filling_with_opacity((uint8_t *)mask,
-                                                    mask_stride,
-                                                    &copy_size,
-                                                    0x00,
-                                                    255 - opa);
+                                                            mask_stride,
+                                                            &copy_size,
+                                                            0x00,
+                                                            255 - opa);
 
             __arm_2d_impl_src_msk_copy((color_int *)src_buf,
                                        src_stride,

--- a/src/draw/arm2d/lv_gpu_arm2d.c
+++ b/src/draw/arm2d/lv_gpu_arm2d.c
@@ -877,12 +877,11 @@ static bool LV_ATTRIBUTE_FAST_MEM arm_2d_copy_normal(lv_color_t * dest_buf,
         }
         /*Handle opa and mask values too*/
         else {
-            __arm_2d_impl_gray8_alpha_blending((uint8_t *)mask,
-                                               mask_stride,
-                                               (uint8_t *)mask,
-                                               mask_stride,
-                                               &copy_size,
-                                               opa);
+            __arm_2d_impl_gray8_colour_filling_with_opacity((uint8_t *)mask,
+                                                    mask_stride,
+                                                    &copy_size,
+                                                    0x00,
+                                                    255 - opa);
 
             __arm_2d_impl_src_msk_copy((color_int *)src_buf,
                                        src_stride,


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

The open-source community reported a blend issue of GPU-Arm2D found in LVGL8.3.11.  
For blend-normal-with-mask-and-opa, the opa has no effects due to using the wrong API of arm-2d. 

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
