### PR TITLE
feat(evdev): automatically calibrate pointer input devices.

### DIFF
--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -179,6 +179,20 @@ lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path)
         goto err_after_open;
     }
 
+    /* Detect the minimum and maximum values of the input device for calibration. */
+
+    if(indev_type == LV_INDEV_TYPE_POINTER) {
+        struct input_absinfo absinfo;
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_X), &absinfo) == 0) {
+            dsc->min_x = absinfo.minimum;
+            dsc->max_x = absinfo.maximum;
+        }
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_Y), &absinfo) == 0) {
+            dsc->min_y = absinfo.minimum;
+            dsc->max_y = absinfo.maximum;
+        }
+    }
+
     lv_indev_t * indev = lv_indev_create();
     if(indev == NULL) goto err_after_open;
     lv_indev_set_type(indev, indev_type);

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -187,9 +187,15 @@ lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path)
             dsc->min_x = absinfo.minimum;
             dsc->max_x = absinfo.maximum;
         }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_X) failed: %s", strerror(errno));
+        }
         if(ioctl(dsc->fd, EVIOCGABS(ABS_Y), &absinfo) == 0) {
             dsc->min_y = absinfo.minimum;
             dsc->max_y = absinfo.maximum;
+        }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_Y) failed: %s", strerror(errno));
         }
     }
 


### PR DESCRIPTION
Pointer input devices support calibration. The values to calibrate the device with can be retrieved from the ABS_X and ABS_Y ioctl parameters.

### Description of the feature or fix

Linux mouse devices support calibration. This PR automatically configures the calibration parameters based on the ABS_X and ABS_Y ioctl parameters.

I'm confident this is not a breaking change, but I would like a critical eye on this. The reason I don't believe this is a breaking change is:

- Without calibration the pointer device is unusable.
- The lv_evdev_set_calibration method can still be called, overriding the default calibration parameters.

Using these assumptions, for devices where the calibration parameters are required, they will have been set by the developer. This PR doesn't break such applications.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
