### PR TITLE
fix(fsdrv): add missing lv_fs_littlefs_init function declaration

### DIFF
--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -47,6 +47,10 @@ void lv_fs_win32_init(void);
 void lv_fs_memfs_init(void);
 #endif
 
+#if LV_USE_FS_LITTLEFS
+void lv_fs_littlefs_init(void);
+#endif
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

Prevent compiler warnings about missing header files