### PR TITLE
fix(sdl): handle both LV_IMAGE_SRC_FILE and LV_IMAGE_SRC_VARIABLE

### DIFF
--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -224,10 +224,41 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * data)
             break;
         case LV_DRAW_TASK_TYPE_IMAGE: {
                 lv_draw_image_dsc_t * image_dsc = task->draw_dsc;
-                const char * path = image_dsc->src;
-                SDL_Surface * surface = IMG_Load(&path[2]);
-                if(surface == NULL) {
-                    fprintf(stderr, "could not load image: %s\n", IMG_GetError());
+                lv_image_src_t type = lv_image_src_get_type(image_dsc->src);
+                SDL_Surface * surface = NULL;
+                if(type == LV_IMAGE_SRC_FILE) {
+                    const char * path = image_dsc->src;
+                    surface = IMG_Load(&path[2]);
+                    if(surface == NULL) {
+                        LV_LOG_ERROR("could not load image from file: %s", IMG_GetError());
+                        return false;
+                    }
+                }
+                else if(type == LV_IMAGE_SRC_VARIABLE) {
+                    lv_image_dsc_t * lvd = image_dsc->src;
+                    surface = SDL_CreateRGBSurfaceFrom(lvd->data,
+                                                       lvd->header.w, lvd->header.h,
+                                                       LV_COLOR_FORMAT_GET_BPP(lvd->header.cf),
+                                                       lvd->header.stride,
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                                                       0x00FF0000,
+                                                       0x0000FF00,
+                                                       0x000000FF,
+                                                       0xFF000000
+#else
+                                                       0x0000FF00,
+                                                       0x00FF0000,
+                                                       0xFF000000,
+                                                       0x000000FF
+#endif
+                                                      );
+                    if(surface == NULL) {
+                        LV_LOG_ERROR("could not load image from variable");
+                        return false;
+                    }
+                }
+                else {
+                    LV_LOG_WARN("image source type unknown");
                     return false;
                 }
 


### PR DESCRIPTION
The SDL image draw code currently assumes that the image source is a filename and attempts to open that filename. This is not necessarily the case, e.g. the lv_demo_fb uses encoded images which are of type LV_IMAGE_SRC_VARIABLE and instead of filename, come with a buffer of pixels. Handle the later using SDL_CreateRGBSurfaceFrom().