### PR TITLE
chore(mem): changed log level to ERROR if memory couldn't be allocated

### DIFF
--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -70,7 +70,7 @@ void * lv_malloc(size_t size)
     void * alloc = lv_malloc_core(size);
 
     if(alloc == NULL) {
-        LV_LOG_INFO("couldn't allocate memory (%lu bytes)", (unsigned long)size);
+        LV_LOG_ERROR("couldn't allocate memory (%lu bytes)", (unsigned long)size);
 #if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
         lv_mem_monitor_t mon;
         lv_mem_monitor(&mon);
@@ -99,7 +99,7 @@ void * lv_malloc_zeroed(size_t size)
 
     void * alloc = lv_malloc_core(size);
     if(alloc == NULL) {
-        LV_LOG_INFO("couldn't allocate memory (%lu bytes)", (unsigned long)size);
+        LV_LOG_ERROR("couldn't allocate memory (%lu bytes)", (unsigned long)size);
 #if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
         lv_mem_monitor_t mon;
         lv_mem_monitor(&mon);


### PR DESCRIPTION
### Description of the feature or fix

If memory couldn't be allocated, this should be logged as an error.

With default log settings (LV_LOG_LEVEL_WARN) currently you are not notified if LVGL is running out of memory. The application simply stops running.

Since LVGL 9 needs approx 33% more memory than LVGL 8, this is now more likely to happen.

Please also see this discussion
https://forum.lvgl.io/t/lvgl-9-higher-memory-usage-and-different-usage-reports-in-lvgl-9-compared-to-8/15308

