### PR TITLE
    feat(cache): use unified cache entry free callback

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -422,11 +422,22 @@ static lv_cache_compare_res_t image_decoder_cache_compare_cb(
 
 static void image_decoder_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
 {
-    LV_UNUSED(user_data); /*Unused*/
-
     const lv_image_decoder_t * decoder = entry->decoder;
-    if(decoder && decoder->cache_free_cb) {
+    if(decoder == NULL) return; /* Why ? */
+
+    if(decoder->cache_free_cb) {
+        /* Decoder wants to free the cache by itself. */
         decoder->cache_free_cb(entry, user_data);
+    }
+    else {
+        /* Destroy the decoded draw buffer if necessary. */
+        lv_draw_buf_t * decoded = (lv_draw_buf_t *)entry->decoded;
+        if(lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_ALLOCATED)) {
+            lv_draw_buf_destroy(decoded);
+        }
+
+        /*Free the duplicated file name*/
+        if(entry->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)entry->src);
     }
 }
 

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -278,6 +278,15 @@ void lv_image_decoder_set_get_area_cb(lv_image_decoder_t * decoder, lv_image_dec
  */
 void lv_image_decoder_set_close_cb(lv_image_decoder_t * decoder, lv_image_decoder_close_f_t close_cb);
 
+/**
+ * Set a custom method to free cache data.
+ * Normally this is not needed. If the custom decoder allocates additional memory other than dsc->decoded
+ * draw buffer, then you need to register your own method to free it. By default the cache entry is free'ed
+ * in `image_decoder_cache_free_cb`.
+ *
+ * @param decoder pointer to the image decoder
+ * @param cache_free_cb the custom callback to free cache data. Refer to `image_decoder_cache_free_cb`.
+ */
 void lv_image_decoder_set_cache_free_cb(lv_image_decoder_t * decoder, lv_cache_free_cb_t cache_free_cb);
 
 #if LV_CACHE_DEF_SIZE > 0

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -43,7 +43,6 @@ typedef struct {
 static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
-static void decoder_cache_free(lv_image_cache_data_t * cached_data, void * user_data);
 static void image_color32_pre_mul(lv_color32_t * img_data, uint32_t px_size);
 static void image_invalidate_cache(void * buf, uint32_t stride,
                                    uint32_t width, uint32_t height,
@@ -67,7 +66,7 @@ void lv_vg_lite_decoder_init(void)
     lv_image_decoder_set_info_cb(decoder, decoder_info);
     lv_image_decoder_set_open_cb(decoder, decoder_open);
     lv_image_decoder_set_close_cb(decoder, decoder_close);
-    lv_image_decoder_set_cache_free_cb(decoder, (lv_cache_free_cb_t)decoder_cache_free);
+    lv_image_decoder_set_cache_free_cb(decoder, NULL); /*Use general cache free method*/
 }
 
 void lv_vg_lite_decoder_deinit(void)
@@ -437,14 +436,6 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
     if(decoder->user_data) free(decoder->user_data);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);
-}
-
-static void decoder_cache_free(lv_image_cache_data_t * cached_data, void * user_data)
-{
-    LV_UNUSED(user_data);
-
-    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
-    decoder_draw_buf_free((lv_draw_buf_t *)cached_data->decoded);
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -71,8 +71,6 @@ static lv_fs_res_t fs_read_file_at(lv_fs_file_t * f, uint32_t pos, void * buff, 
 
 static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image_compressed_t * compressed);
 
-static void bin_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data);
-
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -103,7 +101,7 @@ void lv_bin_decoder_init(void)
     lv_image_decoder_set_open_cb(decoder, lv_bin_decoder_open);
     lv_image_decoder_set_get_area_cb(decoder, lv_bin_decoder_get_area);
     lv_image_decoder_set_close_cb(decoder, lv_bin_decoder_close);
-    lv_image_decoder_set_cache_free_cb(decoder, (lv_cache_free_cb_t)bin_decoder_cache_free_cb);
+    lv_image_decoder_set_cache_free_cb(decoder, NULL); /*Use general cache free method*/
 }
 
 lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
@@ -1143,12 +1141,4 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
 
     decoder_data->decompressed = decompressed; /*Free on decoder close*/
     return LV_RESULT_OK;
