### PR TITLE
feat(image): add etc2 texture support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1049,6 +1049,9 @@ menu "LVGL configuration"
 		config LV_USE_RLE
 			bool "LVGL's version of RLE compression method"
 
+		config LV_USE_ETC2
+			bool "ETC2 decoder library"
+
 		config LV_USE_QRCODE
 			bool "QR code library"
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -654,6 +654,9 @@
 /*RLE decompress library*/
 #define LV_USE_RLE 0
 
+/*ETC2 decoder library*/
+#define LV_USE_ETC2 0
+
 /*QR code library*/
 #define LV_USE_QRCODE 0
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -327,6 +327,7 @@ bool lv_vg_lite_is_src_cf_supported(lv_color_format_t cf)
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
         case LV_COLOR_FORMAT_NV12:
+        case LV_COLOR_FORMAT_ETC2_EAC:
             return true;
         default:
             break;
@@ -375,6 +376,9 @@ vg_lite_buffer_format_t lv_vg_lite_vg_fmt(lv_color_format_t cf)
 
         case LV_COLOR_FORMAT_NV12:
             return VG_LITE_NV12;
+
+        case LV_COLOR_FORMAT_ETC2_EAC:
+            return VG_LITE_RGBA8888_ETC2_EAC;
 
         default:
             LV_LOG_ERROR("unsupport color format: %d", cf);

