### PR TITLE
refactor(anim): rename ready_cb to completed_cb

### DIFF
--- a/demos/multilang/lv_demo_multilang.c
+++ b/demos/multilang/lv_demo_multilang.c
@@ -282,7 +282,7 @@ static void scroll_event_cb(lv_event_t * e)
         lv_anim_t a;
         lv_anim_init(&a);
         lv_anim_set_exec_cb(&a, shrink_anim_cb);
-        lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+        lv_anim_set_completed_cb(&a, lv_obj_delete_anim_completed_cb);
         lv_anim_set_values(&a, 255, 0);
         lv_anim_set_duration(&a, 400);
         lv_anim_set_var(&a, cont);

--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -282,7 +282,7 @@ lv_obj_t * _lv_demo_music_main_create(lv_obj_t * parent)
     lv_anim_set_delay(&a, INTRO_TIME + 1000);
     lv_anim_set_values(&a, 1, LV_SCALE_NONE);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
-    lv_anim_set_ready_cb(&a, NULL);
+    lv_anim_set_completed_cb(&a, NULL);
     lv_anim_start(&a);
 
     /* Create an intro from a logo + label */
@@ -305,7 +305,7 @@ lv_obj_t * _lv_demo_music_main_create(lv_obj_t * parent)
     lv_anim_set_duration(&a, 400);
     lv_anim_set_delay(&a, INTRO_TIME + 800);
     lv_anim_set_values(&a, LV_SCALE_NONE, 10);
-    lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, lv_obj_delete_anim_ready_cb);
     lv_anim_start(&a);
 
     lv_obj_update_layout(main_cont);
@@ -355,7 +355,7 @@ void _lv_demo_music_resume(void)
     lv_anim_set_var(&a, spectrum_obj);
     lv_anim_set_duration(&a, ((spectrum_len - spectrum_i) * 1000) / 30);
     lv_anim_set_playback_duration(&a, 0);
-    lv_anim_set_ready_cb(&a, spectrum_end_cb);
+    lv_anim_set_completed_cb(&a, spectrum_end_cb);
     lv_anim_start(&a);
 
     if(sec_counter_timer) lv_timer_resume(sec_counter_timer);
@@ -713,7 +713,7 @@ static void track_load(uint32_t id)
     }
 #endif
     lv_anim_set_exec_cb(&a, _obj_set_x_anim_cb);
-    lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, lv_obj_delete_anim_ready_cb);
     lv_anim_start(&a);
 
     lv_anim_set_path_cb(&a, lv_anim_path_linear);
@@ -721,7 +721,7 @@ static void track_load(uint32_t id)
     lv_anim_set_duration(&a, 500);
     lv_anim_set_values(&a, LV_SCALE_NONE, LV_SCALE_NONE / 2);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
-    lv_anim_set_ready_cb(&a, NULL);
+    lv_anim_set_completed_cb(&a, NULL);
     lv_anim_start(&a);
 
     album_image_obj = album_image_create(spectrum_obj);
@@ -732,7 +732,7 @@ static void track_load(uint32_t id)
     lv_anim_set_delay(&a, 100);
     lv_anim_set_values(&a, LV_SCALE_NONE / 4, LV_SCALE_NONE);
     lv_anim_set_exec_cb(&a, _image_set_zoom_anim_cb);
-    lv_anim_set_ready_cb(&a, NULL);
+    lv_anim_set_completed_cb(&a, NULL);
     lv_anim_start(&a);
 
     lv_anim_init(&a);

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -432,9 +432,8 @@ static void auto_delete(lv_obj_t * obj, uint32_t delay)
     lv_anim_set_var(&a, obj);
     lv_anim_set_duration(&a, 0);
     lv_anim_set_delay(&a, delay);
-    lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, lv_obj_delete_anim_completed_cb);
     lv_anim_start(&a);
-
 }
 
 static void msgbox_delete(lv_timer_t * tmr)

--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -233,7 +233,7 @@ void lv_demo_widgets_start_slideshow(void)
     lv_anim_set_playback_duration(&a, t);
     lv_anim_set_values(&a, 0, v);
     lv_anim_set_var(&a, tab);
-    lv_anim_set_ready_cb(&a, slideshow_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, slideshow_anim_ready_cb);
     lv_anim_start(&a);
 }
 
@@ -1661,7 +1661,7 @@ static void slideshow_anim_ready_cb(lv_anim_t * a_old)
     lv_anim_set_playback_duration(&a, t);
     lv_anim_set_values(&a, 0, v);
     lv_anim_set_var(&a, tab);
