### PR TITLE
fix(demo/vector_graphic): add missing buffer clear

### DIFF
--- a/demos/vector_graphic/lv_demo_vector_graphic.c
+++ b/demos/vector_graphic/lv_demo_vector_graphic.c
@@ -264,6 +264,8 @@ static void delete_event_cb(lv_event_t * e)
 void lv_demo_vector_graphic(void)
 {
     lv_draw_buf_t * draw_buf = lv_draw_buf_create(WIDTH, HEIGHT, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
+    lv_draw_buf_clear(draw_buf, NULL);
+
     lv_obj_t * canvas = lv_canvas_create(lv_scr_act());
     lv_canvas_set_draw_buf(canvas, draw_buf);
     lv_obj_add_event_cb(canvas, delete_event_cb, LV_EVENT_DELETE, NULL);


### PR DESCRIPTION
### Description of the feature or fix

For the memory obtained by malloc, it should be cleared first before starting drawing to avoid displaying garbage values.

cc @onecoolx 

Before:
![image](https://github.com/lvgl/lvgl/assets/26767803/75ba50c7-d1a8-43e7-a8d3-282a34f2c356)

After:
![image](https://github.com/lvgl/lvgl/assets/26767803/c922a09f-5d64-4d13-a355-a5b7848b1217)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