--- a/src/libs/etc2/lv_etc2.c
+++ b/src/libs/etc2/lv_etc2.c
@@ -1,0 +1,231 @@
+/**
+ * @file lv_etc2.c
+ *
+ */
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../../lvgl.h"
+
+#if LV_USE_ETC2
+
+/*********************
+ *      DEFINES
+ *********************/
+#define ETC2_RGB_NO_MIPMAPS             1
+#define ETC2_RGBA_NO_MIPMAPS            3
+#define ETC2_PKM_HEADER_SIZE            16
+#define ETC2_PKM_FORMAT_OFFSET          6
+#define ETC2_PKM_ENCODED_WIDTH_OFFSET   8
+#define ETC2_PKM_ENCODED_HEIGHT_OFFSET  10
+#define ETC2_PKM_WIDTH_OFFSET           12
+#define ETC2_PKM_HEIGHT_OFFSET          14
+
+#define ETC2_EAC_FORMAT_CODE            3
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static uint16_t read_big_endian_uint16(const uint8_t * buf);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
+                                const lv_image_decoder_args_t * args);
+static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
+static lv_draw_buf_t * decode_etc2_file(const char * filename, lv_image_decoder_dsc_t * dsc);
+static void etc2_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data);
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_etc2_init(void)
+{
+    lv_image_decoder_t * dec = lv_image_decoder_create();
+    lv_image_decoder_set_info_cb(dec, decoder_info);
+    lv_image_decoder_set_open_cb(dec, decoder_open);
+    lv_image_decoder_set_close_cb(dec, decoder_close);
+    lv_image_decoder_set_cache_free_cb(dec, (lv_cache_free_cb_t)etc2_cache_free_cb);
+}
+
+void lv_etc2_deinit(void)
+{
+    lv_image_decoder_t * dec = NULL;
+    while((dec = lv_image_decoder_get_next(dec)) != NULL) {
+        if(dec->info_cb == decoder_info) {
+            lv_image_decoder_delete(dec);
+            break;
+        }
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static uint16_t read_big_endian_uint16(const uint8_t * buf)
+{
+    return (buf[0] << 8) | buf[1];
+}
+
+static lv_res_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+{
+    LV_UNUSED(decoder); /*Unused*/
+
+    lv_image_src_t src_type = lv_image_src_get_type(src);
+
+    if(src_type == LV_IMAGE_SRC_FILE) {
+        const char * ext = lv_fs_get_ext(src);
+        if(!(lv_strcmp(ext, "pkm") == 0)) {
+            return LV_RES_INV;
+        }
+
+        lv_fs_file_t f;
+        lv_fs_res_t res = lv_fs_open(&f, src, LV_FS_MODE_RD);
+        if(res != LV_FS_RES_OK) {
+            LV_LOG_WARN("open %s failed", (const char *)src);
+            return LV_RES_INV;
+        }
+
+        uint32_t rn;
+        uint8_t pkm_header[ETC2_PKM_HEADER_SIZE];
+        static const char pkm_magic[] = { 'P', 'K', 'M', ' ', '2', '0' };
+
+        res = lv_fs_read(&f, pkm_header, ETC2_PKM_HEADER_SIZE, &rn);
+        lv_fs_close(&f);
+
+        if(res != LV_FS_RES_OK || rn != ETC2_PKM_HEADER_SIZE) {
+            LV_LOG_WARN("Image get info read file magic number failed");
+            return LV_RES_INV;
+        }
+
+        if(memcmp(pkm_header, pkm_magic, sizeof(pkm_magic)) != 0) {
+            LV_LOG_WARN("Image get info magic number invalid");
+            return LV_RES_INV;
+        }
+
+        uint16_t pkm_format = read_big_endian_uint16(pkm_header + ETC2_PKM_FORMAT_OFFSET);
+        if(pkm_format != ETC2_EAC_FORMAT_CODE) {
+            LV_LOG_WARN("Image header format invalid : %d", pkm_format);
+            return LV_RES_INV;
+        }
+
+        header->cf = LV_COLOR_FORMAT_ETC2_EAC;
+        header->w = read_big_endian_uint16(pkm_header + ETC2_PKM_WIDTH_OFFSET);
+        header->h = read_big_endian_uint16(pkm_header + ETC2_PKM_HEIGHT_OFFSET);
+        header->stride = read_big_endian_uint16(pkm_header + ETC2_PKM_ENCODED_WIDTH_OFFSET);
+
+        return LV_RES_OK;
+    }
+
+    return LV_RES_INV;
+}
+
+static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
+                                const lv_image_decoder_args_t * args)
+{
+    LV_UNUSED(decoder); /*Unused*/
+    LV_UNUSED(args); /*Unused*/
+
+    if(dsc->src_type == LV_IMAGE_SRC_FILE) {
+        const char * fn = dsc->src;
+        lv_draw_buf_t * decoded = decode_etc2_file(fn, dsc);
+        if(decoded == NULL) {
+            return LV_RESULT_INVALID;
+        }
+
+        dsc->decoded = decoded;
+
+#if LV_CACHE_DEF_SIZE > 0
+        lv_image_cache_data_t search_key;
+        search_key.src_type = dsc->src_type;
+        search_key.src = dsc->src;
+        search_key.slot.size = decoded->data_size;
+
+        lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(decoder, &search_key, decoded, NULL);
+
+        if(entry == NULL) {
+            lv_draw_buf_destroy(decoded);
+            return LV_RESULT_INVALID;
+        }
+        dsc->cache_entry = entry;
+#endif
+        return LV_RESULT_OK;
+    }
+
+    return LV_RES_INV;
+}
+
+static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc)
+{
+    LV_UNUSED(decoder); /*Unused*/
+
+#if LV_CACHE_DEF_SIZE > 0
+    lv_cache_release(dsc->cache, dsc->cache_entry, NULL);
+#else
+    lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
+#endif
+}
+
+static lv_draw_buf_t * decode_etc2_file(const char * filename, lv_image_decoder_dsc_t * dsc)
+{
+    lv_image_header_t * header = &dsc->header;
+    lv_draw_buf_t * decoded;
+
+    decoded = lv_draw_buf_create(header->w, header->h, header->cf, header->stride);
+
+    if(decoded == NULL) {
+        LV_LOG_ERROR("etc2 draw buff alloc %zu failed: %s", (size_t)(header->stride * header->h), filename);
+        return NULL;
+    }
+
+    lv_fs_file_t f;
+    lv_fs_res_t res = lv_fs_open(&f, filename, LV_FS_MODE_RD);
+    if(res != LV_FS_RES_OK) {
+        LV_LOG_WARN("etc2 decoder open %s failed", (const char *)filename);
+        goto failed;
+    }
+
+    res = lv_fs_seek(&f, ETC2_PKM_HEADER_SIZE, LV_FS_SEEK_SET);
+    if(res != LV_FS_RES_OK) {
+        LV_LOG_WARN("etc2 file seek %s failed", (const char *)filename);
+        lv_fs_close(&f);
+        goto failed;
+    }
+
+    uint32_t rn;
+    res = lv_fs_read(&f, decoded->data, decoded->data_size, &rn);
+    lv_fs_close(&f);
+
+    if(res != LV_FS_RES_OK || rn != decoded->data_size) {
+        LV_LOG_WARN("etc2 read data failed, size:%zu", (size_t)decoded->data_size);
+        goto failed;
+    }
+
+    return decoded;
+
+failed:
+    lv_draw_buf_destroy(decoded);
+    return NULL;
+}
+
+static void etc2_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data)
+{
+    LV_UNUSED(user_data);
+
+    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
+    lv_draw_buf_destroy((lv_draw_buf_t *)cached_data->decoded);
+}
+#endif /*LV_USE_ETC2*/

