### PR TITLE
docs(indev): Document the relation between LV_INDEV_MODE_EVENT and data->continue_reading

### DIFF
--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -258,6 +258,8 @@ You can do this in the following way:
 
 .. note:: that :cpp:func:`lv_indev_read`, :cpp:func:`lv_timer_handler` and :cpp:func:`_lv_display_refr_timer` can not run at the same time.
 
+.. note:: For devices in event-driven mode, `data->continue_reading` is ignored.
+
 Further reading
 ***************
 

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -55,7 +55,7 @@ typedef struct {
     int16_t enc_diff; /**< For LV_INDEV_TYPE_ENCODER number of steps since the previous read*/
 
     lv_indev_state_t state; /**< LV_INDEV_STATE_REL or LV_INDEV_STATE_PR*/
-    bool continue_reading;  /**< If set to true, the read callback is invoked again*/
+    bool continue_reading;  /**< If set to true, the read callback is invoked again, unless the device is in event-driven mode*/
 } lv_indev_data_t;
 
 typedef void (*lv_indev_read_cb_t)(lv_indev_t * indev, lv_indev_data_t * data);


### PR DESCRIPTION
This relation was introduced but not documented in commit 1881ef22d ("feat(indev): in event-driven mode,needn't `continue_reading` (#5363)").

---

The alternative and simpler approach would be to respect data->continue_reading unconditionally. Input devices that don't want to trigger the looping logic should simply never set continue_reading then. The following commits could be reverted:

- commit 7e1588697 ("fix(sdl): fix keyboard handling (#5575)")
- commit 1881ef22d ("feat(indev): in event-driven mode,needn't `continue_reading` (#5363)")

Commit 7e1588697 disproves that continue_reading wasn't needed in event-driven mode.