### PR TITLE
refactor(font): refactor release/get_glyph/image API names

### DIFF
--- a/demos/benchmark/assets/lv_font_benchmark_montserrat_12_compr_az.c.c
+++ b/demos/benchmark/assets/lv_font_benchmark_montserrat_12_compr_az.c.c
@@ -303,14 +303,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t lv_font_benchmark_montserrat_12_compr_az = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 13,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_acquire_draw_data/dsc` */
 };
 
 #endif /*#if LV_FONT_BENCHMARK_MONTSERRAT_12_COMPR_AZ*/

--- a/demos/benchmark/assets/lv_font_benchmark_montserrat_16_compr_az.c.c
+++ b/demos/benchmark/assets/lv_font_benchmark_montserrat_16_compr_az.c.c
@@ -341,14 +341,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t lv_font_benchmark_montserrat_16_compr_az = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 15,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_BENCHMARK_MONTSERRAT_16_COMPR_AZ*/

--- a/demos/benchmark/assets/lv_font_benchmark_montserrat_28_compr_az.c.c
+++ b/demos/benchmark/assets/lv_font_benchmark_montserrat_28_compr_az.c.c
@@ -492,14 +492,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t lv_font_benchmark_montserrat_28_compr_az = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 26,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_BENCHMARK_MONTSERRAT_28_COMPR_AZ*/

--- a/demos/multilang/assets/fonts/font_multilang_large.c
+++ b/demos/multilang/assets/fonts/font_multilang_large.c
@@ -1904,8 +1904,8 @@ const lv_font_t font_multilang_large = {
 #else
 lv_font_t font_multilang_large = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 23,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1915,7 +1915,7 @@ lv_font_t font_multilang_large = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if FONT_MULTILANG_LARGE*/

--- a/demos/multilang/assets/fonts/font_multilang_small.c
+++ b/demos/multilang/assets/fonts/font_multilang_small.c
@@ -6326,8 +6326,8 @@ const lv_font_t font_multilang_small = {
 #else
 lv_font_t font_multilang_small = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 23,          /*The maximum line height required by the font*/
     .base_line = 7,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -6337,7 +6337,7 @@ lv_font_t font_multilang_small = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if FONT_MULTILANG_SMALL*/

--- a/docs/ROADMAP.rst
+++ b/docs/ROADMAP.rst
@@ -46,7 +46,7 @@ Architecture
   (see `here <https://github.com/lvgl/lvgl/issues/3379#issuecomment-1140886258>`__)
 - |check| Reconsider masks. There should be a generic high level mask API which is independent of the drawing engine.
   `#4059 <https://github.com/lvgl/lvgl/issues/4059>`__
-- |check| `get_glyph_bitmap` should return an a8 bitmap that can be blended immediately.
+- |check| `glyph_acquire_draw_data` should return an a8 bitmap that can be blended immediately.
   (see `here <https://github.com/lvgl/lvgl/pull/3390#pullrequestreview-990710921>`__)
 - |check| Make LVGL render independent areas in parallel.
   `#4016 <https://github.com/lvgl/lvgl/issues/4016>`__

--- a/docs/overview/font.rst
+++ b/docs/overview/font.rst
@@ -360,8 +360,8 @@ To do this, a custom :cpp:type:`lv_font_t` variable needs to be created:
 
    /*Describe the properties of a font*/
    lv_font_t my_font;
-   my_font.get_glyph_dsc = my_get_glyph_dsc_cb;        /*Set a callback to get info about glyphs*/
-   my_font.get_glyph_bitmap = my_get_glyph_bitmap_cb;  /*Set a callback to get bitmap of a glyph*/
+   my_font.glyph_get_info = my_get_glyph_dsc_cb;        /*Set a callback to get info about glyphs*/
+   my_font.glyph_acquire_draw_data = my_glyph_acquire_draw_data_cb;  /*Set a callback to get bitmap of a glyph*/
    my_font.line_height = height;                       /*The real line height where any text fits*/
    my_font.base_line = base_line;                      /*Base line measured from the top of line_height*/
    my_font.dsc = something_required;                   /*Store any implementation specific data here*/
@@ -392,7 +392,7 @@ To do this, a custom :cpp:type:`lv_font_t` variable needs to be created:
 
 
    /* Get the bitmap of `unicode_letter` from `font`. */
-   const uint8_t * my_get_glyph_bitmap_cb(const lv_font_t * font, uint32_t unicode_letter)
+   const uint8_t * my_glyph_acquire_draw_data_cb(const lv_font_t * font, uint32_t unicode_letter)
    {
        /* Your code here */
 

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -112,7 +112,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_character(lv_layer_t * layer, lv_draw_label_d
     LV_PROFILER_BEGIN;
 
     lv_font_glyph_dsc_t g;
-    lv_font_get_glyph_dsc(dsc->font, &g, unicode_letter, 0);
+    lv_font_glyph_get_glyph_info(dsc->font, &g, unicode_letter, 0);
 
     lv_area_t a;
     a.x1 = point->x;
@@ -379,7 +379,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
         return;
 
     LV_PROFILER_BEGIN;
-    bool g_ret = lv_font_get_glyph_dsc(font, &g, letter, '\0');
+    bool g_ret = lv_font_glyph_get_glyph_info(font, &g, letter, '\0');
     if(g_ret == false) {
         /*Add warning if the dsc is not found*/
         LV_LOG_WARN("lv_draw_letter: glyph dsc. not found for U+%" LV_PRIX32, letter);
@@ -421,7 +421,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
             }
         }
 
-        dsc->glyph_data = (void *) lv_font_get_glyph_bitmap(&g, draw_buf);
+        dsc->glyph_data = (void *) lv_font_glyph_acquire_draw_data(&g, draw_buf);
         dsc->format = dsc->glyph_data ? g.format : LV_FONT_GLYPH_FORMAT_NONE;
     }
     else {
@@ -432,8 +432,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
     dsc->g = &g;
     cb(draw_unit, dsc, NULL, NULL);
 
-    if(g.resolved_font && font->release_glyph) {
-        font->release_glyph(font, &g);
-    }
+    lv_font_glyph_release_draw_data(&g);
+
     LV_PROFILER_END;
 }

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -421,7 +421,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
             }
         }
 
-        dsc->glyph_data = (void *)lv_font_get_glyph_bitmap(&g, letter, draw_buf);
+        dsc->glyph_data = (void *) lv_font_get_glyph_bitmap(&g, draw_buf);
         dsc->format = dsc->glyph_data ? g.format : LV_FONT_GLYPH_FORMAT_NONE;
     }
     else {

--- a/src/font/lv_binfont_loader.c
+++ b/src/font/lv_binfont_loader.c
@@ -479,8 +479,8 @@ static bool lvgl_load_font(lv_fs_file_t * fp, lv_font_t * font)
 
     font->base_line = -font_header.descent;
     font->line_height = font_header.ascent - font_header.descent;
-    font->get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt;
-    font->get_glyph_bitmap = lv_font_get_bitmap_fmt_txt;
+    font->glyph_get_info = lv_font_glyph_get_info_fmt_txt;
+    font->glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt;
     font->subpx = font_header.subpixels_mode;
     font->underline_position = font_header.underline_position;
     font->underline_thickness = font_header.underline_thickness;

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -42,12 +42,11 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                      lv_draw_buf_t * draw_buf)
+const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     const lv_font_t * font_p = g_dsc->resolved_font;
     LV_ASSERT_NULL(font_p);
