### PR TITLE
fix(sdl): fix draw buffer misalignment

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -15,6 +15,10 @@
 #include "../../display/lv_display_private.h"
 #include "../../lv_init.h"
 
+/* for aligned_alloc */
+#define __USE_ISOC11
+#include <stdlib.h>
+
 #define SDL_MAIN_HANDLED /*To fix SDL's "undefined reference to WinMain" issue*/
 #include LV_SDL_INCLUDE_PATH
 
@@ -56,6 +60,8 @@ static void window_update(lv_display_t * disp);
 #if LV_USE_DRAW_SDL == 0
     static void texture_resize(lv_display_t * disp);
 #endif
+static void * sdl_draw_buf_realloc_aligned(void * ptr, size_t new_size);
+static void sdl_draw_buf_free(void * ptr);
 static void sdl_event_handler(lv_timer_t * t);
 static void release_disp_cb(lv_event_t * e);
 
@@ -120,9 +126,9 @@ lv_display_t * lv_sdl_window_create(int32_t hor_res, int32_t ver_res)
 
 #if LV_USE_DRAW_SDL == 0
     if(sdl_render_mode() == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        dsc->buf1 = malloc(32 * 1024);
+        dsc->buf1 = sdl_draw_buf_realloc_aligned(NULL, 32 * 1024);
 #if LV_SDL_BUF_COUNT == 2
-        dsc->buf2 = malloc(32 * 1024);
+        dsc->buf2 = sdl_draw_buf_realloc_aligned(NULL, 32 * 1024);
 #endif
         lv_display_set_buffers(disp, dsc->buf1, dsc->buf2,
                                32 * 1024, LV_DISPLAY_RENDER_MODE_PARTIAL);
@@ -232,7 +238,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 
             /* (Re)allocate temporary buffer if needed */
             if(!dsc->rotated_buf || dsc->rotated_buf_size != buf_size) {
-                dsc->rotated_buf = realloc(dsc->rotated_buf, buf_size);
+                dsc->rotated_buf = sdl_draw_buf_realloc_aligned(dsc->rotated_buf, buf_size);
                 dsc->rotated_buf_size = buf_size;
             }
 
@@ -397,7 +403,7 @@ static void texture_resize(lv_display_t * disp)
     uint32_t stride = lv_draw_buf_width_to_stride(disp->hor_res, lv_display_get_color_format(disp));
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
 
-    dsc->fb1 = realloc(dsc->fb1, stride * disp->ver_res);
+    dsc->fb1 = sdl_draw_buf_realloc_aligned(dsc->fb1, stride * disp->ver_res);
     lv_memzero(dsc->fb1, stride * disp->ver_res);
 
     if(sdl_render_mode() == LV_DISPLAY_RENDER_MODE_PARTIAL) {
@@ -405,7 +411,7 @@ static void texture_resize(lv_display_t * disp)
     }
     else {
 #if LV_SDL_BUF_COUNT == 2
-        dsc->fb2 = realloc(dsc->fb2, stride * disp->ver_res);
+        dsc->fb2 = sdl_draw_buf_realloc_aligned(dsc->fb2, stride * disp->ver_res);
         memset(dsc->fb2, 0x00, stride * disp->ver_res);
 #endif
         lv_display_set_buffers(disp, dsc->fb1, dsc->fb2, stride * disp->ver_res, LV_SDL_RENDER_MODE);
@@ -429,6 +435,31 @@ static void texture_resize(lv_display_t * disp)
     SDL_SetTextureBlendMode(dsc->texture, SDL_BLENDMODE_BLEND);
 }
 #endif
+
+static void * sdl_draw_buf_realloc_aligned(void * ptr, size_t new_size)
+{
+    if(ptr) {
+        sdl_draw_buf_free(ptr);
+    }
+
+    /* No need copy for drawing buffer */
+
+#ifndef _WIN32
+    /* Size must be multiple of align, See: https://en.cppreference.com/w/c/memory/aligned_alloc */
+    return aligned_alloc(LV_DRAW_BUF_ALIGN, LV_ALIGN_UP(new_size, LV_DRAW_BUF_ALIGN));
+#else
+    return _aligned_malloc(LV_ALIGN_UP(new_size, LV_DRAW_BUF_ALIGN), LV_DRAW_BUF_ALIGN);
+#endif /* _WIN32 */
+}
+
+static void sdl_draw_buf_free(void * ptr)
+{
+#ifndef _WIN32
+    free(ptr);
+#else
+    _aligned_free(ptr);
+#endif /* _WIN32 */
+}
 
 static void res_chg_event_cb(lv_event_t * e)
 {
@@ -459,10 +490,10 @@ static void release_disp_cb(lv_event_t * e)
     SDL_DestroyRenderer(dsc->renderer);
     SDL_DestroyWindow(dsc->window);
 #if LV_USE_DRAW_SDL == 0
-    if(dsc->fb1) free(dsc->fb1);
-    if(dsc->fb2) free(dsc->fb2);
-    if(dsc->buf1) free(dsc->buf1);
-    if(dsc->buf2) free(dsc->buf2);
+    if(dsc->fb1) sdl_draw_buf_free(dsc->fb1);
+    if(dsc->fb2) sdl_draw_buf_free(dsc->fb2);
+    if(dsc->buf1) sdl_draw_buf_free(dsc->buf1);
+    if(dsc->buf2) sdl_draw_buf_free(dsc->buf2);
 #endif
     lv_free(dsc);
     lv_display_set_driver_data(disp, NULL);


### PR DESCRIPTION
### Description of the feature or fix

Set `LV_DRAW_BUF_ALIGN` to 64, assertion error occurs:

```bash
[Error] lv_display_set_buffers: Asserted at expression: buf1 == lv_draw_buf_align(buf1, cf) buf1 is not aligned: 0x7fffe823b010 lv_display.c:419
```
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
