### PR TITLE
Revert "refactor(font_load): rename font_load to binfont_load"

### DIFF
--- a/docs/overview/font.rst
+++ b/docs/overview/font.rst
@@ -290,7 +290,7 @@ The built-in symbols are created from the `FontAwesome <https://fontawesome.com/
 Load a font at run-time
 ***********************
 
-:cpp:func:`lv_binfont_load` can be used to load a font from a file. The font needs
+:cpp:func:`lv_font_load` can be used to load a font from a file. The font needs
 to have a special binary format. (Not TTF or WOFF). Use
 `lv_font_conv <https://github.com/lvgl/lv_font_conv/>`__ with the
 ``--format bin`` option to generate an LVGL compatible font file.
@@ -302,19 +302,18 @@ Example
 
 .. code:: c
 
-   static lv_font_t my_font;
-   lv_result_t res = lv_binfont_load(&my_font, "X:/path/to/my_font.bin");
-   if(res != LV_RESULT_OK) return;
+   lv_font_t * my_font;
+   my_font = lv_font_load(X/path/to/my_font.bin);
 
    /*Use the font*/
 
    /*Free the font if not required anymore*/
-   lv_font_free(&my_font);
+   lv_font_free(my_font);
 
 Load a font from a memory buffer at run-time
 ******************************************
 
-:cpp:func:`lv_binfont_load_from_buffer` can be used to load a font from a memory buffer.
+:cpp:func:`lv_font_load_from_buffer` can be used to load a font from a memory buffer.
 This function may be useful to load a font from an external file system, which is not
 supported by LVGL. The font needs to be in the same format as if it were loaded from a file.
 
@@ -325,7 +324,7 @@ Example
 
 .. code:: c
 
-   static lv_font_t my_font;
+   lv_font_t * my_font;
    uint8_t *buf;
    uint32_t bufsize;
 
@@ -333,12 +332,12 @@ Example
    ...
 
    /*Load font from the buffer*/
-   lv_result_t res = lv_binfont_load_from_buffer(&my_font, (void *)buf, buf));
-   if(res != LV_RESULT_OK) return;
+   my_font = lv_font_load_from_buffer((void *)buf, buf));
+
    /*Use the font*/
 
    /*Free the font if not required anymore*/
-   lv_font_free(&my_font);
+   lv_font_free(my_font);
 
 Add a new font engine
 *********************

