### PR TITLE
fix(area): Increase coordinate percent range beyond +-1000

### DIFF
--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -350,8 +350,11 @@ static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_preci
 /*Special coordinates*/
 #define LV_SIZE_CONTENT         LV_COORD_SET_SPEC(LV_COORD_MAX)
 #define _LV_PCT_STORED_MAX      (LV_COORD_MAX - 1)
+#if _LV_PCT_STORED_MAX % 2 != 0
+#error _LV_PCT_STORED_MAX should be an even number
+#endif
 #define _LV_PCT_POS_MAX         (_LV_PCT_STORED_MAX / 2)
-#define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(_LV_PCT_POS_MAX - (x)) : LV_COORD_SET_SPEC(x))
+#define LV_PCT(x)               (LV_COORD_SET_SPEC(((x) < 0 ? ((_LV_PCT_POS_MAX - (x))  % (_LV_PCT_STORED_MAX + 1)) : ((x) % (_LV_PCT_POS_MAX + 1)))))
 #define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= _LV_PCT_STORED_MAX))
 #define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > _LV_PCT_POS_MAX ? _LV_PCT_POS_MAX - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
 

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -347,17 +347,16 @@ static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_preci
 #define LV_COORD_MAX            ((1 << _LV_COORD_TYPE_SHIFT) - 1)
 #define LV_COORD_MIN            (-LV_COORD_MAX)
 
-LV_EXPORT_CONST_INT(LV_COORD_MAX);
-LV_EXPORT_CONST_INT(LV_COORD_MIN);
-
 /*Special coordinates*/
 #define LV_SIZE_CONTENT         LV_COORD_SET_SPEC(LV_COORD_MAX)
-#define LV_PCT_STORED_MAX       (LV_COORD_MAX - 1)
-#define LV_PCT_POS_MAX          (LV_PCT_STORED_MAX / 2)
-#define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(LV_PCT_POS_MAX - (x)) : LV_COORD_SET_SPEC(x))
-#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= LV_PCT_STORED_MAX))
-#define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > LV_PCT_POS_MAX ? LV_PCT_POS_MAX - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
+#define _LV_PCT_STORED_MAX      (LV_COORD_MAX - 1)
+#define _LV_PCT_POS_MAX         (_LV_PCT_STORED_MAX / 2)
+#define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(_LV_PCT_POS_MAX - (x)) : LV_COORD_SET_SPEC(x))
+#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= _LV_PCT_STORED_MAX))
+#define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > _LV_PCT_POS_MAX ? _LV_PCT_POS_MAX - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
 
+LV_EXPORT_CONST_INT(LV_COORD_MAX);
+LV_EXPORT_CONST_INT(LV_COORD_MIN);
 LV_EXPORT_CONST_INT(LV_SIZE_CONTENT);
 
 /**

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../lv_conf_internal.h"
 #include "lv_types.h"
+#include "lv_math.h"
 
 /*********************
  *      DEFINES
@@ -354,7 +355,7 @@ static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_preci
 #error _LV_PCT_STORED_MAX should be an even number
 #endif
 #define _LV_PCT_POS_MAX         (_LV_PCT_STORED_MAX / 2)
-#define LV_PCT(x)               (LV_COORD_SET_SPEC(((x) < 0 ? ((_LV_PCT_POS_MAX - (x))  % (_LV_PCT_STORED_MAX + 1)) : ((x) % (_LV_PCT_POS_MAX + 1)))))
+#define LV_PCT(x)               (LV_COORD_SET_SPEC(((x) < 0 ? (_LV_PCT_POS_MAX - LV_MAX((x), -_LV_PCT_POS_MAX)) : LV_MIN((x), _LV_PCT_POS_MAX))))
 #define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= _LV_PCT_STORED_MAX))
 #define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > _LV_PCT_POS_MAX ? _LV_PCT_POS_MAX - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
 

--- a/src/misc/lv_area.h
+++ b/src/misc/lv_area.h
@@ -343,20 +343,22 @@ static inline void lv_point_precise_swap(lv_point_precise_t * p1, lv_point_preci
 
 #define LV_COORD_SET_SPEC(x)    ((x) | _LV_COORD_TYPE_SPEC)
 
-/*Special coordinates*/
-#define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(1000 - (x)) : LV_COORD_SET_SPEC(x))
-#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= 2000))
-#define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > 1000 ? 1000 - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
-#define LV_SIZE_CONTENT         LV_COORD_SET_SPEC(2001)
-
-LV_EXPORT_CONST_INT(LV_SIZE_CONTENT);
-
 /*Max coordinate value*/
 #define LV_COORD_MAX            ((1 << _LV_COORD_TYPE_SHIFT) - 1)
 #define LV_COORD_MIN            (-LV_COORD_MAX)
 
 LV_EXPORT_CONST_INT(LV_COORD_MAX);
 LV_EXPORT_CONST_INT(LV_COORD_MIN);
