### PR TITLE
fix(sysmon): fix build break

### DIFF
--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -205,7 +205,7 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
            "refr %" LV_PRIu32 "ms (render %" LV_PRIu32 "ms | flush %" LV_PRIu32 "ms), "
            "CPU %" LV_PRIu32 "%%\n",
            perf->calculated.fps, perf->measured.refr_cnt, perf->measured.render_cnt, perf->measured.flush_cnt,
-           perf->calculated.refr_avg_time, perf->calculated.render_real_avg_time, perf->calculated.flush_avg_time,
+           perf->calculated.refr_avg_time, perf->calculated.render_avg_time, perf->calculated.flush_avg_time,
            perf->calculated.cpu);
 #else
     lv_label_set_text_fmt(

--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -82,6 +82,9 @@ typedef void * lv_user_data_t;
 /* Simulate VG-Lite hardware using ThorVG */
 #define LV_USE_VG_LITE_THORVG       1
 
+/* Enable performance monitor log mode for build test */
+#define LV_USE_PERF_MONITOR_LOG_MODE 1
+
 #include "lv_test_conf_full.h"
 #elif LV_TEST_OPTION == 4
 #define  LV_COLOR_DEPTH     24


### PR DESCRIPTION
### Description of the feature or fix

```bash
In file included from lvgl/src/others/sysmon/../../others/observer/../../core/../misc/../font/../draw/../misc/lv_assert.h:17,
                 from lvgl/src/others/sysmon/../../others/observer/../../core/../misc/../font/../draw/../misc/lv_color.h:17,
                 from lvgl/src/others/sysmon/../../others/observer/../../core/../misc/../font/../draw/lv_draw_buf.h:17,
                 from lvgl/src/others/sysmon/../../others/observer/../../core/../misc/../font/lv_font.h:22,
                 from lvgl/src/others/sysmon/../../others/observer/../../core/../misc/lv_style.h:18,
                 from lvgl/src/others/sysmon/../../others/observer/../../core/lv_obj.h:21,
                 from lvgl/src/others/sysmon/../../others/observer/lv_observer.h:17,
                 from lvgl/src/others/sysmon/lv_sysmon.h:18,
                 from lvgl/src/others/sysmon/lv_sysmon.c:10:
lvgl/src/others/sysmon/lv_sysmon.c: In function ‘perf_observer_cb’:
lvgl/src/others/sysmon/lv_sysmon.c:208:61: error: ‘const struct <anonymous>’ has no member named ‘render_real_avg_time’; did you mean ‘render_avg_time’?
  208 |            perf->calculated.refr_avg_time, perf->calculated.render_real_avg_time, perf->calculated.flush_avg_time,
      |                                                             ^~~~~~~~~~~~~~~~~~~~
lvgl/src/others/sysmon/../../others/observer/../../core/../misc/../font/../draw/../misc/lv_log.h:140:32: note: in definition of macro ‘LV_LOG’
  140 | #    define LV_LOG(...) lv_log(__VA_ARGS__)
      |                                ^~~~~~~~~~~
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
