### PR TITLE
fix(display): fix the support for partial mode in lv_display_set_buffers

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -407,7 +407,7 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(LV_DISPLAY_RENDER_MODE_PARTIAL == render_mode) {
         h = buf_size / stride;
-        if (0 == h) {
+        if(0 == h) {
             LV_LOG_ERROR("the buffer is too small for PARTIAL mode");
             LV_ASSERT(0);
             return;

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -405,15 +405,19 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
 
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
-    if(stride * h > buf_size && render_mode != LV_DISPLAY_RENDER_MODE_PARTIAL) {
+    if(LV_DISPLAY_RENDER_MODE_PARTIAL == render_mode) {
+        h = buf_size / stride;
+        if (0 == h) {
+            LV_LOG_ERROR("the buffer is too small for PARTIAL mode");
+            LV_ASSERT(0);
+            return;
+        }
+    }
+    else if(stride * h > buf_size) {
         LV_LOG_ERROR("%s mode requires screen sized buffer(s)",
                      render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
         LV_ASSERT(0);
         return;
-    }
-
-    if(LV_DISPLAY_RENDER_MODE_PARTIAL == render_mode) {
-        h = buf_size / stride;
     }
 
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -407,7 +407,11 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         h = buf_size / stride;
-        LV_ASSERT_MSG(h != 0, "the buffer is too small for PARTIAL mode");
+        if(h == 0) {
+            LV_LOG_ERROR("the buffer is too small for PARTIAL mode");
+            LV_ASSERT(0);
+            return;
+        }
     }
     else if(stride * h > buf_size) {
         LV_LOG_ERROR("%s mode requires screen sized buffer(s)",

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -405,13 +405,9 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
 
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
-    if(LV_DISPLAY_RENDER_MODE_PARTIAL == render_mode) {
+    if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         h = buf_size / stride;
-        if(0 == h) {
-            LV_LOG_ERROR("the buffer is too small for PARTIAL mode");
-            LV_ASSERT(0);
-            return;
-        }
+        LV_ASSERT_MSG(h != 0, "the buffer is too small for PARTIAL mode");
     }
     else if(stride * h > buf_size) {
         LV_LOG_ERROR("%s mode requires screen sized buffer(s)",

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -406,17 +406,18 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
+        /* for partial mode, we calculate the height based on the buf_size and stride */
         h = buf_size / stride;
-        if(h == 0) {
-            LV_LOG_ERROR("the buffer is too small for PARTIAL mode");
-            LV_ASSERT(0);
-            return;
-        }
     }
     else if(stride * h > buf_size) {
         LV_LOG_ERROR("%s mode requires screen sized buffer(s)",
                      render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
         LV_ASSERT(0);
+        return;
+    }
+
+    if(h == 0) {
+        LV_ASSERT_MSG(h != 0, "the buffer is too small");
         return;
     }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -412,6 +412,10 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
         return;
     }
 
+    if(LV_DISPLAY_RENDER_MODE_PARTIAL == render_mode) {
+        h = buf_size / stride;
+    }
+
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
     lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
     lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

The `lv_display_set_buffers` uses screen height in partial mode.  This isn't right.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
