### PR TITLE
fix(draw_buf): use LV_ROUND_UP to align draw buffer address

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -10,6 +10,7 @@
 #include "lv_draw_buf.h"
 #include "../stdlib/lv_string.h"
 #include "../core/lv_global.h"
+#include "../misc/lv_math.h"
 
 /*********************
  *      DEFINES
@@ -522,8 +523,7 @@ static void * buf_align(void * buf, lv_color_format_t color_format)
 
     uint8_t * buf_u8 = buf;
     if(buf_u8) {
-        buf_u8 += LV_DRAW_BUF_ALIGN - 1;
-        buf_u8 = (uint8_t *)((lv_uintptr_t) buf_u8 & ~(LV_DRAW_BUF_ALIGN - 1));
+        buf_u8 = (uint8_t *)LV_ROUND_UP((lv_uintptr_t)buf_u8, LV_DRAW_BUF_ALIGN);
     }
     return buf_u8;
 }

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -29,6 +29,9 @@ extern "C" {
 /*Align up value x to align, align must be a power of two*/
 #define LV_ALIGN_UP(x, align) (((x) + ((align) - 1)) & ~((align) - 1))
 
+/*Round up value x to round, round can be any integer number*/
+#define LV_ROUND_UP(x, round) ((((x) + ((round) - 1)) / (round)) * (round))
+
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

From test config lv_test_conf.h:

/*Use non power of 2 to avoid the case when `malloc` returns aligned pointer by default, and use a large value be sure any issues will cause crash*/
\#define LV_DRAW_BUF_ALIGN                       852

We need to support non-power-of-2 draw buffer alignement. Introduce LV_ROUND_UP in lv_math.h and use it instead.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
