### PR TITLE
docs: simplify the find_version script and fix shellcheck report in it

### DIFF
--- a/scripts/find_version.sh
+++ b/scripts/find_version.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )"
 sed -n '/LVGL_VERSION_MAJOR/ {N;s@#define \+LVGL_VERSION_M.... \+@@g;s@\n@.@p}' "$SCRIPTPATH/../lv_version.h"

--- a/scripts/find_version.sh
+++ b/scripts/find_version.sh
@@ -1,8 +1,4 @@
-#!/bin/bash
-# Credit: https://stackoverflow.com/a/4774063
+#!/bin/sh
+
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-TMPENVFILE=$(mktemp /tmp/lvgl.script.XXXXXX)
-cat $SCRIPTPATH/../lv_version.h | grep "#define LVGL_VERSION_" | sed 's/#define //g' | sed -r 's/\s+/=/' > $TMPENVFILE
-. $TMPENVFILE
-rm $TMPENVFILE
-echo $LVGL_VERSION_MAJOR.$LVGL_VERSION_MINOR
+sed -n '/LVGL_VERSION_MAJOR/ {N;s@#define \+LVGL_VERSION_M.... \+@@g;s@\n@.@p}' "$SCRIPTPATH/../lv_version.h"


### PR DESCRIPTION
Use sed one-liner to extract the version without any temp files.

Fix the following shellcheck report. The cd builtin may fail, handle it gracefully.
```
In scripts/find_version.sh line 3:
SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
               ^-- SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean:
SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )"

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
```