### PR TITLE
Fix clang errors uefi

### DIFF
--- a/src/misc/cache/_lv_cache_lru_rb.c
+++ b/src/misc/cache/_lv_cache_lru_rb.c
@@ -168,13 +168,13 @@ static bool init_cnt_cb(lv_cache_t * cache)
 
     /*add void* to store the ll node pointer*/
     if(!lv_rb_init(&lru->rb, lru->cache.ops.compare_cb, lv_cache_entry_get_size(lru->cache.node_size) + sizeof(void *))) {
-        return NULL;
+        return false;
     }
     _lv_ll_init(&lru->ll, sizeof(void *));
 
     lru->get_data_size_cb = cnt_get_data_size_cb;
 
-    return lru;
+    return true;
 }
 
 static bool init_size_cb(lv_cache_t * cache)
@@ -192,13 +192,13 @@ static bool init_size_cb(lv_cache_t * cache)
 
     /*add void* to store the ll node pointer*/
     if(!lv_rb_init(&lru->rb, lru->cache.ops.compare_cb, lv_cache_entry_get_size(lru->cache.node_size) + sizeof(void *))) {
-        return NULL;
+        return false;
     }
     _lv_ll_init(&lru->ll, sizeof(void *));
 
     lru->get_data_size_cb = size_get_data_size_cb;
 
-    return lru;
+    return true;
 }
 
 static void destroy_cb(lv_cache_t * cache, void * user_data)

--- a/src/misc/lv_rb.c
+++ b/src/misc/lv_rb.c
@@ -243,7 +243,7 @@ bool lv_rb_drop(lv_rb_t * tree, const void * key)
 {
     LV_ASSERT_NULL(tree);
     if(tree == NULL) {
-        return NULL;
+        return false;
     }
 
     void * data = lv_rb_remove(tree, key);


### PR DESCRIPTION
### Description of the feature or fix

I want to build lvgl with clang for uefi. The compiler generates errors for these return vales, they should be bools but are pointers.
