### PR TITLE
Draw buf misc update

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -296,8 +296,12 @@ lv_draw_buf_t * lv_draw_buf_adjust_stride(const lv_draw_buf_t * src, uint32_t st
     lv_draw_buf_t * dst = lv_draw_buf_create(header->w, header->h, header->cf, stride);
     if(dst == NULL) return NULL;
 
+    uint32_t offset = LV_COLOR_INDEXED_PALETTE_SIZE(header->cf) * 4;
+    if(offset) lv_memcpy(dst->data, src->data, offset);
     uint8_t * dst_data = dst->data;
+    dst_data += offset;
     const uint8_t * src_data = src->data;
+    src_data += offset;
     for(int32_t y = 0; y < src->header.h; y++) {
         lv_memcpy(dst_data, src_data, min_stride);
         src_data += src->header.stride;

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -224,6 +224,16 @@ static inline bool lv_draw_buf_has_flag(lv_draw_buf_t * draw_buf, lv_image_flags
     return draw_buf->header.flags & flag;
 }
 
+static inline void lv_draw_buf_set_flag(lv_draw_buf_t * draw_buf, lv_image_flags_t flag)
+{
+    draw_buf->header.flags |= flag;
+}
+
+static inline void lv_draw_buf_clear_flag(lv_draw_buf_t * draw_buf, lv_image_flags_t flag)
+{
+    draw_buf->header.flags &= ~flag;
+}
+
 /**
  * As of now, draw buf share same definition as `lv_image_dsc_t`.
  * And is interchangeable with `lv_image_dsc_t`.

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -104,6 +104,9 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
 
     lv_vg_lite_buffer_from_draw_buf(&u->target_buffer, layer->draw_buf);
 
+    /* VG-Lite will output premultiplied image, set the flag correspondingly. */
+    lv_draw_buf_set_flag(layer->draw_buf, LV_IMAGE_FLAGS_PREMULTIPLIED);
+
     vg_lite_identity(&u->global_matrix);
     vg_lite_translate(-layer->buf_area.x1, -layer->buf_area.y1, &u->global_matrix);
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_layer.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_layer.c
@@ -51,7 +51,9 @@ void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t
     LV_PROFILER_BEGIN;
 
     /* The GPU output should already be premultiplied RGB */
-    layer->draw_buf->header.flags |= LV_IMAGE_FLAGS_PREMULTIPLIED;
+    if(!lv_draw_buf_has_flag(layer->draw_buf, LV_IMAGE_FLAGS_PREMULTIPLIED)) {
+        LV_LOG_WARN("Non-premultiplied layer buffer for GPU to draw.");
+    }
 
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = layer->draw_buf;


### PR DESCRIPTION
### Description of the feature or fix

fix(draw_buf): support adjust stride of indexed image

chore(vg_lite): make the layer VG-Lite has drawn to be premultiplied

The output of VG-Lite is premultiplied image. Set corresponding flag and add warning if it's not already set.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
