### PR TITLE
Update calculation for overlay used memory

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -192,7 +192,7 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
                     int32_t w = lv_area_get_width(&layer_drawn->buf_area);
                     uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, layer_drawn->color_format);
 
-                    _draw_info.used_memory_for_layers_kb = get_layer_size_kb(layer_size_byte);
+                    _draw_info.used_memory_for_layers_kb -= get_layer_size_kb(layer_size_byte);
                     LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
                     lv_draw_buf_destroy(layer_drawn->draw_buf);
                     layer_drawn->draw_buf = NULL;
@@ -370,6 +370,7 @@ void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
     /*If the buffer of the layer is not allocated yet, allocate it now*/
     int32_t w = lv_area_get_width(&layer->buf_area);
     int32_t h = lv_area_get_height(&layer->buf_area);
+    uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, layer->color_format);
 
     layer->draw_buf = lv_draw_buf_create(w, h, layer->color_format, 0);
 
@@ -377,6 +378,9 @@ void * lv_draw_layer_alloc_buf(lv_layer_t * layer)
         LV_LOG_WARN("Allocating layer buffer failed. Try later");
         return NULL;
     }
+
+    _draw_info.used_memory_for_layers_kb += get_layer_size_kb(layer_size_byte);
+    LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
 
     if(lv_color_format_has_alpha(layer->color_format)) {
         lv_draw_buf_clear(layer->draw_buf, NULL);

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -192,7 +192,7 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
                     int32_t w = lv_area_get_width(&layer_drawn->buf_area);
                     uint32_t layer_size_byte = h * lv_draw_buf_width_to_stride(w, layer_drawn->color_format);
 
-                    _draw_info.used_memory_for_layers_kb -= get_layer_size_kb(layer_size_byte);
+                    _draw_info.used_memory_for_layers_kb = get_layer_size_kb(layer_size_byte);
                     LV_LOG_INFO("Layer memory used: %" LV_PRIu32 " kB\n", _draw_info.used_memory_for_layers_kb);
                     lv_draw_buf_destroy(layer_drawn->draw_buf);
                     layer_drawn->draw_buf = NULL;


### PR DESCRIPTION
### Description of the feature or fix

used_memory_for_layers_kb variable subtracted with initial value as zero. Due to this, it is printing large memory value (negative to postive conversion)

Please merge this PR, if it is valid change or suggest right changes.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
