### PR TITLE
chore: fix compile error

### DIFF
--- a/tests/src/test_cases/widgets/test_checkbox.c
+++ b/tests/src/test_cases/widgets/test_checkbox.c
@@ -90,6 +90,7 @@ void test_checkbox_should_allocate_memory_for_static_text(void)
 
     lv_mem_monitor(&m1);
 
+    LV_UNUSED(initial_available_memory);
     LV_HEAP_CHECK(TEST_ASSERT_LESS_THAN(initial_available_memory, m1.free_size));
 }
 

--- a/tests/src/test_cases/widgets/test_switch.c
+++ b/tests/src/test_cases/widgets/test_switch.c
@@ -62,6 +62,7 @@ void test_switch_should_not_leak_memory_after_deletion(void)
         lv_obj_delete(switches[idx]);
     }
 
+    LV_UNUSED(initial_available_memory);
     LV_HEAP_CHECK(TEST_ASSERT_MEM_LEAK_LESS_THAN(initial_available_memory, 24));
 }
 


### PR DESCRIPTION
### Description of the feature or fix

When it use sys_heap to compile the testcase, the contents of HEAP_CHECK will be empty.

So the variable used in the HEAP_CHECK macro will be invalid.

This causes this error.

```shell
lvgl/tests/src/test_cases/widgets/test_switch.c:52:12: error: variable 'initial_available_memory' set but not used [-Werror,-Wunused-but-set-variable]
   52 |     size_t initial_available_memory = 0;
      |            ^
1 error generated.
```
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
