### PR TITLE
fix(lv_vector_path_append_arc): fix the bug that can not add points to path when pie is false

### DIFF
--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -325,7 +325,15 @@ void lv_vector_path_close(lv_vector_path_t * path)
 
 void lv_vector_path_get_bounding(const lv_vector_path_t * path, lv_area_t * area)
 {
+    if(path == NULL || area == NULL) {
+        return;
+    }
+
     uint32_t len = lv_array_size(&path->points);
+    if(len == 0) {
+        return;
+    }
+
     lv_fpoint_t * p = lv_array_front(&path->points);
     float x1 = p[0].x;
     float x2 = p[0].x;

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -530,6 +530,10 @@ void lv_vector_path_append_arc(lv_vector_path_t * path, const lv_fpoint_t * c, f
         lv_vector_path_line_to(path, &(lv_fpoint_t) {
             start.x + cx, start.y + cy
         });
+    } else {
+        lv_vector_path_move_to(path, &(lv_fpoint_t) {
+            start.x + cx, start.y + cy
+        });
     }
     else {
         lv_vector_path_move_to(path, &(lv_fpoint_t) {

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -325,12 +325,12 @@ void lv_vector_path_close(lv_vector_path_t * path)
 
 void lv_vector_path_get_bounding(const lv_vector_path_t * path, lv_area_t * area)
 {
-    if(path == NULL || area == NULL) {
-        return;
-    }
+    LV_ASSERT_NULL(path);
+    LV_ASSERT_NULL(area);
 
     uint32_t len = lv_array_size(&path->points);
     if(len == 0) {
+        lv_memzero(area, sizeof(lv_area_t));
         return;
     }
 


### PR DESCRIPTION
fix the bug when the pie param is false,the lv_vector_path_move_to is not call, path->ops is empty, so lv_vector_path_cubic_to done nothing.