### PR TITLE
doc(stm32): fix typo

### DIFF
--- a/docs/integration/chip/stm32.rst
+++ b/docs/integration/chip/stm32.rst
@@ -193,7 +193,7 @@ variables:
    osThreadId lvgl_timerHandle;
 
    /* definition and creation of lvgl_tick */
-   osThreadDef(lvgl_tick, LGVLTick, osPriorityNormal, 0, 1024);
+   osThreadDef(lvgl_tick, LVGLTick, osPriorityNormal, 0, 1024);
    lvgl_tickHandle = osThreadCreate(osThread(lvgl_tick), NULL);
 
    //LVGL update timer


### PR DESCRIPTION
### Description of the feature or fix

fix typo.

change
```c
osThreadDef(lvgl_tick, LGVLTick, osPriorityNormal, 0, 1024);
```
to
```c
osThreadDef(lvgl_tick, LVGLTick, osPriorityNormal, 0, 1024);
```