### PR TITLE
fix(draw): widen lv_img_header_t dimensions from 11 to 16 bits

### DIFF
--- a/src/draw/lv_img_buf.h
+++ b/src/draw/lv_img_buf.h
@@ -114,9 +114,9 @@ typedef uint8_t lv_img_cf_t;
 #if LV_BIG_ENDIAN_SYSTEM
 typedef struct {
 
-    uint32_t h : 11; /*Height of the image map*/
-    uint32_t w : 11; /*Width of the image map*/
-    uint32_t reserved : 2; /*Reserved to be used later*/
+    uint32_t h : 16; /*Height of the image map*/
+    uint32_t w : 16; /*Width of the image map*/
+    uint32_t reserved : 24; /*Reserved to be used later*/
     uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
                                  non-printable character*/
     uint32_t cf : 5;          /*Color format: See `lv_img_color_format_t`*/
@@ -129,10 +129,10 @@ typedef struct {
     uint32_t always_zero : 3; /*It the upper bits of the first byte. Always zero to look like a
                                  non-printable character*/
 
-    uint32_t reserved : 2; /*Reserved to be used later*/
+    uint32_t reserved : 24; /*Reserved to be used later*/
 
-    uint32_t w : 11; /*Width of the image map*/
-    uint32_t h : 11; /*Height of the image map*/
+    uint32_t w : 16; /*Width of the image map*/
+    uint32_t h : 16; /*Height of the image map*/
 } lv_img_header_t;
 #endif
 


### PR DESCRIPTION
Was observing snapshots larger than 2048px getting mysteriously truncated in LVGL 8. LVGL 9 already widened these:

https://github.com/lvgl/lvgl/blob/09cb87cdc6a0168a98bc0a3182a8439b13249ead/src/draw/lv_image_buf.h#L90-L91