--- a/lvgl.h
+++ b/lvgl.h
@@ -45,7 +45,7 @@ extern "C" {
 #include "src/display/lv_display.h"
 
 #include "src/font/lv_font.h"
-#include "src/font/lv_binfont_loader.h"
+#include "src/font/lv_font_loader.h"
 #include "src/font/lv_font_fmt_txt.h"
 
 #include "src/widgets/animimage/lv_animimage.h"

--- a/src/font/lv_font_loader.c
+++ b/src/font/lv_font_loader.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_binfont_loader.c
+ * @file lv_font_loader.c
  *
  */
 
@@ -12,7 +12,7 @@
 
 #include "../lvgl.h"
 #include "../misc/lv_fs.h"
-#include "lv_binfont_loader.h"
+#include "lv_font_loader.h"
 
 /**********************
  *      TYPEDEFS
@@ -78,7 +78,7 @@ static unsigned int read_bits(bit_iterator_t * it, int n_bits, lv_fs_res_t * res
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_result_t lv_binfont_load(lv_font_t * font, const char * path)
+lv_result_t lv_font_load(lv_font_t * font, const char * path)
 {
     LV_ASSERT_NULL(font);
     LV_ASSERT_NULL(path);
@@ -109,12 +109,12 @@ lv_result_t lv_binfont_load(lv_font_t * font, const char * path)
 }
 
 #if LV_USE_FS_MEMFS
-lv_result_t lv_binfont_load_from_buffer(lv_font_t * font, void * buffer, uint32_t size)
+lv_result_t lv_font_load_from_buffer(lv_font_t * font, void * buffer, uint32_t size)
 {
     lv_fs_path_ex_t mempath;
 
     lv_fs_make_path_from_buffer(&mempath, LV_FS_MEMFS_LETTER, buffer, size);
-    return lv_binfont_load(font, (const char *)&mempath);
+    return lv_font_load(font, (const char *)&mempath);
 }
 #endif
 

--- a/src/font/lv_font_loader.h
+++ b/src/font/lv_font_loader.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_binfont_loader.h
+ * @file lv_font_loader.h
  *
  */
 
@@ -32,7 +32,7 @@ extern "C" {
  * @param path          path where the font file is located
  * @return              LV_RESULT_OK on success; LV_RESULT_INVALID on error
  */
-lv_result_t lv_binfont_load(lv_font_t * font, const char * font_name);
+lv_result_t lv_font_load(lv_font_t * font, const char * font_name);
 
 #if LV_USE_FS_MEMFS
 /**
@@ -43,12 +43,12 @@ lv_result_t lv_binfont_load(lv_font_t * font, const char * font_name);
  * @param size          size of the font file buffer
  * @return              LV_RESULT_OK on success; LV_RESULT_INVALID on error
  */
-lv_result_t lv_binfont_load_from_buffer(lv_font_t * font, void * buffer, uint32_t size);
+lv_result_t lv_font_load_from_buffer(lv_font_t * font, void * buffer, uint32_t size);
 #endif
 
 /**
- * Frees the memory allocated by the `lv_binfont_load()` function
- * @param font          lv_font_t object created by the lv_binfont_load function
+ * Frees the memory allocated by the `lv_font_load()` function
+ * @param font          lv_font_t object created by the lv_font_load function
  */
 void lv_font_free(lv_font_t * font);
 

--- a/src/libs/fsdrv/lv_fs_memfs.c
+++ b/src/libs/fsdrv/lv_fs_memfs.c
@@ -33,7 +33,7 @@
  *
  * The path object can be used at any place where a file path is required, e.g.:
  *
- * lv_font_t* my_font = lv_binfont_load((const char *) & mempath);
+ * lv_font_t* my_font = lv_font_load((const char *) & mempath);
  *
  */
 

--- a/tests/src/test_cases/test_font_loader.c
+++ b/tests/src/test_cases/test_font_loader.c
@@ -102,13 +102,13 @@ void test_font_loader_with_cache(void)
     /*Test with cache ('A' has cache)*/
     lv_result_t res;
 
-    res = lv_binfont_load(&font_1_bin, "A:src/test_assets/font_1.fnt");
+    res = lv_font_load(&font_1_bin, "A:src/test_assets/font_1.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load(&font_2_bin, "A:src/test_assets/font_2.fnt");
+    res = lv_font_load(&font_2_bin, "A:src/test_assets/font_2.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load(&font_3_bin, "A:src/test_assets/font_3.fnt");
+    res = lv_font_load(&font_3_bin, "A:src/test_assets/font_3.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
     common();
@@ -119,13 +119,13 @@ void test_font_loader_no_cache(void)
     /*Test without cache ('B' has NO cache)*/
     lv_result_t res;
 
-    res = lv_binfont_load(&font_1_bin, "B:src/test_assets/font_1.fnt");
+    res = lv_font_load(&font_1_bin, "B:src/test_assets/font_1.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load(&font_2_bin, "B:src/test_assets/font_2.fnt");
+    res = lv_font_load(&font_2_bin, "B:src/test_assets/font_2.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load(&font_3_bin, "B:src/test_assets/font_3.fnt");
+    res = lv_font_load(&font_3_bin, "B:src/test_assets/font_3.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
     common();
@@ -136,13 +136,13 @@ void test_font_loader_from_buffer(void)
     /*Test with memfs*/
     lv_result_t res;
 
-    res = lv_binfont_load_from_buffer(&font_1_bin, (void *)&font_1_buf, sizeof(font_1_buf));
+    res = lv_font_load_from_buffer(&font_1_bin, (void *)&font_1_buf, sizeof(font_1_buf));
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load_from_buffer(&font_2_bin, (void *)&font_2_buf, sizeof(font_2_buf));
+    res = lv_font_load_from_buffer(&font_2_bin, (void *)&font_2_buf, sizeof(font_2_buf));
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
-    res = lv_binfont_load_from_buffer(&font_3_bin, (void *)&font_3_buf, sizeof(font_3_buf));
+    res = lv_font_load_from_buffer(&font_3_bin, (void *)&font_3_buf, sizeof(font_3_buf));
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
     common();
@@ -158,7 +158,7 @@ void test_font_loader_reload(void)
 
     lv_font_t font;
     lv_result_t res;
-    res = lv_binfont_load(&font, "A:src/test_assets/font_2.fnt");
+    res = lv_font_load(&font, "A:src/test_assets/font_2.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
     lv_obj_set_style_text_font(label, &font, 0);
@@ -167,7 +167,7 @@ void test_font_loader_reload(void)
 
     lv_font_free(&font);
 
-    res = lv_binfont_load(&font, "A:src/test_assets/font_3.fnt");
+    res = lv_font_load(&font, "A:src/test_assets/font_3.fnt");
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
 
     lv_obj_report_style_change(NULL);


### PR DESCRIPTION
This reverts commit 51bc45f8701c5588ead8621eef30c724fabe679e.

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

See: https://github.com/lvgl/lvgl/issues/5279

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
