### PR TITLE
chore(sdl): fix build break

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -399,8 +399,8 @@ static void texture_resize(lv_display_t * disp)
     }
     else {
 #if LV_SDL_BUF_COUNT == 2
-        dsc->fb2 = realloc(dsc->fb2, stride * ver_res);
-        memset(dsc->fb2, 0x00, stride * ver_res);
+        dsc->fb2 = realloc(dsc->fb2, stride * disp->ver_res);
+        memset(dsc->fb2, 0x00, stride * disp->ver_res);
 #endif
         lv_display_set_buffers(disp, dsc->fb1, dsc->fb2, stride * disp->ver_res, LV_SDL_RENDER_MODE);
     }


### PR DESCRIPTION
### Description of the feature or fix
When using lvgl 9.1.0 with SDL support and 2 frame buffers for LVGL then this would throw a compile error like this:

lvgl\src\drivers\sdl\lv_sdl_window.c:402:47: error: 'ver_res' undeclared (first use in this function)
402 | dsc->fb2 = realloc(dsc->fb2, stride * ver_res);

This is due to the original author forgetting to specify disp->ver_res.

This is my first pull request so let me know if anything needs to be done different