### PR TITLE
feat(draw_buf): add LV_DRAW_BUF_INIT macro to meet alignment requirement

### DIFF
--- a/examples/widgets/canvas/lv_example_canvas_1.c
+++ b/examples/widgets/canvas/lv_example_canvas_1.c
@@ -27,7 +27,8 @@ void lv_example_canvas_1(void)
     label_dsc.color = lv_palette_main(LV_PALETTE_ORANGE);
     label_dsc.text = "Some text on text canvas";
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf_16bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf_16bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf_16bpp);
 
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
     lv_canvas_set_draw_buf(canvas, &draw_buf_16bpp);
@@ -47,7 +48,9 @@ void lv_example_canvas_1(void)
 
     /*Test the rotation. It requires another buffer where the original image is stored.
      *So use previous canvas as image and rotate it to the new canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf_32bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf_32bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf_32bpp);
+
     /*Create a canvas and initialize its palette*/
     canvas = lv_canvas_create(lv_screen_active());
     lv_canvas_set_draw_buf(canvas, &draw_buf_32bpp);

--- a/examples/widgets/canvas/lv_example_canvas_2.c
+++ b/examples/widgets/canvas/lv_example_canvas_2.c
@@ -12,7 +12,9 @@ void lv_example_canvas_2(void)
     lv_obj_set_style_bg_color(lv_screen_active(), lv_palette_lighten(LV_PALETTE_RED, 5), 0);
 
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
+
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
     lv_canvas_set_draw_buf(canvas, &draw_buf);

--- a/examples/widgets/canvas/lv_example_canvas_3.c
+++ b/examples/widgets/canvas/lv_example_canvas_3.c
@@ -10,7 +10,8 @@
 void lv_example_canvas_3(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());

--- a/examples/widgets/canvas/lv_example_canvas_4.c
+++ b/examples/widgets/canvas/lv_example_canvas_4.c
@@ -10,7 +10,8 @@
 void lv_example_canvas_4(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());

--- a/examples/widgets/canvas/lv_example_canvas_5.c
+++ b/examples/widgets/canvas/lv_example_canvas_5.c
@@ -10,7 +10,8 @@
 void lv_example_canvas_5(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());

--- a/examples/widgets/canvas/lv_example_canvas_7.c
+++ b/examples/widgets/canvas/lv_example_canvas_7.c
@@ -10,7 +10,8 @@
 void lv_example_canvas_7(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());

