### PR TITLE
fix(vg_lite): fix linear image use after free

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -16,6 +16,7 @@
 #include "lv_vg_lite_path.h"
 #include "lv_vg_lite_utils.h"
 #include "lv_vg_lite_decoder.h"
+#include "lv_vg_lite_grad.h"
 
 /*********************
  *      DEFINES
@@ -70,7 +71,7 @@ void lv_draw_vg_lite_init(void)
     unit->base_unit.delete_cb = draw_delete;
     lv_array_init(&unit->img_dsc_pending, 4, sizeof(lv_image_decoder_dsc_t));
 
-    lv_vg_lite_linear_grad_init(unit);
+    lv_vg_lite_grad_init(unit);
 
     lv_vg_lite_path_init(unit);
 
@@ -243,7 +244,7 @@ static int32_t draw_delete(lv_draw_unit_t * draw_unit)
 {
     lv_draw_vg_lite_unit_t * unit = (lv_draw_vg_lite_unit_t *)draw_unit;
     lv_array_deinit(&unit->img_dsc_pending);
-    lv_vg_lite_linear_grad_deinit(unit);
+    lv_vg_lite_grad_deinit(unit);
     lv_vg_lite_path_deinit(unit);
     lv_vg_lite_decoder_deinit();
     return 1;

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -70,6 +70,8 @@ void lv_draw_vg_lite_init(void)
     unit->base_unit.delete_cb = draw_delete;
     lv_array_init(&unit->img_dsc_pending, 4, sizeof(lv_image_decoder_dsc_t));
 
+    lv_vg_lite_linear_grad_init(unit);
+
     lv_vg_lite_path_init(unit);
 
     lv_vg_lite_decoder_init();
@@ -150,7 +152,7 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
             break;
     }
 
-    lv_vg_lite_flush(draw_unit);
+    lv_vg_lite_flush(u);
 }
 
 static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
@@ -167,7 +169,7 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     /* Return 0 is no selection, some tasks can be supported by other units. */
     if(!t || t->preferred_draw_unit_id != VG_LITE_DRAW_UNIT_ID) {
-        lv_vg_lite_finish(draw_unit);
+        lv_vg_lite_finish(u);
         return -1;
     }
 
@@ -241,6 +243,7 @@ static int32_t draw_delete(lv_draw_unit_t * draw_unit)
 {
     lv_draw_vg_lite_unit_t * unit = (lv_draw_vg_lite_unit_t *)draw_unit;
     lv_array_deinit(&unit->img_dsc_pending);
+    lv_vg_lite_linear_grad_deinit(unit);
     lv_vg_lite_path_deinit(unit);
     lv_vg_lite_decoder_deinit();
     return 1;

--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -197,7 +197,7 @@ void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * d
                                        color,
                                        VG_LITE_FILTER_BI_LINEAR));
             LV_PROFILER_END_TAG("vg_lite_draw_pattern");
-            lv_vg_lite_push_image_decoder_dsc(draw_unit, &decoder_dsc);
+            lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
         }
     }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -14,6 +14,7 @@
 #include "lv_draw_vg_lite_type.h"
 #include "lv_vg_lite_path.h"
 #include "lv_vg_lite_utils.h"
+#include "lv_vg_lite_grad.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -84,6 +84,7 @@ void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t *
 
     if(dsc->grad.dir != LV_GRAD_DIR_NONE) {
         lv_vg_lite_draw_linear_grad(
+            u,
             &u->target_buffer,
             vg_lite_path,
             coords,

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -157,7 +157,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
         lv_vg_lite_path_drop(u, path);
     }
 
-    lv_vg_lite_push_image_decoder_dsc(draw_unit, &decoder_dsc);
+    lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
     LV_PROFILER_END;
 }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -220,7 +220,7 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
      * You need to wait for the GPU to finish using the buffer before releasing it.
      * Later, use the font cache for management to improve efficiency.
      */
-    lv_vg_lite_finish(&u->base_unit);
+    lv_vg_lite_finish(u);
     LV_PROFILER_END;
 }
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -14,6 +14,7 @@
 #include "lv_vg_lite_utils.h"
 #include "lv_vg_lite_path.h"
 #include "lv_draw_vg_lite_type.h"
