### PR TITLE
fix(draw_buf): fix user defined draw_buf alloc/destroy not paired

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -23,6 +23,8 @@
 #define img_cache_p         (LV_GLOBAL_DEFAULT()->img_cache)
 #define img_header_cache_p  (LV_GLOBAL_DEFAULT()->img_header_cache)
 #define ctx                 (*(lv_nuttx_ctx_image_cache_t **)&LV_GLOBAL_DEFAULT()->nuttx_ctx->image_cache)
+#define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -56,7 +58,7 @@ static void free_cb(void * draw_buf);
 
 void lv_nuttx_image_cache_init(void)
 {
-    lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
+    lv_draw_buf_handlers_t * handlers = image_cache_draw_buf_handlers;
     handlers->buf_malloc_cb = malloc_cb;
     handlers->buf_free_cb = free_cb;
 

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -360,7 +360,7 @@ void lv_bin_decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 
     decoder_data_t * decoder_data = dsc->user_data;
     if(decoder_data && decoder_data->decoded_partial) {
-        lv_draw_buf_destroy(decoder_data->decoded_partial);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded_partial);
         decoder_data->decoded_partial = NULL;
     }
 
@@ -409,7 +409,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         decoded = lv_draw_buf_reshape(decoder_data->decoded_partial, cf_decoded, w_px, 1, LV_STRIDE_AUTO);
         if(decoded == NULL) {
             if(decoder_data->decoded_partial != NULL) {
-                lv_draw_buf_destroy(decoder_data->decoded_partial);
+                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded_partial);
                 decoder_data->decoded_partial = NULL;
             }
             decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, w_px, 1, cf_decoded, LV_STRIDE_AUTO);
@@ -536,8 +536,8 @@ static void free_decoder_data(lv_image_decoder_dsc_t * dsc)
         lv_free(decoder_data->f);
     }
 
-    if(decoder_data->decoded) lv_draw_buf_destroy(decoder_data->decoded);
-    if(decoder_data->decompressed) lv_draw_buf_destroy(decoder_data->decompressed);
+    if(decoder_data->decoded) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded);
+    if(decoder_data->decompressed) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decompressed);
     lv_free(decoder_data->palette);
     lv_free(decoder_data);
     dsc->user_data = NULL;
@@ -644,7 +644,7 @@ static lv_result_t decode_indexed(lv_image_decoder_t * decoder, lv_image_decoder
     decoder_data->decoded = decoded; /*Free when decoder closes*/
     if(dsc->src_type == LV_IMAGE_SRC_FILE && !is_compressed) {
         decoder_data->palette = (void *)palette; /*Free decoder data on close*/
-        lv_draw_buf_destroy(draw_buf_indexed);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, draw_buf_indexed);
     }
 
     return LV_RESULT_OK;
@@ -654,7 +654,7 @@ exit_with_buf:
         decoder_data->palette = NULL;
     }
 
-    if(draw_buf_indexed) lv_draw_buf_destroy(draw_buf_indexed);
+    if(draw_buf_indexed) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, draw_buf_indexed);
     return LV_RESULT_INVALID;
 #else
     LV_UNUSED(stride);
