### PR TITLE
fix(freetype): correct cache release behavior and change glyph cache cnt macro name

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1156,9 +1156,8 @@ menu "LVGL configuration"
 			config LV_FREETYPE_CACHE_FT_SIZES
 				int "The maximum number of FT_Size"
 				default 8
-			config LV_FREETYPE_CACHE_FT_OUTLINES
-				int "The maximum number of Outline"
-				depends on LV_FREETYPE_CACHE_TYPE_OUTLINE
+			config LV_FREETYPE_CACHE_FT_GLYPH_CNT
+				int "The maximum number of Glyph in count"
 				default 256
 			endmenu
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -662,7 +662,7 @@
     /* (0:use system defaults) */
     #define LV_FREETYPE_CACHE_FT_FACES 8
     #define LV_FREETYPE_CACHE_FT_SIZES 8
-    #define LV_FREETYPE_CACHE_FT_OUTLINES 256
+    #define LV_FREETYPE_CACHE_FT_GLYPH_CNT 256
 #endif
 
 /* Built-in TTF decoder */

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -395,8 +395,14 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
 }
 static void cache_node_cache_free_cb(lv_freetype_cache_node_t * node, void * user_data)
 {
-    if(node->glyph_cache) lv_cache_destroy(node->glyph_cache, user_data);
-    if(node->draw_data_cache) lv_cache_destroy(node->draw_data_cache, user_data);
+    if(node->glyph_cache) {
+        lv_cache_destroy(node->glyph_cache, user_data);
+        node->glyph_cache = NULL;
+    }
+    if(node->draw_data_cache) {
+        lv_cache_destroy(node->draw_data_cache, user_data);
+        node->draw_data_cache = NULL;
+    }
 }
 static lv_cache_compare_res_t cache_node_cache_compare_cb(const lv_freetype_cache_node_t * lhs,
                                                           const lv_freetype_cache_node_t * rhs)

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -20,6 +20,10 @@
 #define ft_ctx LV_GLOBAL_DEFAULT()->ft_context
 #define LV_FREETYPE_OUTLINE_REF_SIZE_DEF 128
 
+#if LV_FREETYPE_CACHE_FT_GLYPH_CNT <= 0
+    #error "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be greater than 0"
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -161,6 +165,7 @@ lv_font_t * lv_freetype_font_create(const char * pathname, lv_freetype_font_rend
     FT_Size ft_size = lv_freetype_lookup_size(dsc);
 
     if(!ft_size || !lv_freetype_on_font_create(dsc)) {
+        lv_cache_release(ctx->cache_node_cache, dsc->cache_node_entry, NULL);
         lv_freetype_drop_face_id(ctx, dsc->face_id);
         lv_free(dsc);
         return NULL;
@@ -390,8 +395,8 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
 }
 static void cache_node_cache_free_cb(lv_freetype_cache_node_t * node, void * user_data)
 {
-    lv_cache_destroy(node->glyph_cache, user_data);
-    lv_cache_destroy(node->draw_data_cache, user_data);
+    if(node->glyph_cache) lv_cache_destroy(node->glyph_cache, user_data);
+    if(node->draw_data_cache) lv_cache_destroy(node->draw_data_cache, user_data);
 }
 static lv_cache_compare_res_t cache_node_cache_compare_cb(const lv_freetype_cache_node_t * lhs,
                                                           const lv_freetype_cache_node_t * rhs)

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -15,7 +15,7 @@
  *      DEFINES
  *********************/
 
-#define LV_FREETYPE_GLYPH_DSC_CACHE_SIZE (LV_FREETYPE_CACHE_FT_OUTLINES * 2)
+#define LV_FREETYPE_GLYPH_DSC_CACHE_SIZE (LV_FREETYPE_CACHE_FT_GLYPH_CNT * 2)
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -74,10 +74,11 @@ bool lv_freetype_image_font_create(lv_freetype_font_dsc_t * dsc)
     }
 
     dsc->cache_node->draw_data_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_image_cache_data_t),
-                                                       LV_FREETYPE_CACHE_FT_OUTLINES, ops);
-    if(dsc->cache_node->draw_data_cache == NULL || dsc->cache_node->glyph_cache == NULL) {
-        LV_LOG_ERROR("lv_cache_create failed");
-        return NULL;
+                                                       LV_FREETYPE_CACHE_FT_GLYPH_CNT, ops);
+    if(dsc->cache_node->draw_data_cache == NULL
+       || dsc->cache_node->glyph_cache == NULL) {
+        LV_LOG_ERROR("draw data cache creating failed");
+        return false;
     }
 
     return true;

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -15,10 +15,6 @@
  *      DEFINES
  *********************/
 
-#if LV_FREETYPE_CACHE_FT_OUTLINES <= 0
-    #error "LV_FREETYPE_CACHE_FT_OUTLINES must be greater than 0"
-#endif
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -77,7 +73,7 @@ bool lv_freetype_outline_font_create(lv_freetype_font_dsc_t * dsc)
     }
 
     dsc->cache_node->draw_data_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_outline_node_t),
-                                                       LV_FREETYPE_CACHE_FT_OUTLINES,
+                                                       LV_FREETYPE_CACHE_FT_GLYPH_CNT,
                                                        glyph_outline_cache_ops);
 
     LV_LOG_INFO("outline cache(name: %s, style: 0x%x) create %p, ref_cnt = %d",

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2206,11 +2206,11 @@
             #define LV_FREETYPE_CACHE_FT_SIZES 8
         #endif
     #endif
-    #ifndef LV_FREETYPE_CACHE_FT_OUTLINES
-        #ifdef CONFIG_LV_FREETYPE_CACHE_FT_OUTLINES
-            #define LV_FREETYPE_CACHE_FT_OUTLINES CONFIG_LV_FREETYPE_CACHE_FT_OUTLINES
+    #ifndef LV_FREETYPE_CACHE_FT_GLYPH_CNT
+        #ifdef CONFIG_LV_FREETYPE_CACHE_FT_GLYPH_CNT
+            #define LV_FREETYPE_CACHE_FT_GLYPH_CNT CONFIG_LV_FREETYPE_CACHE_FT_GLYPH_CNT
         #else
-            #define LV_FREETYPE_CACHE_FT_OUTLINES 256
+            #define LV_FREETYPE_CACHE_FT_GLYPH_CNT 256
         #endif
     #endif
 #endif


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

1. Correct cache release behavior
2. Change `LV_FREETYPE_CACHE_TYPE_OUTLINE` to `LV_FREETYPE_CACHE_FT_GLYPH_CNT` and remove its Kconfig depends.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
