### PR TITLE
refactor(image_decoder): refactor image decoder and image cache

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -61,8 +61,14 @@ void _lv_image_decoder_init(void)
 {
     _lv_ll_init(img_decoder_ll_p, sizeof(lv_image_decoder_t));
 
+    /*Initialize the cache*/
+#if LV_CACHE_DEF_SIZE > 0
     lv_image_cache_init();
+#endif
+
+#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
     lv_image_header_cache_init();
+#endif
 }
 
 /**

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -110,7 +110,6 @@ struct _lv_image_decoder_t {
     lv_image_decoder_get_area_cb_t get_area_cb;
     lv_image_decoder_close_f_t close_cb;
 
-    lv_cache_free_cb_t cache_free_cb;
     void * user_data;
 };
 
@@ -277,17 +276,6 @@ void lv_image_decoder_set_get_area_cb(lv_image_decoder_t * decoder, lv_image_dec
  * @param close_cb a function to close a decoding session
  */
 void lv_image_decoder_set_close_cb(lv_image_decoder_t * decoder, lv_image_decoder_close_f_t close_cb);
-
-/**
- * Set a custom method to free cache data.
- * Normally this is not needed. If the custom decoder allocates additional memory other than dsc->decoded
- * draw buffer, then you need to register your own method to free it. By default the cache entry is free'ed
- * in `image_decoder_cache_free_cb`.
- *
- * @param decoder pointer to the image decoder
- * @param cache_free_cb the custom callback to free cache data. Refer to `image_decoder_cache_free_cb`.
- */
-void lv_image_decoder_set_cache_free_cb(lv_image_decoder_t * decoder, lv_cache_free_cb_t cache_free_cb);
 
 #if LV_CACHE_DEF_SIZE > 0
 lv_cache_entry_t * lv_image_decoder_add_to_cache(lv_image_decoder_t * decoder,

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -63,7 +63,6 @@ void lv_vg_lite_decoder_init(void)
     lv_image_decoder_set_info_cb(decoder, decoder_info);
     lv_image_decoder_set_open_cb(decoder, decoder_open);
     lv_image_decoder_set_close_cb(decoder, decoder_close);
-    lv_image_decoder_set_cache_free_cb(decoder, NULL); /*Use general cache free method*/
 }
 
 void lv_vg_lite_decoder_deinit(void)

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -101,7 +101,6 @@ void lv_bin_decoder_init(void)
     lv_image_decoder_set_open_cb(decoder, lv_bin_decoder_open);
     lv_image_decoder_set_get_area_cb(decoder, lv_bin_decoder_get_area);
     lv_image_decoder_set_close_cb(decoder, lv_bin_decoder_close);
-    lv_image_decoder_set_cache_free_cb(decoder, NULL); /*Use general cache free method*/
 }
 
 lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -72,7 +72,6 @@ void lv_libjpeg_turbo_init(void)
     lv_image_decoder_set_info_cb(dec, decoder_info);
     lv_image_decoder_set_open_cb(dec, decoder_open);
     lv_image_decoder_set_close_cb(dec, decoder_close);
-    lv_image_decoder_set_cache_free_cb(dec, NULL); /*Use general cache free method*/
 }
 
 void lv_libjpeg_turbo_deinit(void)

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -49,7 +49,6 @@ void lv_libpng_init(void)
     lv_image_decoder_set_info_cb(dec, decoder_info);
     lv_image_decoder_set_open_cb(dec, decoder_open);
     lv_image_decoder_set_close_cb(dec, decoder_close);
-    lv_image_decoder_set_cache_free_cb(dec, NULL); /*Use general cache free method*/
 }
 
 void lv_libpng_deinit(void)

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "_lv_cache_lru_rb.h"
 
 #include "lv_image_cache.h"
+#include "lv_image_header_cache.h"
 /*********************
  *      DEFINES
  *********************/

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -9,9 +9,10 @@
 #include "../lv_assert.h"
 #include "lv_image_cache.h"
 #include "lv_image_header_cache.h"
