### PR TITLE
chore: move font/event define to lv_types.h

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -119,15 +119,15 @@ typedef struct _lv_global_t {
 #endif
 
 #if LV_USE_THEME_SIMPLE
-    my_theme_t * theme_simple;
+    void * theme_simple;
 #endif
 
 #if LV_USE_THEME_DEFAULT
-    my_theme_t * theme_default;
+    void * theme_default;
 #endif
 
 #if LV_USE_THEME_MONO
-    my_theme_t * theme_mono;
+    void * theme_mono;
 #endif
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include "lv_symbol_def.h"
 #include "../misc/lv_area.h"
+#include "../misc/lv_types.h"
 #include "../misc/cache/lv_cache.h"
 
 /*********************
@@ -80,7 +81,7 @@ typedef uint8_t lv_font_kerning_t;
 #endif /*DOXYGEN*/
 
 /** Describe the properties of a font*/
-typedef struct _lv_font_t {
+struct _lv_font_t {
     /** Get a glyph's descriptor from a font*/
     bool (*get_glyph_dsc)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
@@ -102,7 +103,7 @@ typedef struct _lv_font_t {
     const void * dsc;               /**< Store implementation specific or run_time data or caching here*/
     const lv_font_t * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
     void * user_data;               /**< Custom user data for font.*/
-} lv_font_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -119,7 +119,7 @@ typedef struct {
     uint32_t cnt;
 } lv_event_list_t;
 
-typedef struct _lv_event_t {
+struct _lv_event_t {
     void * current_target;
     void * original_target;
     lv_event_code_t code;
@@ -129,7 +129,7 @@ typedef struct _lv_event_t {
     uint8_t deleted : 1;
     uint8_t stop_processing : 1;
     uint8_t stop_bubbling : 1;
-} lv_event_t;
+};
 
 /**
  * @brief Event callback.

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -140,9 +140,6 @@ typedef struct _lv_anim_t lv_anim_t;
 struct _lv_font_t;
 typedef struct _lv_font_t lv_font_t;
 
-struct _my_theme_t;
-typedef struct _my_theme_t my_theme_t;
-
 struct _lv_image_decoder_t;
 typedef struct _lv_image_decoder_t lv_image_decoder_t;
 

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -21,7 +21,7 @@
 struct _my_theme_t;
 typedef struct _my_theme_t my_theme_t;
 
-#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_default))
+#define theme_def (*(my_theme_t **)(&LV_GLOBAL_DEFAULT()->theme_default))
 
 #define MODE_DARK 1
 #define RADIUS_DEFAULT _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 12 : 8)
@@ -661,7 +661,7 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
      *In a general case styles could be in a simple `static lv_style_t my_style...` variables*/
 
     if(!lv_theme_default_is_inited()) {
-        LV_GLOBAL_DEFAULT()->theme_default = lv_malloc_zeroed(sizeof(my_theme_t));
+        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;
@@ -719,7 +719,7 @@ void lv_theme_default_deinit(void)
 
         }
         lv_free(theme_def);
-        LV_GLOBAL_DEFAULT()->theme_default = NULL;
+        theme_def = NULL;
     }
 }
 

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -17,7 +17,11 @@
 /*********************
  *      DEFINES
  *********************/
-#define theme_def (LV_GLOBAL_DEFAULT()->theme_default)
+
+struct _my_theme_t;
+typedef struct _my_theme_t my_theme_t;
+
+#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_default))
 
 #define MODE_DARK 1
 #define RADIUS_DEFAULT _LV_DPX_CALC(theme->disp_dpi, theme->disp_size == DISP_LARGE ? 12 : 8)
@@ -657,7 +661,7 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
      *In a general case styles could be in a simple `static lv_style_t my_style...` variables*/
 
     if(!lv_theme_default_is_inited()) {
-        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
+        LV_GLOBAL_DEFAULT()->theme_default = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;
@@ -715,7 +719,7 @@ void lv_theme_default_deinit(void)
 
         }
         lv_free(theme_def);
-        theme_def = NULL;
+        LV_GLOBAL_DEFAULT()->theme_default = NULL;
     }
 }
 

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -16,7 +16,10 @@
 /*********************
  *      DEFINES
  *********************/
