### PR TITLE
fix(vg_lite): fix linear grad use after free

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -70,6 +70,8 @@ void lv_draw_vg_lite_init(void)
     unit->base_unit.delete_cb = draw_delete;
     lv_array_init(&unit->img_dsc_pending, 4, sizeof(lv_image_decoder_dsc_t));
 
+    lv_vg_lite_linear_grad_init(unit);
+
     lv_vg_lite_path_init(unit);
 
     lv_vg_lite_decoder_init();
@@ -150,7 +152,7 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
             break;
     }
 
-    lv_vg_lite_flush(draw_unit);
+    lv_vg_lite_flush(u);
 }
 
 static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
@@ -167,7 +169,7 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     /* Return 0 is no selection, some tasks can be supported by other units. */
     if(!t || t->preferred_draw_unit_id != VG_LITE_DRAW_UNIT_ID) {
-        lv_vg_lite_finish(draw_unit);
+        lv_vg_lite_finish(u);
         return -1;
     }
 
@@ -239,6 +241,7 @@ static int32_t draw_delete(lv_draw_unit_t * draw_unit)
 {
     lv_draw_vg_lite_unit_t * unit = (lv_draw_vg_lite_unit_t *)draw_unit;
     lv_array_deinit(&unit->img_dsc_pending);
+    lv_vg_lite_linear_grad_deinit(unit);
     lv_vg_lite_path_deinit(unit);
     lv_vg_lite_decoder_deinit();
     return 1;

--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -194,7 +194,7 @@ void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * d
                                        color,
                                        VG_LITE_FILTER_BI_LINEAR));
             LV_PROFILER_END_TAG("vg_lite_draw_pattern");
-            lv_vg_lite_push_image_decoder_dsc(draw_unit, &decoder_dsc);
+            lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
         }
     }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -84,6 +84,7 @@ void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t *
 
     if(dsc->grad.dir != LV_GRAD_DIR_NONE) {
         lv_vg_lite_draw_linear_grad(
+            u,
             &u->target_buffer,
             vg_lite_path,
             coords,

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -157,7 +157,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
         lv_vg_lite_path_drop(u, path);
     }
 
-    lv_vg_lite_push_image_decoder_dsc(draw_unit, &decoder_dsc);
+    lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
     LV_PROFILER_END;
 }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -221,7 +221,7 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
      * You need to wait for the GPU to finish using the buffer before releasing it.
      * Later, use the font cache for management to improve efficiency.
      */
-    lv_vg_lite_finish(&u->base_unit);
+    lv_vg_lite_finish(u);
     LV_PROFILER_END;
 }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -77,6 +77,7 @@ void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle
 
     if(dsc->bg_grad.dir != LV_GRAD_DIR_NONE) {
         lv_vg_lite_draw_linear_grad(
+            u,
             &u->target_buffer,
             vg_lite_path,
             &tri_area,

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -39,6 +39,7 @@ struct _lv_draw_vg_lite_unit_t {
     lv_draw_unit_t base_unit;
     lv_draw_task_t * task_act;
     lv_array_t img_dsc_pending;
+    lv_array_t grad_pending;
     uint16_t flush_count;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -164,7 +164,7 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
                                                VG_LITE_FILTER_BI_LINEAR));
                     LV_PROFILER_END_TAG("vg_lite_draw_pattern");
 
-                    lv_vg_lite_push_image_decoder_dsc(&u->base_unit, &decoder_dsc);
+                    lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
                 }
             }
             break;
@@ -178,6 +178,7 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
 
                 if(style == LV_VECTOR_GRADIENT_STYLE_LINEAR) {
                     lv_vg_lite_draw_linear_grad(
+                        u,
                         &u->target_buffer,
                         vg_path,
                         &grad_area,

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -40,6 +40,11 @@
  *      TYPEDEFS
  **********************/
 
+typedef struct {
+    vg_lite_linear_gradient_t grad;
+    bool in_use;
+} gradient_item_t;
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -603,15 +608,15 @@ void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, co
     }
 }
 
-void lv_vg_lite_push_image_decoder_dsc(lv_draw_unit_t * draw_unit, lv_image_decoder_dsc_t * img_dsc)
+void lv_vg_lite_push_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u, lv_image_decoder_dsc_t * img_dsc)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    LV_ASSERT_NULL(u);
+    LV_ASSERT_NULL(img_dsc);
     lv_array_push_back(&u->img_dsc_pending, img_dsc);
 }
 
