### PR TITLE
fix(theme): limit the theme applied tabview header buttons

### DIFF
--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -786,14 +786,16 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 
 #if LV_USE_TABVIEW
         lv_obj_t * parent = lv_obj_get_parent(obj);
-        if(parent && lv_obj_check_type(lv_obj_get_parent(parent), &lv_tabview_class)) {
-            lv_obj_add_style(obj, &theme->styles.pressed, LV_STATE_PRESSED);
-            lv_obj_add_style(obj, &theme->styles.bg_color_primary_muted, LV_STATE_CHECKED);
-            lv_obj_add_style(obj, &theme->styles.tab_btn, LV_STATE_CHECKED);
-            lv_obj_add_style(obj, &theme->styles.outline_primary, LV_STATE_FOCUS_KEY);
-            lv_obj_add_style(obj, &theme->styles.outline_secondary, LV_STATE_EDITED);
-            lv_obj_add_style(obj, &theme->styles.tab_bg_focus, LV_STATE_FOCUS_KEY);
-            return;
+        if(parent && lv_obj_get_index(parent) == 0) { /*Tabview header*/
+            if(lv_obj_check_type(lv_obj_get_parent(parent), &lv_tabview_class)) {
+                lv_obj_add_style(obj, &theme->styles.pressed, LV_STATE_PRESSED);
+                lv_obj_add_style(obj, &theme->styles.bg_color_primary_muted, LV_STATE_CHECKED);
+                lv_obj_add_style(obj, &theme->styles.tab_btn, LV_STATE_CHECKED);
+                lv_obj_add_style(obj, &theme->styles.outline_primary, LV_STATE_FOCUS_KEY);
+                lv_obj_add_style(obj, &theme->styles.outline_secondary, LV_STATE_EDITED);
+                lv_obj_add_style(obj, &theme->styles.tab_bg_focus, LV_STATE_FOCUS_KEY);
+                return;
+            }
         }
 
 #endif


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Limit the theme applied tabview header buttons and not other buttons.
Fixes https://github.com/lvgl/lvgl/issues/4926#issuecomment-1890589747

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
