### PR TITLE
fix（strcpy）: replace `lv_strcpy` to `lv_strncpy`

### DIFF
--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -253,10 +253,10 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path)
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(next_fn, sizeof(next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(next_fn, sizeof(next_fn), "%s", fdata.cFileName);
             }
             break;
         }
@@ -303,10 +303,10 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint3
         }
         else {
             if(fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                sprintf(next_fn, "/%s", fdata.cFileName);
+                lv_snprintf(next_fn, sizeof(next_fn), "/%s", fdata.cFileName);
             }
             else {
-                sprintf(next_fn, "%s", fdata.cFileName);
+                lv_snprintf(next_fn, sizeof(next_fn), "%s", fdata.cFileName);
             }
             break;
         }

--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -291,9 +291,9 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint3
         }
     } while(lv_strcmp(fn, "/.") == 0 || lv_strcmp(fn, "/..") == 0);
 #else
-    lv_strcpy(fn, next_fn, fn_len);
+    lv_strncpy(fn, next_fn, fn_len);
 
-    lv_strcpy(next_fn, "", fn_len);
+    lv_strncpy(next_fn, "", fn_len);
     WIN32_FIND_DATA fdata;
 
     if(FindNextFile(dir_p, &fdata) == false) return LV_FS_RES_OK;


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

replace `lv_strcpy` to `lv_strncpy`

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
