### PR TITLE
fix(demo_music): fix the previous button in the music demo is not clickable

### DIFF
--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -586,6 +586,7 @@ static lv_obj_t * create_ctrl_box(lv_obj_t * parent)
     lv_image_set_src(icon, &img_lv_demo_music_btn_prev);
     lv_obj_set_grid_cell(icon, LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
     lv_obj_add_event_cb(icon, prev_click_event_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_flag(icon, LV_OBJ_FLAG_CLICKABLE);	// Make the prev button clickable
 
     play_obj = lv_imagebutton_create(cont);
     lv_imagebutton_set_src(play_obj, LV_IMAGEBUTTON_STATE_RELEASED, NULL, &img_lv_demo_music_btn_play, NULL);

--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -586,7 +586,7 @@ static lv_obj_t * create_ctrl_box(lv_obj_t * parent)
     lv_image_set_src(icon, &img_lv_demo_music_btn_prev);
     lv_obj_set_grid_cell(icon, LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
     lv_obj_add_event_cb(icon, prev_click_event_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_add_flag(icon, LV_OBJ_FLAG_CLICKABLE);	// Make the prev button clickable
+    lv_obj_add_flag(icon, LV_OBJ_FLAG_CLICKABLE);
 
     play_obj = lv_imagebutton_create(cont);
     lv_imagebutton_set_src(play_obj, LV_IMAGEBUTTON_STATE_RELEASED, NULL, &img_lv_demo_music_btn_play, NULL);


### PR DESCRIPTION
In the music demo, the button to go to the previous title (located to the left of the play button) is not clickable.

Root cause of this problem: The flag 'LV_OBJ_FLAG_CLICKABLE' is not set for this button.

Solution: In the file 'lv_demo_music_main.c' the following line must be added after line 588:
          _lv_obj_add_flag(icon, LV_OBJ_FLAG_CLICKABLE); // Make the prev button clickable_
