### PR TITLE
fix(imagebutton): fix imagebutton not having default size

### DIFF
--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -39,6 +39,8 @@ static void update_src_info(lv_imagebutton_src_info_t * info, const void * src);
 
 const lv_obj_class_t lv_imagebutton_class = {
     .base_class = &lv_obj_class,
+    .width_def = LV_SIZE_CONTENT,
+    .height_def = LV_SIZE_CONTENT,
     .instance_size = sizeof(lv_imagebutton_t),
     .constructor_cb = lv_imagebutton_constructor,
     .event_cb = lv_imagebutton_event,


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

fix the issue where the imagebutton does not have its size set, causing it to display abnormally
### Before repair
![image](https://github.com/lvgl/lvgl/assets/18370433/0c3afb48-06a2-45d4-b455-12fae9d1f10a)
### After repair
![image](https://github.com/lvgl/lvgl/assets/18370433/83dcbb0e-3190-4d7d-8048-a79d1e0144aa)


### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