+#include "lv_vg_lite_grad.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -77,6 +77,7 @@ void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle
 
     if(dsc->bg_grad.dir != LV_GRAD_DIR_NONE) {
         lv_vg_lite_draw_linear_grad(
+            u,
             &u->target_buffer,
             vg_lite_path,
             &tri_area,

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -34,12 +34,11 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-
 struct _lv_draw_vg_lite_unit_t {
     lv_draw_unit_t base_unit;
     lv_draw_task_t * task_act;
     lv_array_t img_dsc_pending;
-    lv_array_t grad_pending;
+    lv_cache_t * grad_cache;
     uint16_t flush_count;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -39,6 +39,7 @@ struct _lv_draw_vg_lite_unit_t {
     lv_draw_task_t * task_act;
     lv_array_t img_dsc_pending;
     lv_cache_t * grad_cache;
+    lv_array_t grad_pending;
     uint16_t flush_count;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -39,6 +39,7 @@ struct _lv_draw_vg_lite_unit_t {
     lv_draw_unit_t base_unit;
     lv_draw_task_t * task_act;
     lv_array_t img_dsc_pending;
+    lv_array_t grad_pending;
     uint16_t flush_count;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -14,6 +14,7 @@
 #include "lv_draw_vg_lite_type.h"
 #include "lv_vg_lite_path.h"
 #include "lv_vg_lite_utils.h"
+#include "lv_vg_lite_grad.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -183,7 +183,7 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
                                                VG_LITE_FILTER_BI_LINEAR));
                     LV_PROFILER_END_TAG("vg_lite_draw_pattern");
 
-                    lv_vg_lite_push_image_decoder_dsc(&u->base_unit, &decoder_dsc);
+                    lv_vg_lite_push_image_decoder_dsc(u, &decoder_dsc);
                 }
             }
             break;
@@ -197,6 +197,7 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
 
                 if(style == LV_VECTOR_GRADIENT_STYLE_LINEAR) {
                     lv_vg_lite_draw_linear_grad(
+                        u,
                         &u->target_buffer,
                         vg_path,
                         &grad_area,

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -1,0 +1,227 @@
+/**
+ * @file lv_vg_lite_grad.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_vg_lite_grad.h"
+
+#if LV_USE_DRAW_VG_LITE
+
+#include "lv_draw_vg_lite_type.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define LV_VG_LITE_GRAD_CACHE_SIZE 16
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    vg_lite_linear_gradient_t vg_grad;
+    lv_grad_dsc_t lv_grad;
+} grad_item_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static vg_lite_linear_gradient_t * lv_vg_lite_linear_grad_get(struct _lv_draw_vg_lite_unit_t * u,
+                                                              const lv_grad_dsc_t * grad);
+
+static bool grad_create_cb(grad_item_t * item, void * user_data);
+static void grad_free_cb(grad_item_t * item, void * user_data);
+static lv_cache_compare_res_t grad_compare_cb(const grad_item_t * lhs, const grad_item_t * rhs);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_vg_lite_grad_init(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    lv_cache_ops_t ops = {
+        .compare_cb = (lv_cache_compare_cb_t)grad_compare_cb,
+        .create_cb = (lv_cache_create_cb_t)grad_create_cb,
+        .free_cb = (lv_cache_free_cb_t)grad_free_cb,
+    };
+
+    u->grad_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(grad_item_t), LV_VG_LITE_GRAD_CACHE_SIZE, ops);
+    LV_ASSERT_NULL(u->grad_cache);
+}
+
+void lv_vg_lite_grad_deinit(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    lv_cache_destroy(u->grad_cache, NULL);
+}
+
+void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
+    vg_lite_buffer_t * buffer,
+    vg_lite_path_t * path,
+    const lv_area_t * area,
+    const lv_grad_dsc_t * grad,
+    const vg_lite_matrix_t * matrix,
+    vg_lite_fill_t fill,
+    vg_lite_blend_t blend)
+{
+    LV_ASSERT_NULL(buffer);
+    LV_ASSERT_NULL(path);
+    LV_ASSERT_NULL(area);
+    LV_ASSERT_NULL(grad);
+    LV_ASSERT_NULL(matrix);
+
+    LV_PROFILER_BEGIN;
+
+    vg_lite_linear_gradient_t * gradient = lv_vg_lite_linear_grad_get(u, grad);
+
+    vg_lite_matrix_t * grad_matrix = vg_lite_get_grad_matrix(gradient);
+    vg_lite_identity(grad_matrix);
+    vg_lite_translate(area->x1, area->y1, grad_matrix);
+
+    if(grad->dir == LV_GRAD_DIR_VER) {
+        vg_lite_scale(1, lv_area_get_height(area) / 256.0f, grad_matrix);
+        vg_lite_rotate(90, grad_matrix);
+    }
+    else if(grad->dir == LV_GRAD_DIR_HOR) {
+        vg_lite_scale(lv_area_get_width(area) / 256.0f, 1, grad_matrix);
+    }
+    else {
+        LV_ASSERT_MSG(false, "Unknown gradient direction");
+    }
+
+    LV_VG_LITE_ASSERT_DEST_BUFFER(buffer);
+    LV_VG_LITE_ASSERT_SRC_BUFFER(&gradient->image);
+    LV_VG_LITE_ASSERT_PATH(path);
+
+    LV_PROFILER_BEGIN_TAG("vg_lite_draw_grad");
+    LV_VG_LITE_CHECK_ERROR(vg_lite_draw_grad(
+                               buffer,
+                               path,
+                               fill,
+                               (vg_lite_matrix_t *)matrix,
+                               gradient,
+                               blend));
+    LV_PROFILER_END_TAG("vg_lite_draw_grad");
+
+    LV_PROFILER_END;
+}
+
+void lv_vg_lite_linear_grad_drop_all(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    lv_cache_drop_all(u->grad_cache, NULL);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static vg_lite_linear_gradient_t * lv_vg_lite_linear_grad_get(struct _lv_draw_vg_lite_unit_t * u,
+                                                              const lv_grad_dsc_t * grad)
+{
+    LV_ASSERT_NULL(u);
+    LV_ASSERT_NULL(grad);
+
+    grad_item_t search_key;
+    lv_memzero(&search_key, sizeof(grad_item_t));
+    search_key.lv_grad = *grad;
+
+    bool cache_hitting = true;
+    lv_cache_entry_t * cache_node_entry = lv_cache_acquire(u->grad_cache, &search_key, NULL);
+    if(cache_node_entry == NULL) {
+        cache_hitting = false;
+        cache_node_entry = lv_cache_acquire_or_create(u->grad_cache, &search_key, NULL);
+        if(cache_node_entry == NULL) {
+            LV_LOG_ERROR("grad cache creating failed");
+            return NULL;
+        }
+    }
+
+    grad_item_t * item = lv_cache_entry_get_data(cache_node_entry);
+    return &item->vg_grad;
+}
+
+static bool grad_create_cb(grad_item_t * item, void * user_data)
+{
+    LV_UNUSED(user_data);
+
+    LV_PROFILER_BEGIN;
+
+    vg_lite_error_t error = vg_lite_init_grad(&item->vg_grad);
+    if(error != VG_LITE_SUCCESS) {
+        LV_PROFILER_END;
+        LV_LOG_ERROR("init grad error(%d): %s", (int)error, lv_vg_lite_error_string(error));
+        return false;
+    }
+
+    vg_lite_uint32_t colors[VLC_MAX_GRADIENT_STOPS];
+    vg_lite_uint32_t stops[VLC_MAX_GRADIENT_STOPS];
+
+    /* Gradient setup */
+    uint8_t cnt = item->lv_grad.stops_count;
+    LV_ASSERT(cnt < VLC_MAX_GRADIENT_STOPS);
+    for(uint8_t i = 0; i < cnt; i++) {
+        stops[i] = item->lv_grad.stops[i].frac;
+        const lv_color_t * c = &item->lv_grad.stops[i].color;
+        lv_opa_t opa = item->lv_grad.stops[i].opa;
+
+        /* lvgl color -> gradient color */
+        lv_color_t grad_color = lv_color_make(c->blue, c->green, c->red);
+        colors[i] = lv_vg_lite_color(grad_color, opa, true);
+    }
+
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&item->vg_grad, cnt, colors, stops));
+
+    LV_PROFILER_BEGIN_TAG("vg_lite_update_grad");
+    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&item->vg_grad));
+    LV_PROFILER_END_TAG("vg_lite_update_grad");
+
+    /* Premultiply the gradient image */
+    lv_color32_t * c32 = item->vg_grad.image.memory;
+    for(int x = 0; x < item->vg_grad.image.width; x++) {
+        lv_color_premultiply(c32);
+        c32++;
+    }
+
+    LV_PROFILER_END;
+    return true;
+}
+
+static void grad_free_cb(grad_item_t * item, void * user_data)
+{
+    LV_UNUSED(user_data);
+    LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&item->vg_grad));
+}
+
+static lv_cache_compare_res_t grad_compare_cb(const grad_item_t * lhs, const grad_item_t * rhs)
+{
+    if(lhs->lv_grad.stops_count != rhs->lv_grad.stops_count) {
+        return lhs->lv_grad.stops_count > rhs->lv_grad.stops_count ? 1 : -1;
+    }
+
+    int cmp_res = memcmp(&lhs->lv_grad, &rhs->lv_grad, sizeof(lhs->lv_grad.stops));
+    if(cmp_res != 0) {
+        return cmp_res > 0 ? 1 : -1;
+    }
+
+    return 0;
+}
+
+#endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -189,10 +189,10 @@ static bool grad_create_cb(grad_item_t * item, void * user_data)
 
     LV_PROFILER_BEGIN;
 
