### PR TITLE
fix(string): need to use correct copy direction when memory overlaps

### DIFF
--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -150,15 +150,25 @@ LV_ATTRIBUTE_FAST_MEM void * lv_memmove(void * dst, const void * src, size_t len
     if(dst < src || (char *)dst > ((char *)src + len)) {
         return lv_memcpy(dst, src, len);
     }
-    else {
-        char * tmp = (char *)dst + len;
-        char * s = (char *) src + len;
+
+    if(dst > src) {
+        char * tmp = (char *)dst + len - 1;
+        char * s   = (char *)src + len - 1;
 
         while(len--) {
-            *--tmp = *--s;
+            *tmp-- = *s--;
         }
-        return dst;
     }
+    else {
+        char * tmp = (char *)dst;
+        char * s   = (char *)src;
+
+        while(len--) {
+            *tmp++ = *s++;
+        }
+    }
+
+    return dst;
 }
 
 /* See https://en.cppreference.com/w/c/string/byte/strlen for reference */
@@ -170,10 +180,10 @@ size_t lv_strlen(const char * str)
     return i;
 }
 
-char * lv_strncpy(char * dst, const char * src, size_t dest_size)
+char * lv_strncpy(char * dst, const char * src, size_t dst_size)
 {
     size_t i;
-    for(i = 0; i < dest_size - 1 && src[i]; i++) {
+    for(i = 0; i < dst_size - 1 && src[i]; i++) {
         dst[i] = src[i];
     }
     dst[i] = '\0';

--- a/tests/src/test_cases/libs/test_memmove.c
+++ b/tests/src/test_cases/libs/test_memmove.c
@@ -1,0 +1,53 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+#include "lv_test_helpers.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+}
+
+void test_memmove(void)
+{
+#if LV_USE_STDLIB_STRING == LV_STDLIB_BUILTIN
+    char buf[6] = {0, 1, 2, 3, 4, 5};
+    char * dst;
+    char * src;
+
+    dst = buf;
+    src = buf;
+
+    /*Case of dst == src*/
+    lv_memmove(dst, src, 4);
+    for(int i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT(i, buf[i]);
+    }
+
+    /* Case of dst < src */
+    dst = &buf[0];
+    src = &buf[1];
+    lv_memmove(dst, src, 4);
+    for(int i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT(i + 1, buf[i]);
+    }
+
+    /* Case of dst > src */
+    for(int i = 0; i < 5; i++) buf[i] = i;
+    dst = &buf[1];
+    src = &buf[0];
+    lv_memmove(dst, src, 4);
+    TEST_ASSERT_EQUAL_INT(0, buf[0]);
+    for(int i = 1; i < 5; i++) {
+        TEST_ASSERT_EQUAL_INT(i - 1, buf[i]);
+    }
+#endif
+}
+
+#endif


### PR DESCRIPTION

Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Start from end to first if dest starts in source.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
