### PR TITLE
fix(image): fix the image decoder if LV_BIN_DECODER_RAM_LOAD == 0

### DIFF
--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -399,7 +399,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     int32_t w_px = lv_area_get_width(full_area);
     uint8_t * img_data = NULL;
     lv_draw_buf_t * decoded = NULL;
-    uint32_t offset = 12;	/*Skip the image header*/
+    uint32_t offset = 12;   /*Skip the image header*/
 
     /*We only support read line by line for now*/
     if(decoded_area->y1 == LV_COORD_MIN) {

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -399,7 +399,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     int32_t w_px = lv_area_get_width(full_area);
     uint8_t * img_data = NULL;
     lv_draw_buf_t * decoded = NULL;
-    uint32_t offset = 12;
+    uint32_t offset = 12;	/*Skip the image header*/
 
     /*We only support read line by line for now*/
     if(decoded_area->y1 == LV_COORD_MIN) {

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -399,7 +399,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     int32_t w_px = lv_area_get_width(full_area);
     uint8_t * img_data = NULL;
     lv_draw_buf_t * decoded = NULL;
-    uint32_t offset = 0;
+    uint32_t offset = 12;
 
     /*We only support read line by line for now*/
     if(decoded_area->y1 == LV_COORD_MIN) {

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -399,7 +399,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
     int32_t w_px = lv_area_get_width(full_area);
     uint8_t * img_data = NULL;
     lv_draw_buf_t * decoded = NULL;
-    uint32_t offset = 12;   /*Skip the image header*/
+    uint32_t offset = dsc->src_type == LV_IMAGE_SRC_FILE ? sizeof(lv_image_header_t) : 0;   /*Skip the image header*/
 
     /*We only support read line by line for now*/
     if(decoded_area->y1 == LV_COORD_MIN) {
@@ -443,7 +443,6 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         offset += decoded_area->y1 * dsc->header.stride;
         offset += decoded_area->x1 * bpp / 8; /*Move to x1*/
         if(dsc->src_type == LV_IMAGE_SRC_FILE) {
-            offset += sizeof(lv_image_header_t); /*File image starts with image header*/
             buf = lv_malloc(len);
             LV_ASSERT_NULL(buf);
             if(buf == NULL)
@@ -884,6 +883,7 @@ static lv_result_t decode_alpha_only(lv_image_decoder_t * decoder, lv_image_deco
 
 static lv_result_t decode_compressed(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc)
 {
+#if LV_BIN_DECODER_RAM_LOAD
     uint32_t rn;
     uint32_t len;
     uint32_t compressed_len;
@@ -989,6 +989,13 @@ static lv_result_t decode_compressed(lv_image_decoder_t * decoder, lv_image_deco
     }
 
     return res;
+#else
+    LV_UNUSED(decompress_image);
+    LV_UNUSED(decoder);
+    LV_UNUSED(dsc);
+    LV_LOG_ERROR("Need LV_BIN_DECODER_RAM_LOAD to be enabled");
+    return LV_RESULT_INVALID;
+#endif
 }
 
 static lv_result_t decode_indexed_line(lv_color_format_t color_format, const lv_color32_t * palette, int32_t x,

--- a/tests/src/test_cases/draw/test_image_formats.c
+++ b/tests/src/test_cases/draw/test_image_formats.c
@@ -284,6 +284,9 @@ void test_image_formats(void)
         for(unsigned mode = 0; mode <= 3; mode++) {
             bool rotate = mode & 0x02;
             bool recolor = mode & 0x01;
+#if LV_BIN_DECODER_RAM_LOAD == 0
+            if(rotate) continue;  /* Transform relies on LV_BIN_DECODER_RAM_LOAD to be enabled */
+#endif
             /*Loop compressions array and do test.*/
             for(unsigned i = 0; i < sizeof(compressions) / sizeof(compressions[0]); i++) {
                 char reference[256];

--- a/tests/src/test_cases/draw/test_image_formats.c
+++ b/tests/src/test_cases/draw/test_image_formats.c
@@ -22,8 +22,10 @@ static const char * color_formats[] = {
 
 static const char * compressions[] = {
     "UNCOMPRESSED",
+#if LV_BIN_DECODER_RAM_LOAD == 1
     "RLE",
     "LZ4"
+#endif
 };
 
 static const char * modes[] = {


### PR DESCRIPTION
### Description of the feature or fix

fixes #5868

Offset should be 12 to skip the image header.
cc @XuNeo 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
