### PR TITLE
fix(encoder): always fire LV_EVENT_LONG_PRESSED to indev callback

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -907,6 +907,10 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
             i->longpr_rep_timestamp = lv_tick_get();
 
             if(data->key == LV_KEY_ENTER) {
+                /* Always send event to indev callbacks*/
+                lv_indev_send_event(indev_act, LV_EVENT_LONG_PRESSED, indev_obj_act);
+                if(indev_reset_check(indev_act)) return;
+
                 bool editable_or_scrollable = lv_obj_is_editable(indev_obj_act) ||
                                               lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_SCROLLABLE);
 
@@ -922,7 +926,8 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
                 /*If not editable then just send a long press event*/
                 else {
                     if(is_enabled) {
-                        if(send_event(LV_EVENT_LONG_PRESSED, indev_act) == LV_RESULT_INVALID) return;
+                        lv_obj_send_event(indev_obj_act, LV_EVENT_LONG_PRESSED, indev_act);
+                        if(indev_reset_check(indev_act)) return;
                     }
                 }
             }


### PR DESCRIPTION
### Description of the feature or fix
Fixes #5991 

Currently LV_EVENT_LONG_PRESSED isn't fired by encoder buttons if the current obj is editable or scrollable - this fixes that by ensuring that it runs every time irrespective of the obj state.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
