### PR TITLE
fix(env): added *.cpp glob in ESP configuration

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE SOURCES ${LVGL_ROOT_DIR}/src/*.c)
+file(GLOB_RECURSE SOURCES ${LVGL_ROOT_DIR}/src/*.c ${LVGL_ROOT_DIR}/src/*.cpp)
 
 idf_build_get_property(LV_MICROPYTHON LV_MICROPYTHON)
 


### PR DESCRIPTION
### Description of the feature or fix

With the inclusion of ThorVG LVGL now contains some C++ code. The ESP build system did not include a glob rule for *.cpp file, so it was not possible to build the project.

I simply added the required rule, extending the `SOURCES` list to include ThorVG C++ files.