### PR TITLE
fix(indev): Fix scroll obj cannot be cleared when waiting until release

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1116,8 +1116,8 @@ static void indev_proc_press(lv_indev_t * indev)
         new_obj_searched = true;
     }
 
-    /*The last object might have scroll throw. Stop it manually*/
-    if(new_obj_searched && indev->pointer.last_obj) {
+    /*The scroll object might have scroll throw. Stop it manually*/
+    if(new_obj_searched && indev->pointer.scroll_obj) {
 
         /*Attempt to stop scroll throw animation firstly*/
         if(!indev->scroll_throw_anim || !lv_anim_delete(indev, indev_scroll_throw_anim_cb)) {
@@ -1158,6 +1158,7 @@ static void indev_proc_press(lv_indev_t * indev)
             indev->pointer.scroll_sum.x     = 0;
             indev->pointer.scroll_sum.y     = 0;
             indev->pointer.scroll_dir = LV_DIR_NONE;
+            indev->pointer.scroll_obj = NULL;
             indev->pointer.gesture_dir = LV_DIR_NONE;
             indev->pointer.gesture_sent   = 0;
             indev->pointer.gesture_sum.x  = 0;
@@ -1350,6 +1351,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
         indev->pointer.scroll_sum.x        = 0;
         indev->pointer.scroll_sum.y        = 0;
         indev->pointer.scroll_dir = LV_DIR_NONE;
+        indev->pointer.scroll_obj = NULL;
         indev->pointer.scroll_throw_vect.x = 0;
         indev->pointer.scroll_throw_vect.y = 0;
         indev->pointer.gesture_sum.x     = 0;


### PR DESCRIPTION
### Description of the feature or fix

When I called lv_indev_wait_release, last_obj was copied to NULL in the indev_proc_release function. As a result, the last hand scrolling cannot be stopped in the next indev_proc_press.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
