### PR TITLE
fix(sysmon): fix MicroPython compilation error when system monitor is enabled

### DIFF
--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -55,6 +55,11 @@
 #endif
 
 /**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static lv_obj_t * _lv_sysmon_create_label(lv_obj_t * parent);
+
+/**********************
  *  STATIC VARIABLES
  **********************/
 

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -92,6 +92,58 @@ void _lv_sysmon_builtin_deinit(void)
 #endif
 }
 
+#if _USE_PERF_MONITOR
+
+void lv_sysmon_show_performance(void)
+{
+    if(!sysmon_perf.inited) {
+        sysmon_perf.label = _lv_sysmon_create_label(lv_layer_sys());
+        lv_obj_align(sysmon_perf.label, LV_USE_PERF_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, sysmon_perf.label, NULL);
+        sysmon_perf.inited = true;
+    }
+
+#if LV_USE_PERF_MONITOR_LOG_MODE
+    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+#else
+    lv_obj_remove_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+#endif
+}
+
+void lv_sysmon_hide_performance(void)
+{
+    if(!sysmon_perf.inited) {
+        return;
+    }
+    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+}
+
+#endif
+
+#if _USE_MEM_MONITOR
+
+void lv_sysmon_show_memory(void)
+{
+    if(!sysmon_mem.inited) {
+        sysmon_mem.label = _lv_sysmon_create_label(lv_layer_sys());
+        lv_obj_align(sysmon_mem.label, LV_USE_MEM_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, sysmon_mem.label, NULL);
+        sysmon_mem.inited = true;
+    }
+
+    lv_obj_remove_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
+}
+
+void lv_sysmon_hide_memory(void)
+{
+    if(!sysmon_mem.inited) {
+        return;
+    }
+    lv_obj_add_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
+}
+
+#endif
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -113,30 +165,6 @@ static lv_obj_t * _lv_sysmon_create_label(lv_obj_t * parent)
 #endif
 
 #if _USE_PERF_MONITOR
