### PR TITLE
feat(cache): image cache supports dynamic setting of cache size

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -103,13 +103,8 @@ typedef struct _lv_global_t {
 
     lv_ll_t img_decoder_ll;
 
-#if LV_CACHE_DEF_SIZE > 0
     lv_cache_t * img_cache;
-#endif
-
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
     lv_cache_t * img_header_cache;
-#endif
 
     lv_draw_global_info_t draw_info;
 #if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -62,13 +62,9 @@ void _lv_image_decoder_init(void)
     _lv_ll_init(img_decoder_ll_p, sizeof(lv_image_decoder_t));
 
     /*Initialize the cache*/
-#if LV_CACHE_DEF_SIZE > 0
-    lv_image_cache_init();
-#endif
-
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-    lv_image_header_cache_init();
-#endif
+    lv_image_cache_init(0);
+//    lv_image_header_cache_init(LV_IMAGE_HEADER_CACHE_DEF_CNT);
+    lv_image_header_cache_init(0);
 }
 
 /**
@@ -76,13 +72,9 @@ void _lv_image_decoder_init(void)
  */
 void _lv_image_decoder_deinit(void)
 {
-#if LV_CACHE_DEF_SIZE > 0
     lv_cache_destroy(img_cache_p, NULL);
-#endif
-
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
     lv_cache_destroy(img_header_cache_p, NULL);
-#endif
+
     _lv_ll_clear(img_decoder_ll_p);
 }
 
@@ -291,9 +283,9 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
     }
 
     lv_image_decoder_t * decoder;
+    bool is_header_cache_disabled = lv_cache_is_disabled(img_header_cache_p);
 
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-    if(src_type == LV_IMAGE_SRC_FILE) {
+    if(!is_header_cache_disabled && src_type == LV_IMAGE_SRC_FILE) {
         lv_image_header_cache_data_t search_key;
         search_key.src_type = src_type;
         search_key.src = src;
@@ -308,7 +300,6 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
             return decoder;
         }
     }
-#endif
 
     _LV_LL_READ(img_decoder_ll_p, decoder) {
         /*Info and Open callbacks are required*/
@@ -324,8 +315,7 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
         }
     }
 
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-    if(src_type == LV_IMAGE_SRC_FILE && decoder) {
+    if(!is_header_cache_disabled && src_type == LV_IMAGE_SRC_FILE && decoder) {
         lv_cache_entry_t * entry;
         lv_image_header_cache_data_t search_key;
         search_key.src_type = src_type;
@@ -341,7 +331,6 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
 
         lv_cache_release(img_header_cache_p, entry, NULL);
     }
-#endif
 
     return decoder;
 }

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -38,9 +38,7 @@ static uint32_t img_width_to_stride(lv_image_header_t * header);
  */
 static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_header_t * header);
 
-#if LV_CACHE_DEF_SIZE > 0
-    static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc);
-#endif
+static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc);
 
 /**********************
  *  STATIC VARIABLES
@@ -57,14 +55,13 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
 /**
  * Initialize the image decoder module
  */
-void _lv_image_decoder_init(void)
+void _lv_image_decoder_init(uint32_t image_cache_size, uint32_t image_header_count)
 {
     _lv_ll_init(img_decoder_ll_p, sizeof(lv_image_decoder_t));
 
     /*Initialize the cache*/
-    lv_image_cache_init(0);
-//    lv_image_header_cache_init(LV_IMAGE_HEADER_CACHE_DEF_CNT);
-    lv_image_header_cache_init(0);
+    lv_image_cache_init(image_cache_size);
+    lv_image_header_cache_init(image_header_count);
 }
 
 /**
@@ -94,16 +91,16 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     dsc->src = src;
     dsc->src_type = lv_image_src_get_type(src);
 
-#if LV_CACHE_DEF_SIZE > 0
-    dsc->cache = img_cache_p;
-    /*Try cache first, unless we are told to ignore cache.*/
-    if(!(args && args->no_cache)) {
-        /*
-        * Check the cache first
-        * If the image is found in the cache, just return it.*/
-        if(try_cache(dsc) == LV_RESULT_OK) return LV_RESULT_OK;
+    if(lv_image_cache_is_disabled() == false) {
+        dsc->cache = img_cache_p;
+        /*Try cache first, unless we are told to ignore cache.*/
+        if(!(args && args->no_cache)) {
+            /*
+            * Check the cache first
+            * If the image is found in the cache, just return it.*/
+            if(try_cache(dsc) == LV_RESULT_OK) return LV_RESULT_OK;
+        }
     }
-#endif
 
     /*Find the decoder that can open the image source, and get the header info in the same time.*/
     dsc->decoder = image_decoder_get_info(src, &dsc->header);
@@ -193,7 +190,6 @@ void lv_image_decoder_set_close_cb(lv_image_decoder_t * decoder, lv_image_decode
     decoder->close_cb = close_cb;
 }
 
-#if LV_CACHE_DEF_SIZE > 0
 lv_cache_entry_t * lv_image_decoder_add_to_cache(lv_image_decoder_t * decoder,
                                                  lv_image_cache_data_t * search_key,
                                                  const lv_draw_buf_t * decoded, void * user_data)
@@ -216,7 +212,6 @@ lv_cache_entry_t * lv_image_decoder_add_to_cache(lv_image_decoder_t * decoder,
 
     return cache_entry;
 }
-#endif
 
 lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_draw_buf_t * decoded)
 {
@@ -283,7 +278,7 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
     }
 
     lv_image_decoder_t * decoder;
