### PR TITLE
fix(windows): remove the imm32 static linking dependency and reduce compilation warnings

### DIFF
--- a/docs/integration/driver/windows.rst
+++ b/docs/integration/driver/windows.rst
@@ -35,7 +35,9 @@ Application Mode
 Prerequisites
 -------------
 
-The minimum Windows OS version this driver supported is Windows Server 2003, or Windows XP with East Asian language support installed because the input method integration support need that.
+The tested minimum Windows OS requirement for this driver is Windows XP RTM.
+
+According to the Windows GDI API this driver used. Maybe the minimum Windows OS requirement for this driver is Windows 2000 RTM.
 
 Configure Windows driver
 --------------------

--- a/src/dev/windows/lv_windows_context.c
+++ b/src/dev/windows/lv_windows_context.c
@@ -97,12 +97,12 @@ void lv_windows_platform_init(void)
     window_class.cbWndExtra = 0;
     window_class.hInstance = NULL;
     window_class.hIcon = NULL;
-    window_class.hCursor = LoadCursorW(NULL, IDC_ARROW);
+    window_class.hCursor = LoadCursorW(NULL, (LPCWSTR)IDC_ARROW);
     window_class.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     window_class.lpszMenuName = NULL;
     window_class.lpszClassName = L"LVGL.Window";
     window_class.hIconSm = NULL;
-    LV_ASSERT_NULL(RegisterClassExW(&window_class));
+    LV_ASSERT(RegisterClassExW(&window_class));
 }
 
 lv_windows_window_context_t * lv_windows_get_window_context(

--- a/src/dev/windows/lv_windows_display.c
+++ b/src/dev/windows/lv_windows_display.c
@@ -71,7 +71,7 @@ lv_display_t * lv_windows_create_display(
                         &data,
                         0,
                         NULL);
-    LV_ASSERT_NULL(thread);
+    LV_ASSERT(thread);
 
     WaitForSingleObjectEx(data.mutex, INFINITE, FALSE);
 
@@ -154,7 +154,7 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
     ShowWindow(window_handle, SW_SHOW);
     UpdateWindow(window_handle);
 
-    LV_ASSERT_NULL(SetEvent(data->mutex));
+    LV_ASSERT(SetEvent(data->mutex));
 
     data = NULL;
 

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -40,7 +40,7 @@
     #include "draw/vg_lite/lv_draw_vg_lite.h"
 #endif
 #if LV_USE_WINDOWS
-    #include "src/dev/windows/lv_windows_context.h"
+    #include "dev/windows/lv_windows_context.h"
 #endif
 
 /*********************


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

![image](https://github.com/lvgl/lvgl/assets/10867563/e2751d7f-8ecd-43ac-8ef5-383683fbd6e5)
- Use LV_ASSERT instead of LV_ASSERT_NULL in some cases to reduce the compilation warnings with MinGW toolchain. (Thanks to @lhdjply.)

![image](https://github.com/lvgl/lvgl/assets/10867563/9a828b70-6783-45bb-9770-2e153e45465e)
- Add cast for IDC_ARROW to reduce the compilation warnings with MinGW toolchain. (Thanks to @lhdjply.)

- Simplify the include in lv_init.c for making non IDE environment like Visual Studio Code happier. (Thanks to @lhdjply.)

![image](https://github.com/lvgl/lvgl/assets/10867563/34aea09e-9b98-434a-a0c2-f7a99c9eff9e)
- Remove the imm32 static linking dependency to achieve the out-of-box experience with MinGW toolchain. (Thanks to @lhdjply.)

![image](https://github.com/lvgl/lvgl/assets/10867563/423cdd81-ccdb-470c-9b4f-1b3a945152f7)
![image](https://github.com/lvgl/lvgl/assets/10867563/8ffe60a6-c754-4778-9831-48ec84275b12)
After this PR merged, the tested minimum Windows OS requirement for Windows backend is Windows XP RTM. According to the Windows GDI API we used in Windows backend. Maybe the minimum Windows OS requirement for Windows backend is Windows 2000 RTM.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)

Kenji Mouri