### PR TITLE
fix(image_decoder): fix decoder not close

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -133,9 +133,6 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     dsc->decoder = image_decoder_get_info(src, &dsc->header);
     if(dsc->decoder == NULL) return LV_RESULT_INVALID;
 
-    /*Duplicate the source if it's a file*/
-    if(dsc->src_type == LV_IMAGE_SRC_FILE) dsc->src = lv_strdup(dsc->src);
-
     /*Make a copy of args*/
     dsc->args = args ? *args : (lv_image_decoder_args_t) {
         .stride_align = LV_DRAW_BUF_STRIDE_ALIGN != 1,
@@ -150,12 +147,6 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
      * If decoder open succeed, add the image to cache if enabled.
      * */
     lv_result_t res = dsc->decoder->open_cb(dsc->decoder, dsc);
-
-    /*Free the source if it's a file*/
-    if(dsc->src_type == LV_IMAGE_SRC_FILE) {
-        lv_free((void *)dsc->src);
-        dsc->src = NULL;
-    }
 
     return res;
 }

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -151,6 +151,12 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
      * */
     lv_result_t res = dsc->decoder->open_cb(dsc->decoder, dsc);
 
+    /*Free the source if it's a file*/
+    if(dsc->src_type == LV_IMAGE_SRC_FILE) {
+        lv_free((void *)dsc->src);
+        dsc->src = NULL;
+    }
+
     return res;
 }
 
@@ -167,11 +173,6 @@ void lv_image_decoder_close(lv_image_decoder_dsc_t * dsc)
 {
     if(dsc->decoder) {
         if(dsc->decoder->close_cb) dsc->decoder->close_cb(dsc->decoder, dsc);
-
-        if(dsc->src_type == LV_IMAGE_SRC_FILE) {
-            lv_free((void *)dsc->src);
-            dsc->src = NULL;
-        }
     }
 }
 

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -442,6 +442,7 @@ static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc)
     if(entry) {
         lv_image_cache_data_t * cached_data = lv_cache_entry_get_data(entry);
         dsc->decoded = cached_data->decoded;
+        dsc->decoder = (lv_image_decoder_t *)cached_data->decoder;
         dsc->cache_entry = entry;     /*Save the cache to release it in decoder_close*/
         return LV_RESULT_OK;
     }


### PR DESCRIPTION
### Description of the feature or fix

If `try_cache` does not assign a value to `dsc->decoder`, the decoder will not be able to close correctly.
```c
void lv_image_decoder_close(lv_image_decoder_dsc_t * dsc)
{
    if(dsc->decoder) {
        if(dsc->decoder->close_cb) dsc->decoder->close_cb(dsc->decoder, dsc);

        if(dsc->src_type == LV_IMAGE_SRC_FILE) {
            lv_free((void *)dsc->src);
            dsc->src = NULL;
        }
    }
}
```

cc @W-Mai 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
