### PR TITLE
feat(test): test bin image loaded to RAM or not

### DIFF
--- a/tests/src/lv_test_conf.h
+++ b/tests/src/lv_test_conf.h
@@ -22,6 +22,7 @@ extern "C" {
 #define LV_USE_STDLIB_SPRINTF       LV_STDLIB_CLIB
 #define LV_USE_OS                   LV_OS_PTHREAD
 #define LV_OBJ_STYLE_CACHE          0
+#define LV_BIN_DECODER_RAM_LOAD     1   /* Run test with bin image loaded to RAM */
 #endif
 
 #ifdef LVGL_CI_USING_DEF_HEAP
@@ -29,6 +30,7 @@ extern "C" {
 #define LV_USE_STDLIB_STRING    LV_STDLIB_BUILTIN
 #define LV_USE_STDLIB_SPRINTF   LV_STDLIB_BUILTIN
 #define LV_OBJ_STYLE_CACHE      1
+#define LV_BIN_DECODER_RAM_LOAD 0
 #endif
 
 #ifdef MICROPYTHON

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -95,7 +95,6 @@
 #define LV_USE_OBJ_ID           1
 #define LV_USE_OBJ_ID_BUILTIN   1
 #define LV_USE_OBJ_PROPERTY     0
-#define LV_BIN_DECODER_RAM_LOAD 1
 
 #define LV_CACHE_DEF_SIZE       (10 * 1024 * 1024)
 


### PR DESCRIPTION

### Description of the feature or fix

Run the two tests with LV_BIN_DECODER_RAM_LOAD enabled or not

CI depends on #5892. Need to retrigger CI once it's merged.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
