### PR TITLE
refactor(display): add API to set raw buffer to display

### DIFF
--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -7,13 +7,13 @@ script_dir = os.path.dirname(script_dir)
 cfg_file = os.path.join(script_dir, 'code-format.cfg')
 
 print("\nFormatting demos")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../demos/*.c,*.h"')
+os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../demos/*.c,*.cpp,*.h"')
 
 print("\nFormatting examples")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../examples/*.c,*.h"')
+os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../examples/*.c,*.cpp,*.h"')
 
 print("Formatting src")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../src/*.c,*.h"')
+os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../src/*.c,*.cpp,*.h"')
 
 print("\nFormatting tests")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../tests/*.c,*.h"')
+os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../tests/*.c,*.cpp,*.h"')

--- a/src/dev/display/drm/lv_linux_drm.c
+++ b/src/dev/display/drm/lv_linux_drm.c
@@ -154,8 +154,8 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
     int32_t width = drm_dev->mmWidth;
 
     size_t buf_size = LV_MIN(drm_dev->drm_bufs[1].size, drm_dev->drm_bufs[0].size);
-    lv_display_set_raw_buffers(disp, drm_dev->drm_bufs[1].map, drm_dev->drm_bufs[0].map, buf_size,
-                               LV_DISPLAY_RENDER_MODE_DIRECT);
+    lv_display_set_buffers(disp, drm_dev->drm_bufs[1].map, drm_dev->drm_bufs[0].map, buf_size,
+                           LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, hor_res, ver_res);
 
     if(width) {

--- a/src/dev/display/drm/lv_linux_drm.c
+++ b/src/dev/display/drm/lv_linux_drm.c
@@ -66,8 +66,6 @@ typedef struct {
     drmModePropertyPtr crtc_props[128];
     drmModePropertyPtr conn_props[128];
     drm_buffer_t drm_bufs[2]; /*DUMB buffers*/
-    lv_draw_buf_t buf1;
-    lv_draw_buf_t buf2;
 } drm_dev_t;
 
 /**********************
@@ -156,11 +154,8 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
     int32_t width = drm_dev->mmWidth;
 
     size_t buf_size = LV_MIN(drm_dev->drm_bufs[1].size, drm_dev->drm_bufs[0].size);
-    lv_draw_buf_init(&drm_dev->buf1, drm_dev->drm_bufs[0].map, hor_res, ver_res, 0, buf_size);
-    lv_draw_buf_init(&drm_dev->buf2, drm_dev->drm_bufs[1].map, hor_res, ver_res, 0, buf_size);
-
-    lv_display_set_draw_buffers(disp, &drm_dev->buf1, &drm_dev->buf2);
-    lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_DIRECT);
+    lv_display_set_raw_buffers(disp, drm_dev->drm_bufs[1].map, drm_dev->drm_bufs[0].map, buf_size,
+                               LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, hor_res, ver_res);
 
     if(width) {

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -202,7 +202,7 @@ void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
         draw_buf_2 = lv_malloc(draw_buf_size);
     }
-    lv_display_set_draw_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
+    lv_display_set_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
     lv_display_set_resolution(disp, hor_res, ver_res);
 
     if(width) {

--- a/src/dev/display/fb/lv_linux_fbdev.c
+++ b/src/dev/display/fb/lv_linux_fbdev.c
@@ -197,13 +197,12 @@ void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         draw_buf_size *= ver_res;
     }
 
-    lv_draw_buf_t * draw_buf = lv_draw_buf_create(hor_res, ver_res, LV_COLOR_FORMAT_NATIVE, 0);
-    lv_draw_buf_t * draw_buf_2 = NULL;
+    lv_color_t * draw_buf = lv_malloc(draw_buf_size);
+    lv_color_t * draw_buf_2 = NULL;
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
-        draw_buf_2 = lv_draw_buf_create(hor_res, ver_res, LV_COLOR_FORMAT_NATIVE, 0);
+        draw_buf_2 = lv_malloc(draw_buf_size);
     }
-    lv_display_set_draw_buffers(disp, draw_buf, draw_buf_2);
-    lv_display_set_render_mode(disp, LV_LINUX_FBDEV_RENDER_MODE);
+    lv_display_set_draw_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
     lv_display_set_resolution(disp, hor_res, ver_res);
 
     if(width) {

--- a/src/dev/display/tft_espi/lv_tft_espi.cpp
+++ b/src/dev/display/tft_espi/lv_tft_espi.cpp
@@ -53,10 +53,10 @@ lv_disp_t * lv_tft_espi_create(uint32_t hor_res, uint32_t ver_res, void * buf, u
 
     dsc->tft = new TFT_eSPI(hor_res, ver_res);
     dsc->tft->begin();          /* TFT init */
