### PR TITLE
fix(indev): use `lv_anim_delete` to delete scroll_throw_anim

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1564,9 +1564,8 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
 
     if(indev->pointer.scroll_dir == LV_DIR_NONE || indev->pointer.scroll_obj == NULL) {
         if(indev->scroll_throw_anim) {
-            /*hacky*/
             LV_LOG_INFO("stop animation");
-            lv_anim_set_duration(indev->scroll_throw_anim, 0);
+            lv_anim_delete(indev, indev_scroll_throw_anim_cb);
         }
     }
 }

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -379,11 +379,11 @@ static void anim_timer(lv_timer_t * param)
                     a->current_value = new_value;
                     /*Apply the calculated value*/
                     if(a->exec_cb) a->exec_cb(a->var, new_value);
-                    if(a->custom_exec_cb) a->custom_exec_cb(a, new_value);
+                    if(!state.anim_list_changed && a->custom_exec_cb) a->custom_exec_cb(a, new_value);
                 }
 
                 /*If the time is elapsed the animation is ready*/
-                if(a->act_time >= a->duration) {
+                if(!state.anim_list_changed && a->act_time >= a->duration) {
                     anim_ready_handler(a);
                 }
             }


### PR DESCRIPTION
1. The infinite animation cannot exit by setting the duration to 0. Instead, update it to exit by directly deleting the animation.
2. Fix the use-after-free issue of the animation after it is deleted in `exec_cb`.

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