@@ -726,7 +726,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         res = fs_read_file_at(f, sizeof(lv_image_header_t), data, palette_len, &rn);
         if(res != LV_FS_RES_OK || rn != palette_len) {
             LV_LOG_WARN("Read palette failed: %d", res);
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -734,7 +734,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         if(lv_fs_seek(f, 0, LV_FS_SEEK_END) != LV_FS_RES_OK ||
            lv_fs_tell(f, &data_len) != LV_FS_RES_OK) {
             LV_LOG_WARN("Failed to get file to size");
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -744,7 +744,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         res = fs_read_file_at(f, data_offset, data, data_len, &rn);
         if(res != LV_FS_RES_OK || rn != data_len) {
             LV_LOG_WARN("Read indexed image failed: %d", res);
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -785,7 +785,7 @@ static lv_result_t decode_rgb(lv_image_decoder_t * decoder, lv_image_decoder_dsc
     res = fs_read_file_at(f, sizeof(lv_image_header_t), img_data, len, &rn);
     if(res != LV_FS_RES_OK || rn != len) {
         LV_LOG_WARN("Read rgb file failed: %d", res);
-        lv_draw_buf_destroy(decoded);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
         return LV_RESULT_INVALID;
     }
 
@@ -842,7 +842,7 @@ static lv_result_t decode_alpha_only(lv_image_decoder_t * decoder, lv_image_deco
         res = fs_read_file_at(decoder_data->f, sizeof(lv_image_header_t), img_data, file_len, &rn);
         if(res != LV_FS_RES_OK || rn != file_len) {
             LV_LOG_WARN("Read header failed: %d", res);
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
     }
@@ -1104,12 +1104,12 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
         len = lv_rle_decompress(input, input_len, output, out_len, pixel_byte);
         if(len != compressed->decompressed_size) {
             LV_LOG_WARN("Decompress failed: %" LV_PRIu32 ", got: %" LV_PRIu32, out_len, len);
-            lv_draw_buf_destroy(decompressed);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
             return LV_RESULT_INVALID;
         }
 #else
         LV_LOG_WARN("RLE decompress is not enabled");
-        lv_draw_buf_destroy(decompressed);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
         return LV_RESULT_INVALID;
 #endif
     }
@@ -1121,19 +1121,19 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
         len = LZ4_decompress_safe(input, output, input_len, out_len);
         if(len < 0 || (uint32_t)len != compressed->decompressed_size) {
             LV_LOG_WARN("Decompress failed: %" LV_PRId32 ", got: %" LV_PRId32, out_len, len);
-            lv_draw_buf_destroy(decompressed);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
             return LV_RESULT_INVALID;
         }
 #else
         LV_LOG_WARN("LZ4 decompress is not enabled");
-        lv_draw_buf_destroy(decompressed);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
         return LV_RESULT_INVALID;
 #endif
     }
     else {
         LV_UNUSED(img_data);
         LV_LOG_WARN("Unknown compression method: %d", compressed->method);
-        lv_draw_buf_destroy(decompressed);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
         return LV_RESULT_INVALID;
     }
 

--- a/src/libs/bmp/lv_bmp.c
+++ b/src/libs/bmp/lv_bmp.c
@@ -206,7 +206,7 @@ static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         lv_draw_buf_t * reshaped = lv_draw_buf_reshape(decoded, dsc->header.cf, w_px, 1, LV_STRIDE_AUTO);
         if(reshaped == NULL) {
             if(decoded != NULL) {
-                lv_draw_buf_destroy(decoded);
+                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
                 decoded = NULL;
                 dsc->decoded = NULL;
             }
@@ -247,7 +247,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
     bmp_dsc_t * b = dsc->user_data;
     lv_fs_close(&b->f);
     lv_free(dsc->user_data);
-    if(dsc->decoded) lv_draw_buf_destroy((void *)dsc->decoded);
+    if(dsc->decoded) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (void *)dsc->decoded);
 
 }
 

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -192,7 +192,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(decoder, &search_key, decoded, NULL);
 
         if(entry == NULL) {
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
         dsc->cache_entry = entry;
@@ -209,7 +209,8 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
+    if(dsc->args.no_cache ||
+       !lv_image_cache_is_enabled()) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (lv_draw_buf_t *)dsc->decoded);
 }
 
 static uint8_t * read_file(const char * filename, uint32_t * size)
@@ -311,7 +312,7 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
         LV_LOG_WARN("decoding error");
 
         if(decoded) {
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
         }
 
         /* If we get here, the JPEG code has signaled an error.

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -139,13 +139,13 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
         lv_draw_buf_t * adjusted = lv_image_decoder_post_process(dsc, decoded);
         if(adjusted == NULL) {
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
 
         /*The adjusted draw buffer is newly allocated.*/
         if(adjusted != decoded) {
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             decoded = adjusted;
         }
 
@@ -165,7 +165,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(decoder, &search_key, decoded, NULL);
 
         if(entry == NULL) {
-            lv_draw_buf_destroy(decoded);
+            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
             return LV_RESULT_INVALID;
         }
         dsc->cache_entry = entry;
@@ -183,7 +183,8 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
+    if(dsc->args.no_cache ||
+       !lv_image_cache_is_enabled()) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (lv_draw_buf_t *)dsc->decoded);
 }
 
 static uint8_t * alloc_file(const char * filename, uint32_t * size)
@@ -293,7 +294,7 @@ static lv_draw_buf_t * decode_png_file(lv_image_decoder_dsc_t * dsc, const char 
     lv_free(data);
     if(!ret) {
         LV_LOG_ERROR("png decode failed: %s", image.message);
-        lv_draw_buf_destroy(decoded);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
         return NULL;
     }
 

--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5350,7 +5350,7 @@ unsigned lodepng_decode(unsigned char ** out, unsigned * w, unsigned * h,
             return 56; /*unsupported color mode conversion*/
         }
 
-        lv_draw_buf_t * new_buf = lv_draw_buf_create(*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
+        lv_draw_buf_t * new_buf = lv_draw_buf_create_user(image_cache_draw_buf_handlers,*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
         if(new_buf == NULL) {
             state->error = 83; /*alloc fail*/
         }
@@ -5359,13 +5359,13 @@ unsigned lodepng_decode(unsigned char ** out, unsigned * w, unsigned * h,
                                             &state->info_raw, &state->info_png.color, *w, *h);
             
             if (state->error) {
-                lv_draw_buf_destroy(new_buf);
+                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers,new_buf);
                 new_buf = NULL;
             }
         }
 
         *out = (unsigned char*)new_buf;
-        lv_draw_buf_destroy(old_buf);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers,old_buf);
     }
     return state->error;
 }

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -19,6 +19,8 @@
 
 #define DECODER_NAME    "LODEPNG"
 
+#define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -191,13 +193,13 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     lv_draw_buf_t * adjusted = lv_image_decoder_post_process(dsc, decoded);
     if(adjusted == NULL) {
-        lv_draw_buf_destroy(decoded);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
         return LV_RESULT_INVALID;
     }
 
     /*The adjusted draw buffer is newly allocated.*/
     if(adjusted != decoded) {
-        lv_draw_buf_destroy(decoded);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
         decoded = adjusted;
     }
 
@@ -234,7 +236,8 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder);
 
-    if(dsc->args.no_cache || !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
+    if(dsc->args.no_cache ||
+       !lv_image_cache_is_enabled()) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (lv_draw_buf_t *)dsc->decoded);
 }
 
 static lv_draw_buf_t * decode_png_data(const void * png_data, size_t png_data_size)

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -20,6 +20,7 @@
 #define CACHE_NAME  "IMAGE"
 
 #define img_cache_p (LV_GLOBAL_DEFAULT()->img_cache)
+#define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
 
 /**********************
  *      TYPEDEFS
@@ -135,7 +136,7 @@ static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
     /* Destroy the decoded draw buffer if necessary. */
     lv_draw_buf_t * decoded = (lv_draw_buf_t *)entry->decoded;
     if(lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_ALLOCATED)) {
-        lv_draw_buf_destroy(decoded);
+        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
     }
 
     /*Free the duplicated file name*/


### PR DESCRIPTION
### Description of the feature or fix

fix user defined draw_buf alloc/destroy not paired

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
