### PR TITLE
feat(display): add save screenshot to file support

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -917,6 +917,13 @@ void * lv_display_get_driver_data(lv_display_t * disp)
     return disp->driver_data;
 }
 
+lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) return NULL;
+    return disp->buf_act;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -534,6 +534,7 @@ void lv_display_set_user_data(lv_display_t * disp, void * user_data);
 void lv_display_set_driver_data(lv_display_t * disp, void * driver_data);
 void * lv_display_get_user_data(lv_display_t * disp);
 void * lv_display_get_driver_data(lv_display_t * disp);
+lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp);
 
 /**********************
  *      MACROS

--- a/src/misc/lv_utils.c
+++ b/src/misc/lv_utils.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "lv_utils.h"
+#include "lv_fs.h"
 
 /*********************
  *      DEFINES
@@ -55,6 +56,38 @@ void * _lv_utils_bsearch(const void * key, const void * base, uint32_t n, uint32
         }
     }
     return NULL;
+}
+
+lv_result_t lv_draw_buf_save_to_file(const lv_draw_buf_t * draw_buf, const char * path)
+{
+    lv_fs_file_t file;
+    lv_fs_res_t res = lv_fs_open(&file, path, LV_FS_MODE_WR);
+    if(res != LV_FS_RES_OK) {
+        LV_LOG_ERROR("create file %s failed", path);
+        return LV_RESULT_INVALID;
+    }
+
+    /*Image content modified, invalidate image cache.*/
+    lv_image_cache_drop(path);
+
+    uint32_t bw;
+    res = lv_fs_write(&file, &draw_buf->header, sizeof(draw_buf->header), &bw);
+    if(res != LV_FS_RES_OK || bw != sizeof(draw_buf->header)) {
+        LV_LOG_ERROR("write draw_buf->header failed");
+        lv_fs_close(&file);
+        return LV_RESULT_INVALID;
+    }
+
+    res = lv_fs_write(&file, draw_buf->data, draw_buf->data_size, &bw);
+    if(res != LV_FS_RES_OK || bw != draw_buf->data_size) {
+        LV_LOG_ERROR("write draw_buf->data failed");
+        lv_fs_close(&file);
+        return LV_RESULT_INVALID;
+    }
+
+    lv_fs_close(&file);
+    LV_LOG_TRACE("saved draw_buf to %s", path);
+    return LV_RESULT_OK;
 }
 
 /**********************

--- a/src/misc/lv_utils.c
+++ b/src/misc/lv_utils.c
@@ -10,6 +10,7 @@
 
 #include "lv_utils.h"
 #include "lv_fs.h"
+#include "cache/lv_image_cache.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_utils.h
+++ b/src/misc/lv_utils.h
@@ -13,6 +13,10 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+
+#include "lv_types.h"
+#include "../draw/lv_draw_buf.h"
+
 #include <stdint.h>
 
 /*********************
@@ -46,6 +50,14 @@ extern "C" {
  */
 void * _lv_utils_bsearch(const void * key, const void * base, uint32_t n, uint32_t size,
                          int32_t (*cmp)(const void * pRef, const void * pElement));
+
+/**
+ * Save a draw buf to a file
+ * @param draw_buf  pointer to a draw buffer
+ * @param path      path to the file to save
+ * @return          LV_RES_OK: success; LV_RES_INV: error
+ */
+lv_result_t lv_draw_buf_save_to_file(const lv_draw_buf_t * draw_buf, const char * path);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

Added screenshot saving file function to facilitate debugging of images during the drawing process.

Thanks to draw_buf, which unifies the data structure of the drawing buffer, it is extremely convenient to expand related functions later.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
