### PR TITLE
fix: fix warnings with -flto on GCC 11

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -932,7 +932,7 @@ static void trans_anim_cb(void * _tr, int32_t v)
                 break;
         }
 
-        lv_style_value_t old_value;
+        lv_style_value_t old_value = {0};
         bool refr = true;
         if(lv_style_get_prop(obj->styles[i].style, tr->prop, &old_value)) {
             if(value_final.ptr == old_value.ptr && lv_color_eq(value_final.color, old_value.color) &&

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -25,6 +25,10 @@
 /**********************
  *      TYPEDEFS
  **********************/
+typedef struct {
+    uint32_t gid_left;
+    uint32_t gid_right;
+} kern_pair_ref_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -274,7 +278,7 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
             /*Use binary search to find the kern value.
              *The pairs are ordered left_id first, then right_id secondly.*/
             const uint16_t * g_ids = kdsc->glyph_ids;
-            uint16_t g_id_both = (gid_right << 8) + gid_left; /*Create one number from the ids*/
+            kern_pair_ref_t g_id_both = {gid_left, gid_right};
             uint16_t * kid_p = _lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 2, kern_pair_8_compare);
 
             /*If the `g_id_both` were found get its index from the pointer*/
@@ -287,7 +291,7 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
             /*Use binary search to find the kern value.
              *The pairs are ordered left_id first, then right_id secondly.*/
             const uint32_t * g_ids = kdsc->glyph_ids;
-            uint32_t g_id_both = (gid_right << 16) + gid_left; /*Create one number from the ids*/
+            kern_pair_ref_t g_id_both = {gid_left, gid_right};
             uint32_t * kid_p = _lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 4, kern_pair_16_compare);
 
             /*If the `g_id_both` were found get its index from the pointer*/
@@ -319,23 +323,23 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
 
 static int32_t kern_pair_8_compare(const void * ref, const void * element)
 {
-    const uint8_t * ref8_p = ref;
+    const kern_pair_ref_t * ref8_p = ref;
     const uint8_t * element8_p = element;
 
     /*If the MSB is different it will matter. If not return the diff. of the LSB*/
-    if(ref8_p[0] != element8_p[0]) return (int32_t)ref8_p[0] - element8_p[0];
-    else return (int32_t) ref8_p[1] - element8_p[1];
+    if(ref8_p->gid_left != element8_p[0]) return (int32_t) ref8_p->gid_left - element8_p[0];
+    else return (int32_t) ref8_p->gid_right - element8_p[1];
 
 }
 
 static int32_t kern_pair_16_compare(const void * ref, const void * element)
 {
-    const uint16_t * ref16_p = ref;
+    const kern_pair_ref_t * ref16_p = ref;
     const uint16_t * element16_p = element;
 
     /*If the MSB is different it will matter. If not return the diff. of the LSB*/
-    if(ref16_p[0] != element16_p[0]) return (int32_t)ref16_p[0] - element16_p[0];
-    else return (int32_t) ref16_p[1] - element16_p[1];
+    if(ref16_p->gid_left != element16_p[0]) return (int32_t) ref16_p->gid_left - element16_p[0];
+    else return (int32_t) ref16_p->gid_right - element16_p[1];
 }
 
 #if LV_USE_FONT_COMPRESSED

--- a/src/misc/cache/_lv_cache_lru_rb.c
+++ b/src/misc/cache/_lv_cache_lru_rb.c
@@ -377,7 +377,7 @@ static void drop_all_cb(lv_cache_t * cache, void * user_data)
             lru->cache.ops.free_cb(search_key, user_data);
         }
         else {
-            LV_LOG_WARN("entry (%p) is still referenced (%" LV_PRId32 ")", entry, lv_cache_entry_get_ref(entry));
+            LV_LOG_WARN("entry (%p) is still referenced (%" LV_PRId32 ")", (void *)entry, lv_cache_entry_get_ref(entry));
             used_cnt++;
         }
     }


### PR DESCRIPTION
* Avoid type punning in kern pair binary search.
* Inline delete_core() into lv_anim_delete (used only once) and avoid invalid function pointer cast.
* %p formatter requires void pointer.
* Work around false-positive -Wmaybe-uninitialized wrt. lv_style_get_prop().