### PR TITLE
fix(obj_tree): fix event loss caused by obj deletion

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -485,7 +485,8 @@ static void lv_obj_delete_async_cb(void * obj)
 static void obj_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
     /*Wait for release to avoid accidentally triggering other obj to be clicked*/
-    lv_indev_wait_release(indev);
+    if (indev->proc.state != LV_INDEV_STATE_RELEASED)
+        lv_indev_wait_release(indev);
 
     /*Reset the input device*/
     lv_indev_reset(indev, obj);

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -484,9 +484,13 @@ static void lv_obj_delete_async_cb(void * obj)
 
 static void obj_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
 {
-    /*Wait for release to avoid accidentally triggering other obj to be clicked*/
-    if (indev->proc.state != LV_INDEV_STATE_RELEASED)
+    /* If the input device is already in the release state,
+     * there is no need to wait for the input device to be released
+     */
+    if(lv_indev_get_state(indev) != LV_INDEV_STATE_RELEASED) {
+        /*Wait for release to avoid accidentally triggering other obj to be clicked*/
         lv_indev_wait_release(indev);
+    }
 
     /*Reset the input device*/
     lv_indev_reset(indev, obj);


### PR DESCRIPTION
### Description of the feature or fix

If the input device is already in the release state, there is no need to wait for the input device to be released, otherwise an input event will be lost.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
