### PR TITLE
fix(thorvg): fix windows build break

### DIFF
--- a/src/libs/thorvg/thorvg.h
+++ b/src/libs/thorvg/thorvg.h
@@ -13,6 +13,7 @@
 
 #include "../../lv_conf_internal.h"
 #if LV_USE_THORVG_INTERNAL
+#define TVG_BUILD 1
 
 
 #ifndef _THORVG_H_

--- a/src/libs/thorvg/thorvg_capi.h
+++ b/src/libs/thorvg/thorvg_capi.h
@@ -17,9 +17,7 @@
 
 #include "../../lv_conf_internal.h"
 #if LV_USE_THORVG_INTERNAL
-
-#include "../../lv_conf_internal.h"
-#if LV_USE_THORVG_INTERNAL
+#define TVG_BUILD 1
 
 #ifndef __THORVG_CAPI_H__
 #define __THORVG_CAPI_H__
@@ -2326,8 +2324,6 @@ TVG_API Tvg_Result tvg_animation_del(Tvg_Animation* animation);
 #endif
 
 #endif //_THORVG_CAPI_H_
-
-#endif /* LV_USE_THORVG_INTERNAL */
 
 
 #endif /* LV_USE_THORVG_INTERNAL */


### PR DESCRIPTION
### Description of the feature or fix

In response to #5946

Error when building thorvg on Windows. Defined functions were being marked with `__declspec(dllimport)`.

https://github.com/lvgl/lvgl/blob/fea8a97f5f6f415236d23c02c19af844475e044a/src/libs/thorvg/thorvg_capi.h#L35-L40

This fix tries to leave the thorvg header untouched except for defining `TVG_BUILD` at the top so it's easier to update thorvg from the upstream. https://github.com/lvgl/lvgl/pull/4691#discussion_r1375604134

Would have been found by the eventual Windows CI #5904

Also remove duplicate guard.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