-    dsc->tft->setRotation( 3 ); /* Landscape orientation, flipped */
+    dsc->tft->setRotation(3);   /* Landscape orientation, flipped */
     lv_disp_set_driver_data(disp, (void *)dsc);
     lv_disp_set_flush_cb(disp, flush_cb);
-    lv_disp_set_draw_buffers(disp, (void*)buf, NULL, buf_size_bytes, LV_DISP_RENDER_MODE_PARTIAL);
+    lv_disp_set_draw_buffers(disp, (void *)buf, NULL, buf_size_bytes, LV_DISP_RENDER_MODE_PARTIAL);
     return disp;
 }
 
@@ -68,15 +68,15 @@ static void flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t * colo
 {
     lv_tft_espi_t * dsc = (lv_tft_espi_t *)lv_disp_get_driver_data(disp);
 
-    uint32_t w = ( area->x2 - area->x1 + 1 );
-    uint32_t h = ( area->y2 - area->y1 + 1 );
+    uint32_t w = (area->x2 - area->x1 + 1);
+    uint32_t h = (area->y2 - area->y1 + 1);
 
     dsc->tft->startWrite();
-    dsc->tft->setAddrWindow( area->x1, area->y1, w, h );
-    dsc->tft->pushColors( ( uint16_t * )&color_p->full, w * h, true );
+    dsc->tft->setAddrWindow(area->x1, area->y1, w, h);
+    dsc->tft->pushColors((uint16_t *)&color_p->full, w * h, true);
     dsc->tft->endWrite();
 
-    lv_disp_flush_ready( disp );
+    lv_disp_flush_ready(disp);
 
 }
 

--- a/src/dev/display/tft_espi/lv_tft_espi.cpp
+++ b/src/dev/display/tft_espi/lv_tft_espi.cpp
@@ -53,10 +53,10 @@ lv_disp_t * lv_tft_espi_create(uint32_t hor_res, uint32_t ver_res, void * buf, u
 
     dsc->tft = new TFT_eSPI(hor_res, ver_res);
     dsc->tft->begin();          /* TFT init */
-    dsc->tft->setRotation(3);   /* Landscape orientation, flipped */
+    dsc->tft->setRotation( 3 ); /* Landscape orientation, flipped */
     lv_disp_set_driver_data(disp, (void *)dsc);
     lv_disp_set_flush_cb(disp, flush_cb);
-    lv_disp_set_draw_buffers(disp, (void *)buf, NULL, buf_size_bytes, LV_DISP_RENDER_MODE_PARTIAL);
+    lv_disp_set_draw_buffers(disp, (void*)buf, NULL, buf_size_bytes, LV_DISP_RENDER_MODE_PARTIAL);
     return disp;
 }
 
