### PR TITLE
fix(sprintf): fix sprintf compile errors

### DIFF
--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -283,7 +283,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
     do {
         entry = readdir(dir_p);
         if(entry) {
-            if(entry->d_type == DT_DIR) sprintf(fn, "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name), "/%s", entry->d_name);
             else lv_strcpy(fn, entry->d_name);
         }
         else {

--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -283,7 +283,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
     do {
         entry = readdir(dir_p);
         if(entry) {
-            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name), "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name) + 2, "/%s", entry->d_name);
             else lv_strcpy(fn, entry->d_name);
         }
         else {

--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -283,7 +283,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
         entry = readdir(handle->dir_p);
         if(entry) {
             /*Note, DT_DIR is not defined in C99*/
-            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name), "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name) + 2, "/%s", entry->d_name);
             else lv_strcpy(fn, entry->d_name);
         }
         else {

--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -283,7 +283,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn)
         entry = readdir(handle->dir_p);
         if(entry) {
             /*Note, DT_DIR is not defined in C99*/
-            if(entry->d_type == DT_DIR) snprintf(fn, strlen(entry->d_name), "/%s", entry->d_name);
+            if(entry->d_type == DT_DIR) lv_snprintf(fn, lv_strlen(entry->d_name), "/%s", entry->d_name);
             else lv_strcpy(fn, entry->d_name);
         }
         else {


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

I got an error when I build on my macOS with

### Description of the feature or fix
```bash
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: arm64-apple-darwin23.2.0
Thread model: posix
```
It complains
```cpp
'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.
```

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
