### PR TITLE
Avoid divided-by-zero during draw event

### DIFF
--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -475,7 +475,7 @@ static void draw_main(lv_event_t * e)
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
             lv_coord_t label_h = lv_obj_get_height(label);
-            if ((label_h - normal_label_font->line_height) > 0) {
+            if((label_h - normal_label_font->line_height) > 0) {
                 label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
             }
 

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -474,7 +474,7 @@ static void draw_main(lv_event_t * e)
 
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
-            lv_coord_t remain_h = lv_obj_get_height(label) - normal_label_font->line_height;
+            int32_t remain_h = lv_obj_get_height(label) - normal_label_font->line_height;
             if(remain_h > 0) {
                 label_y_prop = (label_y_prop << 14) / remain_h;
             }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -474,9 +474,9 @@ static void draw_main(lv_event_t * e)
 
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
-            lv_coord_t label_h = lv_obj_get_height(label);
-            if((label_h - normal_label_font->line_height) > 0) {
-                label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
+            lv_coord_t remain_h = lv_obj_get_height(label) - normal_label_font->line_height;
+            if(remain_h > 0) {
+                label_y_prop = (label_y_prop << 14) / remain_h;
             }
 
             /*We don't want the selected label start and end exactly where the normal label is as

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -474,7 +474,10 @@ static void draw_main(lv_event_t * e)
 
             /*Proportional position from the middle line.
              *Will be 0 for the first option, and 1 for the last option (upscaled by << 14)*/
-            label_y_prop = (label_y_prop << 14) / (lv_obj_get_height(label) - normal_label_font->line_height);
+            lv_coord_t label_h = lv_obj_get_height(label);
+            if ((label_h - normal_label_font->line_height) > 0) {
+                label_y_prop = (label_y_prop << 14) / (label_h - normal_label_font->line_height);
+            }
 
             /*We don't want the selected label start and end exactly where the normal label is as
              *a larger font won't centered on selected area.*/


### PR DESCRIPTION
### Description of the feature or fix

Cherry-picked from https://github.com/lvgl/lvgl/pull/6259
