### PR TITLE
fix(scale): fix the issue of needle sliding in scale

### DIFF
--- a/examples/widgets/scale/lv_example_scale_3.c
+++ b/examples/widgets/scale/lv_example_scale_3.c
@@ -80,9 +80,6 @@ void lv_example_scale_3(void)
     lv_scale_set_angle_range(scale_img, 270);
     lv_scale_set_rotation(scale_img, 135);
 
-    /* so the needle image cannot be scrolled*/
-    lv_obj_remove_flag(scale_img, LV_OBJ_FLAG_SCROLLABLE);
-
     /* image must point to the right. E.g. -O------>*/
     needle_img = lv_image_create(scale_img);
     lv_image_set_src(needle_img, &img_hand);

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -437,6 +437,8 @@ static void lv_scale_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     scale->custom_label_cnt = 0U;
     scale->txt_src = NULL;
 
+    lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
+
     LV_TRACE_OBJ_CREATE("finished");
 }
 


### PR DESCRIPTION
### Description of the feature or fix

@liamHowatt @C47D

#6320 fixed the sliding issue of lv_example_scale_3(). But I found that in lv_demo_widgets(), this issue still occurs when the window is maximized first and then zoomed out (see video below).Therefore, it is best to integrate directly into `lv_scale_set_image needle_value`

https://github.com/lvgl/lvgl/assets/18370433/fa49cabe-95a2-4f73-bc0e-2bb5f0d35ac1



### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
