### PR TITLE
fix(widgets): wrong casting in some widgets when calling lv_event_get…

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -595,7 +595,7 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
     }
     else if(code == LV_EVENT_KEY) {
         if(lv_obj_has_flag(obj, LV_OBJ_FLAG_CHECKABLE)) {
-            char c = *((char *)lv_event_get_param(e));
+            uint32_t c = lv_event_get_key(e);
             if(c == LV_KEY_RIGHT || c == LV_KEY_UP) {
                 lv_obj_add_state(obj, LV_STATE_CHECKED);
             }
@@ -614,7 +614,7 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
             lv_anim_enable_t anim_enable = LV_ANIM_OFF;
             int32_t sl = lv_obj_get_scroll_left(obj);
             int32_t sr = lv_obj_get_scroll_right(obj);
-            char c = *((char *)lv_event_get_param(e));
+            uint32_t c = lv_event_get_key(e);
             if(c == LV_KEY_DOWN) {
                 /*use scroll_to_x/y functions to enforce scroll limits*/
                 lv_obj_scroll_to_y(obj, lv_obj_get_scroll_y(obj) + lv_obj_get_height(obj) / 4, anim_enable);

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -604,7 +604,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
     }
     else if(code == LV_EVENT_KEY) {
-        char c = *((char *)lv_event_get_param(e));
+        uint32_t c = lv_event_get_key(e);
 
         int16_t old_value = arc->value;
         if(c == LV_KEY_RIGHT || c == LV_KEY_UP) {

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -555,7 +555,7 @@ static void lv_buttonmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e
 
         invalidate_button_area(obj, btnm->btn_id_sel);
 
-        char c = *((char *)lv_event_get_param(e));
+        uint32_t c = lv_event_get_key(e);
         if(c == LV_KEY_RIGHT) {
             if(btnm->btn_id_sel == LV_BUTTONMATRIX_BUTTON_NONE)  btnm->btn_id_sel = 0;
             else btnm->btn_id_sel++;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -704,7 +704,7 @@ static void lv_dropdown_event(const lv_obj_class_t * class_p, lv_event_t * e)
         p->y = lv_font_get_line_height(font);
     }
     else if(code == LV_EVENT_KEY) {
-        char c = *((char *)lv_event_get_param(e));
+        uint32_t c = lv_event_get_key(e);
         if(c == LV_KEY_RIGHT || c == LV_KEY_DOWN) {
             if(!lv_dropdown_is_open(obj)) {
                 lv_dropdown_open(obj);

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -364,7 +364,7 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_KEY) {
-        char c = *((char *)lv_event_get_param(e));
+        uint32_t c = lv_event_get_key(e);
         if(c == LV_KEY_RIGHT || c == LV_KEY_DOWN) {
             if(roller->sel_opt_id + 1 < roller->option_cnt) {
                 uint32_t ori_id = roller->sel_opt_id_ori; /*lv_roller_set_selected will overwrite this*/

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -207,7 +207,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
     }
     else if(code == LV_EVENT_KEY) {
-        char c = *((char *)lv_event_get_param(e));
+        uint32_t c = lv_event_get_key(e);
 
         if(c == LV_KEY_RIGHT || c == LV_KEY_UP) {
             if(!slider->left_knob_focus) lv_slider_set_value(obj, lv_slider_get_value(obj) + 1, LV_ANIM_ON);

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -181,7 +181,7 @@ void test_calendar_header_arrow_create_gui(void)
 
 void test_calendar_event_key_down_gui(void)
 {
-    char key = LV_KEY_DOWN;
+    uint32_t key = LV_KEY_DOWN;
 
     lv_calendar_set_showed_date(calendar, 2022, 9);
 

--- a/tests/src/test_cases/widgets/test_slider.c
+++ b/tests/src/test_cases/widgets/test_slider.c
@@ -45,7 +45,7 @@ void test_textarea_should_have_valid_documented_default_values(void)
 
 void test_slider_event_keys_right_and_up_increment_value_by_one(void)
 {
-    char key = LV_KEY_RIGHT;
+    uint32_t key = LV_KEY_RIGHT;
     lv_slider_set_value(slider, 10, LV_ANIM_OFF);
     int32_t value = lv_slider_get_value(slider);
 
@@ -61,7 +61,7 @@ void test_slider_event_keys_right_and_up_increment_value_by_one(void)
 
 void test_slider_event_keys_left_and_down_decrement_value_by_one(void)
 {
-    char key = LV_KEY_LEFT;
+    uint32_t key = LV_KEY_LEFT;
     lv_slider_set_value(slider, 10, LV_ANIM_OFF);
     int32_t value = lv_slider_get_value(slider);
 
@@ -77,7 +77,7 @@ void test_slider_event_keys_left_and_down_decrement_value_by_one(void)
 
 void test_slider_event_invalid_key_should_not_change_values(void)
 {
-    char key = LV_KEY_ENTER;
+    uint32_t key = LV_KEY_ENTER;
     lv_slider_set_value(slider, 10, LV_ANIM_OFF);
     int32_t value = lv_slider_get_value(slider);
 


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix
Fixes: #5083

All lines with `char c = *((char *)lv_event_get_param(e));` have been replaced with `uint32_t c = lv_event_get_key(e);`, as suggested in issue #5083.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
