### PR TITLE
fix(nuttx): fix compile warning

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.h
+++ b/src/drivers/nuttx/lv_nuttx_entry.h
@@ -47,6 +47,8 @@ typedef struct _lv_nuttx_ctx_t {
 
 #if LV_CACHE_DEF_SIZE > 0
     void * image_cache;
+#else
+    void * dummy;
 #endif
 
 } lv_nuttx_ctx_t;


### PR DESCRIPTION


### Description of the feature or fix

The warning is due to the fact that in C++, an empty struct has a size of 1 byte, while in C, it has a size of 0. This can cause compatibility issues when linking C and C++ code together.

```bash
/Users/neo/projects/nuttx/apps/graphics/lvgl/lvgl/src/drivers/nuttx/lv_nuttx_entry.h:46:9: warning: empty struct has size 0 in C, size 1 in C++ [-Wextern-c-compat] typedef struct _lv_nuttx_ctx_t {
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
