### PR TITLE
fix(nuttx): fix assert failed due to wrong color format

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -150,6 +150,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
     }
 
     lv_display_set_draw_buffers(disp, &dsc->buf1, double_buffer ? &dsc->buf2 : NULL);
+    lv_display_set_color_format(disp, color_format);
     lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
     lv_timer_set_cb(disp->refr_timer, display_refr_timer_cb);
@@ -247,6 +248,7 @@ static lv_color_format_t fb_fmt_to_color_format(int fmt)
         case FB_FMT_RGB24:
             return LV_COLOR_FORMAT_RGB888;
         case FB_FMT_RGB32:
+            return LV_COLOR_FORMAT_XRGB8888;
         case FB_FMT_RGBA32:
             return LV_COLOR_FORMAT_ARGB8888;
         default:


### PR DESCRIPTION


### Description of the feature or fix

```bash
_assert: Assertion failed : at file: /home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/src/draw/lv_draw_buf.c:188 task: lvgldemo_main process: lvgldemo_main 0x56468c039e4c
```
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
