### PR TITLE
fix(vg_lite): fix draw layer drawing is incomplete

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_layer.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_layer.c
@@ -42,6 +42,7 @@ void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t
                            const lv_area_t * coords)
 {
     lv_layer_t * layer = (lv_layer_t *)draw_dsc->src;
+    struct _lv_draw_vg_lite_unit_t * u = (struct _lv_draw_vg_lite_unit_t *)draw_unit;
 
     /*It can happen that nothing was draw on a layer and therefore its buffer is not allocated.
      *In this case just return. */
@@ -58,6 +59,11 @@ void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = layer->draw_buf;
     lv_draw_vg_lite_img(draw_unit, &new_draw_dsc, coords, true);
+
+    /* Wait for the GPU drawing to complete here,
+     * otherwise it may cause the drawing to fail. */
+    lv_vg_lite_finish(u);
+
     LV_PROFILER_END;
 }
 


### PR DESCRIPTION
### Description of the feature or fix

The temporary buffer for the layer should be finished immediately to ensure that the drawing is completed.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
