### PR TITLE
feat(bidi): support set neutral string

### DIFF
--- a/src/misc/lv_bidi.c
+++ b/src/misc/lv_bidi.c
@@ -64,6 +64,7 @@ static uint32_t get_txt_len(const char * txt, uint32_t max_len);
  **********************/
 static const uint8_t bracket_left[] = {"<({["};
 static const uint8_t bracket_right[] = {">)}]"};
+static const char * custom_neutrals = NULL;
 
 /**********************
  *      MACROS
@@ -281,6 +282,11 @@ void lv_bidi_calculate_align(lv_text_align_t * align, lv_base_dir_t * base_dir, 
     }
 }
 
+void lv_bidi_set_custom_neutrals_static(const char * neutrals)
+{
+    custom_neutrals = neutrals;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -364,7 +370,11 @@ static bool lv_bidi_letter_is_rtl(uint32_t letter)
 static bool lv_bidi_letter_is_neutral(uint32_t letter)
 {
     uint16_t i;
-    static const char neutrals[] = " \t\n\r.,:;'\"`!?%/\\-=()[]{}<>@#&$|";
+    const char * neutrals = " \t\n\r.,:;'\"`!?%/\\-=()[]{}<>@#&$|";
+    if(custom_neutrals) {
+        neutrals = custom_neutrals;
+    }
+
     for(i = 0; neutrals[i] != '\0'; i++) {
         if(letter == (uint32_t)neutrals[i]) return true;
     }

--- a/src/misc/lv_bidi.h
+++ b/src/misc/lv_bidi.h
@@ -115,6 +115,12 @@ void _lv_bidi_process_paragraph(const char * str_in, char * str_out, uint32_t le
  */
 void lv_bidi_calculate_align(lv_text_align_t * align, lv_base_dir_t * base_dir, const char * txt);
 
+/**
+ * Set custom neutrals string
+ * @param neutrals  default " \t\n\r.,:;'\"`!?%/\\-=()[]{}<>@#&$|"
+ */
+void lv_bidi_set_custom_neutrals_static(const char * neutrals);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### Description of the feature or fix

When switching languages ​​externally, take the initiative to reset the neutral string. https://github.com/lvgl/lvgl/issues/6145

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
