### PR TITLE
chore: add stride information in the image resource file

### DIFF
--- a/demos/benchmark/assets/img_benchmark_cogwheel_alpha256.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_alpha256.c
@@ -133,6 +133,7 @@ const lv_image_dsc_t img_benchmark_cogwheel_alpha256 = {
     .header.cf = LV_COLOR_FORMAT_A8,
     .header.w = 100,
     .header.h = 100,
+    .header.stride = 100,
     .data = img_benchmark_cogwheel_alpha256_map,
     .data_size = sizeof(img_benchmark_cogwheel_alpha256_map),
 };

--- a/demos/benchmark/assets/img_benchmark_cogwheel_argb.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_argb.c
@@ -424,7 +424,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_ARGB uint8_t img_be
 const lv_image_dsc_t img_benchmark_cogwheel_argb = {
     .header.w = 100,
     .header.h = 100,
-    //    .data_size = 10000 * LV_COLOR_FORMAT_NATIVE_ALPHA_SIZE,
+    .header.stride = LV_COLOR_DEPTH == 16 ? 200 : 400,
     .header.cf = LV_COLOR_DEPTH == 16 ? LV_COLOR_FORMAT_RGB565A8 : LV_COLOR_FORMAT_ARGB8888,
     .data = img_benchmark_cogwheel_argb_map,
     .data_size = sizeof(img_benchmark_cogwheel_argb_map),

--- a/demos/benchmark/assets/img_benchmark_cogwheel_indexed16.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_indexed16.c
@@ -134,6 +134,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_INDEXED16 uint8_t i
 const lv_image_dsc_t img_benchmark_cogwheel_indexed16 = {
     .header.w = 100,
     .header.h = 100,
+    .header.stride = 50,
     .header.cf = LV_COLOR_FORMAT_I4,
     .data = img_benchmark_cogwheel_indexed16_map,
     .data_size = sizeof(img_benchmark_cogwheel_indexed16_map),

--- a/demos/benchmark/assets/img_benchmark_cogwheel_rgb.c
+++ b/demos/benchmark/assets/img_benchmark_cogwheel_rgb.c
@@ -325,6 +325,13 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_RGB uint8_t img_ben
 const lv_image_dsc_t img_benchmark_cogwheel_rgb = {
     .header.w = 100,
     .header.h = 100,
+#if LV_COLOR_DEPTH == 1 || LV_COLOR_DEPTH == 8
+    .header.stride = 100,
+#elif LV_COLOR_DEPTH == 16
+    .header.stride = 200,
+#elif LV_COLOR_DEPTH == 32
+    .header.stride = 400,
+#endif
     .header.cf = LV_COLOR_FORMAT_NATIVE,
     .data = img_benchmark_cogwheel_rgb_map,
     .data_size = sizeof(img_benchmark_cogwheel_rgb_map),

--- a/demos/multilang/assets/avatars/img_multilang_avatar_1.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_1.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_1 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_1_map,
     .data_size = sizeof(img_multilang_avatar_1_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_10.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_10.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_10 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_10_map,
     .data_size = sizeof(img_multilang_avatar_10_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_11.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_11.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_11 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_11_map,
     .data_size = sizeof(img_multilang_avatar_11_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_12.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_12.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_12 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_12_map,
     .data_size = sizeof(img_multilang_avatar_12_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_13.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_13.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_13 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_13_map,
     .data_size = sizeof(img_multilang_avatar_13_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_14.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_14.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_14 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_14_map,
     .data_size = sizeof(img_multilang_avatar_14_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_15.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_15.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_15 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_15_map,
     .data_size = sizeof(img_multilang_avatar_15_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_16.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_16.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_16 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_16_map,
     .data_size = sizeof(img_multilang_avatar_16_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_17.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_17.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_17 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_17_map,
     .data_size = sizeof(img_multilang_avatar_17_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_18.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_18.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_18 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_18_map,
     .data_size = sizeof(img_multilang_avatar_18_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_19.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_19.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_19 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_19_map,
     .data_size = sizeof(img_multilang_avatar_19_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_2.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_2.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_2 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_2_map,
     .data_size = sizeof(img_multilang_avatar_2_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_22.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_22.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_22 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_22_map,
     .data_size = sizeof(img_multilang_avatar_22_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_25.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_25.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_25 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_25_map,
     .data_size = sizeof(img_multilang_avatar_25_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_3.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_3.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_3 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_3_map,
     .data_size = sizeof(img_multilang_avatar_3_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_4.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_4.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_4 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_4_map,
     .data_size = sizeof(img_multilang_avatar_4_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_5.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_5.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_5 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_5_map,
     .data_size = sizeof(img_multilang_avatar_5_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_6.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_6.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_6 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_6_map,
     .data_size = sizeof(img_multilang_avatar_6_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_7.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_7.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_7 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_7_map,
     .data_size = sizeof(img_multilang_avatar_7_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_8.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_8.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_8 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_8_map,
     .data_size = sizeof(img_multilang_avatar_8_map),
 };

--- a/demos/multilang/assets/avatars/img_multilang_avatar_9.c
+++ b/demos/multilang/assets/avatars/img_multilang_avatar_9.c
@@ -158,6 +158,7 @@ const lv_image_dsc_t img_multilang_avatar_9 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 128,
     .header.h = 128,
+    .header.stride = 512,
     .data = img_multilang_avatar_9_map,
     .data_size = sizeof(img_multilang_avatar_9_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_artist_palette.c
+++ b/demos/multilang/assets/emojis/img_emoji_artist_palette.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_artist_palette = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_artist_palette_map,
     .data_size = sizeof(img_emoji_artist_palette_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_books.c
+++ b/demos/multilang/assets/emojis/img_emoji_books.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_books = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_books_map,
     .data_size = sizeof(img_emoji_books_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_camera_with_flash.c
+++ b/demos/multilang/assets/emojis/img_emoji_camera_with_flash.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_camera_with_flash = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_camera_with_flash_map,
     .data_size = sizeof(img_emoji_camera_with_flash_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_cat_face.c
+++ b/demos/multilang/assets/emojis/img_emoji_cat_face.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_cat_face = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_cat_face_map,
     .data_size = sizeof(img_emoji_cat_face_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_deciduous_tree.c
+++ b/demos/multilang/assets/emojis/img_emoji_deciduous_tree.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_deciduous_tree = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 16,
     .header.h = 19,
+    .header.stride = 64,
     .data = img_emoji_deciduous_tree_map,
     .data_size = sizeof(img_emoji_deciduous_tree_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_dog_face.c
+++ b/demos/multilang/assets/emojis/img_emoji_dog_face.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_dog_face = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_dog_face_map,
     .data_size = sizeof(img_emoji_dog_face_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_earth_globe_europe_africa.c
+++ b/demos/multilang/assets/emojis/img_emoji_earth_globe_europe_africa.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_earth_globe_europe_africa = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 19,
     .header.h = 19,
+    .header.stride = 76,
     .data = img_emoji_earth_globe_europe_africa_map,
     .data_size = sizeof(img_emoji_earth_globe_europe_africa_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_flexed_biceps.c
+++ b/demos/multilang/assets/emojis/img_emoji_flexed_biceps.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_flexed_biceps = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_flexed_biceps_map,
     .data_size = sizeof(img_emoji_flexed_biceps_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_movie_camera.c
+++ b/demos/multilang/assets/emojis/img_emoji_movie_camera.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_movie_camera = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_movie_camera_map,
     .data_size = sizeof(img_emoji_movie_camera_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_red_heart.c
+++ b/demos/multilang/assets/emojis/img_emoji_red_heart.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_red_heart = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_red_heart_map,
     .data_size = sizeof(img_emoji_red_heart_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_rocket.c
+++ b/demos/multilang/assets/emojis/img_emoji_rocket.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_rocket = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 16,
     .header.h = 19,
+    .header.stride = 64,
     .data = img_emoji_rocket_map,
     .data_size = sizeof(img_emoji_rocket_map),
 };

--- a/demos/multilang/assets/emojis/img_emoji_soccer_ball.c
+++ b/demos/multilang/assets/emojis/img_emoji_soccer_ball.c
@@ -49,6 +49,7 @@ const lv_image_dsc_t img_emoji_soccer_ball = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 18,
     .header.h = 19,
+    .header.stride = 72,
     .data = img_emoji_soccer_ball_map,
     .data_size = sizeof(img_emoji_soccer_ball_map),
 };

--- a/demos/multilang/assets/img_multilang_like.c
+++ b/demos/multilang/assets/img_multilang_like.c
@@ -47,6 +47,7 @@ const lv_image_dsc_t img_multilang_like = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 20,
     .header.h = 17,
+    .header.stride = 80,
     .data = img_multilang_like_map,
     .data_size = sizeof(img_multilang_like_map),
 };

--- a/demos/music/assets/img_lv_demo_music_btn_corner_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_corner_large.c
@@ -49,6 +49,7 @@ img_lv_demo_music_btn_corner_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_corner = {
     .header.w = 32,
     .header.h = 32,
+    .header.stride = 128,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_corner_map,
     .data_size = sizeof(img_lv_demo_music_btn_corner_map),

--- a/demos/music/assets/img_lv_demo_music_btn_list_pause.c
+++ b/demos/music/assets/img_lv_demo_music_btn_list_pause.c
@@ -71,6 +71,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_list_pause_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_list_pause = {
     .header.w = 58,
     .header.h = 60,
+    .header.stride = 232,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_list_pause_map,
     .data_size = sizeof(img_lv_demo_music_btn_list_pause_map),

--- a/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c
@@ -122,6 +122,7 @@ img_lv_demo_music_btn_list_pause_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_list_pause = {
     .header.w = 106,
     .header.h = 105,
+    .header.stride = 424,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_list_pause_map,
     .data_size = sizeof(img_lv_demo_music_btn_list_pause_map),

--- a/demos/music/assets/img_lv_demo_music_btn_list_play.c
+++ b/demos/music/assets/img_lv_demo_music_btn_list_play.c
@@ -71,6 +71,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_list_play_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_list_play = {
     .header.w = 58,
     .header.h = 60,
+    .header.stride = 232,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_list_play_map,
     .data_size = sizeof(img_lv_demo_music_btn_list_play_map),

--- a/demos/music/assets/img_lv_demo_music_btn_list_play_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_list_play_large.c
@@ -122,6 +122,7 @@ img_lv_demo_music_btn_list_play_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_list_play = {
     .header.w = 106,
     .header.h = 105,
+    .header.stride = 424,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_list_play_map,
     .data_size = sizeof(img_lv_demo_music_btn_list_play_map),

--- a/demos/music/assets/img_lv_demo_music_btn_loop.c
+++ b/demos/music/assets/img_lv_demo_music_btn_loop.c
@@ -35,6 +35,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_loop_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_loop = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_loop_map,
     .data_size = sizeof(img_lv_demo_music_btn_loop_map),

--- a/demos/music/assets/img_lv_demo_music_btn_loop_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_loop_large.c
@@ -53,6 +53,7 @@ img_lv_demo_music_btn_loop_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_loop = {
     .header.w = 37,
     .header.h = 36,
+    .header.stride = 148,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_loop_map,
     .data_size = sizeof(img_lv_demo_music_btn_loop_map),

--- a/demos/music/assets/img_lv_demo_music_btn_next.c
+++ b/demos/music/assets/img_lv_demo_music_btn_next.c
@@ -73,6 +73,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_next_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_next = {
     .header.w = 62,
     .header.h = 62,
+    .header.stride = 248,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_next_map,
     .data_size = sizeof(img_lv_demo_music_btn_next_map),

--- a/demos/music/assets/img_lv_demo_music_btn_next_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_next_large.c
@@ -127,6 +127,7 @@ img_lv_demo_music_btn_next_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_next = {
     .header.w = 110,
     .header.h = 110,
+    .header.stride = 440,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_next_map,
     .data_size = sizeof(img_lv_demo_music_btn_next_map),

--- a/demos/music/assets/img_lv_demo_music_btn_pause.c
+++ b/demos/music/assets/img_lv_demo_music_btn_pause.c
@@ -88,6 +88,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_pause_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_pause = {
     .header.w = 79,
     .header.h = 77,
+    .header.stride = 316,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_pause_map,
     .data_size = sizeof(img_lv_demo_music_btn_pause_map),

--- a/demos/music/assets/img_lv_demo_music_btn_pause_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_pause_large.c
@@ -160,6 +160,7 @@ img_lv_demo_music_btn_pause_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_pause = {
     .header.w = 141,
     .header.h = 142,
+    .header.stride = 564,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_pause_map,
     .data_size = sizeof(img_lv_demo_music_btn_pause_map),

--- a/demos/music/assets/img_lv_demo_music_btn_play.c
+++ b/demos/music/assets/img_lv_demo_music_btn_play.c
@@ -88,6 +88,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_play_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_play = {
     .header.w = 79,
     .header.h = 77,
+    .header.stride = 316,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_play_map,
     .data_size = sizeof(img_lv_demo_music_btn_play_map),

--- a/demos/music/assets/img_lv_demo_music_btn_play_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_play_large.c
@@ -160,6 +160,7 @@ img_lv_demo_music_btn_play_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_play = {
     .header.w = 141,
     .header.h = 142,
+    .header.stride = 564,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_play_map,
     .data_size = sizeof(img_lv_demo_music_btn_play_map),

--- a/demos/music/assets/img_lv_demo_music_btn_prev.c
+++ b/demos/music/assets/img_lv_demo_music_btn_prev.c
@@ -73,6 +73,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_prev_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_prev = {
     .header.w = 62,
     .header.h = 62,
+    .header.stride = 248,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_prev_map,
     .data_size = sizeof(img_lv_demo_music_btn_prev_map),

--- a/demos/music/assets/img_lv_demo_music_btn_prev_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_prev_large.c
@@ -128,6 +128,7 @@ img_lv_demo_music_btn_prev_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_prev = {
     .header.w = 110,
     .header.h = 110,
+    .header.stride = 440,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_prev_map,
     .data_size = sizeof(img_lv_demo_music_btn_prev_map),

--- a/demos/music/assets/img_lv_demo_music_btn_rnd.c
+++ b/demos/music/assets/img_lv_demo_music_btn_rnd.c
@@ -35,6 +35,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_btn_rnd_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_rnd = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_rnd_map,
     .data_size = sizeof(img_lv_demo_music_btn_rnd_map),

--- a/demos/music/assets/img_lv_demo_music_btn_rnd_large.c
+++ b/demos/music/assets/img_lv_demo_music_btn_rnd_large.c
@@ -53,6 +53,7 @@ img_lv_demo_music_btn_rnd_map[] = {
 const lv_image_dsc_t img_lv_demo_music_btn_rnd = {
     .header.w = 37,
     .header.h = 36,
+    .header.stride = 148,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_btn_rnd_map,
     .data_size = sizeof(img_lv_demo_music_btn_rnd_map),

--- a/demos/music/assets/img_lv_demo_music_corner_left.c
+++ b/demos/music/assets/img_lv_demo_music_corner_left.c
@@ -29,6 +29,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_corner_left_map[] = {
 const lv_image_dsc_t img_lv_demo_music_corner_left = {
     .header.w = 18,
     .header.h = 18,
+    .header.stride = 72,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_corner_left_map,
     .data_size = sizeof(img_lv_demo_music_corner_left_map),

--- a/demos/music/assets/img_lv_demo_music_corner_left_large.c
+++ b/demos/music/assets/img_lv_demo_music_corner_left_large.c
@@ -51,6 +51,7 @@ img_lv_demo_music_corner_left_map[] = {
 const lv_image_dsc_t img_lv_demo_music_corner_left = {
     .header.w = 32,
     .header.h = 32,
+    .header.stride = 128,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_corner_left_map,
     .data_size = sizeof(img_lv_demo_music_corner_left_map),

--- a/demos/music/assets/img_lv_demo_music_corner_right.c
+++ b/demos/music/assets/img_lv_demo_music_corner_right.c
@@ -29,6 +29,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_corner_right_map[] = {
 const lv_image_dsc_t img_lv_demo_music_corner_right = {
     .header.w = 18,
     .header.h = 18,
+    .header.stride = 72,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_corner_right_map,
     .data_size = sizeof(img_lv_demo_music_corner_right_map),

--- a/demos/music/assets/img_lv_demo_music_corner_right_large.c
+++ b/demos/music/assets/img_lv_demo_music_corner_right_large.c
@@ -51,6 +51,7 @@ img_lv_demo_music_corner_right_map[] = {
 const lv_image_dsc_t img_lv_demo_music_corner_right = {
     .header.w = 32,
     .header.h = 32,
+    .header.stride = 128,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_corner_right_map,
     .data_size = sizeof(img_lv_demo_music_corner_right_map),

--- a/demos/music/assets/img_lv_demo_music_icon_1.c
+++ b/demos/music/assets/img_lv_demo_music_icon_1.c
@@ -36,6 +36,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_icon_1_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_1 = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_1_map,
     .data_size = sizeof(img_lv_demo_music_icon_1_map),

--- a/demos/music/assets/img_lv_demo_music_icon_1_large.c
+++ b/demos/music/assets/img_lv_demo_music_icon_1_large.c
@@ -49,6 +49,7 @@ img_lv_demo_music_icon_1_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_1 = {
     .header.w = 30,
     .header.h = 30,
+    .header.stride = 120,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_1_map,
     .data_size = sizeof(img_lv_demo_music_icon_1_map),

--- a/demos/music/assets/img_lv_demo_music_icon_2.c
+++ b/demos/music/assets/img_lv_demo_music_icon_2.c
@@ -36,6 +36,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_icon_2_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_2 = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_2_map,
     .data_size = sizeof(img_lv_demo_music_icon_2_map),

--- a/demos/music/assets/img_lv_demo_music_icon_2_large.c
+++ b/demos/music/assets/img_lv_demo_music_icon_2_large.c
@@ -50,6 +50,7 @@ img_lv_demo_music_icon_2_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_2 = {
     .header.w = 31,
     .header.h = 31,
+    .header.stride = 124,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_2_map,
     .data_size = sizeof(img_lv_demo_music_icon_2_map),

--- a/demos/music/assets/img_lv_demo_music_icon_3.c
+++ b/demos/music/assets/img_lv_demo_music_icon_3.c
@@ -36,6 +36,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_icon_3_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_3 = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_3_map,
     .data_size = sizeof(img_lv_demo_music_icon_3_map),

--- a/demos/music/assets/img_lv_demo_music_icon_3_large.c
+++ b/demos/music/assets/img_lv_demo_music_icon_3_large.c
@@ -51,6 +51,7 @@ img_lv_demo_music_icon_3_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_3 = {
     .header.w = 34,
     .header.h = 32,
+    .header.stride = 136,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_3_map,
     .data_size = sizeof(img_lv_demo_music_icon_3_map),

--- a/demos/music/assets/img_lv_demo_music_icon_4.c
+++ b/demos/music/assets/img_lv_demo_music_icon_4.c
@@ -36,6 +36,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_icon_4_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_4 = {
     .header.w = 24,
     .header.h = 24,
+    .header.stride = 96,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_4_map,
     .data_size = sizeof(img_lv_demo_music_icon_4_map),

--- a/demos/music/assets/img_lv_demo_music_icon_4_large.c
+++ b/demos/music/assets/img_lv_demo_music_icon_4_large.c
@@ -49,6 +49,7 @@ img_lv_demo_music_icon_4_map[] = {
 const lv_image_dsc_t img_lv_demo_music_icon_4 = {
     .header.w = 32,
     .header.h = 30,
+    .header.stride = 128,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_icon_4_map,
     .data_size = sizeof(img_lv_demo_music_icon_4_map),

--- a/demos/music/assets/img_lv_demo_music_list_border.c
+++ b/demos/music/assets/img_lv_demo_music_list_border.c
@@ -15,6 +15,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_list_border_map[] = {
 const lv_image_dsc_t img_lv_demo_music_list_border = {
     .header.w = 272,
     .header.h = 4,
+    .header.stride = 1088,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_list_border_map,
     .data_size = sizeof(img_lv_demo_music_list_border_map),

--- a/demos/music/assets/img_lv_demo_music_list_border_large.c
+++ b/demos/music/assets/img_lv_demo_music_list_border_large.c
@@ -26,6 +26,7 @@ img_lv_demo_music_list_border_map[] = {
 const lv_image_dsc_t img_lv_demo_music_list_border = {
     .header.w = 479,
     .header.h = 7,
+    .header.stride = 1916,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_list_border_map,
     .data_size = sizeof(img_lv_demo_music_list_border_map),

--- a/demos/music/assets/img_lv_demo_music_logo.c
+++ b/demos/music/assets/img_lv_demo_music_logo.c
@@ -109,6 +109,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_logo_map[] = {
 const lv_image_dsc_t img_lv_demo_music_logo = {
     .header.w = 97,
     .header.h = 97,
+    .header.stride = 388,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_logo_map,
     .data_size = sizeof(img_lv_demo_music_logo_map),

--- a/demos/music/assets/img_lv_demo_music_slider_knob.c
+++ b/demos/music/assets/img_lv_demo_music_slider_knob.c
@@ -49,6 +49,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_slider_knob_map[] = {
 const lv_image_dsc_t img_lv_demo_music_slider_knob = {
     .header.w = 36,
     .header.h = 38,
+    .header.stride = 144,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_slider_knob_map,
     .data_size = sizeof(img_lv_demo_music_slider_knob_map),

--- a/demos/music/assets/img_lv_demo_music_slider_knob_large.c
+++ b/demos/music/assets/img_lv_demo_music_slider_knob_large.c
@@ -84,6 +84,7 @@ img_lv_demo_music_slider_knob_map[] = {
 const lv_image_dsc_t img_lv_demo_music_slider_knob = {
     .header.w = 66,
     .header.h = 66,
+    .header.stride = 264,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_slider_knob_map,
     .data_size = sizeof(img_lv_demo_music_slider_knob_map),

--- a/demos/music/assets/img_lv_demo_music_wave_bottom.c
+++ b/demos/music/assets/img_lv_demo_music_wave_bottom.c
@@ -54,6 +54,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_wave_bottom_map[] = {
 const lv_image_dsc_t img_lv_demo_music_wave_bottom = {
     .header.w = 272,
     .header.h = 42,
+    .header.stride = 1088,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_wave_bottom_map,
     .data_size = sizeof(img_lv_demo_music_wave_bottom_map),

--- a/demos/music/assets/img_lv_demo_music_wave_bottom_large.c
+++ b/demos/music/assets/img_lv_demo_music_wave_bottom_large.c
@@ -92,6 +92,7 @@ img_lv_demo_music_wave_bottom_map[] = {
 const lv_image_dsc_t img_lv_demo_music_wave_bottom = {
     .header.w = 479,
     .header.h = 74,
+    .header.stride = 1916,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_wave_bottom_map,
     .data_size = sizeof(img_lv_demo_music_wave_bottom_map),

--- a/demos/music/assets/img_lv_demo_music_wave_top.c
+++ b/demos/music/assets/img_lv_demo_music_wave_top.c
@@ -54,6 +54,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_wave_top_map[] = {
 const lv_image_dsc_t img_lv_demo_music_wave_top = {
     .header.w = 272,
     .header.h = 42,
+    .header.stride = 1088,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_wave_top_map,
     .data_size = sizeof(img_lv_demo_music_wave_top_map),

--- a/demos/music/assets/img_lv_demo_music_wave_top_large.c
+++ b/demos/music/assets/img_lv_demo_music_wave_top_large.c
@@ -92,6 +92,7 @@ img_lv_demo_music_wave_top_map[] = {
 const lv_image_dsc_t img_lv_demo_music_wave_top = {
     .header.w = 479,
     .header.h = 74,
+    .header.stride = 1916,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_wave_top_map,
     .data_size = sizeof(img_lv_demo_music_wave_top_map),

--- a/demos/render/assets/img_render_arc_bg.c
+++ b/demos/render/assets/img_render_arc_bg.c
@@ -116,6 +116,7 @@ const lv_image_dsc_t img_render_arc_bg = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 100,
     .header.h = 100,
+    .header.stride = 400,
     .data = img_render_arc_bg_map,
     .data_size = sizeof(img_render_arc_bg_map),
 };

--- a/demos/transform/assets/img_transform_avatar_15.c
+++ b/demos/transform/assets/img_transform_avatar_15.c
@@ -109,6 +109,7 @@ const lv_image_dsc_t img_transform_avatar_15 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 80,
     .header.h = 80,
+    .header.stride = 320,
     .data = img_transform_avatar_15_map,
     .data_size = sizeof(img_transform_avatar_15_map),
 };

--- a/demos/vector_graphic/assets/img_demo_vector_avatar.c
+++ b/demos/vector_graphic/assets/img_demo_vector_avatar.c
@@ -183,6 +183,7 @@ const lv_image_dsc_t img_demo_vector_avatar = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 160,
     .header.h = 154,
+    .header.stride = 640,
     .data = img_demo_vector_avatar_map,
     .data_size = sizeof(img_demo_vector_avatar_map),
 };

--- a/demos/widgets/assets/img_clothes.c
+++ b/demos/widgets/assets/img_clothes.c
@@ -249,6 +249,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMG_CLO
 const lv_image_dsc_t img_clothes = {
     .header.w = 56,
     .header.h = 56,
+    .header.stride = LV_COLOR_DEPTH == 16 ? 112 : 224,
     .header.cf = LV_COLOR_DEPTH == 16 ? LV_COLOR_FORMAT_RGB565A8 : LV_COLOR_FORMAT_ARGB8888,
     .data = img_clothes_map,
     .data_size = sizeof(img_clothes_map),

--- a/demos/widgets/assets/img_demo_widgets_avatar.c
+++ b/demos/widgets/assets/img_demo_widgets_avatar.c
@@ -183,6 +183,7 @@ const lv_image_dsc_t img_demo_widgets_avatar = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 160,
     .header.h = 154,
+    .header.stride = 640,
     .data = img_demo_widgets_avatar_map,
     .data_size = sizeof(img_demo_widgets_avatar_map),
 };

--- a/demos/widgets/assets/img_demo_widgets_needle.c
+++ b/demos/widgets/assets/img_demo_widgets_needle.c
@@ -35,6 +35,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_DEMO_WIDGETS_NEEDLE uint8_t 
 const lv_image_dsc_t img_demo_widgets_needle = {
     .header.w = 100,
     .header.h = 9,
+    .header.stride = 400,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data =  img_demo_widgets_needle_map,
 };

--- a/demos/widgets/assets/img_lvgl_logo.c
+++ b/demos/widgets/assets/img_lvgl_logo.c
@@ -60,6 +60,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMG_LVG
 const lv_image_dsc_t img_lvgl_logo = {
     .header.w = 42,
     .header.h = 43,
+    .header.stride = 168,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lvgl_logo_map,
     .data_size = sizeof(img_lvgl_logo_map),

--- a/examples/assets/animimg001.c
+++ b/examples/assets/animimg001.c
@@ -186,6 +186,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t animimg001 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = animimg001_map,
     .data_size = sizeof(animimg001_map),

--- a/examples/assets/animimg002.c
+++ b/examples/assets/animimg002.c
@@ -186,6 +186,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t animimg002 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = animimg002_map,
     .data_size = sizeof(animimg002_map),

--- a/examples/assets/animimg003.c
+++ b/examples/assets/animimg003.c
@@ -186,6 +186,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t animimg003 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = animimg003_map,
     .data_size = sizeof(animimg003_map),

--- a/examples/assets/emoji/img_emoji_F617.c
+++ b/examples/assets/emoji/img_emoji_F617.c
@@ -242,6 +242,13 @@ const lv_image_dsc_t emoji_F617 = {
     .header.cf = LV_COLOR_FORMAT_NATIVE,
     .header.w = 72,
     .header.h = 72,
+#if LV_COLOR_DEPTH == 1 || LV_COLOR_DEPTH == 8
+    .header.stride = 72,
+#elif LV_COLOR_DEPTH == 16
+    .header.stride = 144,
+#elif LV_COLOR_DEPTH == 32
+    .header.stride = 288,
+#endif
     .data = emoji_F617_map,
     .data_size = sizeof(emoji_F617_map),
 };

--- a/examples/assets/img_caret_down.c
+++ b/examples/assets/img_caret_down.c
@@ -49,6 +49,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMG_CAR
 const lv_image_dsc_t img_caret_down = {
     .header.w = 13,
     .header.h = 8,
+    .header.stride = 52,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_caret_down_map,
     .data_size = sizeof(img_caret_down_map),

--- a/examples/assets/img_cogwheel_argb.c
+++ b/examples/assets/img_cogwheel_argb.c
@@ -117,6 +117,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_ARGB uint8_t img_co
 const lv_image_dsc_t img_cogwheel_argb = {
     .header.w = 100,
     .header.h = 100,
+    .header.stride = 400,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_cogwheel_argb_map,
     .data_size = sizeof(img_cogwheel_argb_map),

--- a/examples/assets/img_cogwheel_indexed16.c
+++ b/examples/assets/img_cogwheel_indexed16.c
@@ -133,6 +133,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_INDEXED16 uint8_t i
 const lv_image_dsc_t img_cogwheel_indexed16 = {
     .header.w = 100,
     .header.h = 100,
+    .header.stride = 50,
     .header.cf = LV_COLOR_FORMAT_I4,
     .data = img_cogwheel_indexed16_map,
     .data_size = sizeof(img_cogwheel_indexed16_map),

--- a/examples/assets/img_cogwheel_rgb.c
+++ b/examples/assets/img_cogwheel_rgb.c
@@ -428,6 +428,15 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_COGWHEEL_RGB uint8_t img_cog
 const lv_image_dsc_t img_cogwheel_rgb = {
     .header.w = 100,
     .header.h = 100,
+#if LV_COLOR_DEPTH == 1 || LV_COLOR_DEPTH == 8
+    .header.stride = 100,
+#elif LV_COLOR_DEPTH == 16
+    .header.stride = 200,
+#elif LV_COLOR_DEPTH == 24
+    .header.stride = 300,
+#elif LV_COLOR_DEPTH == 32
+    .header.stride = 400,
+#endif
     .header.cf = LV_COLOR_FORMAT_NATIVE,
     .data = img_cogwheel_rgb_map,
     .data_size = sizeof(img_cogwheel_rgb_map),

--- a/examples/assets/img_hand.c
+++ b/examples/assets/img_hand.c
@@ -25,6 +25,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_HAND uint8_t img_hand_map[] 
 const lv_image_dsc_t img_hand = {
     .header.w = 100,
     .header.h = 9,
+    .header.stride = 400,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_hand_map,
     .data_size = sizeof(img_hand_map),

--- a/examples/assets/img_skew_strip.c
+++ b/examples/assets/img_skew_strip.c
@@ -85,6 +85,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMG_SKE
 const lv_image_dsc_t img_skew_strip = {
     .header.w = 80,
     .header.h = 20,
+    .header.stride = 320,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_skew_strip_map,
     .data_size = sizeof(img_skew_strip_map),

--- a/examples/assets/img_star.c
+++ b/examples/assets/img_star.c
@@ -46,6 +46,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMG_STA
 const lv_image_dsc_t img_star = {
     .header.w = 30,
     .header.h = 29,
+    .header.stride = 120,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_star_map,
     .data_size = sizeof(img_star_map),

--- a/examples/assets/imgbtn_left.c
+++ b/examples/assets/imgbtn_left.c
@@ -67,6 +67,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMGBTN_
 const lv_image_dsc_t imagebutton_left = {
     .header.w = 8,
     .header.h = 50,
+    .header.stride = 32,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = imagebutton_left_map,
     .data_size = sizeof(imagebutton_left_map),

--- a/examples/assets/imgbtn_mid.c
+++ b/examples/assets/imgbtn_mid.c
@@ -66,6 +66,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMGBTN_
 const lv_image_dsc_t imagebutton_mid = {
     .header.w = 5,
     .header.h = 49,
+    .header.stride = 20,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = imagebutton_mid_map,
     .data_size = sizeof(imagebutton_mid_map),

--- a/examples/assets/imgbtn_right.c
+++ b/examples/assets/imgbtn_right.c
@@ -68,6 +68,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMGBTN_
 const lv_image_dsc_t imagebutton_right = {
     .header.w = 8,
     .header.h = 50,
+    .header.stride = 32,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = imagebutton_right_map,
     .data_size = sizeof(imagebutton_right_map),

--- a/tests/src/test_assets/test_animimg001.c
+++ b/tests/src/test_assets/test_animimg001.c
@@ -187,6 +187,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t test_animimg001 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = test_animimg001_map,
 };

--- a/tests/src/test_assets/test_animimg002.c
+++ b/tests/src/test_assets/test_animimg002.c
@@ -187,6 +187,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t test_animimg002 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = test_animimg002_map,
 };

--- a/tests/src/test_assets/test_animimg003.c
+++ b/tests/src/test_assets/test_animimg003.c
@@ -187,6 +187,7 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_ANIMIMG
 const lv_image_dsc_t test_animimg003 = {
     .header.w = 130,
     .header.h = 170,
+    .header.stride = 520,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = test_animimg003_map,
 };

--- a/tests/src/test_assets/test_arc_bg.c
+++ b/tests/src/test_assets/test_arc_bg.c
@@ -324,7 +324,14 @@ const lv_image_dsc_t test_arc_bg = {
     .header.cf = LV_COLOR_FORMAT_NATIVE_WITH_ALPHA,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 0,
+#if LV_COLOR_DEPTH == 1 || LV_COLOR_DEPTH == 8
+    .header.stride = 200,
+#elif LV_COLOR_DEPTH == 16
+    .header.stride = 300,
+#elif LV_COLOR_DEPTH == 32
+    .header.stride = 400,
+#endif
+    .data_size = sizeof(test_arc_bg_map),
     .data = test_arc_bg_map,
 };
 #endif /*LV_BUILD_TEST*/

--- a/tests/src/test_assets/test_img_caret_down.c
+++ b/tests/src/test_assets/test_img_caret_down.c
@@ -27,6 +27,7 @@ test_image_caret_down_map[]
 const lv_image_dsc_t test_image_caret_down = {
     .header.w = 13,
     .header.h = 8,
+    .header.stride = 52,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = test_image_caret_down_map,
 };

--- a/tests/src/test_assets/test_img_cogwheel_a8.c
+++ b/tests/src/test_assets/test_img_cogwheel_a8.c
@@ -117,7 +117,8 @@ const lv_image_dsc_t test_image_cogwheel_a8 = {
     .header.cf = LV_COLOR_FORMAT_A8,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 10000,
+    .header.stride = 100,
+    .data_size = sizeof(test_image_cogwheel_a8_map),
     .data = test_image_cogwheel_a8_map,
 };
 

--- a/tests/src/test_assets/test_img_cogwheel_argb8888.c
+++ b/tests/src/test_assets/test_img_cogwheel_argb8888.c
@@ -117,7 +117,8 @@ const lv_image_dsc_t test_image_cogwheel_argb8888 = {
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 10000 * 4,
+    .header.stride = 400,
+    .data_size = sizeof(test_image_cogwheel_argb8888_map),
     .data = test_image_cogwheel_argb8888_map,
 };
 

--- a/tests/src/test_assets/test_img_cogwheel_i4.c
+++ b/tests/src/test_assets/test_img_cogwheel_i4.c
@@ -134,7 +134,8 @@ const lv_image_dsc_t test_image_cogwheel_i4 = {
     .header.cf = LV_COLOR_FORMAT_I4,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 5064,
+    .header.stride = 50,
+    .data_size = sizeof(test_image_cogwheel_i4_map),
     .data = test_image_cogwheel_i4_map,
 };
 

--- a/tests/src/test_assets/test_img_cogwheel_rgb565.c
+++ b/tests/src/test_assets/test_img_cogwheel_rgb565.c
@@ -118,7 +118,8 @@ const lv_image_dsc_t test_image_cogwheel_rgb565 = {
     .header.cf = LV_COLOR_FORMAT_RGB565,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 10000 * 2,
+    .header.stride = 200,
+    .data_size = sizeof(test_image_cogwheel_rgb565_map),
     .data = test_image_cogwheel_rgb565_map,
 };
 

--- a/tests/src/test_assets/test_img_cogwheel_rgb565a8.c
+++ b/tests/src/test_assets/test_img_cogwheel_rgb565a8.c
@@ -220,7 +220,8 @@ const lv_image_dsc_t test_image_cogwheel_rgb565a8 = {
     .header.w = 100,
     .header.h = 100,
     .header.stride = 200,
-    .data_size = 30000,
+    .header.stride = 200,
+    .data_size = sizeof(test_image_cogwheel_rgb565a8_map),
     .data = test_image_cogwheel_rgb565a8_map,
 };
 

--- a/tests/src/test_assets/test_img_cogwheel_rgb565a8.c
+++ b/tests/src/test_assets/test_img_cogwheel_rgb565a8.c
@@ -220,7 +220,6 @@ const lv_image_dsc_t test_image_cogwheel_rgb565a8 = {
     .header.w = 100,
     .header.h = 100,
     .header.stride = 200,
-    .header.stride = 200,
     .data_size = sizeof(test_image_cogwheel_rgb565a8_map),
     .data = test_image_cogwheel_rgb565a8_map,
 };

--- a/tests/src/test_assets/test_img_cogwheel_xrgb8888.c
+++ b/tests/src/test_assets/test_img_cogwheel_xrgb8888.c
@@ -118,7 +118,8 @@ const lv_image_dsc_t test_image_cogwheel_xrgb8888 = {
     .header.cf = LV_COLOR_FORMAT_XRGB8888,
     .header.w = 100,
     .header.h = 100,
-    .data_size = 10000 * 4,
+    .header.stride = 400,
+    .data_size = sizeof(test_image_cogwheel_xrgb8888_map),
     .data = test_image_cogwheel_xrgb8888_map,
 };
 

--- a/tests/src/test_assets/test_img_emoji_F617.c
+++ b/tests/src/test_assets/test_img_emoji_F617.c
@@ -239,7 +239,14 @@ const lv_image_dsc_t emoji_F617 = {
     .header.cf = LV_COLOR_FORMAT_NATIVE,
     .header.w = 72,
     .header.h = 72,
-    .data_size = 5184 * LV_COLOR_DEPTH / 8,
+#if LV_COLOR_DEPTH == 1 || LV_COLOR_DEPTH == 8
+    .header.stride = 72,
+#elif LV_COLOR_DEPTH == 16
+    .header.stride = 144,
+#elif LV_COLOR_DEPTH == 32
+    .header.stride = 288,
+#endif
+    .data_size = sizeof(emoji_F617_map),
     .data = emoji_F617_map,
 };
 

--- a/tests/src/test_assets/test_img_lvgl_logo_jpg.c
+++ b/tests/src/test_assets/test_img_lvgl_logo_jpg.c
@@ -167,7 +167,7 @@ const lv_image_dsc_t test_img_lvgl_logo_jpg = {
     .header.cf = LV_COLOR_FORMAT_RAW,
     .header.w = 105,
     .header.h = 33,
-    .data_size = 1947,
+    .data_size = sizeof(test_img_lvgl_logo_jpg_map),
     .data = test_img_lvgl_logo_jpg_map,
 };
 

--- a/tests/src/test_assets/test_img_lvgl_logo_png.c
+++ b/tests/src/test_assets/test_img_lvgl_logo_png.c
@@ -162,7 +162,7 @@ const lv_image_dsc_t test_img_lvgl_logo_png = {
     .header.cf = LV_COLOR_FORMAT_RAW_ALPHA,
     .header.w = 105,
     .header.h = 33,
-    .data_size = 1873,
+    .data_size = sizeof(test_img_lvgl_logo_png_map),
     .data = test_img_lvgl_logo_png_map,
 };
 


### PR DESCRIPTION
### Description of the feature or fix

Related discussion: https://github.com/lvgl/lvgl/pull/5471

Due to the large number of files, I used a script to automate the changes, which was written by ChatGPT:

```python3
import os
import re
import sys
import subprocess

def get_stride(w_value, cf_value):
    # 使用subprocess调用外部程序获取返回值
    command = f"./build/bin/main {w_value} {cf_value}"
    result = subprocess.run(command, shell=True, capture_output=True, text=True)
    return result.stdout.strip()

def update_struct_content(struct_content, stride, h_value):
    # 添加新的字段 .header.stride
    updated_content = re.sub(r'(\.header\.h\s*=\s*\w+)', rf'\1,\n    .header.stride = {stride}', struct_content)
    return updated_content

def extract_fields_from_file(file_path):
    with open(file_path, 'r') as file:
        content = file.read()
        # 正则表达式匹配结构体
        matches = re.findall(r'const lv_image_dsc_t\s+(\w+)\s*=\s*{([^}]+)}', content, re.MULTILINE)
        for match in matches:
            struct_name = match[0]
            struct_content = match[1]
            # 提取所需字段
            cf_match = re.search(r'\.header\.cf\s*=\s*(\w+)', struct_content)
            w_match = re.search(r'\.header\.w\s*=\s*(\w+)', struct_content)
            h_match = re.search(r'\.header\.h\s*=\s*(\w+)', struct_content)
            if cf_match and w_match and h_match:
                cf_value = cf_match.group(1)
                w_value = w_match.group(1)
                h_value = h_match.group(1)
                # 调用外部程序
                stride = get_stride(int(w_value), cf_value)
                if(stride == "0"):
                    print(f"Error: Stride is 0 for struct {struct_name}")
                    continue

                # 更新原始文件内容
                updated_content = update_struct_content(struct_content, stride, h_value)
                # 写回到文件中
                updated_file_content = content.replace(struct_content, updated_content)
                with open(file_path, 'w') as updated_file:
                    updated_file.write(updated_file_content)
                print(f"For struct {struct_name}: Stride = {stride}")

def scan_and_extract_fields(directory):
    for root, _, files in os.walk(directory):
        for file in files:
            if file.endswith('.c'):
                file_path = os.path.join(root, file)
                extract_fields_from_file(file_path)

if __name__ == "__main__":
    if len(sys.argv) != 2:
        print("Usage: python script.py /path/to/your/directory")
        sys.exit(1)

    directory_path = sys.argv[1]
    if not os.path.isdir(directory_path):
        print("Invalid directory path.")
        sys.exit(1)

    scan_and_extract_fields(directory_path)
```

Working with this python script, there is also a C program(`./build/bin/main`) to ensure that the stride calculation is exactly the same as before:
```c
static lv_color_format_t str2cf(const char* str)
{
#define CF_STR_CMP(CF)               \
    do {                             \
        if (strcmp(str, #CF) == 0) { \
            return CF;               \
        }                            \
    } while (0)

    CF_STR_CMP(LV_COLOR_FORMAT_RAW);
    CF_STR_CMP(LV_COLOR_FORMAT_RAW_ALPHA);
    CF_STR_CMP(LV_COLOR_FORMAT_L8);
    CF_STR_CMP(LV_COLOR_FORMAT_I1);
    CF_STR_CMP(LV_COLOR_FORMAT_I2);
    CF_STR_CMP(LV_COLOR_FORMAT_I4);
    CF_STR_CMP(LV_COLOR_FORMAT_I8);
    CF_STR_CMP(LV_COLOR_FORMAT_A8);
    CF_STR_CMP(LV_COLOR_FORMAT_RGB565);
    CF_STR_CMP(LV_COLOR_FORMAT_ARGB8565);
    CF_STR_CMP(LV_COLOR_FORMAT_RGB565A8);
    CF_STR_CMP(LV_COLOR_FORMAT_RGB888);
    CF_STR_CMP(LV_COLOR_FORMAT_ARGB8888);
    CF_STR_CMP(LV_COLOR_FORMAT_XRGB8888);
    CF_STR_CMP(LV_COLOR_FORMAT_A1);
    CF_STR_CMP(LV_COLOR_FORMAT_A2);
    CF_STR_CMP(LV_COLOR_FORMAT_A4);
    CF_STR_CMP(LV_COLOR_FORMAT_YUV_START);
    CF_STR_CMP(LV_COLOR_FORMAT_I420);
    CF_STR_CMP(LV_COLOR_FORMAT_I422);
    CF_STR_CMP(LV_COLOR_FORMAT_I444);
    CF_STR_CMP(LV_COLOR_FORMAT_I400);
    CF_STR_CMP(LV_COLOR_FORMAT_NV21);
    CF_STR_CMP(LV_COLOR_FORMAT_NV12);
    CF_STR_CMP(LV_COLOR_FORMAT_YUY2);
    CF_STR_CMP(LV_COLOR_FORMAT_UYVY);

    return LV_COLOR_FORMAT_UNKNOWN;
}

void img_stride_calc(int argc, const char* argv[])
{
    if (argc < 3) {
        printf("Usage: %s <width>\n", argv[0]);
        return;
    }
    int w = atoi(argv[1]);
    lv_color_format_t cf = str2cf(argv[2]);
    uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
    printf("%d\n", stride);
}

int main(int argc, const char* argv[])
{
    /*Initialize LVGL*/
    lv_init();

    img_stride_calc(argc, argv);

    return 0;
}
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
