### PR TITLE
fix(assert): add new macro to format assert message

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -406,8 +406,8 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     LV_ASSERT_MSG(w != 0 && h != 0, "display resolution is 0");
 
     /* buf1 or buf2 is not aligned according to LV_DRAW_BUF_ALIGN */
-    LV_ASSERT_MSG(buf1 == lv_draw_buf_align(buf1, cf), "buf1 is not aligned: %p", buf1);
-    LV_ASSERT_MSG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), "buf2 is not aligned: %p", buf2);
+    LV_ASSERT_FORMAT_MSG(buf1 == lv_draw_buf_align(buf1, cf), "buf1 is not aligned: %p", buf1);
+    LV_ASSERT_FORMAT_MSG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), "buf2 is not aligned: %p", buf2);
 
     uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
@@ -416,8 +416,8 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
         LV_ASSERT_MSG(h != 0, "the buffer is too small");
     }
     else {
-        LV_ASSERT_MSG(stride * h <= buf_size, "%s mode requires screen sized buffer(s)",
-                      render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
+        LV_ASSERT_FORMAT_MSG(stride * h <= buf_size, "%s mode requires screen sized buffer(s)",
+                             render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
     }
 
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);

--- a/src/misc/lv_assert.h
+++ b/src/misc/lv_assert.h
@@ -42,10 +42,18 @@ extern "C" {
         }                                                      \
     } while(0)
 
-#define LV_ASSERT_MSG(expr, format, ...)                                                \
+#define LV_ASSERT_MSG(expr, msg)                                         \
+    do {                                                                 \
+        if(!(expr)) {                                                    \
+            LV_LOG_ERROR("Asserted at expression: %s (%s)", #expr, msg); \
+            LV_ASSERT_HANDLER                                            \
+        }                                                                \
+    } while(0)
+
+#define LV_ASSERT_FORMAT_MSG(expr, format, ...)                                         \
     do {                                                                                \
         if(!(expr)) {                                                                   \
-            LV_LOG_ERROR("Asserted at expression: %s " format , #expr, ##__VA_ARGS__);  \
+            LV_LOG_ERROR("Asserted at expression: %s " format , #expr, __VA_ARGS__);    \
             LV_ASSERT_HANDLER                                                           \
         }                                                                               \
     } while(0)


### PR DESCRIPTION
### Description of the feature or fix

Fix #5441

Since `LV_LOG_ERROR` and similar macro works for all, let's add a new macro specially to format assert message. This way it's sure the VAR_ARGS is not empty.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