-    lv_anim_set_ready_cb(&a, slideshow_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, slideshow_anim_ready_cb);
     lv_anim_start(&a);
 }
 

--- a/docs/overview/animations.rst
+++ b/docs/overview/animations.rst
@@ -59,8 +59,8 @@ and configured with ``lv_anim_set_...()`` functions.
    /*Set path (curve). Default is linear*/
    lv_anim_set_path(&a, lv_anim_path_ease_in);
 
-   /*Set a callback to indicate when the animation is ready (idle).*/
-   lv_anim_set_ready_cb(&a, ready_cb);
+   /*Set a callback to indicate when the animation is completed.*/
+   lv_anim_set_completed_cb(&a, completed_cb);
 
    /*Set a callback to indicate when the animation is deleted (idle).*/
    lv_anim_set_deleted_cb(&a, deleted_cb);

--- a/examples/others/observer/lv_example_observer_4.c
+++ b/examples/others/observer/lv_example_observer_4.c
@@ -87,7 +87,7 @@ static void cont_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
     lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
     lv_anim_set_exec_cb(&a, anim_set_x_cb);
     lv_anim_set_get_value_cb(&a, anim_get_x_cb);
-    lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, lv_obj_delete_anim_completed_cb);
 
     uint32_t i;
     uint32_t delay = 0;
@@ -131,7 +131,7 @@ static void cont_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
     }
 
     /*Animate in the new widgets*/
-    lv_anim_set_ready_cb(&a, NULL);
+    lv_anim_set_completed_cb(&a, NULL);
     for(i = child_cnt_prev; i < lv_obj_get_child_count(cont); i++) {
         lv_obj_t * child = lv_obj_get_child(cont, i);
         lv_anim_set_var(&a, child);

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -33,7 +33,7 @@
  **********************/
 static void scroll_x_anim(void * obj, int32_t v);
 static void scroll_y_anim(void * obj, int32_t v);
-static void scroll_anim_ready_cb(lv_anim_t * a);
+static void scroll_completed_ready_cb(lv_anim_t * a);
 static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_point_t * scroll_value,
                                   lv_anim_enable_t anim_en);
 
@@ -309,7 +309,7 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         lv_anim_t a;
         lv_anim_init(&a);
         lv_anim_set_var(&a, obj);
-        lv_anim_set_ready_cb(&a, scroll_anim_ready_cb);
+        lv_anim_set_completed_cb(&a, scroll_completed_ready_cb);
 
         if(dx) {
             uint32_t t = lv_anim_speed_clamped((lv_display_get_horizontal_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
@@ -675,7 +675,7 @@ static void scroll_y_anim(void * obj, int32_t v)
     _lv_obj_scroll_by_raw(obj, 0, v + lv_obj_get_scroll_y(obj));
 }
 
-static void scroll_anim_ready_cb(lv_anim_t * a)
+static void scroll_completed_ready_cb(lv_anim_t * a)
 {
     lv_obj_send_event(a->var, LV_EVENT_SCROLL_END, NULL);
 }

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -57,11 +57,11 @@ static void refresh_children_style(lv_obj_t * obj);
 static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
 static void trans_anim_cb(void * _tr, int32_t v);
 static void trans_anim_start_cb(lv_anim_t * a);
-static void trans_anim_ready_cb(lv_anim_t * a);
+static void trans_anim_completed_cb(lv_anim_t * a);
 static lv_layer_type_t calculate_layer_type(lv_obj_t * obj);
 static void full_cache_refresh(lv_obj_t * obj, lv_part_t part);
 static void fade_anim_cb(void * obj, int32_t v);
-static void fade_in_anim_ready(lv_anim_t * a);
+static void fade_in_anim_completed(lv_anim_t * a);
 static bool style_has_flag(const lv_style_t * style, uint32_t flag);
 static lv_style_res_t get_selector_style_prop(const lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop,
                                               lv_style_value_t * value_act);
@@ -522,7 +522,7 @@ void _lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t 
     lv_anim_set_var(&a, tr);
     lv_anim_set_exec_cb(&a, trans_anim_cb);
     lv_anim_set_start_cb(&a, trans_anim_start_cb);
-    lv_anim_set_ready_cb(&a, trans_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, trans_anim_completed_cb);
     lv_anim_set_values(&a, 0x00, 0xFF);
     lv_anim_set_duration(&a, tr_dsc->time);
     lv_anim_set_delay(&a, tr_dsc->delay);
@@ -611,7 +611,7 @@ void lv_obj_fade_in(lv_obj_t * obj, uint32_t time, uint32_t delay)
     lv_anim_set_var(&a, obj);
     lv_anim_set_values(&a, 0, LV_OPA_COVER);
     lv_anim_set_exec_cb(&a, fade_anim_cb);
-    lv_anim_set_ready_cb(&a, fade_in_anim_ready);
+    lv_anim_set_completed_cb(&a, fade_in_anim_completed);
     lv_anim_set_duration(&a, time);
     lv_anim_set_delay(&a, delay);
     lv_anim_start(&a);
@@ -970,7 +970,7 @@ static void trans_anim_start_cb(lv_anim_t * a)
 
 }
 
-static void trans_anim_ready_cb(lv_anim_t * a)
+static void trans_anim_completed_cb(lv_anim_t * a)
 {
     trans_t * tr = a->var;
     lv_obj_t * obj = tr->obj;
@@ -1075,7 +1075,7 @@ static void fade_anim_cb(void * obj, int32_t v)
     lv_obj_set_style_opa(obj, v, 0);
 }
 
-static void fade_in_anim_ready(lv_anim_t * a)
+static void fade_in_anim_completed(lv_anim_t * a)
 {
     lv_obj_remove_local_style_prop(a->var, LV_STYLE_OPA, 0);
 }

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -126,11 +126,11 @@ void lv_obj_delete_delayed(lv_obj_t * obj, uint32_t delay_ms)
     lv_anim_set_exec_cb(&a, NULL);
     lv_anim_set_duration(&a, 1);
     lv_anim_set_delay(&a, delay_ms);
-    lv_anim_set_ready_cb(&a, lv_obj_delete_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, lv_obj_delete_anim_completed_cb);
     lv_anim_start(&a);
 }
 
