### PR TITLE
refactor(nuttx_image_cache): remove LV_CACHE_DEF_SIZE dependency

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -104,9 +104,7 @@ void lv_nuttx_init(const lv_nuttx_dsc_t * dsc, lv_nuttx_result_t * result)
 
     lv_nuttx_cache_init();
 
-#if LV_CACHE_DEF_SIZE > 0
     lv_nuttx_image_cache_init();
-#endif
 
 #if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
     lv_nuttx_profiler_init();

--- a/src/drivers/nuttx/lv_nuttx_entry.h
+++ b/src/drivers/nuttx/lv_nuttx_entry.h
@@ -44,13 +44,7 @@ typedef struct {
 } lv_nuttx_result_t;
 
 typedef struct _lv_nuttx_ctx_t {
-
-#if LV_CACHE_DEF_SIZE > 0
     void * image_cache;
-#else
-    void * dummy;
-#endif
-
 } lv_nuttx_ctx_t;
 
 /**********************

--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -10,8 +10,6 @@
 #include "lv_nuttx_cache.h"
 #include "../../../lvgl.h"
 
-#if LV_CACHE_DEF_SIZE > 0
-
 #if LV_USE_NUTTX
 
 #include <nuttx/mm/mm.h>
@@ -76,6 +74,11 @@ static bool defer_init(void)
 {
     if(ctx->mem != NULL && ctx->heap != NULL) {
         return true;
+    }
+
+    if(img_cache_p->max_size == 0) {
+        LV_LOG_INFO("Image cache is not initialized yet. Skipping deferred initialization. Because max_size is 0.");
+        return false;
     }
 
     ctx->mem_size = img_cache_p->max_size;
@@ -150,4 +153,3 @@ static void free_cb(void * draw_buf)
 }
 
 #endif /* LV_USE_NUTTX */
-#endif /* LV_CACHE_DEF_SIZE > 0 */

--- a/src/drivers/nuttx/lv_nuttx_image_cache.h
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.h
@@ -16,8 +16,6 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#if LV_CACHE_DEF_SIZE > 0
-
 /*********************
  *      DEFINES
  *********************/
@@ -35,8 +33,6 @@ void lv_nuttx_image_cache_init(void);
 /**********************
  *      MACROS
  **********************/
-
-#endif /*LV_CACHE_DEF_SIZE > 0*/
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
