### PR TITLE
fix(fsdrv/fatfs): fix does not detect the end of entries in fs_dir_read

### DIFF
--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -256,7 +256,7 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint3
         res = f_readdir(dir_p, &fno);
         if(res != FR_OK) return LV_FS_RES_UNKNOWN;
 
-        if (fno.fname[0] == 0) break; /* End of the directory */
+        if(fno.fname[0] == 0) break; /* End of the directory */
 
         if(fno.fattrib & AM_DIR) {
             lv_snprintf(fn, fn_len, "/%s", fno.fname);

--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -256,6 +256,8 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint3
         res = f_readdir(dir_p, &fno);
         if(res != FR_OK) return LV_FS_RES_UNKNOWN;
 
+        if (fno.fname[0] == 0) break; /* End of the directory */
+
         if(fno.fattrib & AM_DIR) {
             lv_snprintf(fn, fn_len, "/%s", fno.fname);
         }


### PR DESCRIPTION
The fs_dir_read function not takes into account the end of the entries, since it never finishes reading the next one, thus entering a loop (#5823).

### Description of the feature or fix

fix to exit loop upon reaching last entry 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
