### PR TITLE
fix(fbdev): set resolution prior to buffer

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -233,8 +233,8 @@ void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         draw_buf_2 = malloc(draw_buf_size);
     }
 
-    lv_display_set_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
     lv_display_set_resolution(disp, hor_res, ver_res);
+    lv_display_set_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
 
     if(width > 0) {
         lv_display_set_dpi(disp, DIV_ROUND_UP(hor_res * 254, width * 10));


### PR DESCRIPTION
This fixes an issue where the fbdev driver fails to set up a buffer due to buffer size mismatch. It happens when the actual screen resolution is smaller than the default one 800x480 because the actual resolution was being set _after_ lv_display_set_buffers.
