### PR TITLE
chore(decoder): call image post process directly

### DIFF
--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -135,20 +135,16 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             return LV_RESULT_INVALID;
         }
 
-        /*Stride check and adjustment accordingly*/
-        if(args && args->stride_align) {
-            uint32_t expected = lv_draw_buf_width_to_stride(decoded->header.w, decoded->header.cf);
-            if(expected != decoded->header.stride) {
-                LV_LOG_INFO("Convert PNG stride to %" LV_PRId32, expected);
-                lv_draw_buf_t * aligned = lv_draw_buf_adjust_stride(decoded, expected);
-                lv_draw_buf_destroy(decoded);
-                if(aligned == NULL) {
-                    LV_LOG_ERROR("png stride adjust failed");
-                    return LV_RESULT_INVALID;
-                }
+        lv_draw_buf_t * adjusted = lv_image_decoder_post_process(dsc, decoded);
+        if(adjusted == NULL) {
+            lv_draw_buf_destroy(decoded);
+            return LV_RESULT_INVALID;
+        }
 
-                decoded = aligned;
-            }
+        /*The adjusted draw buffer is newly allocated.*/
+        if(adjusted != decoded) {
+            lv_draw_buf_destroy(decoded);
+            decoded = adjusted;
         }
 
         dsc->decoded = decoded;


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

The `lv_image_decoder_post_process` can be used to make sure decoded image meets decoder arguments

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
