### PR TITLE
fix(docs): Fix failing docs build in master since lottie

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -850,7 +850,8 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */libs/thorvg/rapidjson/* \
+                         */libs/thorvg/tvg*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
### Description of the feature or fix

Docs finish building successfully.

Fixes #6262

Thanks @FASTSHIFT for highlighting rapidjson as the source of the issue. #6309

Fix this docs build error:
```
****************
Building
****************
Generate the list of examples
Add translation
Running doxygen

cd "/tmp/tmp3x60_4o4.lvgl_docs" && doxygen Doxyfile
-------------------------------------
Reading Doxygen output
Traceback (most recent call last):
  File "docs/build.py", line 147, in <module>
    doc_builder.run(
  File "/home/liam/lvgl/lvgl/docs/doc_builder.py", line 663, in run
    globals()[compound.attrib['kind'].upper()](
  File "/home/liam/lvgl/lvgl/docs/doc_builder.py", line 494, in __init__
    cls = globals()[member.attrib['kind'].upper()]
KeyError: 'FRIEND'
```

This error happens because Doxygen is run on `src/` and then the docs builder script traverses the XML output, matching certain symbol types in the Doxygen output. Since the script traverses all of the Doxygen output, and Doxygen parses everything in `src/`, the script has to be able to match every kind of symbol in `src/`, including C++ code. The docs build script is designed to handle some C++ keywords like `namespace`, but not `friend`, which was introduced by the dependency `src/libs/thorvg/rapidjson` when Lottie was added.

I attempted to add this to docs_builder.py:
```py
# ignore
class FRIEND(object):
    def __init__(self, *args, **kwargs):
        pass
```

but there were further niche edge cases triggered by rapidjson which seemed too much to support in the script.

So my solution was to exclude rapidjson (and tvg*) from the Doxygen parse.

in `docs/Doxyfile`:
```
EXCLUDE_PATTERNS       = */libs/thorvg/rapidjson/* \
                         */libs/thorvg/tvg*
```

Exclude rapidjson and files that start with "tvg", but keep thorvg_capi.h.

The reason I had to use a leading wildcard is because the paths are relative to the tempdir where Doxygen is invoked, while those source directories are not in that tempdir, so I cannot use a rel path or an abspath without knowing about the host's file system organization.

#### Drawbacks

1. This is kind of hidden away in a large - otherwise default - Doxyfile and might be hard for someone to find if more paths need to be added or removed.

2. An HTML page for rapidjson is still generated and it has a warning box. ![image](https://github.com/lvgl/lvgl/assets/30486941/b4fec15d-9e24-4c10-af29-9dec86889b78)
   It's mostly harmless. Someone viewing the docs would not be disturbed by this too much, since it's out of the way in the API/libs/... section.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
