### PR TITLE
fix(vg_lite): fix incorrect cache operation

### DIFF
--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -76,7 +76,7 @@ typedef void (*lv_draw_buf_free_cb)(void * draw_buf);
 
 typedef void * (*lv_draw_buf_align_cb)(void * buf, lv_color_format_t color_format);
 
-typedef void (*lv_draw_buf_invalidate_cache_cb)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+typedef void (*lv_draw_buf_cache_operation_cb)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
 
@@ -84,7 +84,8 @@ typedef struct {
     lv_draw_buf_malloc_cb buf_malloc_cb;
     lv_draw_buf_free_cb buf_free_cb;
     lv_draw_buf_align_cb align_pointer_cb;
-    lv_draw_buf_invalidate_cache_cb invalidate_cache_cb;
+    lv_draw_buf_cache_operation_cb invalidate_cache_cb;
+    lv_draw_buf_cache_operation_cb flush_cache_cb;
     lv_draw_buf_width_to_stride_cb width_to_stride_cb;
 } lv_draw_buf_handlers_t;
 
@@ -118,7 +119,8 @@ void lv_draw_buf_init_handlers(lv_draw_buf_handlers_t * handlers,
                                lv_draw_buf_malloc_cb buf_malloc_cb,
                                lv_draw_buf_free_cb buf_free_cb,
                                lv_draw_buf_align_cb align_pointer_cb,
-                               lv_draw_buf_invalidate_cache_cb invalidate_cache_cb,
+                               lv_draw_buf_cache_operation_cb invalidate_cache_cb,
+                               lv_draw_buf_cache_operation_cb flush_cache_cb,
                                lv_draw_buf_width_to_stride_cb width_to_stride_cb);
 
 /**
@@ -161,6 +163,23 @@ void lv_draw_buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_
  */
 void lv_draw_buf_invalidate_cache_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf,
                                        const lv_area_t * area);
+
+/**
+ * Flush the cache of the buffer
+ * @param draw_buf     the draw buffer needs to be flushed
+ * @param area         the area to flush in the buffer,
+ *                     use NULL to flush the whole draw buffer address range
+ */
+void lv_draw_buf_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+
+/**
+ * Flush the cache of the buffer using the user-defined callback
+ * @param handlers     the draw buffer handlers
+ * @param draw_buf     the draw buffer needs to be flushed
+ * @param area         the area to flush in the buffer,
+ */
+void lv_draw_buf_flush_cache_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf,
+                                  const lv_area_t * area);
 
 /**
  * Calculate the stride in bytes based on a width and color format

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -112,6 +112,7 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
         .premultiply = false,
         .no_cache = false,
         .use_indexed = false,
+        .flush_cache = false,
     };
 
     /*
@@ -120,6 +121,18 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
      * If decoder open succeed, add the image to cache if enabled.
      * */
     lv_result_t res = dsc->decoder->open_cb(dsc->decoder, dsc);
+
+    /* Flush the D-Cache if enabled and the image was successfully opened */
+    if(dsc->args.flush_cache && res == LV_RESULT_OK) {
+        lv_draw_buf_flush_cache(dsc->decoded, NULL);
+        LV_LOG_INFO("Flushed D-cache: src %p (%s) (W%" LV_PRId32 " x H%" LV_PRId32 ", data: %p cf: %d)",
+                    src,
+                    dsc->src_type == LV_IMAGE_SRC_FILE ? (const char *)src : "c-array",
+                    dsc->decoded->header.w,
+                    dsc->decoded->header.h,
+                    dsc->decoded->data,
+                    dsc->decoded->header.cf);
+    }
 
     return res;
 }

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -62,6 +62,7 @@ typedef struct _lv_image_decoder_args_t {
     bool premultiply;       /*Whether image should be premultiplied or not after decoding*/
     bool no_cache;          /*When set, decoded image won't be put to cache, and decoder open will also ignore cache.*/
     bool use_indexed;       /*Decoded indexed image as is. Convert to ARGB8888 if false.*/
+    bool flush_cache;       /*Whether to flush the data cache after decoding*/
 } lv_image_decoder_args_t;
 
 /**

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -248,8 +248,8 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
         dest += dest_stride;
     }
 
-    /* invalidate D-Cache */
-    lv_draw_buf_invalidate_cache(draw_buf, NULL);
+    /* flush D-Cache to ensure the image data is in RAM */
+    lv_draw_buf_flush_cache(draw_buf, NULL);
     LV_LOG_INFO("image %p (W%" LV_PRId32 " x H%" LV_PRId32 ", buffer: %p, cf: %d) decode finish",
                 image_data, width, height, draw_buf->data, src_cf);
 