@@ -68,15 +68,15 @@ static void flush_cb(lv_disp_t * disp, const lv_area_t * area, lv_color_t * colo
 {
     lv_tft_espi_t * dsc = (lv_tft_espi_t *)lv_disp_get_driver_data(disp);
 
-    uint32_t w = (area->x2 - area->x1 + 1);
-    uint32_t h = (area->y2 - area->y1 + 1);
+    uint32_t w = ( area->x2 - area->x1 + 1 );
+    uint32_t h = ( area->y2 - area->y1 + 1 );
 
     dsc->tft->startWrite();
-    dsc->tft->setAddrWindow(area->x1, area->y1, w, h);
-    dsc->tft->pushColors((uint16_t *)&color_p->full, w * h, true);
+    dsc->tft->setAddrWindow( area->x1, area->y1, w, h );
+    dsc->tft->pushColors( ( uint16_t * )&color_p->full, w * h, true );
     dsc->tft->endWrite();
 
-    lv_disp_flush_ready(disp);
+    lv_disp_flush_ready( disp );
 
 }
 

--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -40,9 +40,6 @@ typedef struct {
     void * mem;
     void * mem2;
     uint32_t mem2_yoffset;
-
-    lv_draw_buf_t buf1;
-    lv_draw_buf_t buf2;
 } lv_nuttx_fb_t;
 
 /**********************
@@ -126,24 +123,16 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         goto errout;
     }
 
-    uint32_t w = dsc->vinfo.xres;
-    uint32_t h = dsc->vinfo.yres;
-    uint32_t stride = dsc->pinfo.stride;
-    uint32_t data_size = h * stride;
-    lv_draw_buf_init(&dsc->buf1, w, h, LV_COLOR_FORMAT_NATIVE, stride, dsc->mem, data_size);
-
     /* double buffer mode */
 
     if(dsc->pinfo.yres_virtual == (dsc->vinfo.yres * 2)) {
         if((ret = fbdev_init_mem2(dsc)) < 0) {
             goto errout;
         }
-
-        lv_draw_buf_init(&dsc->buf2, w, h, LV_COLOR_FORMAT_NATIVE, stride, dsc->mem2, data_size);
     }
 
-    lv_display_set_draw_buffers(disp, &dsc->buf1, &dsc->buf2);
-    lv_display_set_render_mode(disp, LV_DISP_RENDER_MODE_DIRECT);
+    lv_display_set_raw_buffers(disp, dsc->mem, dsc->mem2,
+                               (dsc->pinfo.stride * dsc->vinfo.yres), LV_DISP_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
 
@@ -216,7 +205,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     /* double framebuffer */
 
     if(dsc->mem2 != NULL) {
-        if(disp->buf_act == disp->buf_1) {
+        if(disp->buf_act == &disp->buf_1) {
             dsc->pinfo.yoffset = 0;
         }
         else {

--- a/src/dev/nuttx/lv_nuttx_fbdev.c
+++ b/src/dev/nuttx/lv_nuttx_fbdev.c
@@ -131,8 +131,8 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         }
     }
 
-    lv_display_set_raw_buffers(disp, dsc->mem, dsc->mem2,
-                               (dsc->pinfo.stride * dsc->vinfo.yres), LV_DISP_RENDER_MODE_DIRECT);
+    lv_display_set_buffers(disp, dsc->mem, dsc->mem2,
+                           (dsc->pinfo.stride * dsc->vinfo.yres), LV_DISP_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
 

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -197,7 +197,7 @@ static lv_display_t * lcd_init(int fd, int hor_res, int ver_res)
     }
 
     lcd->disp = disp;
-    lv_display_set_raw_buffers(lcd->disp, draw_buf, draw_buf_2, buf_size, render_mode);
+    lv_display_set_buffers(lcd->disp, draw_buf, draw_buf_2, buf_size, render_mode);
     lv_display_set_flush_cb(lcd->disp, flush_cb);
     lv_display_add_event_cb(lcd->disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, lcd);
     lv_display_add_event_cb(lcd->disp, display_release_cb, LV_EVENT_DELETE, lcd->disp);

--- a/src/dev/nuttx/lv_nuttx_lcd.c
+++ b/src/dev/nuttx/lv_nuttx_lcd.c
@@ -197,7 +197,7 @@ static lv_display_t * lcd_init(int fd, int hor_res, int ver_res)
     }
 
     lcd->disp = disp;
-    lv_display_set_draw_buffers(lcd->disp, draw_buf, draw_buf_2, buf_size, render_mode);
+    lv_display_set_raw_buffers(lcd->disp, draw_buf, draw_buf_2, buf_size, render_mode);
     lv_display_set_flush_cb(lcd->disp, flush_cb);
     lv_display_add_event_cb(lcd->disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, lcd);
     lv_display_add_event_cb(lcd->disp, display_release_cb, LV_EVENT_DELETE, lcd->disp);
@@ -216,7 +216,6 @@ static void display_release_cb(lv_event_t * e)
 
         /* clear display buffer */
         if(disp->buf_1) {
-# warning "fix me"
             lv_free(disp->buf_1);
             disp->buf_1 = NULL;
         }

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -113,15 +113,15 @@ lv_display_t * lv_sdl_window_create(int32_t hor_res, int32_t ver_res)
 #if LV_SDL_BUF_COUNT == 2
         buf2 = malloc(32 * 1024);
 #endif
-        lv_display_set_raw_buffers(disp, buf1, buf2,
-                                   32 * 1024, LV_DISPLAY_RENDER_MODE_PARTIAL);
+        lv_display_set_buffers(disp, buf1, buf2,
+                               32 * 1024, LV_DISPLAY_RENDER_MODE_PARTIAL);
     }
     /*LV_DISPLAY_RENDER_MODE_DIRECT or FULL */
     else {
         uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp),
                                                       lv_display_get_color_format(disp));
