### PR TITLE
feat(stdlib): add lv_strncat and refactor strcat uses

### DIFF
--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -14,18 +14,7 @@ static void file_explorer_event_handler(lv_event_t * e)
     if(code == LV_EVENT_VALUE_CHANGED) {
         const char * cur_path =  lv_file_explorer_get_current_path(obj);
         const char * sel_fn = lv_file_explorer_get_selected_file_name(obj);
-        uint16_t path_len = strlen(cur_path);
-        uint16_t fn_len = strlen(sel_fn);
-
-        if((path_len + fn_len) <= LV_FILE_EXPLORER_PATH_MAX_LEN) {
-            char file_info[LV_FILE_EXPLORER_PATH_MAX_LEN];
-
-            strcpy(file_info, cur_path);
-            strcat(file_info, sel_fn);
-
-            LV_LOG_USER("%s", file_info);
-        }
-        else    LV_LOG_USER("%s%s", cur_path, sel_fn);
+        LV_LOG_USER("%s%s", cur_path, sel_fn);
     }
 }
 

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -14,18 +14,8 @@ static void file_explorer_event_handler(lv_event_t * e)
     if(code == LV_EVENT_VALUE_CHANGED) {
         const char * cur_path =  lv_file_explorer_get_current_path(obj);
         const char * sel_fn = lv_file_explorer_get_selected_file_name(obj);
-        uint16_t path_len = strlen(cur_path);
-        uint16_t fn_len = strlen(sel_fn);
 
-        if((path_len + fn_len) <= LV_FILE_EXPLORER_PATH_MAX_LEN) {
-            char file_info[LV_FILE_EXPLORER_PATH_MAX_LEN];
-
-            strcpy(file_info, cur_path);
-            strcat(file_info, sel_fn);
-
-            LV_LOG_USER("%s", file_info);
-        }
-        else    LV_LOG_USER("%s%s", cur_path, sel_fn);
+        LV_LOG_USER("%s%s", cur_path, sel_fn);
     }
 }
 

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -50,8 +50,6 @@ static void file_explorer_event_handler(lv_event_t * e)
     if(code == LV_EVENT_VALUE_CHANGED) {
         const char * cur_path =  lv_file_explorer_get_current_path(obj);
         const char * sel_fn = lv_file_explorer_get_selected_file_name(obj);
-        uint16_t path_len = strlen(cur_path);
-        uint16_t fn_len = strlen(sel_fn);
 
         LV_LOG_USER("%s%s", cur_path, sel_fn);
     }

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -53,15 +53,7 @@ static void file_explorer_event_handler(lv_event_t * e)
         uint16_t path_len = strlen(cur_path);
         uint16_t fn_len = strlen(sel_fn);
 
