### PR TITLE
fix(vg_lite): fix stroke path memory leak

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -104,9 +104,8 @@ void lv_vg_lite_path_destroy(lv_vg_lite_path_t * path)
         lv_free(path->base.path);
         path->base.path = NULL;
 
-        if(path->base.stroke) {
-            LV_LOG_ERROR("can't free stroke path");
-        }
+        /* clear remaining path data */
+        LV_VG_LITE_CHECK_ERROR(vg_lite_clear_path(&path->base));
     }
     lv_free(path);
     LV_PROFILER_END;

--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -888,7 +888,7 @@ extern "C" {
             path->stroke = NULL;
         }
 
-        return VG_LITE_NOT_SUPPORT;
+        return VG_LITE_SUCCESS;
     }
 
     vg_lite_uint32_t vg_lite_get_path_length(vg_lite_uint8_t * opcode,

--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -2136,9 +2136,7 @@ static Result shape_append_path(std::unique_ptr<Shape> & shape, vg_lite_path_t *
                 break;
 
             case VLC_OP_CLOSE:
-            case VLC_OP_END: {
-                    TVG_CHECK_RETURN_RESULT(shape->close());
-                }
+                TVG_CHECK_RETURN_RESULT(shape->close());
                 break;
 
             default:


### PR DESCRIPTION
### Description of the feature or fix

1. Use `vg_lite_clear_path` to clear stroke data.
2. Remove redundant path close.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