-        lv_display_set_raw_buffers(disp, dsc->fb1, dsc->fb2, stride * lv_display_get_vertical_resolution(disp),
-                                   LV_SDL_RENDER_MODE);
+        lv_display_set_buffers(disp, dsc->fb1, dsc->fb2, stride * lv_display_get_vertical_resolution(disp),
+                               LV_SDL_RENDER_MODE);
     }
     lv_display_add_event_cb(disp, res_chg_event_cb, LV_EVENT_RESOLUTION_CHANGED, NULL);
 
@@ -328,7 +328,7 @@ static void texture_resize(lv_display_t * disp)
         dsc->fb2 = realloc(dsc->fb2, stride * ver_res);
         memset(dsc->fb2, 0x00, stride * ver_res);
 #endif
-        lv_display_set_raw_buffers(disp, dsc->fb1, dsc->fb2, stride * ver_res, LV_SDL_RENDER_MODE);
+        lv_display_set_buffers(disp, dsc->fb1, dsc->fb2, stride * ver_res, LV_SDL_RENDER_MODE);
     }
     if(dsc->texture) SDL_DestroyTexture(dsc->texture);
 

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -32,10 +32,9 @@ typedef struct {
     SDL_Window * window;
     SDL_Renderer * renderer;
     SDL_Texture * texture;
-    lv_draw_buf_t * buf1;
-    lv_draw_buf_t * buf2;
-    lv_draw_buf_t * buf_act;
-    void * fb_full;
+    uint8_t * fb1;
+    uint8_t * fb2;
+    uint8_t * fb_act;
     uint8_t zoom;
     uint8_t ignore_size_chg;
 } lv_sdl_window_t;
@@ -105,24 +104,27 @@ lv_display_t * lv_sdl_window_create(int32_t hor_res, int32_t ver_res)
     }
     lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
     lv_display_set_driver_data(disp, dsc);
+    window_create(disp);
+
     lv_display_set_flush_cb(disp, flush_cb);
     if(LV_SDL_RENDER_MODE == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        lv_draw_buf_t * buf1 = lv_draw_buf_create(1024, 4, LV_COLOR_FORMAT_NATIVE, 0);
-        lv_draw_buf_t * buf2 = NULL;
+        uint8_t * buf1 = malloc(32 * 1024);
+        uint8_t * buf2 = NULL;
 #if LV_SDL_BUF_COUNT == 2
-        buf2 = lv_draw_buf_create(1024, 4, LV_COLOR_FORMAT_NATIVE, 0);
+        buf2 = malloc(32 * 1024);
 #endif
-        lv_display_set_draw_buffers(disp, buf1, buf2);
-        lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_PARTIAL);
-        dsc->buf_act = buf1;
-        dsc->buf1 = buf1;
-        dsc->buf2 = buf2;
+        lv_display_set_raw_buffers(disp, buf1, buf2,
+                                   32 * 1024, LV_DISPLAY_RENDER_MODE_PARTIAL);
     }
-    /*LV_DISPLAY_RENDER_MODE_DIRECT or FULL will have draw buffer created in texture_resize*/
-
-    window_create(disp);
-    dsc->buf_act = dsc->buf1;
+    /*LV_DISPLAY_RENDER_MODE_DIRECT or FULL */
+    else {
+        uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp),
+                                                      lv_display_get_color_format(disp));
+        lv_display_set_raw_buffers(disp, dsc->fb1, dsc->fb2, stride * lv_display_get_vertical_resolution(disp),
+                                   LV_SDL_RENDER_MODE);
+    }
     lv_display_add_event_cb(disp, res_chg_event_cb, LV_EVENT_RESOLUTION_CHANGED, NULL);
