### PR TITLE
fix(image): fix wrong log level statement

### DIFF
--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -139,7 +139,7 @@ void lv_image_set_src(lv_obj_t * obj, const void * src)
     lv_image_src_t src_type = lv_image_src_get_type(src);
     lv_image_t * img = (lv_image_t *)obj;
 
-#if LV_USE_LOG && LV_LOG_LEVEL >= LV_LOG_LEVEL_INFO
+#if LV_USE_LOG && LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
     switch(src_type) {
         case LV_IMAGE_SRC_FILE:
             LV_LOG_TRACE("`LV_IMAGE_SRC_FILE` type found");


### PR DESCRIPTION
### Description of the feature or fix

This fixes wrong log level statement for image type log.

Because the higher the level, the fewer logs will be printed:

```c
#define LV_LOG_LEVEL_TRACE 0 /**< A lot of logs to give detailed information*/
#define LV_LOG_LEVEL_INFO  1 /**< Log important events*/
#define LV_LOG_LEVEL_WARN  2 /**< Log if something unwanted happened but didn't caused problem*/
#define LV_LOG_LEVEL_ERROR 3 /**< Only critical issue, when the system may fail*/
#define LV_LOG_LEVEL_USER  4 /**< Custom logs from the user*/
#define LV_LOG_LEVEL_NONE  5 /**< Do not log anything*/
#define _LV_LOG_LEVEL_NUM  6 /**< Number of log levels*/
```
* https://github.com/lvgl/lvgl/blob/bf47753ee0d2980b104342fc37633a5fafd72e84/src/misc/lv_log.h#L27-L33


### Checkpoints
* [x]  Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
* [ ]  Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
* [ ]  Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
* [ ]  Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
* [ ]  If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).

Be sure the following conventions are followed:

* [ ]  Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
* [ ]  Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
* [ ]  In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
* [ ]  Use typed pointers instead of `void *` pointers
* [ ]  Do not `malloc` into a static or global variables. Instead declare the variable in `lv_global_t` structure in [`lv_global.h`](https://github.com/lvgl/lvgl/blob/master/src/core/lv_global.h) and mark the variable with `(LV_GLOBAL_DEFAULT()->variable)` when it's used. See a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#memory-management).
* [ ]  Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
* [ ]  Widget members function must start with `lv_<module_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.
* [ ]  `struct`s should be used via an API and not modified directly via their elements.
* [ ]  `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
* [ ]  Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
* [ ]  Arguments must be named in H files too.
* [ ]  To register and use callbacks one of the following needs to be followed (see a detailed description [here](https://docs.lvgl.io/master/get-started/bindings/micropython.html#callbacks)):
  
  * For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  * The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  * Callback types not following these conventions should end with `xcb_t`.

