### PR TITLE
fix(roller): Avoid divided-by-zero during draw event

### DIFF
--- a/src/widgets/lv_roller.c
+++ b/src/widgets/lv_roller.c
@@ -488,7 +488,10 @@ static void draw_main(lv_event_t * e)
 
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
-            label_y_prop = (label_y_prop << 14) / (lv_obj_get_height(label) - normal_label_font->line_height);
+            lv_coord_t label_h = lv_obj_get_height(label);
+            if ((label_h - normal_label_font->line_height) > 0) {
+                label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
+            }
 
             /*We don't want the selected label start and end exactly where the normal label is as
              *a larger font won't centered on selected area.*/

--- a/src/widgets/lv_roller.c
+++ b/src/widgets/lv_roller.c
@@ -488,9 +488,9 @@ static void draw_main(lv_event_t * e)
 
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
-            lv_coord_t label_h = lv_obj_get_height(label);
-            if((label_h - normal_label_font->line_height) > 0) {
-                label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
+            lv_coord_t remain_h = lv_obj_get_height(label) - normal_label_font->line_height;
+            if(remain_h > 0) {
+                label_y_prop = (label_y_prop << 14) / remain_h;
             }
 
             /*We don't want the selected label start and end exactly where the normal label is as

--- a/src/widgets/lv_roller.c
+++ b/src/widgets/lv_roller.c
@@ -489,7 +489,7 @@ static void draw_main(lv_event_t * e)
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
             lv_coord_t label_h = lv_obj_get_height(label);
-            if ((label_h - normal_label_font->line_height) > 0) {
+            if((label_h - normal_label_font->line_height) > 0) {
                 label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
             }
 


### PR DESCRIPTION
### Description of the feature or fix

(1) height of label on roller
(2) line height of font (on label)

If these values are same, it caused divided-by-zero exception.

