### PR TITLE
perf(vg_lite): invert the vector font Y axis coordinate in advance

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -255,9 +255,6 @@ static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_
     /* scale size */
     vg_lite_scale(scale, scale, &matrix);
 
-    /* Cartesian coordinates to LCD coordinates */
-    lv_vg_lite_matrix_flip_y(&matrix);
-
     /* calc inverse matrix */
     vg_lite_matrix_t result;
     if(!lv_vg_lite_matrix_inverse(&result, &matrix)) {
@@ -305,23 +302,28 @@ static void vg_lite_outline_push(const lv_freetype_outline_event_param_t * param
 
     lv_freetype_outline_type_t type = param->type;
     switch(type) {
+
+        /**
+         * Reverse the Y-axis coordinate direction to achieve
+         * the conversion from Cartesian coordinate system to LCD coordinate system
+         */
         case LV_FREETYPE_OUTLINE_END:
             lv_vg_lite_path_end(outline);
             break;
         case LV_FREETYPE_OUTLINE_MOVE_TO:
-            lv_vg_lite_path_move_to(outline, param->to.x, param->to.y);
+            lv_vg_lite_path_move_to(outline, param->to.x, -param->to.y);
             break;
         case LV_FREETYPE_OUTLINE_LINE_TO:
-            lv_vg_lite_path_line_to(outline, param->to.x, param->to.y);
+            lv_vg_lite_path_line_to(outline, param->to.x, -param->to.y);
             break;
         case LV_FREETYPE_OUTLINE_CUBIC_TO:
-            lv_vg_lite_path_cubic_to(outline, param->control1.x, param->control1.y,
-                                     param->control2.x, param->control2.y,
-                                     param->to.x, param->to.y);
+            lv_vg_lite_path_cubic_to(outline, param->control1.x, -param->control1.y,
+                                     param->control2.x, -param->control2.y,
+                                     param->to.x, -param->to.y);
             break;
         case LV_FREETYPE_OUTLINE_CONIC_TO:
-            lv_vg_lite_path_quad_to(outline, param->control1.x, param->control1.y,
-                                    param->to.x, param->to.y);
+            lv_vg_lite_path_quad_to(outline, param->control1.x, -param->control1.y,
+                                    param->to.x, -param->to.y);
             break;
         default:
             LV_LOG_ERROR("unknown point type: %d", type);

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -964,11 +964,6 @@ void lv_vg_lite_matrix_multiply(vg_lite_matrix_t * matrix, const vg_lite_matrix_
     lv_memcpy(matrix, &temp, sizeof(temp));
 }
 
-void lv_vg_lite_matrix_flip_y(vg_lite_matrix_t * matrix)
-{
-    matrix->m[1][1] = -matrix->m[1][1];
-}
-
 bool lv_vg_lite_matrix_inverse(vg_lite_matrix_t * result, const vg_lite_matrix_t * matrix)
 {
     vg_lite_float_t det00, det01, det02;

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -159,8 +159,6 @@ bool lv_vg_lite_16px_align(void);
 
 void lv_vg_lite_matrix_multiply(vg_lite_matrix_t * matrix, const vg_lite_matrix_t * mult);
 
-void lv_vg_lite_matrix_flip_y(vg_lite_matrix_t * matrix);
-
 bool lv_vg_lite_matrix_inverse(vg_lite_matrix_t * result, const vg_lite_matrix_t * matrix);
 
 lv_point_precise_t lv_vg_lite_matrix_transform_point(const vg_lite_matrix_t * matrix, const lv_point_precise_t * point);


### PR DESCRIPTION
### Description of the feature or fix

Invert the Y axis coordinate in advance.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
