### PR TITLE
Updated BIDI text support to include persian and arabic

### DIFF
--- a/src/lv_misc/lv_bidi.c
+++ b/src/lv_misc/lv_bidi.c
@@ -127,9 +127,16 @@ bool lv_bidi_letter_is_weak(uint32_t letter)
 
 bool lv_bidi_letter_is_rtl(uint32_t letter)
 {
-     if(letter >= 0x5d0 && letter <= 0x5ea) return true;
     if(letter == 0x202E) return true;               /*Unicode of LV_BIDI_RLO*/
-//    if(letter >= 'a' && letter <= 'z') return true;
+
+    /*Check for Persian and Arabic characters [https://en.wikipedia.org/wiki/Arabic_script_in_Unicode]*/
+    if(letter >= 0x600 && letter <= 0x6FF) return true;
+    if(letter >= 0xFB50 && letter <= 0xFDFF) return true;
+    if(letter >= 0xFE70 && letter <= 0xFEFF) return true;
+
+    /*Check for Hebrew characters [https://en.wikipedia.org/wiki/Unicode_and_HTML_for_the_Hebrew_alphabet]*/
+    if(letter >= 0x590 && letter <= 0x5FF) return true;
+    if(letter >= 0xFB1D && letter <= 0xFB4F) return true;
 
     return false;
 }
@@ -299,7 +306,7 @@ static void fill_pos_conv(uint16_t * out, uint16_t len, uint16_t index)
         out[i] = SET_RTL_POS(index, false);
         index++;
     }
-} 
+}
 
 static lv_bidi_dir_t get_next_run(const char * txt, lv_bidi_dir_t base_dir, uint32_t max_len, uint32_t * len, uint16_t  * pos_conv_len)
 {
@@ -421,7 +428,7 @@ static void rtl_reverse(char * dest, const char * src, uint32_t len, uint16_t *p
             }
 
             if (dest) memcpy(&dest[wr], &src[first_weak], last_weak - first_weak + 1);
-            if (pos_conv_out) fill_pos_conv(&pos_conv_out[pos_conv_wr], pos_conv_last_weak - pos_conv_first_weak + 1, pos_conv_rd_base + pos_conv_first_weak); 
+            if (pos_conv_out) fill_pos_conv(&pos_conv_out[pos_conv_wr], pos_conv_last_weak - pos_conv_first_weak + 1, pos_conv_rd_base + pos_conv_first_weak);
             wr += last_weak - first_weak + 1;
             pos_conv_wr += pos_conv_last_weak - pos_conv_first_weak + 1;
         }


### PR DESCRIPTION
### Description of the feature or fix

I need to add arabic support to a legacy application that uses LVGL v6.0; I realized that the internal function to distinguish between LTR and RTL text does not recognize arabic/persian characters as RTL. I added the feature as it is found in the latest versions.
