### PR TITLE
In lv_linux_fbdev, no lvgl.h header file issue fixed

### DIFF
--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -26,7 +26,11 @@
     #include <linux/fb.h>
 #endif /* LV_LINUX_FBDEV_BSD */
 
-#include <lvgl/lvgl.h>
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+    #include "lvgl.h"
+#else
+    #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -26,12 +26,6 @@
     #include <linux/fb.h>
 #endif /* LV_LINUX_FBDEV_BSD */
 
-#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
-    #include "lvgl.h"
-#else
-    #include "lvgl/lvgl.h"
-#endif
-
 /*********************
  *      DEFINES
  *********************/


### PR DESCRIPTION
### Description of the feature or fix

lvgl/lvgl.h: No such file or directory compilation error observed when LV_LVGL_H_INCLUDE_SIMPLE defined.

### Checkpoints
- Verified code by build for Cortex-A7 processor with GCC complier 
