### PR TITLE
feat(micropython): improve mem core micropython

### DIFF
--- a/src/stdlib/micropython/lv_mem_core_micropython.c
+++ b/src/stdlib/micropython/lv_mem_core_micropython.c
@@ -62,17 +62,32 @@ void lv_mem_remove_pool(lv_mem_pool_t pool)
 
 void * lv_malloc_core(size_t size)
 {
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    return gc_alloc(size, true);
+#else
     return m_malloc(size);
+#endif
 }
 
 void * lv_realloc_core(void * p, size_t new_size)
 {
+
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    return gc_realloc(p, new_size, true);
+#else
     return m_realloc(p, new_size);
+#endif
 }
 
 void lv_free_core(void * p)
 {
+
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    gc_free(p);
+
+#else
     m_free(p);
+#endif
 }
 
 void lv_mem_monitor_core(lv_mem_monitor_t * mon_p)


### PR DESCRIPTION
Allow using `MICROPY_MALLOC_USES_ALLOCATED_SIZE` option required to build `lv_bindings_micropython` with upstream MicroPython.

Required for ~https://github.com/lvgl/lv_binding_micropython/pull/242~
https://github.com/lvgl/lv_binding_micropython/pull/341