-    bool is_header_cache_disabled = lv_cache_is_disabled(img_header_cache_p);
+    bool is_header_cache_disabled = lv_image_header_cache_is_disabled();
 
     if(!is_header_cache_disabled && src_type == LV_IMAGE_SRC_FILE) {
         lv_image_header_cache_data_t search_key;
@@ -345,7 +340,6 @@ static uint32_t img_width_to_stride(lv_image_header_t * header)
     }
 }
 
-#if LV_CACHE_DEF_SIZE > 0
 static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc)
 {
     lv_cache_t * cache = dsc->cache;
@@ -366,4 +360,3 @@ static lv_result_t try_cache(lv_image_decoder_dsc_t * dsc)
 
     return LV_RESULT_INVALID;
 }
-#endif

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -91,7 +91,7 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     dsc->src = src;
     dsc->src_type = lv_image_src_get_type(src);
 
-    if(lv_image_cache_is_disabled() == false) {
+    if(lv_image_cache_is_enabled()) {
         dsc->cache = img_cache_p;
         /*Try cache first, unless we are told to ignore cache.*/
         if(!(args && args->no_cache)) {
@@ -278,9 +278,9 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
     }
 
     lv_image_decoder_t * decoder;
-    bool is_header_cache_disabled = lv_image_header_cache_is_disabled();
+    bool is_header_cache_enabled = lv_image_header_cache_is_enabled();
 
-    if(!is_header_cache_disabled && src_type == LV_IMAGE_SRC_FILE) {
+    if(is_header_cache_enabled && src_type == LV_IMAGE_SRC_FILE) {
         lv_image_header_cache_data_t search_key;
         search_key.src_type = src_type;
         search_key.src = src;
@@ -310,7 +310,7 @@ static lv_image_decoder_t * image_decoder_get_info(const void * src, lv_image_he
         }
     }
 
-    if(!is_header_cache_disabled && src_type == LV_IMAGE_SRC_FILE && decoder) {
+    if(is_header_cache_enabled && src_type == LV_IMAGE_SRC_FILE && decoder) {
         lv_cache_entry_t * entry;
         lv_image_header_cache_data_t search_key;
         search_key.src_type = src_type;

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -179,7 +179,7 @@ struct _lv_image_decoder_dsc_t {
 /**
  * Initialize the image decoder module
  */
-void _lv_image_decoder_init(void);
+void _lv_image_decoder_init(uint32_t image_cache_size, uint32_t image_header_count);
 
 /**
  * Deinitialize the image decoder module
@@ -276,11 +276,9 @@ void lv_image_decoder_set_get_area_cb(lv_image_decoder_t * decoder, lv_image_dec
  */
 void lv_image_decoder_set_close_cb(lv_image_decoder_t * decoder, lv_image_decoder_close_f_t close_cb);
 
-#if LV_CACHE_DEF_SIZE > 0
 lv_cache_entry_t * lv_image_decoder_add_to_cache(lv_image_decoder_t * decoder,
                                                  lv_image_cache_data_t * search_key,
                                                  const lv_draw_buf_t * decoded, void * user_data);
-#endif
 
 /**
  * Check the decoded image, make any modification if decoder `args` requires.

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -178,6 +178,8 @@ struct _lv_image_decoder_dsc_t {
 
 /**
  * Initialize the image decoder module
+ * @param image_cache_size    Image cache size in bytes. 0 to disable cache.
+ * @param image_header_count  Number of header cache entries. 0 to disable header cache.
  */
 void _lv_image_decoder_init(uint32_t image_cache_size, uint32_t image_header_count);
 

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -394,7 +394,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->args.no_cache) return res;
 
     /*If the image cache is disabled, just return the decoded image*/
-    if(lv_image_cache_is_disabled() == true) return res;
+    if(!lv_image_cache_is_enabled()) return res;
 
     /*Add the decoded image to the cache*/
     if(res == LV_RESULT_OK) {
@@ -420,7 +420,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
+    if(dsc->args.no_cache || !lv_image_cache_is_enabled())
         decoder_draw_buf_free((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -393,7 +393,10 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     if(dsc->args.no_cache) return res;
 
-#if LV_CACHE_DEF_SIZE > 0
+    /*If the image cache is disabled, just return the decoded image*/
+    if(lv_image_cache_is_disabled() == true) return res;
+
+    /*Add the decoded image to the cache*/
     if(res == LV_RESULT_OK) {
         lv_image_cache_data_t search_key;
         search_key.src_type = dsc->src_type;
@@ -409,7 +412,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         }
         dsc->cache_entry = entry;
     }
-#endif
 
     return res;
 }
@@ -418,7 +420,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || LV_CACHE_DEF_SIZE == 0)
+    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
         decoder_draw_buf_free((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -327,7 +327,7 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(use_directly || dsc->args.no_cache) return LV_RESULT_OK; /*Do not put image to cache if it can be used directly.*/
 
     /*If the image cache is disabled, just return the decoded image*/
-    if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+    if(!lv_image_cache_is_enabled()) return LV_RESULT_OK;
 
     /*Add it to cache*/
     lv_image_cache_data_t search_key;

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -326,7 +326,8 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     if(use_directly || dsc->args.no_cache) return LV_RESULT_OK; /*Do not put image to cache if it can be used directly.*/
 
-#if LV_CACHE_DEF_SIZE > 0
+    /*If the image cache is disabled, just return the decoded image*/
+    if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
 
     /*Add it to cache*/
     lv_image_cache_data_t search_key;
@@ -342,7 +343,6 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     dsc->cache_entry = cache_entry;
     decoder_data_t * decoder_data = get_decoder_data(dsc);
     decoder_data->decoded = NULL; /*Cache will take care of it*/
-#endif
 
     return LV_RESULT_OK;
 }

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -173,7 +173,10 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
         if(dsc->args.no_cache) return LV_RES_OK;
 
-#if LV_CACHE_DEF_SIZE > 0
+        /*If the image cache is disabled, just return the decoded image*/
+        if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+
+        /*Add the decoded image to the cache*/
         lv_image_cache_data_t search_key;
         search_key.src_type = dsc->src_type;
         search_key.src = dsc->src;
@@ -186,7 +189,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             return LV_RESULT_INVALID;
         }
         dsc->cache_entry = entry;
-#endif
         return LV_RESULT_OK;    /*If not returned earlier then it failed*/
     }
 
@@ -200,7 +202,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || LV_CACHE_DEF_SIZE == 0)
+    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -174,7 +174,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         if(dsc->args.no_cache) return LV_RES_OK;
 
         /*If the image cache is disabled, just return the decoded image*/
-        if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+        if(!lv_image_cache_is_enabled()) return LV_RESULT_OK;
 
         /*Add the decoded image to the cache*/
         lv_image_cache_data_t search_key;
@@ -202,7 +202,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
+    if(dsc->args.no_cache || !lv_image_cache_is_enabled())
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -148,7 +148,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         if(dsc->args.no_cache) return LV_RES_OK;
 
         /*If the image cache is disabled, just return the decoded image*/
-        if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+        if(!lv_image_cache_is_enabled()) return LV_RESULT_OK;
 
         /*Add the decoded image to the cache*/
         lv_image_cache_data_t search_key;
@@ -177,7 +177,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
+    if(dsc->args.no_cache || !lv_image_cache_is_enabled())
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -147,7 +147,10 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
         if(dsc->args.no_cache) return LV_RES_OK;
 
-#if LV_CACHE_DEF_SIZE > 0
+        /*If the image cache is disabled, just return the decoded image*/
+        if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+
+        /*Add the decoded image to the cache*/
         lv_image_cache_data_t search_key;
         search_key.src_type = dsc->src_type;
         search_key.src = dsc->src;
@@ -160,7 +163,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             return LV_RESULT_INVALID;
         }
         dsc->cache_entry = entry;
-#endif
+
         return LV_RESULT_OK;     /*The image is fully decoded. Return with its pointer*/
     }
 
@@ -174,7 +177,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || LV_CACHE_DEF_SIZE == 0)
+    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -201,7 +201,10 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     if(dsc->args.no_cache) return LV_RES_OK;
 