-    return font_p->get_glyph_bitmap(g_dsc, letter, draw_buf);
+    return font_p->get_glyph_bitmap(g_dsc, draw_buf);
 }
 
 bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -63,16 +63,19 @@ typedef uint8_t lv_font_glyph_format_t;
 /** Describes the properties of a glyph.*/
 typedef struct {
     const lv_font_t *
-    resolved_font; /**< Pointer to a font where the glyph was actually found after handling fallbacks*/
+    resolved_font;  /**< Pointer to a font where the glyph was actually found after handling fallbacks*/
     uint16_t adv_w; /**< The glyph needs this space. Draw the next glyph after this width.*/
     uint16_t box_w; /**< Width of the glyph's bounding box*/
     uint16_t box_h; /**< Height of the glyph's bounding box*/
     int16_t ofs_x;  /**< x offset of the bounding box*/
     int16_t ofs_y;  /**< y offset of the bounding box*/
     lv_font_glyph_format_t format;  /**< Font format of the glyph see @lv_font_glyph_format_t*/
-    uint8_t is_placeholder: 1; /**< Glyph is missing. But placeholder will still be displayed*/
+    uint8_t is_placeholder: 1;      /**< Glyph is missing. But placeholder will still be displayed*/
 
-    uint64_t glyph_index; /**< The index of the glyph in the font file. Used by the font cache*/
+    union {
+        uint32_t index;       /**< Unicode code point*/
+        const void * src;     /**< Pointer to the source data used by image fonts*/
+    } gid;                    /**< The index of the glyph in the font file. Used by the font cache*/
     lv_cache_entry_t * entry; /**< The cache entry of the glyph draw data. Used by the font cache*/
 } lv_font_glyph_dsc_t;
 

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -72,7 +72,7 @@ typedef struct {
     lv_font_glyph_format_t format;  /**< Font format of the glyph see @lv_font_glyph_format_t*/
     uint8_t is_placeholder: 1; /**< Glyph is missing. But placeholder will still be displayed*/
 
-    uint32_t glyph_index; /**< The index of the glyph in the font file. Used by the font cache*/
+    uint64_t glyph_index; /**< The index of the glyph in the font file. Used by the font cache*/
     lv_cache_entry_t * entry; /**< The cache entry of the glyph draw data. Used by the font cache*/
 } lv_font_glyph_dsc_t;
 
@@ -108,7 +108,7 @@ struct _lv_font_t {
     bool (*get_glyph_dsc)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
 
     /** Get a glyph's bitmap from a font*/
-    const void * (*get_glyph_bitmap)(lv_font_glyph_dsc_t *, uint32_t, lv_draw_buf_t *);
+    const void * (*get_glyph_bitmap)(lv_font_glyph_dsc_t *, lv_draw_buf_t *);
 
     /** Release a glyph*/
     void (*release_glyph)(const lv_font_t *, lv_font_glyph_dsc_t *);
@@ -133,13 +133,12 @@ struct _lv_font_t {
 
 /**
  * Return with the bitmap of a font.
- * @param g_dsc         the glyph descriptor including which font to use etc.
- * @param letter        a UNICODE character code
+ * @note You must call @lv_font_get_glyph_dsc to get @g_dsc (@lv_font_glyph_dsc_t) before you can call this function.
+ * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and the format.
  * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
  * @return pointer to the glyph's data. It can be a draw buffer for bitmap fonts or an image source for imgfonts.
  */
-const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t letter,
-                                      lv_draw_buf_t * draw_buf);
+const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 /**
  * Get the descriptor of a glyph

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -105,43 +105,35 @@ typedef _lv_font_kerning_t lv_font_kerning_t;
 typedef uint8_t lv_font_kerning_t;
 #endif /*DOXYGEN*/
 
+typedef bool (*lv_font_glyph_get_info_cb_t)(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc,
+                                            uint32_t unicode,
+                                            uint32_t unicode_next);
+typedef const void * (*lv_font_glyph_acquire_draw_data_cb_t)(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+typedef void (*lv_font_glyph_release_draw_data_cb_t)(lv_font_glyph_dsc_t * g_dsc);
+
 /** Describe the properties of a font*/
 struct _lv_font_t {
-    /** Get a glyph's descriptor from a font*/
-    bool (*get_glyph_dsc)(const lv_font_t *, lv_font_glyph_dsc_t *, uint32_t letter, uint32_t letter_next);
-
-    /** Get a glyph's bitmap from a font*/
-    const void * (*get_glyph_bitmap)(lv_font_glyph_dsc_t *, lv_draw_buf_t *);
-
-    /** Release a glyph*/
-    void (*release_glyph)(const lv_font_t *, lv_font_glyph_dsc_t *);
+    lv_font_glyph_get_info_cb_t glyph_get_info;                   /**< Get a glyph's descriptor from a font*/
+    lv_font_glyph_acquire_draw_data_cb_t glyph_acquire_draw_data; /**< Acquire a glyph's bitmap from a font*/
+    lv_font_glyph_release_draw_data_cb_t glyph_release_draw_data; /**< Release a glyph*/
 
     /*Pointer to the font in a font pack (must have the same line height)*/
     int32_t line_height;         /**< The real line height where any text fits*/
     int32_t base_line;           /**< Base line measured from the top of the line_height*/
-    uint8_t subpx   : 2;            /**< An element of `lv_font_subpx_t`*/
-    uint8_t kerning : 1;            /**< An element of `lv_font_kerning_t`*/
+    uint8_t subpx   : 2;         /**< An element of `lv_font_subpx_t`*/
+    uint8_t kerning : 1;         /**< An element of `lv_font_kerning_t`*/
 
-    int8_t underline_position;      /**< Distance between the top of the underline and base line (< 0 means below the base line)*/
-    int8_t underline_thickness;     /**< Thickness of the underline*/
+    int8_t underline_position;   /**< Distance between the top of the underline and base line (< 0 means below the base line)*/
+    int8_t underline_thickness;  /**< Thickness of the underline*/
 
-    const void * dsc;               /**< Store implementation specific or run_time data or caching here*/
-    const lv_font_t * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
-    void * user_data;               /**< Custom user data for font.*/
+    const void * dsc;            /**< Store implementation specific or run_time data or caching here*/
+    const lv_font_t * fallback;  /**< Fallback font for missing glyph. Resolved recursively */
+    void * user_data;            /**< Custom user data for font.*/
 };
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
-/**
- * Return with the bitmap of a font.
- * @note You must call @lv_font_get_glyph_dsc to get @g_dsc (@lv_font_glyph_dsc_t) before you can call this function.
- * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and the format.
- * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
- * @return pointer to the glyph's data. It can be a draw buffer for bitmap fonts or an image source for imgfonts.
- */
-const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 /**
  * Get the descriptor of a glyph
@@ -152,8 +144,26 @@ const void * lv_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t
  * @return true: descriptor is successfully loaded into `dsc_out`.
  *         false: the letter was not found, no data is loaded to `dsc_out`
  */
-bool lv_font_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,
-                           uint32_t letter_next);
+bool lv_font_glyph_get_glyph_info(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
+                                  uint32_t letter,
+                                  uint32_t letter_next);
+
+/**
+ * Return with the draw data of a glyph. Which can be a draw buffer for bitmap fonts or an image source for imgfonts,
+ * even a vector font with its paths..
+ * @note You must call @lv_font_get_glyph_dsc to get @g_dsc (@lv_font_glyph_dsc_t) before you can call this function.
+ * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and the format.
+ * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
+ * @return pointer to the glyph's data. It can be a draw buffer for bitmap fonts or an image source for imgfonts.
+ */
+const void * lv_font_glyph_acquire_draw_data(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+
+/**
+ * Release the bitmap of a font.
+ * @note You must call @lv_font_get_glyph_dsc to get @g_dsc (@lv_font_glyph_dsc_t) before you can call this function.
+ * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and the format.
+ */
+void lv_font_glyph_release_draw_data(lv_font_glyph_dsc_t * g_dsc);
 
 /**
  * Get the width of a glyph with kerning

--- a/src/font/lv_font_dejavu_16_persian_hebrew.c
+++ b/src/font/lv_font_dejavu_16_persian_hebrew.c
@@ -6588,8 +6588,8 @@ const lv_font_t lv_font_dejavu_16_persian_hebrew = {
 #else
 lv_font_t lv_font_dejavu_16_persian_hebrew = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 24,          /*The maximum line height required by the font*/
     .base_line = 7,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -6599,7 +6599,7 @@ lv_font_t lv_font_dejavu_16_persian_hebrew = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_DEJAVU_16_PERSIAN_HEBREW*/

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -75,7 +75,7 @@ static const uint8_t opa2_table[4] = {0, 85, 170, 255};
  *   GLOBAL FUNCTIONS
  **********************/
 
-const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+const void * lv_font_glyph_acquire_draw_data_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     const lv_font_t * font = g_dsc->resolved_font;
     uint8_t * bitmap_out = draw_buf->data;
@@ -165,8 +165,8 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
     return NULL;
 }
 
-bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
-                                   uint32_t unicode_letter_next)
+bool lv_font_glyph_get_info_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
+                                    uint32_t unicode_letter_next)
 {
     /*It fixes a strange compiler optimization issue: https://github.com/lvgl/lvgl/issues/4370*/
     bool is_tab = unicode_letter == '\t';

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -75,16 +75,13 @@ static const uint8_t opa2_table[4] = {0, 85, 170, 255};
  *   GLOBAL FUNCTIONS
  **********************/
 
-const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                        lv_draw_buf_t * draw_buf)
+const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     const lv_font_t * font = g_dsc->resolved_font;
     uint8_t * bitmap_out = draw_buf->data;
 
