### PR TITLE
fix(Windows): use global lock

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1699,6 +1699,7 @@ menu "LVGL configuration"
 
 		config LV_USE_WINDOWS
 			bool "Use LVGL Windows backend"
+			depends on LV_OS_WINDOWS
 			default n
 
 		config LV_USE_OPENGLES

--- a/docs/integration/driver/windows.rst
+++ b/docs/integration/driver/windows.rst
@@ -97,7 +97,9 @@ Usage
             return -1;
         }
 
+        lv_lock();
         lv_demo_widgets();
+        lv_unlock();
 
         while (1)
         {

--- a/docs/integration/driver/windows.rst
+++ b/docs/integration/driver/windows.rst
@@ -79,6 +79,8 @@ Usage
             return -1;
         }
 
+        lv_lock();
+
         lv_indev_t* pointer_device = lv_windows_acquire_pointer_indev(display);
         if (!pointer_device)
         {
@@ -97,8 +99,8 @@ Usage
             return -1;
         }
 
-        lv_lock();
         lv_demo_widgets();
+
         lv_unlock();
 
         while (1)

--- a/src/drivers/windows/lv_windows_context.c
+++ b/src/drivers/windows/lv_windows_context.c
@@ -471,16 +471,20 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                     return -1;
                 }
 
+                lv_lock();
+
                 lv_windows_window_context_t * context =
                     (lv_windows_window_context_t *)(HeapAlloc(
                                                         GetProcessHeap(),
                                                         HEAP_ZERO_MEMORY,
                                                         sizeof(lv_windows_window_context_t)));
                 if(!context) {
+                    lv_unlock();
                     return -1;
                 }
 
                 if(!SetPropW(hWnd, L"LVGL.Window.Context", (HANDLE)(context))) {
+                    lv_unlock();
                     return -1;
                 }
 
@@ -500,6 +504,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
 
                 context->display_device_object = lv_display_create(0, 0);
                 if(!context->display_device_object) {
+                    lv_unlock();
                     return -1;
                 }
                 RECT request_content_size;
@@ -530,6 +535,8 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                             context->display_device_object);
                 }
 
+                lv_unlock();
+
                 lv_windows_register_touch_window(hWnd, 0);
 
                 lv_windows_enable_child_window_dpi_message(hWnd);
@@ -538,6 +545,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
             }
         case WM_SIZE: {
                 if(wParam != SIZE_MINIMIZED) {
+                    lv_lock();
                     lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                                 lv_windows_get_window_context(hWnd));
                     if(context) {
@@ -591,10 +599,12 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE);
                         }
                     }
+                    lv_unlock();
                 }
                 break;
             }
         case WM_DPICHANGED: {
+                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -617,6 +627,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                         suggested_rect->bottom,
                         SWP_NOZORDER | SWP_NOACTIVATE);
                 }
+                lv_unlock();
 
                 break;
             }
@@ -624,6 +635,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                 return TRUE;
             }
         case WM_DESTROY: {
+                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             RemovePropW(hWnd, L"LVGL.Window.Context"));
                 if(context) {
@@ -637,12 +649,14 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
 
                     HeapFree(GetProcessHeap(), 0, context);
                 }
+                lv_unlock();
 
                 PostQuitMessage(0);
 
                 break;
             }
         default: {
+                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -654,6 +668,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                            wParam,
                            lParam,
                            &lResult)) {
+                        lv_unlock();
                         return lResult;
                     }
                     else if(context->keypad.indev &&
@@ -663,6 +678,7 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                                 wParam,
                                 lParam,
                                 &lResult)) {
+                        lv_unlock();
                         return lResult;
                     }
                     else if(context->encoder.indev &&
@@ -672,9 +688,11 @@ static LRESULT CALLBACK lv_windows_window_message_callback(
                                 wParam,
                                 lParam,
                                 &lResult)) {
+                        lv_unlock();
                         return lResult;
                     }
                 }
+                lv_unlock();
 
                 return DefWindowProcW(hWnd, uMsg, wParam, lParam);
             }

