### PR TITLE
fix(drm): Default to XRGB8888 framebuffer

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -24,7 +24,7 @@
  *      DEFINES
  *********************/
 #if LV_COLOR_DEPTH == 32
-    #define DRM_FOURCC DRM_FORMAT_ARGB8888
+    #define DRM_FOURCC DRM_FORMAT_XRGB8888
 #elif LV_COLOR_DEPTH == 16
     #define DRM_FOURCC DRM_FORMAT_RGB565
 #else


### PR DESCRIPTION
The ARGB8888 framebuffer format for base canvas makes little sense as the base canvas is unlikely to be transparent and require alpha. Use XRGB8888 framebuffer format which is more widely supported by DRM drivers as base plane pixel format.

This makes e.g. i.MX8M Nano work by default.

---

This is identical fix to lv_drivers https://github.com/lvgl/lv_drivers/pull/282