### PR TITLE
fix(display): load screen from matching display

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1031,7 +1031,7 @@ static void scr_load_anim_start(lv_anim_t * a)
 {
     lv_display_t * d = lv_obj_get_display(a->var);
 
-    d->prev_scr = lv_screen_active();
+    d->prev_scr = lv_display_get_screen_active(d);
     d->act_scr = a->var;
 
     lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOAD_START, NULL);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -570,7 +570,7 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
                          bool auto_del)
 {
     lv_display_t * d = lv_obj_get_display(new_scr);
-    lv_obj_t * act_scr = lv_screen_active();
+    lv_obj_t * act_scr = d->act_scr;
 
     if(act_scr == new_scr || d->scr_to_load == new_scr) {
         return;
@@ -586,7 +586,7 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
         if(d->del_prev) {
             lv_obj_delete(act_scr);
         }
-        act_scr = lv_screen_active(); /*Active screen changed.*/
+        act_scr = d->act_scr; /*Active screen changed.*/
 
         scr_load_internal(d->scr_to_load);
     }
@@ -1031,7 +1031,7 @@ static void scr_load_anim_start(lv_anim_t * a)
 {
     lv_display_t * d = lv_obj_get_display(a->var);
 
-    d->prev_scr = lv_display_get_screen_active(d);
+    d->prev_scr = d->act_scr;
     d->act_scr = a->var;
 
     lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOAD_START, NULL);


### PR DESCRIPTION
If the function "lv_screen_load_anim()" is used to change the screen with a defined delay and the default display is changed within the delay in a multi-display setup, the wrong screen is loaded as the "previous" screen.

Fix: lv_screen_active() replaced with lv_display_get_screen_active()
(lv_display.c)



https://github.com/lvgl/lvgl/assets/33206578/57f44d72-3430-4665-87d6-51aabfababd3

The bug can be seen in the video:
the top left display is set as the default display. When starting the animation from the lower display and the upper right display, the active screen is loaded from the upper left display.


Kind regards and have a nice day! :)