-#define theme_def (LV_GLOBAL_DEFAULT()->theme_mono)
+struct _my_theme_t;
+typedef struct _my_theme_t my_theme_t;
+
+#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_mono))
 
 #define COLOR_FG      dark_bg ? lv_color_white() : lv_color_black()
 #define COLOR_BG      dark_bg ? lv_color_black() : lv_color_white()
@@ -195,7 +198,7 @@ void lv_theme_mono_deinit(void)
             }
         }
         lv_free(theme_def);
-        theme_def = NULL;
+        LV_GLOBAL_DEFAULT()->theme_default = NULL;
     }
 }
 
@@ -205,7 +208,7 @@ lv_theme_t * lv_theme_mono_init(lv_display_t * disp, bool dark_bg, const lv_font
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_mono_is_inited()) {
-        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
+        LV_GLOBAL_DEFAULT()->theme_default = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -19,7 +19,7 @@
 struct _my_theme_t;
 typedef struct _my_theme_t my_theme_t;
 
-#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_mono))
+#define theme_def (*(my_theme_t **)(&LV_GLOBAL_DEFAULT()->theme_mono))
 
 #define COLOR_FG      dark_bg ? lv_color_white() : lv_color_black()
 #define COLOR_BG      dark_bg ? lv_color_black() : lv_color_white()
@@ -198,7 +198,7 @@ void lv_theme_mono_deinit(void)
             }
         }
         lv_free(theme_def);
-        LV_GLOBAL_DEFAULT()->theme_default = NULL;
+        theme_def = NULL;
     }
 }
 
@@ -208,7 +208,7 @@ lv_theme_t * lv_theme_mono_init(lv_display_t * disp, bool dark_bg, const lv_font
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_mono_is_inited()) {
-        LV_GLOBAL_DEFAULT()->theme_default = lv_malloc_zeroed(sizeof(my_theme_t));
+        theme_def = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;

--- a/src/themes/simple/lv_theme_simple.c
+++ b/src/themes/simple/lv_theme_simple.c
@@ -20,7 +20,7 @@
 struct _my_theme_t;
 typedef struct _my_theme_t my_theme_t;
 
-#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_simple))
+#define theme_def (*(my_theme_t **)(&LV_GLOBAL_DEFAULT()->theme_simple))
 
 #define COLOR_SCR     lv_palette_lighten(LV_PALETTE_GREY, 4)
 #define COLOR_WHITE   lv_color_white()
@@ -169,7 +169,7 @@ void lv_theme_simple_deinit(void)
             }
         }
         lv_free(theme_def);
-        LV_GLOBAL_DEFAULT()->theme_default = NULL;
+        theme_def = NULL;
     }
 }
 
@@ -179,7 +179,7 @@ lv_theme_t * lv_theme_simple_init(lv_display_t * disp)
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_simple_is_inited()) {
-        LV_GLOBAL_DEFAULT()->theme_default  = lv_malloc_zeroed(sizeof(my_theme_t));
+        theme_def  = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;

--- a/src/themes/simple/lv_theme_simple.c
+++ b/src/themes/simple/lv_theme_simple.c
@@ -16,7 +16,11 @@
 /*********************
  *      DEFINES
  *********************/
-#define theme_def (LV_GLOBAL_DEFAULT()->theme_simple)
+
+struct _my_theme_t;
+typedef struct _my_theme_t my_theme_t;
+
+#define theme_def ((my_theme_t *)(LV_GLOBAL_DEFAULT()->theme_simple))
 
 #define COLOR_SCR     lv_palette_lighten(LV_PALETTE_GREY, 4)
 #define COLOR_WHITE   lv_color_white()
@@ -165,7 +169,7 @@ void lv_theme_simple_deinit(void)
             }
         }
         lv_free(theme_def);
-        theme_def = NULL;
+        LV_GLOBAL_DEFAULT()->theme_default = NULL;
     }
 }
 
@@ -175,7 +179,7 @@ lv_theme_t * lv_theme_simple_init(lv_display_t * disp)
      *styles' data if LVGL is used in a binding (e.g. Micropython)
      *In a general case styles could be in simple `static lv_style_t my_style...` variables*/
     if(!lv_theme_simple_is_inited()) {
-        theme_def  = lv_malloc_zeroed(sizeof(my_theme_t));
+        LV_GLOBAL_DEFAULT()->theme_default  = lv_malloc_zeroed(sizeof(my_theme_t));
     }
 
     my_theme_t * theme = theme_def;


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

move font/event define to lv_types.h

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
