### PR TITLE
fix(vg_lite): fix freetype build break and imgfont draw error

### DIFF
--- a/examples/others/imgfont/lv_example_imgfont_1.c
+++ b/examples/others/imgfont/lv_example_imgfont_1.c
@@ -22,7 +22,7 @@ static const void * get_imgfont_path(const lv_font_t * font, uint32_t unicode, u
     else if(unicode == 0xF600) {
 #if LV_USE_FFMPEG
         return "lvgl/examples/assets/emoji/F600.png";
-#elif LV_USE_LODEPNG
+#else
         return "A:lvgl/examples/assets/emoji/F600.png";
 #endif
     }

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -200,6 +200,7 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
     /*In case of uncompressed formats the image stored in the ROM/RAM.
      *So simply give its pointer*/
     const uint8_t * image_data = ((lv_image_dsc_t *)dsc->src)->data;
+    uint32_t image_data_size = ((lv_image_dsc_t *)dsc->src)->data_size;
 
     bool has_alpha = lv_color_format_has_alpha(cf);
     bool is_indexed = LV_COLOR_FORMAT_IS_INDEXED(cf);
@@ -219,7 +220,7 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
 
         lv_draw_buf_t * draw_buf = lv_malloc_zeroed(sizeof(lv_draw_buf_t));
         LV_ASSERT_MALLOC(draw_buf);
-        lv_draw_buf_init(draw_buf, width, height, cf, stride, (void *)image_data, LV_VG_LITE_IMAGE_NO_CACHE);
+        lv_draw_buf_init(draw_buf, width, height, cf, stride, (void *)image_data, image_data_size);
         dsc->decoded = draw_buf;
         return LV_RESULT_OK;
     }


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

