### PR TITLE
feat(test): add multiple color formats to stride adjust test

### DIFF
--- a/tests/src/test_cases/test_draw_buf_stride.c
+++ b/tests/src/test_cases/test_draw_buf_stride.c
@@ -17,57 +17,99 @@ void tearDown(void)
 void test_draw_buf_stride_adjust(void)
 {
 #if LV_BIN_DECODER_RAM_LOAD == 1
-    const char * img_src = "A:test_images/stride_align64/UNCOMPRESSED/test_ARGB8888.bin";
-    lv_obj_t * img = lv_image_create(lv_screen_active());
-    lv_obj_center(img);
-    lv_image_set_src(img, img_src);
-    TEST_ASSERT_EQUAL_SCREENSHOT("draw/temp.o"); /*Generate the reference image, use .o so git ignore it*/
-
-    lv_image_decoder_args_t args = {
-        .no_cache = false,
-        .premultiply = false,
-        .stride_align = false,
-        .use_indexed = false,
+    const char * color_formats[] = {
+        "I1",
+        "I2",
+        "I4",
+        "I8",
+#if 0   /* Decoder will convert them to A8 anyway.*/
+        "A1",
+        "A2",
+        "A4",
+#endif
+        "A8",
+        "RGB565",
+#if 0   /* RGB565 with alpha is not supported*/
+        "RGB565A8",
+        "ARGB8565",
+#endif
+        "RGB888",
+        "ARGB8888",
+        "XRGB8888",
     };
 
-    lv_image_decoder_dsc_t decoder_dsc;
-    lv_result_t res = lv_image_decoder_open(&decoder_dsc, img_src, &args);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    lv_obj_t * img = lv_image_create(lv_screen_active());
+    lv_obj_center(img);
 
-    const lv_image_header_t header = decoder_dsc.decoded->header;
-    /*The test image must have aligned stride different with width * bpp*/
-    TEST_ASSERT_NOT_EQUAL(header.w * 4, header.stride);
+    const lv_image_decoder_args_t args = {
+        .no_cache = true,
+        .premultiply = false,
+        .stride_align = false,
+        .use_indexed = true,
+    };
 
-    lv_draw_buf_t * dup = lv_draw_buf_dup(decoder_dsc.decoded);
-    TEST_ASSERT_NOT_NULL(dup);
+    for(unsigned long i = 0; i < sizeof(color_formats) / sizeof(color_formats[0]); i++) {
+        char img_src[256];
+        char ref_image[256];
+        snprintf(img_src, sizeof(img_src), "A:test_images/stride_align1/UNCOMPRESSED/test_%s.bin", color_formats[i]);
+        snprintf(ref_image, sizeof(ref_image), "draw/temp_%s.o", color_formats[i]); /*Use .o file name so git ignores it.*/
 
-    /*Close the decoder since we copied out the decoded draw buffer*/
-    lv_image_decoder_close(&decoder_dsc);
+        lv_image_set_src(img, img_src);
+        TEST_ASSERT_EQUAL_SCREENSHOT(ref_image); /*Generate the reference image, use .o so git ignore it*/
 
-    /* Shrink stride to below minimal stride(by -1 in code below) should fail */
-    res = lv_draw_buf_adjust_stride(dup, header.w * 4 - 1);
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+        lv_image_cache_drop(img_src); /* Image could be added to cache during lv_image_set_src*/
 
-    res = lv_draw_buf_adjust_stride(dup, header.stride + 1);
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+        lv_image_decoder_dsc_t decoder_dsc;
+        lv_result_t res = lv_image_decoder_open(&decoder_dsc, img_src, &args);
+        TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+        lv_draw_buf_t * decoded = lv_draw_buf_dup(decoder_dsc.decoded);
+        TEST_ASSERT_NOT_NULL(decoded);
 
-    /*Expand the stride should fail if stride is too large that buffer size overflow*/
-    res = lv_draw_buf_adjust_stride(dup, header.stride + 1);
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+        const lv_image_header_t header = decoder_dsc.decoded->header;
+        uint32_t image_width = header.w;
+        uint32_t image_height = header.h;
+        uint32_t image_stride = header.stride;
+        uint32_t min_stride = (image_width * lv_color_format_get_bpp(header.cf) + 7) >> 3;
 
-    /* Expand the stride should work, use a proper stride value should succeed*/
-    res = lv_draw_buf_adjust_stride(dup, (header.stride + header.w * 4) / 2);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
-    lv_image_set_src(img, dup);
-    TEST_ASSERT_EQUAL_SCREENSHOT("draw/temp.o"); /*The image should still looks same*/
+        /*Close the decoder since we copied out the decoded draw buffer*/
+        lv_image_decoder_close(&decoder_dsc);
 
-    /* Shrink stride to minimal stride should succeed */
-    res = lv_draw_buf_adjust_stride(dup, header.w * 4);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
-    lv_image_set_src(img, dup);
-    TEST_ASSERT_EQUAL_SCREENSHOT("draw/temp.o"); /*Test against with above reference image*/
+        /* Shrink stride to below minimal stride(by -1 in code below) should fail */
+        res = lv_draw_buf_adjust_stride(decoded, min_stride - 1);
+        TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
 
-    lv_draw_buf_destroy(dup);
+        /*Expand the stride should fail if stride is too large that buffer size overflow*/
+        res = lv_draw_buf_adjust_stride(decoded, image_stride + 1);
+        TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+
+        /*Create a larger draw buffer*/
+        lv_draw_buf_t * larger = lv_draw_buf_create(image_width, image_height, header.cf, min_stride + 100);
+
+        /*Copy draw buffer, it should look same.*/
+        lv_draw_buf_copy(larger, NULL, decoded, NULL);
+        lv_image_cache_drop(larger);
+        lv_image_set_src(img, larger);
+        TEST_ASSERT_EQUAL_SCREENSHOT(ref_image); /*The image should still looks same*/
+
+        /* Shrink stride to minimal stride should succeed */
+        res = lv_draw_buf_adjust_stride(larger, min_stride);
+        TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+        lv_image_cache_drop(larger);
+        lv_image_set_src(img, larger);
+        TEST_ASSERT_EQUAL_SCREENSHOT(ref_image); /*Test against with above reference image*/
+
+        /* Expand the stride should work, use a proper stride value should succeed*/
+        res = lv_draw_buf_adjust_stride(larger, min_stride + 20);
+        TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+        lv_image_cache_drop(larger);
+        lv_image_set_src(img, larger);
+        TEST_ASSERT_EQUAL_SCREENSHOT(ref_image); /*The image should still look same*/
+
+        lv_draw_buf_destroy(larger);
+        lv_draw_buf_destroy(decoded);
+    }
+
+    lv_obj_delete(img);
 #endif
 }
 


### PR DESCRIPTION

### Description of the feature or fix

Alpha only 1/2/4 image and RGB565 with alpha is not supported yet, thus disabled in test.

CI will fail because it depends on other PRs. I'll rebase this one when those are reviewed and merged.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
