### PR TITLE
fix(event): fix assert in event bubble mode.

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -390,7 +390,7 @@ static void lv_obj_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 static void lv_obj_draw(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     if(code == LV_EVENT_COVER_CHECK) {
         lv_cover_check_info_t * info = lv_event_get_param(e);
         if(info->res == LV_COVER_RES_MASKED) return;

--- a/src/dev/display/lcd/lv_lcd_generic_mipi.c
+++ b/src/dev/display/lcd/lv_lcd_generic_mipi.c
@@ -317,7 +317,7 @@ static void set_rotation(lv_lcd_generic_mipi_driver_t * drv, lv_display_rotation
  */
 static void res_chg_event_cb(lv_event_t * e)
 {
-    lv_display_t * disp = lv_event_get_target(e);
+    lv_display_t * disp = lv_event_get_current_target(e);
     lv_lcd_generic_mipi_driver_t * drv = get_driver(disp);
 
     uint16_t hor_res = lv_display_get_horizontal_resolution(disp);

--- a/src/dev/sdl/lv_sdl_window.c
+++ b/src/dev/sdl/lv_sdl_window.c
@@ -357,7 +357,7 @@ static void texture_resize(lv_display_t * disp)
 
 static void res_chg_event_cb(lv_event_t * e)
 {
-    lv_display_t * disp = lv_event_get_target(e);
+    lv_display_t * disp = lv_event_get_current_target(e);
 
     int32_t hor_res = lv_display_get_horizontal_resolution(disp);
     int32_t ver_res = lv_display_get_vertical_resolution(disp);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1039,7 +1039,7 @@ static bool is_out_anim(lv_screen_load_anim_t anim_type)
 static void disp_event_cb(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_display_t * disp = lv_event_get_target(e);
+    lv_display_t * disp = lv_event_get_current_target(e);
     switch(code) {
         case LV_EVENT_REFR_REQUEST:
             if(disp->refr_timer) lv_timer_resume(disp->refr_timer);

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -420,7 +420,7 @@ static void init_style(lv_obj_t * obj)
 static void quick_access_event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * btn = lv_event_get_target(e);
+    lv_obj_t * btn = lv_event_get_current_target(e);
     lv_obj_t * obj = lv_event_get_user_data(e);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -457,7 +457,7 @@ static void quick_access_event_handler(lv_event_t * e)
 static void quick_access_area_event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * area = lv_event_get_target(e);
+    lv_obj_t * area = lv_event_get_current_target(e);
     lv_obj_t * obj = lv_event_get_user_data(e);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;

--- a/src/others/gridnav/lv_gridnav.c
+++ b/src/others/gridnav/lv_gridnav.c
@@ -132,7 +132,7 @@ void lv_gridnav_set_focused(lv_obj_t * cont, lv_obj_t * to_focus, lv_anim_enable
 
 static void gridnav_event_cb(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_gridnav_dsc_t * dsc = lv_event_get_user_data(e);
     lv_event_code_t code = lv_event_get_code(e);
 

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -603,7 +603,7 @@ static void lv_ime_pinyin_destructor(const lv_obj_class_t * class_p, lv_obj_t * 
 static void lv_ime_pinyin_kb_event(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * kb = lv_event_get_target(e);
+    lv_obj_t * kb = lv_event_get_current_target(e);
     lv_obj_t * obj = lv_event_get_user_data(e);
 
     lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
@@ -739,7 +739,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
 static void lv_ime_pinyin_cand_panel_event(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * cand_panel = lv_event_get_target(e);
+    lv_obj_t * cand_panel = lv_event_get_current_target(e);
     lv_obj_t * obj = (lv_obj_t *)lv_event_get_user_data(e);
 
     lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
@@ -842,7 +842,7 @@ static void pinyin_page_proc(lv_obj_t * obj, uint16_t dir)
 static void lv_ime_pinyin_style_change_event(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     lv_ime_pinyin_t * pinyin_ime = (lv_ime_pinyin_t *)obj;
 

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -444,8 +444,8 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
-    lv_arc_t * arc = (lv_arc_t *)lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
+    lv_arc_t * arc = (lv_arc_t *)obj;
     if(code == LV_EVENT_PRESSING) {
         lv_indev_t * indev = lv_indev_active();
         if(indev == NULL) return;
@@ -670,7 +670,7 @@ static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void lv_arc_draw(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_arc_t * arc = (lv_arc_t *)obj;
 
     lv_layer_t * layer = lv_event_get_layer(e);

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -260,7 +260,7 @@ static void lv_bar_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
 static void draw_indic(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_bar_t * bar = (lv_bar_t *)obj;
 
     lv_layer_t * layer = lv_event_get_layer(e);
@@ -560,7 +560,7 @@ static void lv_bar_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         int32_t indic_size;

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -399,7 +399,7 @@ static void lv_buttonmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_buttonmatrix_t * btnm = (lv_buttonmatrix_t *)obj;
     lv_point_t p;
 
@@ -661,7 +661,7 @@ static void lv_buttonmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_buttonmatrix_t * btnm = (lv_buttonmatrix_t *)obj;
     if(btnm->btn_cnt == 0) return;
 

--- a/src/widgets/calendar/lv_calendar.c
+++ b/src/widgets/calendar/lv_calendar.c
@@ -296,7 +296,7 @@ static void lv_calendar_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
 
 static void draw_task_added_event_cb(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_draw_task_t * draw_task = lv_event_get_param(e);
     if(((lv_draw_dsc_base_t *)draw_task->draw_dsc)->part != LV_PART_ITEMS) return;
 

--- a/src/widgets/calendar/lv_calendar_header_arrow.c
+++ b/src/widgets/calendar/lv_calendar_header_arrow.c
@@ -102,7 +102,7 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
 static void month_event_cb(lv_event_t * e)
 {
-    lv_obj_t * btn = lv_event_get_target(e);
+    lv_obj_t * btn = lv_event_get_current_target(e);
 
     lv_obj_t * header = lv_obj_get_parent(btn);
     lv_obj_t * calendar = lv_obj_get_parent(header);
@@ -139,7 +139,7 @@ static void month_event_cb(lv_event_t * e)
 
 static void value_changed_event_cb(lv_event_t * e)
 {
-    lv_obj_t * header = lv_event_get_target(e);
+    lv_obj_t * header = lv_event_get_current_target(e);
     lv_obj_t * calendar = lv_obj_get_parent(header);
 
     const lv_calendar_date_t * cur_date = lv_calendar_get_showed_date(calendar);

--- a/src/widgets/calendar/lv_calendar_header_dropdown.c
+++ b/src/widgets/calendar/lv_calendar_header_dropdown.c
@@ -124,7 +124,7 @@ static void my_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
 static void month_event_cb(lv_event_t * e)
 {
-    lv_obj_t * dropdown = lv_event_get_target(e);
+    lv_obj_t * dropdown = lv_event_get_current_target(e);
     lv_obj_t * calendar = lv_event_get_user_data(e);
 
     uint32_t sel = lv_dropdown_get_selected(dropdown);
@@ -139,7 +139,7 @@ static void month_event_cb(lv_event_t * e)
 
 static void year_event_cb(lv_event_t * e)
 {
-    lv_obj_t * dropdown = lv_event_get_target(e);
+    lv_obj_t * dropdown = lv_event_get_current_target(e);
     lv_obj_t * calendar = lv_event_get_user_data(e);
 
     uint32_t sel = lv_dropdown_get_selected(dropdown);
@@ -161,7 +161,7 @@ static void year_event_cb(lv_event_t * e)
 
 static void value_changed_event_cb(lv_event_t * e)
 {
-    lv_obj_t * header = lv_event_get_target(e);
+    lv_obj_t * header = lv_event_get_current_target(e);
     lv_obj_t * calendar = lv_obj_get_parent(header);
     const lv_calendar_date_t * cur_date = lv_calendar_get_showed_date(calendar);
 

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -650,7 +650,7 @@ static void lv_chart_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     lv_chart_t * chart  = (lv_chart_t *)obj;
     if(code == LV_EVENT_PRESSED) {

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -172,7 +172,7 @@ static void lv_checkbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_GET_SELF_SIZE) {
         lv_point_t * p = lv_event_get_param(e);
@@ -210,7 +210,7 @@ static void lv_checkbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void lv_checkbox_draw(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_checkbox_t * cb = (lv_checkbox_t *)obj;
 
     lv_layer_t * layer = lv_event_get_layer(e);

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -664,7 +664,7 @@ static void lv_dropdown_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
 
     if(code == LV_EVENT_FOCUSED) {
@@ -755,7 +755,7 @@ static void lv_dropdown_list_event(const lv_obj_class_t * class_p, lv_event_t * 
         res = lv_obj_event_base(MY_CLASS_LIST, e);
         if(res != LV_RESULT_OK) return;
     }
-    lv_obj_t * list = lv_event_get_target(e);
+    lv_obj_t * list = lv_event_get_current_target(e);
     lv_obj_t * dropdown_obj = ((lv_dropdown_list_t *)list)->dropdown;
     lv_dropdown_t * dropdown = (lv_dropdown_t *)dropdown_obj;
 
@@ -780,7 +780,7 @@ static void lv_dropdown_list_event(const lv_obj_class_t * class_p, lv_event_t * 
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
 
@@ -897,7 +897,7 @@ static void draw_main(lv_event_t * e)
 
 static void draw_list(lv_event_t * e)
 {
-    lv_obj_t * list_obj = lv_event_get_target(e);
+    lv_obj_t * list_obj = lv_event_get_current_target(e);
     lv_dropdown_list_t * list = (lv_dropdown_list_t *)list_obj;
     lv_obj_t * dropdown_obj = list->dropdown;
     lv_dropdown_t * dropdown = (lv_dropdown_t *)dropdown_obj;

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -582,7 +582,7 @@ static void lv_image_event(const lv_obj_class_t * class_p, lv_event_t * e)
     lv_result_t res = lv_obj_event_base(MY_CLASS, e);
     if(res != LV_RESULT_OK) return;
 
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_image_t * img = (lv_image_t *)obj;
     lv_point_t pivot_px;
     lv_image_get_pivot(obj, &pivot_px);
@@ -652,7 +652,7 @@ static void lv_image_event(const lv_obj_class_t * class_p, lv_event_t * e)
 static void draw_image(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_image_t * img = (lv_image_t *)obj;
     if(code == LV_EVENT_COVER_CHECK) {
         lv_cover_check_info_t * info = lv_event_get_param(e);

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -153,7 +153,7 @@ static void lv_imagebutton_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     if(code == LV_EVENT_PRESSED || code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
         refr_image(obj);
     }
@@ -178,7 +178,7 @@ static void lv_imagebutton_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_imagebutton_t * imagebutton = (lv_imagebutton_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
 

--- a/src/widgets/keyboard/lv_keyboard.c
+++ b/src/widgets/keyboard/lv_keyboard.c
@@ -272,7 +272,7 @@ bool lv_buttonmatrix_get_popovers(const lv_obj_t * obj)
 
 void lv_keyboard_def_event_cb(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_keyboard_t * keyboard = (lv_keyboard_t *)obj;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -672,7 +672,7 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     const lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if((code == LV_EVENT_STYLE_CHANGED) || (code == LV_EVENT_SIZE_CHANGED)) {
         /*Revert dots for proper refresh*/
@@ -716,7 +716,7 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_label_t * label = (lv_label_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
 

--- a/src/widgets/led/lv_led.c
+++ b/src/widgets/led/lv_led.c
@@ -140,7 +140,7 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(res != LV_RESULT_OK) return;
     }
 
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     if(code == LV_EVENT_DRAW_MAIN) {
         /*Make darker colors in a temporary style according to the brightness*/
         lv_led_t * led = (lv_led_t *)obj;

--- a/src/widgets/line/lv_line.c
+++ b/src/widgets/line/lv_line.c
@@ -143,7 +143,7 @@ static void lv_line_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         /*The corner of the skew lines is out of the intended area*/

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -708,7 +708,7 @@ static void lv_menu_refr_main_header_mode(lv_obj_t * obj)
 
 static void lv_menu_load_page_event_cb(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_menu_load_page_event_data_t * event_data = lv_event_get_user_data(e);
     lv_menu_t * menu = (lv_menu_t *)(event_data->menu);
     lv_obj_t * page = event_data->page;
@@ -758,7 +758,7 @@ static void lv_menu_back_event_cb(lv_event_t * e)
     lv_event_code_t code = lv_event_get_code(e);
     /* LV_EVENT_CLICKED */
     if(code == LV_EVENT_CLICKED) {
-        lv_obj_t * obj = lv_event_get_target(e);
+        lv_obj_t * obj = lv_event_get_current_target(e);
         lv_menu_t * menu = (lv_menu_t *)lv_event_get_user_data(e);
 
         if(!(obj == menu->main_header_back_btn || obj == menu->sidebar_header_back_btn)) return;

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -270,7 +270,7 @@ void lv_msgbox_close_async(lv_obj_t * obj)
 
 static void msgbox_close_click_event_cb(lv_event_t * e)
 {
-    lv_obj_t * btn = lv_event_get_target(e);
+    lv_obj_t * btn = lv_event_get_current_target(e);
     lv_obj_t * mbox = lv_obj_get_parent(lv_obj_get_parent(btn));
     lv_msgbox_close(mbox);
 }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -403,7 +403,7 @@ static void lv_roller_label_event(const lv_obj_class_t * class_p, lv_event_t * e
         if(res != LV_RESULT_OK) return;
     }
 
-    lv_obj_t * label = lv_event_get_target(e);
+    lv_obj_t * label = lv_event_get_current_target(e);
     if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         /*If the selected text has a larger font it needs some extra space to draw it*/
         int32_t * s = lv_event_get_param(e);
@@ -423,7 +423,7 @@ static void lv_roller_label_event(const lv_obj_class_t * class_p, lv_event_t * e
 static void draw_main(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     if(code == LV_EVENT_DRAW_MAIN) {
         /*Draw the selected rectangle*/
         lv_layer_t * layer = lv_event_get_layer(e);
@@ -498,7 +498,7 @@ static void draw_label(lv_event_t * e)
 {
     /* Split the drawing of the label into  an upper (above the selected area)
      * and a lower (below the selected area)*/
-    lv_obj_t * label_obj = lv_event_get_target(e);
+    lv_obj_t * label_obj = lv_event_get_current_target(e);
     lv_obj_t * roller = lv_obj_get_parent(label_obj);
     lv_draw_label_dsc_t label_draw_dsc;
     lv_draw_label_dsc_init(&label_draw_dsc);

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -441,7 +441,7 @@ static void lv_scale_event(const lv_obj_class_t * class_p, lv_event_t * event)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t event_code = lv_event_get_code(event);
-    lv_obj_t * obj = lv_event_get_target(event);
+    lv_obj_t * obj = lv_event_get_current_target(event);
     lv_scale_t * scale = (lv_scale_t *) obj;
     LV_UNUSED(scale);
 

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -110,7 +110,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_slider_t * slider = (lv_slider_t *)obj;
     lv_slider_mode_t type = lv_slider_get_mode(obj);
 
@@ -231,7 +231,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_knob(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_slider_t * slider = (lv_slider_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
 

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -564,7 +564,7 @@ static void lv_spangroup_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(lv_obj_event_base(MY_CLASS, e) != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_spangroup_t * spans = (lv_spangroup_t *)obj;
 
     if(code == LV_EVENT_DRAW_MAIN) {
@@ -615,7 +615,7 @@ static void lv_spangroup_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_layer_t * layer = lv_event_get_layer(e);
 
     lv_draw_span(obj, layer);

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -303,7 +303,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     const lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
     if(code == LV_EVENT_RELEASED) {
         /*If released with an ENCODER then move to the next digit*/

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -117,7 +117,7 @@ static void lv_switch_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         int32_t knob_left = lv_obj_get_style_pad_left(obj,   LV_PART_KNOB);
@@ -145,7 +145,7 @@ static void lv_switch_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_switch_t * sw = (lv_switch_t *)obj;
 
     lv_layer_t * layer = lv_event_get_layer(e);

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -535,7 +535,7 @@ static void lv_table_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_table_t * table = (lv_table_t *)obj;
 
     if(code == LV_EVENT_STYLE_CHANGED) {
@@ -647,7 +647,7 @@ static void lv_table_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void draw_main(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_table_t * table = (lv_table_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
     lv_area_t clip_area;

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -280,7 +280,7 @@ static void lv_tabview_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * target = lv_event_get_target(e);
+    lv_obj_t * target = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_SIZE_CHANGED) {
         lv_tabview_set_active(target, lv_tabview_get_tab_active(target), LV_ANIM_OFF);
@@ -289,7 +289,7 @@ static void lv_tabview_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
 static void button_clicked_event_cb(lv_event_t * e)
 {
-    lv_obj_t * button = lv_event_get_target(e);
+    lv_obj_t * button = lv_event_get_current_target(e);
 
     lv_obj_t * tv = lv_obj_get_parent(lv_obj_get_parent(button));
     int32_t idx = lv_obj_get_index_by_type(button, &lv_button_class);
@@ -298,7 +298,7 @@ static void button_clicked_event_cb(lv_event_t * e)
 
 static void cont_scroll_end_event_cb(lv_event_t * e)
 {
-    lv_obj_t * cont = lv_event_get_target(e);
+    lv_obj_t * cont = lv_event_get_current_target(e);
     lv_event_code_t code = lv_event_get_code(e);
 
     lv_obj_t * tv = lv_obj_get_parent(cont);

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -880,7 +880,7 @@ static void lv_textarea_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(res != LV_RESULT_OK) return;
 
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
 
     if(code == LV_EVENT_FOCUSED) {
         start_cursor_blink(obj);
@@ -924,7 +924,7 @@ static void lv_textarea_event(const lv_obj_class_t * class_p, lv_event_t * e)
 static void label_event_cb(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * label = lv_event_get_target(e);
+    lv_obj_t * label = lv_event_get_current_target(e);
     lv_obj_t * ta = lv_obj_get_parent(label);
 
     if(code == LV_EVENT_STYLE_CHANGED || code == LV_EVENT_SIZE_CHANGED) {
@@ -1144,7 +1144,7 @@ static void update_cursor_position_on_click(lv_event_t * e)
     lv_indev_t * click_source = lv_indev_active();
     if(click_source == NULL) return;
 
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     if(ta->cursor.click_pos == 0) return;
 
@@ -1279,7 +1279,7 @@ static lv_result_t insert_handler(lv_obj_t * obj, const char * txt)
 
 static void draw_placeholder(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
     const char * txt = lv_label_get_text(ta->label);
@@ -1305,7 +1305,7 @@ static void draw_placeholder(lv_event_t * e)
 
 static void draw_cursor(lv_event_t * e)
 {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     lv_layer_t * layer = lv_event_get_layer(e);
     const char * txt = lv_label_get_text(ta->label);

--- a/src/widgets/tileview/lv_tileview.c
+++ b/src/widgets/tileview/lv_tileview.c
@@ -151,7 +151,7 @@ static void lv_tileview_tile_constructor(const lv_obj_class_t * class_p, lv_obj_
 static void tileview_event_cb(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t * obj = lv_event_get_current_target(e);
     lv_tileview_t * tv = (lv_tileview_t *) obj;
 
     if(code == LV_EVENT_SCROLL_END) {


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

We should use `lv_event_get_current_target` to get target object in event callback.
If a event is bubbled, `current_target` is the parent of `original_target`,
in this case, we'll get a wrong target object which may cause assert in `LV_ASSERT_OBJ(obj, MY_CLASS);`

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
