### PR TITLE
fix:replace lv_image_get_zoom with lv_image_get_scale

### DIFF
--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -808,7 +808,7 @@ static void spectrum_draw_event_cb(lv_event_t * e)
 #else
         int32_t r_in = 160;
 #endif
-        r_in = (r_in * lv_image_get_zoom(album_image_obj)) >> 8;
+        r_in = (r_in * lv_image_get_scale(album_image_obj)) >> 8;
         for(i = 0; i < BAR_CNT; i++) r[i] = r_in + min_a + 77;
 
         uint32_t s;


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix
#5367 I missed a spot. I'm sorry.
fix:replace lv_image_get_zoom with lv_image_get_scale

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
