### PR TITLE
fix(docs): fix broken links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: Forum
     url: https://forum.lvgl.io
     about: For topics like How-to, Getting started, Feature request
-  - name: CONTRIBUTING.md
-    url: https://github.com/lvgl/lvgl/blob/master/docs/CONTRIBUTING.md#faq-about-contributing
+  - name: CONTRIBUTING.rst
+    url: https://github.com/lvgl/lvgl/blob/master/docs/CONTRIBUTING.rst
     about: The basic rules of contributing
-  - name: CODING_STYLE.md
-    url: https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md
+  - name: CODING_STYLE.rst
+    url: https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.rst
     about: Quick summary of LVGL's code style

--- a/docs/CODING_STYLE.rst
+++ b/docs/CODING_STYLE.rst
@@ -1,3 +1,5 @@
+.. _coding-style:
+
 Coding style
 ============
 

--- a/docs/integration/bindings/micropython.rst
+++ b/docs/integration/bindings/micropython.rst
@@ -182,7 +182,7 @@ The Micropython Binding is auto generated!
 LVGL C API Coding Conventions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For a summary of coding conventions to follow see the `CODING STYLE <CODING_STYLE>`__.
+For a summary of coding conventions to follow see the :ref:`coding-style`.
 
 .. _memory_management:
 


### PR DESCRIPTION
Fixing broken links of:
- [https://github.com/lvgl/lvgl/issues/new/choose](https://github.com/lvgl/lvgl/issues/new/choose)
    CODING_STYLE.md -> `Open` button goes to old file
- [https://docs.lvgl.io/master/integration/bindings/micropython.html#lvgl-c-api-coding-conventions](https://docs.lvgl.io/master/integration/bindings/micropython.html#lvgl-c-api-coding-conventions)
   CODING_STYLE goes to `404 Not found`