1.Fix compilation error when closing freetype.
```bash
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘lv_draw_vg_lite_label’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:68:9: warning: implicit declaration of function ‘lv_freetype_outline_add_event’; did you mean ‘freetype_outline_event_cb’? [-Wimplicit-function-declaration]
   68 |         lv_freetype_outline_add_event(freetype_outline_event_cb, LV_EVENT_ALL, draw_unit);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         freetype_outline_event_cb
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/draw/vg_lite/lv_vg_lite_path.c.o
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/draw/vg_lite/lv_vg_lite_utils.c.o
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘draw_letter_cb’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:98:16: warning: implicit declaration of function ‘lv_freetype_is_outline_font’ [-Wimplicit-function-declaration]
   98 |             if(lv_freetype_is_outline_font(glyph_draw_dsc->g->resolved_font)) {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_binfont_loader.c.o
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘draw_letter_outline’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:31:38: warning: implicit declaration of function ‘LV_FREETYPE_F26DOT6_TO_FLOAT’ [-Wimplicit-function-declaration]
   31 | #define FT_F26DOT6_TO_PATH_SCALE(x) (LV_FREETYPE_F26DOT6_TO_FLOAT(x) / (1 << FT_F26DOT6_SHIFT))
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:209:19: note: in expansion of macro ‘FT_F26DOT6_TO_PATH_SCALE’
  209 |     float scale = FT_F26DOT6_TO_PATH_SCALE(lv_freetype_outline_get_scale(dsc->g->resolved_font));
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_font.c.o
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:209:44: warning: implicit declaration of function ‘lv_freetype_outline_get_scale’; did you mean ‘freetype_outline_event_cb’? [-Wimplicit-function-declaration]
  209 |     float scale = FT_F26DOT6_TO_PATH_SCALE(lv_freetype_outline_get_scale(dsc->g->resolved_font));
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:31:67: note: in definition of macro ‘FT_F26DOT6_TO_PATH_SCALE’
   31 | #define FT_F26DOT6_TO_PATH_SCALE(x) (LV_FREETYPE_F26DOT6_TO_FLOAT(x) / (1 << FT_F26DOT6_SHIFT))
      |                                                                   ^
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: At top level:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:251:40: error: unknown type name ‘lv_freetype_outline_event_param_t’
  251 | static void vg_lite_outline_push(const lv_freetype_outline_event_param_t * param)
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘vg_lite_outline_push’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:253:40: error: request for member ‘outline’ in something not a structure or union
  253 |     lv_vg_lite_path_t * outline = param->outline;
      |                                        ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:256:5: error: unknown type name ‘lv_freetype_outline_type_t’
  256 |     lv_freetype_outline_type_t type = param->type;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:256:44: error: request for member ‘type’ in something not a structure or union
  256 |     lv_freetype_outline_type_t type = param->type;
      |                                            ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:258:14: error: ‘LV_FREETYPE_OUTLINE_END’ undeclared (first use in this function); did you mean ‘LV_STYLE_OUTLINE_PAD’?
  258 |         case LV_FREETYPE_OUTLINE_END:
      |              ^~~~~~~~~~~~~~~~~~~~~~~
      |              LV_STYLE_OUTLINE_PAD
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:258:14: note: each undeclared identifier is reported only once for each function it appears in
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_font_fmt_txt.c.o
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_font_dejavu_16_persian_hebrew.c.o
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:261:14: error: ‘LV_FREETYPE_OUTLINE_MOVE_TO’ undeclared (first use in this function)
  261 |         case LV_FREETYPE_OUTLINE_MOVE_TO:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:262:51: error: request for member ‘to’ in something not a structure or union
  262 |             lv_vg_lite_path_move_to(outline, param->to.x, param->to.y);
      |                                                   ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:262:64: error: request for member ‘to’ in something not a structure or union
  262 |             lv_vg_lite_path_move_to(outline, param->to.x, param->to.y);
      |                                                                ^~
[ 26%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_font_montserrat_10.c.o
[ 27%] Building C object build_lvgl/CMakeFiles/lvgl.dir/src/font/lv_font_montserrat_12.c.o
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:264:14: error: ‘LV_FREETYPE_OUTLINE_LINE_TO’ undeclared (first use in this function)
  264 |         case LV_FREETYPE_OUTLINE_LINE_TO:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:265:51: error: request for member ‘to’ in something not a structure or union
  265 |             lv_vg_lite_path_line_to(outline, param->to.x, param->to.y);
      |                                                   ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:265:64: error: request for member ‘to’ in something not a structure or union
  265 |             lv_vg_lite_path_line_to(outline, param->to.x, param->to.y);
      |                                                                ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:267:14: error: ‘LV_FREETYPE_OUTLINE_CUBIC_TO’ undeclared (first use in this function)
  267 |         case LV_FREETYPE_OUTLINE_CUBIC_TO:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:268:52: error: request for member ‘control1’ in something not a structure or union
  268 |             lv_vg_lite_path_cubic_to(outline, param->control1.x, param->control1.y,
      |                                                    ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:268:71: error: request for member ‘control1’ in something not a structure or union
  268 |             lv_vg_lite_path_cubic_to(outline, param->control1.x, param->control1.y,
      |                                                                       ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:269:43: error: request for member ‘control2’ in something not a structure or union
  269 |                                      param->control2.x, param->control2.y,
      |                                           ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:269:62: error: request for member ‘control2’ in something not a structure or union
  269 |                                      param->control2.x, param->control2.y,
      |                                                              ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:270:43: error: request for member ‘to’ in something not a structure or union
  270 |                                      param->to.x, param->to.y);
      |                                           ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:270:56: error: request for member ‘to’ in something not a structure or union
  270 |                                      param->to.x, param->to.y);
      |                                                        ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:272:14: error: ‘LV_FREETYPE_OUTLINE_CONIC_TO’ undeclared (first use in this function)
  272 |         case LV_FREETYPE_OUTLINE_CONIC_TO:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:273:51: error: request for member ‘control1’ in something not a structure or union
  273 |             lv_vg_lite_path_quad_to(outline, param->control1.x, param->control1.y,
      |                                                   ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:273:70: error: request for member ‘control1’ in something not a structure or union
  273 |             lv_vg_lite_path_quad_to(outline, param->control1.x, param->control1.y,
      |                                                                      ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:274:42: error: request for member ‘to’ in something not a structure or union
  274 |                                     param->to.x, param->to.y);
      |                                          ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:274:55: error: request for member ‘to’ in something not a structure or union
  274 |                                     param->to.x, param->to.y);
      |                                                       ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c: In function ‘freetype_outline_event_cb’:
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:286:5: error: unknown type name ‘lv_freetype_outline_event_param_t’
  286 |     lv_freetype_outline_event_param_t * param = lv_event_get_param(e);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:289:18: error: request for member ‘outline’ in something not a structure or union
  289 |             param->outline = lv_vg_lite_path_create(PATH_DATA_COORD_FORMAT);
      |                  ^~
lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c:292:42: error: request for member ‘outline’ in something not a structure or union
  292 |             lv_vg_lite_path_destroy(param->outline);
      |                                          ^~
```

2.Fix imgfont drawing error.
```bash
[Warn] draw_letter: lv_draw_letter: glyph dsc. not found for U+F600 lv_draw_label.c:380
[Error] lv_vg_lite_buffer_check: buffer address(0x555556dee560) is not aligned to 64 lv_vg_lite_utils.c:763
[Error] draw_letter_bitmap: Asserted at expression: lv_vg_lite_buffer_check(&src_buf, 1) lv_draw_vg_lite_label.c:133
```

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
