### PR TITLE
fix(freetype): fix build break when disable LV_USE_FS_MEMFS

### DIFF
--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -360,15 +360,18 @@ static FTC_FaceID lv_freetype_req_face_id(lv_freetype_context_t * ctx, const cha
     node = _lv_ll_ins_tail(ll_p);
     LV_ASSERT_MALLOC(node);
 
-    if(LV_FS_MEMFS_LETTER == pathname[0]) {
-        len = sizeof(lv_fs_path_ex_t);
+#if LV_USE_FS_MEMFS
+    if(pathname[0] == LV_FS_MEMFS_LETTER) {
+        node->pathname = lv_malloc(sizeof(lv_fs_path_ex_t));
+        LV_ASSERT_MALLOC(node->pathname);
+        lv_memcpy(node->pathname, pathname, sizeof(lv_fs_path_ex_t));
     }
-    else {
-        len++;
+    else
+#endif
+    {
+        node->pathname = lv_strdup(pathname);
+        LV_ASSERT_NULL(node->pathname);
     }
-    node->pathname = lv_malloc(len);
-    LV_ASSERT_MALLOC(node->pathname);
-    memcpy(node->pathname, pathname, len);
 
     LV_LOG_INFO("add face_id: %s", node->pathname);
 

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -362,6 +362,9 @@ static FTC_FaceID lv_freetype_req_face_id(lv_freetype_context_t * ctx, const cha
 
 #if LV_USE_FS_MEMFS
     if(pathname[0] == LV_FS_MEMFS_LETTER) {
+#if !LV_FREETYPE_USE_LVGL_PORT
+        LV_LOG_WARN("LV_FREETYPE_USE_LVGL_PORT is not enabled");
+#endif
         node->pathname = lv_malloc(sizeof(lv_fs_path_ex_t));
         LV_ASSERT_MALLOC(node->pathname);
         lv_memcpy(node->pathname, pathname, sizeof(lv_fs_path_ex_t));


### PR DESCRIPTION
### Description of the feature or fix

```bash
lvgl/src/libs/freetype/lv_freetype.c: In function ‘lv_freetype_req_face_id’:
lvgl/src/libs/freetype/lv_freetype.c:363:8: error: ‘LV_FS_MEMFS_LETTER’ undeclared (first use in this function); did you mean ‘LV_FS_POSIX_LETTER’?
  363 |     if(LV_FS_MEMFS_LETTER == pathname[0]) {
      |        ^~~~~~~~~~~~~~~~~~
      |        LV_FS_POSIX_LETTER
```

cc @hpfaz 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
