### PR TITLE
chore(vg_lite): remove duplicate parameter judgments

### DIFF
--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -50,6 +50,9 @@ lv_draw_line_dsc_t * lv_draw_task_get_line_dsc(lv_draw_task_t * task)
 
 void LV_ATTRIBUTE_FAST_MEM lv_draw_line(lv_layer_t * layer, const lv_draw_line_dsc_t * dsc)
 {
+    if(dsc->width == 0) return;
+    if(dsc->opa <= LV_OPA_MIN) return;
+
     LV_PROFILER_BEGIN;
     lv_area_t a;
     a.x1 = (int32_t)LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width;

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -56,6 +56,8 @@ lv_draw_triangle_dsc_t * lv_draw_task_get_triangle_dsc(lv_draw_task_t * task)
 
 void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
 {
+    if(dsc->bg_opa <= LV_OPA_MIN) return;
+
     LV_PROFILER_BEGIN;
     lv_area_t a;
     a.x1 = (int32_t)LV_MIN3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);

--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -12,7 +12,6 @@
 #if LV_USE_DRAW_VG_LITE
 
 #include "lv_vg_lite_utils.h"
-#include <string.h>
 
 /*********************
  *      DEFINES

--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -52,13 +52,6 @@
 void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
                          const lv_area_t * coords)
 {
-    if(dsc->opa <= LV_OPA_MIN)
-        return;
-    if(dsc->width <= 0)
-        return;
-    if(dsc->start_angle == dsc->end_angle)
-        return;
-
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     lv_area_t clip_area;

--- a/src/draw/vg_lite/lv_draw_vg_lite_border.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_border.c
@@ -42,13 +42,6 @@
 void lv_draw_vg_lite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
                             const lv_area_t * coords)
 {
-    if(dsc->opa <= LV_OPA_MIN)
-        return;
-    if(dsc->width == 0)
-        return;
-    if(dsc->side == LV_BORDER_SIDE_NONE)
-        return;
-
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     lv_area_t clip_area;

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -46,10 +46,6 @@
 
 void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
 {
-    if(dsc->opa <= LV_OPA_MIN) {
-        return;
-    }
-
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     lv_area_t clip_area;

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -44,10 +44,6 @@
 void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
                          const lv_area_t * coords, bool no_cache)
 {
-    if(dsc->opa <= LV_OPA_MIN) {
-        return;
-    }
-
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     /* The coordinates passed in by coords are not transformed,

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -63,8 +63,6 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
 void lv_draw_vg_lite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
                            const lv_area_t * coords)
 {
-    if(dsc->opa <= LV_OPA_MIN) return;
-
     LV_PROFILER_BEGIN;
 
 #if LV_USE_FREETYPE

--- a/src/draw/vg_lite/lv_draw_vg_lite_line.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_line.c
@@ -44,11 +44,6 @@
 
 void lv_draw_vg_lite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
 {
-    if(dsc->opa <= LV_OPA_MIN)
-        return;
-    if(dsc->width == 0)
-        return;
-
     float p1_x = dsc->p1.x;
     float p1_y = dsc->p1.y;
     float p2_x = dsc->p2.x;

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -42,8 +42,6 @@
 
 void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc)
 {
-    if(dsc->bg_opa <= LV_OPA_MIN) return;
-
     lv_area_t tri_area;
     tri_area.x1 = (int32_t)LV_MIN3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
     tri_area.y1 = (int32_t)LV_MIN3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);


### PR DESCRIPTION
### Description of the feature or fix

Focus judgments similar to `if(dsc->opa <= LV_OPA_MIN) return;` on the public function of `lv_draw`.
The GPU drawing adaptation layer no longer requires judgment, making the code concise.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.10](https://github.com/szepeviktor/astyle/releases/tag/v3.4.10) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