-        if((path_len + fn_len) <= LV_FILE_EXPLORER_PATH_MAX_LEN) {
-            char file_info[LV_FILE_EXPLORER_PATH_MAX_LEN];
-
-            strcpy(file_info, cur_path);
-            strcat(file_info, sel_fn);
-
-            LV_LOG_USER("%s", file_info);
-        }
-        else    LV_LOG_USER("%s%s", cur_path, sel_fn);
+        LV_LOG_USER("%s%s", cur_path, sel_fn);
     }
     else if(code == LV_EVENT_READY) {
         lv_obj_t * tb = lv_file_explorer_get_file_table(obj);

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -243,7 +243,7 @@ char * lv_strncat(char * dst, const char * src, size_t src_len)
     while(*dst != '\0') {
         dst++;
     }
-    while (src_len != 0 && *src != '\0') {
+    while(src_len != 0 && *src != '\0') {
         src_len--;
         *dst++ = *src++;
     }

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -237,6 +237,20 @@ char * lv_strcat(char * dst, const char * src)
     return tmp;
 }
 
+char * lv_strncat(char * dst, const char * src, size_t src_len)
+{
+    char * tmp = dst;
+    while(*dst != '\0') {
+        dst++;
+    }
+    while (src_len != 0 && *src != '\0') {
+        src_len--;
+        *dst++ = *src++;
+    }
+    *dst = '\0';
+    return tmp;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -96,6 +96,11 @@ char * lv_strcat(char * dst, const char * src)
     return strcat(dst, src);
 }
 
+char * lv_strncat(char * dst, const char * src, size_t src_len)
+{
+    return strncat(dst, src, src_len);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -124,6 +124,18 @@ char * lv_strdup(const char * src);
  */
 char * lv_strcat(char * dst, const char * src);
 
+/**
+ * @brief Copies up to src_len characters from the string pointed to by src
+ *        to the end of the string pointed to by dst.
+ *        A terminating null character is appended to dst even if no null character
+ *        was encountered in src after src_len characters were copied.
+ * @param dst Pointer to the destination string where the content is to be appended.
+ * @param src Pointer to the source of data to be copied.
+ * @param src_len Maximum number of characters from src to be copied to the end of dst.
+ * @return A pointer to the destination string, which is dst.
+ */
+char * lv_strncat(char * dst, const char * src, size_t src_len);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -90,6 +90,11 @@ char * lv_strcat(char * dst, const char * src)
     return strcat(dst, src);
 }
 
+char * lv_strncat(char * dst, const char * src, size_t src_len)
+{
+    return rt_strncat(dst, src, src_len);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -92,7 +92,7 @@ char * lv_strcat(char * dst, const char * src)
 
 char * lv_strncat(char * dst, const char * src, size_t src_len)
 {
-    return rt_strncat(dst, src, src_len);
+    return lv_strncpy(dst + lv_strlen(dst), src, src_len);
 }
 
 /**********************

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -92,7 +92,14 @@ char * lv_strcat(char * dst, const char * src)
 
 char * lv_strncat(char * dst, const char * src, size_t src_len)
 {
-    return lv_strncpy(dst + lv_strlen(dst), src, src_len);
+    char * tmp = dst;
+    dst += lv_strlen(dst);
+    while(src_len != 0 && *src != '\0') {
+        src_len--;
+        *dst++ = *src++;
+    }
+    *dst = '\0';
+    return tmp;
 }
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

Implement `lv_strncat` and replace `(lv_)strcat` with `(lv_)strncat` where possible.

A goal of this PR was to replace `strcat` with `strncat` where possible. In practice, that refactor is only helpful if the `src` param is is potentially unterminated. In most cases, `src` is known to be terminated. What needs to be protected in most cases is overrunning `dst`, but `strncat` is not the right tool for that.

This is the kind of refactor that would improve most uses of `strcat`.

https://github.com/lvgl/lvgl/blob/905de3d7c81367608577e1e38d032831a7871c16/examples/others/file_explorer/lv_example_file_explorer_1.c#L53-L58


```c
    const char * envvar = "HOME";
    char home_dir[LV_FS_MAX_PATH_LENGTH];
    /* get the user's home directory from the HOME environment variable*/
    int res = lv_snprintf(home_dir, LV_FS_MAX_PATH_LENGTH, "A:%s", getenv(envvar));
    if (res < 0 || res >= GPIO_MAX_NAME_SIZE) {
        /* optionally handle error */
    }
    LV_LOG_USER("home_dir: %s\n", home_dir);
```


#### Re `strcpy`:

The current builtin `lv_strncpy` is subtly incompatible with the C spec behavior of `strncpy`. A future PR could be opened to change the behavior of the builtin to match the standard.

For that reason, the builtin `lv_strncat` was not implemented in terms of the builtin `lv_strncpy` in this PR since the builtin `lv_strncpy` could change at some point. ~~In a `lv_strncpy` PR, the builtin `lv_strncat` can be written in terms of the builtin `lv_strncpy`.~~ (Edit: The current, subtly flawed, implementation of `lv_strncpy` could be used to implement `lv_strncat` right now, but once it gets fixed, it couldn't be used to implement `lv_strncat` anymore. 😅️)


#### Appendix: Standard behavior of `strncat` and `strncpy`

`strncat` adds a null terminator to `dst` no matter what. (implemented in builtin `lv_strncat` in this PR)

`strncpy` will not add a null terminator if `dest_size` chars are copied before the null terminator. (not the current behavior of the builtin `lv_strncpy`)


<br>


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
