### PR TITLE
fix(example): LVGL_Arduino.ino millis() as tick source

### DIFF
--- a/docs/porting/tick.rst
+++ b/docs/porting/tick.rst
@@ -12,7 +12,7 @@ There are two ways to provide the tick to LVGL:
 1. Call ``lv_tick_set_cb(my_get_milliseconds_function);``: `my_get_milliseconds_function` needs to tell how many milliseconds have elapsed since start up. Most of the platforms have built-in functions that can be used as they are. For example
 
    - SDL: ``lv_tick_set_cb(SDL_GetTicks);``
-   - Arduino: ``lv_tick_set_cb(my_tick);``, where ``my_tick`` is a wrapper for ``millis();``
+   - Arduino: ``lv_tick_set_cb(my_tick_get_cb);``, where ``my_tick_get_cb`` is: ``static uint32_t my_tick_get_cb(void) { return millis(); }``
    - FreeRTOS: ``lv_tick_set_cb(xTaskGetTickCount);``
    - STM32: ``lv_tick_set_cb(HAL_GetTick);``
    - ESP32: ``lv_tick_set_cb(my_tick_get_cb);``, where ``my_tick_get_cb`` is a wrapper for ``esp_timer_get_time() / 1000;``

--- a/docs/porting/tick.rst
+++ b/docs/porting/tick.rst
@@ -12,7 +12,7 @@ There are two ways to provide the tick to LVGL:
 1. Call ``lv_tick_set_cb(my_get_milliseconds_function);``: `my_get_milliseconds_function` needs to tell how many milliseconds have elapsed since start up. Most of the platforms have built-in functions that can be used as they are. For example
 
    - SDL: ``lv_tick_set_cb(SDL_GetTicks);``
-   - Arduino: ``lv_tick_set_cb(millis);``
+   - Arduino: ``lv_tick_set_cb(my_tick);``, where ``my_tick`` is a wrapper for ``millis();``
    - FreeRTOS: ``lv_tick_set_cb(xTaskGetTickCount);``
    - STM32: ``lv_tick_set_cb(HAL_GetTick);``
    - ESP32: ``lv_tick_set_cb(my_tick_get_cb);``, where ``my_tick_get_cb`` is a wrapper for ``esp_timer_get_time() / 1000;``

--- a/examples/arduino/LVGL_Arduino/LVGL_Arduino.ino
+++ b/examples/arduino/LVGL_Arduino/LVGL_Arduino.ino
@@ -67,6 +67,12 @@ void my_touchpad_read( lv_indev_t * indev, lv_indev_data_t * data )
      */
 }
 
+/*use Arduinos millis() as tick source*/
+uint32_t my_tick(void)
+{
+    return millis();
+}
+
 void setup()
 {
     String LVGL_Arduino = "Hello Arduino! ";
@@ -78,7 +84,7 @@ void setup()
     lv_init();
 
     /*Set a tick source so that LVGL will know how much time elapsed. */
-    lv_tick_set_cb(millis);
+    lv_tick_set_cb(my_tick);
 
     /* register print function for debugging */
 #if LV_USE_LOG != 0

--- a/examples/arduino/LVGL_Arduino/LVGL_Arduino.ino
+++ b/examples/arduino/LVGL_Arduino/LVGL_Arduino.ino
@@ -68,7 +68,7 @@ void my_touchpad_read( lv_indev_t * indev, lv_indev_data_t * data )
 }
 
 /*use Arduinos millis() as tick source*/
-uint32_t my_tick(void)
+static uint32_t my_tick(void)
 {
     return millis();
 }


### PR DESCRIPTION
### Description of the feature or fix

The example "LVGL_Arduino.ino" does not compile.
```
error: invalid conversion from 'long unsigned int (*)()' to 'lv_tick_get_cb_t' {aka 'unsigned int (*)()'} [-fpermissive]
     lv_tick_set_cb(millis);
                    ^~~~~~
```
Although data types are indeed the same (32 bit unsigned integer), it does not work this way.

Please see also https://forum.lvgl.io/t/updating-lvgl-library/15307