### PR TITLE
fix(draw): fix the default draw thread stack is too large

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -183,6 +183,13 @@ menu "LVGL configuration"
 				it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
 				"Transformed layers" (if `transform_angle/zoom` are set) use larger buffers and can't be drawn in chunks.
 
+		config LV_DRAW_THREAD_STACK_SIZE
+			int "Stack size of draw thread in bytes"
+			default 8192
+			depends on LV_USE_OS > 0
+			help
+				FreeType req. stack size >= 24KB.
+
 		config LV_USE_DRAW_SW
 			bool "Enable software rendering"
 			default y
@@ -197,11 +204,6 @@ menu "LVGL configuration"
 				> 1 requires an operating system enabled in `LV_USE_OS`
 				> 1 means multiply threads will render the screen in parallel
 
-		config LV_DRAW_THREAD_STACKSIZE
-			int "stack size of draw thread in byte"
-			default 32768
-			depends on LV_USE_OS > 0
-			
 		config LV_USE_DRAW_ARM2D_SYNC
 			bool "Enable Arm's 2D image processing library (Arm-2D) for all Cortex-M processors"
 			default n

--- a/Kconfig
+++ b/Kconfig
@@ -188,7 +188,7 @@ menu "LVGL configuration"
 			default 8192
 			depends on LV_USE_OS > 0
 			help
-				FreeType req. stack size >= 24KB.
+				If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
 
 		config LV_USE_DRAW_SW
 			bool "Enable software rendering"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -113,6 +113,11 @@
 /*The target buffer size for simple layer chunks.*/
 #define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
 
+/* The stack size of the drawing thread.
+ * NOTE: FreeType req. stack size >= 24KB.
+ */
+#define LV_DRAW_THREAD_STACK_SIZE    (8 * 1024)   /*[bytes]*/
+
 #define LV_USE_DRAW_SW 1
 #if LV_USE_DRAW_SW == 1
     /* Set the number of draw unit.
@@ -149,9 +154,6 @@
         #define  LV_DRAW_SW_ASM_CUSTOM_INCLUDE ""
     #endif
 #endif
-
-/* Set stack size of drawing thread. Unit is byte. If Thorvg is enabled, 128kB is required tested on simulator.*/
-#define LV_DRAW_THREAD_STACKSIZE 32768
 
 /* Use NXP's VG-Lite GPU on iMX RTxxx platforms. */
 #define LV_USE_DRAW_VGLITE 0

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -114,7 +114,7 @@
 #define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
 
 /* The stack size of the drawing thread.
- * NOTE: FreeType req. stack size >= 24KB.
+ * NOTE: If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
  */
 #define LV_DRAW_THREAD_STACK_SIZE    (8 * 1024)   /*[bytes]*/
 

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -197,6 +197,12 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_USE_THORVG  (LV_USE_THORVG_INTERNAL || LV_USE_THORVG_EXTERNAL)
 #endif
 
+#if LV_USE_OS
+    #if LV_USE_FREETYPE && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
+        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType. Please increase it to at least 24KB"
+    #endif
+#endif
+
 /*If running without lv_conf.h add typedefs with default value*/
 #ifdef LV_CONF_SKIP
     #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -198,8 +198,8 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif
 
 #if LV_USE_OS
-    #if LV_USE_FREETYPE && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
-        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType. Please increase it to at least 24KB"
+    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
+        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType or ThorVG. It recommended to set it to 32KB or more."
     #endif
 #endif
 

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -198,8 +198,8 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif
 
 #if LV_USE_OS
-    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
-        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType or ThorVG. It recommended to set it to 32KB or more."
+    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
+        #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
 #endif
 

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -201,6 +201,11 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
         #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
+
+    #if defined(LV_DRAW_THREAD_STACKSIZE) && !defined(LV_DRAW_THREAD_STACK_SIZE)
+        #warning "LV_DRAW_THREAD_STACKSIZE was renamed to LV_DRAW_THREAD_STACK_SIZE. Please update lv_conf.h or run menuconfig again."
+        #define LV_DRAW_THREAD_STACK_SIZE LV_DRAW_THREAD_STACKSIZE
+    #endif
 #endif
 
 /*If running without lv_conf.h add typedefs with default value*/

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -143,7 +143,7 @@ void lv_draw_sw_init(void)
         draw_sw_unit->base_unit.delete_cb = LV_USE_OS ? lv_draw_sw_delete : NULL;
 
 #if LV_USE_OS
-        lv_thread_init(&draw_sw_unit->thread, LV_THREAD_PRIO_HIGH, render_thread_cb, LV_DRAW_THREAD_STACKSIZE, draw_sw_unit);
+        lv_thread_init(&draw_sw_unit->thread, LV_THREAD_PRIO_HIGH, render_thread_cb, LV_DRAW_THREAD_STACK_SIZE, draw_sw_unit);
 #endif
     }
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3303,8 +3303,8 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif
 
 #if LV_USE_OS
