### PR TITLE
fix(drm): eliminate use of non-existent lv_api_map.h and enable smoke tests

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -95,7 +95,7 @@ jobs:
 
           install: |
             apt-get update -y
-            apt-get install build-essential ccache libgcc-10-dev python3 libpng-dev ruby-full gcovr cmake libjpeg62-turbo-dev libfreetype6-dev libasan6 pngquant python3-pip libinput-dev libxkbcommon-dev pkg-config ninja-build -q -y
+            apt-get install build-essential ccache libgcc-10-dev python3 libpng-dev ruby-full gcovr cmake libjpeg62-turbo-dev libfreetype6-dev libasan6 pngquant python3-pip libinput-dev libxkbcommon-dev libdrm-dev pkg-config ninja-build -q -y
             pip install pypng lz4
             /usr/sbin/update-ccache-symlinks
             echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -6,5 +6,5 @@
 #
 # Note: This script is run by the CI workflows.
 sudo apt update
-sudo apt install gcc python3 ninja-build libpng-dev ruby-full gcovr cmake libjpeg-turbo8-dev libfreetype6-dev pngquant libinput-dev libxkbcommon-dev pkg-config
+sudo apt install gcc python3 ninja-build libpng-dev ruby-full gcovr cmake libjpeg-turbo8-dev libfreetype6-dev pngquant libinput-dev libxkbcommon-dev libdrm-dev pkg-config
 pip3 install pypng lz4

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -9,8 +9,6 @@
 #include "lv_linux_drm.h"
 #if LV_USE_LINUX_DRM
 
-#include "../../../lv_api_map.h"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -258,25 +258,30 @@ find_package(Libinput OPTIONAL_COMPONENTS)
 include_directories(${LIBINPUT_INCLUDE_DIRS})
 
 if (NOT LIBINPUT_FOUND)
-message("libinput is not found, defaulting to 0")
-add_definitions(-DLV_USE_LIBINPUT=0)
+    message("libinput not found, defaulting to 0")
+    add_definitions(-DLV_USE_LIBINPUT=0)
 endif()
 
 find_package(PkgConfig)
 pkg_check_modules(xkbcommon pkg_check_modules xkbcommon)
 
 if (NOT xkbcommon_FOUND)
-message("xkbcommon is not found, defaulting to 0")
-add_definitions(-DLV_LIBINPUT_XKB=0)
+    message("xkbcommon not found, defaulting to 0")
+    add_definitions(-DLV_LIBINPUT_XKB=0)
 endif()
 
 # libdrm is required for the DRM display driver test case
 include(${CMAKE_CURRENT_LIST_DIR}/FindLibDRM.cmake)
 if(Libdrm_FOUND)
-include_directories(${Libdrm_INCLUDE_DIRS})
+    include_directories(${Libdrm_INCLUDE_DIRS})
 else()
-message("libdrm not found, defaulting to 0")
-add_definitions(-DLV_USE_LINUX_DRM=0)
+    message("libdrm not found, defaulting to 0")
+    add_definitions(-DLV_USE_LINUX_DRM=0)
+endif()
+
+# If we are running on mac, set LV_USE_LINUX_FBDEV to 0
+if(APPLE)
+    add_definitions(-DLV_USE_LINUX_FBDEV=0)
 endif()
 
 # disable test targets for build only tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -270,6 +270,15 @@ message("xkbcommon is not found, defaulting to 0")
 add_definitions(-DLV_LIBINPUT_XKB=0)
 endif()
 