--- a/src/drivers/windows/lv_windows_context.h
+++ b/src/drivers/windows/lv_windows_context.h
@@ -19,6 +19,10 @@ extern "C" {
 
 #if LV_USE_WINDOWS
 
+#if LV_USE_OS != LV_OS_WINDOWS
+#error [lv_windows] LV_OS_WINDOWS is required. Enable it in lv_conf.h (LV_USE_OS LV_OS_WINDOWS)
+#endif
+
 #include <windows.h>
 
 /*********************
@@ -41,7 +45,6 @@ typedef struct _lv_windows_keypad_queue_item_t {
 } lv_windows_keypad_queue_item_t;
 
 typedef struct _lv_windows_keypad_context_t {
-    CRITICAL_SECTION mutex;
     lv_ll_t queue;
     uint16_t utf16_high_surrogate;
     uint16_t utf16_low_surrogate;

--- a/src/drivers/windows/lv_windows_context.h
+++ b/src/drivers/windows/lv_windows_context.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file lv_windows_context.h
  *
  */
@@ -24,6 +24,14 @@ extern "C" {
 #endif
 
 #include <windows.h>
+
+#ifndef CREATE_WAITABLE_TIMER_MANUAL_RESET
+#define CREATE_WAITABLE_TIMER_MANUAL_RESET  0x00000001
+#endif
+
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
 
 /*********************
  *      DEFINES

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -88,7 +88,10 @@ lv_display_t * lv_windows_create_display(
 
 HWND lv_windows_get_display_window_handle(lv_display_t * display)
 {
-    return (HWND)lv_display_get_driver_data(display);
+    lv_lock();
+    void * display_window_handle = lv_display_get_driver_data(display);
+    lv_unlock();
+    return (HWND)display_window_handle;
 }
 
 int32_t lv_windows_zoom_to_logical(int32_t physical, int32_t zoom_level)
@@ -143,13 +146,16 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
         return 0;
     }
 
+    lv_lock();
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
+        lv_unlock();
         return 0;
     }
 
     data->display = context->display_device_object;
+    lv_unlock();
 
     ShowWindow(window_handle, SW_SHOW);
     UpdateWindow(window_handle);

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -88,10 +88,7 @@ lv_display_t * lv_windows_create_display(
 
 HWND lv_windows_get_display_window_handle(lv_display_t * display)
 {
-    lv_lock();
-    void * display_window_handle = lv_display_get_driver_data(display);
-    lv_unlock();
-    return (HWND)display_window_handle;
+    return (HWND)lv_display_get_driver_data(display);
 }
 
 int32_t lv_windows_zoom_to_logical(int32_t physical, int32_t zoom_level)
@@ -146,16 +143,13 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
         return 0;
     }
 
-    lv_lock();
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
-        lv_unlock();
         return 0;
     }
 
     data->display = context->display_device_object;
-    lv_unlock();
 
     ShowWindow(window_handle, SW_SHOW);
     UpdateWindow(window_handle);

--- a/src/drivers/windows/lv_windows_input.c
+++ b/src/drivers/windows/lv_windows_input.c
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file lv_windows_input.c
  *
  */
@@ -68,10 +68,7 @@ static void lv_windows_release_encoder_device_event_callback(lv_event_t * e);
 
 HWND lv_windows_get_indev_window_handle(lv_indev_t * indev)
 {
-    lv_lock();
-    lv_display_t * display = lv_indev_get_display(indev);
-    lv_unlock();
-    return lv_windows_get_display_window_handle(display);
+    return lv_windows_get_display_window_handle(lv_indev_get_display(indev));
 }
 
 lv_indev_t * lv_windows_acquire_pointer_indev(lv_display_t * display)
@@ -81,11 +78,9 @@ lv_indev_t * lv_windows_acquire_pointer_indev(lv_display_t * display)
         return NULL;
     }
 
-    lv_lock();
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
-        lv_unlock();
         return NULL;
     }
 
@@ -116,10 +111,7 @@ lv_indev_t * lv_windows_acquire_pointer_indev(lv_display_t * display)
         }
     }
 
-    lv_indev_t * indev = context->pointer.indev;
-    lv_unlock();
-
-    return indev;
+    return context->pointer.indev;
 }
 
 lv_indev_t * lv_windows_acquire_keypad_indev(lv_display_t * display)
@@ -129,11 +121,9 @@ lv_indev_t * lv_windows_acquire_keypad_indev(lv_display_t * display)
         return NULL;
     }
 
-    lv_lock();
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
-        lv_unlock();
         return NULL;
     }
 
@@ -166,10 +156,7 @@ lv_indev_t * lv_windows_acquire_keypad_indev(lv_display_t * display)
         }
     }
 
-    lv_indev_t * indev = context->keypad.indev;
-    lv_unlock();
-
-    return indev;
+    return context->keypad.indev;
 }
 
 lv_indev_t * lv_windows_acquire_encoder_indev(lv_display_t * display)
@@ -179,11 +166,9 @@ lv_indev_t * lv_windows_acquire_encoder_indev(lv_display_t * display)
         return NULL;
     }
 
-    lv_lock();
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
-        lv_unlock();
         return NULL;
     }
 
