### PR TITLE
chore(vg_lite): clean useless function and macro

### DIFF
--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -7,15 +7,11 @@
  *      INCLUDES
  *********************/
 
-/*Fix warning for aligned_alloc. See https://stackoverflow.com/questions/29247065/compiler-cant-find-aligned-alloc-function*/
-#define _ISOC11_SOURCE
-
 #include "lv_draw_vg_lite.h"
 
 #if LV_USE_DRAW_VG_LITE
 
 #include "lv_vg_lite_utils.h"
-#include <stdlib.h>
 
 /*********************
  *      DEFINES
@@ -29,10 +25,6 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void * buf_malloc(size_t size, lv_color_format_t color_format);
-static void buf_free(void * buf);
-static void * buf_align(void * buf, lv_color_format_t color_format);
-static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area);
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
 
 /**********************
@@ -50,43 +42,12 @@ static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
 void lv_draw_buf_vg_lite_init_handlers(void)
 {
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
-
-    handlers->buf_malloc_cb = buf_malloc;
-    handlers->buf_free_cb = buf_free;
-    handlers->align_pointer_cb = buf_align;
-    handlers->invalidate_cache_cb = invalidate_cache;
     handlers->width_to_stride_cb = width_to_stride;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-static void * buf_malloc(size_t size_bytes, lv_color_format_t color_format)
-{
-    LV_UNUSED(color_format);
-    size_bytes = LV_VG_LITE_ALIGN(size_bytes, LV_VG_LITE_BUF_ALIGN);
-    return aligned_alloc(LV_VG_LITE_BUF_ALIGN, size_bytes);
-}
-
-static void buf_free(void * buf)
-{
-    free(buf);
-}
-
-static void * buf_align(void * buf, lv_color_format_t color_format)
-{
-    LV_UNUSED(color_format);
-    return (void *)LV_VG_LITE_ALIGN((lv_uintptr_t)buf, LV_VG_LITE_BUF_ALIGN);
-}
-
-static void invalidate_cache(void * buf, uint32_t stride, lv_color_format_t color_format, const lv_area_t * area)
-{
-    LV_UNUSED(buf);
-    LV_UNUSED(stride);
-    LV_UNUSED(color_format);
-    LV_UNUSED(area);
-}
 
 static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
 {

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -230,7 +230,7 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
     /* Since the palette and index image are next to each other,
      * the palette size needs to be aligned to ensure that the image is aligned.
      */
-    uint32_t palette_size_bytes_aligned = LV_VG_LITE_ALIGN(palette_size_bytes, LV_VG_LITE_BUF_ALIGN);
+    uint32_t palette_size_bytes_aligned = LV_VG_LITE_ALIGN(palette_size_bytes, LV_DRAW_BUF_ALIGN);
 
     lv_draw_buf_t * draw_buf = lv_draw_buf_create(width, height, cf, stride);
     if(draw_buf == NULL) {
@@ -304,7 +304,7 @@ static lv_result_t decoder_open_file(lv_image_decoder_t * decoder, lv_image_deco
     /* Since the palette and index image are next to each other,
      * the palette size needs to be aligned to ensure that the image is aligned.
      */
-    uint32_t palette_size_bytes_aligned = LV_VG_LITE_ALIGN(palette_size_bytes, LV_VG_LITE_BUF_ALIGN);
+    uint32_t palette_size_bytes_aligned = LV_VG_LITE_ALIGN(palette_size_bytes, LV_DRAW_BUF_ALIGN);
 
     lv_draw_buf_t * draw_buf = lv_draw_buf_create(width, height, cf, stride);
     if(draw_buf == NULL) {

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -759,8 +759,8 @@ bool lv_vg_lite_buffer_check(const vg_lite_buffer_t * buffer, bool is_src)
         return false;
     }
 
-    if(!LV_VG_LITE_IS_ALIGNED(buffer->memory, LV_VG_LITE_BUF_ALIGN)) {
-        LV_LOG_ERROR("buffer address(%p) is not aligned to %d", buffer->memory, LV_VG_LITE_BUF_ALIGN);
+    if(!LV_VG_LITE_IS_ALIGNED(buffer->memory, LV_DRAW_BUF_ALIGN)) {
+        LV_LOG_ERROR("buffer address(%p) is not aligned to %d", buffer->memory, LV_DRAW_BUF_ALIGN);
         return false;
     }
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -29,7 +29,9 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define LV_VG_LITE_BUF_ALIGN 64
+#if LV_DRAW_BUF_ALIGN != 64
+#error "LV_DRAW_BUF_ALIGN must be 64"
+#endif
 
 #define LV_VG_LITE_IS_ERROR(err) (err > 0)
 

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -82,6 +82,9 @@ typedef void * lv_user_data_t;
 /* Simulate VG-Lite hardware using ThorVG */
 #define LV_USE_VG_LITE_THORVG       1
 
+/* VG-Lite GPU buffer alignment. */
+#define LV_DRAW_BUF_ALIGN           64
+
 #include "lv_test_conf_full.h"
 #elif LV_TEST_OPTION == 4
 #define  LV_COLOR_DEPTH     24
@@ -106,8 +109,10 @@ typedef void * lv_user_data_t;
 /*Use a large value be sure any issues will cause crash*/
 #define LV_DRAW_BUF_STRIDE_ALIGN                64
 
+#if !defined(LV_DRAW_BUF_ALIGN)
 /*Use non power of 2 to avoid the case when `malloc` returns aligned pointer by default, and use a large value be sure any issues will cause crash*/
 #define LV_DRAW_BUF_ALIGN                       852
+#endif
 
 /*For screenshots*/
 #undef LV_USE_PERF_MONITOR


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

1. Use the publicly implemented draw_buf interface.
2. Replace `LV_VG_LITE_BUF_ALIGN` -> `LV_DRAW_BUF_ALIGN`.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
