### PR TITLE
chore(observer): rename lv_button_bind_checked to lv_obj_bind_checked

### DIFF
--- a/docs/others/observer.rst
+++ b/docs/others/observer.rst
@@ -272,14 +272,11 @@ Set an object state if an integer subject's value is not equal to a reference va
 
     observer = lv_obj_bind_state_if_not_eq(obj, &subject, LV_STATE_*, ref_value);
 
-Button
-------
-
-Set an integer subject to 1 when a button is checked and set it 0 when unchecked.
+Set an integer subject to 1 when an object is checked and set it 0 when unchecked.
 
 .. code:: c
 
-    observer = lv_button_bind_checked(obj, &subject);
+    observer = lv_obj_bind_checked(obj, &subject);
 
 Label
 -----

--- a/src/lv_api_map_v9_0.h
+++ b/src/lv_api_map_v9_0.h
@@ -37,6 +37,8 @@ extern "C" {
 #define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE
 #endif
 
+#define lv_button_bind_checked           lv_obj_bind_checked
+
 /**********************
  *      MACROS
  **********************/

--- a/src/others/observer/lv_observer.c
+++ b/src/others/observer/lv_observer.c
@@ -34,10 +34,7 @@ static lv_observer_t * bind_to_bitfield(lv_subject_t * subject, lv_obj_t * obj, 
                                         int32_t ref_value, bool inv);
 static void obj_flag_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
 static void obj_state_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
-
-#if LV_USE_BUTTON
-    static void btn_value_changed_event_cb(lv_event_t * e);
-#endif
+static void obj_value_changed_event_cb(lv_event_t * e);
 
 #if LV_USE_LABEL
     static void label_text_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
@@ -360,10 +357,7 @@ void lv_subject_remove_all_obj(lv_subject_t * subject, lv_obj_t * obj)
     }
 
     while(lv_obj_remove_event_cb(obj, unsubscribe_on_delete_cb));
-
-#if LV_USE_BUTTON
-    while(lv_obj_remove_event_cb(obj, btn_value_changed_event_cb));
-#endif /*LV_USE_BUTTON*/
+    while(lv_obj_remove_event_cb(obj, obj_value_changed_event_cb));
 
 #if LV_USE_ARC
     while(lv_obj_remove_event_cb(obj, arc_value_changed_event_cb));
@@ -440,14 +434,12 @@ lv_observer_t * lv_obj_bind_state_if_not_eq(lv_obj_t * obj, lv_subject_t * subje
     return observable;
 }
 
-#if LV_USE_BUTTON
-lv_observer_t * lv_button_bind_checked(lv_obj_t * obj, lv_subject_t * subject)
+lv_observer_t * lv_obj_bind_checked(lv_obj_t * obj, lv_subject_t * subject)
 {
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, LV_STATE_CHECKED, 1, false);
-    lv_obj_add_event_cb(obj, btn_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
+    lv_obj_add_event_cb(obj, obj_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
     return observable;
 }
-#endif /*LV_USE_BUTTON*/
 
 #if LV_USE_LABEL
 lv_observer_t * lv_label_bind_text(lv_obj_t * obj, lv_subject_t * subject, const char * fmt)
@@ -606,17 +598,13 @@ static void obj_state_observer_cb(lv_observer_t * observer, lv_subject_t * subje
     }
 }
 
-#if LV_USE_BUTTON
-
-static void btn_value_changed_event_cb(lv_event_t * e)
+static void obj_value_changed_event_cb(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_current_target(e);
     lv_subject_t * subject = lv_event_get_user_data(e);
 
     lv_subject_set_int(subject, lv_obj_has_state(obj, LV_STATE_CHECKED));
 }
-
-#endif /*LV_USE_BUTTON*/
 
 #if LV_USE_LABEL
 

--- a/src/others/observer/lv_observer.h
+++ b/src/others/observer/lv_observer.h
@@ -329,15 +329,14 @@ lv_observer_t * lv_obj_bind_state_if_eq(lv_obj_t * obj, lv_subject_t * subject, 
 lv_observer_t * lv_obj_bind_state_if_not_eq(lv_obj_t * obj, lv_subject_t * subject, lv_state_t state,
                                             int32_t ref_value);
 
-#if LV_USE_BUTTON
 /**
- * Set an integer subject to 1 when a button is checked and set it 0 when unchecked.
- * @param obj       pointer to a button
+ * Set an integer subject to 1 when an object is checked and set it 0 when unchecked.
+ * @param obj       pointer to an object
  * @param subject   pointer to a subject
  * @return          pointer to the created observer
+ * @note            Ensure the object's `LV_OBJ_FLAG_CHECKABLE` flag is set
  */
-lv_observer_t * lv_button_bind_checked(lv_obj_t * obj, lv_subject_t * subject);
-#endif
+lv_observer_t * lv_obj_bind_checked(lv_obj_t * obj, lv_subject_t * subject);
 
 #if LV_USE_LABEL
 /**

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -286,12 +286,12 @@ void test_observer_button_checked(void)
     /*Can bind only to int*/
     static lv_subject_t subject_wrong;
     lv_subject_init_pointer(&subject_wrong, NULL);
-    lv_observer_t * observer = lv_button_bind_checked(obj, &subject_wrong);
+    lv_observer_t * observer = lv_obj_bind_checked(obj, &subject_wrong);
     TEST_ASSERT_EQUAL_PTR(NULL, observer);
 
     static lv_subject_t subject;
     lv_subject_init_int(&subject, 1);
-    lv_button_bind_checked(obj, &subject);
+    lv_obj_bind_checked(obj, &subject);
 
     TEST_ASSERT_EQUAL(true, lv_obj_has_state(obj, LV_STATE_CHECKED));
 


### PR DESCRIPTION
### Description of the feature or fix

In response to #5902

Rename the observer function `lv_button_bind_checked` to `lv_obj_bind_checked`.

It doesn't rely on anything button-specific, unlike the other widget-specific observer functions so make it generic to all objects since all objects can be `LV_OBJ_FLAG_CHECKABLE`.

Add an api_map macro for backwards compatibility.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
