### PR TITLE
fix(draw_buf): init struct member in order

### DIFF
--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -57,11 +57,13 @@ typedef struct {
     static uint8_t buf_##name[_LV_DRAW_BUF_SIZE(_w, _h, _cf)]; \
     static lv_draw_buf_t name = { \
                                   .header = { \
-                                              .w = (_w), \
-                                              .h = (_h), \
+                                              .magic = LV_IMAGE_HEADER_MAGIC, \
                                               .cf = (_cf), \
                                               .flags = LV_IMAGE_FLAGS_MODIFIABLE, \
+                                              .w = (_w), \
+                                              .h = (_h), \
                                               .stride = _LV_DRAW_BUF_STRIDE(_w, _cf), \
+                                              .reserved_2 = 0, \
                                             }, \
                                   .data_size = sizeof(buf_##name), \
                                   .data = buf_##name, \


### PR DESCRIPTION


### Description of the feature or fix

Mentioned in #5709, to fix warning: `error: designator order for field 'lv_image_header_t::cf' does not match declaration order in 'lv_image_header_t'`
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
