### PR TITLE
fix(ci): workaround ASAN error in CI with Ubuntu 22.04 image

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -101,6 +101,12 @@ jobs:
           install: |
             apt-get update -y
             if [[ "${{ matrix.distro }}" == "ubuntu22.04" ]]; then
+              # ASan in llvm 14 provided in ubuntu-22.04 is incompatible with
+              # high-entropy ASLR configured in much newer kernels that GitHub
+              # runners are using leading to random crashes:
+              #   https://github.com/actions/runner-images/issues/9491
+              # can remove this once the issue is fixed.
+              sudo sysctl -w vm.mmap_rnd_bits=28
               apt-get install libjpeg-turbo8-dev -q -y
             else
               apt-get install libjpeg62-turbo-dev -q -y

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -106,7 +106,7 @@ jobs:
               # runners are using leading to random crashes:
               #   https://github.com/actions/runner-images/issues/9491
               # can remove this once the issue is fixed.
-              sudo sysctl -w vm.mmap_rnd_bits=28
+              sysctl -w vm.mmap_rnd_bits=28
               apt-get install libjpeg-turbo8-dev -q -y
             else
               apt-get install libjpeg62-turbo-dev -q -y

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -117,7 +117,7 @@ jobs:
               # runners are using leading to random crashes:
               #   https://github.com/actions/runner-images/issues/9491
               # can remove this once the issue is fixed.
-              sysctl -w vm.mmap_rnd_bits=28
+              sysctl -w vm.mmap_rnd_bits=18
             fi
             env PATH="/usr/lib/ccache:$PATH" NON_AMD64_BUILD=1 ASAN_OPTIONS=detect_leaks=0 python3 tests/main.py test
       - name: Archive screenshot errors

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -101,12 +101,6 @@ jobs:
           install: |
             apt-get update -y
             if [[ "${{ matrix.distro }}" == "ubuntu22.04" ]]; then
-              # ASan in llvm 14 provided in ubuntu-22.04 is incompatible with
-              # high-entropy ASLR configured in much newer kernels that GitHub
-              # runners are using leading to random crashes:
-              #   https://github.com/actions/runner-images/issues/9491
-              # can remove this once the issue is fixed.
-              sysctl -w vm.mmap_rnd_bits=28
               apt-get install libjpeg-turbo8-dev -q -y
             else
               apt-get install libjpeg62-turbo-dev -q -y
@@ -117,6 +111,14 @@ jobs:
             echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
 
           run: |
+            if [[ "${{ matrix.distro }}" == "ubuntu22.04" ]]; then
+              # ASan in llvm 14 provided in ubuntu-22.04 is incompatible with
+              # high-entropy ASLR configured in much newer kernels that GitHub
+              # runners are using leading to random crashes:
+              #   https://github.com/actions/runner-images/issues/9491
+              # can remove this once the issue is fixed.
+              sysctl -w vm.mmap_rnd_bits=28
+            fi
             env PATH="/usr/lib/ccache:$PATH" NON_AMD64_BUILD=1 ASAN_OPTIONS=detect_leaks=0 python3 tests/main.py test
       - name: Archive screenshot errors
         if: failure()

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -35,6 +35,11 @@ jobs:
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: Install prerequisites
       run: scripts/install-prerequisites.sh
+    - name: Fix kernel mmap rnd bits
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Run tests
       run: python tests/main.py --report --update-image test
     - name: Archive screenshot errors
@@ -117,7 +122,7 @@ jobs:
               # runners are using leading to random crashes:
               #   https://github.com/actions/runner-images/issues/9491
               # can remove this once the issue is fixed.
-              sysctl -w vm.mmap_rnd_bits=18
+              sysctl -w vm.mmap_rnd_bits=28
             fi
             env PATH="/usr/lib/ccache:$PATH" NON_AMD64_BUILD=1 ASAN_OPTIONS=detect_leaks=0 python3 tests/main.py test
       - name: Archive screenshot errors


### PR DESCRIPTION
### Description of the feature or fix

ASan in llvm 14 provided in ubuntu-22.04 is incompatible with high-entropy ASLR configured in much newer kernels that GitHub runners are using leading to random crashes:
- https://github.com/actions/runner-images/issues/9491

The code can be removed when this issue is closed.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
