### PR TITLE
Remove TRUECOLOR for LVGLImage.py

### DIFF
--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -104,8 +104,6 @@ class CompressMethod(Enum):
 
 class ColorFormat(Enum):
     UNKNOWN = 0x00
-    TRUECOLOR = 0x04
-    TRUECOLOR_ALPHA = 0x05
     L8 = 0x06
     I1 = 0x07
     I2 = 0x08
@@ -142,8 +140,6 @@ class ColorFormat(Enum):
             ColorFormat.RGB565: 16,
             ColorFormat.RGB565A8: 16,  # 16bpp + a8 map
             ColorFormat.RGB888: 24,
-            ColorFormat.TRUECOLOR: 32,
-            ColorFormat.TRUECOLOR_ALPHA: 32,
         }
 
         return cf_map[self]
@@ -179,16 +175,13 @@ class ColorFormat(Enum):
         return self.is_alpha_only or self in (
             ColorFormat.ARGB8888,
             ColorFormat.XRGB8888,  # const alpha: 0xff
-            ColorFormat.TRUECOLOR,  # const alpha: 0xff
-            ColorFormat.TRUECOLOR_ALPHA,
             ColorFormat.RGB565A8)
 
     @property
     def is_colormap(self) -> bool:
         return self in (ColorFormat.ARGB8888, ColorFormat.RGB888,
                         ColorFormat.XRGB8888, ColorFormat.RGB565A8,
-                        ColorFormat.RGB565, ColorFormat.TRUECOLOR_ALPHA,
-                        ColorFormat.TRUECOLOR)
+                        ColorFormat.RGB565)
 
     @property
     def is_luma_only(self) -> bool:
@@ -819,11 +812,11 @@ const lv_img_dsc_t {varname} = {{
 
     def _png_to_colormap(self, cf, filename: str):
 
-        if cf in (ColorFormat.ARGB8888, ColorFormat.TRUECOLOR_ALPHA):
+        if cf == ColorFormat.ARGB8888:
 
             def pack(r, g, b, a):
                 return uint32_t((a << 24) | (r << 16) | (g << 8) | (b << 0))
-        elif cf in (ColorFormat.XRGB8888, ColorFormat.TRUECOLOR):
+        elif cf == ColorFormat.XRGB8888:
 
             def pack(r, g, b, a):
                 r, g, b, a = color_pre_multiply(r, g, b, a, self.background)
@@ -1064,8 +1057,7 @@ def main():
         default="I8",
         choices=[
             "L8", "I1", "I2", "I4", "I8", "A1", "A2", "A4", "A8", "ARGB8888",
-            "XRGB8888", "RGB565", "RGB565A8", "RGB888", "TRUECOLOR",
-            "TRUECOLOR_ALPHA", "AUTO"
+            "XRGB8888", "RGB565", "RGB565A8", "RGB888", "AUTO"
         ])
 
     parser.add_argument('--compress',

--- a/tests/main.py
+++ b/tests/main.py
@@ -145,7 +145,7 @@ def generate_code_coverage_report():
 
 
 def generate_test_images():
-    invalids = (ColorFormat.UNKNOWN, ColorFormat.TRUECOLOR, ColorFormat.TRUECOLOR_ALPHA)
+    invalids = (ColorFormat.UNKNOWN,)
     formats = [i for i in ColorFormat if i not in invalids]
     png_path = os.path.join(lvgl_test_dir, "test_images/pngs")
     pngs = list(Path(png_path).rglob("*.[pP][nN][gG]"))


### PR DESCRIPTION
### Description of the feature or fix

Based on this [commit](https://github.com/lvgl/lvgl/commit/124f9b0f9f045025360e9167ddcf8e7122a083a4) TRUECOLOR usage is now outdated. If I'm not wrong, only RGB8888 should be used for TRUECOLOR and ARGB8888 for TRUE_COLOR_ALPHA

This is what I get when using this tool:

> src/assets/background/background_10.c:268:16: error: 'LV_COLOR_FORMAT_TRUECOLOR' undeclared here (not in a function); did you mean 'LV_COLOR_FORMAT_YUV_END'

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
