### PR TITLE
fix(test): allow to run test locally on mac

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -254,12 +254,21 @@ find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})
 
 # libinput is required for the libinput device driver test case
-find_package(Libinput REQUIRED)
+find_package(Libinput OPTIONAL_COMPONENTS)
 include_directories(${LIBINPUT_INCLUDE_DIRS})
 
-# libxkbcommon is required for the libinput device driver test case
+if (NOT LIBINPUT_FOUND)
+message("libinput is not found, defaulting to 0")
+add_definitions(-DLV_USE_LIBINPUT=0)
+endif()
+
 find_package(PkgConfig)
-pkg_check_modules(xkbcommon REQUIRED xkbcommon)
+pkg_check_modules(xkbcommon pkg_check_modules xkbcommon)
+
+if (NOT xkbcommon_FOUND)
+message("xkbcommon is not found, defaulting to 0")
+add_definitions(-DLV_LIBINPUT_XKB=0)
+endif()
 
 # disable test targets for build only tests
 if (ENABLE_TESTS)
@@ -274,6 +283,10 @@ foreach( test_case_fname ${TEST_CASE_FILES} )
     if (${test_name} STREQUAL "_test_template")
         continue()
     endif()
+
+    # gather all test cases
+    list(APPEND TEST_CASES ${test_name})
+
     # Create path to auto-generated source file.
     set(test_runner_fname ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_Runner.c)
     # Run ruby to generate source in build directory
@@ -308,5 +321,12 @@ foreach( test_case_fname ${TEST_CASE_FILES} )
         WORKING_DIRECTORY ${LVGL_TEST_DIR}
         COMMAND ${test_name})
 endforeach( test_case_fname ${TEST_CASE_FILES} )
+
+add_custom_target(run
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --timeout 300
+    WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}
+    DEPENDS ${TEST_CASES}
+    USES_TERMINAL
+)
 
 endif()

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -105,8 +105,14 @@
 #define LV_USE_ST7735       1
 #define LV_USE_ST7789       1
 #define LV_USE_ST7796       1
-#define LV_USE_LIBINPUT     1
-#define LV_LIBINPUT_XKB     1
+
+#ifndef LV_USE_LIBINPUT
+    #define LV_USE_LIBINPUT     1
+#endif
+
+#ifndef LV_LIBINPUT_XKB
+    #define LV_LIBINPUT_XKB     1
+#endif
 
 #define LV_USE_FREETYPE 1
 #define LV_FREETYPE_CACHE_SIZE 768


### PR DESCRIPTION

### Description of the feature or fix

Make `libinput` and `xbkcommon` optional in test because they are not available on mac. 
Add custom target `run` to make it easier to run all tests.

Now the tests can be run locally in below steps
- `cd lvgl/tests`
- config. `cmake -Bbuild -GNinja -DOPTIONS_TEST_DEFHEAP=1`
- `ninja -Cbuild run` will firstly build all testcases and then call `ctest`

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html)
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
