### PR TITLE
fix(vg_lite): fix the loss of display accuracy of rounded rectangles

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_border.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_border.c
@@ -70,7 +70,7 @@ void lv_draw_vg_lite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc
     int32_t border_w = dsc->width;
     float r_in = LV_MAX(0, r_out - border_w);
 
-    lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_S16);
+    lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
     lv_vg_lite_path_set_quality(path, dsc->radius == 0 ? VG_LITE_LOW : VG_LITE_HIGH);
     lv_vg_lite_path_set_bonding_box_area(path, &clip_area);
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -72,7 +72,7 @@ void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t *
         r = LV_MIN(r, r_short);
     }
 
-    lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_S16);
+    lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
     lv_vg_lite_path_set_quality(path, dsc->radius == 0 ? VG_LITE_LOW : VG_LITE_HIGH);
     lv_vg_lite_path_set_bonding_box_area(path, &clip_area);
     lv_vg_lite_path_append_rect(path, coords->x1, coords->y1, w, h, r, r);

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -123,7 +123,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
         LV_PROFILER_END_TAG("vg_lite_blit_rect");
     }
     else {
-        lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_S16);
+        lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
         lv_vg_lite_path_append_rect(
             path,
             clip_area.x1, clip_area.y1,


### PR DESCRIPTION
### Description of the feature or fix

Using integer coordinates results in insufficient accuracy for Bezier curves.
![image](https://github.com/lvgl/lvgl/assets/26767803/8dcdabde-feb0-44ce-ad76-5c679c981988)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
