### PR TITLE
chore(draw_buf): add invalid cf and stride check

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -147,6 +147,8 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
     void * buf = lv_draw_buf_malloc(size, cf);
     LV_ASSERT_MALLOC(buf);
     if(buf == NULL) {
+        LV_LOG_WARN("No memory: %"LV_PRIu32"x%"LV_PRIu32", cf: %d, stride: %"LV_PRIu32", %"LV_PRIu32"Byte, ",
+                    w, h, cf, stride, size);
         lv_free(draw_buf);
         return NULL;
     }
@@ -156,6 +158,7 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
     draw_buf->header.cf = cf;
     draw_buf->header.flags = LV_IMAGE_FLAGS_MODIFIABLE | LV_IMAGE_FLAGS_ALLOCATED;
     draw_buf->header.stride = stride;
+    draw_buf->header.magic = LV_IMAGE_HEADER_MAGIC;
     draw_buf->data = lv_draw_buf_align(buf, cf);
     draw_buf->unaligned_data = buf;
     draw_buf->data_size = size;
@@ -184,6 +187,8 @@ lv_draw_buf_t * lv_draw_buf_reshape(lv_draw_buf_t * draw_buf, lv_color_format_t 
 {
     if(draw_buf == NULL) return NULL;
 
+    /*If color format is unknown, keep using the original color format.*/
+    if(cf == LV_COLOR_FORMAT_UNKNOWN) cf = draw_buf->header.cf;
     if(stride == 0) stride = lv_draw_buf_width_to_stride(w, cf);
 
     uint32_t size = _calculate_draw_buf_size(w, h, cf, stride);
@@ -236,18 +241,23 @@ lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t st
     if(src == NULL) return NULL;
     if(src->data == NULL) return NULL;
 
+    const lv_image_header_t * header = &src->header;
+
+    /*Use global stride*/
+    if(stride == 0) stride = lv_draw_buf_width_to_stride(header->w, header->cf);
+
     /*Check if stride already match*/
-    if(src->header.stride == stride) return NULL;
+    if(header->stride == stride) return NULL;
 
     /*Calculate the minimal stride allowed from bpp*/
-    uint32_t bpp = lv_color_format_get_bpp(src->header.cf);
-    uint32_t min_stride = (src->header.w * bpp + 7) >> 3;
+    uint32_t bpp = lv_color_format_get_bpp(header->cf);
+    uint32_t min_stride = (header->w * bpp + 7) >> 3;
     if(stride < min_stride) {
         LV_LOG_WARN("New stride is too small. min: %" LV_PRId32, min_stride);
         return NULL;
     }
 
-    lv_draw_buf_t * dst = lv_draw_buf_create(src->header.w, src->header.h, src->header.cf, stride);
+    lv_draw_buf_t * dst = lv_draw_buf_create(header->w, header->h, header->cf, stride);
     if(dst == NULL) return NULL;
 
     uint8_t * dst_data = dst->data;

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -192,7 +192,7 @@ lv_draw_buf_t * lv_draw_buf_dup(const lv_draw_buf_t * draw_buf);
  * Keep using the existing memory, reshape the draw buffer to the given width and height.
  * Return NULL if data_size is smaller than the required size.
  * @param draw_buf  pointer to a draw buffer
- * @param cf        the new color format
+ * @param cf        the new color format, use 0 or LV_COLOR_FORMAT_UNKNOWN to keep using the original color format.
  * @param w         the new width in pixels
  * @param h         the new height in pixels
  * @param stride    the stride in bytes for image. Use 0 for automatic calculation.


### PR DESCRIPTION


Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

If cf and stride is invalid value 0, use default cf for reshape, and use global stride instead of 0. Add error log when malloc failed.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
