### PR TITLE
fix(event): fix LV_EVENT_PREPROCESS flag was not processed correctly on VisualStudio

### DIFF
--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -20,7 +20,7 @@
 typedef struct _lv_event_dsc_t {
     lv_event_cb_t cb;
     void * user_data;
-    lv_event_code_t filter : 8;
+    uint8_t filter;		/* uint8_t to guarantee the size that lv_event_code_t expects. */
 } lv_event_dsc_t;
 
 /**********************

--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -20,7 +20,7 @@
 typedef struct _lv_event_dsc_t {
     lv_event_cb_t cb;
     void * user_data;
-    uint8_t filter;		/* uint8_t to guarantee the size that lv_event_code_t expects. */
+    uint8_t filter;
 } lv_event_dsc_t;
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

Related to #2985 #3003 

Fix #3003 was not working properly on VisualStudio.

On VisualStudio, the type size of lv_event_code_t was not the size expected by #3003.
Therefore, it was fixed to explicitly limit the size.

This problem has already been reported in the following thread.
https://github.com/lvgl/lvgl/pull/3003#issuecomment-1941396211