### PR TITLE
chore: use replace some %u with LV_PRIu32

### DIFF
--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -101,7 +101,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
 
     lv_cache_entry_t * entry = lv_cache_acquire_or_create(glyph_cache, &search_key, dsc);
     if(entry == NULL) {
-        LV_LOG_ERROR("glyph lookup failed for unicode = %" LV_PRIu32, unicode_letter);
+        LV_LOG_ERROR("glyph lookup failed for unicode = 0x%" LV_PRIx32, unicode_letter);
         return false;
     }
     lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -101,7 +101,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
 
     lv_cache_entry_t * entry = lv_cache_acquire_or_create(glyph_cache, &search_key, dsc);
     if(entry == NULL) {
-        LV_LOG_ERROR("glyph lookup failed for unicode = %u", unicode_letter);
+        LV_LOG_ERROR("glyph lookup failed for unicode = %" LV_PRIu32, unicode_letter);
         return false;
     }
     lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -128,7 +128,7 @@ static bool freetype_glyph_outline_create_cb(lv_freetype_outline_node_t * node, 
         return false;
     }
 
-    LV_LOG_INFO("glyph_index = %" LV_PRIu32, node->glyph_index);
+    LV_LOG_INFO("glyph_index = 0x%" LV_PRIx32, (uint32_t)node->glyph_index);
 
     node->outline = outline;
     return true;
@@ -194,7 +194,7 @@ static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * ds
 
     lv_cache_entry_t * entry = lv_cache_acquire_or_create(cache_node->draw_data_cache, &tmp_node, dsc);
     if(!entry) {
-        LV_LOG_ERROR("glyph outline lookup failed for glyph_index = %" LV_PRIu32, glyph_index);
+        LV_LOG_ERROR("glyph outline lookup failed for glyph_index = 0x%" LV_PRIx32, (uint32_t)glyph_index);
         return NULL;
     }
     return entry;

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -128,7 +128,7 @@ static bool freetype_glyph_outline_create_cb(lv_freetype_outline_node_t * node, 
         return false;
     }
 
-    LV_LOG_INFO("glyph_index = %u", node->glyph_index);
+    LV_LOG_INFO("glyph_index = %" LV_PRIu32, node->glyph_index);
 
     node->outline = outline;
     return true;
@@ -194,7 +194,7 @@ static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * ds
 
     lv_cache_entry_t * entry = lv_cache_acquire_or_create(cache_node->draw_data_cache, &tmp_node, dsc);
     if(!entry) {
-        LV_LOG_ERROR("glyph outline lookup failed for glyph_index = %u", glyph_index);
+        LV_LOG_ERROR("glyph outline lookup failed for glyph_index = %" LV_PRIu32, glyph_index);
         return NULL;
     }
     return entry;

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -167,7 +167,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 if(png_data != NULL) {
                     lv_free((void *)png_data);
                 }
-                LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %" LV_PRIu32 ": %s\n", error, lodepng_error_text(error));
                 return LV_RESULT_INVALID;
             }
         }

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -167,7 +167,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 if(png_data != NULL) {
                     lv_free((void *)png_data);
                 }
-                LV_LOG_WARN("error %" LV_PRIu32 ": %s\n", error, lodepng_error_text(error));
+                LV_LOG_WARN("error %u: %s\n", error, lodepng_error_text(error));
                 return LV_RESULT_INVALID;
             }
         }


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

use replace some %u with LV_PRIu32

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
