### PR TITLE
[Draft] Permanently align/anchor 2 objects (w/o parent-child relationship)

### DIFF
--- a/examples/styles/lv_example_style.h
+++ b/examples/styles/lv_example_style.h
@@ -40,6 +40,7 @@ void lv_example_style_12(void);
 void lv_example_style_13(void);
 void lv_example_style_14(void);
 void lv_example_style_15(void);
+void lv_example_style_16(void);
 
 /**********************
  *      MACROS

--- a/examples/styles/lv_example_style_16.c
+++ b/examples/styles/lv_example_style_16.c
@@ -1,0 +1,82 @@
+#include "../lv_examples.h"
+#if LV_BUILD_EXAMPLES && LV_USE_LABEL
+
+#define OBJ_HOR_LEN     (LV_HOR_RES/5)
+#define OBJ_VER_LEN     (LV_VER_RES/5)
+#define MAX_ANIM        (LV_VER_RES - OBJ_VER_LEN)
+static lv_obj_t * obj_reference;
+
+/* Animate the reference object to bounce up & down. */
+static void lv_anim_callback(void * obj, int value)
+{
+    (void) obj;
+
+    if(value <= MAX_ANIM) {
+        lv_obj_set_y(obj_reference, value);
+    }
+    else {
+        lv_obj_set_y(obj_reference, 2 * MAX_ANIM - value);
+    }
+}
+
+/* Create the following (i.e. anchored) objects. */
+static void create_follower_object(int index)
+{
+    lv_obj_t * obj;
+    lv_obj_t * label;
+
+    obj = lv_obj_create(lv_scr_act());
+    lv_obj_set_size(obj, OBJ_HOR_LEN, OBJ_VER_LEN);
+    lv_obj_align_to(obj, obj_reference, LV_ALIGN_OUT_RIGHT_MID, OBJ_HOR_LEN * (index - 1), 0);
+    lv_obj_set_style_bg_color(obj, lv_palette_main(LV_PALETTE_BLUE), 0);
+
+    label = lv_label_create(obj);
+    lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+    lv_label_set_text_fmt(label, "Follower #%d", index);
+}
+
+/**
+ * Align some objects to a non-parent anchor then move the anchor
+ * and check that the anchored objects follow it.
+ */
+void lv_example_style_16(void)
+{
+    lv_obj_t * label;
+    lv_obj_t * obj_child;
+
+    lv_obj_set_style_pad_all(lv_scr_act(), 0, 0);
+
+    /* Reference object. */
+    obj_reference = lv_obj_create(lv_scr_act());
+    lv_obj_set_size(obj_reference, OBJ_HOR_LEN, OBJ_VER_LEN);
+    lv_obj_align(obj_reference, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_set_style_bg_color(obj_reference, lv_palette_main(LV_PALETTE_RED), 0);
+
+    /* Normal child of the reference object. */
+    obj_child = lv_obj_create(obj_reference);
+    lv_obj_set_size(obj_child, LV_PCT(100), LV_PCT(100));
+    lv_obj_align(obj_child, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_set_style_bg_color(obj_child, lv_palette_main(LV_PALETTE_GREEN), 0);
+
+    label = lv_label_create(obj_child);
+    lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+    lv_label_set_text(label, "Child");
+
+    /* Some anchored followers of the reference object. */
+    create_follower_object(1);
+    create_follower_object(2);
+    create_follower_object(3);
+
+    lv_anim_t anim;
+    lv_anim_init(&anim);
+    lv_anim_set_var(&anim, obj_reference);
+    lv_anim_set_path_cb(&anim, lv_anim_path_linear);
+    lv_anim_set_values(&anim, 0, MAX_ANIM * 2);
+    lv_anim_set_time(&anim, 3000);
+    lv_anim_set_repeat_count(&anim, LV_ANIM_REPEAT_INFINITE);
+    lv_anim_set_exec_cb(&anim, lv_anim_callback);
+
+    lv_anim_start(&anim);
+}
+
+#endif

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -198,8 +198,10 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
  */
 typedef struct {
     lv_obj_t ** children;   /**< Store the pointer of the children in an array.*/
+    lv_obj_t ** anchored_children; /**< Array of pointers to anchored children. */
     lv_group_t * group_p;
     lv_event_list_t event_list;
+
 
     lv_point_t scroll;              /**< The current X/Y scroll offset*/
 
@@ -207,6 +209,7 @@ typedef struct {
     int32_t ext_draw_size;          /**< EXTend the size in every direction for drawing.*/
 
     uint16_t child_cnt;             /**< Number of children*/
+    uint32_t anchored_child_count;  /**< Number of anchored children. */
     uint16_t scrollbar_mode : 2;    /**< How to display scrollbars, see `lv_scrollbar_mode_t`*/
     uint16_t scroll_snap_x : 2;     /**< Where to align the snappable children horizontally, see `lv_scroll_snap_t`*/
     uint16_t scroll_snap_y : 2;     /**< Where to align the snappable children vertically*/
@@ -217,6 +220,7 @@ typedef struct {
 struct _lv_obj_t {
     const lv_obj_class_t * class_p;
     lv_obj_t * parent;
+    lv_obj_t * anchor_parent;
     _lv_obj_spec_attr_t * spec_attr;
     _lv_obj_style_t * styles;
 #if LV_OBJ_STYLE_CACHE

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -54,6 +54,7 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t se
                                     lv_style_value_t * v);
 static void report_style_change_core(void * style, lv_obj_t * obj);
 static void refresh_children_style(lv_obj_t * obj);
+static void refresh_anchored_children(lv_obj_t * obj);
 static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
 static void trans_anim_cb(void * _tr, int32_t v);
 static void trans_anim_start_cb(lv_anim_t * a);
@@ -296,6 +297,9 @@ void lv_obj_refresh_style(lv_obj_t * obj, lv_style_selector_t selector, lv_style
     if((part == LV_PART_ANY || part == LV_PART_MAIN) && (prop == LV_STYLE_PROP_ANY || is_layout_refr)) {
         lv_obj_t * parent = lv_obj_get_parent(obj);
         if(parent) lv_obj_mark_layout_as_dirty(parent);
+    }
+    if((part == LV_PART_ANY || part == LV_PART_MAIN) && is_layout_refr) {
+        refresh_anchored_children(obj);
     }
 
     /*Cache the layer type*/
@@ -779,6 +783,22 @@ static void refresh_children_style(lv_obj_t * obj)
         lv_obj_invalidate(child);
 
         refresh_children_style(child); /*Check children too*/
+    }
+}
+
+/**
+ * Mark anchored objects as dirty.
+ * @param obj pointer to an object.
+ */
+static void refresh_anchored_children(lv_obj_t * obj)
+{
+    uint32_t i;
+
+    if(obj->spec_attr == NULL) return;
+
+    for(i = 0; i < obj->spec_attr->anchored_child_count; i++) {
+        lv_obj_t * child = obj->spec_attr->anchored_children[i];
+        lv_obj_mark_layout_as_dirty(child);
     }
 }
 


### PR DESCRIPTION
### Description of the feature or fix

When an object is aligned with `align_to()` then if the reference if moved, the aligned object will follow.

This PR also add an example making use of this feature: 1 parent object is created together with 3 followers. Then the parent is moved up & down on the screen and the followers follow it.

I marked as draft because this is my very first PR in LVGL so I would like to know whether this PR is moving in the right direction or not according to what it has been required in #5665.

Resolves #5665 