### PR TITLE
fix(canvas): invalidate canvas on finish layer

### DIFF
--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -333,11 +333,12 @@ void lv_canvas_init_layer(lv_obj_t * obj, lv_layer_t * layer)
 
 void lv_canvas_finish_layer(lv_obj_t * canvas, lv_layer_t * layer)
 {
+    if(layer->draw_task_head == NULL) return;
     while(layer->draw_task_head) {
         lv_draw_dispatch_wait_for_request();
         lv_draw_dispatch_layer(lv_obj_get_display(canvas), layer);
-        lv_obj_invalidate(canvas);
     }
+    lv_obj_invalidate(canvas);
 }
 
 /**********************

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -336,6 +336,7 @@ void lv_canvas_finish_layer(lv_obj_t * canvas, lv_layer_t * layer)
     while(layer->draw_task_head) {
         lv_draw_dispatch_wait_for_request();
         lv_draw_dispatch_layer(lv_obj_get_display(canvas), layer);
+        lv_obj_invalidate(canvas);
     }
 }
 

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -1,0 +1,64 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+static lv_obj_t * g_screen_active;
+
+void setUp(void)
+{
+    g_screen_active = lv_screen_active();
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(g_screen_active);
+}
+
+static void draw_event_cb(lv_event_t * e)
+{
+    int * draw_counter = lv_event_get_user_data(e);
+    (*draw_counter)++;
+}
+void test_canvas_functions_invalidate(void)
+{
+    lv_obj_t * canvas = lv_canvas_create(g_screen_active);
+    int draw_counter = 0;
+    lv_obj_add_event_cb(canvas, draw_event_cb, LV_EVENT_DRAW_MAIN, &draw_counter);
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 0);
+
+    LV_DRAW_BUF_DEFINE(draw_buf, 100, 100, LV_COLOR_FORMAT_NATIVE);
+    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 1);
+
+    lv_canvas_set_px(canvas, 0, 0, lv_color_black(), LV_OPA_COVER);
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 2);
+
+    lv_canvas_fill_bg(canvas, lv_color_black(), LV_OPA_COVER);
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 3);
+
+    {
+        lv_layer_t layer;
+        lv_canvas_init_layer(canvas, &layer);
+        lv_draw_line_dsc_t line_dsc;
+        lv_draw_line_dsc_init(&line_dsc);
+        line_dsc.p1.x = 10;
+        line_dsc.p1.y = 10;
+        line_dsc.p2.x = 20;
+        line_dsc.p2.y = 20;
+        line_dsc.width = 5;
+        lv_draw_line(&layer, &line_dsc);
+        lv_canvas_finish_layer(canvas, &layer);
+        lv_refr_now(NULL);
+        TEST_ASSERT(draw_counter == 4);
+    }
+
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 4);
+}
+
+#endif

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -41,21 +41,19 @@ void test_canvas_functions_invalidate(void)
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 3);
 
-    {
-        lv_layer_t layer;
-        lv_canvas_init_layer(canvas, &layer);
-        lv_draw_line_dsc_t line_dsc;
-        lv_draw_line_dsc_init(&line_dsc);
-        line_dsc.p1.x = 10;
-        line_dsc.p1.y = 10;
-        line_dsc.p2.x = 20;
-        line_dsc.p2.y = 20;
-        line_dsc.width = 5;
-        lv_draw_line(&layer, &line_dsc);
-        lv_canvas_finish_layer(canvas, &layer);
-        lv_refr_now(NULL);
-        TEST_ASSERT(draw_counter == 4);
-    }
+    lv_layer_t layer;
+    lv_canvas_init_layer(canvas, &layer);
+    lv_draw_line_dsc_t line_dsc;
+    lv_draw_line_dsc_init(&line_dsc);
+    line_dsc.p1.x = 10;
+    line_dsc.p1.y = 10;
+    line_dsc.p2.x = 20;
+    line_dsc.p2.y = 20;
+    line_dsc.width = 5;
+    lv_draw_line(&layer, &line_dsc);
+    lv_canvas_finish_layer(canvas, &layer);
+    lv_refr_now(NULL);
+    TEST_ASSERT(draw_counter == 4);
 
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 4);


### PR DESCRIPTION
### Description of the feature or fix

Fixes #6005

`lv_canvas_finish_layer` does not invalidate the canvas. Changes are not drawn unless other canvas functions are called before the refresh.

Invalidate the canvas in `lv_canvas_finish_layer`. Add a test case that asserts all canvas drawing functions invalidate the canvas.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
