### PR TITLE
fix(gridnav): fix the `lv_gridnav_remove` which may remove the event incorrectly

### DIFF
--- a/src/others/gridnav/lv_gridnav.c
+++ b/src/others/gridnav/lv_gridnav.c
@@ -85,9 +85,11 @@ void lv_gridnav_remove(lv_obj_t * obj)
     }
 
     if(event_dsc) {
-        lv_free(lv_event_dsc_get_user_data(event_dsc));
-        lv_obj_remove_event(obj, i);
-
+        if(lv_event_dsc_get_cb(event_dsc) == gridnav_event_cb) {
+            lv_free(lv_event_dsc_get_user_data(event_dsc));
+            lv_obj_remove_event(obj, i);
+            
+        }
     }
 }
 

--- a/src/others/gridnav/lv_gridnav.c
+++ b/src/others/gridnav/lv_gridnav.c
@@ -81,7 +81,7 @@ void lv_gridnav_remove(lv_obj_t * obj)
         event_dsc = lv_obj_get_event_dsc(obj, i);
         if(lv_event_dsc_get_cb(event_dsc) == gridnav_event_cb) {
             lv_free(lv_event_dsc_get_user_data(event_dsc));
-            lv_obj_remove_event(obj, i);         
+            lv_obj_remove_event(obj, i);
             break;
         }
     }

--- a/src/others/gridnav/lv_gridnav.c
+++ b/src/others/gridnav/lv_gridnav.c
@@ -88,7 +88,7 @@ void lv_gridnav_remove(lv_obj_t * obj)
         if(lv_event_dsc_get_cb(event_dsc) == gridnav_event_cb) {
             lv_free(lv_event_dsc_get_user_data(event_dsc));
             lv_obj_remove_event(obj, i);
-            
+
         }
     }
 }

--- a/src/others/gridnav/lv_gridnav.c
+++ b/src/others/gridnav/lv_gridnav.c
@@ -80,17 +80,12 @@ void lv_gridnav_remove(lv_obj_t * obj)
     for(i = 0; i < event_cnt; i++) {
         event_dsc = lv_obj_get_event_dsc(obj, i);
         if(lv_event_dsc_get_cb(event_dsc) == gridnav_event_cb) {
+            lv_free(lv_event_dsc_get_user_data(event_dsc));
+            lv_obj_remove_event(obj, i);         
             break;
         }
     }
 
-    if(event_dsc) {
-        if(lv_event_dsc_get_cb(event_dsc) == gridnav_event_cb) {
-            lv_free(lv_event_dsc_get_user_data(event_dsc));
-            lv_obj_remove_event(obj, i);
-
-        }
-    }
 }
 
 void lv_gridnav_set_focused(lv_obj_t * cont, lv_obj_t * to_focus, lv_anim_enable_t anim_en)


### PR DESCRIPTION
### Description of the feature or fix
![图片](https://github.com/lvgl/lvgl/assets/141553835/f9f3c5f5-4b52-47b3-bcaf-40df221023a0)
In function void lv_gridnav_remove(lv_obj_t * obj) if the obj has no event which has its callback function is gridnav_event_cb, but the obj has at least one event.The function will delete the last event of the obj and free its userdata.In some case,it's will course immediately crash.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