--- a/examples/widgets/canvas/lv_example_canvas_8.c
+++ b/examples/widgets/canvas/lv_example_canvas_8.c
@@ -12,7 +12,8 @@
 void lv_example_canvas_8(void)
 {
     /*Create a buffer for the canvas*/
-    LV_DRAW_BUF_DEFINE(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_ARGB8888);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
 
     /*Create a canvas and initialize its palette*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());

--- a/examples/widgets/label/lv_example_label_4.c
+++ b/examples/widgets/label/lv_example_label_4.c
@@ -5,11 +5,11 @@
 #define MASK_WIDTH 150
 #define MASK_HEIGHT 60
 
-static void generate_mask(uint8_t * mask, int32_t w, int32_t h, const char * txt)
+static void generate_mask(lv_draw_buf_t * mask, int32_t w, int32_t h, const char * txt)
 {
     /*Create a "8 bit alpha" canvas and clear it*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
-    lv_canvas_set_buffer(canvas, mask, w, h, LV_COLOR_FORMAT_L8);
+    lv_canvas_set_draw_buf(canvas, mask);
     lv_canvas_fill_bg(canvas, lv_color_black(), LV_OPA_TRANSP);
 
     lv_layer_t layer;
@@ -36,11 +36,10 @@ static void generate_mask(uint8_t * mask, int32_t w, int32_t h, const char * txt
 void lv_example_label_4(void)
 {
     /* Create the mask of a text by drawing it to a canvas*/
-    static uint8_t mask[MASK_WIDTH * MASK_HEIGHT];
-    generate_mask(mask, MASK_WIDTH, MASK_HEIGHT, "Text with gradient");
+    LV_DRAW_BUF_DEFINE_STATIC(mask, MASK_WIDTH, MASK_HEIGHT, LV_COLOR_FORMAT_L8);
+    LV_DRAW_BUF_INIT_STATIC(mask);
 
-    static lv_draw_buf_t draw_buf;
-    lv_draw_buf_init(&draw_buf, MASK_WIDTH, MASK_HEIGHT, LV_COLOR_FORMAT_A8, LV_STRIDE_AUTO, mask, sizeof(mask));
+    generate_mask(&mask, MASK_WIDTH, MASK_HEIGHT, "Text with gradient");
 
     /* Create an object from where the text will be masked out.
      * Now it's a rectangle with a gradient but it could be an image too*/
@@ -50,7 +49,7 @@ void lv_example_label_4(void)
     lv_obj_set_style_bg_color(grad, lv_color_hex(0xff0000), 0);
     lv_obj_set_style_bg_grad_color(grad, lv_color_hex(0x0000ff), 0);
     lv_obj_set_style_bg_grad_dir(grad, LV_GRAD_DIR_HOR, 0);
-    lv_obj_set_style_bitmap_mask_src(grad, &draw_buf, 0);
+    lv_obj_set_style_bitmap_mask_src(grad, &mask, 0);
 }
 
 #endif

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -240,7 +240,8 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
         lv_area_t mask_area;
         lv_result_t decoder_res = lv_image_decoder_open(&mask_decoder_dsc, draw_dsc->bitmap_mask_src, NULL);
         if(decoder_res == LV_RESULT_OK && mask_decoder_dsc.decoded) {
-            if(mask_decoder_dsc.decoded->header.cf == LV_COLOR_FORMAT_A8) {
+            if(mask_decoder_dsc.decoded->header.cf == LV_COLOR_FORMAT_A8 ||
+               mask_decoder_dsc.decoded->header.cf == LV_COLOR_FORMAT_L8) {
                 const lv_draw_buf_t * mask_img = mask_decoder_dsc.decoded;
                 blend_dsc.mask_buf = mask_img->data;
                 blend_dsc.mask_stride = mask_img->header.stride;
@@ -254,7 +255,7 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
                 blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
             }
             else {
-                LV_LOG_WARN("The mask image doesn'thave A8 format. Drawing the image without mask.");
+                LV_LOG_WARN("The mask image is not A8/L8 format. Drawing the image without mask.");
             }
         }
         else {

--- a/src/lv_api_map_v9_0.h
+++ b/src/lv_api_map_v9_0.h
@@ -39,6 +39,8 @@ extern "C" {
 
 #define lv_button_bind_checked           lv_obj_bind_checked
 
+#define LV_DRAW_BUF_DEFINE               LV_DRAW_BUF_DEFINE_STATIC
+
 /**********************
  *      MACROS
  **********************/

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -68,7 +68,7 @@ void lv_canvas_set_buffer(lv_obj_t * obj, void * buf, int32_t w, int32_t h, lv_c
 
 /**
  * Set a draw buffer for the canvas. A draw buffer either can be allocated by `lv_draw_buf_create()`
- * or defined statically by `LV_DRAW_BUF_DEFINE`. When buffer start address and stride has alignment
+ * or defined statically by `LV_DRAW_BUF_DEFINE_STATIC`. When buffer start address and stride has alignment
  * requirement, it's recommended to use `lv_draw_buf_create`.
  * @param obj       pointer to a canvas object
  * @param draw_buf  pointer to a draw buffer

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -28,7 +28,9 @@ void test_canvas_functions_invalidate(void)
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 0);
 
-    LV_DRAW_BUF_DEFINE(draw_buf, 100, 100, LV_COLOR_FORMAT_NATIVE);
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, 100, 100, LV_COLOR_FORMAT_NATIVE);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
+
     lv_canvas_set_draw_buf(canvas, &draw_buf);
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 1);


### PR DESCRIPTION
### Description of the feature or fix

For draw buffer has memory start address alignment requirement, need to call LV_DRAW_BUF_INIT at run time to set the draw_buf->data to aligned address. Do this in run time is much easier than compile time.

CI need https://github.com/lvgl/lvgl/pull/6101 to pass.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