-}
-
-static void bin_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data)
-{
-    LV_UNUSED(user_data); /*Unused*/
-
-    lv_draw_buf_destroy((lv_draw_buf_t *)cached_data->decoded);
-    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
 }

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -38,7 +38,6 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 static lv_draw_buf_t * decode_jpeg_file(const char * filename);
 static bool get_jpeg_size(const char * filename, uint32_t * width, uint32_t * height);
 static void error_exit(j_common_ptr cinfo);
-static void jpeg_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -60,7 +59,7 @@ void lv_libjpeg_turbo_init(void)
     lv_image_decoder_set_info_cb(dec, decoder_info);
     lv_image_decoder_set_open_cb(dec, decoder_open);
     lv_image_decoder_set_close_cb(dec, decoder_close);
-    lv_image_decoder_set_cache_free_cb(dec, (lv_cache_free_cb_t)jpeg_decoder_cache_free_cb);
+    lv_image_decoder_set_cache_free_cb(dec, NULL); /*Use general cache free method*/
 }
 
 void lv_libjpeg_turbo_deinit(void)
@@ -446,14 +445,6 @@ static void error_exit(j_common_ptr cinfo)
     error_mgr_t * myerr = (error_mgr_t *)cinfo->err;
     (*cinfo->err->output_message)(cinfo);
     longjmp(myerr->jb, 1);
-}
-
-static void jpeg_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data)
-{
-    LV_UNUSED(user_data);
-
-    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
-    lv_draw_buf_destroy((lv_draw_buf_t *)cached_data->decoded);
 }
 
 #endif /*LV_USE_LIBJPEG_TURBO*/

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -28,7 +28,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static lv_draw_buf_t * decode_png_file(const char * filename);
 
-static void png_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -50,7 +49,7 @@ void lv_libpng_init(void)
     lv_image_decoder_set_info_cb(dec, decoder_info);
     lv_image_decoder_set_open_cb(dec, decoder_open);
     lv_image_decoder_set_close_cb(dec, decoder_close);
-    lv_image_decoder_set_cache_free_cb(dec, (lv_cache_free_cb_t)png_decoder_cache_free_cb);
+    lv_image_decoder_set_cache_free_cb(dec, NULL); /*Use general cache free method*/
 }
 
 void lv_libpng_deinit(void)
@@ -283,14 +282,6 @@ static lv_draw_buf_t * decode_png_file(const char * filename)
     }
 
     return decoded;
-}
-
-static void png_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data)
-{
-    LV_UNUSED(user_data);
-
-    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
-    lv_draw_buf_destroy((lv_draw_buf_t *)cached_data->decoded);
 }
 
 #endif /*LV_USE_LIBPNG*/

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -29,7 +29,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
 static void convert_color_depth(uint8_t * img_p, uint32_t px_cnt);
 static lv_draw_buf_t * decode_png_data(const void * png_data, size_t png_data_size);
-static void lodepng_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -51,7 +50,6 @@ void lv_lodepng_init(void)
     lv_image_decoder_set_info_cb(dec, decoder_info);
     lv_image_decoder_set_open_cb(dec, decoder_open);
     lv_image_decoder_set_close_cb(dec, decoder_close);
-    lv_image_decoder_set_cache_free_cb(dec, (lv_cache_free_cb_t)lodepng_decoder_cache_free_cb);
 }
 
 void lv_lodepng_deinit(void)
@@ -269,14 +267,6 @@ static void convert_color_depth(uint8_t * img_p, uint32_t px_cnt)
         img_argb[i].blue = img_argb[i].red;
         img_argb[i].red = blue;
     }
-}
-
-static void lodepng_decoder_cache_free_cb(lv_image_cache_data_t * cached_data, void * user_data)
-{
-    LV_UNUSED(user_data);
-
-    if(cached_data->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)cached_data->src);
-    lv_draw_buf_destroy((lv_draw_buf_t *)cached_data->decoded);
 }
 
 #endif /*LV_USE_LODEPNG*/


### PR DESCRIPTION
### Description of the feature or fix

Before this, the only exception is vg-lite decoder. It needs to check if the draw buffer should be free'd or not. Now it's unified.

User could still set a custom callback to free cache data but all built-in decoders now have the unified callback.

For VG-Lite decoder, the memory of YUV variable image is not allocated by lvgl and thus clear ALLOCATED bit to avoid it being destroyed after decoder closes. And do not add this kind of image to cache, since its life is managed by user.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