-#if LV_CACHE_DEF_SIZE > 0
+    /*If the image cache is disabled, just return the decoded image*/
+    if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+
+    /*Add the decoded image to the cache*/
     lv_image_cache_data_t search_key;
     search_key.src_type = dsc->src_type;
     search_key.src = dsc->src;
@@ -213,7 +216,6 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         return LV_RESULT_INVALID;
     }
     dsc->cache_entry = entry;
-#endif
 
     return LV_RESULT_OK;    /*If not returned earlier then it failed*/
 }
@@ -228,7 +230,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder);
 
-    if(dsc->args.no_cache || LV_CACHE_DEF_SIZE == 0)
+    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -202,7 +202,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->args.no_cache) return LV_RES_OK;
 
     /*If the image cache is disabled, just return the decoded image*/
-    if(lv_image_cache_is_disabled() == true) return LV_RESULT_OK;
+    if(!lv_image_cache_is_enabled()) return LV_RESULT_OK;
 
     /*Add the decoded image to the cache*/
     lv_image_cache_data_t search_key;
@@ -230,7 +230,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder);
 
-    if(dsc->args.no_cache || lv_image_cache_is_disabled() == true)
+    if(dsc->args.no_cache || !lv_image_cache_is_enabled())
         lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
     else
         lv_cache_release(dsc->cache, dsc->cache_entry, NULL);

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -200,7 +200,7 @@ void lv_init(void)
     _lv_sysmon_builtin_init();
 #endif
 
