### PR TITLE
fix(cmake): generate versioned shared libraries

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -1,3 +1,10 @@
+set(LVGL_VERSION_MAJOR "9")
+set(LVGL_VERSION_MINOR "1")
+set(LVGL_VERSION_PATCH "1")
+set(LVGL_VERSION_INFO  "dev")
+set(LVGL_VERSION ${LVGL_VERSION_MAJOR}.${LVGL_VERSION_MINOR}.${LVGL_VERSION_PATCH})
+set(LVGL_SOVERSION ${LVGL_VERSION_MAJOR})
+
 # Option to define LV_LVGL_H_INCLUDE_SIMPLE, default: ON
 option(LV_LVGL_H_INCLUDE_SIMPLE
        "Use #include \"lvgl.h\" instead of #include \"../../lvgl.h\"" ON)
@@ -41,7 +48,7 @@ if(LV_CONF_SKIP)
 endif()
 
 # Include root and optional parent path of LV_CONF_PATH
-target_include_directories(lvgl SYSTEM PUBLIC ${LVGL_ROOT_DIR} ${LV_CONF_DIR})
+target_include_directories(lvgl SYSTEM PUBLIC ${LVGL_ROOT_DIR} ${LV_CONF_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 
 if(NOT LV_CONF_BUILD_DISABLE_THORVG_INTERNAL)
@@ -112,6 +119,7 @@ endif()
 
 
 configure_file("${LVGL_ROOT_DIR}/lvgl.pc.in" lvgl.pc @ONLY)
+configure_file("${LVGL_ROOT_DIR}/lv_version.h.in" lv_version.h @ONLY)
 
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/lvgl.pc"
@@ -121,6 +129,8 @@ install(
 set_target_properties(
   lvgl
   PROPERTIES OUTPUT_NAME lvgl
+             VERSION ${LVGL_VERSION}
+             SOVERSION ${LVGL_SOVERSION}
              ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
              LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
              RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
@@ -139,6 +149,8 @@ if(NOT LV_CONF_BUILD_DISABLE_THORVG_INTERNAL)
   set_target_properties(
     lvgl_thorvg
     PROPERTIES OUTPUT_NAME lvgl_thorvg
+               VERSION ${LVGL_VERSION}
+               SOVERSION ${LVGL_SOVERSION}
                ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
@@ -157,6 +169,8 @@ if(NOT LV_CONF_BUILD_DISABLE_DEMOS)
   set_target_properties(
     lvgl_demos
     PROPERTIES OUTPUT_NAME lvgl_demos
+               VERSION ${LVGL_VERSION}
+               SOVERSION ${LVGL_SOVERSION}
                ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
@@ -175,6 +189,8 @@ if(NOT LV_CONF_BUILD_DISABLE_EXAMPLES)
   set_target_properties(
     lvgl_examples
     PROPERTIES OUTPUT_NAME lvgl_examples
+               VERSION ${LVGL_VERSION}
+               SOVERSION ${LVGL_SOVERSION}
                ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/lv_version.h
+++ b/lv_version.h
@@ -1,0 +1,14 @@
+/**
+ * @file version.h
+ * The current version of LVGL
+ */
+
+#ifndef LVGL_VERSION_H
+#define LVGL_VERSION_H
+
+#define LVGL_VERSION_MAJOR 9
+#define LVGL_VERSION_MINOR 1
+#define LVGL_VERSION_PATCH 1
+#define LVGL_VERSION_INFO "dev"
+
+#endif /*LVGL_VERSION_H*/

--- a/lv_version.h.in
+++ b/lv_version.h.in
@@ -1,0 +1,14 @@
+/**
+ * @file version.h
+ * The current version of LVGL
+ */
+
+#ifndef LVGL_VERSION_H
+#define LVGL_VERSION_H
+
+#define LVGL_VERSION_MAJOR @LVGL_VERSION_MAJOR@
+#define LVGL_VERSION_MINOR @LVGL_VERSION_MINOR@
+#define LVGL_VERSION_PATCH @LVGL_VERSION_PATCH@
+#define LVGL_VERSION_INFO "@LVGL_VERSION_INFO@"
+
+#endif /*LVGL_VERSION_H*/

--- a/lvgl.h
+++ b/lvgl.h
@@ -13,10 +13,7 @@ extern "C" {
 /***************************
  * CURRENT VERSION OF LVGL
  ***************************/
-#define LVGL_VERSION_MAJOR 9
-#define LVGL_VERSION_MINOR 1
-#define LVGL_VERSION_PATCH 1
-#define LVGL_VERSION_INFO  "dev"
+#include "lv_version.h"
 
 /*********************
  *      INCLUDES

--- a/lvgl.pc.in
+++ b/lvgl.pc.in
@@ -5,6 +5,6 @@ libdir=${prefix}/lib
 Name: lvgl
 Description: Light and Versatile Graphics Library
 URL: https://lvgl.io/
-Version: 9.1.0
+Version: @LVGL_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -llvgl


### PR DESCRIPTION
Add missing version suffix to shared libraries. Currently the filename of generated shared libraries is only liblvgl.so, which prevents coexistence of different versions of LVGL on the same system. Set VERSION and SOVERSION to make cmake add the version suffix to generated shared libraries. That changes the filename to liblvgl.so.9.0.0 and includes symlink with major ABI version, i.e. liblvgl.so.9 .