-#include "../../core/lv_global.h"
 
 #if LV_CACHE_DEF_SIZE > 0
+
+#include "../../core/lv_global.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -50,24 +50,32 @@ static void image_header_cache_free_cb(lv_image_header_cache_data_t * entry, voi
  *   GLOBAL FUNCTIONS
  **********************/
 
-bool lv_image_cache_init(void)
+lv_result_t lv_image_cache_init(void)
 {
 #if LV_CACHE_DEF_SIZE > 0
+    if(img_cache_p != NULL) {
+        return LV_RESULT_OK;
+    }
+
     img_cache_p = lv_cache_create(&lv_cache_class_lru_rb_size,
     sizeof(lv_image_cache_data_t), LV_CACHE_DEF_SIZE, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t) image_cache_compare_cb,
         .create_cb = NULL,
         .free_cb = (lv_cache_free_cb_t) image_cache_free_cb,
     });
-    return img_cache_p != NULL;
+    return img_cache_p != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
 #else
-    return false;
+    return LV_RESULT_INVALID;
 #endif
 }
 
-bool lv_image_header_cache_init(void)
+lv_result_t lv_image_header_cache_init(void)
 {
 #if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
+    if(img_header_cache_p != NULL) {
+        return LV_RESULT_OK;
+    }
+
     img_header_cache_p = lv_cache_create(&lv_cache_class_lru_rb_count,
     sizeof(lv_image_header_cache_data_t), LV_IMAGE_HEADER_CACHE_DEF_CNT, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t) image_header_cache_compare_cb,
@@ -75,9 +83,9 @@ bool lv_image_header_cache_init(void)
         .free_cb = (lv_cache_free_cb_t) image_header_cache_free_cb
     });
 
-    return img_header_cache_p != NULL;
+    return img_header_cache_p != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
 #else
