### PR TITLE
feat(cache): refactor cache framework and add new APIs

### DIFF
--- a/src/misc/cache/lv_cache.c
+++ b/src/misc/cache/lv_cache.c
@@ -23,6 +23,8 @@
  *  STATIC PROTOTYPES
  **********************/
 static void cache_drop_internal_no_lock(lv_cache_t * cache, const void * key, void * user_data);
+static bool cache_evict_one_internal_no_lock(lv_cache_t * cache, void * user_data);
+static lv_cache_entry_t * cache_add_internal_no_lock(lv_cache_t * cache, const void * key, void * user_data);
 /**********************
  *  GLOBAL VARIABLES
  **********************/
@@ -106,11 +108,12 @@ lv_cache_entry_t * lv_cache_add(lv_cache_t * cache, const void * key, void * use
     LV_ASSERT_NULL(key);
 
     lv_mutex_lock(&cache->lock);
-    lv_cache_entry_t * entry = cache->clz->add_cb(cache, key, user_data);
+    lv_cache_entry_t * entry = cache_add_internal_no_lock(cache, key, user_data);
     if(entry != NULL) {
         lv_cache_entry_acquire_data(entry);
     }
     lv_mutex_unlock(&cache->lock);
+
     return entry;
 }
 lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * key, void * user_data)
@@ -125,7 +128,7 @@ lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * k
         lv_mutex_unlock(&cache->lock);
         return entry;
     }
-    entry = cache->clz->add_cb(cache, key, user_data);
+    entry = cache_add_internal_no_lock(cache, key, user_data);
     if(entry == NULL) {
         lv_mutex_unlock(&cache->lock);
         return NULL;
@@ -142,6 +145,16 @@ lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * k
     lv_mutex_unlock(&cache->lock);
     return entry;
 }
+void lv_cache_reserve(lv_cache_t * cache, uint32_t reserved_size, void * user_data)
+{
+    LV_ASSERT_NULL(cache);
+
+    for(lv_cache_reserve_cond_res_t reserve_cond_res = cache->clz->reserve_cond_cb(cache, NULL, reserved_size, user_data);
+        reserve_cond_res == LV_CACHE_RESERVE_COND_NEED_VICTIM;
+        reserve_cond_res = cache->clz->reserve_cond_cb(cache, NULL, reserved_size, user_data))
+        cache_evict_one_internal_no_lock(cache, user_data);
+
+}
 void lv_cache_drop(lv_cache_t * cache, const void * key, void * user_data)
 {
     LV_ASSERT_NULL(cache);
@@ -150,6 +163,16 @@ void lv_cache_drop(lv_cache_t * cache, const void * key, void * user_data)
     lv_mutex_lock(&cache->lock);
     cache_drop_internal_no_lock(cache, key, user_data);
     lv_mutex_unlock(&cache->lock);
+}
+bool lv_cache_evict_one(lv_cache_t * cache, void * user_data)
+{
+    LV_ASSERT_NULL(cache);
+
+    lv_mutex_lock(&cache->lock);
+    bool res = cache_evict_one_internal_no_lock(cache, user_data);
+    lv_mutex_unlock(&cache->lock);
+
+    return res;
 }
 void lv_cache_drop_all(lv_cache_t * cache, void * user_data)
 {
@@ -195,9 +218,11 @@ void lv_cache_set_free_cb(lv_cache_t * cache, lv_cache_free_cb_t free_cb, void *
     LV_UNUSED(user_data);
     cache->ops.free_cb = free_cb;
 }
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
 static void cache_drop_internal_no_lock(lv_cache_t * cache, const void * key, void * user_data)
 {
     lv_cache_entry_t * entry = cache->clz->get_cb(cache, key, user_data);
@@ -214,4 +239,36 @@ static void cache_drop_internal_no_lock(lv_cache_t * cache, const void * key, vo
         lv_cache_entry_set_invalid(entry, true);
         cache->clz->remove_cb(cache, entry, user_data);
     }
+}
+
+static bool cache_evict_one_internal_no_lock(lv_cache_t * cache, void * user_data)
+{
+    lv_cache_entry_t * victim = cache->clz->get_victim_cb(cache, user_data);
+
+    if(victim == NULL) {
+        LV_LOG_ERROR("No victim found");
+        return false;
+    }
+
+    cache->clz->remove_cb(cache, victim, user_data);
+    cache->ops.free_cb(lv_cache_entry_get_data(victim), user_data);
+    lv_cache_entry_delete(victim);
+    return true;
+}
+
+static lv_cache_entry_t * cache_add_internal_no_lock(lv_cache_t * cache, const void * key, void * user_data)
+{
+    lv_cache_reserve_cond_res_t reserve_cond_res = cache->clz->reserve_cond_cb(cache, key, 0, user_data);
+    if(reserve_cond_res == LV_CACHE_RESERVE_COND_TOO_LARGE) {
+        LV_LOG_ERROR("data %p is too large that exceeds max size (%" LV_PRIu32 ")", key, cache->max_size);
+    }
+
+    for(; reserve_cond_res == LV_CACHE_RESERVE_COND_NEED_VICTIM;
+        reserve_cond_res = cache->clz->reserve_cond_cb(cache, key, 0, user_data))
+        if(cache_evict_one_internal_no_lock(cache, user_data) == false)
+            return NULL;
+
+    lv_cache_entry_t * entry = cache->clz->add_cb(cache, key, user_data);
+
+    return entry;
 }

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -41,10 +41,12 @@ lv_cache_entry_t * lv_cache_acquire(lv_cache_t * cache, const void * key, void *
 lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * key, void * user_data);
 lv_cache_entry_t * lv_cache_add(lv_cache_t * cache, const void * key, void * user_data);
 void lv_cache_release(lv_cache_t * cache, lv_cache_entry_t * entry, void * user_data);
+void lv_cache_reserve(lv_cache_t * cache, uint32_t reserved_size, void * user_data);
 void lv_cache_drop(lv_cache_t * cache, const void * key, void * user_data);
 void lv_cache_drop_all(lv_cache_t * cache, void * user_data);
+bool lv_cache_evict_one(lv_cache_t * cache, void * user_data);
 
-void lv_cache_set_max_size(lv_cache_t * cache, size_t max_size, void * user_data);
+void   lv_cache_set_max_size(lv_cache_t * cache, size_t max_size, void * user_data);
 size_t lv_cache_get_max_size(lv_cache_t * cache, void * user_data);
 size_t lv_cache_get_size(lv_cache_t * cache, void * user_data);
 size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data);

