### PR TITLE
feat(chart): patch for adding space between newest data and oldest data in charts

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -881,8 +881,8 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                         }
                     }
                     else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE){
-                    	y_min = p2.y;
-                    	y_max = p2.y;
+                    	y_min = line_dsc.p2.y;
+                    	y_max = line_dsc.p2.y;
                     }
                 }
                 else {

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -462,7 +462,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
 
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
-    // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
+// If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
     for(int32_t i = 1; i < 10; i++) {
         if(ser->start_point + i < chart->point_cnt)
             ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -455,7 +455,7 @@ void lv_chart_set_all_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t val
     lv_chart_refresh(obj);
 }
 
-void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len)
+void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(ser);
@@ -463,7 +463,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
-    for (int32_t i = 1; i < space_len; i++)
+    for (int32_t i = 1; i < 10; i++)
     {
         if(ser->start_point+i < chart->point_cnt)
         	ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -455,15 +455,25 @@ void lv_chart_set_all_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t val
     lv_chart_refresh(obj);
 }
 
-void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value)
+void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(ser);
 
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
+    // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
+    for (int32_t i = 1; i < space_len; i++)
+    {
+        if(ser->start_point+i < chart->point_cnt)
+        	ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
+        else
+            ser->y_points[ser->start_point + i - chart->point_cnt] = LV_CHART_POINT_NONE;
+    }
     invalidate_point(obj, ser->start_point);
-    ser->start_point = (ser->start_point + 1) % chart->point_cnt;
+    ser->start_point++;
+    if(ser->start_point >= chart->point_cnt)
+        ser->start_point = 0;
     invalidate_point(obj, ser->start_point);
 }
 
@@ -869,6 +879,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                             y_min = y_cur;  /*Start the line of the next x from the current last y*/
                             y_max = y_cur;
                         }
+                    }
+                    else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE){
+                    	y_min = p2.y;
+                    	y_max = p2.y;
                     }
                 }
                 else {

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -463,7 +463,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
-    for (int32_t i = 1; i < 10; i++) {
+    for(int32_t i = 1; i < 10; i++) {
         if(ser->start_point + i < chart->point_cnt)
             ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
         else

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -463,8 +463,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
-    for (int32_t i = 1; i < 10; i++)
-    {
+    for (int32_t i = 1; i < 10; i++) {
         if(ser->start_point+i < chart->point_cnt)
         	ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
         else
@@ -881,8 +880,8 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                         }
                     }
                     else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                    	y_min = line_dsc.p2.y;
-                    	y_max = line_dsc.p2.y;
+                    	 y_min = line_dsc.p2.y;
+                    	 y_max = line_dsc.p2.y;
                     }
                 }
                 else {

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -462,7 +462,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
 
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
-// If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
+    // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.
     for(int32_t i = 1; i < 10; i++) {
         if(ser->start_point + i < chart->point_cnt)
             ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -463,11 +463,13 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.
-    for(int32_t i = 1; i < 10; i++) {
-        if(ser->start_point + i < chart->point_cnt)
-            ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
-        else
-            ser->y_points[ser->start_point + i - chart->point_cnt] = LV_CHART_POINT_NONE;
+    if(chart->type == LV_CHART_TYPE_LINE) {
+        for(int32_t i = 1; i < 10; i++) {
+            if(ser->start_point + i < chart->point_cnt)
+                ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
+            else
+                ser->y_points[ser->start_point + i - chart->point_cnt] = LV_CHART_POINT_NONE;
+        }
     }
     invalidate_point(obj, ser->start_point);
     ser->start_point++;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -880,8 +880,8 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                         }
                     }
                     else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
-                    	 y_min = line_dsc.p2.y;
-                    	 y_max = line_dsc.p2.y;
+                        y_min = line_dsc.p2.y;
+                        y_max = line_dsc.p2.y;
                     }
                 }
                 else {

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -462,7 +462,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
 
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
-    // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.
+    /* If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.*/
     if(chart->type == LV_CHART_TYPE_LINE && chart->update_mode == LV_CHART_UPDATE_MODE_CIRCULAR) {
         for(int32_t i = 1; i < 10; i++) {
             if(ser->start_point + i < chart->point_cnt)

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -880,7 +880,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                             y_max = y_cur;
                         }
                     }
-                    else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE){
+                    else if(ser->y_points[p_prev] == LV_CHART_POINT_NONE && ser->y_points[p_act] != LV_CHART_POINT_NONE) {
                     	y_min = line_dsc.p2.y;
                     	y_max = line_dsc.p2.y;
                     }

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -464,8 +464,8 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.  
     for (int32_t i = 1; i < 10; i++) {
-        if(ser->start_point+i < chart->point_cnt)
-        	ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
+        if(ser->start_point + i < chart->point_cnt)
+            ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;
         else
             ser->y_points[ser->start_point + i - chart->point_cnt] = LV_CHART_POINT_NONE;
     }

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -463,7 +463,7 @@ void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t va
     lv_chart_t * chart  = (lv_chart_t *)obj;
     ser->y_points[ser->start_point] = value;
     // If optimization isn't enabled or chart data series aren't updated synchronously, this part makes disturbances.
-    if(chart->type == LV_CHART_TYPE_LINE) {
+    if(chart->type == LV_CHART_TYPE_LINE && chart->update_mode == LV_CHART_UPDATE_MODE_CIRCULAR) {
         for(int32_t i = 1; i < 10; i++) {
             if(ser->start_point + i < chart->point_cnt)
                 ser->y_points[ser->start_point + i] = LV_CHART_POINT_NONE;

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -314,7 +314,7 @@ void lv_chart_set_all_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t val
  * @param ser       pointer to a data series on 'chart'
  * @param value     the new value of the next data
  */
-void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len);
+void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value);
 
 /**
  * Set the next point's X and Y value according to the update mode policy.

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -314,7 +314,7 @@ void lv_chart_set_all_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t val
  * @param ser       pointer to a data series on 'chart'
  * @param value     the new value of the next data
  */
-void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len)
+void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len);
 
 /**
  * Set the next point's X and Y value according to the update mode policy.

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -314,7 +314,7 @@ void lv_chart_set_all_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t val
  * @param ser       pointer to a data series on 'chart'
  * @param value     the new value of the next data
  */
-void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value);
+void lv_chart_set_next_value(lv_obj_t * obj, lv_chart_series_t * ser, int32_t value,int32_t space_len)
 
 /**
  * Set the next point's X and Y value according to the update mode policy.


### PR DESCRIPTION
### Description of the feature or fix

This patch adds space between the newest and oldest data available on the chart in line circular mode.