### PR TITLE
fix(decoder_dsc): replace `decoder_dsc.header` with `decoder_dsc.decoded->header`

### DIFF
--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -126,9 +126,9 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
         lv_image_decoder_open(&decoder_dsc, dsc->img_src, NULL);
         img_area.x1 = 0;
         img_area.y1 = 0;
-        img_area.x2 = decoder_dsc.header.w - 1;
-        img_area.y2 = decoder_dsc.header.h - 1;
-        int32_t ofs = decoder_dsc.header.w / 2;
+        img_area.x2 = decoder_dsc.decoded->header.w - 1;
+        img_area.y2 = decoder_dsc.decoded->header.h - 1;
+        int32_t ofs = decoder_dsc.decoded->header.w / 2;
         lv_area_move(&img_area, dsc->center.x - ofs, dsc->center.y - ofs);
         blend_dsc.src_area = &img_area;
         blend_dsc.src_buf = decoder_dsc.decoded->data;

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -305,7 +305,7 @@ static void _set_paint_fill_pattern(Tvg_Paint * obj, Tvg_Canvas * canvas, const 
     }
 
     const uint8_t * src_buf = decoder_dsc.decoded->data;
-    const lv_image_header_t * header = &decoder_dsc.header;
+    const lv_image_header_t * header = &decoder_dsc.decoded->header;
     lv_color_format_t cf = header->cf;
 
     if(cf != LV_COLOR_FORMAT_ARGB8888) {

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -76,7 +76,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
     }
 
     vg_lite_color_t color = 0;
-    if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(decoder_dsc.header.cf) || dsc->recolor_opa > LV_OPA_MIN) {
+    if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(decoder_dsc.decoded->header.cf) || dsc->recolor_opa > LV_OPA_MIN) {
         /* alpha image and image recolor */
         src_buf.image_mode = VG_LITE_MULTIPLY_IMAGE_MODE;
         color = lv_vg_lite_color(dsc->recolor, LV_OPA_MIX2(dsc->opa, dsc->recolor_opa), true);


### PR DESCRIPTION
### Description of the feature or fix

Image decoder only cache `decoded` data, please don't rely on `decoder_dsc.header`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