-void lv_obj_delete_anim_ready_cb(lv_anim_t * a)
+void lv_obj_delete_anim_completed_cb(lv_anim_t * a)
 {
     lv_obj_delete(a->var);
 }

--- a/src/core/lv_obj_tree.h
+++ b/src/core/lv_obj_tree.h
@@ -66,7 +66,7 @@ void lv_obj_delete_delayed(lv_obj_t * obj, uint32_t delay_ms);
  * A function to be easily used in animation ready callback to delete an object when the animation is ready
  * @param a         pointer to the animation
  */
-void lv_obj_delete_anim_ready_cb(lv_anim_t * a);
+void lv_obj_delete_anim_completed_cb(lv_anim_t * a);
 
 /**
  * Helper function for asynchronously deleting objects.

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -38,7 +38,7 @@ static void scr_load_anim_start(lv_anim_t * a);
 static void opa_scale_anim(void * obj, int32_t v);
 static void set_x_anim(void * obj, int32_t v);
 static void set_y_anim(void * obj, int32_t v);
-static void scr_anim_ready(lv_anim_t * a);
+static void scr_anim_completed(lv_anim_t * a);
 static bool is_out_anim(lv_screen_load_anim_t a);
 static void disp_event_cb(lv_event_t * e);
 
@@ -620,7 +620,7 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
     lv_anim_init(&a_new);
     lv_anim_set_var(&a_new, new_scr);
     lv_anim_set_start_cb(&a_new, scr_load_anim_start);
-    lv_anim_set_ready_cb(&a_new, scr_anim_ready);
+    lv_anim_set_completed_cb(&a_new, scr_anim_completed);
     lv_anim_set_duration(&a_new, time);
     lv_anim_set_delay(&a_new, delay);
 
@@ -1012,7 +1012,7 @@ static void set_y_anim(void * obj, int32_t v)
     lv_obj_set_y(obj, v);
 }
 
-static void scr_anim_ready(lv_anim_t * a)
+static void scr_anim_completed(lv_anim_t * a)
 {
     lv_display_t * d = lv_obj_get_display(a->var);
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -75,7 +75,7 @@ static lv_result_t send_event(lv_event_code_t code, void * param);
 
 static void indev_scroll_throw_anim_start(lv_indev_t * indev);
 static void indev_scroll_throw_anim_cb(void * var, int32_t v);
-static void indev_scroll_throw_anim_ready_cb(lv_anim_t * anim);
+static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim);
 static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
 {
     if(indev) {
@@ -1570,7 +1570,7 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
     }
 }
 
-static void indev_scroll_throw_anim_ready_cb(lv_anim_t * anim)
+static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim)
 {
     if(anim) {
         indev_scroll_throw_anim_reset((lv_indev_t *)anim->var);
@@ -1587,8 +1587,8 @@ static void indev_scroll_throw_anim_start(lv_indev_t * indev)
     lv_anim_set_duration(&a, 1024);
     lv_anim_set_values(&a, 0, 1024);
     lv_anim_set_exec_cb(&a, indev_scroll_throw_anim_cb);
-    lv_anim_set_ready_cb(&a, indev_scroll_throw_anim_ready_cb);
-    lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_ready_cb);
+    lv_anim_set_completed_cb(&a, indev_scroll_throw_anim_completed_cb);
+    lv_anim_set_deleted_cb(&a, indev_scroll_throw_anim_completed_cb);
     lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
 
     indev->scroll_throw_anim = lv_anim_start(&a);

--- a/src/lv_api_map.h
+++ b/src/lv_api_map.h
@@ -50,6 +50,7 @@ typedef lv_image_dsc_t              lv_img_dsc_t;
 typedef lv_display_t                lv_disp_t;
 typedef lv_display_rotation_t       lv_disp_rotation_t;
 typedef lv_display_render_mode_t    lv_disp_render_t;
+typedef lv_anim_completed_cb_t      lv_anim_ready_cb_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -160,6 +161,7 @@ static inline void lv_obj_move_background(lv_obj_t * obj)
 
 #define lv_anim_del                     lv_anim_delete
 #define lv_anim_del_all                 lv_anim_delete_all
+#define lv_anim_set_ready_cb            lv_anim_set_completed_cb
 
 #define lv_group_del                    lv_group_delete
 

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -33,7 +33,7 @@
  **********************/
 static void anim_timer(lv_timer_t * param);
 static void anim_mark_list_change(void);