@@ -346,8 +346,8 @@ static lv_result_t decoder_open_file(lv_image_decoder_t * decoder, lv_image_deco
 
     lv_fs_close(&file);
 
-    /* invalidate D-Cache */
-    lv_draw_buf_invalidate_cache(draw_buf, NULL);
+    /* flush D-Cache to ensure the image data is in RAM */
+    lv_draw_buf_flush_cache(draw_buf, NULL);
 
     LV_LOG_INFO("image %s (W%" LV_PRId32 " x H%" LV_PRId32 ", buffer: %p cf: %d) decode finish",
                 path, width, height, draw_buf->data, src_header.cf);

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -248,11 +248,6 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
         dest += dest_stride;
     }
 
-    /* flush D-Cache to ensure the image data is in RAM */
-    lv_draw_buf_flush_cache(draw_buf, NULL);
-    LV_LOG_INFO("image %p (W%" LV_PRId32 " x H%" LV_PRId32 ", buffer: %p, cf: %d) decode finish",
-                image_data, width, height, draw_buf->data, src_cf);
-
     return LV_RESULT_OK;
 }
 
@@ -345,12 +340,6 @@ static lv_result_t decoder_open_file(lv_image_decoder_t * decoder, lv_image_deco
     lv_free(src_temp);
 
     lv_fs_close(&file);
-
-    /* flush D-Cache to ensure the image data is in RAM */
-    lv_draw_buf_flush_cache(draw_buf, NULL);
-
-    LV_LOG_INFO("image %s (W%" LV_PRId32 " x H%" LV_PRId32 ", buffer: %p cf: %d) decode finish",
-                path, width, height, draw_buf->data, src_header.cf);
     return LV_RESULT_OK;
 
 failed:

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -629,6 +629,7 @@ bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_ds
     args.stride_align = true;
     args.use_indexed = true;
     args.no_cache = no_cache;
+    args.flush_cache = true;
 
     lv_result_t res = lv_image_decoder_open(decoder_dsc, src, &args);
     if(res != LV_RESULT_OK) {

--- a/src/drivers/nuttx/lv_nuttx_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_cache.c
@@ -27,6 +27,7 @@
  **********************/
 
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 /**********************
  *  STATIC VARIABLES
@@ -44,28 +45,44 @@ void lv_nuttx_cache_init(void)
 {
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
     handlers->invalidate_cache_cb = invalidate_cache;
+    handlers->flush_cache_cb = flush_cache;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+static void draw_buf_to_region(
+    const lv_draw_buf_t * draw_buf, const lv_area_t * area,
+    lv_uintptr_t * start, lv_uintptr_t * end)
 {
     LV_ASSERT_NULL(draw_buf);
+    LV_ASSERT_NULL(area);
+    LV_ASSERT_NULL(start);
+    LV_ASSERT_NULL(end);
+
     void * buf = draw_buf->data;
     uint32_t stride = draw_buf->header.stride;
 
+    int32_t h = lv_area_get_height(area);
+    *start = (lv_uintptr_t)buf + area->y1 * stride;
+    *end = *start + h * stride;
+}
+
+static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
     lv_uintptr_t start;
     lv_uintptr_t end;
-
-    int32_t h = lv_area_get_height(area);
-    start = (lv_uintptr_t)buf + area->y1 * stride;
-    end = start + h * stride;
-
-    LV_UNUSED(start);
-    LV_UNUSED(end);
+    draw_buf_to_region(draw_buf, area, &start, &end);
     up_invalidate_dcache(start, end);
+}
+
+static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    lv_uintptr_t start;
+    lv_uintptr_t end;
+    draw_buf_to_region(draw_buf, area, &start, &end);
+    up_flush_dcache(start, end);
 }
 
 #endif /* LV_USE_NUTTX */


### PR DESCRIPTION
### Description of the feature or fix

After the CPU decodes the image, it should call the flush D-Cache operation to completely write the pixel data in the cache to RAM.

The invalidate D-Cache operation is incorrect, which will cause the data in the cache that is not written to RAM to be lost.

Invalidate cache is usually done when the peripheral writes to the memory first and the CPU needs to read it.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
