### PR TITLE
fix(scroll): fix deletion animation causing missing scroll end event

### DIFF
--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -33,7 +33,7 @@
  **********************/
 static void scroll_x_anim(void * obj, int32_t v);
 static void scroll_y_anim(void * obj, int32_t v);
-static void scroll_completed_completed_cb(lv_anim_t * a);
+static void scroll_end_cb(lv_anim_t * a);
 static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_point_t * scroll_value,
                                   lv_anim_enable_t anim_en);
 
@@ -309,7 +309,7 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         lv_anim_t a;
         lv_anim_init(&a);
         lv_anim_set_var(&a, obj);
-        lv_anim_set_completed_cb(&a, scroll_completed_completed_cb);
+        lv_anim_set_deleted_cb(&a, scroll_end_cb);
 
         if(dx) {
             uint32_t t = lv_anim_speed_clamped((lv_display_get_horizontal_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
@@ -675,7 +675,7 @@ static void scroll_y_anim(void * obj, int32_t v)
     _lv_obj_scroll_by_raw(obj, 0, v + lv_obj_get_scroll_y(obj));
 }
 
-static void scroll_completed_completed_cb(lv_anim_t * a)
+static void scroll_end_cb(lv_anim_t * a)
 {
     lv_obj_send_event(a->var, LV_EVENT_SCROLL_END, NULL);
 }
@@ -776,13 +776,8 @@ static void scroll_area_into_view(const lv_area_t * area, lv_obj_t * child, lv_p
     }
 
     /*Remove any pending scroll animations.*/
-    bool y_del = lv_anim_delete(parent, scroll_y_anim);
-    bool x_del = lv_anim_delete(parent, scroll_x_anim);
-    if(y_del || x_del) {
-        lv_result_t res;
-        res = lv_obj_send_event(parent, LV_EVENT_SCROLL_END, NULL);
-        if(res != LV_RESULT_OK) return;
-    }
+    lv_anim_delete(parent, scroll_y_anim);
+    lv_anim_delete(parent, scroll_x_anim);
 
     if((scroll_dir & LV_DIR_LEFT) == 0 && x_scroll < 0) x_scroll = 0;
     if((scroll_dir & LV_DIR_RIGHT) == 0 && x_scroll > 0) x_scroll = 0;


### PR DESCRIPTION
### Description of the feature or fix

Anim's completed_cb will not be called when the animation is deleted, so if the animation is deleted, there will be no scroll end event.
In the example below, when the blue block animation scrolls to position 320, completed cb has not been called yet. Click btn to scroll to position 320. At this time, the animation will be deleted. You can see in the log that there is no scroll end event.
```C
static void anim_completed_cb(lv_anim_t* a)
{
  LV_LOG_USER("completed cb");
  lv_anim_completed_cb_t completed = a->user_data;
  if (completed) {
    completed(a);
  }
}

static void scroll_event_cb(lv_event_t* e)
{
  if (e->code == LV_EVENT_SCROLL_BEGIN) {

    lv_anim_t * a = lv_event_get_scroll_anim(e);
    if (a) {
      lv_anim_set_user_data(a, a->completed_cb);
      a->completed_cb = anim_completed_cb;
      a->duration = 20000;
    }
    LV_LOG_USER("LV_EVENT_SCROLL_BEGIN");
  } else if (e->code == LV_EVENT_SCROLL_END) {
    LV_LOG_USER("LV_EVENT_SCROLL_END");
  }
}

static void btn_cb(lv_event_t* e)
{
  lv_obj_t* cont = lv_event_get_user_data(e);
  lv_obj_scroll_to(cont, 0, 320, LV_ANIM_OFF);
  LV_LOG_USER("scroll to 320");
}

static void lv_scroll_demo(void)
{
  lv_obj_t* cont = lv_obj_create(lv_scr_act());
  lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
  lv_obj_set_scroll_snap_y(cont, LV_SCROLL_SNAP_CENTER);
  lv_obj_add_event_cb(cont, scroll_event_cb, LV_EVENT_SCROLL_BEGIN, NULL);
  lv_obj_add_event_cb(cont, scroll_event_cb, LV_EVENT_SCROLL_END, NULL);

  lv_obj_t* obj = lv_obj_create(cont);
  lv_obj_set_size(obj, LV_PCT(100), LV_PCT(100));
  lv_obj_set_style_bg_color(obj, lv_color_hex(0xff0000), 0);

  obj = lv_obj_create(cont);
  lv_obj_set_size(obj, LV_PCT(100), LV_PCT(100));
  lv_obj_set_style_bg_color(obj, lv_color_hex(0x0000ff), 0);
  lv_obj_set_y(obj, LV_VER_RES);

  lv_obj_t* btn = lv_obj_create(lv_layer_sys());
  lv_obj_center(btn);
  lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
  lv_obj_add_event_cb(btn, btn_cb, LV_EVENT_CLICKED, cont);
}
```

https://github.com/lvgl/lvgl/assets/51692568/ae7ec502-78ff-4db8-be3c-23bd6d275703


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