-    vg_lite_error_t error = vg_lite_init_grad(&item->vg_grad);
-    if(error != VG_LITE_SUCCESS) {
+    vg_lite_error_t err = vg_lite_init_grad(&item->vg_grad);
+    if(err != VG_LITE_SUCCESS) {
         LV_PROFILER_END;
-        LV_LOG_ERROR("init grad error(%d): %s", (int)error, lv_vg_lite_error_string(error));
+        LV_LOG_ERROR("init grad error(%d): %s", (int)err, lv_vg_lite_error_string(err));
         return false;
     }
 

--- a/src/draw/vg_lite/lv_vg_lite_grad.h
+++ b/src/draw/vg_lite/lv_vg_lite_grad.h
@@ -1,0 +1,61 @@
+/**
+ * @file lv_vg_lite_grad.h
+ *
+ */
+
+#ifndef LV_VG_LITE_GRAD_H
+#define LV_VG_LITE_GRAD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../lvgl.h"
+
+#if LV_USE_DRAW_VG_LITE
+
+#include "lv_vg_lite_utils.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+void lv_vg_lite_grad_init(struct _lv_draw_vg_lite_unit_t * u);
+
+void lv_vg_lite_grad_deinit(struct _lv_draw_vg_lite_unit_t * u);
+
+void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
+    vg_lite_buffer_t * buffer,
+    vg_lite_path_t * path,
+    const lv_area_t * area,
+    const lv_grad_dsc_t * grad,
+    const vg_lite_matrix_t * matrix,
+    vg_lite_fill_t fill,
+    vg_lite_blend_t blend);
+
+void lv_vg_lite_linear_grad_drop_all(struct _lv_draw_vg_lite_unit_t * u);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_DRAW_VG_LITE*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_VG_LITE_GRAD_H*/

