### PR TITLE
feat(decoder): do not even try cache if 'no_cache' is set

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -123,10 +123,13 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
 
 #if LV_CACHE_DEF_SIZE > 0
     dsc->cache = img_cache_p;
-    /*
-     * Check the cache first
-     * If the image is found in the cache, just return it.*/
-    if(try_cache(dsc) == LV_RESULT_OK) return LV_RESULT_OK;
+    /*Try cache first, unless we are told to ignore cache.*/
+    if(!(args && args->no_cache)) {
+        /*
+        * Check the cache first
+        * If the image is found in the cache, just return it.*/
+        if(try_cache(dsc) == LV_RESULT_OK) return LV_RESULT_OK;
+    }
 #endif
 
     /*Find the decoder that can open the image source, and get the header info in the same time.*/

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -61,7 +61,7 @@ typedef struct _lv_image_decoder_dsc_t lv_image_decoder_dsc_t;
 typedef struct _lv_image_decoder_args_t {
     bool stride_align;      /*Whether stride should be aligned*/
     bool premultiply;       /*Whether image should be premultiplied or not after decoding*/
-    bool no_cache;          /*Whether this image should be kept out of cache*/
+    bool no_cache;          /*When set, decoded image won't be put to cache, and decoder open will also ignore cache.*/
     bool use_indexed;       /*Decoded indexed image as is. Convert to ARGB8888 if false.*/
 } lv_image_decoder_args_t;
 


### PR DESCRIPTION

### Description of the feature or fix

When 'no_cache' is set in decoder args, do not add decoded image to cache, but also ignore cached image the next time to call decoder_open

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