-static void anim_ready_handler(lv_anim_t * a);
+static void anim_completed_handler(lv_anim_t * a);
 static int32_t lv_anim_path_cubic_bezier(const lv_anim_t * a, int32_t x1,
                                          int32_t y1, int32_t x2, int32_t y2);
 static uint32_t convert_speed_to_time(uint32_t speed, int32_t start, int32_t end);
@@ -343,7 +343,7 @@ static void anim_timer(lv_timer_t * param)
         a->last_timer_run = lv_tick_get();
 
         /*It can be set by `lv_anim_delete()` typically in `end_cb`. If set then an animation delete
-         * happened in `anim_ready_handler` which could make this linked list reading corrupt
+         * happened in `anim_completed_handler` which could make this linked list reading corrupt
          * because the list is changed meanwhile
          */
         state.anim_list_changed = false;
@@ -384,7 +384,7 @@ static void anim_timer(lv_timer_t * param)
 
                 /*If the time is elapsed the animation is ready*/
                 if(!state.anim_list_changed && a->act_time >= a->duration) {
-                    anim_ready_handler(a);
+                    anim_completed_handler(a);
                 }
             }
         }
@@ -400,11 +400,11 @@ static void anim_timer(lv_timer_t * param)
 }
 
 /**
- * Called when an animation is ready to do the necessary thinks
+ * Called when an animation is completed to do the necessary things
  * e.g. repeat, play back, delete etc.
  * @param a pointer to an animation descriptor
  */