+
+/*Special coordinates*/
+#define LV_SIZE_CONTENT         LV_COORD_SET_SPEC(LV_COORD_MAX)
+#define LV_PCT_STORED_MAX       (LV_COORD_MAX - 1)
+#define LV_PCT_POS_MAX          (LV_PCT_STORED_MAX / 2)
+#define LV_PCT(x)               (x < 0 ? LV_COORD_SET_SPEC(LV_PCT_POS_MAX - (x)) : LV_COORD_SET_SPEC(x))
+#define LV_COORD_IS_PCT(x)      ((LV_COORD_IS_SPEC(x) && _LV_COORD_PLAIN(x) <= LV_PCT_STORED_MAX))
+#define LV_COORD_GET_PCT(x)     (_LV_COORD_PLAIN(x) > LV_PCT_POS_MAX ? LV_PCT_POS_MAX - _LV_COORD_PLAIN(x) : _LV_COORD_PLAIN(x))
+
+LV_EXPORT_CONST_INT(LV_SIZE_CONTENT);
 
 /**
  * Convert a percentage value to `int32_t`.

--- a/tests/src/test_cases/test_area.c
+++ b/tests/src/test_cases/test_area.c
@@ -86,10 +86,7 @@ void test_pct(void)
 
     /**
      * Out of bounds behavior.
-     * The behavior has been strongly defined such
-     * that the coord will be a PCT and SPEC
-     * and the number will be consistent
-     * but not intended to be usable.
+     * The pct value will be clamped to the max/min value if it's out of bounds.
     */
 
     pct_val = PCT_MAX_VALUE + 1;
@@ -97,32 +94,28 @@ void test_pct(void)
     TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
     TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
     TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
-    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
-    TEST_ASSERT_EQUAL_INT32(0, LV_COORD_GET_PCT(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(PCT_MAX_VALUE, LV_COORD_GET_PCT(pct_coord));
 
     pct_val = PCT_MAX_VALUE + 100;
     pct_coord = lv_pct(pct_val);
     TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
     TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
     TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
-    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
-    TEST_ASSERT_EQUAL_INT32(99, LV_COORD_GET_PCT(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(PCT_MAX_VALUE, LV_COORD_GET_PCT(pct_coord));
 
     pct_val = -PCT_MAX_VALUE - 1;
     pct_coord = lv_pct(pct_val);
     TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
     TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
     TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
-    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
-    TEST_ASSERT_EQUAL_INT32(0, LV_COORD_GET_PCT(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(-PCT_MAX_VALUE, LV_COORD_GET_PCT(pct_coord));
 
     pct_val = -PCT_MAX_VALUE - 100;
     pct_coord = lv_pct(pct_val);
     TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
     TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
     TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
-    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
-    TEST_ASSERT_EQUAL_INT32(99, LV_COORD_GET_PCT(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(-PCT_MAX_VALUE, LV_COORD_GET_PCT(pct_coord));
 }
 
 #endif

--- a/tests/src/test_cases/test_area.c
+++ b/tests/src/test_cases/test_area.c
@@ -1,0 +1,128 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+#define PCT_MAX_VALUE 268435455
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+void test_pct(void)
+{
+    int32_t pct_val;
+    int32_t pct_coord;
+
+    pct_val = 0;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = 1;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = 100;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = 111111111;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = PCT_MAX_VALUE;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -1;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -100;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -111111111;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -PCT_MAX_VALUE;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    TEST_ASSERT_EQUAL_INT32(pct_val, LV_COORD_GET_PCT(pct_coord));
+
+    /**
+     * Out of bounds behavior.
+     * The behavior has been strongly defined such
+     * that the coord will be a PCT and SPEC
+     * and the number will be consistent
+     * but not intended to be usable.
+    */
+
+    pct_val = PCT_MAX_VALUE + 1;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
+    TEST_ASSERT_EQUAL_INT32(0, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = PCT_MAX_VALUE + 100;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
+    TEST_ASSERT_EQUAL_INT32(99, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -PCT_MAX_VALUE - 1;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
+    TEST_ASSERT_EQUAL_INT32(0, LV_COORD_GET_PCT(pct_coord));
+
+    pct_val = -PCT_MAX_VALUE - 100;
+    pct_coord = lv_pct(pct_val);
+    TEST_ASSERT_TRUE(LV_COORD_IS_PCT(pct_coord));
+    TEST_ASSERT_FALSE(LV_COORD_IS_PX(pct_coord));
+    TEST_ASSERT_TRUE(LV_COORD_IS_SPEC(pct_coord));
+    /* out of bounds values become ABS(orig) % (MAX_PCT + 1) */
+    TEST_ASSERT_EQUAL_INT32(99, LV_COORD_GET_PCT(pct_coord));
+}
+
+#endif


### PR DESCRIPTION
### Description of the feature or fix

Fixes #6046

Use all the available bits in a `int32_t` coordinate for storing percent values instead of limiting it to just +-1000%. See the issue for more details. The issue was a case where percent values >1000% were failing to be created in a `tileview` with more than 10 tiles.

The new coordinate percent range is +-268435455%

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