-
-void lv_sysmon_show_performance()
-{
-    if(!sysmon_perf.inited) {
-        sysmon_perf.label = _lv_sysmon_create_label(lv_layer_sys());
-        lv_obj_align(sysmon_perf.label, LV_USE_PERF_MONITOR_POS, 0, 0);
-        lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, sysmon_perf.label, NULL);
-        sysmon_perf.inited = true;
-    }
-
-#if LV_USE_PERF_MONITOR_LOG_MODE
-    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
-#else
-    lv_obj_remove_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
-#endif
-}
-
-void lv_sysmon_hide_performance()
-{
-    if(!sysmon_perf.inited) {
-        return;
-    }
-    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
-}
 
 static void perf_monitor_disp_event_cb(lv_event_t * e)
 {
@@ -266,26 +294,6 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 #endif
 
 #if _USE_MEM_MONITOR
-
-void lv_sysmon_show_memory()
-{
-    if(!sysmon_mem.inited) {
-        sysmon_mem.label = _lv_sysmon_create_label(lv_layer_sys());
-        lv_obj_align(sysmon_mem.label, LV_USE_MEM_MONITOR_POS, 0, 0);
-        lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, sysmon_mem.label, NULL);
-        sysmon_mem.inited = true;
-    }
-
-    lv_obj_remove_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
-}
-
-void lv_sysmon_hide_memory()
-{
-    if(!sysmon_mem.inited) {
-        return;
-    }
-    lv_obj_add_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
-}
 
 static void mem_update_timer_cb(lv_timer_t * t)
 {

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -99,7 +99,7 @@ void _lv_sysmon_builtin_deinit(void)
 
 #if _USE_PERF_MONITOR || _USE_MEM_MONITOR
 
-static lv_obj_t * _lv_sysmon_create(lv_obj_t * parent)
+static lv_obj_t * _lv_sysmon_create_label(lv_obj_t * parent)
 {
     LV_LOG_INFO("begin");
     lv_obj_t * label = lv_label_create(parent);
@@ -114,6 +114,30 @@ static lv_obj_t * _lv_sysmon_create(lv_obj_t * parent)
 #endif
 
 #if _USE_PERF_MONITOR
+
+void lv_sysmon_show_performance()
+{
+    if(!sysmon_perf.inited) {
+        sysmon_perf.label = _lv_sysmon_create_label(lv_layer_sys());
+        lv_obj_align(sysmon_perf.label, LV_USE_PERF_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, sysmon_perf.label, NULL);
+        sysmon_perf.inited = true;
+    }
+    
+#if LV_USE_PERF_MONITOR_LOG_MODE
+    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+#else
+    lv_obj_remove_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+#endif
+}
+
+void lv_sysmon_hide_performance()
+{
+    if(!sysmon_perf.inited) {
+        return;
+    }
+    lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
+}
 
 static void perf_monitor_disp_event_cb(lv_event_t * e)
 {
@@ -167,13 +191,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     if(!sysmon_perf.inited && lv_display_get_default()) {
         lv_display_add_event_cb(lv_display_get_default(), perf_monitor_disp_event_cb, LV_EVENT_ALL, NULL);
 
-        lv_obj_t * obj1 = _lv_sysmon_create(lv_layer_sys());
-        lv_obj_align(obj1, LV_USE_PERF_MONITOR_POS, 0, 0);
-        lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, obj1, NULL);
-#if LV_USE_PERF_MONITOR_LOG_MODE
-        lv_obj_add_flag(obj1, LV_OBJ_FLAG_HIDDEN);
-#endif
-        sysmon_perf.inited = true;
+        lv_sysmon_show_performance();
     }
 
     if(!sysmon_perf.inited) return;
@@ -250,14 +268,31 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 
 #if _USE_MEM_MONITOR
 
+void lv_sysmon_show_memory()
+{
+    if(!sysmon_mem.inited) {
+        sysmon_mem.label = _lv_sysmon_create_label(lv_layer_sys());
+        lv_obj_align(sysmon_mem.label, LV_USE_MEM_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, sysmon_mem.label, NULL);
+        sysmon_mem.inited = true;
+    }
+    
+    lv_obj_remove_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
+}
+
+void lv_sysmon_hide_memory()
+{
+    if(!sysmon_mem.inited) {
+        return;
+    }
+    lv_obj_add_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
+}
+
 static void mem_update_timer_cb(lv_timer_t * t)
 {
     /*Wait for a display*/
     if(!sysmon_mem.inited && lv_display_get_default()) {
-        lv_obj_t * obj2 = _lv_sysmon_create(lv_layer_sys());
-        lv_obj_align(obj2, LV_USE_MEM_MONITOR_POS, 0, 0);
-        lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, obj2, NULL);
-        sysmon_mem.inited = true;
+        lv_sysmon_show_memory();
     }
 
     if(!sysmon_mem.inited) return;

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -19,7 +19,6 @@
 /*********************
  *      DEFINES
  *********************/
-#define MY_CLASS (&lv_sysmon_class)
 
 #define SYSMON_REFR_PERIOD_DEF 300 /* ms */
 
@@ -93,7 +92,12 @@ void _lv_sysmon_builtin_deinit(void)
 #endif
 }
 
-lv_obj_t * lv_sysmon_create(lv_obj_t * parent)
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static lv_obj_t * _lv_sysmon_create(lv_obj_t * parent)
 {
     LV_LOG_INFO("begin");
     lv_obj_t * label = lv_label_create(parent);
@@ -104,10 +108,6 @@ lv_obj_t * lv_sysmon_create(lv_obj_t * parent)
     lv_label_set_text(label, "?");
     return label;
 }
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
 
 #if _USE_PERF_MONITOR
 
@@ -163,7 +163,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     if(!sysmon_perf.inited && lv_display_get_default()) {
         lv_display_add_event_cb(lv_display_get_default(), perf_monitor_disp_event_cb, LV_EVENT_ALL, NULL);
 
-        lv_obj_t * obj1 = lv_sysmon_create(lv_layer_sys());
+        lv_obj_t * obj1 = _lv_sysmon_create(lv_layer_sys());
         lv_obj_align(obj1, LV_USE_PERF_MONITOR_POS, 0, 0);
         lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, obj1, NULL);
 #if LV_USE_PERF_MONITOR_LOG_MODE
@@ -250,7 +250,7 @@ static void mem_update_timer_cb(lv_timer_t * t)
 {
     /*Wait for a display*/
     if(!sysmon_mem.inited && lv_display_get_default()) {
-        lv_obj_t * obj2 = lv_sysmon_create(lv_layer_sys());
+        lv_obj_t * obj2 = _lv_sysmon_create(lv_layer_sys());
         lv_obj_align(obj2, LV_USE_MEM_MONITOR_POS, 0, 0);
         lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, obj2, NULL);
         sysmon_mem.inited = true;

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -92,7 +92,6 @@ void _lv_sysmon_builtin_deinit(void)
 #endif
 }
 
-
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -123,7 +122,7 @@ void lv_sysmon_show_performance()
         lv_subject_add_observer_obj(&sysmon_perf.subject, perf_observer_cb, sysmon_perf.label, NULL);
         sysmon_perf.inited = true;
     }
-    
+
 #if LV_USE_PERF_MONITOR_LOG_MODE
     lv_obj_add_flag(sysmon_perf.label, LV_OBJ_FLAG_HIDDEN);
 #else
@@ -276,7 +275,7 @@ void lv_sysmon_show_memory()
         lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, sysmon_mem.label, NULL);
         sysmon_mem.inited = true;
     }
-    
+
     lv_obj_remove_flag(sysmon_mem.label, LV_OBJ_FLAG_HIDDEN);
 }
 

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -54,10 +54,9 @@
     static void mem_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
 #endif
 
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-static lv_obj_t * _lv_sysmon_create_label(lv_obj_t * parent);
+#if _USE_PERF_MONITOR || _USE_MEM_MONITOR
+    static lv_obj_t * _lv_sysmon_create_label(lv_obj_t * parent);
+#endif
 
 /**********************
  *  STATIC VARIABLES

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -97,6 +97,8 @@ void _lv_sysmon_builtin_deinit(void)
  *   STATIC FUNCTIONS
  **********************/
 