--- a/src/misc/cache/lv_cache_private.h
+++ b/src/misc/cache/lv_cache_private.h
@@ -26,9 +26,13 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-/*-----------------
- * Cache entry slot
- *----------------*/
+typedef enum {
+    LV_CACHE_RESERVE_COND_OK,
+    LV_CACHE_RESERVE_COND_TOO_LARGE,
+    LV_CACHE_RESERVE_COND_NEED_VICTIM,
+    LV_CACHE_RESERVE_COND_ERROR
+} lv_cache_reserve_cond_res_t;
+
 struct _lv_cache_ops_t;
 struct _lv_cache_t;
 struct _lv_cache_class_t;
@@ -52,6 +56,9 @@ typedef lv_cache_entry_t * (*lv_cache_add_cb_t)(lv_cache_t * cache, const void *
 typedef void (*lv_cache_remove_cb_t)(lv_cache_t * cache, lv_cache_entry_t * entry, void * user_data);
 typedef void (*lv_cache_drop_cb_t)(lv_cache_t * cache, const void * key, void * user_data);
 typedef void (*lv_cache_clear_cb_t)(lv_cache_t * cache, void * user_data);
+typedef lv_cache_entry_t * (*lv_cache_get_victim_cb)(lv_cache_t * cache, void * user_data);
+typedef lv_cache_reserve_cond_res_t (*lv_cache_reserve_cond_cb)(lv_cache_t * cache, const void * key, size_t size,
+                                                                void * user_data);
 
 struct _lv_cache_ops_t {
     lv_cache_compare_cb_t compare_cb;
@@ -62,10 +69,10 @@ struct _lv_cache_ops_t {
 struct _lv_cache_t {
     const lv_cache_class_t * clz;
 
-    size_t node_size;
+    uint32_t node_size;
 
-    size_t max_size;
-    size_t size;
+    uint32_t max_size;
+    uint32_t size;
 
     lv_cache_ops_t ops;
 
@@ -82,6 +89,8 @@ struct _lv_cache_class_t {
     lv_cache_remove_cb_t remove_cb;
     lv_cache_drop_cb_t drop_cb;
     lv_cache_clear_cb_t drop_all_cb;
+    lv_cache_get_victim_cb get_victim_cb;
+    lv_cache_reserve_cond_cb reserve_cond_cb;
 };
 
 /*-----------------


### PR DESCRIPTION
### Description of the feature or fix

Refactor cache framework and add new APIs:
```cpp
void lv_cache_reserve(lv_cache_t * cache, uint32_t reserved_size, void * user_data);
bool lv_cache_evict_one(lv_cache_t * cache, void * user_data);
```

- `reserve` is aim to ensure cache will reserve size space.
- `evict` is aim to evict one cache manually by with cache's aging algorithm.

## CACHE's DOCS AND COMMENTS ARE IN PROGRESS

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
