### PR TITLE
add ARGB8565 format

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -362,6 +362,21 @@ lv_result_t lv_draw_buf_premultiply(lv_draw_buf_t * draw_buf)
             alpha += alpha_stride;
         }
     }
+    else if(cf == LV_COLOR_FORMAT_ARGB8565) {
+        uint32_t h = draw_buf->header.h;
+        uint32_t w = draw_buf->header.w;
+        uint32_t stride = draw_buf->header.stride;
+        uint8_t * line = (uint8_t *)draw_buf->data;
+        for(uint32_t y = 0; y < h; y++) {
+            uint8_t * pixel = line;
+            for(uint32_t x = 0; x < w; x++) {
+                uint8_t alpha = pixel[2];
+                lv_color16_premultiply((lv_color16_t *)pixel, alpha);
+                pixel += 3;
+            }
+            line += stride;
+        }
+    }
     else if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf)) {
         /*Pass*/
     }

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -230,7 +230,8 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 || cf == LV_COLOR_FORMAT_XRGB8888   \
                 || cf == LV_COLOR_FORMAT_RGB888     \
                 || cf == LV_COLOR_FORMAT_RGB565     \
-                || cf == LV_COLOR_FORMAT_RGB565A8) {
+                || cf == LV_COLOR_FORMAT_RGB565A8   \
+                || cf == LV_COLOR_FORMAT_ARGB8565) {
             res = decode_rgb(decoder, dsc);
         }
 #else
@@ -381,6 +382,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
                      || cf == LV_COLOR_FORMAT_XRGB8888  \
                      || cf == LV_COLOR_FORMAT_RGB888    \
                      || cf == LV_COLOR_FORMAT_RGB565    \
+                     || cf == LV_COLOR_FORMAT_ARGB8565  \
                      || cf == LV_COLOR_FORMAT_RGB565A8;
     if(!supported) {
         LV_LOG_WARN("CF: %d is not supported", cf);
@@ -469,7 +471,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     }
 
     if(cf == LV_COLOR_FORMAT_ARGB8888 || cf == LV_COLOR_FORMAT_XRGB8888 || cf == LV_COLOR_FORMAT_RGB888
-       || cf == LV_COLOR_FORMAT_RGB565) {
+       || cf == LV_COLOR_FORMAT_RGB565 || cf == LV_COLOR_FORMAT_ARGB8565) {
         uint32_t len = (w_px * bpp) / 8;
         offset += decoded_area->y1 * dsc->header.stride;
         offset += decoded_area->x1 * bpp / 8; /*Move to x1*/

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -57,10 +57,11 @@ uint8_t lv_color_format_get_bpp(lv_color_format_t cf)
         case LV_COLOR_FORMAT_A8:
         case LV_COLOR_FORMAT_I8:
             return 8;
+
+        case LV_COLOR_FORMAT_RGB565A8:
         case LV_COLOR_FORMAT_RGB565:
             return 16;
 
-        case LV_COLOR_FORMAT_RGB565A8:
         case LV_COLOR_FORMAT_RGB888:
             return 24;
         case LV_COLOR_FORMAT_ARGB8888:

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -62,6 +62,7 @@ uint8_t lv_color_format_get_bpp(lv_color_format_t cf)
         case LV_COLOR_FORMAT_RGB565:
             return 16;
 
+        case LV_COLOR_FORMAT_ARGB8565:
         case LV_COLOR_FORMAT_RGB888:
             return 24;
         case LV_COLOR_FORMAT_ARGB8888:

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -76,6 +76,7 @@ typedef uint8_t lv_opa_t;
                                             (cf) == LV_COLOR_FORMAT_I8 ? 8 :        \
                                             (cf) == LV_COLOR_FORMAT_RGB565 ? 16 :   \
                                             (cf) == LV_COLOR_FORMAT_RGB565A8 ? 16 : \
+                                            (cf) == LV_COLOR_FORMAT_ARGB8565 ? 24 : \
                                             (cf) == LV_COLOR_FORMAT_RGB888 ? 24 :   \
                                             (cf) == LV_COLOR_FORMAT_ARGB8888 ? 32 : \
                                             (cf) == LV_COLOR_FORMAT_XRGB8888 ? 32 : \
@@ -127,6 +128,7 @@ enum _lv_color_format_t {
 
     /*2 byte (+alpha) formats*/
     LV_COLOR_FORMAT_RGB565            = 0x12,
+    LV_COLOR_FORMAT_ARGB8565          = 0x13,   /**< Not supported by sw renderer yet. */
     LV_COLOR_FORMAT_RGB565A8          = 0x14    /**< Color array followed by Alpha array*/,
 
     /*3 byte (+alpha) formats*/

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -75,7 +75,7 @@ typedef uint8_t lv_opa_t;
                                             (cf) == LV_COLOR_FORMAT_A8 ? 8 :        \
                                             (cf) == LV_COLOR_FORMAT_I8 ? 8 :        \
                                             (cf) == LV_COLOR_FORMAT_RGB565 ? 16 :   \
-                                            (cf) == LV_COLOR_FORMAT_RGB565A8 ? 24 : \
+                                            (cf) == LV_COLOR_FORMAT_RGB565A8 ? 16 : \
                                             (cf) == LV_COLOR_FORMAT_RGB888 ? 24 :   \
                                             (cf) == LV_COLOR_FORMAT_ARGB8888 ? 32 : \
                                             (cf) == LV_COLOR_FORMAT_XRGB8888 ? 32 : \


### PR DESCRIPTION
### Description of the feature or fix

Added definition of ARGB8565.
Change bpp of RGB565A8 to 16. 

For RGB565A8, both 24 and 16 are wrong, 16 is slightly better because that alpha stride is calculated based on map stride which can use 16 as bpp.

Software renderer does not support ARGB8565 yet. Some of the GPU like VG-Lite can support it.
Need to upgrade python image converter script and VG-Lite porting code.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