-    _lv_image_decoder_init();
+    _lv_image_decoder_init(LV_CACHE_DEF_SIZE, LV_IMAGE_HEADER_CACHE_DEF_CNT);
     lv_bin_decoder_init();  /*LVGL built-in binary image decoder*/
 
 #if LV_USE_DRAW_VG_LITE

--- a/src/misc/cache/_lv_cache_lru_rb.c
+++ b/src/misc/cache/_lv_cache_lru_rb.c
@@ -198,8 +198,7 @@ static bool init_cnt_cb(lv_cache_t * cache)
     LV_ASSERT_NULL(lru->cache.ops.free_cb);
     LV_ASSERT(lru->cache.node_size > 0);
 
-    if(lru->cache.node_size <= 0 || lru->cache.max_size < 0
-       || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
+    if(lru->cache.node_size <= 0 || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
         return false;
     }
 
@@ -222,8 +221,7 @@ static bool init_size_cb(lv_cache_t * cache)
     LV_ASSERT_NULL(lru->cache.ops.free_cb);
     LV_ASSERT(lru->cache.node_size > 0);
 
-    if(lru->cache.node_size <= 0 || lru->cache.max_size < 0
-       || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
+    if(lru->cache.node_size <= 0 || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
         return false;
     }
 

--- a/src/misc/cache/_lv_cache_lru_rb.c
+++ b/src/misc/cache/_lv_cache_lru_rb.c
@@ -198,7 +198,7 @@ static bool init_cnt_cb(lv_cache_t * cache)
     LV_ASSERT_NULL(lru->cache.ops.free_cb);
     LV_ASSERT(lru->cache.node_size > 0);
 
-    if(lru->cache.node_size <= 0 || lru->cache.max_size <= 0
+    if(lru->cache.node_size <= 0 || lru->cache.max_size < 0
        || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
         return false;
     }
@@ -222,7 +222,7 @@ static bool init_size_cb(lv_cache_t * cache)
     LV_ASSERT_NULL(lru->cache.ops.free_cb);
     LV_ASSERT(lru->cache.node_size > 0);
 
-    if(lru->cache.node_size <= 0 || lru->cache.max_size <= 0
+    if(lru->cache.node_size <= 0 || lru->cache.max_size < 0
        || lru->cache.ops.compare_cb == NULL || lru->cache.ops.free_cb == NULL) {
         return false;
     }

--- a/src/misc/cache/lv_cache.c
+++ b/src/misc/cache/lv_cache.c
@@ -83,7 +83,7 @@ lv_cache_entry_t * lv_cache_acquire(lv_cache_t * cache, const void * key, void *
 
     lv_mutex_lock(&cache->lock);
 
-    if (cache->size == 0) {
+    if(cache->size == 0) {
         lv_mutex_unlock(&cache->lock);
         return NULL;
     }
@@ -114,7 +114,7 @@ lv_cache_entry_t * lv_cache_add(lv_cache_t * cache, const void * key, void * use
     LV_ASSERT_NULL(key);
 
     lv_mutex_lock(&cache->lock);
-    if (cache->max_size == 0) {
+    if(cache->max_size == 0) {
         lv_mutex_unlock(&cache->lock);
         return NULL;
     }
@@ -135,7 +135,7 @@ lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * k
     lv_mutex_lock(&cache->lock);
     lv_cache_entry_t * entry = NULL;
 
-    if (cache->size == 0) {
+    if(cache->size != 0) {
         entry = cache->clz->get_cb(cache, key, user_data);
         if(entry != NULL) {
             lv_cache_entry_acquire_data(entry);
@@ -144,7 +144,7 @@ lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * k
         }
     }
 
-    if (cache->max_size == 0) {
+    if(cache->max_size == 0) {
         lv_mutex_unlock(&cache->lock);
         return NULL;
     }
@@ -224,7 +224,8 @@ size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data)
     LV_UNUSED(user_data);
     return cache->max_size - cache->size;
 }
-bool lv_cache_is_disabled(lv_cache_t * cache) {
+bool lv_cache_is_disabled(lv_cache_t * cache)
+{
     return cache->max_size == 0;
 }
 void lv_cache_set_compare_cb(lv_cache_t * cache, lv_cache_compare_cb_t compare_cb, void * user_data)

--- a/src/misc/cache/lv_cache.c
+++ b/src/misc/cache/lv_cache.c
@@ -82,6 +82,12 @@ lv_cache_entry_t * lv_cache_acquire(lv_cache_t * cache, const void * key, void *
     LV_ASSERT_NULL(key);
 
     lv_mutex_lock(&cache->lock);
+
+    if (cache->size == 0) {
+        lv_mutex_unlock(&cache->lock);
+        return NULL;
+    }
+
     lv_cache_entry_t * entry = cache->clz->get_cb(cache, key, user_data);
     if(entry != NULL) {
         lv_cache_entry_acquire_data(entry);
@@ -108,6 +114,11 @@ lv_cache_entry_t * lv_cache_add(lv_cache_t * cache, const void * key, void * use
     LV_ASSERT_NULL(key);
 
     lv_mutex_lock(&cache->lock);
+    if (cache->max_size == 0) {
+        lv_mutex_unlock(&cache->lock);
+        return NULL;
+    }
+
     lv_cache_entry_t * entry = cache_add_internal_no_lock(cache, key, user_data);
     if(entry != NULL) {
         lv_cache_entry_acquire_data(entry);
@@ -122,12 +133,22 @@ lv_cache_entry_t * lv_cache_acquire_or_create(lv_cache_t * cache, const void * k
     LV_ASSERT_NULL(key);
 
     lv_mutex_lock(&cache->lock);
-    lv_cache_entry_t * entry = cache->clz->get_cb(cache, key, user_data);
-    if(entry != NULL) {
-        lv_cache_entry_acquire_data(entry);
-        lv_mutex_unlock(&cache->lock);
-        return entry;
+    lv_cache_entry_t * entry = NULL;
+
+    if (cache->size == 0) {
+        entry = cache->clz->get_cb(cache, key, user_data);
+        if(entry != NULL) {
+            lv_cache_entry_acquire_data(entry);
+            lv_mutex_unlock(&cache->lock);
+            return entry;
+        }
     }
+
+    if (cache->max_size == 0) {
+        lv_mutex_unlock(&cache->lock);
+        return NULL;
+    }
+
     entry = cache_add_internal_no_lock(cache, key, user_data);
     if(entry == NULL) {
         lv_mutex_unlock(&cache->lock);
@@ -202,6 +223,9 @@ size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data)
 {
     LV_UNUSED(user_data);
     return cache->max_size - cache->size;
+}
+bool lv_cache_is_disabled(lv_cache_t * cache) {
+    return cache->max_size == 0;
 }
 void lv_cache_set_compare_cb(lv_cache_t * cache, lv_cache_compare_cb_t compare_cb, void * user_data)
 {

--- a/src/misc/cache/lv_cache.c
+++ b/src/misc/cache/lv_cache.c
@@ -224,9 +224,9 @@ size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data)
     LV_UNUSED(user_data);
     return cache->max_size - cache->size;
 }
-bool lv_cache_is_disabled(lv_cache_t * cache)
+bool lv_cache_is_enabled(lv_cache_t * cache)
 {
-    return cache->max_size == 0;
+    return cache->max_size > 0;
 }
 void lv_cache_set_compare_cb(lv_cache_t * cache, lv_cache_compare_cb_t compare_cb, void * user_data)
 {

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -169,6 +169,14 @@ size_t lv_cache_get_size(lv_cache_t * cache, void * user_data);
 size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data);
 
 /**
+ * Return true if the cache is disabled.
+ * Disabled cache means that when the max_size of the cache is 0. In this case, all cache operations will be no-op.
+ * @param cache         The cache object pointer to check if it's disabled.
+ * @return              Returns true if the cache is disabled, false otherwise.
+ */
+bool lv_cache_is_disabled(lv_cache_t * cache);
+
+/**
  * Set the compare callback of the cache.
  * @param cache         The cache object pointer to set the compare callback.
  * @param compare_cb    The compare callback to set.

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -170,12 +170,12 @@ size_t lv_cache_get_size(lv_cache_t * cache, void * user_data);
 size_t lv_cache_get_free_size(lv_cache_t * cache, void * user_data);
 
 /**
- * Return true if the cache is disabled.
+ * Return true if the cache is enabled.
  * Disabled cache means that when the max_size of the cache is 0. In this case, all cache operations will be no-op.
  * @param cache         The cache object pointer to check if it's disabled.
- * @return              Returns true if the cache is disabled, false otherwise.
+ * @return              Returns true if the cache is enabled, false otherwise.
  */
-bool lv_cache_is_disabled(lv_cache_t * cache);
+bool lv_cache_is_enabled(lv_cache_t * cache);
 
 /**
  * Set the compare callback of the cache.

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -137,6 +137,7 @@ bool lv_cache_evict_one(lv_cache_t * cache, void * user_data);
 /**
  * Set the maximum size of the cache.
  * If the current cache size is greater than the new maximum size, the cache's policy will be used to evict entries until the new maximum size is reached.
+ * If set to 0, the cache will be disabled.
  * @note But this behavior will happen only new entries are added to the cache.
  * @param cache         The cache object pointer to set the maximum size.
  * @param max_size      The new maximum size of the cache.

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -88,9 +88,9 @@ void lv_image_cache_drop(const void * src)
     lv_cache_drop(img_cache_p, &search_key, NULL);
 }
 
-bool lv_image_cache_is_disabled(void)
+bool lv_image_cache_is_enabled(void)
 {
-    return lv_cache_is_disabled(img_cache_p);
+    return lv_cache_is_enabled(img_cache_p);
 }
 
 /**********************

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -88,6 +88,11 @@ void lv_image_cache_drop(const void * src)
     lv_cache_drop(img_cache_p, &search_key, NULL);
 }
 
+bool lv_image_cache_is_disabled(void)
+{
+    return lv_cache_is_disabled(img_cache_p);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -6,14 +6,12 @@
 /*********************
  *      INCLUDES
  *********************/
+
 #include "../lv_assert.h"
-#include "lv_image_header_cache.h"
+#include "../../core/lv_global.h"
 
 #include "lv_image_cache.h"
-
-#if LV_CACHE_DEF_SIZE > 0
-
-#include "../../core/lv_global.h"
+#include "lv_image_header_cache.h"
 
 /*********************
  *      DEFINES
@@ -49,14 +47,14 @@ static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_result_t lv_image_cache_init(void)
+lv_result_t lv_image_cache_init(uint32_t size)
 {
     if(img_cache_p != NULL) {
         return LV_RESULT_OK;
     }
 
     img_cache_p = lv_cache_create(&lv_cache_class_lru_rb_size,
-    sizeof(lv_image_cache_data_t), LV_CACHE_DEF_SIZE, (lv_cache_ops_t) {
+    sizeof(lv_image_cache_data_t), size, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t) image_cache_compare_cb,
         .create_cb = NULL,
         .free_cb = (lv_cache_free_cb_t) image_cache_free_cb,
@@ -72,14 +70,11 @@ void lv_image_cache_resize(uint32_t new_size, bool evict_now)
     }
 }
 
-#endif
-
 void lv_image_cache_drop(const void * src)
 {
     /*If user invalidate image, the header cache should be invalidated too.*/
     lv_image_header_cache_drop(src);
 
-#if LV_CACHE_DEF_SIZE > 0
     if(src == NULL) {
         lv_cache_drop_all(img_cache_p, NULL);
         return;
@@ -91,16 +86,11 @@ void lv_image_cache_drop(const void * src)
     };
 
     lv_cache_drop(img_cache_p, &search_key, NULL);
-#else
-    LV_UNUSED(src);
-#endif
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-#if LV_CACHE_DEF_SIZE > 0
 
 inline static lv_cache_compare_res_t image_cache_common_compare(const void * lhs_src, lv_image_src_t lhs_src_type,
                                                                 const void * rhs_src, lv_image_src_t rhs_src_type)
@@ -142,4 +132,3 @@ static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
     /*Free the duplicated file name*/
     if(entry->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)entry->src);
 }
-#endif

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -37,6 +37,7 @@ lv_result_t lv_image_cache_init(uint32_t size);
 
 /**
  * Resize image cache.
+ * If set to 0, the cache will be disabled.
  * @param new_size  new size of the cache in bytes.
  * @param evict_now true: evict the images should be removed by the eviction policy, false: wait for the next cache cleanup.
  */

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -31,6 +31,7 @@ extern "C" {
 
 /**
  * Initialize image cache.
+ * @param  size size of the cache in bytes.
  * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
 lv_result_t lv_image_cache_init(uint32_t size);
@@ -50,10 +51,10 @@ void lv_image_cache_resize(uint32_t new_size, bool evict_now);
 void lv_image_cache_drop(const void * src);
 
 /**
- * Return true if the image cache is disabled.
- * @return true: disabled, false: enabled.
+ * Return true if the image cache is enabled.
+ * @return true: enabled, false: disabled.
  */
-bool lv_image_cache_is_disabled(void);
+bool lv_image_cache_is_enabled(void);
 
 /*************************
  *    GLOBAL VARIABLES

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -35,7 +35,7 @@ extern "C" {
  * Initialize image cache.
  * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
-lv_result_t lv_image_cache_init(void);
+lv_result_t lv_image_cache_init(uint32_t size);
 
 /**
  * Resize image cache.

--- a/src/misc/cache/lv_image_cache.h
+++ b/src/misc/cache/lv_image_cache.h
@@ -17,8 +17,6 @@ extern "C" {
 #include "../../lv_conf_internal.h"
 #include "../lv_types.h"
 
-#if LV_CACHE_DEF_SIZE > 0
-
 /*********************
  *      DEFINES
  *********************/
@@ -44,13 +42,17 @@ lv_result_t lv_image_cache_init(uint32_t size);
  */
 void lv_image_cache_resize(uint32_t new_size, bool evict_now);
 
-#endif /*LV_CACHE_DEF_SIZE > 0*/
-
 /**
  * Invalidate image cache. Use NULL to invalidate all images.
  * @param src pointer to an image source.
  */
 void lv_image_cache_drop(const void * src);
+
+/**
+ * Return true if the image cache is disabled.
+ * @return true: disabled, false: enabled.
+ */
+bool lv_image_cache_is_disabled(void);
 
 /*************************
  *    GLOBAL VARIABLES

--- a/src/misc/cache/lv_image_header_cache.c
+++ b/src/misc/cache/lv_image_header_cache.c
@@ -62,11 +62,11 @@ lv_result_t lv_image_header_cache_init(uint32_t count)
     return img_header_cache_p != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
-void lv_image_header_cache_resize(uint32_t new_size, bool evict_now)
+void lv_image_header_cache_resize(uint32_t count, bool evict_now)
 {
-    lv_cache_set_max_size(img_header_cache_p, new_size, NULL);
+    lv_cache_set_max_size(img_header_cache_p, count, NULL);
     if(evict_now) {
-        lv_cache_reserve(img_header_cache_p, new_size, NULL);
+        lv_cache_reserve(img_header_cache_p, count, NULL);
     }
 }
 
@@ -85,9 +85,9 @@ void lv_image_header_cache_drop(const void * src)
     lv_cache_drop(img_header_cache_p, &search_key, NULL);
 }
 
-bool lv_image_header_cache_is_disabled(void)
+bool lv_image_header_cache_is_enabled(void)
 {
-    return lv_cache_is_disabled(img_header_cache_p);
+    return lv_cache_is_enabled(img_header_cache_p);
 }
 
 /**********************

--- a/src/misc/cache/lv_image_header_cache.c
+++ b/src/misc/cache/lv_image_header_cache.c
@@ -6,12 +6,11 @@
 /*********************
  *      INCLUDES
  *********************/
+
 #include "../lv_assert.h"
-#include "lv_image_header_cache.h"
-
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-
 #include "../../core/lv_global.h"
+
+#include "lv_image_header_cache.h"
 
 /*********************
  *      DEFINES
@@ -47,14 +46,14 @@ static void image_header_cache_free_cb(lv_image_header_cache_data_t * entry, voi
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_result_t lv_image_header_cache_init(void)
+lv_result_t lv_image_header_cache_init(uint32_t count)
 {
     if(img_header_cache_p != NULL) {
         return LV_RESULT_OK;
     }
 
     img_header_cache_p = lv_cache_create(&lv_cache_class_lru_rb_count,
-    sizeof(lv_image_header_cache_data_t), LV_IMAGE_HEADER_CACHE_DEF_CNT, (lv_cache_ops_t) {
+    sizeof(lv_image_header_cache_data_t), count, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t) image_header_cache_compare_cb,
         .create_cb = NULL,
         .free_cb = (lv_cache_free_cb_t) image_header_cache_free_cb
@@ -71,11 +70,8 @@ void lv_image_header_cache_resize(uint32_t new_size, bool evict_now)
     }
 }
 
-#endif
-
 void lv_image_header_cache_drop(const void * src)
 {
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
     if(src == NULL) {
         lv_cache_drop_all(img_header_cache_p, NULL);
         return;
@@ -87,17 +83,11 @@ void lv_image_header_cache_drop(const void * src)
     };
 
     lv_cache_drop(img_header_cache_p, &search_key, NULL);
-#else
-    LV_UNUSED(src);
-#endif
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
 
 inline static lv_cache_compare_res_t image_cache_common_compare(const void * lhs_src, lv_image_src_t lhs_src_type,
                                                                 const void * rhs_src, lv_image_src_t rhs_src_type)
@@ -132,5 +122,3 @@ static void image_header_cache_free_cb(lv_image_header_cache_data_t * entry, voi
 
     if(entry->src_type == LV_IMAGE_SRC_FILE) lv_free((void *)entry->src);
 }
-
-#endif

--- a/src/misc/cache/lv_image_header_cache.c
+++ b/src/misc/cache/lv_image_header_cache.c
@@ -85,6 +85,11 @@ void lv_image_header_cache_drop(const void * src)
     lv_cache_drop(img_header_cache_p, &search_key, NULL);
 }
 
+bool lv_image_header_cache_is_disabled(void)
+{
+    return lv_cache_is_disabled(img_header_cache_p);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -31,6 +31,7 @@ extern "C" {
 
 /**
  * Initialize image header cache.
+ * @param  count initial size of the cache in count of image headers.
  * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
 lv_result_t lv_image_header_cache_init(uint32_t count);
@@ -38,10 +39,10 @@ lv_result_t lv_image_header_cache_init(uint32_t count);
 /**
  * Resize image header cache.
  * If set to 0, the cache is disabled.
- * @param new_size  new size of the cache in count of image headers.
+ * @param count  new max count of cached image headers.
  * @param evict_now true: evict the image headers should be removed by the eviction policy, false: wait for the next cache cleanup.
  */
-void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
+void lv_image_header_cache_resize(uint32_t count, bool evict_now);
 
 /**
  * Invalidate image header cache. Use NULL to invalidate all image headers.
@@ -51,10 +52,10 @@ void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
 void lv_image_header_cache_drop(const void * src);
 
 /**
- * Return true if the image header cache is disabled.
- * @return true: disabled, false: enabled.
+ * Return true if the image header cache is enabled.
+ * @return true: enabled, false: disabled.
  */
-bool lv_image_header_cache_is_disabled(void);
+bool lv_image_header_cache_is_enabled(void);
 
 /*************************
  *    GLOBAL VARIABLES

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -37,6 +37,7 @@ lv_result_t lv_image_header_cache_init(uint32_t count);
 
 /**
  * Resize image header cache.
+ * If set to 0, the cache is disabled.
  * @param new_size  new size of the cache in count of image headers.
  * @param evict_now true: evict the image headers should be removed by the eviction policy, false: wait for the next cache cleanup.
  */

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -49,6 +49,12 @@ void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
  */
 void lv_image_header_cache_drop(const void * src);
 
+/**
+ * Return true if the image header cache is disabled.
+ * @return true: disabled, false: enabled.
+ */
+bool lv_image_header_cache_is_disabled(void);
+
 /*************************
  *    GLOBAL VARIABLES
  *************************/

--- a/src/misc/cache/lv_image_header_cache.h
+++ b/src/misc/cache/lv_image_header_cache.h
@@ -17,8 +17,6 @@ extern "C" {
 #include "../../lv_conf_internal.h"
 #include "../lv_types.h"
 
-#if LV_IMAGE_HEADER_CACHE_DEF_CNT > 0
-
 /*********************
  *      DEFINES
  *********************/
@@ -35,7 +33,7 @@ extern "C" {
  * Initialize image header cache.
  * @return LV_RESULT_OK: initialization succeeded, LV_RESULT_INVALID: failed.
  */
-lv_result_t lv_image_header_cache_init(void);
+lv_result_t lv_image_header_cache_init(uint32_t count);
 
 /**
  * Resize image header cache.
@@ -43,8 +41,6 @@ lv_result_t lv_image_header_cache_init(void);
  * @param evict_now true: evict the image headers should be removed by the eviction policy, false: wait for the next cache cleanup.
  */
 void lv_image_header_cache_resize(uint32_t new_size, bool evict_now);
-
-#endif /*LV_IMAGE_HEADER_CACHE_DEF_CNT > 0*/
 
 /**
  * Invalidate image header cache. Use NULL to invalidate all image headers.


### PR DESCRIPTION
### Description of the feature or fix

1. Now `LV_CACHE_DEF_SIZE` and `LV_IMAGE_HEADER_CACHE_DEF_CNT` only appear in `lv_init.c`.
2. Now you can dynamically set the size of both caches through `lv_image_cache_resize` and `lv_image_header_cache_resize`.
3. If the cache is dynamically set to `0` at runtime, the decoded images will no longer go through cache, but **directly** return the decoded data. Other situations are the same as before.

Refs issues:
- #5579 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