-    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
-        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType or ThorVG. It recommended to set it to 32KB or more."
+    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
+        #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -305,6 +305,17 @@
     #endif
 #endif
 
+/* The stack size of the drawing thread.
+ * NOTE: FreeType req. stack size >= 24KB.
+ */
+#ifndef LV_DRAW_THREAD_STACK_SIZE
+    #ifdef CONFIG_LV_DRAW_THREAD_STACK_SIZE
+        #define LV_DRAW_THREAD_STACK_SIZE CONFIG_LV_DRAW_THREAD_STACK_SIZE
+    #else
+        #define LV_DRAW_THREAD_STACK_SIZE    (8 * 1024)   /*[bytes]*/
+    #endif
+#endif
+
 #ifndef LV_USE_DRAW_SW
     #ifdef _LV_KCONFIG_PRESENT
         #ifdef CONFIG_LV_USE_DRAW_SW
@@ -405,15 +416,6 @@
                 #define  LV_DRAW_SW_ASM_CUSTOM_INCLUDE ""
             #endif
         #endif
-    #endif
-#endif
-
-/* Set stack size of drawing thread. Unit is byte. If Thorvg is enabled, 128kB is required tested on simulator.*/
-#ifndef LV_DRAW_THREAD_STACKSIZE
-    #ifdef CONFIG_LV_DRAW_THREAD_STACKSIZE
-        #define LV_DRAW_THREAD_STACKSIZE CONFIG_LV_DRAW_THREAD_STACKSIZE
-    #else
-        #define LV_DRAW_THREAD_STACKSIZE 32768
     #endif
 #endif
 
@@ -3298,6 +3300,12 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 
 #ifndef LV_USE_THORVG
     #define LV_USE_THORVG  (LV_USE_THORVG_INTERNAL || LV_USE_THORVG_EXTERNAL)
+#endif
+
+#if LV_USE_OS
+    #if LV_USE_FREETYPE && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
+        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType. Please increase it to at least 24KB"
+    #endif
 #endif
 
 /*If running without lv_conf.h add typedefs with default value*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3306,6 +3306,11 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
         #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
+
+    #if defined(LV_DRAW_THREAD_STACKSIZE) && !defined(LV_DRAW_THREAD_STACK_SIZE)
+        #warning "LV_DRAW_THREAD_STACKSIZE was renamed to LV_DRAW_THREAD_STACK_SIZE. Please update lv_conf.h or run menuconfig again."
+        #define LV_DRAW_THREAD_STACK_SIZE LV_DRAW_THREAD_STACKSIZE
+    #endif
 #endif
 
 /*If running without lv_conf.h add typedefs with default value*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -306,7 +306,7 @@
 #endif
 
 /* The stack size of the drawing thread.
- * NOTE: FreeType req. stack size >= 24KB.
+ * NOTE: If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
  */
 #ifndef LV_DRAW_THREAD_STACK_SIZE
     #ifdef CONFIG_LV_DRAW_THREAD_STACK_SIZE
@@ -3303,8 +3303,8 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif
 
 #if LV_USE_OS
-    #if LV_USE_FREETYPE && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
-        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType. Please increase it to at least 24KB"
+    #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (24 * 1024)
+        #warning "LV_DRAW_THREAD_STACK_SIZE is too small for FreeType or ThorVG. It recommended to set it to 32KB or more."
     #endif
 #endif
 

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -1,6 +1,6 @@
 #define LV_MEM_SIZE                     (32 * 1024 * 1024)
 #define LV_DRAW_SW_SHADOW_CACHE_SIZE    8
-#define LV_DRAW_THREAD_STACK_SIZE    (64 * 1024) /*Increase stack size to 64KB in order to run Thorvg*/
+#define LV_DRAW_THREAD_STACK_SIZE    (64 * 1024) /*Increase stack size to 64KB in order to run ThorVG*/
 #define LV_USE_LOG              1
 #define LV_LOG_LEVEL            LV_LOG_LEVEL_TRACE
 #define LV_LOG_PRINTF           1

--- a/tests/src/lv_test_conf_full.h
+++ b/tests/src/lv_test_conf_full.h
@@ -1,6 +1,6 @@
 #define LV_MEM_SIZE                     (32 * 1024 * 1024)
 #define LV_DRAW_SW_SHADOW_CACHE_SIZE    8
-#define LV_DRAW_THREAD_STACKSIZE    (128 * 1024) /*Increase stack size to 128kB in order to run Thorvg*/
+#define LV_DRAW_THREAD_STACK_SIZE    (64 * 1024) /*Increase stack size to 64KB in order to run Thorvg*/
 #define LV_USE_LOG              1
 #define LV_LOG_LEVEL            LV_LOG_LEVEL_TRACE
 #define LV_LOG_PRINTF           1


### PR DESCRIPTION
### Description of the feature or fix

Fix the memory waste caused by the default draw thread stack being too large, and add a stack size check when some components that consume stack space are opened.

cc @GorgonMeducer 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
