### PR TITLE
fix(textarea): update password bullets immediately on set

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -313,6 +313,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
     }
 
     if(ta->pwd_mode) {
+        lv_free(ta->pwd_tmp);
         ta->pwd_tmp = lv_strdup(txt);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
@@ -423,6 +424,7 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
     /*Pwd mode is now enabled*/
     if(en) {
         char * txt = lv_label_get_text(ta->label);
+        lv_free(ta->pwd_tmp);
         ta->pwd_tmp = lv_strdup(txt);
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -59,6 +59,7 @@ static lv_result_t insert_handler(lv_obj_t * obj, const char * txt);
 static void draw_placeholder(lv_event_t * e);
 static void draw_cursor(lv_event_t * e);
 static void auto_hide_characters(lv_obj_t * obj);
+static void auto_hide_characters_cancel(lv_obj_t * obj);
 static inline bool is_valid_but_non_printable_char(const uint32_t letter);
 
 /**********************
@@ -316,8 +317,7 @@ void lv_textarea_set_text(lv_obj_t * obj, const char * txt)
         LV_ASSERT_MALLOC(ta->pwd_tmp);
         if(ta->pwd_tmp == NULL) return;
 
-        /*Auto hide characters*/
-        auto_hide_characters(obj);
+        pwd_char_hider(obj);
     }
 
     lv_obj_send_event(obj, LV_EVENT_VALUE_CHANGED, NULL);
@@ -469,7 +469,7 @@ void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
         ta->pwd_bullet[txt_len] = '\0';
     }
 
-    lv_obj_invalidate(obj);
+    pwd_char_hider(obj);
 }
 
 void lv_textarea_set_one_line(lv_obj_t * obj, bool en)
@@ -544,6 +544,7 @@ void lv_textarea_set_password_show_time(lv_obj_t * obj, uint32_t time)
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
     ta->pwd_show_time = time;
+    pwd_char_hider(obj);
 }
 
 void lv_textarea_set_align(lv_obj_t * obj, lv_text_align_t align)
@@ -1016,6 +1017,8 @@ static void pwd_char_hider(lv_obj_t * obj)
     lv_label_set_text(ta->label, txt_tmp);
     lv_free(txt_tmp);
 
+    auto_hide_characters_cancel(obj);
+
     refr_cursor_area(obj);
 }
 
@@ -1378,6 +1381,11 @@ static void auto_hide_characters(lv_obj_t * obj)
         lv_anim_set_completed_cb(&a, pwd_char_hider_anim_completed);
         lv_anim_start(&a);
     }
+}
+
+static void auto_hide_characters_cancel(lv_obj_t * obj)
+{
+    lv_anim_delete(obj, pwd_char_hider_anim);
 }
 
 static inline bool is_valid_but_non_printable_char(const uint32_t letter)

--- a/tests/src/test_cases/widgets/test_textarea.c
+++ b/tests/src/test_cases/widgets/test_textarea.c
@@ -16,7 +16,7 @@ void setUp(void)
 
 void tearDown(void)
 {
-    /* Function run after every test */
+    lv_obj_clean(active_screen);
 }
 
 void test_textarea_should_have_valid_documented_default_values(void)
@@ -102,6 +102,35 @@ void test_textarea_in_one_line_mode_should_ignore_line_break_characters(void)
 
     lv_textarea_add_char(textarea, '\r');
     TEST_ASSERT_EQUAL_STRING(textarea_default_text, lv_textarea_get_text(textarea));
+}
+
+void test_textarea_should_hide_password_characters(void)
+{
+    lv_textarea_set_password_mode(textarea, true);
+    lv_textarea_set_text(textarea, "12345");
+
+    /* setting bullet hides characters */
+    lv_textarea_set_password_bullet(textarea, "O");
+    TEST_ASSERT_EQUAL_STRING("OOOOO", lv_label_get_text(lv_textarea_get_label(textarea)));
+
+    /* setting text hides characters */
+    lv_textarea_set_text(textarea, "A");
+    TEST_ASSERT_EQUAL_STRING("O", lv_label_get_text(lv_textarea_get_label(textarea)));
+
+    lv_textarea_add_char(textarea, 'B');
+    TEST_ASSERT_EQUAL_STRING("OB", lv_label_get_text(lv_textarea_get_label(textarea)));
+
+    /* setting show time hides characters */
+    /* current behavior is to hide the characters upon setting the show time regardless of the value */
+    lv_textarea_set_password_show_time(textarea, lv_textarea_get_password_show_time(textarea));
+    TEST_ASSERT_EQUAL_STRING("OO", lv_label_get_text(lv_textarea_get_label(textarea)));
+
+    lv_textarea_set_password_mode(textarea, false);
+    TEST_ASSERT_EQUAL_STRING("AB", lv_label_get_text(lv_textarea_get_label(textarea)));
+
+    /* enabling password mode hides characters */
+    lv_textarea_set_password_mode(textarea, true);
+    TEST_ASSERT_EQUAL_STRING("OO", lv_label_get_text(lv_textarea_get_label(textarea)));
 }
 
 #endif


### PR DESCRIPTION
### Description of the feature or fix

In response to issue #5918

- Hide all characters immediately after manually setting text when password mode is on.
- Update bullets after setting new bullet while there is already content in the textarea.
- Hide all characters immediately after setting a new password show time.
- Extra: cancel running hider countdown in `pwd_char_hider`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
