### PR TITLE
feat(vg_lite/vector): add compatible processing for non-scissor support

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -132,7 +132,8 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
         lv_point_precise_t p1 = { dsc->scissor_area.x1, dsc->scissor_area.y1 };
         lv_point_precise_t p1_res = lv_vg_lite_matrix_transform_point(&result, &p1);
 
-        lv_point_precise_t p2 = { dsc->scissor_area.x2, dsc->scissor_area.y2 };
+        /* vg-lite bounding_box will crop the pixels on the edge, so +1px is needed here */
+        lv_point_precise_t p2 = { dsc->scissor_area.x2 + 1, dsc->scissor_area.y2 + 1 };
         lv_point_precise_t p2_res = lv_vg_lite_matrix_transform_point(&result, &p2);
 
         lv_vg_lite_path_set_bonding_box(lv_vg_path, p1_res.x, p1_res.y, p2_res.x, p2_res.y);

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -94,9 +94,6 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
         return;
     }
 
-    /* set scissor area */
-    lv_vg_lite_set_scissor_area(&dsc->scissor_area);
-
     /* convert color */
     vg_lite_color_t vg_color = lv_color32_to_vg(dsc->fill_dsc.color, dsc->fill_dsc.opa);
 
@@ -117,6 +114,29 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
     /* get path bounds */
     float min_x, min_y, max_x, max_y;
     lv_vg_lite_path_get_bonding_box(lv_vg_path, &min_x, &min_y, &max_x, &max_y);
+
+    if(vg_lite_query_feature(gcFEATURE_BIT_VG_SCISSOR)) {
+        /* set scissor area */
+        lv_vg_lite_set_scissor_area(&dsc->scissor_area);
+    }
+    else {
+        /* calc inverse matrix */
+        vg_lite_matrix_t result;
+        if(!lv_vg_lite_matrix_inverse(&result, &matrix)) {
+            LV_LOG_ERROR("no inverse matrix");
+            LV_PROFILER_END;
+            return;
+        }
+
+        /* Reverse the clip area on the source */
+        lv_point_precise_t p1 = { dsc->scissor_area.x1, dsc->scissor_area.y1 };
+        lv_point_precise_t p1_res = lv_vg_lite_matrix_transform_point(&result, &p1);
+
+        lv_point_precise_t p2 = { dsc->scissor_area.x2, dsc->scissor_area.y2 };
+        lv_point_precise_t p2_res = lv_vg_lite_matrix_transform_point(&result, &p2);
+
+        lv_vg_lite_path_set_bonding_box(lv_vg_path, p1_res.x, p1_res.y, p2_res.x, p2_res.y);
+    }
 
     switch(dsc->fill_dsc.style) {
         case LV_VECTOR_DRAW_STYLE_SOLID: {
@@ -202,8 +222,10 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
     /* drop path */
     lv_vg_lite_path_drop(u, lv_vg_path);
 
-    /* disable scissor */
-    lv_vg_lite_disable_scissor();
+    if(vg_lite_query_feature(gcFEATURE_BIT_VG_SCISSOR)) {
+        /* disable scissor */
+        lv_vg_lite_disable_scissor();
+    }
 
     LV_PROFILER_END;
 }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1075,17 +1075,17 @@ lv_point_precise_t lv_vg_lite_matrix_transform_point(const vg_lite_matrix_t * ma
 
 void lv_vg_lite_set_scissor_area(const lv_area_t * area)
 {
-    vg_lite_enable_scissor();
-    vg_lite_set_scissor(
-        area->x1,
-        area->y1,
-        lv_area_get_width(area),
-        lv_area_get_height(area));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_enable_scissor());
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_scissor(
+                               area->x1,
+                               area->y1,
+                               lv_area_get_width(area),
+                               lv_area_get_height(area)));
 }
 
 void lv_vg_lite_disable_scissor(void)
 {
-    vg_lite_disable_scissor();
+    LV_VG_LITE_CHECK_ERROR(vg_lite_disable_scissor());
 }
 
 void lv_vg_lite_flush(lv_draw_unit_t * draw_unit)

--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -734,7 +734,6 @@ extern "C" {
     {
         switch(feature) {
             case gcFEATURE_BIT_VG_IM_INDEX_FORMAT:
-            case gcFEATURE_BIT_VG_SCISSOR:
             case gcFEATURE_BIT_VG_BORDER_CULLING:
             case gcFEATURE_BIT_VG_RGBA2_FORMAT:
             case gcFEATURE_BIT_VG_IM_FASTCLAER:


### PR DESCRIPTION
### Description of the feature or fix

Use the inverse matrix to inverse the clipping area to support hardware without scissor features.

![image](https://github.com/lvgl/lvgl/assets/26767803/020c6db1-4622-48c8-969f-b6f0e0f05b8b)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
