### PR TITLE
feat(freetype): add invalid font descriptor printing

### DIFF
--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -181,7 +181,6 @@ void lv_freetype_font_delete(lv_font_t * font)
     LV_ASSERT_NULL(font);
     lv_freetype_context_t * ctx = lv_freetype_get_context();
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)(font->dsc);
-    LV_ASSERT_NULL(dsc);
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
     lv_cache_release(ctx->cache_node_cache, dsc->cache_node_entry, NULL);

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -43,7 +43,8 @@ extern "C" {
 #define LV_ASSERT_FREETYPE_FONT_DSC(dsc)                                                   \
     do {                                                                                   \
         LV_ASSERT_NULL(dsc);                                                               \
-        LV_ASSERT_MSG(LV_FREETYPE_FONT_DSC_HAS_MAGIC_NUM(dsc), "Invalid font descriptor"); \
+        LV_ASSERT_FORMAT_MSG(LV_FREETYPE_FONT_DSC_HAS_MAGIC_NUM(dsc),                      \
+                             "Invalid font descriptor: 0x%" LV_PRIx32, (dsc)->magic_num);  \
     } while (0)
 
 #define FT_INT_TO_F26DOT6(x) ((x) << 6)


### PR DESCRIPTION
### Description of the feature or fix

Output error value when user tries to delete non-FreeType fonts.

```c
lv_freetype_font_delete(LV_FONT_DEFAULT);
```

```bash
[Error] (1.015, +1015)   lv_freetype_font_delete: Asserted at expression: LV_FREETYPE_FONT_DSC_HAS_MAGIC_NUM(dsc) Invalid font descriptor: 0x556c34c0 lv_freetype.c:185
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
