### PR TITLE
fix(vg_lite): fix GPU draw unit fallback not finish

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -253,8 +253,19 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
         lv_draw_unit_t * u = _draw_info.unit_head;
         while(u) {
             int32_t taken_cnt = u->dispatch_cb(u, layer);
+#if LV_USE_OS
             if(taken_cnt >= 0) render_running = true;
             u = u->next;
+#else
+            if(taken_cnt >= 0) {
+                render_running = true;
+                break;
+            }
+            else {
+                /*If the unit is not suitable for the layer, try the next unit*/
+                u = u->next;
+            }
+#endif
         }
     }
 


### PR DESCRIPTION
### Description of the feature or fix

When using single-thread + GPU rendering, drawing operations that are not supported by the GPU need to fallback to software rendering.

At present, it is found that there are some problems in the draw fallback process, that is, the CPU does not wait for the GPU rendering to finish before rendering.
For example, the draw task queue currently has two tasks, the first task is dispatched to the GPU, and the second task is dispatched to the CPU.

The dispatch fallback process before modification:
dispatch_cb -> vg_lite_dispatch -> lv_draw_get_next_available_task -> vg_lite_draw -> vg_lite_flush ->
dispatch_cb -> sw_dispatch -> lv_draw_get_next_available_task -> sw draw

Modified process:
dispatch_cb -> vg_lite_dispatch -> lv_draw_get_next_available_task -> vg_lite_draw -> vg_lite_flush ->
dispatch_cb -> vg_lite_dispatch -> lv_draw_get_next_available_task -> task == NULL -> vg_lite_finish ->
dispatch_cb -> sw_dispatch -> lv_draw_get_next_available_task -> sw draw

I'm actually not sure whether this modification is correct, but after testing, the rendering behavior is as expected. If you have any questions, please correct me.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
