### PR TITLE
fix(fs_littlefs): fix maybe-uninitialized warning

### DIFF
--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -67,7 +67,7 @@ void lv_fs_littlefs_init(void)
  */
 static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
 {
-    int flags;
+    int flags = 0;
     if(mode == LV_FS_MODE_WR)
         flags = LFS_O_WRONLY;
     else if(mode == LV_FS_MODE_RD)
@@ -152,7 +152,7 @@ static lv_fs_res_t fs_write(lv_fs_drv_t * drv, void * file_p, const void * buf, 
  */
 static lv_fs_res_t fs_seek(lv_fs_drv_t * drv, void * file_p, uint32_t pos, lv_fs_whence_t whence)
 {
-    int mode;
+    int mode = 0;
     if(whence == LV_FS_SEEK_SET)
         mode = LFS_SEEK_SET;
     else if(whence == LV_FS_SEEK_CUR)


### PR DESCRIPTION
'mode' may be used uninitialized [-Wmaybe-uninitialized]; 
'flags' may be used uninitialized [-Wmaybe-uninitialized]
