### PR TITLE
fix(indev): fix use after free of last hovered object

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -537,6 +537,9 @@ static void obj_delete_core(lv_obj_t * obj)
             if(indev->pointer.last_pressed == obj) {
                 indev->pointer.last_pressed = NULL;
             }
+            if(indev->pointer.last_hovered == obj) {
+                indev->pointer.last_hovered = NULL;
+            }
         }
 
         if(indev->group == group && obj == lv_indev_get_active_obj()) {

--- a/tests/src/test_cases/test_hover.c
+++ b/tests/src/test_cases/test_hover.c
@@ -81,14 +81,16 @@ void test_hover_basic(void)
 
 void test_hover_delete(void)
 {
-    lv_obj_t * button = lv_button_create(lv_screen_active());
-    lv_obj_set_size(button, 200, 100);
+    for(int i = 0; i < 4; i++) {
+        lv_obj_t * btn = lv_button_create(lv_screen_active());
+        lv_obj_set_size(btn, 200, 100);
 
-    lv_test_indev_wait(50);
-    lv_test_mouse_move_to(50, 50);
-    lv_test_indev_wait(50);
-    lv_obj_delete(button);  /*No crash while deleting the hovered button*/
-    lv_test_indev_wait(50);
+        lv_test_mouse_move_to(i * 10, 50);
+        lv_test_indev_wait(50);
+
+        lv_obj_delete(btn);  /*No crash while deleting the hovered button*/
+        lv_test_indev_wait(50);
+    }
 }
 
 


### PR DESCRIPTION
Expands `test_hover_delete()` to demonstrate a use after free of `indev->pointer.last_hovered`, trying to dispatch `LV_EVENT_HOVER_LEAVE` to a deleted object.

```
==1991549==ERROR: AddressSanitizer: heap-use-after-free on address 0x5070000045b0 at pc 0x63e0827514c7 bp 0x7ffd5543cb40 sp 0x7ffd5543cb30
READ of size 8 at 0x5070000045b0 thread T0
    #0 0x63e0827514c6 in lv_obj_has_class lvgl/src/core/lv_obj.c:290
    #1 0x63e08276868f in lv_obj_send_event lvgl/src/core/lv_obj_event.c:49
    #2 0x63e0828449d7 in indev_proc_release lvgl/src/indev/lv_indev.c:1281
    #3 0x63e0828378eb in indev_pointer_proc lvgl/src/indev/lv_indev.c:680
    #4 0x63e082830dca in lv_indev_read lvgl/src/indev/lv_indev.c:245
[...]
```

Fixed by resetting it just like `indev->pointer.last_pressed`.