--- a/src/draw/vg_lite/lv_vg_lite_grad.h
+++ b/src/draw/vg_lite/lv_vg_lite_grad.h
@@ -46,7 +46,7 @@ void lv_vg_lite_draw_linear_grad(
     vg_lite_fill_t fill,
     vg_lite_blend_t blend);
 
-void lv_vg_lite_linear_grad_drop_all(struct _lv_draw_vg_lite_unit_t * u);
+void lv_vg_lite_linear_grad_release_all(struct _lv_draw_vg_lite_unit_t * u);
 
 /**********************
  *      MACROS

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -40,6 +40,11 @@
  *      TYPEDEFS
  **********************/
 
+typedef struct {
+    vg_lite_linear_gradient_t grad;
+    bool in_use;
+} gradient_item_t;
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -612,15 +617,15 @@ void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, co
     }
 }
 
-void lv_vg_lite_push_image_decoder_dsc(lv_draw_unit_t * draw_unit, lv_image_decoder_dsc_t * img_dsc)
+void lv_vg_lite_push_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u, lv_image_decoder_dsc_t * img_dsc)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    LV_ASSERT_NULL(u);
+    LV_ASSERT_NULL(img_dsc);
     lv_array_push_back(&u->img_dsc_pending, img_dsc);
 }
 
