### PR TITLE
feat(refr): updates LVGL's refresh when double buffering is being used.

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -74,6 +74,16 @@
 /*Default display refresh, input device read and animation step period.*/
 #define LV_DEF_REFR_PERIOD  33      /*[ms]*/
 
+/* This is used to control what LVGL does if it has to wait for a buffer
+ * to finish flushing. Instead of just spinning the wheels this sets the
+ * refresh timer to 1 millisecond and then exist the refresh should it have to
+ * wait for the buffer to finish flushing. This only happen with double
+ * buffering. If DMA memory is being used it allows the processor to complete
+ * ther tasks instead of just sitting there spinning it's wheels.
+ */
+#define LV_RETURN_FROM_FLUSH_WAIT 0
+
+
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #define LV_DPI_DEF 130     /*[px/inch]*/

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -78,25 +78,21 @@ bool lv_refr_now(lv_display_t * disp)
 {
     lv_anim_refr_now();
     bool ret = true;
-    if(disp) {
+    if(disp && disp->refr_timer) {
         _lv_display_refr_timer(disp->refr_timer);
 #if LV_RETURN_FROM_FLUSH_WAIT
-        if(lv_display_is_double_buffered(disp) && !(disp->refresh_skipped)) {
-            ret = false;
-        }
+        if(lv_display_is_double_buffered(disp) && !(disp->refresh_skipped)) ret = false}
 #endif
-    }
-    else {
-
+    } else {
         lv_display_t * d;
         d = lv_display_get_next(NULL);
         while(d) {
-            _lv_display_refr_timer(d->refr_timer);
+            if (d->refr_timer) {
+                _lv_display_refr_timer(d->refr_timer);
 #if LV_RETURN_FROM_FLUSH_WAIT
-            if(lv_display_is_double_buffered(d) && !(d->refresh_skipped)) {
-                ret = false;
-            }
+                if(lv_display_is_double_buffered(d) && !(d->refresh_skipped)) ret = false;
 #endif
+            }
             d = lv_display_get_next(d);
         }
     }

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -81,9 +81,10 @@ bool lv_refr_now(lv_display_t * disp)
     if(disp && disp->refr_timer) {
         _lv_display_refr_timer(disp->refr_timer);
 #if LV_RETURN_FROM_FLUSH_WAIT
-        if(lv_display_is_double_buffered(disp) && !(disp->refresh_skipped)) ret = false}
+        if(lv_display_is_double_buffered(disp) && !(disp->refresh_skipped)) ret = false
 #endif
-    } else {
+    }
+    else {
         lv_display_t * d;
         d = lv_display_get_next(NULL);
         while(d) {
@@ -336,7 +337,8 @@ void _lv_display_refr_timer(lv_timer_t * tmr)
 
     if(tmr) {
         disp_refr = tmr->user_data;
-    } else {
+    }
+    else {
         disp_refr = lv_display_get_default();
     }
 
@@ -351,7 +353,7 @@ void _lv_display_refr_timer(lv_timer_t * tmr)
         return;
     }
 
-     /* In double buffered mode wait until the other buffer is freed
+    /* In double buffered mode wait until the other buffer is freed
      * and driver is ready to receive the new buffer.
      * If we need to wait here it means that the content of one buffer is being sent to display
      * and other buffer already contains the new rendered image.
@@ -362,15 +364,17 @@ void _lv_display_refr_timer(lv_timer_t * tmr)
     if(lv_display_is_double_buffered(disp_refr)) {
 #if LV_RETURN_FROM_FLUSH_WAIT
         if(tmr) {
-            if (disp_refr->flushing == 1) {
+            if(disp_refr->flushing == 1) {
                 lv_timer_set_period(tmr, 1);
                 disp_refr->refresh_skipped = true;
                 return;
-            } else {
+            }
+            else {
                 lv_timer_set_period(tmr, LV_DEF_REFR_PERIOD);
                 disp_refr->refresh_skipped = false;
             }
-        } else {
+        }
+        else {
             wait_for_flushing(disp_refr);
         }
 #else

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -340,14 +340,7 @@ void _lv_display_refr_timer(lv_timer_t * tmr)
 
     if(tmr) {
         disp_refr = tmr->user_data;
-        /* Ensure the timer does not run again automatically.
-         * This is done before refreshing in case refreshing invalidates something else.
-         * However if the performance monitor is enabled keep the timer running to count the FPS.*/
-#if LV_USE_PERF_MONITOR
-        lv_timer_pause(tmr);
-#endif
-    }
-    else {
+    } else {
         disp_refr = lv_display_get_default();
     }
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -88,7 +88,7 @@ bool lv_refr_now(lv_display_t * disp)
         lv_display_t * d;
         d = lv_display_get_next(NULL);
         while(d) {
-            if (d->refr_timer) {
+            if(d->refr_timer) {
                 _lv_display_refr_timer(d->refr_timer);
 #if LV_RETURN_FROM_FLUSH_WAIT
                 if(lv_display_is_double_buffered(d) && !(d->refresh_skipped)) ret = false;

--- a/src/core/lv_refr.h
+++ b/src/core/lv_refr.h
@@ -57,8 +57,9 @@ void _lv_refr_deinit(void);
  * can prevent the call of `lv_timer_handler`. In this case if the GUI is updated in the process
  * (e.g. progress bar) this function can be called when the screen should be updated.
  * @param disp pointer to display to refresh. NULL to refresh all displays.
+ * @return false if double buffering and refresh doesn't completes, else true
  */
-void lv_refr_now(lv_display_t * disp);
+bool lv_refr_now(lv_display_t * disp);
 
 /**
  * Redrawn on object and all its children using the passed draw context

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -163,6 +163,9 @@ struct _lv_display_t {
     lv_obj_t * mem_label;
 #endif
 
+#if LV_RETURN_FROM_FLUSH_WAIT
+    bool refresh_skipped;
+#endif
 };
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -227,6 +227,22 @@
     #endif
 #endif
 
+/* This is used to control what LVGL does if it has to wait for a buffer
+ * to finish flushing. Instead of just spinning the wheels this sets the
+ * refresh timer to 1 millisecond and then exist the refresh should it have to
+ * wait for the buffer to finish flushing. This only happen with double
+ * buffering. If DMA memory is being used it allows the processor to complete
+ * ther tasks instead of just sitting there spinning it's wheels.
+ */
+#ifndef LV_RETURN_FROM_FLUSH_WAIT
+    #ifdef CONFIG_LV_RETURN_FROM_FLUSH_WAIT
+        #define LV_RETURN_FROM_FLUSH_WAIT CONFIG_LV_RETURN_FROM_FLUSH_WAIT
+    #else
+        #define LV_RETURN_FROM_FLUSH_WAIT 0
+    #endif
+#endif
+
+
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #ifndef LV_DPI_DEF


### PR DESCRIPTION
### Description of the feature or fix
There was no reason to have the wait for the buffer flushing called more than a single time during the refresh. I move it so it is being called right away.  

I also removed the else statement in the wait_for_flushing function that would do the spinning wheels and the automatic setting of disp-> flushing to zero if the the flush_wait_cb has been set. The user is able to call the flush ready function from inside of the callback should they want to notify LVGL that the buffer has actually flushed. That is the reason why I removed the else statement that checks to see if the `disp->flushing` flag has been set. This allows the user to use the callback to complete other tasks while a buffer is flushing. 

It leaves it up to the user to decide if that callback is to be used as a way to stall LVGL without having a spinning wheels while the buffer is transferring or if they want to use that callback to do something else like checking pin states on an MCU in the event there is a wait that has to take place.  

The other thing I added was an exit from doing the refresh if using double buffering instead of sitting there spinning it's wheels. for the most part double buffering and DMA memory use go hand in hand. The benefit it to be able to do other things while the buffer is still being transmitted. LVGL causing a stall is wasted processor time. So when is done is the timer duration gets reduced to a 1 so next time lv_task_handler gets called the refresh will check if the buffer has finished and if it has then it will perform the refresh. This allows other things to get processed instead of wasting processor time. This can be enabled or disabled using the LV_RETURN_FROM_FLUSH_WAIT which is in the config template. 

I also changed the refr_now function so it will inform the user if the refresh has completed or not. It will only return false if double buffer is enabled and LV_RETURN_FROM_FLUSH_WAIT is set to 1 and the refresh doesn't complete. Otherwise it will always return true

I also removed the the pausing of the refresh timer as this wasn't doing anything except going to cause an issue because it was backwards. It was set to pause when the performance monitor was running and it was supposed to be the opposite of that. But seeing as how time spent doing a refresh is time spent it should not be paused to begin with. LVGL function fine without pausing it so there is no need to have it there to begin with. I was also unable to locate where the timer was being unpaused as well so if the performance monitor was running it would have caused issues with the refresh occurring when it should be.

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
