### PR TITLE
fix(decoder): treat ALLOCATED c-array image as draw buffer

### DIFF
--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -282,9 +282,16 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
              *So simply give its pointer*/
 
             decoder_data_t * decoder_data = get_decoder_data(dsc);
-            lv_draw_buf_t * decoded = &decoder_data->c_array;
+            lv_draw_buf_t * decoded;
+            if(image->header.flags & LV_IMAGE_FLAGS_ALLOCATED) {
+                decoded = (lv_draw_buf_t *)image;
+            }
+            else {
+                decoded = &decoder_data->c_array;
+                lv_draw_buf_from_image(decoded, image);
+            }
+
             dsc->decoded = decoded;
-            lv_draw_buf_from_image(decoded, image);
 
             if(decoded->header.stride == 0) {
                 /*Use the auto calculated value from decoder_info callback*/
@@ -686,9 +693,16 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     if(dsc->src_type == LV_IMAGE_SRC_VARIABLE) {
         lv_image_dsc_t * image = (lv_image_dsc_t *)dsc->src;
-        lv_draw_buf_t * decoded = &decoder_data->c_array;
+        lv_draw_buf_t * decoded;
+        if(image->header.flags & LV_IMAGE_FLAGS_ALLOCATED) {
+            decoded = (lv_draw_buf_t *)image;
+        }
+        else {
+            decoded = &decoder_data->c_array;
+            lv_draw_buf_from_image(decoded, image);
+        }
+
         dsc->decoded = decoded;
-        lv_draw_buf_from_image(decoded, image);
 
         if(decoded->header.stride == 0) {
             /*Use the auto calculated value from decoder_info callback*/


### PR DESCRIPTION


### Description of the feature or fix

If the c-array image can be used directly, and it's allocated, then it must be a draw buffer. The following up stride/premultiply adjustment to this draw buffer should update the original image flag rather than the fake static draw buffer struct.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
