### PR TITLE
feat(drivers): account for the frame buffer virtual resolution deviating from the visible resolution.

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -312,8 +312,12 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         return;
     }
 
-    uint32_t color_pos = (area->x1 + dsc->vinfo.xoffset) * px_size + area->y1 * dsc->finfo.line_length;
-    uint32_t fb_pos = color_pos + dsc->vinfo.yoffset * dsc->finfo.line_length;
+    uint32_t color_pos =
+        area->x1 * px_size +
+        area->y1 * dsc->vinfo.xres * px_size;
+    uint32_t fb_pos =
+        (area->x1 + dsc->vinfo.xoffset) * px_size +
+        (area->y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
 
     uint8_t * fbp = (uint8_t *)dsc->fbp;
     int32_t y;
@@ -321,7 +325,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         for(y = area->y1; y <= area->y2; y++) {
             lv_memcpy(&fbp[fb_pos], &color_p[color_pos], w * px_size);
             fb_pos += dsc->finfo.line_length;
-            color_pos += dsc->finfo.line_length;
+            color_pos += dsc->vinfo.xres * px_size;
         }
     }
     else {

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -314,7 +314,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
 
     uint32_t color_pos =
         area->x1 * px_size +
-        area->y1 * dsc->vinfo.xres * px_size;
+        area->y1 * disp->hor_res * px_size;
     uint32_t fb_pos =
         (area->x1 + dsc->vinfo.xoffset) * px_size +
         (area->y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
@@ -325,7 +325,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         for(y = area->y1; y <= area->y2; y++) {
             lv_memcpy(&fbp[fb_pos], &color_p[color_pos], w * px_size);
             fb_pos += dsc->finfo.line_length;
-            color_pos += dsc->vinfo.xres * px_size;
+            color_pos += disp->hor_res * px_size;
         }
     }
     else {

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -312,9 +312,6 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         return;
     }
 
-    uint32_t color_pos =
-        area->x1 * px_size +
-        area->y1 * disp->hor_res * px_size;
     uint32_t fb_pos =
         (area->x1 + dsc->vinfo.xoffset) * px_size +
         (area->y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
@@ -322,6 +319,10 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     uint8_t * fbp = (uint8_t *)dsc->fbp;
     int32_t y;
     if(LV_LINUX_FBDEV_RENDER_MODE == LV_DISPLAY_RENDER_MODE_DIRECT) {
+        uint32_t color_pos =
+            area->x1 * px_size +
+            area->y1 * disp->hor_res * px_size;
+
         for(y = area->y1; y <= area->y2; y++) {
             lv_memcpy(&fbp[fb_pos], &color_p[color_pos], w * px_size);
             fb_pos += dsc->finfo.line_length;


### PR DESCRIPTION
The Linux frame buffer flush_cb method now accounts for the virtual resolution deviating from the visible resolution. The offset into the paint buffer is calculated based on the visible resolution, and the offset into the frame buffer is calculated using the line_length, i.e. stride. The x offset and y offset are only used to calculate the position into the frame buffer, not the position into the paint buffer.

### Description of the feature or fix

On Linux devices where the virtual resolution of the frame buffer deviate from the visible resolution, the flush_cb method would fail. In such a configuration, the line_length (stride) differs from the xres of the device. The line_length was used to calculate the offset into the paint buffer, causing issues.

I've also made a change to how the xoffset and yoffset are used. I've removed usage of these parameters to calculate the offset into the paint buffer. xoffset was used, and is not anymore. yoffset wasn't used in the first place. Since these parameters are offsets of the visible resolution into the virtual resolution, they couldn't have been needed for the paint buffer. That being said, I wasn't able to test this as I'm not sure how to configure them using fbset.

I've tested this with different resolutions, and both the direct and partial rendering modes.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