-static void anim_ready_handler(lv_anim_t * a)
+static void anim_completed_handler(lv_anim_t * a)
 {
     /*In the end of a forward anim decrement repeat cnt.*/
     if(a->playback_now == 0 && a->repeat_cnt > 0 && a->repeat_cnt != LV_ANIM_REPEAT_INFINITE) {
@@ -423,7 +423,7 @@ static void anim_ready_handler(lv_anim_t * a)
         anim_mark_list_change();
 
         /*Call the callback function at the end*/
-        if(a->ready_cb != NULL) a->ready_cb(a);
+        if(a->completed_cb != NULL) a->completed_cb(a);
         if(a->deleted_cb != NULL) a->deleted_cb(a);
         lv_free(a);
     }

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -112,7 +112,7 @@ typedef void (*lv_anim_exec_xcb_t)(void *, int32_t);
 typedef void (*lv_anim_custom_exec_cb_t)(lv_anim_t *, int32_t);
 
 /** Callback to call when the animation is ready*/
-typedef void (*lv_anim_ready_cb_t)(lv_anim_t *);
+typedef void (*lv_anim_completed_cb_t)(lv_anim_t *);
 
 /** Callback to call when the animation really stars (considering `delay`)*/
 typedef void (*lv_anim_start_cb_t)(lv_anim_t *);
@@ -137,7 +137,7 @@ struct _lv_anim_t {
     lv_anim_custom_exec_cb_t custom_exec_cb;/**< Function to execute to animate,
                                                  same purpose as exec_cb but different parameters*/
     lv_anim_start_cb_t start_cb;         /**< Call it when the animation is starts (considering `delay`)*/
-    lv_anim_ready_cb_t ready_cb;         /**< Call it when the animation is ready*/
+    lv_anim_completed_cb_t completed_cb; /**< Call it when the animation is fully completed*/
     lv_anim_deleted_cb_t deleted_cb;     /**< Call it when the animation is deleted*/
     lv_anim_get_value_cb_t get_value_cb; /**< Get the current value in relative mode*/
     void * user_data;                    /**< Custom user data*/
@@ -297,13 +297,13 @@ static inline void lv_anim_set_get_value_cb(lv_anim_t * a, lv_anim_get_value_cb_
 }
 
 /**
- * Set a function call when the animation is ready
- * @param a         pointer to an initialized `lv_anim_t` variable
- * @param ready_cb  a function call when the animation is ready
+ * Set a function call when the animation is completed
+ * @param a             pointer to an initialized `lv_anim_t` variable
+ * @param completed_cb  a function call when the animation is fully completed
  */
-static inline void lv_anim_set_ready_cb(lv_anim_t * a, lv_anim_ready_cb_t ready_cb)
+static inline void lv_anim_set_completed_cb(lv_anim_t * a, lv_anim_completed_cb_t completed_cb)
 {
-    a->ready_cb = ready_cb;
+    a->completed_cb = completed_cb;
 }
 
 /**

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -52,7 +52,7 @@ static void lv_bar_set_value_with_anim(lv_obj_t * obj, int32_t new_value, int32_
                                        _lv_bar_anim_t * anim_info, lv_anim_enable_t en);
 static void lv_bar_init_anim(lv_obj_t * bar, _lv_bar_anim_t * bar_anim);
 static void lv_bar_anim(void * bar, int32_t value);
-static void lv_bar_anim_ready(lv_anim_t * a);
+static void lv_bar_anim_completed(lv_anim_t * a);
 
 /**********************
  *  STATIC VARIABLES
@@ -597,7 +597,7 @@ static void lv_bar_anim(void * var, int32_t value)
     lv_obj_invalidate(bar_anim->bar);
 }
 
-static void lv_bar_anim_ready(lv_anim_t * a)
+static void lv_bar_anim_completed(lv_anim_t * a)
 {
     _lv_bar_anim_t * var = a->var;
     lv_obj_t * obj = (lv_obj_t *)var->bar;
@@ -645,7 +645,7 @@ static void lv_bar_set_value_with_anim(lv_obj_t * obj, int32_t new_value, int32_
         lv_anim_set_var(&a, anim_info);
         lv_anim_set_exec_cb(&a, lv_bar_anim);
         lv_anim_set_values(&a, LV_BAR_ANIM_STATE_START, LV_BAR_ANIM_STATE_END);
-        lv_anim_set_ready_cb(&a, lv_bar_anim_ready);
+        lv_anim_set_completed_cb(&a, lv_bar_anim_completed);
         lv_anim_set_duration(&a, lv_obj_get_style_anim_duration(obj, LV_PART_MAIN));
         lv_anim_start(&a);
     }

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -820,7 +820,7 @@ static void overwrite_anim_property(lv_anim_t * dest, const lv_anim_t * src, lv_
                 dest->act_time = src->act_time;
             dest->repeat_cnt = src->repeat_cnt;
             dest->repeat_delay = src->repeat_delay;
-            dest->ready_cb = src->ready_cb;
+            dest->completed_cb = src->completed_cb;
             dest->playback_delay = src->playback_delay;
             break;
         case LV_LABEL_LONG_SCROLL_CIRCULAR:
@@ -829,7 +829,7 @@ static void overwrite_anim_property(lv_anim_t * dest, const lv_anim_t * src, lv_
                 dest->act_time = src->act_time;
             dest->repeat_cnt = src->repeat_cnt;
             dest->repeat_delay = src->repeat_delay;
-            dest->ready_cb = src->ready_cb;
+            dest->completed_cb = src->completed_cb;
             break;
         default:
             break;

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -42,7 +42,7 @@ static lv_result_t release_handler(lv_obj_t * obj);
 static void inf_normalize(lv_obj_t * obj_scrl);
 static lv_obj_t * get_label(const lv_obj_t * obj);
 static int32_t get_selected_label_width(const lv_obj_t * obj);
-static void scroll_anim_ready_cb(lv_anim_t * a);
+static void scroll_anim_completed_cb(lv_anim_t * a);
 static void set_y_anim(void * obj, int32_t v);
 static void transform_vect_recursive(lv_obj_t * roller, lv_point_t * vect);
 
@@ -623,7 +623,7 @@ static void refr_position(lv_obj_t * obj, lv_anim_enable_t anim_en)
         lv_anim_set_exec_cb(&a, set_y_anim);
         lv_anim_set_values(&a, lv_obj_get_y(label), new_y);
         lv_anim_set_duration(&a, anim_time);
-        lv_anim_set_ready_cb(&a, scroll_anim_ready_cb);
+        lv_anim_set_completed_cb(&a, scroll_anim_completed_cb);
         lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
         lv_anim_start(&a);
     }
@@ -763,7 +763,7 @@ static int32_t get_selected_label_width(const lv_obj_t * obj)
     return size.x;
 }
 
-static void scroll_anim_ready_cb(lv_anim_t * a)
+static void scroll_anim_completed_cb(lv_anim_t * a)
 {
     lv_obj_t * obj = lv_obj_get_parent(a->var); /*The label is animated*/
     inf_normalize(obj);

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -46,7 +46,7 @@ static void draw_main(lv_event_t * e);
 
 static void lv_switch_anim_exec_cb(void * sw, int32_t value);
 static void lv_switch_trigger_anim(lv_obj_t * obj);
-static void lv_switch_anim_ready(lv_anim_t * a);
+static void lv_switch_anim_completed(lv_anim_t * a);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -212,7 +212,7 @@ static void lv_switch_anim_exec_cb(void * var, int32_t value)
 /**
  * Resets the switch's animation state to "no animation in progress".
  */
-static void lv_switch_anim_ready(lv_anim_t * a)
+static void lv_switch_anim_completed(lv_anim_t * a)
 {
     lv_switch_t * sw = a->var;
     sw->anim_state = LV_SWITCH_ANIM_STATE_INV;
@@ -255,7 +255,7 @@ static void lv_switch_trigger_anim(lv_obj_t * obj)
         lv_anim_set_var(&a, sw);
         lv_anim_set_exec_cb(&a, lv_switch_anim_exec_cb);
         lv_anim_set_values(&a, anim_start, anim_end);
-        lv_anim_set_ready_cb(&a, lv_switch_anim_ready);
+        lv_anim_set_completed_cb(&a, lv_switch_anim_completed);
         lv_anim_set_duration(&a, anim_dur);
         lv_anim_start(&a);
     }

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -50,7 +50,7 @@ static void lv_textarea_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void label_event_cb(lv_event_t * e);
 static void cursor_blink_anim_cb(void * obj, int32_t show);
 static void pwd_char_hider_anim(void * obj, int32_t x);
-static void pwd_char_hider_anim_ready(lv_anim_t * a);
+static void pwd_char_hider_anim_completed(lv_anim_t * a);
 static void pwd_char_hider(lv_obj_t * obj);
 static bool char_is_accepted(lv_obj_t * obj, uint32_t c);
 static void start_cursor_blink(lv_obj_t * obj);
@@ -971,7 +971,7 @@ static void pwd_char_hider_anim(void * obj, int32_t x)
  * Call when an animation is ready to convert all characters to '*'
  * @param a pointer to the animation
  */
-static void pwd_char_hider_anim_ready(lv_anim_t * a)
+static void pwd_char_hider_anim_completed(lv_anim_t * a)
 {
     lv_obj_t * obj = a->var;
     pwd_char_hider(obj);
@@ -1365,7 +1365,7 @@ static void auto_hide_characters(lv_obj_t * obj)
         lv_anim_set_duration(&a, ta->pwd_show_time);
         lv_anim_set_values(&a, 0, 1);
         lv_anim_set_path_cb(&a, lv_anim_path_step);
-        lv_anim_set_ready_cb(&a, pwd_char_hider_anim_ready);
+        lv_anim_set_completed_cb(&a, pwd_char_hider_anim_completed);
         lv_anim_start(&a);
     }
 }


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

anim_ready_cb is ambiguous, use anim_completed_cb instead.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