@@ -213,10 +198,7 @@ lv_indev_t * lv_windows_acquire_encoder_indev(lv_display_t * display)
         }
     }
 
-    lv_indev_t * indev = context->encoder.indev;
-    lv_unlock();
-
-    return indev;
+    return context->encoder.indev;
 }
 
 /**********************
@@ -227,7 +209,6 @@ static void lv_windows_pointer_driver_read_callback(
     lv_indev_t * indev,
     lv_indev_data_t * data)
 {
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 lv_windows_get_indev_window_handle(indev));
     if(!context) {
@@ -250,7 +231,6 @@ static void lv_windows_release_pointer_device_event_callback(lv_event_t * e)
         return;
     }
 
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
@@ -312,9 +292,6 @@ bool lv_windows_pointer_device_window_message_handler(
     LPARAM lParam,
     LRESULT * plResult)
 {
-    bool handled = true;
-
-    lv_lock();
     switch(uMsg) {
         case WM_MOUSEMOVE: {
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
@@ -424,21 +401,19 @@ bool lv_windows_pointer_device_window_message_handler(
                 break;
             }
         default:
-            handled = false;
+            // Not Handled
+            return false;
     }
-    lv_unlock();
 
-    if(handled) {
-        *plResult = 0;
-    }
-    return handled;
+    // Handled
+    *plResult = 0;
+    return true;
 }
 
 static void lv_windows_keypad_driver_read_callback(
     lv_indev_t * indev,
     lv_indev_data_t * data)
 {
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 lv_windows_get_indev_window_handle(indev));
     if(!context) {
@@ -470,7 +445,6 @@ static void lv_windows_release_keypad_device_event_callback(lv_event_t * e)
         return;
     }
 
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
@@ -584,9 +558,7 @@ bool lv_windows_keypad_device_window_message_handler(
     LRESULT * plResult)
 {
     LV_UNUSED(lParam);
-    bool handled = true;
 
-    lv_lock();
     switch(uMsg) {
         case WM_KEYDOWN:
         case WM_KEYUP: {
@@ -758,21 +730,19 @@ bool lv_windows_keypad_device_window_message_handler(
                 break;
             }
         default:
-            handled = false;
+            // Not Handled
+            return false;
     }
-    lv_unlock();
 
-    if(handled) {
-        *plResult = 0;
-    }
-    return handled;
+    // Handled
+    *plResult = 0;
+    return true;
 }
 
 static void lv_windows_encoder_driver_read_callback(
     lv_indev_t * indev,
     lv_indev_data_t * data)
 {
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 lv_windows_get_indev_window_handle(indev));
     if(!context) {
@@ -796,7 +766,6 @@ static void lv_windows_release_encoder_device_event_callback(lv_event_t * e)
         return;
     }
 
-    /* lv_lock is held by lv_timer_handler */
     lv_windows_window_context_t * context = lv_windows_get_window_context(
                                                 window_handle);
     if(!context) {
@@ -817,9 +786,7 @@ bool lv_windows_encoder_device_window_message_handler(
     LRESULT * plResult)
 {
     LV_UNUSED(lParam);
-    bool handled = true;
 
-    lv_lock();
     switch(uMsg) {
         case WM_MBUTTONDOWN:
         case WM_MBUTTONUP: {
@@ -845,14 +812,13 @@ bool lv_windows_encoder_device_window_message_handler(
                 break;
             }
         default:
-            handled = false;
+            // Not Handled
+            return false;
     }
-    lv_unlock();
 
-    if(handled) {
-        *plResult = 0;
-    }
-    return handled;
+    // Handled
+    *plResult = 0;
+    return true;
 }
 
 #endif // LV_USE_WINDOWS

--- a/src/drivers/windows/lv_windows_input.c
+++ b/src/drivers/windows/lv_windows_input.c
@@ -312,9 +312,11 @@ bool lv_windows_pointer_device_window_message_handler(
     LPARAM lParam,
     LRESULT * plResult)
 {
+    bool handled = true;
+
+    lv_lock();
     switch(uMsg) {
         case WM_MOUSEMOVE: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -350,13 +352,11 @@ bool lv_windows_pointer_device_window_message_handler(
                         context->pointer.point.y = ver_res - 1;
                     }
                 }
-                lv_unlock();
 
                 break;
             }
         case WM_LBUTTONDOWN:
         case WM_LBUTTONUP: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -365,12 +365,10 @@ bool lv_windows_pointer_device_window_message_handler(
                                                  ? LV_INDEV_STATE_PRESSED
                                                  : LV_INDEV_STATE_RELEASED);
                 }
-                lv_unlock();
 
                 break;
             }
         case WM_TOUCH: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -422,18 +420,18 @@ bool lv_windows_pointer_device_window_message_handler(
 
                     lv_windows_close_touch_input_handle(touch_input_handle);
                 }
