### PR TITLE
feat(draw): add lv_draw_sw_rgb565_to_l1 for simpler conversation to monochrome

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -227,15 +227,17 @@ void lv_draw_sw_rgb565_to_l1(void * buf, uint32_t buf_size_px)
     lv_color16_t * in = buf;
     uint32_t i;
     for(i = 0; i < buf_size_px; i += 8) {
-        *out = 0;
-        if(in[0].blue > 16)(*out) |= (1 << 7);
-        if(in[1].blue > 16)(*out) |= (1 << 6);
-        if(in[2].blue > 16)(*out) |= (1 << 5);
-        if(in[3].blue > 16)(*out) |= (1 << 4);
-        if(in[4].blue > 16)(*out) |= (1 << 3);
-        if(in[5].blue > 16)(*out) |= (1 << 2);
-        if(in[6].blue > 16)(*out) |= (1 << 1);
-        if(in[7].blue > 16)(*out) |= (1 << 0);
+        uint8_t tmp = 0;
+        if(in[0].blue > 16)tmp |= (1 << 7);
+        if(in[1].blue > 16)tmp |= (1 << 6);
+        if(in[2].blue > 16)tmp |= (1 << 5);
+        if(in[3].blue > 16)tmp |= (1 << 4);
+        if(in[4].blue > 16)tmp |= (1 << 3);
+        if(in[5].blue > 16)tmp |= (1 << 2);
+        if(in[6].blue > 16)tmp |= (1 << 1);
+        if(in[7].blue > 16)tmp |= (1 << 0);
+
+        *out = tmp;
 
         in += 8;
         out += 1;

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -216,6 +216,32 @@ void lv_draw_sw_rgb565_swap(void * buf, uint32_t buf_size_px)
 
 }
 
+void lv_draw_sw_rgb565_to_l1(void * buf, uint32_t buf_size_px)
+{
+    if(buf_size_px & 0x7) {
+        LV_LOG_WARN("buf_size_px must be multiple of 8");
+        return;
+    }
+
+    uint8_t * out = buf;
+    lv_color16_t * in = buf;
+    uint32_t i;
+    for(i = 0; i < buf_size_px; i += 8) {
+        *out = 0;
+        if(in[0].blue > 16)(*out) |= (1 << 7);
+        if(in[1].blue > 16)(*out) |= (1 << 6);
+        if(in[2].blue > 16)(*out) |= (1 << 5);
+        if(in[3].blue > 16)(*out) |= (1 << 4);
+        if(in[4].blue > 16)(*out) |= (1 << 3);
+        if(in[5].blue > 16)(*out) |= (1 << 2);
+        if(in[6].blue > 16)(*out) |= (1 << 1);
+        if(in[7].blue > 16)(*out) |= (1 << 0);
+
+        in += 8;
+        out += 1;
+    }
+}
+
 void lv_draw_sw_rotate(const void * src, void * dest, int32_t src_width, int32_t src_height, int32_t src_sride,
                        int32_t dest_stride, lv_display_rotation_t rotation, lv_color_format_t color_format)
 {

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -228,14 +228,14 @@ void lv_draw_sw_rgb565_to_l1(void * buf, uint32_t buf_size_px)
     uint32_t i;
     for(i = 0; i < buf_size_px; i += 8) {
         uint8_t tmp = 0;
-        if(in[0].blue > 16)tmp |= (1 << 7);
-        if(in[1].blue > 16)tmp |= (1 << 6);
-        if(in[2].blue > 16)tmp |= (1 << 5);
-        if(in[3].blue > 16)tmp |= (1 << 4);
-        if(in[4].blue > 16)tmp |= (1 << 3);
-        if(in[5].blue > 16)tmp |= (1 << 2);
-        if(in[6].blue > 16)tmp |= (1 << 1);
-        if(in[7].blue > 16)tmp |= (1 << 0);
+        if(in[0].blue > 16) tmp |= (1 << 7);
+        if(in[1].blue > 16) tmp |= (1 << 6);
+        if(in[2].blue > 16) tmp |= (1 << 5);
+        if(in[3].blue > 16) tmp |= (1 << 4);
+        if(in[4].blue > 16) tmp |= (1 << 3);
+        if(in[5].blue > 16) tmp |= (1 << 2);
+        if(in[6].blue > 16) tmp |= (1 << 1);
+        if(in[7].blue > 16) tmp |= (1 << 0);
 
         *out = tmp;
 

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -180,6 +180,15 @@ void lv_draw_sw_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc
 void lv_draw_sw_rgb565_swap(void * buf, uint32_t buf_size_px);
 
 /**
+ * This is helper to easily convert RGB565 color to 1 bit monochrome.
+ * The conversation is done in-place.
+ * The bits are in a row.
+ * @param buf           the source buffer with RGB565 data, the output 1 bit data will be written here as well
+ * @param buf_size_px   number of pixels in the buffer. Must be multiple of 8.
+ */
+void lv_draw_sw_rgb565_to_l1(void * buf, uint32_t buf_size_px);
+
+/**
  * Rotate a buffer into an other buffer
  * @param src           the source buffer
  * @param dest          the destination buffer


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Related to https://github.com/lvgl/lvgl/issues/4926#issuecomment-1893601117

@espzav
Please this function. I'm not sure if the bit order is correct for real display controllers. 

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