+
     return disp;
 }
 
@@ -186,7 +188,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
     if(LV_SDL_RENDER_MODE == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         int32_t y;
-        uint8_t * fb_tmp = dsc->fb_full;
+        uint8_t * fb_tmp = dsc->fb_act;
         uint32_t px_size = lv_color_format_get_size(lv_display_get_color_format(disp));
         uint32_t px_map_stride = lv_area_get_width(area) * px_size;
         int32_t fb_stride = lv_display_get_horizontal_resolution(disp) * px_size;
@@ -203,9 +205,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
      * If it was the last part to refresh update the texture of the window.*/
     if(lv_display_flush_is_last(disp)) {
         if(LV_SDL_RENDER_MODE != LV_DISPLAY_RENDER_MODE_PARTIAL) {
-#if LV_SDL_BUF_COUNT == 2
-            dsc->buf_act = px_map == dsc->buf1->data ? dsc->buf2 : dsc->buf1;
-#endif
+            dsc->fb_act = px_map;
         }
         window_update(disp);
     }
@@ -284,6 +284,11 @@ static void window_create(lv_display_t * disp)
     dsc->renderer = SDL_CreateRenderer(dsc->window, -1, SDL_RENDERER_SOFTWARE);
     texture_resize(disp);
 
+    uint32_t px_size = lv_color_format_get_size(lv_display_get_color_format(disp));
+    lv_memset(dsc->fb1, 0xff, hor_res * ver_res * px_size);
+#if LV_SDL_BUF_COUNT == 2
+    lv_memset(dsc->fb2, 0xff, hor_res * ver_res * px_size);
+#endif
     /*Some platforms (e.g. Emscripten) seem to require setting the size again */
     SDL_SetWindowSize(dsc->window, hor_res * dsc->zoom, ver_res * dsc->zoom);
     texture_resize(disp);
@@ -293,10 +298,9 @@ static void window_update(lv_display_t * disp)
 {
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
 #if LV_USE_DRAW_SDL == 0
-    if(LV_SDL_RENDER_MODE == LV_DISPLAY_RENDER_MODE_PARTIAL)
-        SDL_UpdateTexture(dsc->texture, NULL, dsc->fb_full, dsc->buf_act->header.stride);
-    else
-        SDL_UpdateTexture(dsc->texture, NULL, dsc->buf_act->data, dsc->buf_act->header.stride);
+    int32_t hor_res = lv_display_get_horizontal_resolution(disp);
+    uint32_t stride = lv_draw_buf_width_to_stride(hor_res, lv_display_get_color_format(disp));
+    SDL_UpdateTexture(dsc->texture, NULL, dsc->fb_act, stride);
 
     SDL_RenderClear(dsc->renderer);
 
@@ -308,36 +312,24 @@ static void window_update(lv_display_t * disp)
 
 static void texture_resize(lv_display_t * disp)
 {
-    lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
     int32_t hor_res = lv_display_get_horizontal_resolution(disp);
     int32_t ver_res = lv_display_get_vertical_resolution(disp);
-    lv_color_format_t cf = lv_display_get_color_format(disp);
+    uint32_t stride = lv_draw_buf_width_to_stride(hor_res, lv_display_get_color_format(disp));
+    lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
 
-    uint32_t stride = lv_draw_buf_width_to_stride(hor_res, cf);
+    dsc->fb1 = realloc(dsc->fb1, stride * ver_res);
+    memset(dsc->fb1, 0x00, stride * ver_res);
 
-    /*In partial mode, need a full buffer*/
     if(LV_SDL_RENDER_MODE == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        dsc->fb_full = realloc(dsc->fb_full, stride * ver_res);
-        memset(dsc->fb_full, 0x00, stride * ver_res);
+        dsc->fb_act = dsc->fb1;
     }
-
-    /*Partial mode update doesn't need to update draw buffer.*/
-    if(LV_SDL_RENDER_MODE != LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        if(dsc->buf1) lv_draw_buf_destroy(dsc->buf1);
-        dsc->buf1 = lv_draw_buf_create(hor_res, ver_res, cf, 0);
-        LV_ASSERT_NULL(dsc->buf1);
-        /*@todo lv_draw_buf_clear(dsc->buf1)*/
-
+    else {
 #if LV_SDL_BUF_COUNT == 2
-        if(dsc->buf2) lv_draw_buf_destroy(dsc->buf2);
-        dsc->buf2 = lv_draw_buf_create(hor_res, ver_res, cf, 0);
-        LV_ASSERT_NULL(dsc->buf2);
+        dsc->fb2 = realloc(dsc->fb2, stride * ver_res);
+        memset(dsc->fb2, 0x00, stride * ver_res);
 #endif
-        dsc->buf_act = dsc->buf1;
-        lv_display_set_draw_buffers(disp, dsc->buf1, dsc->buf2);
-        lv_display_set_render_mode(disp, LV_SDL_RENDER_MODE);
+        lv_display_set_raw_buffers(disp, dsc->fb1, dsc->fb2, stride * ver_res, LV_SDL_RENDER_MODE);
     }
-
     if(dsc->texture) SDL_DestroyTexture(dsc->texture);
 
 #if LV_COLOR_DEPTH == 32
@@ -383,8 +375,8 @@ static void release_disp_cb(lv_event_t * e)
     SDL_DestroyTexture(dsc->texture);
     SDL_DestroyRenderer(dsc->renderer);
     SDL_DestroyWindow(dsc->window);
-    if(dsc->buf1) lv_draw_buf_destroy(dsc->buf1);
-    if(dsc->buf2) lv_draw_buf_destroy(dsc->buf2);
+    if(dsc->fb1) free(dsc->fb1);
+    if(dsc->fb2) free(dsc->fb2);
     lv_free(dsc);
     lv_display_set_driver_data(disp, NULL);
 }

--- a/src/dev/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/dev/vg_lite_tvg/vg_lite_tvg.cpp
@@ -936,7 +936,7 @@ extern "C" {
 
 #if LV_VG_LITE_THORVG_TRACE_API
         LV_LOG_USER("vg_lite_set_linear_grad %p %d %p (%f %f %f %f) %d %d", grad, count, color_ramp,
-                   linear_gradient.X0, linear_gradient.X1, linear_gradient.Y0, linear_gradient.Y1, spread_mode, pre_multiplied);
+                    linear_gradient.X0, linear_gradient.X1, linear_gradient.Y0, linear_gradient.Y1, spread_mode, pre_multiplied);
 #endif
 
         /* Reset the count. */
@@ -1213,7 +1213,7 @@ Empty_sequence_handler:
 
 #if LV_VG_LITE_THORVG_TRACE_API
         LV_LOG_USER("vg_lite_set_radial_grad %p %d %p (%f %f %f %f %f) %d %d", grad, count, color_ramp,
-                   radial_grad.cx, radial_grad.cy, radial_grad.fx, radial_grad.fy, radial_grad.r, spread_mode, pre_multiplied);
+                    radial_grad.cx, radial_grad.cy, radial_grad.fx, radial_grad.fy, radial_grad.r, spread_mode, pre_multiplied);
 #endif
 
         /* Reset the count. */

--- a/src/dev/x11/lv_x11_display.c
+++ b/src/dev/x11/lv_x11_display.c
@@ -177,7 +177,7 @@ static void x11_resolution_evt_cb(lv_event_t * e)
         int sz_buffers = (hor_res * ver_res * (LV_COLOR_DEPTH + 7) / 8);
         xd->buffer[0] = lv_realloc(xd->buffer[0], sz_buffers);
         xd->buffer[1] = (LV_X11_DOUBLE_BUFFER ?  lv_realloc(xd->buffer[1], sz_buffers) : NULL);
-        lv_display_set_raw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
+        lv_display_set_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
     }
 
     /* re-create cache image with new size */
@@ -199,7 +199,7 @@ static void x11_disp_delete_evt_cb(lv_event_t * e)
 
     lv_timer_delete(xd->timer);
 
-    lv_display_set_raw_buffers(disp, NULL, NULL, 0, LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_buffers(disp, NULL, NULL, 0, LV_DISPLAY_RENDER_MODE_PARTIAL);
     lv_free(xd->buffer[0]);
     if(LV_X11_DOUBLE_BUFFER) {
         lv_free(xd->buffer[1]);
@@ -381,7 +381,7 @@ lv_display_t * lv_x11_window_create(char const * title, int32_t hor_res, int32_t
     }
     xd->buffer[0] = lv_malloc(sz_buffers);
     xd->buffer[1] = (LV_X11_DOUBLE_BUFFER ? lv_malloc(sz_buffers) : NULL);
-    lv_display_set_raw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
+    lv_display_set_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
 
     xd->timer = lv_timer_create(x11_event_handler, 5, disp);
 

--- a/src/dev/x11/lv_x11_display.c
+++ b/src/dev/x11/lv_x11_display.c
@@ -177,7 +177,7 @@ static void x11_resolution_evt_cb(lv_event_t * e)
         int sz_buffers = (hor_res * ver_res * (LV_COLOR_DEPTH + 7) / 8);
         xd->buffer[0] = lv_realloc(xd->buffer[0], sz_buffers);
         xd->buffer[1] = (LV_X11_DOUBLE_BUFFER ?  lv_realloc(xd->buffer[1], sz_buffers) : NULL);
-        lv_display_set_draw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
+        lv_display_set_raw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
     }
 
     /* re-create cache image with new size */
@@ -199,7 +199,7 @@ static void x11_disp_delete_evt_cb(lv_event_t * e)
 
     lv_timer_delete(xd->timer);
 
-    lv_display_set_draw_buffers(disp, NULL, NULL, 0, LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_raw_buffers(disp, NULL, NULL, 0, LV_DISPLAY_RENDER_MODE_PARTIAL);
     lv_free(xd->buffer[0]);
     if(LV_X11_DOUBLE_BUFFER) {
         lv_free(xd->buffer[1]);
@@ -381,7 +381,7 @@ lv_display_t * lv_x11_window_create(char const * title, int32_t hor_res, int32_t
     }
     xd->buffer[0] = lv_malloc(sz_buffers);
     xd->buffer[1] = (LV_X11_DOUBLE_BUFFER ? lv_malloc(sz_buffers) : NULL);
-    lv_display_set_draw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
+    lv_display_set_raw_buffers(disp, xd->buffer[0], xd->buffer[1], sz_buffers, LV_X11_RENDER_MODE);
 
     xd->timer = lv_timer_create(x11_event_handler, 5, disp);
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -406,7 +406,8 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(stride * h > buf_size && render_mode != LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        LV_ASSERT_MSG(false, "buffer too small for non partial render mode.");
+        LV_ASSERT_MSG(false, "buffer too small for full screen in %s mode.",
+                      render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
         return;
     }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -396,8 +396,8 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
     disp->buf_act = disp->buf_1;
 }
 
-void lv_display_set_raw_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
-                                lv_display_render_mode_t render_mode)
+void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
+                            lv_display_render_mode_t render_mode)
 {
     uint32_t w = lv_display_get_horizontal_resolution(disp);
     uint32_t h = lv_display_get_vertical_resolution(disp);
@@ -406,9 +406,8 @@ void lv_display_set_raw_buffers(lv_display_t * disp, void * buf1, void * buf2, u
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(stride * h > buf_size && render_mode != LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        LV_LOG_ERROR("buffer too small for non partial render mode.");
-        render_mode = LV_DISPLAY_RENDER_MODE_PARTIAL;
-        h = buf_size / stride;
+        LV_ASSERT_MSG(false, "buffer too small for non partial render mode.");
+        return;
     }
 
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -406,8 +406,9 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(stride * h > buf_size && render_mode != LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        LV_ASSERT_MSG(false, "buffer too small for full screen in %s mode.",
-                      render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
+        LV_LOG_ERROR("%s mode requires screen sized buffer(s)",
+                     render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
+        LV_ASSERT(0);
         return;
     }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -396,6 +396,27 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
     disp->buf_act = disp->buf_1;
 }
 
+void lv_display_set_raw_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
+                                lv_display_render_mode_t render_mode)
+{
+    uint32_t w = lv_display_get_horizontal_resolution(disp);
+    uint32_t h = lv_display_get_vertical_resolution(disp);
+    LV_ASSERT(w != 0 && h != 0);
+
+    lv_color_format_t cf = lv_display_get_color_format(disp);
+    uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
+    if(stride * h > buf_size && render_mode != LV_DISPLAY_RENDER_MODE_PARTIAL) {
+        LV_LOG_ERROR("buffer too small for non partial render mode.");
+        render_mode = LV_DISPLAY_RENDER_MODE_PARTIAL;
+        h = buf_size / stride;
+    }
+
+    lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
+    lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
+    lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
+    lv_display_set_render_mode(disp, render_mode);
+}
+
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode)
 {
     if(disp == NULL) disp = lv_display_get_default();

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -232,8 +232,8 @@ int32_t lv_display_get_dpi(const lv_display_t * disp);
  * @param buf1              first buffer
  * @param buf2              second buffer (can be `NULL`)
  */
-void lv_display_set_raw_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
-                                lv_display_render_mode_t render_mode);
+void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
+                            lv_display_render_mode_t render_mode);
 
 /**
  * Set the buffers for a display, accept a draw buffer pointer.

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -227,7 +227,16 @@ int32_t lv_display_get_dpi(const lv_display_t * disp);
  *--------------------*/
 
 /**
- * Set the buffers for a display
+ * Set the buffers for a display, similarly to `lv_display_set_draw_buffers`, but accept the raw buffer pointers.
+ * @param disp              pointer to a display
+ * @param buf1              first buffer
+ * @param buf2              second buffer (can be `NULL`)
+ */
+void lv_display_set_raw_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
+                                lv_display_render_mode_t render_mode);
+
+/**
+ * Set the buffers for a display, accept a draw buffer pointer.
  * @param disp              pointer to a display
  * @param buf1              first buffer
  * @param buf2              second buffer (can be `NULL`)

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -99,6 +99,8 @@ struct _lv_display_t {
     /** Double buffer sync areas (redrawn during last refresh) */
     lv_ll_t sync_areas;
 
+    lv_draw_buf_t _static_buf1; /*Used when user pass in a raw buffer as display draw buffer*/
+    lv_draw_buf_t _static_buf2;
     /*---------------------
      * Layer
      *--------------------*/

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -33,10 +33,8 @@ static void hal_init(void)
 
     static lv_color32_t test_fb[(HOR_RES + LV_DRAW_BUF_STRIDE_ALIGN - 1) * VER_RES + LV_DRAW_BUF_ALIGN];
     lv_display_t * disp = lv_display_create(HOR_RES, VER_RES);
-    static lv_draw_buf_t draw_buf;
-    lv_draw_buf_init(&draw_buf, HOR_RES, VER_RES, LV_COLOR_FORMAT_ARGB8888, 0, test_fb, sizeof(test_fb));
-    lv_display_set_draw_buffers(disp, &draw_buf, NULL);
-    lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_DIRECT);
+    lv_display_set_raw_buffers(disp, lv_draw_buf_align(test_fb, LV_COLOR_FORMAT_ARGB8888), NULL, HOR_RES * VER_RES * 4,
+                               LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_flush_cb(disp, dummy_flush_cb);
 
     lv_test_mouse_indev = lv_indev_create();

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -33,8 +33,8 @@ static void hal_init(void)
 
     static lv_color32_t test_fb[(HOR_RES + LV_DRAW_BUF_STRIDE_ALIGN - 1) * VER_RES + LV_DRAW_BUF_ALIGN];
     lv_display_t * disp = lv_display_create(HOR_RES, VER_RES);
-    lv_display_set_raw_buffers(disp, lv_draw_buf_align(test_fb, LV_COLOR_FORMAT_ARGB8888), NULL, HOR_RES * VER_RES * 4,
-                               LV_DISPLAY_RENDER_MODE_DIRECT);
+    lv_display_set_buffers(disp, lv_draw_buf_align(test_fb, LV_COLOR_FORMAT_ARGB8888), NULL, HOR_RES * VER_RES * 4,
+                           LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_flush_cb(disp, dummy_flush_cb);
 
     lv_test_mouse_indev = lv_indev_create();


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

The drivers have been changed back original logic. Fix #5270  Fix #5271
Related to #5204 lvgl/lv_binding_micropython#313
Discussion on #5273

`lv_display_set_raw_buffers` is kept.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
