### PR TITLE
fix(label): remove automatically adding ext. draw size

### DIFF
--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -679,15 +679,6 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_label_revert_dots(obj);
         lv_label_refr_text(obj);
     }
-    else if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
-        /* Italic or other non-typical letters can be drawn of out of the object.
-         * It happens if box_w + ofs_x > adw_w in the glyph.
-         * To avoid this add some extra draw area.
-         * font_h / 4 is an empirical value. */
-        const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
-        const int32_t font_h = lv_font_get_line_height(font);
-        lv_event_set_ext_draw_size(e, font_h / 4);
-    }
     else if(code == LV_EVENT_GET_SELF_SIZE) {
         lv_label_t * label = (lv_label_t *)obj;
         if(label->invalid_size_cache) {


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

use padding for explicit control

fixes #4735

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
