### PR TITLE
fix(animimage): add NULL pointer check

### DIFF
--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -36,7 +36,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void index_change(lv_obj_t * obj, int32_t index);
+static void index_change(lv_obj_t * obj, int32_t idx);
 static void lv_animimg_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 
 /**********************
@@ -156,9 +156,8 @@ static void lv_animimg_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     lv_anim_set_repeat_count(&animimg->anim, LV_ANIM_REPEAT_INFINITE);
 }
 
-static void index_change(lv_obj_t * obj, int32_t index)
+static void index_change(lv_obj_t * obj, int32_t idx)
 {
-    int32_t idx;
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
 
     if(animimg->dsc == NULL) {
@@ -166,7 +165,7 @@ static void index_change(lv_obj_t * obj, int32_t index)
         return;
     }
 
-    idx = index % animimg->pic_count;
+    if(idx >= animimg->pic_count) idx =  animimg->pic_count - 1;
 
     lv_image_set_src(obj, animimg->dsc[idx]);
 }

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -162,7 +162,7 @@ static void index_change(lv_obj_t * obj, int32_t index)
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
 
     if(animimg->dsc == NULL) {
-        LV_LOG_ERROR("dsc is null");
+        LV_LOG_WARN("dsc is null");
         return;
     }
 

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -72,7 +72,7 @@ void lv_animimg_set_src(lv_obj_t * obj, const void * dsc[], size_t num)
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
     animimg->dsc = dsc;
     animimg->pic_count = num;
-    lv_anim_set_values(&animimg->anim, 0, (int32_t)num - 1);
+    lv_anim_set_values(&animimg->anim, 0, (int32_t)num);
 }
 
 void lv_animimg_start(lv_obj_t * obj)

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -161,6 +161,11 @@ static void index_change(lv_obj_t * obj, int32_t index)
     int32_t idx;
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
 
+    if(animimg->dsc == NULL) {
+        LV_LOG_ERROR("dsc is null");
+        return;
+    }
+
     idx = index % animimg->pic_count;
 
     lv_image_set_src(obj, animimg->dsc[idx]);


### PR DESCRIPTION
### Description of the feature or fix

When dsc sets an incorrect NULL value, it can cause the animation's callback function to incorrectly take an array subscript value for the NULL value and cause the program to crash, which should prompt an error message and return.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
