### PR TITLE
chore(tests): replace sprintf -> lv_snprintf

### DIFF
--- a/tests/src/test_cases/draw/test_image_formats.c
+++ b/tests/src/test_cases/draw/test_image_formats.c
@@ -258,8 +258,9 @@ static void bin_image_create(bool rotate, bool recolor, int align, int compress)
     char path[256];
     int stride = stride_align[align];
     for(unsigned i = 0; i < sizeof(color_formats) / sizeof(color_formats[0]); i++) {
-        sprintf(name, "bin%s", color_formats[i]);
-        sprintf(path, "A:test_images/stride_align%d/%s/test_%s.bin", stride, compressions[compress], color_formats[i]);
+        lv_snprintf(name, sizeof(name), "bin%s", color_formats[i]);
+        lv_snprintf(path, sizeof(path), "A:test_images/stride_align%d/%s/test_%s.bin", stride, compressions[compress],
+                    color_formats[i]);
         img_create(name, path, rotate, recolor);
     }
 }
@@ -268,7 +269,7 @@ static void c_array_image_create(bool rotate, bool recolor, int align, int compr
 {
     char name[32];
     for(unsigned i = 0; i < sizeof(color_formats) / sizeof(color_formats[0]); i++) {
-        sprintf(name, "%s%s", compressions[compress], color_formats[i]);
+        lv_snprintf(name, sizeof(name), "%s%s", compressions[compress], color_formats[i]);
         const void * src = c_array_images[align][compress][i];
         img_create(name, src, rotate, recolor);
     }
@@ -285,12 +286,13 @@ void test_image_formats()
             for(unsigned i = 0; i < sizeof(compressions) / sizeof(compressions[0]); i++) {
                 char reference[256];
                 bin_image_create(rotate, recolor, align, i);
-                snprintf(reference, sizeof(reference), "draw/bin_image_stride%d_%s_%s.png", stride, compressions[i], modes[mode]);
+                lv_snprintf(reference, sizeof(reference), "draw/bin_image_stride%d_%s_%s.png", stride, compressions[i], modes[mode]);
                 TEST_ASSERT_EQUAL_SCREENSHOT(reference);
                 lv_obj_clean(lv_screen_active());
 
                 c_array_image_create(rotate, recolor, align, i);
-                snprintf(reference, sizeof(reference), "draw/c_array_image_stride%d_%s_%s.png", stride, compressions[i], modes[mode]);
+                lv_snprintf(reference, sizeof(reference), "draw/c_array_image_stride%d_%s_%s.png", stride, compressions[i],
+                            modes[mode]);
                 TEST_ASSERT_EQUAL_SCREENSHOT(reference);
                 lv_obj_clean(lv_screen_active());
             }

--- a/tests/src/test_cases/widgets/test_spinner.c
+++ b/tests/src/test_cases/widgets/test_spinner.c
@@ -26,7 +26,7 @@ void test_spinner_spinning(void)
         lv_task_handler();
 
         char filename[32];
-        snprintf(filename, sizeof(filename), "widgets/spinner_%02d.png", i);
+        lv_snprintf(filename, sizeof(filename), "widgets/spinner_%02d.png", i);
         TEST_ASSERT_EQUAL_SCREENSHOT(filename);
     }
 }

--- a/tests/unity/unity_support.c
+++ b/tests/unity/unity_support.c
@@ -129,7 +129,7 @@ static bool screenhot_compare(const char * fn_ref, const char * mode, uint8_t to
 {
 
     char fn_ref_full[256];
-    sprintf(fn_ref_full, "%s%s", REF_IMGS_PATH, fn_ref);
+    lv_snprintf(fn_ref_full, sizeof(fn_ref_full), "%s%s", REF_IMGS_PATH, fn_ref);
 
     lv_refr_now(NULL);
 
@@ -191,7 +191,7 @@ static bool screenhot_compare(const char * fn_ref, const char * mode, uint8_t to
         fn_ref_no_ext[strlen(fn_ref_no_ext) - 4] = '\0';
 
         char fn_err_full[256];
-        sprintf(fn_err_full, "%s%s_err.png", REF_IMGS_PATH, fn_ref_no_ext);
+        lv_snprintf(fn_err_full, sizeof(fn_err_full), "%s%s_err.png", REF_IMGS_PATH, fn_ref_no_ext);
 
         write_png_file(screen_buf_xrgb8888, 800, 480, fn_err_full);
     }


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Remove unsafe `sprintf` calls.

cc @XuNeo 

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
