### PR TITLE
fix(nuttx): fix build warning using nuttx

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -83,9 +83,11 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         }
 
         switch(layer->color_format) {
+#if LV_DRAW_SW_SUPPORT_RGB565
             case LV_COLOR_FORMAT_RGB565:
                 lv_draw_sw_blend_color_to_rgb565(&fill_dsc);
                 break;
+#endif
 #if LV_DRAW_SW_SUPPORT_ARGB8888
             case LV_COLOR_FORMAT_ARGB8888:
                 lv_draw_sw_blend_color_to_argb8888(&fill_dsc);

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -160,6 +160,13 @@ void lv_draw_sw_transform(lv_draw_unit_t * draw_unit, const lv_area_t * dest_are
     int32_t xs_ups = 0, ys_ups = 0, ys_ups_start = 0, ys_step_256_original = 0;
     int32_t xs_step_256 = 0, ys_step_256 = 0;
 
+    /*When some of the color formats are disabled, these variables could be unused, avoid warning here*/
+    LV_UNUSED(aa);
+    LV_UNUSED(xs_ups);
+    LV_UNUSED(ys_ups);
+    LV_UNUSED(xs_step_256);
+    LV_UNUSED(ys_step_256);
+
     /*If scaled only make some simplification to avoid rounding errors.
      *For example if there is a 100x100 image zoomed to 300%
      *The destination area in X will be x1=0; x2=299


### PR DESCRIPTION

### Description of the feature or fix

Fix several warnings about unused variable when all LV_DRAW_SW_SUPPORT_XXXX is disabled(this is wrong).

NuttX has copied Kconfig file from lvgl, thus configuration is wrong.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
