### PR TITLE
chore(draw_sw): optimize lv_draw_sw_rotate judgment logic

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -227,6 +227,7 @@ void lv_draw_sw_rotate(const void * src, void * dest, int32_t src_width, int32_t
             case LV_COLOR_FORMAT_RGB888:
                 rotate90_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;
+            case LV_COLOR_FORMAT_XRGB8888:
             case LV_COLOR_FORMAT_ARGB8888:
                 rotate90_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;
@@ -245,6 +246,7 @@ void lv_draw_sw_rotate(const void * src, void * dest, int32_t src_width, int32_t
             case LV_COLOR_FORMAT_RGB888:
                 rotate180_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;
+            case LV_COLOR_FORMAT_XRGB8888:
             case LV_COLOR_FORMAT_ARGB8888:
                 rotate180_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;
@@ -263,6 +265,7 @@ void lv_draw_sw_rotate(const void * src, void * dest, int32_t src_width, int32_t
             case LV_COLOR_FORMAT_RGB888:
                 rotate270_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;
+            case LV_COLOR_FORMAT_XRGB8888:
             case LV_COLOR_FORMAT_ARGB8888:
                 rotate270_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
                 break;

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -219,21 +219,58 @@ void lv_draw_sw_rgb565_swap(void * buf, uint32_t buf_size_px)
 void lv_draw_sw_rotate(const void * src, void * dest, int32_t src_width, int32_t src_height, int32_t src_sride,
                        int32_t dest_stride, lv_display_rotation_t rotation, lv_color_format_t color_format)
 {
-    uint32_t px_bpp = lv_color_format_get_bpp(color_format);
     if(rotation == LV_DISPLAY_ROTATION_90) {
-        if(px_bpp == 16) rotate90_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 24) rotate90_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 32) rotate90_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+        switch(color_format) {
+            case LV_COLOR_FORMAT_RGB565:
+                rotate90_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_RGB888:
+                rotate90_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_ARGB8888:
+                rotate90_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            default:
+                break;
+        }
+
+        return;
     }
-    else if(rotation == LV_DISPLAY_ROTATION_180) {
-        if(px_bpp == 16) rotate180_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 24) rotate180_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 32) rotate180_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+
+    if(rotation == LV_DISPLAY_ROTATION_180) {
+        switch(color_format) {
+            case LV_COLOR_FORMAT_RGB565:
+                rotate180_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_RGB888:
+                rotate180_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_ARGB8888:
+                rotate180_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            default:
+                break;
+        }
+
+        return;
     }
-    else if(rotation == LV_DISPLAY_ROTATION_270) {
-        if(px_bpp == 16) rotate270_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 24) rotate270_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
-        if(px_bpp == 32) rotate270_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+
+    if(rotation == LV_DISPLAY_ROTATION_270) {
+        switch(color_format) {
+            case LV_COLOR_FORMAT_RGB565:
+                rotate270_rgb565(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_RGB888:
+                rotate270_rgb888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            case LV_COLOR_FORMAT_ARGB8888:
+                rotate270_argb8888(src, dest, src_width, src_height, src_sride, dest_stride);
+                break;
+            default:
+                break;
+        }
+
+        return;
     }
 }
 


### PR DESCRIPTION
### Description of the feature or fix

We should choose the conversion method based on the specific format instead of converting to bpp first and then judging, because some formats bpp are the same, such as RGB888 and ARGB5658 are both 24bpp.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
