### PR TITLE
fix(fbdev): wrong stride for direct rendering on sub-display

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -312,8 +312,10 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         return;
     }
 
-    uint32_t color_pos = (area->x1 + dsc->vinfo.xoffset) * px_size + area->y1 * dsc->finfo.line_length;
-    uint32_t fb_pos = color_pos + dsc->vinfo.yoffset * dsc->finfo.line_length;
+    uint32_t color_stride = disp->hor_res * px_size;
+    uint32_t color_pos = (area->x1 + dsc->vinfo.xoffset) * px_size + area->y1 * color_stride;
+    uint32_t fb_pos = (area->x1 + dsc->vinfo.xoffset) * px_size + area->y1 * dsc->finfo.line_length + dsc->vinfo.yoffset *
+                      dsc->finfo.line_length;
 
     uint8_t * fbp = (uint8_t *)dsc->fbp;
     int32_t y;
@@ -321,7 +323,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         for(y = area->y1; y <= area->y2; y++) {
             lv_memcpy(&fbp[fb_pos], &color_p[color_pos], w * px_size);
             fb_pos += dsc->finfo.line_length;
-            color_pos += dsc->finfo.line_length;
+            color_pos += color_stride;
         }
     }
     else {


### PR DESCRIPTION
### Description of the feature or fix

When using a sub-display (meaning the display resolution is smaller than the physical display resolution) using the framebuffer's line length as stride is wrong and leads to garbled output.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
