### PR TITLE
fix(imagebutton): fix the example

### DIFF
--- a/docs/widgets/imagebutton.rst
+++ b/docs/widgets/imagebutton.rst
@@ -37,6 +37,10 @@ To set the image in a state, use the
 The image sources work the same as described in the `Image object </widgets/image>`__
 except that "Symbols" are not supported by the Image button. Any of the sources can ``NULL``.
 
+If only ``src_center`` is specified, the width of the widget will be set automatically to the
+width of the image. However, if all three sources are set, the width needs to be set by the user
+(using e.g. :cpp:expr:`lv_obj_set_width`) and the center image will be tiled to fill the given size.
+
 The possible states are:
 
 - :cpp:enumerator:`LV_IMAGEBUTTON_STATE_RELEASED`
@@ -53,7 +57,7 @@ they will be used in pressed state instead of the released images.
 States
 ------
 
-Instead of the regular :cpp:func:`lv_obj_add_state` and :cpp:func:`lv_obj_remove_state` functions, 
+Instead of the regular :cpp:func:`lv_obj_add_state` and :cpp:func:`lv_obj_remove_state` functions,
 the :cpp:expr:`lv_imagebutton_set_state(imagebutton, LV_IMAGEBUTTON_STATE_...)` function should be
 used to manually set a state.
 

--- a/examples/widgets/imagebutton/lv_example_imagebutton_1.c
+++ b/examples/widgets/imagebutton/lv_example_imagebutton_1.c
@@ -31,6 +31,7 @@ void lv_example_imagebutton_1(void)
     lv_obj_add_style(imagebutton1, &style_def, 0);
     lv_obj_add_style(imagebutton1, &style_pr, LV_STATE_PRESSED);
 
+    lv_obj_set_width(imagebutton1, 100);
     lv_obj_align(imagebutton1, LV_ALIGN_CENTER, 0, 0);
 
     /*Create a label on the image button*/

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -231,27 +231,15 @@ static void draw_main(lv_event_t * e)
         clip_area_center.y1 = coords.y1;
         clip_area_center.y2 = coords.y2;
 
-        bool comm_res;
-        comm_res = _lv_area_intersect(&clip_area_center, &clip_area_center, &layer->_clip_area);
-        if(comm_res) {
-            int32_t i;
-
-            const lv_area_t clip_area_ori = layer->_clip_area;
+        if(_lv_area_intersect(&clip_area_center, &clip_area_center, &layer->_clip_area)) {
+            lv_area_t clip_area_ori = layer->_clip_area;
             layer->_clip_area = clip_area_center;
-
-            coords_part.x1 = coords.x1 + left_w;
-            coords_part.y1 = coords.y1;
-            coords_part.x2 = coords_part.x1 + src_info->header.w - 1;
-            coords_part.y2 = coords_part.y1 + src_info->header.h - 1;
-
-            for(i = coords_part.x1; i < (int32_t)(clip_area_center.x2 + src_info->header.w - 1); i += src_info->header.w) {
-                img_dsc.src = src_info->img_src;
-                lv_draw_image(layer, &img_dsc, &coords_part);
-                coords_part.x1 = coords_part.x2 + 1;
-                coords_part.x2 += src_info->header.w;
-            }
+            img_dsc.src = src_info->img_src;
+            img_dsc.tile = 1;
+            lv_draw_image(layer, &img_dsc, &clip_area_center);
             layer->_clip_area = clip_area_ori;
         }
+
     }
 }
 


### PR DESCRIPTION
### Description of the feature or fix

By default the width is 0 if all 3 sources are set. Also simplify image button rendering and update the docs. 


fixes #5700

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
