### PR TITLE
fix(vg_lite): add missing 24bit color support check

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -83,6 +83,18 @@ void lv_draw_vg_lite_deinit(void)
  *   STATIC FUNCTIONS
  **********************/
 
+static bool check_image_is_supported(const lv_draw_image_dsc_t * dsc)
+{
+    lv_image_header_t header;
+    lv_result_t res = lv_image_decoder_get_info(dsc->src, &header);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_TRACE("get image info failed");
+        return false;
+    }
+
+    return lv_vg_lite_is_src_cf_supported(header.cf);
+}
+
 static void draw_execute(lv_draw_vg_lite_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
@@ -191,23 +203,33 @@ static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
         case LV_DRAW_TASK_TYPE_FILL:
         case LV_DRAW_TASK_TYPE_BORDER:
         case LV_DRAW_TASK_TYPE_BOX_SHADOW:
-        case LV_DRAW_TASK_TYPE_IMAGE:
         case LV_DRAW_TASK_TYPE_LAYER:
         case LV_DRAW_TASK_TYPE_LINE:
         case LV_DRAW_TASK_TYPE_ARC:
         case LV_DRAW_TASK_TYPE_TRIANGLE:
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
-            // case LV_DRAW_TASK_TYPE_MASK_BITMAP:
+
 #if LV_USE_VECTOR_GRAPHIC
         case LV_DRAW_TASK_TYPE_VECTOR:
 #endif
-            task->preference_score = 80;
-            task->preferred_draw_unit_id = VG_LITE_DRAW_UNIT_ID;
-            return 1;
-        default:
             break;
+
+        case LV_DRAW_TASK_TYPE_IMAGE: {
+                if(!check_image_is_supported(task->draw_dsc)) {
+                    return 0;
+                }
+            }
+            break;
+
+        default:
+            /*The draw unit is not able to draw this task. */
+            return 0;
     }
-    return 0;
+
+    /* The draw unit is able to draw this task. */
+    task->preference_score = 80;
+    task->preferred_draw_unit_id = VG_LITE_DRAW_UNIT_ID;
+    return 1;
 }
 
 static int32_t draw_delete(lv_draw_unit_t * draw_unit)

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -305,14 +305,18 @@ bool lv_vg_lite_is_dest_cf_supported(lv_color_format_t cf)
 {
     switch(cf) {
         case LV_COLOR_FORMAT_RGB565:
-        case LV_COLOR_FORMAT_RGB565A8:
-        case LV_COLOR_FORMAT_RGB888:
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
             return true;
+
+        case LV_COLOR_FORMAT_RGB565A8:
+        case LV_COLOR_FORMAT_RGB888:
+            return vg_lite_query_feature(gcFEATURE_BIT_VG_24BIT) ? true : false;
+
         default:
             break;
     }
+
     return false;
 }
 
@@ -323,15 +327,21 @@ bool lv_vg_lite_is_src_cf_supported(lv_color_format_t cf)
         case LV_COLOR_FORMAT_A8:
         case LV_COLOR_FORMAT_I8:
         case LV_COLOR_FORMAT_RGB565:
-        case LV_COLOR_FORMAT_RGB565A8:
-        case LV_COLOR_FORMAT_RGB888:
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
-        case LV_COLOR_FORMAT_NV12:
             return true;
+
+        case LV_COLOR_FORMAT_RGB565A8:
+        case LV_COLOR_FORMAT_RGB888:
+            return vg_lite_query_feature(gcFEATURE_BIT_VG_24BIT) ? true : false;
+
+        case LV_COLOR_FORMAT_NV12:
+            return vg_lite_query_feature(gcFEATURE_BIT_VG_YUV_INPUT) ? true : false;
+
         default:
             break;
     }
+
     return false;
 }
 


### PR DESCRIPTION
### Description of the feature or fix

Some older GPUs do not support 24bit color formats such as RGB888.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