+# libdrm is required for the DRM display driver test case
+include(${CMAKE_CURRENT_LIST_DIR}/FindLibDRM.cmake)
+if(Libdrm_FOUND)
+include_directories(${Libdrm_INCLUDE_DIRS})
+else()
+message("libdrm not found, defaulting to 0")
+add_definitions(-DLV_USE_LINUX_DRM=0)
+endif()
+
 # disable test targets for build only tests
 if (ENABLE_TESTS)
     file( GLOB_RECURSE TEST_CASE_FILES src/test_cases/*.c )
@@ -309,6 +318,7 @@ foreach( test_case_fname ${TEST_CASE_FILES} )
             lvgl_thorvg
             ${PNG_LIBRARIES}
             ${FREETYPE_LIBRARIES}
+            ${LIBDRM_LIBRARIES}
             ${LIBINPUT_LIBRARIES}
             ${JPEG_LIBRARIES}
             m

--- a/tests/FindLibDRM.cmake
+++ b/tests/FindLibDRM.cmake
@@ -1,0 +1,45 @@
+find_package(PkgConfig)
+pkg_check_modules(PKG_Libdrm pkg_check_modules libdrm)
+
+set(Libdrm_DEFINITIONS ${PKG_Libdrm_CFLAGS_OTHER})
+set(Libdrm_VERSION ${PKG_Libdrm_VERSION})
+
+find_path(Libdrm_INCLUDE_DIR
+    NAMES
+        xf86drm.h
+    HINTS
+        ${PKG_Libdrm_INCLUDE_DIRS}
+)
+find_library(Libdrm_LIBRARY
+    NAMES
+        drm
+    HINTS
+        ${PKG_Libdrm_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libdrm
+    FOUND_VAR
+        Libdrm_FOUND
+    REQUIRED_VARS
+        Libdrm_LIBRARY
+        Libdrm_INCLUDE_DIR
+    VERSION_VAR
+        Libdrm_VERSION
+)
+
+if(Libdrm_FOUND AND NOT TARGET Libdrm::Libdrm)
+    add_library(Libdrm::Libdrm UNKNOWN IMPORTED)
+    set_target_properties(Libdrm::Libdrm PROPERTIES
+        IMPORTED_LOCATION "${Libdrm_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${Libdrm_DEFINITIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Libdrm_INCLUDE_DIR}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Libdrm_INCLUDE_DIR}/libdrm"
+    )
+endif()
+
+mark_as_advanced(Libdrm_LIBRARY Libdrm_INCLUDE_DIR)
+
+set(Libdrm_LIBRARIES ${Libdrm_LIBRARY})
+set(Libdrm_INCLUDE_DIRS ${Libdrm_INCLUDE_DIR} "${Libdrm_INCLUDE_DIR}/libdrm")
+set(Libdrm_VERSION_STRING ${Libdrm_VERSION}    ${PKG_Libdrm_LIBRARY_DIRS})

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -101,8 +101,13 @@
 
 #define LV_CACHE_DEF_SIZE       (10 * 1024 * 1024)
 
+#ifndef LV_USE_LINUX_DRM
 #define LV_USE_LINUX_DRM    1
+#endif
+
+#ifndef LV_USE_LINUX_FBDEV
 #define LV_USE_LINUX_FBDEV  1
+#endif
 
 #define LV_USE_ILI9341      1
 #define LV_USE_ST7735       1

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -102,11 +102,11 @@
 #define LV_CACHE_DEF_SIZE       (10 * 1024 * 1024)
 
 #ifndef LV_USE_LINUX_DRM
-#define LV_USE_LINUX_DRM    1
+    #define LV_USE_LINUX_DRM    1
 #endif
 
 #ifndef LV_USE_LINUX_FBDEV
-#define LV_USE_LINUX_FBDEV  1
+    #define LV_USE_LINUX_FBDEV  1
 #endif
 
 #define LV_USE_ILI9341      1

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -101,6 +101,9 @@
 
 #define LV_CACHE_DEF_SIZE       (10 * 1024 * 1024)
 
+#define LV_USE_LINUX_DRM    1
+#define LV_USE_LINUX_FBDEV  1
+
 #define LV_USE_ILI9341      1
 #define LV_USE_ST7735       1
 #define LV_USE_ST7789       1


### PR DESCRIPTION
### Description of the feature or fix

Compiling the DRM display driver currently fails because it uses a non-existent include.

```
FAILED: unl0kr.p/.._lvgl_src_drivers_display_drm_lv_linux_drm.c.o 
cc -Iunl0kr.p -I. -I.. -I../.. -I/usr/include/libdrm -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -O0 -g '-DUL_VERSION="2.0.2"' -DLV_USE_LINUX_DRM=1 -MD -MQ unl0kr.p/.._lvgl_src_drivers_display_drm_lv_linux_drm.c.o -MF unl0kr.p/.._lvgl_src_drivers_display_drm_lv_linux_drm.c.o.d -o unl0kr.p/.._lvgl_src_drivers_display_drm_lv_linux_drm.c.o -c ../../lvgl/src/drivers/display/drm/lv_linux_drm.c
../../lvgl/src/drivers/display/drm/lv_linux_drm.c:12:10: fatal error: ../../../lv_api_map.h: No such file or directory
   12 | #include "../../../lv_api_map.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```

This PR simply removes the include.

I also tried enabling compilation of both the DRM and FBDEV drivers on the CI in this PR.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