--- a/src/libs/etc2/lv_etc2.h
+++ b/src/libs/etc2/lv_etc2.h
@@ -1,0 +1,49 @@
+/**
+ * @file lv_etc2.h
+ *
+ */
+
+#ifndef LV_ETC2_H
+#define LV_ETC2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lv_conf_internal.h"
+#if LV_USE_ETC2
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Register the ETC2 decoder functions in LVGL
+ */
+
+void lv_etc2_init(void);
+
+void lv_etc2_deinit(void);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_ETC2*/
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /*LV_ETC2_H*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2172,6 +2172,15 @@
     #endif
 #endif
 
+/*ETC2 decoder library*/
+#ifndef LV_USE_ETC2
+    #ifdef CONFIG_LV_USE_ETC2
+        #define LV_USE_ETC2 CONFIG_LV_USE_ETC2
+    #else
+        #define LV_USE_ETC2 0
+    #endif
+#endif
+
 /*QR code library*/
 #ifndef LV_USE_QRCODE
     #ifdef CONFIG_LV_USE_QRCODE

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -21,6 +21,7 @@
 #include "libs/libjpeg_turbo/lv_libjpeg_turbo.h"
 #include "libs/lodepng/lv_lodepng.h"
 #include "libs/libpng/lv_libpng.h"
+#include "libs/etc2/lv_etc2.h"
 #include "draw/lv_draw.h"
 #include "misc/lv_async.h"
 #include "misc/lv_fs.h"
@@ -285,6 +286,10 @@ void lv_init(void)
     lv_bmp_init();
 #endif
 
+#if LV_USE_ETC2
+    lv_etc2_init();
+#endif
+
     /*Make FFMPEG last because the last converter will be checked first and
      *it's superior to any other */
 #if LV_USE_FFMPEG
@@ -373,6 +378,10 @@ void lv_deinit(void)
 
 #if LV_USE_DRAW_VG_LITE
     lv_draw_vg_lite_deinit();
+#endif
+
+#if LV_USE_ETC2
+    lv_etc2_deinit();
 #endif
 
 #if LV_USE_DRAW_SW

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -155,6 +155,8 @@ enum _lv_color_format_t {
 
     LV_COLOR_FORMAT_YUV_END           = LV_COLOR_FORMAT_UYVY,
 
+    LV_COLOR_FORMAT_ETC2_EAC          = 0x30,
+
     /*Color formats in which LVGL can render*/
 #if LV_COLOR_DEPTH == 8
     LV_COLOR_FORMAT_NATIVE            = LV_COLOR_FORMAT_L8,


### PR DESCRIPTION
Help us review this PR! Anyone can [approve it or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

### Description of the feature or fix

Add ETC2 compressed image(texture) decoder, only for `.pkm` files and `ETC_EAC` format now.
I have tested on vg_lite GPU platform, later I'll add a soft GPU support in `vg_lite_tvg`.

### Checkpoints
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