-    if(unicode_letter == '\t') unicode_letter = ' ';
-
     lv_font_fmt_txt_dsc_t * fdsc = (lv_font_fmt_txt_dsc_t *)font->dsc;
-    uint32_t gid = get_glyph_dsc_id(font, unicode_letter);
+    uint32_t gid = (uint32_t)g_dsc->glyph_index;
     if(!gid) return NULL;
 
     const lv_font_fmt_txt_glyph_dsc_t * gdsc = &fdsc->glyph_dsc[gid];
@@ -206,6 +203,7 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     dsc_out->ofs_y = gdsc->ofs_y;
     dsc_out->format = (uint8_t)fdsc->bpp;
     dsc_out->is_placeholder = false;
+    dsc_out->glyph_index = gid;
 
     if(is_tab) dsc_out->box_w = dsc_out->box_w * 2;
 

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -81,7 +81,7 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
     uint8_t * bitmap_out = draw_buf->data;
 
     lv_font_fmt_txt_dsc_t * fdsc = (lv_font_fmt_txt_dsc_t *)font->dsc;
-    uint32_t gid = (uint32_t)g_dsc->glyph_index;
+    uint32_t gid = g_dsc->gid.index;
     if(!gid) return NULL;
 
     const lv_font_fmt_txt_glyph_dsc_t * gdsc = &fdsc->glyph_dsc[gid];
@@ -203,7 +203,7 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     dsc_out->ofs_y = gdsc->ofs_y;
     dsc_out->format = (uint8_t)fdsc->bpp;
     dsc_out->is_placeholder = false;
-    dsc_out->glyph_index = gid;
+    dsc_out->gid.index = gid;
 
     if(is_tab) dsc_out->box_w = dsc_out->box_w * 2;
 

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -215,12 +215,12 @@ typedef struct {
  **********************/
 
 /**
- * Used as `get_glyph_bitmap` callback in lvgl's native font format if the font is uncompressed.
+ * Used as `glyph_acquire_draw_data` callback in lvgl's native font format if the font is uncompressed.
  * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and format.
  * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
  * @return pointer to an A8 bitmap (not necessarily bitmap_out) or NULL if `unicode_letter` not found
  */
-const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+const void * lv_font_glyph_acquire_draw_data_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 /**
  * Used as `get_glyph_dsc` callback in lvgl's native font format if the font is uncompressed.
@@ -231,8 +231,8 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
  * @return true: descriptor is successfully loaded into `dsc_out`.
  *         false: the letter was not found, no data is loaded to `dsc_out`
  */
-bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
-                                   uint32_t unicode_letter_next);
+bool lv_font_glyph_get_info_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
+                                    uint32_t unicode_letter_next);
 
 /**********************
  *      MACROS

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -216,13 +216,11 @@ typedef struct {
 
 /**
  * Used as `get_glyph_bitmap` callback in lvgl's native font format if the font is uncompressed.
- * @param g_dsc         the glyph descriptor including which font to use etc.
- * @param letter        a UNICODE character code
+ * @param g_dsc         the glyph descriptor including which font to use, which supply the glyph_index and format.
  * @param draw_buf      a draw buffer that can be used to store the bitmap of the glyph, it's OK not to use it.
  * @return pointer to an A8 bitmap (not necessarily bitmap_out) or NULL if `unicode_letter` not found
  */
-const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                        lv_draw_buf_t * draw_buf);
+const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 /**
  * Used as `get_glyph_dsc` callback in lvgl's native font format if the font is uncompressed.

--- a/src/font/lv_font_montserrat_10.c
+++ b/src/font/lv_font_montserrat_10.c
@@ -1637,8 +1637,8 @@ const lv_font_t lv_font_montserrat_10 = {
 #else
 lv_font_t lv_font_montserrat_10 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 11,          /*The maximum line height required by the font*/
     .base_line = 2,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1648,7 +1648,7 @@ lv_font_t lv_font_montserrat_10 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_10*/

