### PR TITLE
fix(canvas): lv_canvas_transform negative offset_y parameter

### DIFF
--- a/src/widgets/lv_canvas.c
+++ b/src/widgets/lv_canvas.c
@@ -189,20 +189,18 @@ void lv_canvas_transform(lv_obj_t * obj, lv_img_dsc_t * src_img, int16_t angle, 
     lv_color_t * cbuf = lv_mem_alloc(dest_img->header.w * sizeof(lv_color_t));
     lv_opa_t * abuf = lv_mem_alloc(dest_img->header.w * sizeof(lv_opa_t));
     for(y = 0; y < dest_img->header.h; y++) {
-        if(y + offset_y >= 0) {
-            lv_draw_sw_transform(NULL, &dest_area, src_img->data, src_img->header.w, src_img->header.h, src_img->header.w,
-                                 &draw_dsc, canvas->dsc.header.cf, cbuf, abuf);
+        lv_draw_sw_transform(NULL, &dest_area, src_img->data, src_img->header.w, src_img->header.h, src_img->header.w,
+                             &draw_dsc, canvas->dsc.header.cf, cbuf, abuf);
 
-            for(x = 0; x < dest_img->header.w; x++) {
-                if(abuf[x]) {
-                    lv_img_buf_set_px_color(dest_img, x, y, cbuf[x]);
-                    lv_img_buf_set_px_alpha(dest_img, x, y, abuf[x]);
-                }
+        for(x = 0; x < dest_img->header.w; x++) {
+            if(abuf[x]) {
+                lv_img_buf_set_px_color(dest_img, x, y, cbuf[x]);
+                lv_img_buf_set_px_alpha(dest_img, x, y, abuf[x]);
             }
-
-            dest_area.y1++;
-            dest_area.y2++;
         }
+
+        dest_area.y1++;
+        dest_area.y2++;
     }
     lv_mem_free(cbuf);
     lv_mem_free(abuf);


### PR DESCRIPTION
### Description of the feature or fix

Addresses  #5827 -- see for details and screenshots

Negative values of offset_y do not render as expected. This appears to be the whole fix.

This is a v8.3 bugfix.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
