### PR TITLE
fix(math): fix compile warning

### DIFF
--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -305,7 +305,7 @@ nr1:
     xn = (xn + 1 + x / xn) / 2;
 adj:
 
-    if(xn * xn > x)   /* Correct rounding if necessary */
+    if(xn * xn > (int32_t)x)   /* Correct rounding if necessary */
         xn--;
 
     return xn;


### PR DESCRIPTION


### Description of the feature or fix

```
/Users/neo/projects/lvgl/lv_port_pc_eclipse/lvgl/src/misc/lv_math.c:308:16: warning: comparison of integers of different signs: 'int32_t' (aka 'int') and 'uint32_t' (aka 'unsigned int') [-Wsign-compare]
    if(xn * xn > x)   /* Correct rounding if necessary */
       ~~~~~~~ ^ ~
1 warning generated.
```
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