--- a/src/font/lv_font_montserrat_12.c
+++ b/src/font/lv_font_montserrat_12.c
@@ -1898,8 +1898,8 @@ const lv_font_t lv_font_montserrat_12 = {
 #else
 lv_font_t lv_font_montserrat_12 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 15,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1909,7 +1909,7 @@ lv_font_t lv_font_montserrat_12 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_12*/

--- a/src/font/lv_font_montserrat_14.c
+++ b/src/font/lv_font_montserrat_14.c
@@ -2174,8 +2174,8 @@ const lv_font_t lv_font_montserrat_14 = {
 #else
 lv_font_t lv_font_montserrat_14 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 16,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -2185,7 +2185,7 @@ lv_font_t lv_font_montserrat_14 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_14*/

--- a/src/font/lv_font_montserrat_16.c
+++ b/src/font/lv_font_montserrat_16.c
@@ -2443,8 +2443,8 @@ const lv_font_t lv_font_montserrat_16 = {
 #else
 lv_font_t lv_font_montserrat_16 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 18,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -2454,7 +2454,7 @@ lv_font_t lv_font_montserrat_16 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_16*/

--- a/src/font/lv_font_montserrat_18.c
+++ b/src/font/lv_font_montserrat_18.c
@@ -2843,8 +2843,8 @@ const lv_font_t lv_font_montserrat_18 = {
 #else
 lv_font_t lv_font_montserrat_18 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 21,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -2854,7 +2854,7 @@ lv_font_t lv_font_montserrat_18 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_18*/

--- a/src/font/lv_font_montserrat_20.c
+++ b/src/font/lv_font_montserrat_20.c
@@ -3200,8 +3200,8 @@ const lv_font_t lv_font_montserrat_20 = {
 #else
 lv_font_t lv_font_montserrat_20 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -3211,7 +3211,7 @@ lv_font_t lv_font_montserrat_20 = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_20*/

--- a/src/font/lv_font_montserrat_22.c
+++ b/src/font/lv_font_montserrat_22.c
@@ -3629,8 +3629,8 @@ const lv_font_t lv_font_montserrat_22 = {
 #else
 lv_font_t lv_font_montserrat_22 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 24,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -3640,7 +3640,7 @@ lv_font_t lv_font_montserrat_22 = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_22*/

--- a/src/font/lv_font_montserrat_24.c
+++ b/src/font/lv_font_montserrat_24.c
@@ -4040,8 +4040,8 @@ const lv_font_t lv_font_montserrat_24 = {
 #else
 lv_font_t lv_font_montserrat_24 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 27,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -4051,7 +4051,7 @@ lv_font_t lv_font_montserrat_24 = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_24*/

--- a/src/font/lv_font_montserrat_26.c
+++ b/src/font/lv_font_montserrat_26.c
@@ -4575,8 +4575,8 @@ const lv_font_t lv_font_montserrat_26 = {
 #else
 lv_font_t lv_font_montserrat_26 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 29,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -4586,7 +4586,7 @@ lv_font_t lv_font_montserrat_26 = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_26*/

--- a/src/font/lv_font_montserrat_28.c
+++ b/src/font/lv_font_montserrat_28.c
@@ -5123,8 +5123,8 @@ const lv_font_t lv_font_montserrat_28 = {
 #else
 lv_font_t lv_font_montserrat_28 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 30,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -5134,7 +5134,7 @@ lv_font_t lv_font_montserrat_28 = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_28*/

--- a/src/font/lv_font_montserrat_28_compressed.c
+++ b/src/font/lv_font_montserrat_28_compressed.c
@@ -3254,8 +3254,8 @@ const lv_font_t lv_font_montserrat_28_compressed = {
 #else
 lv_font_t lv_font_montserrat_28_compressed = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 30,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -3265,7 +3265,7 @@ lv_font_t lv_font_montserrat_28_compressed = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_28_COMPRESSED*/

--- a/src/font/lv_font_montserrat_30.c
+++ b/src/font/lv_font_montserrat_30.c
@@ -5706,8 +5706,8 @@ const lv_font_t lv_font_montserrat_30 = {
 #else
 lv_font_t lv_font_montserrat_30 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 33,          /*The maximum line height required by the font*/
     .base_line = 6,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -5717,7 +5717,7 @@ lv_font_t lv_font_montserrat_30 = {
     .underline_position = -2,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_30*/

--- a/src/font/lv_font_montserrat_32.c
+++ b/src/font/lv_font_montserrat_32.c
@@ -6195,8 +6195,8 @@ const lv_font_t lv_font_montserrat_32 = {
 #else
 lv_font_t lv_font_montserrat_32 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 35,          /*The maximum line height required by the font*/
     .base_line = 6,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -6206,7 +6206,7 @@ lv_font_t lv_font_montserrat_32 = {
     .underline_position = -2,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_32*/

--- a/src/font/lv_font_montserrat_34.c
+++ b/src/font/lv_font_montserrat_34.c
@@ -6994,8 +6994,8 @@ const lv_font_t lv_font_montserrat_34 = {
 #else
 lv_font_t lv_font_montserrat_34 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 38,          /*The maximum line height required by the font*/
     .base_line = 7,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -7005,7 +7005,7 @@ lv_font_t lv_font_montserrat_34 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_34*/

--- a/src/font/lv_font_montserrat_36.c
+++ b/src/font/lv_font_montserrat_36.c
@@ -7638,8 +7638,8 @@ const lv_font_t lv_font_montserrat_36 = {
 #else
 lv_font_t lv_font_montserrat_36 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 40,          /*The maximum line height required by the font*/
     .base_line = 7,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -7649,7 +7649,7 @@ lv_font_t lv_font_montserrat_36 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_36*/

--- a/src/font/lv_font_montserrat_38.c
+++ b/src/font/lv_font_montserrat_38.c
@@ -8383,8 +8383,8 @@ const lv_font_t lv_font_montserrat_38 = {
 #else
 lv_font_t lv_font_montserrat_38 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 41,          /*The maximum line height required by the font*/
     .base_line = 7,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -8394,7 +8394,7 @@ lv_font_t lv_font_montserrat_38 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_38*/

--- a/src/font/lv_font_montserrat_40.c
+++ b/src/font/lv_font_montserrat_40.c
@@ -9231,8 +9231,8 @@ const lv_font_t lv_font_montserrat_40 = {
 #else
 lv_font_t lv_font_montserrat_40 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 44,          /*The maximum line height required by the font*/
     .base_line = 8,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -9242,7 +9242,7 @@ lv_font_t lv_font_montserrat_40 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_40*/

--- a/src/font/lv_font_montserrat_42.c
+++ b/src/font/lv_font_montserrat_42.c
@@ -10073,8 +10073,8 @@ const lv_font_t lv_font_montserrat_42 = {
 #else
 lv_font_t lv_font_montserrat_42 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 46,          /*The maximum line height required by the font*/
     .base_line = 8,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -10084,7 +10084,7 @@ lv_font_t lv_font_montserrat_42 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_42*/

--- a/src/font/lv_font_montserrat_44.c
+++ b/src/font/lv_font_montserrat_44.c
@@ -10899,8 +10899,8 @@ const lv_font_t lv_font_montserrat_44 = {
 #else
 lv_font_t lv_font_montserrat_44 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 49,          /*The maximum line height required by the font*/
     .base_line = 9,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -10910,7 +10910,7 @@ lv_font_t lv_font_montserrat_44 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_44*/

--- a/src/font/lv_font_montserrat_46.c
+++ b/src/font/lv_font_montserrat_46.c
@@ -11851,8 +11851,8 @@ const lv_font_t lv_font_montserrat_46 = {
 #else
 lv_font_t lv_font_montserrat_46 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 50,          /*The maximum line height required by the font*/
     .base_line = 9,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -11862,7 +11862,7 @@ lv_font_t lv_font_montserrat_46 = {
     .underline_position = -3,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_46*/

--- a/src/font/lv_font_montserrat_48.c
+++ b/src/font/lv_font_montserrat_48.c
@@ -12552,8 +12552,8 @@ const lv_font_t lv_font_montserrat_48 = {
 #else
 lv_font_t lv_font_montserrat_48 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 52,          /*The maximum line height required by the font*/
     .base_line = 9,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -12563,7 +12563,7 @@ lv_font_t lv_font_montserrat_48 = {
     .underline_position = -4,
     .underline_thickness = 2,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_48*/

--- a/src/font/lv_font_montserrat_8.c
+++ b/src/font/lv_font_montserrat_8.c
@@ -1423,8 +1423,8 @@ const lv_font_t lv_font_montserrat_8 = {
 #else
 lv_font_t lv_font_montserrat_8 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 10,          /*The maximum line height required by the font*/
     .base_line = 2,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1434,7 +1434,7 @@ lv_font_t lv_font_montserrat_8 = {
     .underline_position = -1,
     .underline_thickness = 0,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_MONTSERRAT_8*/

--- a/src/font/lv_font_simsun_16_cjk.c
+++ b/src/font/lv_font_simsun_16_cjk.c
@@ -23755,8 +23755,8 @@ const lv_font_t lv_font_simsun_16_cjk = {
 #else
 lv_font_t lv_font_simsun_16_cjk = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 19,          /*The maximum line height required by the font*/
     .base_line = 3,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -23766,7 +23766,7 @@ lv_font_t lv_font_simsun_16_cjk = {
     .underline_position = -2,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_SIMSUN_16_CJK*/

--- a/src/font/lv_font_unscii_16.c
+++ b/src/font/lv_font_unscii_16.c
@@ -624,8 +624,8 @@ const lv_font_t lv_font_unscii_16 = {
 #else
 lv_font_t lv_font_unscii_16 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 17,          /*The maximum line height required by the font*/
     .base_line = 0,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -635,7 +635,7 @@ lv_font_t lv_font_unscii_16 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_UNSCII_16*/

--- a/src/font/lv_font_unscii_8.c
+++ b/src/font/lv_font_unscii_8.c
@@ -460,8 +460,8 @@ const lv_font_t lv_font_unscii_8 = {
 #else
 lv_font_t lv_font_unscii_8 = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 9,          /*The maximum line height required by the font*/
     .base_line = 0,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -471,7 +471,7 @@ lv_font_t lv_font_unscii_8 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if LV_FONT_UNSCII_8*/

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -169,7 +169,7 @@ static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void
     }
 
     dsc_out->is_placeholder = glyph_index == 0;
-    dsc_out->glyph_index = glyph_index;
+    dsc_out->gid.index = (uint32_t)glyph_index;
 
     return true;
 }

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -29,8 +29,8 @@ typedef struct _lv_freetype_glyph_cache_data_t {
  *  STATIC PROTOTYPES
  **********************/
 
-static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                      uint32_t unicode_letter_next);
+static bool freetype_glyph_get_info_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                       uint32_t unicode_letter_next);
 
 static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
 static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
@@ -65,15 +65,15 @@ lv_cache_t * lv_freetype_create_glyph_cache(uint32_t cache_size)
 void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
+    dsc->font.glyph_get_info = freetype_glyph_get_info_cb;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                      uint32_t unicode_letter_next)
+static bool freetype_glyph_get_info_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                       uint32_t unicode_letter_next)
 {
     LV_ASSERT_NULL(font);
     LV_ASSERT_NULL(g_dsc);

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -29,9 +29,7 @@ typedef struct _lv_freetype_image_cache_data_t {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                                 uint32_t unicode_letter,
-                                                 lv_draw_buf_t * draw_buf);
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void * user_data);
 static void freetype_image_free_cb(lv_freetype_image_cache_data_t * node, void * user_data);
@@ -76,18 +74,14 @@ void lv_freetype_set_cbs_image_font(lv_freetype_font_dsc_t * dsc)
  *   STATIC FUNCTIONS
  **********************/
 
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                                 uint32_t unicode_letter,
-                                                 lv_draw_buf_t * draw_buf)
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
-    LV_UNUSED(unicode_letter);
     LV_UNUSED(draw_buf);
     const lv_font_t * font = g_dsc->resolved_font;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
-    FT_Face face = dsc->cache_node->face;
-    FT_UInt glyph_index = FT_Get_Char_Index(face, unicode_letter);
+    FT_UInt glyph_index = (FT_UInt)g_dsc->glyph_index;
 
     lv_cache_t * cache = dsc->cache_node->draw_data_cache;
 

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -81,7 +81,7 @@ static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
-    FT_UInt glyph_index = (FT_UInt)g_dsc->glyph_index;
+    FT_UInt glyph_index = (FT_UInt)g_dsc->gid.index;
 
     lv_cache_t * cache = dsc->cache_node->draw_data_cache;
 

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -29,14 +29,15 @@ typedef struct _lv_freetype_image_cache_data_t {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 
 static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void * user_data);
 static void freetype_image_free_cb(lv_freetype_image_cache_data_t * node, void * user_data);
 static lv_cache_compare_res_t freetype_image_compare_cb(const lv_freetype_image_cache_data_t * lhs,
                                                         const lv_freetype_image_cache_data_t * rhs);
 
-static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
+static const void * freetype_image_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+static void freetype_image_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -66,15 +67,15 @@ lv_cache_t * lv_freetype_create_draw_data_image(uint32_t cache_size)
 void lv_freetype_set_cbs_image_font(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    dsc->font.get_glyph_bitmap = freetype_get_glyph_bitmap_cb;
-    dsc->font.release_glyph = freetype_image_release_cb;
+    dsc->font.glyph_acquire_draw_data = freetype_image_glyph_acquire_draw_data_cb;
+    dsc->font.glyph_release_draw_data = freetype_image_glyph_release_draw_data_cb;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+static const void * freetype_image_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
     const lv_font_t * font = g_dsc->resolved_font;
@@ -98,10 +99,9 @@ static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv
     return cache_node->draw_buf;
 }
 
-static void freetype_image_release_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)
+static void freetype_image_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc)
 {
-    LV_ASSERT_NULL(font);
-    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
+    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)g_dsc->resolved_font->dsc;
     lv_cache_release(dsc->cache_node->draw_data_cache, g_dsc->entry, NULL);
     g_dsc->entry = NULL;
 }

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -157,7 +157,7 @@ static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv
     const lv_font_t * font = g_dsc->resolved_font;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    lv_cache_entry_t * entry = lv_freetype_outline_lookup(dsc, (FT_UInt)g_dsc->glyph_index);
+    lv_cache_entry_t * entry = lv_freetype_outline_lookup(dsc, (FT_UInt)g_dsc->gid.index);
     if(entry == NULL) {
         return NULL;
     }

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -28,11 +28,13 @@ typedef struct _lv_freetype_outline_node_t {
  *  STATIC PROTOTYPES
  **********************/
 
+static const void * freetype_outline_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+static void freetype_outline_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc);
+
 static lv_freetype_outline_t outline_create(lv_freetype_context_t * ctx, FT_Face face, FT_UInt glyph_index,
                                             uint32_t size, uint32_t strength);
+
 static lv_result_t outline_delete(lv_freetype_context_t * ctx, lv_freetype_outline_t outline);
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
-static void freetype_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 
 static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, FT_UInt glyph_index);
 
@@ -72,8 +74,8 @@ lv_cache_t * lv_freetype_create_draw_data_outline(uint32_t cache_size)
 void lv_freetype_set_cbs_outline_font(lv_freetype_font_dsc_t * dsc)
 {
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    dsc->font.get_glyph_bitmap = freetype_get_glyph_bitmap_cb;
-    dsc->font.release_glyph = freetype_release_glyph_cb;
+    dsc->font.glyph_acquire_draw_data = freetype_outline_glyph_acquire_draw_data_cb;
+    dsc->font.glyph_release_draw_data = freetype_outline_glyph_release_draw_data_cb;
 }
 
 void lv_freetype_outline_add_event(lv_event_cb_t event_cb, lv_event_code_t filter, void * user_data)
@@ -150,7 +152,7 @@ static lv_cache_compare_res_t freetype_glyph_outline_cmp_cb(const lv_freetype_ou
     return node_a->glyph_index > node_b->glyph_index ? 1 : -1;
 }
 
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+static const void * freetype_outline_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
 
@@ -168,10 +170,9 @@ static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv
     return node ? node->outline : NULL;
 }
 
-static void freetype_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)
+static void freetype_outline_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc)
 {
-    LV_ASSERT_NULL(font);
-    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
+    lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)g_dsc->resolved_font->dsc;
 
     if(g_dsc->entry == NULL) {
         return;

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -31,12 +31,10 @@ typedef struct _lv_freetype_outline_node_t {
 static lv_freetype_outline_t outline_create(lv_freetype_context_t * ctx, FT_Face face, FT_UInt glyph_index,
                                             uint32_t size, uint32_t strength);
 static lv_result_t outline_delete(lv_freetype_context_t * ctx, lv_freetype_outline_t outline);
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                                 uint32_t unicode_letter,
-                                                 lv_draw_buf_t * draw_buf);
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 static void freetype_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 
-static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, uint32_t unicode_letter);
+static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, FT_UInt glyph_index);
 
 /*glyph dsc cache lru callbacks*/
 static bool freetype_glyph_outline_create_cb(lv_freetype_outline_node_t * node, lv_freetype_font_dsc_t * dsc);
@@ -152,15 +150,14 @@ static lv_cache_compare_res_t freetype_glyph_outline_cmp_cb(const lv_freetype_ou
     return node_a->glyph_index > node_b->glyph_index ? 1 : -1;
 }
 
-static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                                 uint32_t unicode_letter,
-                                                 lv_draw_buf_t * draw_buf)
+static const void * freetype_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
+
     const lv_font_t * font = g_dsc->resolved_font;
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    lv_cache_entry_t * entry = lv_freetype_outline_lookup(dsc, unicode_letter);
+    lv_cache_entry_t * entry = lv_freetype_outline_lookup(dsc, (FT_UInt)g_dsc->glyph_index);
     if(entry == NULL) {
         return NULL;
     }
@@ -183,12 +180,9 @@ static void freetype_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_
     g_dsc->entry = NULL;
 }
 
-static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, uint32_t unicode_letter)
+static lv_cache_entry_t * lv_freetype_outline_lookup(lv_freetype_font_dsc_t * dsc, FT_UInt glyph_index)
 {
     lv_freetype_cache_node_t * cache_node = dsc->cache_node;
-
-    FT_Face face = cache_node->face;
-    FT_UInt glyph_index = FT_Get_Char_Index(face, unicode_letter);
 
     lv_freetype_outline_node_t tmp_node;
     tmp_node.glyph_index = glyph_index;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -63,7 +63,7 @@ typedef struct ttf_font_desc {
 
 typedef struct _tiny_ttf_cache_data_t {
     lv_font_t * font;
-    uint32_t unicode;
+    uint32_t glyph_index;
     uint32_t size;
     lv_draw_buf_t * draw_buf;
 } tiny_ttf_cache_data_t;
@@ -72,8 +72,7 @@ typedef struct _tiny_ttf_cache_data_t {
  **********************/
 static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                  uint32_t unicode_letter_next);
-static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                            uint32_t unicode_letter, lv_draw_buf_t * draw_buf);
+static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
 static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size_t data_size,
                                       int32_t font_size,
@@ -222,17 +221,18 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     dsc_out->ofs_y = -y2;                   /*Y offset of the bitmap measured from the as line*/
     dsc_out->format = LV_FONT_GLYPH_FORMAT_A8;
     dsc_out->is_placeholder = false;
+    dsc_out->glyph_index = g1;
     return true; /*true: glyph found; false: glyph was not found*/
 }
 
-static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc,
-                                            uint32_t unicode_letter, lv_draw_buf_t * draw_buf)
+static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
+    uint32_t glyph_index = (uint32_t)g_dsc->glyph_index;
     const lv_font_t * font = g_dsc->resolved_font;
     tiny_ttf_cache_data_t search_key = {
         .font = (lv_font_t *)font,
-        .unicode = unicode_letter,
+        .glyph_index = glyph_index,
         .size = font->line_height,
     };
 
@@ -340,10 +340,9 @@ static bool tiny_ttf_cache_create_cb(tiny_ttf_cache_data_t * node, void * user_d
 {
 
     ttf_font_desc_t * dsc = (ttf_font_desc_t *)user_data;
-    uint32_t unicode_letter = node->unicode;
 
     const stbtt_fontinfo * info = (const stbtt_fontinfo *)&dsc->info;
-    int g1 = stbtt_FindGlyphIndex(info, (int)unicode_letter);
+    int g1 = (int)node->glyph_index;
     if(g1 == 0) {
         /* Glyph not found */
         return false;
@@ -382,8 +381,8 @@ static lv_cache_compare_res_t tiny_ttf_cache_compare_cb(const tiny_ttf_cache_dat
         return lhs->font > rhs->font ? 1 : -1;
     }
 
-    if(lhs->unicode != rhs->unicode) {
-        return lhs->unicode > rhs->unicode ? 1 : -1;
+    if(lhs->glyph_index != rhs->glyph_index) {
+        return lhs->glyph_index > rhs->glyph_index ? 1 : -1;
     }
 
     if(lhs->size != rhs->size) {

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -70,10 +70,12 @@ typedef struct _tiny_ttf_cache_data_t {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
-                                 uint32_t unicode_letter_next);
-static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
-static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc);
+static bool ttf_glyph_get_info_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
+                                  uint32_t unicode_letter,
+                                  uint32_t unicode_letter_next);
+static const void * ttf_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+static void ttf_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc);
+
 static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size_t data_size,
                                       int32_t font_size,
                                       size_t cache_size);
@@ -182,8 +184,8 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position)
 }
 #endif
 
-static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
-                                 uint32_t unicode_letter_next)
+static bool ttf_glyph_get_info_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
+                                  uint32_t unicode_letter_next)
 {
     if(unicode_letter < 0x20 ||
        unicode_letter == 0xf8ff || /*LV_SYMBOL_DUMMY*/
@@ -225,7 +227,7 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     return true; /*true: glyph found; false: glyph was not found*/
 }
 
-static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+static const void * ttf_glyph_acquire_draw_data_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
     uint32_t glyph_index = g_dsc->gid.index;
@@ -248,9 +250,8 @@ static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw
     return cached_data->draw_buf;
 }
 
-static void ttf_release_glyph_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc)
+static void ttf_glyph_release_draw_data_cb(lv_font_glyph_dsc_t * g_dsc)
 {
-    LV_ASSERT_NULL(font);
     if(g_dsc->entry == NULL) {
         return;
     }
@@ -306,9 +307,9 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
         LV_LOG_ERROR("tiny_ttf: out of memory\n");
         return NULL;
     }
-    out_font->get_glyph_dsc = ttf_get_glyph_dsc_cb;
-    out_font->get_glyph_bitmap = ttf_get_glyph_bitmap_cb;
-    out_font->release_glyph = ttf_release_glyph_cb;
+    out_font->glyph_get_info = ttf_glyph_get_info_cb;
+    out_font->glyph_acquire_draw_data = ttf_glyph_acquire_draw_data_cb;
+    out_font->glyph_release_draw_data = ttf_glyph_release_draw_data_cb;
     out_font->dsc = dsc;
     lv_tiny_ttf_set_size(out_font, font_size);
     return out_font;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -221,14 +221,14 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     dsc_out->ofs_y = -y2;                   /*Y offset of the bitmap measured from the as line*/
     dsc_out->format = LV_FONT_GLYPH_FORMAT_A8;
     dsc_out->is_placeholder = false;
-    dsc_out->glyph_index = g1;
+    dsc_out->gid.index = (uint32_t)g1;
     return true; /*true: glyph found; false: glyph was not found*/
 }
 
 static const void * ttf_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
-    uint32_t glyph_index = (uint32_t)g_dsc->glyph_index;
+    uint32_t glyph_index = g_dsc->gid.index;
     const lv_font_t * font = g_dsc->resolved_font;
     tiny_ttf_cache_data_t search_key = {
         .font = (lv_font_t *)font,

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -83,7 +83,7 @@ static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_dra
 {
     LV_UNUSED(draw_buf);
 
-    const void * img_src = (const void *)(lv_uintptr_t)g_dsc->glyph_index;
+    const void * img_src = g_dsc->gid.src;
     return img_src;
 }
 
@@ -113,7 +113,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
     dsc_out->ofs_x  = 0;
     dsc_out->ofs_y  = offset_y;
     dsc_out->format = LV_FONT_GLYPH_FORMAT_IMAGE;   /* is image identifier */
-    dsc_out->glyph_index = (uint64_t)(lv_uintptr_t *)img_src;
+    dsc_out->gid.src = img_src;
 
     return true;
 }

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -26,8 +26,7 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
-                                             lv_draw_buf_t * draw_buf);
+static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
 static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
                                   uint32_t unicode, uint32_t unicode_next);
 
@@ -80,15 +79,11 @@ void lv_imgfont_destroy(lv_font_t * font)
  *   STATIC FUNCTIONS
  **********************/
 
-static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, uint32_t unicode,
-                                             lv_draw_buf_t * draw_buf)
+static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
-    const lv_font_t * font = g_dsc->resolved_font;
 
-    imgfont_dsc_t * dsc = (imgfont_dsc_t *)font->dsc;
-    int32_t offset_y = 0;
-    const void * img_src = dsc->path_cb(font, unicode, 0, &offset_y, dsc->user_data);
+    const void * img_src = (const void *)g_dsc->glyph_index;
     return img_src;
 }
 
@@ -118,6 +113,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
     dsc_out->ofs_x  = 0;
     dsc_out->ofs_y  = offset_y;
     dsc_out->format = LV_FONT_GLYPH_FORMAT_IMAGE;   /* is image identifier */
+    dsc_out->glyph_index = (uint64_t) img_src;
 
     return true;
 }

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -83,7 +83,7 @@ static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_dra
 {
     LV_UNUSED(draw_buf);
 
-    const void * img_src = (const void *)g_dsc->glyph_index;
+    const void * img_src = (const void *)(lv_uintptr_t)g_dsc->glyph_index;
     return img_src;
 }
 
@@ -113,7 +113,7 @@ static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * 
     dsc_out->ofs_x  = 0;
     dsc_out->ofs_y  = offset_y;
     dsc_out->format = LV_FONT_GLYPH_FORMAT_IMAGE;   /* is image identifier */
-    dsc_out->glyph_index = (uint64_t) img_src;
+    dsc_out->glyph_index = (uint64_t)(lv_uintptr_t *)img_src;
 
     return true;
 }

--- a/src/others/imgfont/lv_imgfont.c
+++ b/src/others/imgfont/lv_imgfont.c
@@ -26,9 +26,9 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
-static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
-                                  uint32_t unicode, uint32_t unicode_next);
+static const void * imgfont_glyph_get_draw_data(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf);
+static bool imgfont_glyph_get_info(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
+                                   uint32_t unicode, uint32_t unicode_next);
 
 /**********************
  *  STATIC VARIABLES
@@ -56,8 +56,8 @@ lv_font_t * lv_imgfont_create(uint16_t height, lv_imgfont_get_path_cb_t path_cb,
 
     lv_font_t * font = &dsc->font;
     font->dsc = dsc;
-    font->get_glyph_dsc = imgfont_get_glyph_dsc;
-    font->get_glyph_bitmap = imgfont_get_glyph_bitmap;
+    font->glyph_get_info = imgfont_glyph_get_info;
+    font->glyph_acquire_draw_data = imgfont_glyph_get_draw_data;
     font->subpx = LV_FONT_SUBPX_NONE;
     font->line_height = height;
     font->base_line = 0;
@@ -79,7 +79,7 @@ void lv_imgfont_destroy(lv_font_t * font)
  *   STATIC FUNCTIONS
  **********************/
 
