### PR TITLE
fix(obj) search child object using dfs(depth-first search)

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -623,7 +623,7 @@ static lv_obj_tree_walk_res_t dump_tree_core(lv_obj_t * obj, int32_t depth)
         for(uint32_t i = 0; i < obj->spec_attr->child_cnt; i++) {
             res = dump_tree_core(lv_obj_get_child(obj, i), depth + 1);
             if(res == LV_OBJ_TREE_WALK_END)
-                break;
+                continue;
         }
         return LV_OBJ_TREE_WALK_NEXT;
     }

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -35,7 +35,7 @@
 static void lv_obj_delete_async_cb(void * obj);
 static void obj_delete_core(lv_obj_t * obj);
 static lv_obj_tree_walk_res_t walk_core(lv_obj_t * obj, lv_obj_tree_walk_cb_t cb, void * user_data);
-static lv_obj_tree_walk_res_t dump_tree_core(lv_obj_t * obj, int32_t depth);
+static void dump_tree_core(lv_obj_t * obj, int32_t depth);
 static lv_obj_t * lv_obj_get_first_not_deleting_child(lv_obj_t * obj);
 
 /**********************
@@ -600,10 +600,8 @@ static lv_obj_tree_walk_res_t walk_core(lv_obj_t * obj, lv_obj_tree_walk_cb_t cb
     return LV_OBJ_TREE_WALK_NEXT;
 }
 
-static lv_obj_tree_walk_res_t dump_tree_core(lv_obj_t * obj, int32_t depth)
+static void dump_tree_core(lv_obj_t * obj, int32_t depth)
 {
-    lv_obj_tree_walk_res_t res;
-
 #if LV_USE_LOG
     const char * id;
 
@@ -621,14 +619,8 @@ static lv_obj_tree_walk_res_t dump_tree_core(lv_obj_t * obj, int32_t depth)
 
     if(obj && obj->spec_attr && obj->spec_attr->child_cnt) {
         for(uint32_t i = 0; i < obj->spec_attr->child_cnt; i++) {
-            res = dump_tree_core(lv_obj_get_child(obj, i), depth + 1);
-            if(res == LV_OBJ_TREE_WALK_END)
-                continue;
+            dump_tree_core(lv_obj_get_child(obj, i), depth + 1);
         }
-        return LV_OBJ_TREE_WALK_NEXT;
-    }
-    else {
-        return LV_OBJ_TREE_WALK_END;
     }
 }
 


### PR DESCRIPTION
Change-Id: I9a8b3dd664e7fb2701feaeb170e77283c28a5ff2

### Description of the feature or fix

To support the object dump function, all children of an object are searched using a depth-first search method. however, When the first leaf node is encountered, the for statement is exited using a break statement and the sibling node is not searched.
