### PR TITLE
fix(lv_table): suppressed compilation warnings due to zero-size arrays

### DIFF
--- a/src/widgets/lv_table.h
+++ b/src/widgets/lv_table.h
@@ -52,7 +52,7 @@ typedef struct {
 #if LV_USE_USER_DATA
     void * user_data; /**< Custom user data*/
 #endif
-    char txt[];
+    char txt[1];
 } lv_table_cell_t;
 
 /*Data of table*/


### PR DESCRIPTION
### Description of the feature or fix

Related to #6171 

On VisualStudio, the following warning message occurs frequently whenever sources that includes lv_table.h are built.
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-2-and-4-c4200?view=msvc-170