-static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+static const void * imgfont_glyph_get_draw_data(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
     LV_UNUSED(draw_buf);
 
@@ -87,8 +87,8 @@ static const void * imgfont_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_dra
     return img_src;
 }
 
-static bool imgfont_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
-                                  uint32_t unicode, uint32_t unicode_next)
+static bool imgfont_glyph_get_info(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out,
+                                   uint32_t unicode, uint32_t unicode_next)
 {
     LV_ASSERT_NULL(font);
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -640,7 +640,7 @@ const char * lv_textarea_get_password_bullet(lv_obj_t * obj)
     const lv_font_t * font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
 
     /*If the textarea's font has the bullet character use it else fallback to "*"*/
-    if(lv_font_get_glyph_dsc(font, &g, LV_TEXTAREA_PWD_BULLET_UNICODE, 0))
+    if(lv_font_glyph_get_glyph_info(font, &g, LV_TEXTAREA_PWD_BULLET_UNICODE, 0))
         return LV_SYMBOL_BULLET;
     return "*";
 }

--- a/tests/src/test_assets/test_font_1.c
+++ b/tests/src/test_assets/test_font_1.c
@@ -1361,14 +1361,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t test_font_1 = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 10,          /*The maximum line height required by the font*/
     .base_line = 2,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if FONT_1*/

