### PR TITLE
fix(windows): improve graphic performance via using high resolution tick count and timer delay implementation

### DIFF
--- a/docs/integration/driver/windows.rst
+++ b/docs/integration/driver/windows.rst
@@ -102,7 +102,7 @@ Usage
         while (1)
         {
             uint32_t time_till_next = lv_timer_handler();
-            Sleep(time_till_next);
+            lv_delay_ms(time_till_next);
         }
 
         return 0;


### PR DESCRIPTION
### Description of the feature or fix

Here are the before vs after style screenshots to talk about the graphic performance improvement.

![image](https://github.com/lvgl/lvgl/assets/10867563/cad915b1-d025-4cda-91c6-fcd4fcd543b7)
Before (LVGL Benchmark Demo, 800x480, set LV_DEF_REFR_PERIOD to 1, set LV_USE_OS to LV_OS_NONE, i7-11800H)

![image](https://github.com/lvgl/lvgl/assets/10867563/2efe1dc1-4298-4cba-97df-0c33d7c7d752)
After (LVGL Benchmark Demo, 800x480,  set LV_DEF_REFR_PERIOD to 1, set LV_USE_OS to LV_OS_NONE, i7-11800H)

![image](https://github.com/lvgl/lvgl/assets/10867563/551d924e-8658-4b19-8036-cf47077a4892)
After (LVGL Benchmark Demo, 1920x1080, set LV_DEF_REFR_PERIOD to 1, set LV_USE_OS to LV_OS_NONE, i7-7700)

Note: I think lv_delay_ms is a good interface to make people using every backend more happily. And I suggest more and more LVGL drivers will adapt to this API.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).

Kenji Mouri