### PR TITLE
perf(libpng): performance optimization

### DIFF
--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -264,7 +264,7 @@ static lv_draw_buf_t * decode_png_file(const char * filename)
 
     /*Alloc image buffer*/
     lv_draw_buf_t * decoded;
-    decoded = lv_draw_buf_create(image.width, image.height, LV_COLOR_FORMAT_ARGB8888, PNG_IMAGE_ROW_STRIDE(image));
+    decoded = lv_draw_buf_create(image.width, image.height, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
     if(decoded == NULL) {
         LV_LOG_ERROR("alloc PNG_IMAGE_SIZE(%" LV_PRIu32 ") failed: %s", (uint32_t)PNG_IMAGE_SIZE(image), filename);
         lv_free(data);
@@ -272,7 +272,7 @@ static lv_draw_buf_t * decode_png_file(const char * filename)
     }
 
     /*Start decoding*/
-    ret = png_image_finish_read(&image, NULL, decoded->data, 0, NULL);
+    ret = png_image_finish_read(&image, NULL, decoded->data, decoded->header.stride, NULL);
     png_image_free(&image);
     lv_free(data);
     if(!ret) {

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -27,7 +27,7 @@
 static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
-static lv_draw_buf_t * decode_png_file(const char * filename);
+static lv_draw_buf_t * decode_png_file(lv_image_decoder_dsc_t * dsc, const char * filename);
 
 /**********************
  *  STATIC VARIABLES
@@ -126,7 +126,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     /*If it's a PNG file...*/
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * fn = dsc->src;
-        lv_draw_buf_t * decoded = decode_png_file(fn);
+        lv_draw_buf_t * decoded = decode_png_file(dsc, fn);
         if(decoded == NULL) {
             return LV_RESULT_INVALID;
         }
@@ -235,7 +235,7 @@ failed:
     return data;
 }
 
-static lv_draw_buf_t * decode_png_file(const char * filename)
+static lv_draw_buf_t * decode_png_file(lv_image_decoder_dsc_t * dsc, const char * filename)
 {
     int ret;
 
@@ -259,24 +259,34 @@ static lv_draw_buf_t * decode_png_file(const char * filename)
         return NULL;
     }
 
-    /*Set color format*/
-    image.format = PNG_FORMAT_BGRA;
+    lv_color_format_t cf;
+    if(dsc->args.use_indexed && (image.format & PNG_FORMAT_FLAG_COLORMAP)) {
+        cf = LV_COLOR_FORMAT_I8;
+        image.format = PNG_FORMAT_BGRA_COLORMAP;
+    }
+    else {
+        cf = LV_COLOR_FORMAT_ARGB8888;
+        image.format = PNG_FORMAT_BGRA;
+    }
 
     /*Alloc image buffer*/
     lv_draw_buf_t * decoded;
-    decoded = lv_draw_buf_create(image.width, image.height, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
+    decoded = lv_draw_buf_create(image.width, image.height, cf, LV_STRIDE_AUTO);
     if(decoded == NULL) {
         LV_LOG_ERROR("alloc PNG_IMAGE_SIZE(%" LV_PRIu32 ") failed: %s", (uint32_t)PNG_IMAGE_SIZE(image), filename);
         lv_free(data);
         return NULL;
     }
 
+    void * palette = decoded->data;
+    void * map = decoded->data + LV_COLOR_INDEXED_PALETTE_SIZE(cf) * sizeof(lv_color32_t);
+
     /*Start decoding*/
-    ret = png_image_finish_read(&image, NULL, decoded->data, decoded->header.stride, NULL);
+    ret = png_image_finish_read(&image, NULL, map, decoded->header.stride, palette);
     png_image_free(&image);
     lv_free(data);
     if(!ret) {
-        LV_LOG_ERROR("png decode failed: %d", ret);
+        LV_LOG_ERROR("png decode failed: %s", image.message);
         lv_draw_buf_destroy(decoded);
         return NULL;
     }


### PR DESCRIPTION
### Description of the feature or fix

1. let libpng handle stride adjustment directly by specify `row_stride`.
2. If renderer support I8 image format, and PNG is in 8bit mode, use it directly.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
