### PR TITLE
fix(pxp): fix issues in pxp cache management callback

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -70,7 +70,7 @@ void * lv_draw_buf_align(void * data, lv_color_format_t color_format)
     else return NULL;
 }
 
-void lv_draw_buf_invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
+void lv_draw_buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
     if(handlers.invalidate_cache_cb) {
         LV_ASSERT_NULL(draw_buf);

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -74,7 +74,7 @@ typedef void (*lv_draw_buf_free_cb)(void * draw_buf);
 
 typedef void * (*lv_draw_buf_align_cb)(void * buf, lv_color_format_t color_format);
 
-typedef void (*lv_draw_buf_invalidate_cache_cb)(lv_draw_buf_t * draw_buf, const lv_area_t * area);
+typedef void (*lv_draw_buf_invalidate_cache_cb)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
 
@@ -116,7 +116,7 @@ void * lv_draw_buf_align(void * buf, lv_color_format_t color_format);
  * @param area         the area to invalidate in the buffer,
  *                     use NULL to invalidate the whole draw buffer address range
  */
-void lv_draw_buf_invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area);
+void lv_draw_buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 /**
  * Calculate the stride in bytes based on a width and color format

--- a/src/draw/nxp/pxp/lv_draw_buf_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_buf_pxp.c
@@ -33,7 +33,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void _invalidate_cache(void * buf, uint32_t stride, lv_color_format_t cf, const lv_area_t * area);
+static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 /**********************
  *  STATIC VARIABLES
@@ -58,7 +58,7 @@ void lv_draw_buf_pxp_init_handlers(void)
  *   STATIC FUNCTIONS
  **********************/
 
-static void _invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
+static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
     const lv_image_header_t * header = &draw_buf->header;
     uint32_t stride = header->stride;
@@ -68,11 +68,11 @@ static void _invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
         uint16_t size = stride * lv_area_get_height(area);
 
         /* Invalidate full buffer. */
-        DEMO_CleanInvalidateCacheByAddr((void *)buf, size);
+        DCACHE_CleanInvalidateByRange((uint32_t)draw_buf->data, size);
         return;
     }
 
-    const uint8_t * buf_u8 = buf;
+    const uint8_t * buf_u8 = draw_buf->data;
     /* ARM require a 32 byte aligned address. */
     uint8_t align_bytes = 32;
     uint8_t bits_per_pixel = lv_color_format_get_bpp(cf);
@@ -103,7 +103,7 @@ static void _invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
     for(uint16_t y = 0; y < area_height; y++) {
         const void * line_addr = buf_u8 + y * stride;
 
-        DEMO_CleanInvalidateCacheByAddr((void *)line_addr, line_size);
+        DCACHE_CleanInvalidateByRange((uint32_t)line_addr, line_size);
     }
 }
 

--- a/src/draw/nxp/vglite/lv_draw_buf_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_buf_vglite.c
@@ -37,7 +37,7 @@ static void * _buf_malloc(size_t size_bytes, lv_color_format_t cf);
 
 static void * _buf_align(void * buf, lv_color_format_t cf);
 
-static void _invalidate_cache(void * buf, uint32_t stride, lv_color_format_t cf, const lv_area_t * area);
+static void _invalidate_cache(const void * buf, uint32_t stride, lv_color_format_t cf, const lv_area_t * area);
 
 static uint32_t _width_to_stride(uint32_t w, lv_color_format_t cf);
 
@@ -90,7 +90,7 @@ static void * _buf_align(void * buf, lv_color_format_t cf)
     return buf_u8;
 }
 
-static void _invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
+static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
     const lv_image_header_t * header = &draw_buf->header;
     uint32_t stride = header->stride;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -29,7 +29,7 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u);
 
 #if defined(RENESAS_CORTEX_M85)
     #if (BSP_CFG_DCACHE_ENABLED)
-        static void _dave2d_buf_invalidate_cache_cb(lv_draw_buf_t * draw_buf, const lv_area_t * area);
+        static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
     #endif
 #endif
 
@@ -122,7 +122,7 @@ static void lv_draw_buf_dave2d_init_handlers(void)
 
 #if defined(RENESAS_CORTEX_M85)
 #if (BSP_CFG_DCACHE_ENABLED)
-static void _dave2d_buf_invalidate_cache_cb(lv_draw_buf_t * draw_buf, const lv_area_t * area)
+static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
     const lv_image_header_t * header = &draw_buf->header;
     uint32_t stride = header->stride;

--- a/src/drivers/nuttx/lv_nuttx_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_cache.c
@@ -26,7 +26,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 /**********************
  *  STATIC VARIABLES
@@ -50,7 +50,7 @@ void lv_nuttx_cache_init(void)
  *   STATIC FUNCTIONS
  **********************/
 
-static void invalidate_cache(lv_draw_buf_t * draw_buf, const lv_area_t * area)
+static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
     LV_ASSERT_NULL(draw_buf);
     void * buf = draw_buf->data;


### PR DESCRIPTION
### Description of the feature or fix

fix `_invalidate_cache` wrong signature in declaration
fix `_invalidate_cache` uses `draw_buf` as a data buffer
fix `_invalidate_cache` uses unknown `DEMO_CleanInvalidateCacheByAddr` instead of `DCACHE_CleanInvalidateByRange`
update the `*invalidate_cache*` functions signature to make `draw_buf` a pointer to `const`

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
