### PR TITLE
fix(demo): fix memory leak in vector demo

### DIFF
--- a/demos/vector_graphic/lv_demo_vector_graphic.c
+++ b/demos/vector_graphic/lv_demo_vector_graphic.c
@@ -242,6 +242,13 @@ static void draw_vector(lv_layer_t * layer)
     lv_vector_dsc_delete(ctx);
 }
 
+static void delete_event_cb(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target(e);
+    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
+    lv_draw_buf_destroy(draw_buf);
+}
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -259,6 +266,7 @@ void lv_demo_vector_graphic(void)
     lv_draw_buf_t * draw_buf = lv_draw_buf_create(WIDTH, HEIGHT, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
     lv_obj_t * canvas = lv_canvas_create(lv_scr_act());
     lv_canvas_set_draw_buf(canvas, draw_buf);
+    lv_obj_add_event_cb(canvas, delete_event_cb, LV_EVENT_DELETE, NULL);
 
     lv_layer_t layer;
     lv_canvas_init_layer(canvas, &layer);


### PR DESCRIPTION
### Description of the feature or fix

The canvas doesn't free the draw buffer on delete.

The other option would be to use a static buffer, but it wouldn't play well with stride and multi-instance support. 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
