### PR TITLE
fix(rtthread): implement lv_strcat function in rt-thread due to absence of rt_strcat

### DIFF
--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -229,12 +229,8 @@ char * lv_strdup(const char * src)
 
 char * lv_strcat(char * dst, const char * src)
 {
-    char * tmp = dst;
-    while(*dst != '\0') {
-        dst++;
-    }
-    lv_strcpy(dst, src);
-    return tmp;
+    lv_strcpy(dst + lv_strlen(dst), src);
+    return dst;
 }
 
 /**********************

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -87,7 +87,10 @@ char * lv_strdup(const char * src)
 
 char * lv_strcat(char * dst, const char * src)
 {
-    return strcat(dst, src);
+    /*Since RT-thread does not have rt_strcat,
+    the following code is used instead.*/
+    lv_strcpy(dst + lv_strlen(dst), src);
+    return dst;
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

fix(warning): fix the issue of lv_string_rtthread prompting for the lack of strcat

![image](https://github.com/lvgl/lvgl/assets/18370433/01bb579a-3d65-4bdd-af93-689de4c81c77)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
