### PR TITLE
test(obj): Add initial tests for `lv_obj_move_to_index`

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -210,7 +210,9 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
     }
 
     const uint32_t parent_child_count = lv_obj_get_child_count(parent);
+    /* old_index only can be 0 or greater, this point can not be reached if the parent is null */
     const int32_t old_index = lv_obj_get_index(obj);
+    LV_ASSERT(0 <= old_index);
 
     if(index < 0) {
         index += parent_child_count;
@@ -416,14 +418,16 @@ int32_t lv_obj_get_index(const lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_obj_t * parent = lv_obj_get_parent(obj);
-    if(parent == NULL) return 0xFFFFFFFF;
+    if(parent == NULL) return -1;
 
     int32_t i = 0;
     for(i = 0; i < parent->spec_attr->child_cnt; i++) {
         if(parent->spec_attr->children[i] == obj) return i;
     }
 
-    return -1; /*Shouldn't happen*/
+    /*Shouldn't reach this point*/
+    LV_ASSERT(0);
+    return -1;
 }
 
 int32_t lv_obj_get_index_by_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -202,22 +202,28 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
+    /* Check parent validity */
     lv_obj_t * parent = lv_obj_get_parent(obj);
-
     if(!parent) {
         LV_LOG_WARN("parent is NULL");
         return;
     }
 
-    if(index < 0) {
-        index = lv_obj_get_child_count(parent) + index;
-    }
-
+    const uint32_t parent_child_count = lv_obj_get_child_count(parent);
     const int32_t old_index = lv_obj_get_index(obj);
 
-    if(index < 0) return;
-    if(index >= (int32_t) lv_obj_get_child_count(parent)) return;
-    if(index == old_index) return;
+    if(index < 0) {
+        index += parent_child_count;
+    }
+
+    if((index < 0)
+       /* Index is same or bigger than parent child count */
+       || (index >= (int32_t) parent_child_count)
+       /* If both previous and new index are the same */
+       || (index == old_index)) {
+
+        return;
+    }
 
     int32_t i = old_index;
     if(index < old_index) {

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -210,7 +210,7 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
     }
 
     const uint32_t parent_child_count = lv_obj_get_child_count(parent);
-    /* old_index only can be 0 or greater, this point can not be reached if the parent is null */
+    /* old_index only can be 0 or greater, this point can not be reached if the parent is not null */
     const int32_t old_index = lv_obj_get_index(obj);
     LV_ASSERT(0 <= old_index);
 

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -216,6 +216,7 @@ void lv_obj_move_to_index(lv_obj_t * obj, int32_t index)
         index += parent_child_count;
     }
 
+    /* Index was negative and the absolute value is greater than parent child count */
     if((index < 0)
        /* Index is same or bigger than parent child count */
        || (index >= (int32_t) parent_child_count)

--- a/tests/src/test_cases/widgets/test_obj_tree.c
+++ b/tests/src/test_cases/widgets/test_obj_tree.c
@@ -80,4 +80,32 @@ void test_obj_tree_3(void)
     TEST_ASSERT_EQUAL(lv_obj_get_child(parent2, 0), child1);
 }
 
+/** lv_obj_move_to_index **/
+
+void test_obj_move_to_index_move_to_the_background(void)
+{
+
+}
+
+void test_obj_move_to_index_move_forward(void)
+{
+
+}
+
+/* Tests scenarios when no operation is performed */
+void test_obj_move_to_index_no_operation_when_parent_is_null(void)
+{
+
+}
+
+void test_obj_move_to_index_no_operation_when_index_is_same_or_bigger_than_parent_child_count(void)
+{
+
+}
+
+void test_obj_move_to_index_no_operation_when_new_index_is_the_same_as_previous_index(void)
+{
+
+}
+
 #endif

--- a/tests/src/test_cases/widgets/test_obj_tree.c
+++ b/tests/src/test_cases/widgets/test_obj_tree.c
@@ -164,4 +164,22 @@ void test_obj_move_to_index_no_operation_when_new_index_is_the_same_as_previous_
     TEST_ASSERT_EQUAL(1, lv_obj_get_index(child2));
 }
 
+void test_obj_move_to_index_no_operation_when_requested_negative_index_is_greater_than_child_count(void)
+{
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
+    lv_obj_t * child2 = NULL;
+
+    parent = lv_obj_create(lv_screen_active());
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+    /* index is 1 */
+    child2 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child1, -4);
+
+    TEST_ASSERT_EQUAL(0, lv_obj_get_index(child1));
+    TEST_ASSERT_EQUAL(1, lv_obj_get_index(child2));
+}
+
 #endif

--- a/tests/src/test_cases/widgets/test_obj_tree.c
+++ b/tests/src/test_cases/widgets/test_obj_tree.c
@@ -84,28 +84,84 @@ void test_obj_tree_3(void)
 
 void test_obj_move_to_index_move_to_the_background(void)
 {
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
+    lv_obj_t * child2 = NULL;
 
+    parent = lv_obj_create(lv_screen_active());
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+    /* index is 1 */
+    child2 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child2, 0);
+
+    TEST_ASSERT_EQUAL(1, lv_obj_get_index(child1));
+    TEST_ASSERT_EQUAL(0, lv_obj_get_index(child2));
 }
 
 void test_obj_move_to_index_move_forward(void)
 {
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
+    lv_obj_t * child2 = NULL;
 
+    parent = lv_obj_create(lv_screen_active());
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+    /* index is 1 */
+    child2 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child1, lv_obj_get_index(child1) - 1);
+
+    TEST_ASSERT_EQUAL(1, lv_obj_get_index(child1));
+    TEST_ASSERT_EQUAL(0, lv_obj_get_index(child2));
 }
 
 /* Tests scenarios when no operation is performed */
 void test_obj_move_to_index_no_operation_when_parent_is_null(void)
 {
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
 
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child1, 0);
+
+    TEST_ASSERT_EQUAL_INT32(0xFFFFFFFF, lv_obj_get_index(child1));
 }
 
 void test_obj_move_to_index_no_operation_when_index_is_same_or_bigger_than_parent_child_count(void)
 {
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
 
+    parent = lv_obj_create(lv_screen_active());
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child1, 3U);
+
+    TEST_ASSERT_EQUAL(0, lv_obj_get_index(child1));
 }
 
 void test_obj_move_to_index_no_operation_when_new_index_is_the_same_as_previous_index(void)
 {
+    lv_obj_t * parent = NULL;
+    lv_obj_t * child1 = NULL;
+    lv_obj_t * child2 = NULL;
 
+    parent = lv_obj_create(lv_screen_active());
+    /* index is 0 */
+    child1 = lv_obj_create(parent);
+    /* index is 1 */
+    child2 = lv_obj_create(parent);
+
+    lv_obj_move_to_index(child2, 1U);
+
+    TEST_ASSERT_EQUAL(0, lv_obj_get_index(child1));
+    TEST_ASSERT_EQUAL(1, lv_obj_get_index(child2));
 }
 
 #endif


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Improve `lv_obj_move_to_index` as ravioli marks it's complexity as 9.
Planned to be merged into master after v9 release

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