-void lv_vg_lite_clear_image_decoder_dsc(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_clear_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
     lv_array_t * arr = &u->img_dsc_pending;
     uint32_t size = lv_array_size(arr);
     if(size == 0) {
@@ -913,7 +918,73 @@ bool lv_vg_lite_16px_align(void)
     return vg_lite_query_feature(gcFEATURE_BIT_VG_16PIXELS_ALIGN);
 }
 
+static vg_lite_linear_gradient_t * lv_vg_lite_linear_grad_get(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        if(!item[i].in_use) {
+            /* Mark as in use */
+            item[i].in_use = true;
+            LV_LOG_TRACE("get gradient: %p", &item[i].grad);
+
+            /* return the gradient */
+            return &item[i].grad;
+        }
+    }
+
+    /* No free gradient, create a new one */
+    gradient_item_t new_item;
+    lv_memzero(&new_item, sizeof(new_item));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_init_grad(&new_item.grad));
+    LV_ASSERT(lv_array_push_back(&u->grad_pending, &new_item) == LV_RESULT_OK);
+
+    /* Get the last one */
+    gradient_item_t * back = lv_array_back(&u->grad_pending);
+    LV_ASSERT_NULL(back);
+    return &back->grad;
+}
+
+static void lv_vg_lite_linear_grad_drop_all(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        if(item[i].in_use) {
+            LV_LOG_TRACE("drop gradient: %p", &item[i].grad);
+            item[i].in_use = false;
+        }
+    }
+}
+
+void lv_vg_lite_linear_grad_init(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    lv_array_init(&u->grad_pending, 4, sizeof(gradient_item_t));
+}
+
+void lv_vg_lite_linear_grad_deinit(struct _lv_draw_vg_lite_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+
+    /* Clear all pending gradients */
+    uint32_t size = lv_array_size(&u->grad_pending);
+    gradient_item_t * item = lv_array_front(&u->grad_pending);
+    for(uint32_t i = 0; i < size; i++) {
+        LV_ASSERT_MSG(!item[i].in_use, "gradient is still in use");
+        LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&item[i].grad));
+    }
+
+    /* Deinit array */
+    lv_array_deinit(&u->grad_pending);
+}
+
 void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
     vg_lite_buffer_t * buffer,
     vg_lite_path_t * path,
     const lv_area_t * area,
@@ -947,17 +1018,14 @@ void lv_vg_lite_draw_linear_grad(
         colors[i] = lv_vg_lite_color(grad_color, opa, true);
     }
 
-    vg_lite_linear_gradient_t gradient;
-    lv_memzero(&gradient, sizeof(gradient));
-
-    LV_VG_LITE_CHECK_ERROR(vg_lite_init_grad(&gradient));
-    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&gradient, cnt, colors, stops));
+    vg_lite_linear_gradient_t * gradient = lv_vg_lite_linear_grad_get(u);
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(gradient, cnt, colors, stops));
 
     LV_PROFILER_BEGIN_TAG("vg_lite_update_grad");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&gradient));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(gradient));
     LV_PROFILER_END_TAG("vg_lite_update_grad");
 
-    vg_lite_matrix_t * grad_matrix = vg_lite_get_grad_matrix(&gradient);
+    vg_lite_matrix_t * grad_matrix = vg_lite_get_grad_matrix(gradient);
     vg_lite_identity(grad_matrix);
     vg_lite_translate(area->x1, area->y1, grad_matrix);
 
@@ -979,11 +1047,10 @@ void lv_vg_lite_draw_linear_grad(
                                path,
                                fill,
                                (vg_lite_matrix_t *)matrix,
-                               &gradient,
+                               gradient,
                                blend));
     LV_PROFILER_END_TAG("vg_lite_draw_grad");
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&gradient));
     LV_PROFILER_END;
 }
 
@@ -1092,10 +1159,10 @@ void lv_vg_lite_disable_scissor(void)
     LV_VG_LITE_CHECK_ERROR(vg_lite_disable_scissor());
 }
 
