### PR TITLE
refact(display): Use draw_buf to replace raw pointers

### DIFF
--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -205,7 +205,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     /* double framebuffer */
 
     if(dsc->mem2 != NULL) {
-        if(disp->buf_act == disp->buf_1) {
+        if(disp->buf_act == &disp->buf_1) {
             dsc->pinfo.yoffset = 0;
         }
         else {

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -393,17 +393,12 @@ void lv_display_set_draw_buffers(lv_display_t * disp, void * buf1, void * buf2, 
     if(disp == NULL) return;
 
     LV_ASSERT_MSG(buf1 == lv_draw_buf_align(buf1, disp->color_format), "buf1 must be aligned");
-
-    uint32_t stride = lv_draw_buf_width_to_stride(disp->hor_res, disp->color_format);
-
-    lv_image_header_init(&disp->buf_1.header, disp->hor_res, disp->ver_res, disp->color_format, stride, 0);
     disp->buf_1.data = buf1;
     disp->buf_1.unaligned_data = buf1;
     disp->buf_1.data_size = buf_size_in_bytes;
 
     if(buf2) {
         LV_ASSERT_MSG(buf2 == lv_draw_buf_align(buf2, disp->color_format), "buf2 must be aligned");
-        lv_image_header_init(&disp->buf_2.header, disp->hor_res, disp->ver_res, disp->color_format, stride, 0);
         disp->buf_2.data = buf2;
         disp->buf_2.unaligned_data = buf2;
         disp->buf_2.data_size = buf_size_in_bytes;

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -392,10 +392,20 @@ void lv_display_set_draw_buffers(lv_display_t * disp, void * buf1, void * buf2, 
     if(disp == NULL) disp = lv_display_get_default();
     if(disp == NULL) return;
 
-    disp->buf_1 = buf1;
-    disp->buf_2 = buf2;
-    disp->buf_act = buf1;
-    disp->buf_size_in_bytes = buf_size_in_bytes;
+    LV_ASSERT_MSG(buf1 == lv_draw_buf_align(buf1, disp->color_format), "buf1 must be aligned");
+    LV_ASSERT_MSG(buf2 == lv_draw_buf_align(buf2, disp->color_format), "buf2 must be aligned");
+
+    lv_image_header_init(&disp->buf_1.header, 0, 0, disp->color_format, 0, 0);
+    disp->buf_1.data = buf1;
+    disp->buf_1.unaligned_data = buf1;
+    disp->buf_1.data_size = buf_size_in_bytes;
+
+    lv_image_header_init(&disp->buf_2.header, 0, 0, disp->color_format, 0, 0);
+    disp->buf_2.data = buf2;
+    disp->buf_2.unaligned_data = buf2;
+    disp->buf_2.data_size = buf_size_in_bytes;
+
+    disp->buf_act = &disp->buf_1;
     disp->render_mode = render_mode;
 }
 
@@ -463,7 +473,7 @@ LV_ATTRIBUTE_FLUSH_READY bool lv_display_flush_is_last(lv_display_t * disp)
 
 bool lv_display_is_double_buffered(lv_display_t * disp)
 {
-    return disp->buf_2 != NULL;
+    return disp->buf_2.data != NULL;
 }
 
 /*---------------------

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -393,17 +393,21 @@ void lv_display_set_draw_buffers(lv_display_t * disp, void * buf1, void * buf2, 
     if(disp == NULL) return;
 
     LV_ASSERT_MSG(buf1 == lv_draw_buf_align(buf1, disp->color_format), "buf1 must be aligned");
-    LV_ASSERT_MSG(buf2 == lv_draw_buf_align(buf2, disp->color_format), "buf2 must be aligned");
 
-    lv_image_header_init(&disp->buf_1.header, 0, 0, disp->color_format, 0, 0);
+    uint32_t stride = lv_draw_buf_width_to_stride(disp->hor_res, disp->color_format);
+
+    lv_image_header_init(&disp->buf_1.header, disp->hor_res, disp->ver_res, disp->color_format, stride, 0);
     disp->buf_1.data = buf1;
     disp->buf_1.unaligned_data = buf1;
     disp->buf_1.data_size = buf_size_in_bytes;
 
-    lv_image_header_init(&disp->buf_2.header, 0, 0, disp->color_format, 0, 0);
-    disp->buf_2.data = buf2;
-    disp->buf_2.unaligned_data = buf2;
-    disp->buf_2.data_size = buf_size_in_bytes;
+    if(buf2) {
+        LV_ASSERT_MSG(buf2 == lv_draw_buf_align(buf2, disp->color_format), "buf2 must be aligned");
+        lv_image_header_init(&disp->buf_2.header, disp->hor_res, disp->ver_res, disp->color_format, stride, 0);
+        disp->buf_2.data = buf2;
+        disp->buf_2.unaligned_data = buf2;
+        disp->buf_2.data_size = buf_size_in_bytes;
+    }
 
     disp->buf_act = &disp->buf_1;
     disp->render_mode = render_mode;

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -58,12 +58,11 @@ struct _lv_display_t {
     /*---------------------
      * Buffering
      *--------------------*/
-    uint8_t * buf_1;
-    uint8_t * buf_2;
+    lv_draw_buf_t buf_1;
+    lv_draw_buf_t buf_2;
 
     /** Internal, used by the library*/
-    uint8_t * buf_act;
-    uint32_t buf_size_in_bytes;
+    lv_draw_buf_t * buf_act;
 
     /** MANDATORY: Write the internal buffer (draw_buf) to the display. 'lv_display_flush_ready()' has to be
      * called when finished*/


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Use the draw_buf structure to unify the buffer description in lvgl.

cc @XuNeo 

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
