### PR TITLE
fix(drivers): drm driver not initialising with small screens

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -153,9 +153,12 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
     int32_t width = drm_dev->mmWidth;
 
     size_t buf_size = LV_MIN(drm_dev->drm_bufs[1].size, drm_dev->drm_bufs[0].size);
+    /* Resolution must be set first because if the screen is smaller than the size passed
+     * to lv_display_create then the buffers aren't big enough for LV_DISPLAY_RENDER_MODE_DIRECT.
+     */
+    lv_display_set_resolution(disp, hor_res, ver_res);
     lv_display_set_buffers(disp, drm_dev->drm_bufs[1].map, drm_dev->drm_bufs[0].map, buf_size,
                            LV_DISPLAY_RENDER_MODE_DIRECT);
-    lv_display_set_resolution(disp, hor_res, ver_res);
 
     if(width) {
         lv_display_set_dpi(disp, DIV_ROUND_UP(hor_res * 25400, width * 1000));


### PR DESCRIPTION
### Description of the feature or fix

The DRM display driver would not initialise with screens smaller than the 800x480 passed to lv_display_create because it called lv_display_set_buffers with buffers that were too small for the expected resolution when doing direct rendering.