-    return false;
+    return LV_RESULT_INVALID;
 #endif
 }
 

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -28,6 +28,18 @@ extern "C" {
  **********************/
 
 /**
+ * Initialize image cache.
+ * @return true: initialization succeeded, false: failed.
+ */
+bool lv_image_cache_init(void);
+
+/**
+ * Initialize image header cache.
+ * @return true: initialization succeeded, false: failed.
+ */
+bool lv_image_header_cache_init(void);
+
+/**
  * Invalidate image cache. Use NULL to invalidate all images.
  * @param src pointer to an image source.
  */

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -15,6 +15,8 @@ extern "C" {
  *********************/
 #include "lv_cache_private.h"
 
+#if LV_CACHE_DEF_SIZE > 0
+
 /*********************
  *      DEFINES
  *********************/
@@ -34,37 +36,19 @@ extern "C" {
 lv_result_t lv_image_cache_init(void);
 
 /**
- * Initialize image header cache.
- * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
- */
-lv_result_t lv_image_header_cache_init(void);
-
-/**
- * Invalidate image cache. Use NULL to invalidate all images.
- * @param src pointer to an image source.
- */
-void lv_image_cache_drop(const void * src);
-
-/**
  * Resize image cache.
  * @param new_size  new size of the cache in bytes.
  * @param evict_now true: evict the images should be removed by the eviction policy, false: wait for the next cache cleanup.
  */
 void lv_image_cache_resize(uint32_t new_size, bool evict_now);
 
-/**
- * Invalidate image header cache. Use NULL to invalidate all image headers.
- * It's also automatically called when an image is invalidated.
- * @param src pointer to an image source.
- */
-void lv_image_header_cache_drop(const void * src);
+#endif /*LV_CACHE_DEF_SIZE > 0*/
 
 /**
- * Resize image header cache.
- * @param new_size  new size of the cache in count of image headers.
- * @param evict_now true: evict the image headers should be removed by the eviction policy, false: wait for the next cache cleanup.
+ * Invalidate image cache. Use NULL to invalidate all images.
+ * @param src pointer to an image source.
  */
-void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
+void lv_image_cache_drop(const void * src);
 
 /*************************
  *    GLOBAL VARIABLES

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -13,7 +13,9 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_cache_private.h"
+
+#include "../../lv_conf_internal.h"
+#include <stdbool.h>
 
 #if LV_CACHE_DEF_SIZE > 0
 

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -29,15 +29,15 @@ extern "C" {
 
 /**
  * Initialize image cache.
- * @return true: initialization succeeded, false: failed.
+ * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
-bool lv_image_cache_init(void);
+lv_result_t lv_image_cache_init(void);
 
 /**
  * Initialize image header cache.
- * @return true: initialization succeeded, false: failed.
+ * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
-bool lv_image_header_cache_init(void);
+lv_result_t lv_image_header_cache_init(void);
 
 /**
  * Invalidate image cache. Use NULL to invalidate all images.

--- a/src/misc/cache/lv_image_header_cache.c
+++ b/src/misc/cache/lv_image_header_cache.c
@@ -1,5 +1,5 @@
 /**
-* @file lv_image_cache.c
+* @file lv_image_header_cache.c
 *
  */
 
@@ -7,17 +7,16 @@
  *      INCLUDES
  *********************/
 #include "../lv_assert.h"
-#include "lv_image_cache.h"
 #include "lv_image_header_cache.h"
 #include "../../core/lv_global.h"
 
-#if LV_CACHE_DEF_SIZE > 0
+#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
 
 /*********************
  *      DEFINES
  *********************/
 
-#define img_cache_p (LV_GLOBAL_DEFAULT()->img_cache)
+#define img_header_cache_p (LV_GLOBAL_DEFAULT()->img_header_cache)
 
 /**********************
  *      TYPEDEFS
@@ -27,9 +26,9 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static lv_cache_compare_res_t image_cache_compare_cb(const lv_image_cache_data_t * lhs,
-                                                     const lv_image_cache_data_t * rhs);
-static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data);
+static lv_cache_compare_res_t image_header_cache_compare_cb(const lv_image_header_cache_data_t * lhs,
+                                                            const lv_image_header_cache_data_t * rhs);
+static void image_header_cache_free_cb(lv_image_header_cache_data_t * entry, void * user_data);
 
 /**********************
  *  GLOBAL VARIABLES
@@ -47,48 +46,46 @@ static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_result_t lv_image_cache_init(void)
+lv_result_t lv_image_header_cache_init(void)
 {
-    if(img_cache_p != NULL) {
+    if(img_header_cache_p != NULL) {
         return LV_RESULT_OK;
     }
 
-    img_cache_p = lv_cache_create(&lv_cache_class_lru_rb_size,
-    sizeof(lv_image_cache_data_t), LV_CACHE_DEF_SIZE, (lv_cache_ops_t) {
-        .compare_cb = (lv_cache_compare_cb_t) image_cache_compare_cb,
+    img_header_cache_p = lv_cache_create(&lv_cache_class_lru_rb_count,
+    sizeof(lv_image_header_cache_data_t), LV_IMAGE_HEADER_CACHE_DEF_CNT, (lv_cache_ops_t) {
+        .compare_cb = (lv_cache_compare_cb_t) image_header_cache_compare_cb,
         .create_cb = NULL,
-        .free_cb = (lv_cache_free_cb_t) image_cache_free_cb,
+        .free_cb = (lv_cache_free_cb_t) image_header_cache_free_cb
     });
-    return img_cache_p != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
+
+    return img_header_cache_p != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
-void lv_image_cache_resize(uint32_t new_size, bool evict_now)
+void lv_image_header_cache_resize(uint32_t new_size, bool evict_now)
 {
-    lv_cache_set_max_size(img_cache_p, new_size, NULL);
+    lv_cache_set_max_size(img_header_cache_p, new_size, NULL);
     if(evict_now) {
-        lv_cache_reserve(img_cache_p, new_size, NULL);
+        lv_cache_reserve(img_header_cache_p, new_size, NULL);
     }
 }
 
 #endif
 
-void lv_image_cache_drop(const void * src)
+void lv_image_header_cache_drop(const void * src)
 {
-    /*If user invalidate image, the header cache should be invalidated too.*/
-    lv_image_header_cache_drop(src);
-
-#if LV_CACHE_DEF_SIZE > 0
+#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
     if(src == NULL) {
-        lv_cache_drop_all(img_cache_p, NULL);
+        lv_cache_drop_all(img_header_cache_p, NULL);
         return;
     }
 
-    lv_image_cache_data_t search_key = {
+    lv_image_header_cache_data_t search_key = {
         .src = src,
         .src_type = lv_image_src_get_type(src),
     };
 
-    lv_cache_drop(img_cache_p, &search_key, NULL);
+    lv_cache_drop(img_header_cache_p, &search_key, NULL);
 #else
     LV_UNUSED(src);
 #endif
@@ -98,7 +95,8 @@ void lv_image_cache_drop(const void * src)
  *   STATIC FUNCTIONS
  **********************/
 
-#if LV_CACHE_DEF_SIZE > 0
+
+#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
 
 inline static lv_cache_compare_res_t image_cache_common_compare(const void * lhs_src, lv_image_src_t lhs_src_type,
                                                                 const void * rhs_src, lv_image_src_t rhs_src_type)
@@ -120,24 +118,18 @@ inline static lv_cache_compare_res_t image_cache_common_compare(const void * lhs
     return lhs_src_type > rhs_src_type ? 1 : -1;
 }
 
-static lv_cache_compare_res_t image_cache_compare_cb(
-    const lv_image_cache_data_t * lhs,
-    const lv_image_cache_data_t * rhs)
+static lv_cache_compare_res_t image_header_cache_compare_cb(
+    const lv_image_header_cache_data_t * lhs,
+    const lv_image_header_cache_data_t * rhs)
 {
     return image_cache_common_compare(lhs->src, lhs->src_type, rhs->src, rhs->src_type);
 }
 
-static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
+static void image_header_cache_free_cb(lv_image_header_cache_data_t * entry, void * user_data)
 {
-    LV_UNUSED(user_data);
+    LV_UNUSED(user_data); /*Unused*/
 
-    /* Destroy the decoded draw buffer if necessary. */
-    lv_draw_buf_t * decoded = (lv_draw_buf_t *)entry->decoded;
-    if(lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_ALLOCATED)) {
-        lv_draw_buf_destroy(decoded);
-    }
-
-    /*Free the duplicated file name*/
     if(entry->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)entry->src);
 }
+
 #endif

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -1,0 +1,66 @@
+/**
+* @file lv_image_header_cache.h
+*
+ */
+
+#ifndef LV_IMAGE_HEADER_CACHE_H
+#define LV_IMAGE_HEADER_CACHE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_cache_private.h"
+
+#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Initialize image header cache.
+ * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
+ */
+lv_result_t lv_image_header_cache_init(void);
+
+/**
+ * Resize image header cache.
+ * @param new_size  new size of the cache in count of image headers.
+ * @param evict_now true: evict the image headers should be removed by the eviction policy, false: wait for the next cache cleanup.
+ */
+void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
+
+#endif /*LV_IMAGE_HEADER_CACHE_DEF_CNT > 0*/
+
+/**
+ * Invalidate image header cache. Use NULL to invalidate all image headers.
+ * It's also automatically called when an image is invalidated.
+ * @param src pointer to an image source.
+ */
+void lv_image_header_cache_drop(const void * src);
+
+/*************************
+ *    GLOBAL VARIABLES
+ *************************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IMAGE_HEADER_CACHE_H*/

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -13,7 +13,9 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_cache_private.h"
+
+#include "../../lv_conf_internal.h"
+#include <stdbool.h>
 
 #if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
 


### PR DESCRIPTION
### Description of the feature or fix

Move image cache callbacks to image cache module.

Because there were some dependencies before, there was no way to put these callbacks into the image cache module. Now it can do this. This makes the image decoder module code clearer and more concise.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
