### PR TITLE
fix(display): cancelled screen animation may block input indefinitely

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -602,10 +602,8 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
 
     d->scr_to_load = new_scr;
 
-    if(d->prev_scr && d->del_prev) {
-        lv_obj_delete(d->prev_scr);
-        d->prev_scr = NULL;
-    }
+    if(d->prev_scr && d->del_prev) lv_obj_delete(d->prev_scr);
+    d->prev_scr = NULL;
 
     d->draw_prev_over_act = is_out_anim(anim_type);
     d->del_prev = auto_del;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -211,8 +211,11 @@ void lv_indev_read(lv_indev_t * indev)
     /*Handle reset query before processing the point*/
     indev_proc_reset_query_handler(indev);
 
-    if((indev->enabled == 0) ||
-       (indev->disp->prev_scr != NULL)) return; /*Input disabled or screen animation active*/
+    if(indev->enabled == 0) return;
+    if(indev->disp->prev_scr != NULL) {
+        LV_TRACE_INDEV("input blocked while screen animation active");
+        return;
+    }
 
     LV_PROFILER_BEGIN;
 


### PR DESCRIPTION
When calling `lv_screen_load_anim()` without `auto_del` while the previous screen change is still ongoing, input may end up being blocked indefinitely:

* Input is blocked while `d->prev_scr` is set
* `scr_load_anim_start` sets `d->prev_scr`
* `scr_anim_completed` unsets `d->prev_src`, but this does not happen if the animation is cancelled