### PR TITLE
chore(cache): only cache header info for file type of image

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -318,18 +318,20 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
     lv_image_decoder_t * decoder;
 
 #if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-    lv_image_header_cache_data_t search_key;
-    search_key.src_type = src_type;
-    search_key.src = src;
+    if(src_type == LV_IMAGE_SRC_FILE) {
+        lv_image_header_cache_data_t search_key;
+        search_key.src_type = src_type;
+        search_key.src = src;
 
-    lv_cache_entry_t * entry = lv_cache_acquire(img_header_cache_p, &search_key, NULL);
+        lv_cache_entry_t * entry = lv_cache_acquire(img_header_cache_p, &search_key, NULL);
 
-    if(entry) {
-        lv_image_header_cache_data_t * cached_data = lv_cache_entry_get_data(entry);
-        *header = cached_data->header;
-        decoder = cached_data->decoder;
-        lv_cache_release(img_header_cache_p, entry, NULL);
-        return decoder;
+        if(entry) {
+            lv_image_header_cache_data_t * cached_data = lv_cache_entry_get_data(entry);
+            *header = cached_data->header;
+            decoder = cached_data->decoder;
+            lv_cache_release(img_header_cache_p, entry, NULL);
+            return decoder;
+        }
     }
 #endif
 
@@ -345,8 +347,11 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
     }
 
 #if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-    if(decoder) {
-        if(src_type == LV_IMAGE_SRC_FILE) search_key.src = lv_strdup(src);
+    if(src_type == LV_IMAGE_SRC_FILE && decoder) {
+        lv_cache_entry_t * entry;
+        lv_image_header_cache_data_t search_key;
+        search_key.src_type = src_type;
+        search_key.src = lv_strdup(src);
         search_key.decoder = decoder;
         search_key.header = *header;
         entry = lv_cache_add(img_header_cache_p, &search_key, NULL);


### PR DESCRIPTION
### Description of the feature or fix

For variable type of image, the header cache won't be that useful considering that PNG, JPG are easy to get info.
Furthermore, if the image has changed, which is usual for variable type of image in RAM, user must manually invalidate the cache.

So it's better to only add header to cache for file type of image.

cc @W-Mai 
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
