### PR TITLE
refactor(conf): rename LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE to LV_DRAW_LAYER_SIMPLE_BUF_SIZE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -154,7 +154,7 @@ menu "LVGL configuration"
 			default 4 if LV_OS_RTTHREAD
 			default 5 if LV_OS_WINDOWS
 			default 255 if LV_OS_CUSTOM
-		
+
 		config LV_OS_CUSTOM_INCLUDE
 			string "Custom OS include header"
 			default "stdint.h"
@@ -173,6 +173,15 @@ menu "LVGL configuration"
 			default 4
 		help
 			Align the start address of draw_buf addresses to this bytes.
+
+		config LV_DRAW_LAYER_SIMPLE_BUF_SIZE
+			int "Optimal size to buffer the widget with opacity"
+			default 24576
+			depends on LV_USE_DRAW_SW
+			help
+				If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
+				it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+				"Transformed layers" (if `transform_angle/zoom` are set) use larger buffers and can't be drawn in chunks.
 
 		config LV_USE_DRAW_SW
 			bool "Enable software rendering"
@@ -201,15 +210,6 @@ menu "LVGL configuration"
 			depends on LV_USE_DRAW_SW
 			help
 				Disabling this allows arm2d to work on its own (for testing only)
-
-		config LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
-			int "Optimal size to buffer the widget with opacity"
-			default 24576
-			depends on LV_USE_DRAW_SW
-			help
-				If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-				it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-				"Transformed layers" (if `transform_angle/zoom` are set) use larger buffers and can't be drawn in chunks.
 
 		config LV_DRAW_SW_COMPLEX
 			bool "Enable complex draw engine"
@@ -1087,7 +1087,7 @@ menu "LVGL configuration"
 		config LV_GIF_CACHE_DECODE_DATA
 			bool "Use extra 16KB RAM to cache decoded data to accerlate"
 			depends on LV_USE_GIF
-		
+
 		config LV_BIN_DECODER_RAM_LOAD
 			bool "Decode whole image to RAM for bin decoder"
 			default n
@@ -1306,7 +1306,7 @@ menu "LVGL configuration"
 			string "SDL include path"
 			depends on LV_USE_SDL
 			default "SDL2/SDL.h"
-	
+
 		choice
 			prompt "SDL rendering mode"
 			depends on LV_USE_SDL
@@ -1323,7 +1323,7 @@ menu "LVGL configuration"
 			config LV_SDL_RENDER_MODE_FULL
 				bool "Always redraw the whole screen even if only one pixel has been changed with 2 screen sized buffers"
 		endchoice
-		
+
 		choice
 			prompt "SDL buffer size"
 			depends on LV_USE_SDL

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -99,6 +99,14 @@
 /*Align the start address of draw_buf addresses to this bytes*/
 #define LV_DRAW_BUF_ALIGN                       4
 
+/* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
+ * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+ * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
+ * and can't be drawn in chunks. */
+
+/*The target buffer size for simple layer chunks.*/
+#define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
+
 #define LV_USE_DRAW_SW 1
 #if LV_USE_DRAW_SW == 1
     /* Set the number of draw unit.
@@ -111,14 +119,6 @@
 
     /* Enable native helium assembly to be compiled */
     #define LV_USE_NATIVE_HELIUM_ASM    1
-
-    /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
-     * and can't be drawn in chunks. */
-
-    /*The target buffer size for simple layer chunks.*/
-    #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
 
     /* 0: use a simple renderer capable of drawing only simple rectangles with gradient, images, texts, and straight lines only
      * 1: use a complex renderer capable of drawing rounded corners, shadow, skew lines, and arcs too */

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -906,8 +906,8 @@ void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
         if(layer_type == LV_LAYER_TYPE_SIMPLE) {
             int32_t w = lv_area_get_width(&layer_area_full);
             uint8_t px_size = lv_color_format_get_size(disp_refr->color_format);
-            max_rgb_row_height = LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE / w / px_size;
-            max_argb_row_height = LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE / w / sizeof(lv_color32_t);
+            max_rgb_row_height = LV_DRAW_LAYER_SIMPLE_BUF_SIZE / w / px_size;
+            max_argb_row_height = LV_DRAW_LAYER_SIMPLE_BUF_SIZE / w / sizeof(lv_color32_t);
         }
 
         lv_area_t layer_area_act;

--- a/src/lv_api_map_v9_0.h
+++ b/src/lv_api_map_v9_0.h
@@ -33,6 +33,10 @@ extern "C" {
 #define lv_image_set_align               lv_image_set_inner_align
 #define lv_image_get_align               lv_image_get_inner_align
 
+#ifndef LV_DRAW_LAYER_SIMPLE_BUF_SIZE
+#define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
+#endif
+
 /**********************
  *      MACROS
  **********************/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -249,6 +249,20 @@
     #endif
 #endif
 
+/* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
+ * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+ * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
+ * and can't be drawn in chunks. */
+
+/*The target buffer size for simple layer chunks.*/
+#ifndef LV_DRAW_LAYER_SIMPLE_BUF_SIZE
+    #ifdef CONFIG_LV_DRAW_LAYER_SIMPLE_BUF_SIZE
+        #define LV_DRAW_LAYER_SIMPLE_BUF_SIZE CONFIG_LV_DRAW_LAYER_SIMPLE_BUF_SIZE
+    #else
+        #define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
+    #endif
+#endif
+
 #ifndef LV_USE_DRAW_SW
     #ifdef _LV_KCONFIG_PRESENT
         #ifdef CONFIG_LV_USE_DRAW_SW
@@ -295,20 +309,6 @@
             #endif
         #else
             #define LV_USE_NATIVE_HELIUM_ASM    1
-        #endif
-    #endif
-
-    /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
-     * and can't be drawn in chunks. */
-
-    /*The target buffer size for simple layer chunks.*/
-    #ifndef LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
-        #ifdef CONFIG_LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
-            #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE CONFIG_LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
-        #else
-            #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
         #endif
     #endif
 


### PR DESCRIPTION


the layer size is not realted only to SW rendering.

Fixes #5775

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
