### PR TITLE
perf(draw): improve execute time of transforming widget

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -781,6 +781,12 @@ void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive
 void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, bool recursive,
                                  bool inv)
 {
+    int32_t angle = lv_obj_get_style_transform_rotation(obj, 0);
+    int32_t scale_x = lv_obj_get_style_transform_scale_x_safe(obj, 0);
+    int32_t scale_y = lv_obj_get_style_transform_scale_y_safe(obj, 0);
+
+    if(angle == 0 && scale_x == LV_SCALE_NONE && scale_y == LV_SCALE_NONE) return;
+
     lv_point_t p[4] = {
         {area->x1, area->y1},
         {area->x1, area->y2},


### PR DESCRIPTION
Change-Id: I7fb91f884dc23c01f38e074bf13a666ca39d7293

I think,
if obj doesn't have any transform, there is no benefit to execute lv_obj_get_transformed_area(), however it result in increasing  execute time. 
also, eventually, transform_point function check that obj has any transform and  if there isn't any transform, just return, do nothing. 

In order to avoid performing unnecessary lv_obj_transform_point functions, the condition for determining whether a transform has been applied to an object has been moved a little forward.

Please review whether there are any parts that may cause problems when the condition that determines whether or not to perform the transform is moved to the front.

in my case, 
after applying this patch, improve execute time of lv_obj_get_transformed_area function from 147.4us to 13.9us
Although the difference in the execution time of the function is minimal, it is believed that there will be an improvement effect if the function is performed repeatedly.