### PR TITLE
docs: fix typo in the comments [ci skip]

### DIFF
--- a/docs/integration/driver/display/lcd_stm32_guide.rst
+++ b/docs/integration/driver/display/lcd_stm32_guide.rst
@@ -239,7 +239,7 @@ Step-by-step instructions
 				/* DCX high (data) */
 				HAL_GPIO_WritePin(LCD_DCX_GPIO_Port, LCD_DCX_Pin, GPIO_PIN_SET);
 				/* for color data use DMA transfer */
-				/* Set the SPI in 16-bit mode to match endianess */
+				/* Set the SPI in 16-bit mode to match endianness */
 				hspi1.Init.DataSize = SPI_DATASIZE_16BIT;
 				HAL_SPI_Init(&hspi1);
 				lcd_bus_busy = 1;

--- a/examples/porting/lv_port_lcd_stm32_template.c
+++ b/examples/porting/lv_port_lcd_stm32_template.c
@@ -167,7 +167,7 @@ static void lcd_send_color(lv_display_t * disp, const uint8_t * cmd, size_t cmd_
         /* DCX high (data) */
         HAL_GPIO_WritePin(LCD_DCX_GPIO_Port, LCD_DCX_Pin, GPIO_PIN_SET);
         /* for color data use DMA transfer */
-        /* Set the SPI in 16-bit mode to match endianess */
+        /* Set the SPI in 16-bit mode to match endianness */
         hspi1.Init.DataSize = SPI_DATASIZE_16BIT;
         HAL_SPI_Init(&hspi1);
         lcd_bus_busy = 1;


### PR DESCRIPTION
### Description of the fix

fix same typo in comment section of 2 files in `docs` and `examples`

