### PR TITLE
Fix accepted chars issue on big endian systems

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -121,7 +121,7 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
     if(c != 0) while(*letter_buf == 0) ++letter_buf;
 
     // The byte order may or may not need to be swapped here to get correct c_uni below,
-    // since lv_textarea_add_text is ordering bytes correctly bfore calling lv_textarea_add_char.
+    // since lv_textarea_add_text is ordering bytes correctly before calling lv_textarea_add_char.
     // Assume swapping is needed if MSB is zero. May not be foolproof.
     if((c != 0) && ((c & 0xff000000) == 0)) {
         c2 = ((c >> 24) & 0xff) | // move byte 3 to byte 0

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -116,14 +116,25 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
 
     const char * letter_buf = (char *)&u32_buf;
 
+    uint32_t c2 = c;
 #if LV_BIG_ENDIAN_SYSTEM
     if(c != 0) while(*letter_buf == 0) ++letter_buf;
+
+    // The byte order may or may not need to be swapped here to get correct c_uni below,
+    // since lv_textarea_add_text is ordering bytes correctly bfore calling lv_textarea_add_char.
+    // Assume swapping is needed if MSB is zero. May not be foolproof.
+    if((c != 0) && ((c & 0xff000000) == 0)) {
+        c2 = ((c >> 24) & 0xff) | // move byte 3 to byte 0
+             ((c << 8) & 0xff0000) | // move byte 1 to byte 2
+             ((c >> 8) & 0xff00) | // move byte 2 to byte 1
+             ((c << 24) & 0xff000000); // byte 0 to byte 3
+    }
 #endif
 
     lv_result_t res = insert_handler(obj, letter_buf);
     if(res != LV_RESULT_OK) return;
 
-    uint32_t c_uni = _lv_text_encoded_next((const char *)&c, NULL);
+    uint32_t c_uni = _lv_text_encoded_next((const char *)&c2, NULL);
 
     if(char_is_accepted(obj, c_uni) == false) {
         LV_LOG_INFO("Character is not accepted by the text area (too long text or not in the accepted list)");

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -120,14 +120,14 @@ void lv_textarea_add_char(lv_obj_t * obj, uint32_t c)
 #if LV_BIG_ENDIAN_SYSTEM
     if(c != 0) while(*letter_buf == 0) ++letter_buf;
 
-    // The byte order may or may not need to be swapped here to get correct c_uni below,
-    // since lv_textarea_add_text is ordering bytes correctly before calling lv_textarea_add_char.
-    // Assume swapping is needed if MSB is zero. May not be foolproof.
+    /*The byte order may or may not need to be swapped here to get correct c_uni below,
+      since lv_textarea_add_text is ordering bytes correctly before calling lv_textarea_add_char.
+      Assume swapping is needed if MSB is zero. May not be foolproof. */
     if((c != 0) && ((c & 0xff000000) == 0)) {
-        c2 = ((c >> 24) & 0xff) | // move byte 3 to byte 0
-             ((c << 8) & 0xff0000) | // move byte 1 to byte 2
-             ((c >> 8) & 0xff00) | // move byte 2 to byte 1
-             ((c << 24) & 0xff000000); // byte 0 to byte 3
+        c2 = ((c >> 24) & 0xff) | /*move byte 3 to byte 0*/
+             ((c << 8) & 0xff0000) | /*move byte 1 to byte 2*/
+             ((c >> 8) & 0xff00) | /*move byte 2 to byte 1*/
+             ((c << 24) & 0xff000000); /*byte 0 to byte 3*/
     }
 #endif
 


### PR DESCRIPTION
Fixes: #5454

### Description of the feature or fix

When adding accepted chars to a textarea, no characters are accepted on big-endian systems.

In the function lv_textarea_add_char, the character to add is taken as a uint32_t parameter, called c. When encoded, this is casted to a char pointer. On big endian systems this pointer will point to the wrong byte in the uint32_t, and the wrong encoded character, c_uni, will be used when checking for valid characters.

The root of the issue is the following line:
`uint32_t c_uni = _lv_txt_encoded_next((const char *)&c, NULL);`

The reference to uint32_t c should not be casted to a char pointer. To change this, I believe require pretty big changes to the code, since _lv_txt_encoded_next requires a const char *.

The solution/workaround made here is to swap the byte order of, c in case of big-endian system. But if lv_textarea_add_char is called from lv_textarea_add_text, the byte order of c is already correct, so then the bytes order shall not be swapped. Here we assume that the byte order shall be swapped if the most significant byte of c is zero. This worked in my case but will not give the correct value of c_uni if c is a 4 byte code. However, since I believe accepted characters will always be a char, I think this will never be an issue.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
