### PR TITLE
fix(imagebutton): clipped area of mid part

### DIFF
--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -225,18 +225,18 @@ static void draw_main(lv_event_t * e)
 
     src_info = &imagebutton->src_mid[state];
     if(src_info->img_src) {
-        lv_area_t clip_area_center;
-        clip_area_center.x1 = coords.x1 + left_w;
-        clip_area_center.x2 = coords.x2 - right_w;
-        clip_area_center.y1 = coords.y1;
-        clip_area_center.y2 = coords.y2;
+        coords_part.x1 = coords.x1 + left_w;
+        coords_part.x2 = coords.x2 - right_w;
+        coords_part.y1 = coords.y1;
+        coords_part.y2 = coords.y2;
 
-        if(_lv_area_intersect(&clip_area_center, &clip_area_center, &layer->_clip_area)) {
+        lv_area_t clip_area_center;
+        if(_lv_area_intersect(&clip_area_center, &coords_part, &layer->_clip_area)) {
             lv_area_t clip_area_ori = layer->_clip_area;
             layer->_clip_area = clip_area_center;
             img_dsc.src = src_info->img_src;
             img_dsc.tile = 1;
-            lv_draw_image(layer, &img_dsc, &clip_area_center);
+            lv_draw_image(layer, &img_dsc, &coords_part);
             layer->_clip_area = clip_area_ori;
         }
 


### PR DESCRIPTION
### Description of the feature or fix

Discovered while debugging issue #5803
Related to PR #5719

#### Before
![image](https://github.com/lvgl/lvgl/assets/30486941/d7fa5f92-eec7-4676-a7fd-f72016e8150a)


#### After
![image](https://github.com/lvgl/lvgl/assets/30486941/45cdd445-035e-4804-aee5-76f9790194a1)

When a sub clip of the mid part of the imagebutton is redrawn it draws it with respect to the top-left-corner because the clip coords are passed to `lv_draw_image` instead of the image part coords. Can be reproduced with `lv_example_imagebutton_1` and the play/pause button of `lv_demo_music` by moving something off of the mid part, such as a mouse cursor image.

Also, I'm not sure why, but the first draw of the mid part is also wrong too on my simulator only when I use `COLOR_DEPTH` 24 or 32, but fine for 16:
![image](https://github.com/lvgl/lvgl/assets/30486941/4ac36fb6-d964-4ded-a8cc-d1e59f25cdda)
(fixed by these changes)
Edit: this was because of partial render mode

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
