### PR TITLE
feat(draw_buf) make lv_draw_buf_malloc a static function

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -26,6 +26,8 @@
 static void * buf_malloc(size_t size, lv_color_format_t color_format);
 static void buf_free(void * buf);
 static void * buf_align(void * buf, lv_color_format_t color_format);
+static void * draw_buf_malloc(size_t size_bytes, lv_color_format_t color_format);
+static void draw_buf_free(void * buf);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
 static uint32_t _calculate_draw_buf_size(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride);
 
@@ -60,17 +62,6 @@ uint32_t lv_draw_buf_width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
     if(handlers.width_to_stride_cb) return handlers.width_to_stride_cb(w, color_format);
     else return 0;
-}
-
-void * lv_draw_buf_malloc(size_t size_bytes, lv_color_format_t color_format)
-{
-    if(handlers.buf_malloc_cb) return handlers.buf_malloc_cb(size_bytes, color_format);
-    else return NULL;
-}
-
-void lv_draw_buf_free(void * buf)
-{
-    if(handlers.buf_free_cb) handlers.buf_free_cb(buf);
 }
 
 void * lv_draw_buf_align(void * data, lv_color_format_t color_format)
@@ -170,7 +161,7 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
 
     uint32_t size = _calculate_draw_buf_size(w, h, cf, stride);
 
-    void * buf = lv_draw_buf_malloc(size, cf);
+    void * buf = draw_buf_malloc(size, cf);
     LV_ASSERT_MALLOC(buf);
     if(buf == NULL) {
         LV_LOG_WARN("No memory: %"LV_PRIu32"x%"LV_PRIu32", cf: %d, stride: %"LV_PRIu32", %"LV_PRIu32"Byte, ",
@@ -238,7 +229,7 @@ void lv_draw_buf_destroy(lv_draw_buf_t * buf)
     if(buf == NULL) return;
 
     if(buf->header.flags & LV_IMAGE_FLAGS_ALLOCATED) {
-        lv_draw_buf_free(buf->unaligned_data);
+        draw_buf_free(buf->unaligned_data);
         lv_free(buf);
     }
     else {
@@ -396,6 +387,17 @@ static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
     width_byte = w * lv_color_format_get_bpp(color_format);
     width_byte = (width_byte + 7) >> 3; /*Round up*/
     return (width_byte + LV_DRAW_BUF_STRIDE_ALIGN - 1) & ~(LV_DRAW_BUF_STRIDE_ALIGN - 1);
+}
+
+static void * draw_buf_malloc(size_t size_bytes, lv_color_format_t color_format)
+{
+    if(handlers.buf_malloc_cb) return handlers.buf_malloc_cb(size_bytes, color_format);
+    else return NULL;
+}
+
+static void draw_buf_free(void * buf)
+{
+    if(handlers.buf_free_cb) handlers.buf_free_cb(buf);
 }
 
 /**

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -103,22 +103,6 @@ void _lv_draw_buf_init_handlers(void);
 lv_draw_buf_handlers_t * lv_draw_buf_get_handlers(void);
 
 /**
- * Allocate a buffer with the given size. It might allocate slightly larger buffer to fulfill the alignment requirements.
- * @param size          the size to allocate in bytes
- * @param color_format  the color format of the buffer to allocate
- * @return              the allocated buffer.
- * @note The returned value can be saved in draw_buf->buf
- * @note lv_draw_buf_align can be sued the align the returned pointer
- */
-void * lv_draw_buf_malloc(size_t size_bytes, lv_color_format_t color_format);
-
-/**
- * Free a buffer allocated by lv_draw_buf_malloc
- * @param buf      pointer to a buffer
- */
-void lv_draw_buf_free(void  * buf);
-
-/**
  * Align the address of a buffer. The buffer needs to be large enough for the real data after alignment
  * @param buf           the data to align
  * @param color_format  the color format of the buffer

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -640,8 +640,9 @@ static lv_result_t decode_indexed(lv_image_decoder_t * decoder, lv_image_decoder
 exit_with_buf:
     if(dsc->src_type == LV_IMAGE_SRC_FILE && !is_compressed) {
         lv_free((void *)palette);
-        lv_draw_buf_free((void *)indexed_data);
     }
+
+    if(draw_buf_indexed) lv_draw_buf_destroy(draw_buf_indexed);
     return LV_RESULT_INVALID;
 #else
     LV_UNUSED(stride);
@@ -759,7 +760,7 @@ static lv_result_t decode_rgb(lv_image_decoder_t * decoder, lv_image_decoder_dsc
     res = fs_read_file_at(f, sizeof(lv_image_header_t), img_data, len, &rn);
     if(res != LV_FS_RES_OK || rn != len) {
         LV_LOG_WARN("Read rgb file failed: %d", res);
-        lv_draw_buf_free(img_data);
+        lv_draw_buf_destroy(decoded);
         return LV_RESULT_INVALID;
     }
 

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -268,7 +268,7 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
     JSAMPARRAY buffer;  /* Output row buffer */
     int row_stride;     /* physical row width in output buffer */
 
-    uint8_t * output_buffer = NULL;
+    lv_draw_buf_t * decoded = NULL;
 
     /* In this example we want to open the input file before doing anything else,
      * so that the setjmp() error recovery below can assume the file is open.
@@ -293,8 +293,8 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
 
         LV_LOG_WARN("decoding error");
 
-        if(output_buffer) {
-            lv_draw_buf_free(output_buffer);
+        if(decoded) {
+            lv_draw_buf_destroy(decoded);
         }
 
         /* If we get here, the JPEG code has signaled an error.
@@ -344,7 +344,6 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
      * In this example, we need to make an output work buffer of the right size.
      */
     /* JSAMPLEs per row in output buffer */
-    lv_draw_buf_t * decoded;
     row_stride = cinfo.output_width * cinfo.output_components;
     /* Make a one-row-high sample array that will go away when done with image */
     buffer = (*cinfo.mem->alloc_sarray)


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Fix #4868

From now on, should use lv_draw_buf_create instead because lv_draw_buf_malloc does not return aligned pointer

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
