### PR TITLE
perf(vg_lite): simplify the global path acquisition method

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -39,8 +39,8 @@ struct _lv_draw_vg_lite_unit_t {
     lv_draw_task_t * task_act;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;
-    lv_ll_t path_free_ll;
-    int path_max_cnt;
+    struct _lv_vg_lite_path_t * global_path;
+    bool path_in_use;
 };
 
 /**********************

--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -20,7 +20,6 @@
  *********************/
 
 #define PATH_KAPPA 0.552284f
-#define PATH_MAX_CNT 32
 
 /* Magic number from https://spencermortensen.com/articles/bezier-circle/ */
 #define PATH_ARC_MAGIC 0.55191502449351f
@@ -40,8 +39,6 @@ struct _lv_vg_lite_path_t {
     size_t mem_size;
     uint8_t format_len;
 };
-
-typedef struct _lv_vg_lite_path_t * lv_vg_lite_path_ref_t;
 
 typedef struct {
     float min_x;
@@ -69,21 +66,16 @@ typedef struct {
 void lv_vg_lite_path_init(struct _lv_draw_vg_lite_unit_t * unit)
 {
     LV_ASSERT_NULL(unit);
-    _lv_ll_init(&unit->path_free_ll, sizeof(lv_vg_lite_path_ref_t));
+    unit->global_path = lv_vg_lite_path_create(VG_LITE_FP32);
+    unit->path_in_use = false;
 }
 
 void lv_vg_lite_path_deinit(struct _lv_draw_vg_lite_unit_t * unit)
 {
     LV_ASSERT_NULL(unit);
-
-    lv_ll_t * ll_p = &unit->path_free_ll;
-    lv_vg_lite_path_ref_t * path_ref;
-
-    _LV_LL_READ(ll_p, path_ref) {
-        lv_vg_lite_path_destroy(*path_ref);
-    }
-
-    _lv_ll_clear(ll_p);
+    LV_ASSERT(!unit->path_in_use);
+    lv_vg_lite_path_destroy(unit->global_path);
+    unit->global_path = NULL;
 }
 
 lv_vg_lite_path_t * lv_vg_lite_path_create(vg_lite_format_t data_format)
@@ -115,52 +107,25 @@ void lv_vg_lite_path_destroy(lv_vg_lite_path_t * path)
 lv_vg_lite_path_t * lv_vg_lite_path_get(struct _lv_draw_vg_lite_unit_t * unit, vg_lite_format_t data_format)
 {
     LV_ASSERT_NULL(unit);
-
-    unit->path_max_cnt++;
-    LV_ASSERT(unit->path_max_cnt < PATH_MAX_CNT);
-
-    lv_ll_t * ll_p = &unit->path_free_ll;
-
-    lv_vg_lite_path_ref_t * path_ref = _lv_ll_get_head(ll_p);
-    if(path_ref) {
-        lv_vg_lite_path_t * path = *path_ref;
-        lv_vg_lite_path_reset(path, data_format);
-        _lv_ll_remove(ll_p, path_ref);
-        lv_free(path_ref);
-
-        return path;
-    }
-
-    return lv_vg_lite_path_create(data_format);
+    LV_ASSERT_NULL(unit->global_path);
+    LV_ASSERT(!unit->path_in_use);
+    lv_vg_lite_path_reset(unit->global_path, data_format);
+    unit->path_in_use = true;
+    return unit->global_path;
 }
 
 void lv_vg_lite_path_drop(struct _lv_draw_vg_lite_unit_t * unit, lv_vg_lite_path_t * path)
 {
     LV_ASSERT_NULL(unit);
     LV_ASSERT_NULL(path);
-
-    unit->path_max_cnt--;
-    LV_ASSERT(unit->path_max_cnt >= 0);
-
-    lv_ll_t * ll_p = &unit->path_free_ll;
-
-    uint32_t len = _lv_ll_get_len(ll_p);
-    if(len >= PATH_MAX_CNT) {
-        lv_vg_lite_path_ref_t * tail = _lv_ll_get_tail(ll_p);
-        lv_vg_lite_path_destroy(*tail);
-        _lv_ll_remove(ll_p, tail);
-        lv_free(tail);
-    }
-
-    lv_vg_lite_path_ref_t * head = _lv_ll_ins_head(ll_p);
-    LV_ASSERT_MALLOC(head);
-    *head = path;
+    LV_ASSERT(unit->global_path == path);
+    LV_ASSERT(unit->path_in_use);
+    unit->path_in_use = false;
 }
 
 void lv_vg_lite_path_reset(lv_vg_lite_path_t * path, vg_lite_format_t data_format)
 {
     LV_ASSERT_NULL(path);
-    lv_memzero(path->base.path, path->mem_size);
     path->base.path_length = 0;
     path->base.format = data_format;
     path->base.quality = VG_LITE_MEDIUM;


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

1. Use a single global path to improve acquisition and drop efficiency.
2. Remove unnecessary path memory cleaning.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
