### PR TITLE
Windows: Size window to have a client size of requested rectangle

### DIFF
--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -126,6 +126,10 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
         window_style &= ~(WS_SIZEBOX | WS_MAXIMIZEBOX | WS_THICKFRAME);
     }
 
+    // ask Windows how big a window needs to be for hor_res and ver_res
+    RECT rect = { 0, 0, data->hor_res, data->ver_res };
+    AdjustWindowRect(&rect, window_style, false);
+
     HWND window_handle = CreateWindowExW(
                              WS_EX_CLIENTEDGE,
                              L"LVGL.Window",
@@ -133,8 +137,8 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
                              window_style,
                              CW_USEDEFAULT,
                              0,
-                             data->hor_res,
-                             data->ver_res,
+                             rect.right - rect.left,
+                             rect.bottom - rect.top,
                              NULL,
                              NULL,
                              NULL,


### PR DESCRIPTION
### Description of the feature or fix

Creating a window in Windows only vaguely respects the `hor_res` and `ver_res` parameters.
With this proposal, the window decoration is better taken into account, creating a window that is more close to the requested size.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
