### PR TITLE
fix(driver): lv_x11_input.c fixes

### DIFF
--- a/src/drivers/x11/lv_x11_input.c
+++ b/src/drivers/x11/lv_x11_input.c
@@ -10,12 +10,11 @@
 
 #if LV_USE_X11
 
+#include <string.h>
 #include <stdbool.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include "../../stdlib/lv_string.h"
 #include "../../widgets/image/lv_image.h"
-#include "../../core/lv_obj.h"
 
 /*********************
  *      DEFINES
@@ -274,7 +273,6 @@ static lv_indev_t * lv_x11_keyboard_create(lv_display_t * disp)
 static lv_indev_t * lv_x11_mouse_create(lv_display_t * disp, lv_image_dsc_t const * symb)
 {
     lv_indev_t * indev = lv_indev_create();
-    LV_ASSERT_OBJ(indev, MY_CLASS);
     if(NULL != indev) {
         lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
         lv_indev_set_read_cb(indev, x11_mouse_read_cb);
@@ -293,7 +291,6 @@ static lv_indev_t * lv_x11_mouse_create(lv_display_t * disp, lv_image_dsc_t cons
 static lv_indev_t * lv_x11_mousewheel_create(lv_display_t * disp)
 {
     lv_indev_t * indev = lv_indev_create();
-    LV_ASSERT_OBJ(indev, MY_CLASS);
     if(NULL != indev) {
         lv_indev_set_type(indev, LV_INDEV_TYPE_ENCODER);
         lv_indev_set_read_cb(indev, x11_mousewheel_read_cb);


### PR DESCRIPTION
### Description of the feature or fix

A regression since #5767. lv_x11_input.c was missed in the refactor. Update the includes.

Also remove unnecessary `LV_ASSERT_OBJ`s that will not compile if `LV_USE_ASSERT_OBJ` is `1`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