--- a/tests/src/test_assets/test_font_2.c
+++ b/tests/src/test_assets/test_font_2.c
@@ -1391,14 +1391,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t test_font_2 = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 10,          /*The maximum line height required by the font*/
     .base_line = 2,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if FONT_2*/

--- a/tests/src/test_assets/test_font_3.c
+++ b/tests/src/test_assets/test_font_3.c
@@ -933,14 +933,14 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 lv_font_t test_font_3 = {
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 5,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = LV_FONT_SUBPX_NONE,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if FONT_3*/

--- a/tests/src/test_assets/test_font_montserrat_ascii_1bpp.c
+++ b/tests/src/test_assets/test_font_montserrat_ascii_1bpp.c
@@ -1009,8 +1009,8 @@ const lv_font_t test_font_montserrat_ascii_1bpp = {
 #else
 lv_font_t test_font_montserrat_ascii_1bpp = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1020,7 +1020,7 @@ lv_font_t test_font_montserrat_ascii_1bpp = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if TEST_FONT_MONTSERRAT_ASCII_1BPP*/

--- a/tests/src/test_assets/test_font_montserrat_ascii_2bpp.c
+++ b/tests/src/test_assets/test_font_montserrat_ascii_2bpp.c
@@ -1233,8 +1233,8 @@ const lv_font_t test_font_montserrat_ascii_2bpp = {
 #else
 lv_font_t test_font_montserrat_ascii_2bpp = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1244,7 +1244,7 @@ lv_font_t test_font_montserrat_ascii_2bpp = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if TEST_FONT_MONTSERRAT_ASCII_2BPP*/

--- a/tests/src/test_assets/test_font_montserrat_ascii_4bpp.c
+++ b/tests/src/test_assets/test_font_montserrat_ascii_4bpp.c
@@ -1650,8 +1650,8 @@ const lv_font_t test_font_montserrat_ascii_4bpp = {
 #else
 lv_font_t test_font_montserrat_ascii_4bpp = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1661,7 +1661,7 @@ lv_font_t test_font_montserrat_ascii_4bpp = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if TEST_FONT_MONTSERRAT_ASCII_4BPP*/

--- a/tests/src/test_assets/test_font_montserrat_ascii_4bpp_compressed.c
+++ b/tests/src/test_assets/test_font_montserrat_ascii_4bpp_compressed.c
@@ -1407,8 +1407,8 @@ const lv_font_t test_font_montserrat_ascii_4bpp_compressed = {
 #else
 lv_font_t test_font_montserrat_ascii_4bpp_compressed = {
 #endif
-    .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
-    .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/
+    .glyph_get_info = lv_font_glyph_get_info_fmt_txt,    /*Function pointer to get glyph's data*/
+    .glyph_acquire_draw_data = lv_font_glyph_acquire_draw_data_fmt_txt,    /*Function pointer to get glyph's bitmap*/
     .line_height = 22,          /*The maximum line height required by the font*/
     .base_line = 4,             /*Baseline measured from the bottom of the line*/
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
@@ -1418,7 +1418,7 @@ lv_font_t test_font_montserrat_ascii_4bpp_compressed = {
     .underline_position = -1,
     .underline_thickness = 1,
 #endif
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
+    .dsc = &font_dsc           /*The custom font data. Will be accessed by `glyph_get_info/glyph_acquire_draw_data` */
 };
 
 #endif /*#if TEST_FONT_MONTSERRAT_ASCII_4BPP_COMPRESSED*/

--- a/tests/src/test_cases/libs/test_freetype.c
+++ b/tests/src/test_cases/libs/test_freetype.c
@@ -479,7 +479,7 @@ void test_freetype_outline_rendering_test(void)
     lv_font_get_glyph_dsc(font_italic, &g, 0x9F98, '\0');
 
     const lv_ll_t * outline_data;
-    outline_data = (lv_ll_t *)lv_font_get_glyph_bitmap(&g, 0x9F98, NULL);
+    outline_data = (lv_ll_t *) lv_font_get_glyph_bitmap(&g, NULL);
 
     uint32_t i = 0;
     lv_freetype_outline_event_param_t * param;

--- a/tests/src/test_cases/libs/test_freetype.c
+++ b/tests/src/test_cases/libs/test_freetype.c
@@ -476,10 +476,10 @@ void test_freetype_outline_rendering_test(void)
 
     lv_font_glyph_dsc_t g;
 
-    lv_font_get_glyph_dsc(font_italic, &g, 0x9F98, '\0');
+    lv_font_glyph_get_glyph_info(font_italic, &g, 0x9F98, '\0');
 
     const lv_ll_t * outline_data;
-    outline_data = (lv_ll_t *) lv_font_get_glyph_bitmap(&g, NULL);
+    outline_data = (lv_ll_t *) lv_font_glyph_acquire_draw_data(&g, NULL);
 
     uint32_t i = 0;
     lv_freetype_outline_event_param_t * param;
@@ -505,7 +505,7 @@ void test_freetype_outline_rendering_test(void)
         i++;
     }
 
-    font_italic->release_glyph(font_italic, &g);
+    lv_font_glyph_release_draw_data(&g);
 
     lv_freetype_font_delete(font_italic);
 }


### PR DESCRIPTION
### Description of the feature or fix

Refactor font related API names

```cpp
get_glyph_dsc     -->   glyph_get_info
get_glyph_bitmap  -->   glyph_acquire_draw_data
release_glyph     -->   glyph_release_draw_data
```

Because the data obtained from the glyph of the font includes the path data of the vector font, the image source data of the image font and the bitmap font, it is more appropriate to call it `draw_data`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
