### PR TITLE
chore(vg_lite): fix build warning

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -29,14 +29,14 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-typedef struct _lv_draw_vg_lite_unit_t {
+struct _lv_draw_vg_lite_unit_t {
     lv_draw_unit_t base_unit;
     lv_draw_task_t * task_act;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;
     lv_ll_t path_free_ll;
     int path_max_cnt;
-} lv_draw_vg_lite_unit_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

```cpp
Building C object build_lvgl/CMakeFiles/lvgl.dir/src/draw/vg_lite/lv_draw_vg_lite.c.o
In file included from lvgl/src/draw/vg_lite/lv_draw_vg_lite.c:16:
lvgl/src/draw/vg_lite/lv_vg_lite_path.h:26:40: warning: redefinition of typedef 'lv_draw_vg_lite_unit_t' is a C11 feature [-Wtypedef-redefinition]
typedef struct _lv_draw_vg_lite_unit_t lv_draw_vg_lite_unit_t;
                                       ^
lvgl/src/draw/vg_lite/lv_draw_vg_lite_type.h:39:3: note: previous definition is here
} lv_draw_vg_lite_unit_t;
  ^
1 warning generated.
```

this pr introduced this warning: #5161

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
