### PR TITLE
fix(obj_tree): fix unintended click triggers on object deletion

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -484,6 +484,15 @@ static void lv_obj_delete_async_cb(void * obj)
     lv_obj_delete(obj);
 }
 
+static void obj_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
+{
+    /*Wait for release to avoid accidentally triggering other obj to be clicked*/
+    lv_indev_wait_release(indev);
+
+    /*Reset the input device*/
+    lv_indev_reset(indev, obj);
+}
+
 static void obj_delete_core(lv_obj_t * obj)
 {
     if(obj->is_deleting)
@@ -516,7 +525,7 @@ static void obj_delete_core(lv_obj_t * obj)
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         if(indev_type == LV_INDEV_TYPE_POINTER || indev_type == LV_INDEV_TYPE_BUTTON) {
             if(indev->pointer.act_obj == obj || indev->pointer.last_obj == obj || indev->pointer.scroll_obj == obj) {
-                lv_indev_reset(indev, obj);
+                obj_indev_reset(indev, obj);
             }
             if(indev->pointer.last_pressed == obj) {
                 indev->pointer.last_pressed = NULL;
@@ -524,7 +533,7 @@ static void obj_delete_core(lv_obj_t * obj)
         }
 
         if(indev->group == group && obj == lv_indev_get_active_obj()) {
-            lv_indev_reset(indev, obj);
+            obj_indev_reset(indev, obj);
         }
         indev = lv_indev_get_next(indev);
     }

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -422,6 +422,8 @@ void test_observer_arc_value(void)
 
     lv_obj_update_layout(obj);
     lv_test_mouse_release();
+    lv_test_indev_wait(100);
+
     lv_test_mouse_move_to(65, 10);
     lv_test_mouse_press();
     lv_test_indev_wait(100);
@@ -446,9 +448,12 @@ void test_observer_slider_value(void)
 
     lv_obj_update_layout(obj);
     lv_test_mouse_release();
+    lv_test_indev_wait(100);
+
     lv_test_mouse_move_to(65, 10);
     lv_test_mouse_press();
     lv_test_indev_wait(100);
+
     lv_test_mouse_move_to(75, 10);
     lv_test_mouse_press();
     lv_test_indev_wait(100);


### PR DESCRIPTION
### Description of the feature or fix

When obj is deleted, indev will be reset. At this time, if the finger happens to be released when sliding to another obj, the click event will be triggered by the obj by mistake.

```c
static void gesture_event_cb(lv_event_t* e)
{
    lv_obj_t* obj = lv_event_get_current_target(e);
    lv_obj_del(obj);
}

static void click_event_cb(lv_event_t* e)
{
    LV_LOG_USER("Clicked");
}

static void swipe_test(void)
{
    lv_obj_t* obj = lv_obj_create(lv_scr_act());
    lv_obj_set_size(obj, 200, 200);
    lv_obj_center(obj);
    lv_obj_clear_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE);
    lv_obj_add_event_cb(obj, gesture_event_cb, LV_EVENT_GESTURE, NULL);

    lv_obj_t* btn = lv_btn_create(lv_scr_act());
    lv_obj_set_size(btn, 100, 100);
    lv_obj_align_to(btn, obj, LV_ALIGN_OUT_BOTTOM_MID, 0, -30);
    lv_obj_add_event_cb(btn, click_event_cb, LV_EVENT_CLICKED, NULL);
}
```

https://github.com/lvgl/lvgl/assets/26767803/2ca2b37e-3055-4df8-b8a3-e173f030d1bc

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