-void lv_vg_lite_clear_image_decoder_dsc(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_clear_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
     lv_array_t * arr = &u->img_dsc_pending;
     uint32_t size = lv_array_size(arr);
     if(size == 0) {
@@ -895,7 +900,73 @@ bool lv_vg_lite_16px_align(void)
     return vg_lite_query_feature(gcFEATURE_BIT_VG_16PIXELS_ALIGN);
 }
 
+static vg_lite_linear_gradient_t * lv_vg_lite_linear_grad_get(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        if(!item[i].in_use) {
+            /* Mark as in use */
+            item[i].in_use = true;
+            LV_LOG_TRACE("get gradient: %p", &item[i].grad);
+
+            /* return the gradient */
+            return &item[i].grad;
+        }
+    }
+
+    /* No free gradient, create a new one */
+    gradient_item_t new_item;
+    lv_memzero(&new_item, sizeof(new_item));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_init_grad(&new_item.grad));
+    LV_ASSERT(lv_array_push_back(&u->grad_pending, &new_item) == LV_RESULT_OK);
+
+    /* Get the last one */
+    gradient_item_t * back = lv_array_back(&u->grad_pending);
+    LV_ASSERT_NULL(back);
+    return &back->grad;
+}
+
+static void lv_vg_lite_linear_grad_drop_all(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        if(item[i].in_use) {
+            LV_LOG_TRACE("drop gradient: %p", &item[i].grad);
+            item[i].in_use = false;
+        }
+    }
+}
+
+void lv_vg_lite_linear_grad_init(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    lv_array_init(&u->grad_pending, 4, sizeof(gradient_item_t));
+}
+
+void lv_vg_lite_linear_grad_deinit(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    /* Clear all pending gradients */
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        LV_ASSERT_MSG(!item[i].in_use, "gradient is still in use");
+        LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&item[i].grad));
+    }
+
+    /* Deinit array */
+    lv_array_deinit(&u->grad_pending);
+}
+
 void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
     vg_lite_buffer_t * buffer,
     vg_lite_path_t * path,
     const lv_area_t * area,
@@ -929,17 +1000,14 @@ void lv_vg_lite_draw_linear_grad(
         colors[i] = lv_vg_lite_color(grad_color, opa, true);
     }
 
-    vg_lite_linear_gradient_t gradient;
-    lv_memzero(&gradient, sizeof(gradient));
-
-    LV_VG_LITE_CHECK_ERROR(vg_lite_init_grad(&gradient));
-    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&gradient, cnt, colors, stops));
+    vg_lite_linear_gradient_t * gradient = lv_vg_lite_linear_grad_get(u);
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(gradient, cnt, colors, stops));
 
     LV_PROFILER_BEGIN_TAG("vg_lite_update_grad");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&gradient));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(gradient));
     LV_PROFILER_END_TAG("vg_lite_update_grad");
 
-    vg_lite_matrix_t * grad_matrix = vg_lite_get_grad_matrix(&gradient);
+    vg_lite_matrix_t * grad_matrix = vg_lite_get_grad_matrix(gradient);
     vg_lite_identity(grad_matrix);
     vg_lite_translate(area->x1, area->y1, grad_matrix);
 
@@ -957,11 +1025,10 @@ void lv_vg_lite_draw_linear_grad(
                                path,
                                fill,
                                (vg_lite_matrix_t *)matrix,
-                               &gradient,
+                               gradient,
                                blend));
     LV_PROFILER_END_TAG("vg_lite_draw_grad");
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&gradient));
     LV_PROFILER_END;
 }
 
@@ -1066,10 +1133,10 @@ void lv_vg_lite_disable_scissor(void)
     vg_lite_disable_scissor();
 }
 
-void lv_vg_lite_flush(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
 {
+    LV_ASSERT_NULL(u);
     LV_PROFILER_BEGIN;
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     u->flush_count++;
     if(u->flush_count < LV_VG_LITE_FLUSH_MAX_COUNT) {
@@ -1083,15 +1150,18 @@ void lv_vg_lite_flush(lv_draw_unit_t * draw_unit)
     LV_PROFILER_END;
 }
 
-void lv_vg_lite_finish(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u)
 {
+    LV_ASSERT_NULL(u);
     LV_PROFILER_BEGIN;
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
 
+    /* Clear all pending gradients */
+    lv_vg_lite_linear_grad_drop_all(u);
+
     /* Clear image decoder dsc reference */
-    lv_vg_lite_clear_image_decoder_dsc(draw_unit);
+    lv_vg_lite_clear_image_decoder_dsc(u);
     u->flush_count = 0;
     LV_PROFILER_END;
 }

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -70,6 +70,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+struct _lv_draw_vg_lite_unit_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -122,9 +124,9 @@ void lv_vg_lite_buffer_from_draw_buf(vg_lite_buffer_t * buffer, const lv_draw_bu
 
 void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, const lv_draw_image_dsc_t * dsc);
 
-void lv_vg_lite_push_image_decoder_dsc(lv_draw_unit_t * draw_unit, lv_image_decoder_dsc_t * img_dsc);
+void lv_vg_lite_push_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u, lv_image_decoder_dsc_t * img_dsc);
 
-void lv_vg_lite_clear_image_decoder_dsc(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_clear_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u);
 
 bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_dsc_t * decoder_dsc, const void * src,
                                   bool no_cache);
@@ -149,7 +151,12 @@ bool lv_vg_lite_support_blend_normal(void);
 
 bool lv_vg_lite_16px_align(void);
 
+void lv_vg_lite_linear_grad_init(struct _lv_draw_vg_lite_unit_t * u);
+
+void lv_vg_lite_linear_grad_deinit(struct _lv_draw_vg_lite_unit_t * u);
+
 void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
     vg_lite_buffer_t * buffer,
     vg_lite_path_t * path,
     const lv_area_t * area,
@@ -170,9 +177,9 @@ void lv_vg_lite_set_scissor_area(const lv_area_t * area);
 
 void lv_vg_lite_disable_scissor(void);
 
-void lv_vg_lite_flush(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u);
 
-void lv_vg_lite_finish(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Description of the feature or fix

The linear gradient of vg lite is simulated using draw image.
Therefore, `vg_lite_clear_grad` cannot be called immediately after calling `vg_lite_draw_gradient` to release memory, because when using asynchronous drawing mode, the GPU does not draw immediately, and you need to wait for the GPU drawing to complete before marking the gradient structure as available for reuse.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