-                lv_unlock();
 
                 break;
             }
         default:
-            // Not Handled
-            return false;
+            handled = false;
     }
+    lv_unlock();
 
-    // Handled
-    *plResult = 0;
-    return true;
+    if(handled) {
+        *plResult = 0;
+    }
+    return handled;
 }
 
 static void lv_windows_keypad_driver_read_callback(
@@ -586,11 +584,12 @@ bool lv_windows_keypad_device_window_message_handler(
     LRESULT * plResult)
 {
     LV_UNUSED(lParam);
+    bool handled = true;
 
+    lv_lock();
     switch(uMsg) {
         case WM_KEYDOWN:
         case WM_KEYUP: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -649,12 +648,10 @@ bool lv_windows_keypad_device_window_message_handler(
                              : LV_INDEV_STATE_PRESSED));
                     }
                 }
-                lv_unlock();
 
                 break;
             }
         case WM_CHAR: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -697,7 +694,6 @@ bool lv_windows_keypad_device_window_message_handler(
                             LV_INDEV_STATE_RELEASED);
                     }
                 }
-                lv_unlock();
 
                 break;
             }
@@ -720,8 +716,6 @@ bool lv_windows_keypad_device_window_message_handler(
         case WM_IME_STARTCOMPOSITION: {
                 HIMC imm_context_handle = lv_windows_imm_get_context(hWnd);
                 if(imm_context_handle) {
-                    lv_lock();
-
                     lv_obj_t * textarea_object = NULL;
                     lv_obj_t * focused_object = lv_group_get_focused(
                                                     lv_group_get_default());
@@ -758,21 +752,20 @@ bool lv_windows_keypad_device_window_message_handler(
                     lv_windows_imm_release_context(
                         hWnd,
                         imm_context_handle);
-
-                    lv_unlock();
                 }
 
                 *plResult = DefWindowProcW(hWnd, uMsg, wParam, wParam);
                 break;
             }
         default:
-            // Not Handled
-            return false;
+            handled = false;
     }
+    lv_unlock();
 
-    // Handled
-    *plResult = 0;
-    return true;
+    if(handled) {
+        *plResult = 0;
+    }
+    return handled;
 }
 
 static void lv_windows_encoder_driver_read_callback(
@@ -824,11 +817,12 @@ bool lv_windows_encoder_device_window_message_handler(
     LRESULT * plResult)
 {
     LV_UNUSED(lParam);
+    bool handled = true;
 
+    lv_lock();
     switch(uMsg) {
         case WM_MBUTTONDOWN:
         case WM_MBUTTONUP: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
@@ -837,30 +831,28 @@ bool lv_windows_encoder_device_window_message_handler(
                                                  ? LV_INDEV_STATE_PRESSED
                                                  : LV_INDEV_STATE_RELEASED);
                 }
-                lv_unlock();
 
                 break;
             }
         case WM_MOUSEWHEEL: {
-                lv_lock();
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(
                                                             lv_windows_get_window_context(hWnd));
                 if(context) {
                     context->encoder.enc_diff =
                         -(GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA);
                 }
-                lv_unlock();
 
                 break;
             }
         default:
-            // Not Handled
-            return false;
+            handled = false;
     }
+    lv_unlock();
 
-    // Handled
-    *plResult = 0;
-    return true;
+    if(handled) {
+        *plResult = 0;
+    }
+    return handled;
 }
 
 #endif // LV_USE_WINDOWS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,7 @@ endif()
 if(WIN32)
     add_definitions(-DLV_USE_LINUX_FBDEV=0)
     add_definitions(-DLV_USE_WINDOWS=1)
+    add_definitions(-LV_USE_OS=LV_OS_WINDOWS)
 endif()
 
 # disable test targets for build only tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,7 +388,7 @@ endif()
 if(WIN32)
     add_definitions(-DLV_USE_LINUX_FBDEV=0)
     add_definitions(-DLV_USE_WINDOWS=1)
-    add_definitions(-LV_USE_OS=LV_OS_WINDOWS)
+    add_definitions(-DLV_USE_OS=LV_OS_WINDOWS)
 endif()
 
 # disable test targets for build only tests


### PR DESCRIPTION
### Description of the feature or fix

Fixes #6059

Use the LVGL global lock in the Windows backend to control access to data and LVGL APIs shared with the Windows backend thread message callback.

Prevent memory faults, especially when the display is deleted.

CC @MouriNaruto

Fixes #6428

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
