### PR TITLE
fix include path of lvgl.h

### DIFF
--- a/src/font/lv_font_simsun_14_cjk.c
+++ b/src/font/lv_font_simsun_14_cjk.c
@@ -7,7 +7,7 @@
 #ifdef LV_LVGL_H_INCLUDE_SIMPLE
     #include "lvgl.h"
 #else
-    #include "lvgl/lvgl.h"
+    #include "../../lvgl.h"
 #endif
 
 #ifndef LV_FONT_SIMSUN_14_CJK


### PR DESCRIPTION
### fix compilation error `lvgl/src/font/lv_font_simsun_14_cjk.c:10:14: fatal error: lvgl/lvgl.h: No such file or directory`
```
lvgl/src/font/lv_font_simsun_14_cjk.c:10:14: fatal error: lvgl/lvgl.h: No such file or directory
   10 |     #include "lvgl/lvgl.h"
      |              ^~~~~~~~~~~~~
```

looking at the other font files, the include path in this file is wrong.
Compilation succeeds after the change.
Compiled from https://github.com/kdschlosser/lvgl_micropython