### PR TITLE
fix(env): fix meson build break

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -32,16 +32,9 @@ file(GLOB_RECURSE THORVG_SOURCES ${LVGL_ROOT_DIR}/src/libs/thorvg/*.cpp ${LVGL_R
 add_library(lvgl ${SOURCES})
 add_library(lvgl::lvgl ALIAS lvgl)
 
-if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
-  target_compile_definitions(
-    lvgl PUBLIC $<$<BOOL:${LV_LVGL_H_INCLUDE_SIMPLE}>:LV_LVGL_H_INCLUDE_SIMPLE>
-                $<$<BOOL:${LV_CONF_INCLUDE_SIMPLE}>:LV_CONF_INCLUDE_SIMPLE>
-                $<$<COMPILE_LANGUAGE:ASM>:__ASSEMBLY__>)
-else()
-  target_compile_definitions(
-    lvgl PUBLIC $<$<BOOL:${LV_LVGL_H_INCLUDE_SIMPLE}>:LV_LVGL_H_INCLUDE_SIMPLE>
-                $<$<BOOL:${LV_CONF_INCLUDE_SIMPLE}>:LV_CONF_INCLUDE_SIMPLE>)
-endif()
+target_compile_definitions(
+  lvgl PUBLIC $<$<BOOL:${LV_LVGL_H_INCLUDE_SIMPLE}>:LV_LVGL_H_INCLUDE_SIMPLE>
+              $<$<BOOL:${LV_CONF_INCLUDE_SIMPLE}>:LV_CONF_INCLUDE_SIMPLE>)
 
 # Add definition of LV_CONF_PATH only if needed
 if(LV_CONF_PATH)


### PR DESCRIPTION
Linked to #5735.
I am not suggesting these as the actual changes to patch the current makefile in 9.0.

This is just me forcing my way to make it work.
I basically started from the 8.3 makefile which was fine in meson, and I added back most of the new features from the 9.0 version until it broke again.
Tested in meson 1.3.x.