### PR TITLE
docs(display): use lv_display_delete_refr_timer to delete display timer

### DIFF
--- a/docs/porting/display.rst
+++ b/docs/porting/display.rst
@@ -214,9 +214,7 @@ You can do this in the following way:
 .. code:: c
 
    /*Delete the original display refresh timer*/
-   lv_timer_delete(disp->refr_timer);
-   disp->refr_timer = NULL;
-
+   lv_display_delete_refr_timer(disp);
 
    /*Call this anywhere you want to refresh the dirty areas*/
    _lv_display_refr_timer(NULL);


### PR DESCRIPTION
While not a valid LVGL program, the following snippet illustrates the problem with the current
example:

```c
// main.c
#include <lvgl.h>

int main(void) {
	lv_display_t* disp = (void*)0xFEEDBEEF;

	lv_timer_delete(disp->refr_timer);
	disp->refr_timer = NULL;
}
```

Because `lv_display_t` is an opaque typedef:

```
../main.c: In function ‘main’:
../main.c:6:29: error: invalid use of incomplete typedef ‘lv_display_t’ {aka ‘struct _lv_display_t’}
    6 |         lv_timer_delete(disp->refr_timer);
      |                             ^~
../main.c:7:13: error: invalid use of incomplete typedef ‘lv_display_t’ {aka ‘struct _lv_display_t’}
    7 |         disp->refr_timer = NULL;
      |             ^~
```