-void lv_vg_lite_flush(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
 {
+    LV_ASSERT_NULL(u);
     LV_PROFILER_BEGIN;
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     u->flush_count++;
 
@@ -1120,15 +1187,18 @@ void lv_vg_lite_flush(lv_draw_unit_t * draw_unit)
     LV_PROFILER_END;
 }
 
-void lv_vg_lite_finish(lv_draw_unit_t * draw_unit)
+void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u)
 {
+    LV_ASSERT_NULL(u);
     LV_PROFILER_BEGIN;
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
 
+    /* Clear all pending gradients */
+    lv_vg_lite_linear_grad_drop_all(u);
+
     /* Clear image decoder dsc reference */
-    lv_vg_lite_clear_image_decoder_dsc(draw_unit);
+    lv_vg_lite_clear_image_decoder_dsc(u);
     u->flush_count = 0;
     LV_PROFILER_END;
 }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1055,7 +1055,7 @@ void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u)
     LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
 
     /* Clear all gradient caches */
-    lv_vg_lite_linear_grad_drop_all(u);
+    lv_vg_lite_linear_grad_release_all(u);
 
     /* Clear image decoder dsc reference */
     lv_vg_lite_clear_image_decoder_dsc(u);

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -70,6 +70,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+struct _lv_draw_vg_lite_unit_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -122,9 +124,9 @@ void lv_vg_lite_buffer_from_draw_buf(vg_lite_buffer_t * buffer, const lv_draw_bu
 
 void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, const lv_draw_image_dsc_t * dsc);
 
-void lv_vg_lite_push_image_decoder_dsc(lv_draw_unit_t * draw_unit, lv_image_decoder_dsc_t * img_dsc);
+void lv_vg_lite_push_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u, lv_image_decoder_dsc_t * img_dsc);
 
-void lv_vg_lite_clear_image_decoder_dsc(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_clear_image_decoder_dsc(struct _lv_draw_vg_lite_unit_t * u);
 
 bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_dsc_t * decoder_dsc, const void * src,
                                   bool no_cache);
@@ -149,7 +151,12 @@ bool lv_vg_lite_support_blend_normal(void);
 
 bool lv_vg_lite_16px_align(void);
 
+void lv_vg_lite_linear_grad_init(struct _lv_draw_vg_lite_unit_t * u);
+
+void lv_vg_lite_linear_grad_deinit(struct _lv_draw_vg_lite_unit_t * u);
+
 void lv_vg_lite_draw_linear_grad(
+    struct _lv_draw_vg_lite_unit_t * u,
     vg_lite_buffer_t * buffer,
     vg_lite_path_t * path,
     const lv_area_t * area,
@@ -170,9 +177,9 @@ void lv_vg_lite_set_scissor_area(const lv_area_t * area);
 
 void lv_vg_lite_disable_scissor(void);
 
-void lv_vg_lite_flush(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u);
 
-void lv_vg_lite_finish(lv_draw_unit_t * draw_unit);
+void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u);
 
 /**********************
  *      MACROS

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -151,20 +151,6 @@ bool lv_vg_lite_support_blend_normal(void);
 
 bool lv_vg_lite_16px_align(void);
 
-void lv_vg_lite_linear_grad_init(struct _lv_draw_vg_lite_unit_t * u);
-
-void lv_vg_lite_linear_grad_deinit(struct _lv_draw_vg_lite_unit_t * u);
-
-void lv_vg_lite_draw_linear_grad(
-    struct _lv_draw_vg_lite_unit_t * u,
-    vg_lite_buffer_t * buffer,
-    vg_lite_path_t * path,
-    const lv_area_t * area,
-    const lv_grad_dsc_t * grad,
-    const vg_lite_matrix_t * matrix,
-    vg_lite_fill_t fill,
-    vg_lite_blend_t blend);
-
 void lv_vg_lite_matrix_multiply(vg_lite_matrix_t * matrix, const vg_lite_matrix_t * mult);
 
 void lv_vg_lite_matrix_flip_y(vg_lite_matrix_t * matrix);


### PR DESCRIPTION
### Description of the feature or fix

linear grad in vg-lite is simulated using image, which means that `vg_lite_clear_grad` cannot be called immediately after calling `vg_lite_draw_grad` to free the image memory because the GPU may not have finished drawing.
Therefore, I introduced cache for management. On the one hand, it can reduce the overhead of frequently creating grad image images, and on the other hand, it can solve the problem of using after free asynchronous rendering by using delayed release.

cc @W-Mai 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
