### PR TITLE
chore(decoder): only premultiply for images have alpha

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -308,6 +308,8 @@ lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_d
 
     /*Premultiply alpha channel*/
     if(args->premultiply
+       && !LV_COLOR_FORMAT_IS_ALPHA_ONLY(decoded->header.cf)
+       && lv_color_format_has_alpha(decoded->header.cf)
        && !lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_PREMULTIPLIED) /*Hasn't done yet*/
       ) {
         LV_LOG_TRACE("Alpha premultiply.");

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -76,7 +76,13 @@ uint8_t lv_color_format_get_bpp(lv_color_format_t cf)
 bool lv_color_format_has_alpha(lv_color_format_t cf)
 {
     switch(cf) {
+        case LV_COLOR_FORMAT_A1:
+        case LV_COLOR_FORMAT_A2:
+        case LV_COLOR_FORMAT_A4:
         case LV_COLOR_FORMAT_A8:
+        case LV_COLOR_FORMAT_I1:
+        case LV_COLOR_FORMAT_I2:
+        case LV_COLOR_FORMAT_I4:
         case LV_COLOR_FORMAT_I8:
         case LV_COLOR_FORMAT_RGB565A8:
         case LV_COLOR_FORMAT_ARGB8888:


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Only images have alpha need to consider premultiply.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