+#if _USE_PERF_MONITOR || _USE_MEM_MONITOR
+
 static lv_obj_t * _lv_sysmon_create(lv_obj_t * parent)
 {
     LV_LOG_INFO("begin");
@@ -108,6 +110,8 @@ static lv_obj_t * _lv_sysmon_create(lv_obj_t * parent)
     lv_label_set_text(label, "?");
     return label;
 }
+
+#endif
 
 #if _USE_PERF_MONITOR
 

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -38,6 +38,7 @@ extern "C" {
 typedef struct {
     lv_subject_t subject;
     lv_timer_t * timer;
+    lv_obj_t * label;
     bool inited;
 } lv_sysmon_backend_data_t;
 
@@ -77,6 +78,34 @@ typedef struct {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+#if LV_USE_SYSMON && LV_USE_PERF_MONITOR
+
+/**
+ * Show system performance monitor: CPU usage and FPS count
+ */
+void lv_sysmon_show_performance();
+
+/**
+ * Hide system performance monitor
+ */
+void lv_sysmon_hide_performance();
+
+#endif
+
+#if LV_USE_SYSMON && LV_USE_MEM_MONITOR
+
+/**
+ * Show system memory monitor: used memory and the memory fragmentation
+ */
+void lv_sysmon_show_memory();
+
+/**
+ * Hide system memory monitor
+ */
+void lv_sysmon_hide_memory();
+
+#endif
 
 /**
  * Initialize built-in system monitor, such as performance and memory monitor.

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -78,34 +78,37 @@ typedef struct {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+#if LV_USE_SYSMON
 
-#if LV_USE_SYSMON && LV_USE_PERF_MONITOR
+#if LV_USE_PERF_MONITOR
 
 /**
  * Show system performance monitor: CPU usage and FPS count
  */
-void lv_sysmon_show_performance();
+void lv_sysmon_show_performance(void);
 
 /**
  * Hide system performance monitor
  */
-void lv_sysmon_hide_performance();
+void lv_sysmon_hide_performance(void);
 
-#endif
+#endif /*LV_USE_PERF_MONITOR*/
 
-#if LV_USE_SYSMON && LV_USE_MEM_MONITOR
+#if LV_USE_MEM_MONITOR
 
 /**
  * Show system memory monitor: used memory and the memory fragmentation
  */
-void lv_sysmon_show_memory();
+void lv_sysmon_show_memory(void);
 
 /**
  * Hide system memory monitor
  */
-void lv_sysmon_hide_memory();
+void lv_sysmon_hide_memory(void);
 
-#endif
+#endif /*LV_USE_MEM_MONITOR*/
+
+#endif /*LV_USE_SYSMON*/
 
 /**
  * Initialize built-in system monitor, such as performance and memory monitor.

--- a/src/others/sysmon/lv_sysmon.h
+++ b/src/others/sysmon/lv_sysmon.h
@@ -79,20 +79,6 @@ typedef struct {
  **********************/
 
 /**
- * Create a system monitor object.
- * @param parent pointer to an object, it will be the parent of the new system monitor
- * @return       pointer to the new system monitor object
- */
-lv_obj_t * lv_sysmon_create(lv_obj_t * parent);
-
-/**
- * Set the refresh period of the system monitor object
- * @param obj    pointer to a system monitor object
- * @param period the refresh period in milliseconds
- */
-void lv_sysmon_set_refr_period(lv_obj_t * obj, uint32_t period);
-
-/**
  * Initialize built-in system monitor, such as performance and memory monitor.
  */
 void _lv_sysmon_builtin_init(void);


### PR DESCRIPTION
### Description of the feature or fix

Fix for https://github.com/lvgl/lvgl/issues/5547

When system monitor is enabled in MicroPython binding, then the unix port build fails with following error:
```
CC build-standard/lvgl/lv_mpy.c
build-standard/lvgl/lv_mpy.c:21405:22: error: ‘lv_sysmon_class’ undeclared here (not in a function); did you mean ‘lv_sysmon_create’?
21405 |     .lv_obj_class = &lv_sysmon_class,
      |                      ^~~~~~~~~~~~~~~
      |                      lv_sysmon_create
-e See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
make: *** [../../py/mkrules.mk:83: build-standard/build-standard/lvgl/lv_mpy.o] Error 1
```

There was a refactor of system monitor, and since then there is no `lv_sysmon_class`: https://github.com/lvgl/lvgl/commit/a61d87f8403d7be17f238640b520ca0fd96c5c57#diff-931dc821c9118f8f5432800178c30f1c9bc562ad1c72ff51ebdd8c0aed5232d9L61

Build of other ports fail, too.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
