### PR TITLE
fix(examples): correct typo in widgets example doc

### DIFF
--- a/examples/widgets/arc/index.rst
+++ b/examples/widgets/arc/index.rst
@@ -4,7 +4,7 @@ Simple Arc
 
 .. lv_example:: widgets/arc/lv_example_arc_1
   :language: c
-  :description: A simple example to demonstrate the use  ofan arc.
+  :description: A simple example to demonstrate the use of an arc.
 
 Loader with Arc
 ---------------


### PR DESCRIPTION


### Description of the feature or fix

Fixes a typo in the widgets example documentation.
