### PR TITLE
feat(draw_buf): make draw buf API more OOP style

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -85,11 +85,11 @@ lv_draw_buf_handlers_t * lv_draw_buf_get_handlers(void)
 
 uint32_t lv_draw_buf_width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
-    return lv_draw_buf_width_to_stride_user(&default_handlers, w, color_format);
+    return lv_draw_buf_width_to_stride_ex(&default_handlers, w, color_format);
 }
 
-uint32_t lv_draw_buf_width_to_stride_user(const lv_draw_buf_handlers_t * handlers, uint32_t w,
-                                          lv_color_format_t color_format)
+uint32_t lv_draw_buf_width_to_stride_ex(const lv_draw_buf_handlers_t * handlers, uint32_t w,
+                                        lv_color_format_t color_format)
 {
     if(handlers->width_to_stride_cb) return handlers->width_to_stride_cb(w, color_format);
     else return 0;
@@ -97,10 +97,10 @@ uint32_t lv_draw_buf_width_to_stride_user(const lv_draw_buf_handlers_t * handler
 
 void * lv_draw_buf_align(void * data, lv_color_format_t color_format)
 {
-    return lv_draw_buf_align_user(&default_handlers, data, color_format);
+    return lv_draw_buf_align_ex(&default_handlers, data, color_format);
 }
 
-void * lv_draw_buf_align_user(const lv_draw_buf_handlers_t * handlers, void * data, lv_color_format_t color_format)
+void * lv_draw_buf_align_ex(const lv_draw_buf_handlers_t * handlers, void * data, lv_color_format_t color_format)
 {
     if(handlers->align_pointer_cb) return handlers->align_pointer_cb(data, color_format);
     else return NULL;
@@ -267,11 +267,11 @@ lv_result_t lv_draw_buf_init(lv_draw_buf_t * draw_buf, uint32_t w, uint32_t h, l
 
 lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf, uint32_t stride)
 {
-    return lv_draw_buf_create_user(&default_handlers, w, h, cf, stride);
+    return lv_draw_buf_create_ex(&default_handlers, w, h, cf, stride);
 }
 
-lv_draw_buf_t * lv_draw_buf_create_user(const lv_draw_buf_handlers_t * handlers, uint32_t w, uint32_t h,
-                                        lv_color_format_t cf, uint32_t stride)
+lv_draw_buf_t * lv_draw_buf_create_ex(const lv_draw_buf_handlers_t * handlers, uint32_t w, uint32_t h,
+                                      lv_color_format_t cf, uint32_t stride)
 {
     lv_draw_buf_t * draw_buf = lv_malloc_zeroed(sizeof(lv_draw_buf_t));
     LV_ASSERT_MALLOC(draw_buf);
@@ -304,13 +304,13 @@ lv_draw_buf_t * lv_draw_buf_create_user(const lv_draw_buf_handlers_t * handlers,
 
 lv_draw_buf_t * lv_draw_buf_dup(const lv_draw_buf_t * draw_buf)
 {
-    return lv_draw_buf_dup_user(&default_handlers, draw_buf);
+    return lv_draw_buf_dup_ex(&default_handlers, draw_buf);
 }
 
-lv_draw_buf_t * lv_draw_buf_dup_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf)
+lv_draw_buf_t * lv_draw_buf_dup_ex(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf)
 {
     const lv_image_header_t * header = &draw_buf->header;
-    lv_draw_buf_t * new_buf = lv_draw_buf_create_user(handlers, header->w, header->h, header->cf, header->stride);
+    lv_draw_buf_t * new_buf = lv_draw_buf_create_ex(handlers, header->w, header->h, header->cf, header->stride);
     if(new_buf == NULL) return NULL;
 
     new_buf->header.flags = draw_buf->header.flags;

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../misc/lv_types.h"
 #include "../misc/lv_area.h"
 #include "../misc/lv_color.h"
 #include "../stdlib/lv_string.h"
@@ -25,17 +26,6 @@ extern "C" {
 /** Use this value to let LVGL calculate stride automatically */
 #define LV_STRIDE_AUTO 0
 LV_EXPORT_CONST_INT(LV_STRIDE_AUTO);
-
-/**********************
- *      TYPEDEFS
- **********************/
-
-typedef struct {
-    lv_image_header_t header;
-    uint32_t data_size;     /**< Total buf size in bytes */
-    uint8_t * data;
-    void * unaligned_data;  /**< Unaligned address of `data`, used internally by lvgl */
-} lv_draw_buf_t;
 
 /**
  * Stride alignment for draw buffers.
@@ -81,6 +71,10 @@ typedef struct {
         lv_draw_buf_set_flag(&name, LV_IMAGE_FLAGS_MODIFIABLE); \
     } while(0)
 
+/**********************
+ *      TYPEDEFS
+ **********************/
+
 typedef void * (*lv_draw_buf_malloc_cb)(size_t size, lv_color_format_t color_format);
 
 typedef void (*lv_draw_buf_free_cb)(void * draw_buf);
@@ -90,6 +84,14 @@ typedef void * (*lv_draw_buf_align_cb)(void * buf, lv_color_format_t color_forma
 typedef void (*lv_draw_buf_cache_operation_cb)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
+
+struct lv_draw_buf_t {
+    lv_image_header_t header;
+    uint32_t data_size;     /*Total buf size in bytes*/
+    uint8_t * data;
+    void * unaligned_data;  /*Unaligned address of `data`, used internally by lvgl*/
+    const lv_draw_buf_handlers_t * handlers; /* draw buffer alloc/free ops. */
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -137,7 +139,8 @@ lv_draw_buf_handlers_t * lv_draw_buf_get_handlers(void);
 void * lv_draw_buf_align(void * buf, lv_color_format_t color_format);
 
 /**
- * Align the address of a buffer. The buffer needs to be large enough for the real data after alignment
+ * Align the address of a buffer with custom draw buffer handlers.
+ * The buffer needs to be large enough for the real data after alignment
  * @param handlers      the draw buffer handlers
  * @param buf           the data to align
  * @param color_format  the color format of the buffer
@@ -154,30 +157,12 @@ void * lv_draw_buf_align_user(const lv_draw_buf_handlers_t * handlers, void * bu
 void lv_draw_buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
 
 /**
- * Invalidate the cache of the buffer using the user-defined callback
- * @param handlers     the draw buffer handlers
- * @param draw_buf     the draw buffer needs to be invalidated
- * @param area         the area to invalidate in the buffer,
- */
-void lv_draw_buf_invalidate_cache_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf,
-                                       const lv_area_t * area);
-
-/**
  * Flush the cache of the buffer
  * @param draw_buf     the draw buffer needs to be flushed
  * @param area         the area to flush in the buffer,
  *                     use NULL to flush the whole draw buffer address range
  */
 void lv_draw_buf_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
-
-/**
- * Flush the cache of the buffer using the user-defined callback
- * @param handlers     the draw buffer handlers
- * @param draw_buf     the draw buffer needs to be flushed
- * @param area         the area to flush in the buffer,
- */
-void lv_draw_buf_flush_cache_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf,
-                                  const lv_area_t * area);
 
 /**
  * Calculate the stride in bytes based on a width and color format
@@ -295,16 +280,7 @@ lv_draw_buf_t * lv_draw_buf_reshape(lv_draw_buf_t * draw_buf, lv_color_format_t 
  *
  * @param buf       the draw buffer to destroy
  */
-void lv_draw_buf_destroy(lv_draw_buf_t * buf);
-
-/**
- * Destroy a draw buf by free the actual buffer if it's marked as LV_IMAGE_FLAGS_ALLOCATED in header.
- * Then free the lv_draw_buf_t struct.
- *
- * @param handlers  the draw buffer handlers
- * @param buf       the draw buffer to destroy
- */
-void lv_draw_buf_destroy_user(const lv_draw_buf_handlers_t * handlers, lv_draw_buf_t * buf);
+void lv_draw_buf_destroy(lv_draw_buf_t * draw_buf);
 
 /**
  * Return pointer to the buffer at the given coordinates

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -146,7 +146,7 @@ void * lv_draw_buf_align(void * buf, lv_color_format_t color_format);
  * @param color_format  the color format of the buffer
  * @return              the aligned buffer
  */
-void * lv_draw_buf_align_user(const lv_draw_buf_handlers_t * handlers, void * buf, lv_color_format_t color_format);
+void * lv_draw_buf_align_ex(const lv_draw_buf_handlers_t * handlers, void * buf, lv_color_format_t color_format);
 
 /**
  * Invalidate the cache of the buffer
@@ -179,8 +179,8 @@ uint32_t lv_draw_buf_width_to_stride(uint32_t w, lv_color_format_t color_format)
  * @param color_format      the color format
  * @return                  the stride in bytes
  */
-uint32_t lv_draw_buf_width_to_stride_user(const lv_draw_buf_handlers_t * handlers, uint32_t w,
-                                          lv_color_format_t color_format);
+uint32_t lv_draw_buf_width_to_stride_ex(const lv_draw_buf_handlers_t * handlers, uint32_t w,
+                                        lv_color_format_t color_format);
 
 /**
  * Clear an area on the buffer
@@ -230,8 +230,8 @@ lv_draw_buf_t * lv_draw_buf_create(uint32_t w, uint32_t h, lv_color_format_t cf,
  * @param stride    the stride in bytes for image. Use 0 for automatic calculation based on
  *                  w, cf, and global stride alignment configuration.
  */
-lv_draw_buf_t * lv_draw_buf_create_user(const lv_draw_buf_handlers_t * handlers, uint32_t w, uint32_t h,
-                                        lv_color_format_t cf, uint32_t stride);
+lv_draw_buf_t * lv_draw_buf_create_ex(const lv_draw_buf_handlers_t * handlers, uint32_t w, uint32_t h,
+                                      lv_color_format_t cf, uint32_t stride);
 
 /**
  * Duplicate a draw buf with same image size, stride and color format. Copy the image data too.
@@ -246,7 +246,7 @@ lv_draw_buf_t * lv_draw_buf_dup(const lv_draw_buf_t * draw_buf);
  * @param draw_buf  the draw buf to duplicate
  * @return          the duplicated draw buf on success, NULL if failed
  */
-lv_draw_buf_t * lv_draw_buf_dup_user(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf);
+lv_draw_buf_t * lv_draw_buf_dup_ex(const lv_draw_buf_handlers_t * handlers, const lv_draw_buf_t * draw_buf);
 
 /**
  * Initialize a draw buf with the given buffer and parameters. Clear draw buffer flag to zero.

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -369,7 +369,7 @@ void lv_draw_label_iterate_characters(lv_draw_unit_t * draw_unit, const lv_draw_
         if(pos.y > draw_unit->clip_area->y2) break;
     }
 
-    if(draw_letter_dsc._draw_buf) lv_draw_buf_destroy_user(font_draw_buf_handlers, draw_letter_dsc._draw_buf);
+    if(draw_letter_dsc._draw_buf) lv_draw_buf_destroy(draw_letter_dsc._draw_buf);
 
     LV_ASSERT_MEM_INTEGRITY();
 }
@@ -418,7 +418,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
             /*Only check draw buf for bitmap glyph*/
             draw_buf = lv_draw_buf_reshape(dsc->_draw_buf, 0, g.box_w, g.box_h, LV_STRIDE_AUTO);
             if(draw_buf == NULL) {
-                if(dsc->_draw_buf) lv_draw_buf_destroy_user(font_draw_buf_handlers, dsc->_draw_buf);
+                if(dsc->_draw_buf) lv_draw_buf_destroy(dsc->_draw_buf);
 
                 uint32_t h = g.box_h;
                 if(h * g.box_w < 64) h *= 2; /*Alloc a slightly larger buffer*/

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -422,7 +422,7 @@ static void draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  
 
                 uint32_t h = g.box_h;
                 if(h * g.box_w < 64) h *= 2; /*Alloc a slightly larger buffer*/
-                draw_buf = lv_draw_buf_create_user(font_draw_buf_handlers, g.box_w, h, LV_COLOR_FORMAT_A8, LV_STRIDE_AUTO);
+                draw_buf = lv_draw_buf_create_ex(font_draw_buf_handlers, g.box_w, h, LV_COLOR_FORMAT_A8, LV_STRIDE_AUTO);
                 LV_ASSERT_MALLOC(draw_buf);
                 draw_buf->header.h = g.box_h;
                 dsc->_draw_buf = draw_buf;

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -248,8 +248,8 @@ lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_d
             LV_LOG_TRACE("Stride mismatch");
             lv_result_t res = lv_draw_buf_adjust_stride(decoded, stride_expect);
             if(res != LV_RESULT_OK) {
-                lv_draw_buf_t * aligned = lv_draw_buf_create_user(image_cache_draw_buf_handlers, decoded->header.w, decoded->header.h,
-                                                                  decoded->header.cf, stride_expect);
+                lv_draw_buf_t * aligned = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, decoded->header.w, decoded->header.h,
+                                                                decoded->header.cf, stride_expect);
                 if(aligned == NULL) {
                     LV_LOG_ERROR("No memory for Stride adjust.");
                     return NULL;
@@ -273,7 +273,7 @@ lv_draw_buf_t * lv_image_decoder_post_process(lv_image_decoder_dsc_t * dsc, lv_d
             lv_draw_buf_premultiply(decoded);
         }
         else {
-            decoded = lv_draw_buf_dup_user(image_cache_draw_buf_handlers, decoded);
+            decoded = lv_draw_buf_dup_ex(image_cache_draw_buf_handlers, decoded);
             if(decoded == NULL) {
                 LV_LOG_ERROR("No memory for premultiplying.");
                 return NULL;

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -186,8 +186,8 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
     int32_t height = dsc->header.h;
 
     /* create draw buf */
-    lv_draw_buf_t * draw_buf = lv_draw_buf_create_user(image_cache_draw_buf_handlers, width, height, DEST_IMG_FORMAT,
-                                                       LV_STRIDE_AUTO);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, width, height, DEST_IMG_FORMAT,
+                                                     LV_STRIDE_AUTO);
     if(draw_buf == NULL) {
         return LV_RESULT_INVALID;
     }
@@ -258,8 +258,8 @@ static lv_result_t decoder_open_file(lv_image_decoder_t * decoder, lv_image_deco
         return LV_RESULT_INVALID;
     }
 
-    lv_draw_buf_t * draw_buf = lv_draw_buf_create_user(image_cache_draw_buf_handlers, width, height, DEST_IMG_FORMAT,
-                                                       LV_STRIDE_AUTO);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, width, height, DEST_IMG_FORMAT,
+                                                     LV_STRIDE_AUTO);
     if(draw_buf == NULL) {
         lv_fs_close(&file);
         return LV_RESULT_INVALID;

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -294,7 +294,14 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             }
             else {
                 decoded = &decoder_data->c_array;
-                lv_draw_buf_from_image(decoded, image);
+                if(image->header.stride == 0) {
+                    /*If image doesn't have stride, treat it as lvgl v8 legacy image format*/
+                    lv_image_dsc_t tmp = *image;
+                    tmp.header.stride = (tmp.header.w * lv_color_format_get_bpp(cf) + 7) >> 3;
+                    lv_draw_buf_from_image(decoded, &tmp);
+                }
+                else
+                    lv_draw_buf_from_image(decoded, image);
             }
 
             dsc->decoded = decoded;
@@ -361,7 +368,7 @@ void lv_bin_decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 
     decoder_data_t * decoder_data = dsc->user_data;
     if(decoder_data && decoder_data->decoded_partial) {
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded_partial);
+        lv_draw_buf_destroy(decoder_data->decoded_partial);
         decoder_data->decoded_partial = NULL;
     }
 
@@ -410,7 +417,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         decoded = lv_draw_buf_reshape(decoder_data->decoded_partial, cf_decoded, w_px, 1, LV_STRIDE_AUTO);
         if(decoded == NULL) {
             if(decoder_data->decoded_partial != NULL) {
-                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded_partial);
+                lv_draw_buf_destroy(decoder_data->decoded_partial);
                 decoder_data->decoded_partial = NULL;
             }
             decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, w_px, 1, cf_decoded, LV_STRIDE_AUTO);
@@ -537,8 +544,8 @@ static void free_decoder_data(lv_image_decoder_dsc_t * dsc)
         lv_free(decoder_data->f);
     }
 
-    if(decoder_data->decoded) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decoded);
-    if(decoder_data->decompressed) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoder_data->decompressed);
+    if(decoder_data->decoded) lv_draw_buf_destroy(decoder_data->decoded);
+    if(decoder_data->decompressed) lv_draw_buf_destroy(decoder_data->decompressed);
     lv_free(decoder_data->palette);
     lv_free(decoder_data);
     dsc->user_data = NULL;
@@ -645,7 +652,7 @@ static lv_result_t decode_indexed(lv_image_decoder_t * decoder, lv_image_decoder
     decoder_data->decoded = decoded; /*Free when decoder closes*/
     if(dsc->src_type == LV_IMAGE_SRC_FILE && !is_compressed) {
         decoder_data->palette = (void *)palette; /*Free decoder data on close*/
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, draw_buf_indexed);
+        lv_draw_buf_destroy(draw_buf_indexed);
     }
 
     return LV_RESULT_OK;
@@ -655,7 +662,7 @@ exit_with_buf:
         decoder_data->palette = NULL;
     }
 
-    if(draw_buf_indexed) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, draw_buf_indexed);
+    if(draw_buf_indexed) lv_draw_buf_destroy(draw_buf_indexed);
     return LV_RESULT_INVALID;
 #else
     LV_UNUSED(stride);
@@ -727,7 +734,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         res = fs_read_file_at(f, sizeof(lv_image_header_t), data, palette_len, &rn);
         if(res != LV_FS_RES_OK || rn != palette_len) {
             LV_LOG_WARN("Read palette failed: %d", res);
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -735,7 +742,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         if(lv_fs_seek(f, 0, LV_FS_SEEK_END) != LV_FS_RES_OK ||
            lv_fs_tell(f, &data_len) != LV_FS_RES_OK) {
             LV_LOG_WARN("Failed to get file to size");
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -745,7 +752,7 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
         res = fs_read_file_at(f, data_offset, data, data_len, &rn);
         if(res != LV_FS_RES_OK || rn != data_len) {
             LV_LOG_WARN("Read indexed image failed: %d", res);
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
 
@@ -786,7 +793,7 @@ static lv_result_t decode_rgb(lv_image_decoder_t * decoder, lv_image_decoder_dsc
     res = fs_read_file_at(f, sizeof(lv_image_header_t), img_data, len, &rn);
     if(res != LV_FS_RES_OK || rn != len) {
         LV_LOG_WARN("Read rgb file failed: %d", res);
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+        lv_draw_buf_destroy(decoded);
         return LV_RESULT_INVALID;
     }
 
@@ -843,7 +850,7 @@ static lv_result_t decode_alpha_only(lv_image_decoder_t * decoder, lv_image_deco
         res = fs_read_file_at(decoder_data->f, sizeof(lv_image_header_t), img_data, file_len, &rn);
         if(res != LV_FS_RES_OK || rn != file_len) {
             LV_LOG_WARN("Read header failed: %d", res);
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
     }
@@ -1092,7 +1099,7 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
 
     if(out_len > decompressed->data_size) {
         LV_LOG_ERROR("Decompressed size mismatch: %" LV_PRIu32 " > %" LV_PRIu32, out_len, decompressed->data_size);
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+        lv_draw_buf_destroy(decompressed);
         return LV_RESULT_INVALID;
     }
 
@@ -1112,12 +1119,12 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
         len = lv_rle_decompress(input, input_len, output, out_len, pixel_byte);
         if(len != compressed->decompressed_size) {
             LV_LOG_WARN("Decompress failed: %" LV_PRIu32 ", got: %" LV_PRIu32, out_len, len);
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+            lv_draw_buf_destroy(decompressed);
             return LV_RESULT_INVALID;
         }
 #else
         LV_LOG_WARN("RLE decompress is not enabled");
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+        lv_draw_buf_destroy(decompressed);
         return LV_RESULT_INVALID;
 #endif
     }
@@ -1129,19 +1136,19 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
         len = LZ4_decompress_safe(input, output, input_len, out_len);
         if(len < 0 || (uint32_t)len != compressed->decompressed_size) {
             LV_LOG_WARN("Decompress failed: %" LV_PRId32 ", got: %" LV_PRId32, out_len, len);
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+            lv_draw_buf_destroy(decompressed);
             return LV_RESULT_INVALID;
         }
 #else
         LV_LOG_WARN("LZ4 decompress is not enabled");
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+        lv_draw_buf_destroy(decompressed);
         return LV_RESULT_INVALID;
 #endif
     }
     else {
         LV_UNUSED(img_data);
         LV_LOG_WARN("Unknown compression method: %d", compressed->method);
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decompressed);
+        lv_draw_buf_destroy(decompressed);
         return LV_RESULT_INVALID;
     }
 

--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -420,7 +420,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
                 lv_draw_buf_destroy(decoder_data->decoded_partial);
                 decoder_data->decoded_partial = NULL;
             }
-            decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, w_px, 1, cf_decoded, LV_STRIDE_AUTO);
+            decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, w_px, 1, cf_decoded, LV_STRIDE_AUTO);
             if(decoded == NULL) return LV_RESULT_INVALID;
             decoder_data->decoded_partial = decoded; /*Free on decoder close*/
         }
@@ -590,8 +590,8 @@ static lv_result_t decode_indexed(lv_image_decoder_t * decoder, lv_image_decoder
         decoder_data->palette = (void *)palette; /*Need to free when decoder closes*/
 
 #if LV_BIN_DECODER_RAM_LOAD
-        draw_buf_indexed = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
-                                                   dsc->header.stride);
+        draw_buf_indexed = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
+                                                 dsc->header.stride);
         if(draw_buf_indexed == NULL) {
             LV_LOG_ERROR("Draw buffer alloc failed");
             goto exit_with_buf;
@@ -629,9 +629,9 @@ static lv_result_t decode_indexed(lv_image_decoder_t * decoder, lv_image_decoder
 
 #if LV_BIN_DECODER_RAM_LOAD
     /*Convert to ARGB8888, since sw renderer cannot render it directly even it's in RAM*/
-    lv_draw_buf_t * decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h,
-                                                      LV_COLOR_FORMAT_ARGB8888,
-                                                      0);
+    lv_draw_buf_t * decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h,
+                                                    LV_COLOR_FORMAT_ARGB8888,
+                                                    0);
     if(decoded == NULL) {
         LV_LOG_ERROR("No memory for indexed image");
         goto exit_with_buf;
@@ -722,8 +722,8 @@ static lv_result_t load_indexed(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         lv_color_format_t cf = dsc->header.cf;
         lv_fs_file_t * f = decoder_data->f;
-        lv_draw_buf_t * decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
-                                                          dsc->header.stride);
+        lv_draw_buf_t * decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
+                                                        dsc->header.stride);
         if(decoded == NULL) {
             LV_LOG_ERROR("Draw buffer alloc failed");
             return LV_RESULT_INVALID;
@@ -780,8 +780,8 @@ static lv_result_t decode_rgb(lv_image_decoder_t * decoder, lv_image_decoder_dsc
         len += (dsc->header.stride / 2) * dsc->header.h; /*A8 mask*/
     }
 
-    lv_draw_buf_t * decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
-                                                      dsc->header.stride);
+    lv_draw_buf_t * decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, cf,
+                                                    dsc->header.stride);
     if(decoded == NULL) {
         LV_LOG_ERROR("No memory for rgb file read");
         return LV_RESULT_INVALID;
@@ -833,8 +833,8 @@ static lv_result_t decode_alpha_only(lv_image_decoder_t * decoder, lv_image_deco
     lv_draw_buf_t * decoded;
     uint32_t file_len = (uint32_t)dsc->header.stride * dsc->header.h;
 
-    decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, LV_COLOR_FORMAT_A8,
-                                      buf_stride);
+    decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h, LV_COLOR_FORMAT_A8,
+                                    buf_stride);
     if(decoded == NULL) {
         LV_LOG_ERROR("Out of memory");
         return LV_RESULT_INVALID;
@@ -1089,9 +1089,9 @@ static lv_result_t decompress_image(lv_image_decoder_dsc_t * dsc, const lv_image
     LV_UNUSED(input_len);
     LV_UNUSED(out_len);
 
-    lv_draw_buf_t * decompressed = lv_draw_buf_create_user(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h,
-                                                           dsc->header.cf,
-                                                           dsc->header.stride);
+    lv_draw_buf_t * decompressed = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, dsc->header.w, dsc->header.h,
+                                                         dsc->header.cf,
+                                                         dsc->header.stride);
     if(decompressed == NULL) {
         LV_LOG_WARN("No memory for decompressed image, input: %" LV_PRIu32 ", output: %" LV_PRIu32, input_len, out_len);
         return LV_RESULT_INVALID;

--- a/src/libs/bmp/lv_bmp.c
+++ b/src/libs/bmp/lv_bmp.c
@@ -209,7 +209,7 @@ static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
                 decoded = NULL;
                 dsc->decoded = NULL;
             }
-            decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, w_px, 1, dsc->header.cf, LV_STRIDE_AUTO);
+            decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, w_px, 1, dsc->header.cf, LV_STRIDE_AUTO);
             if(decoded == NULL) return LV_RESULT_INVALID;
         }
         else {

--- a/src/libs/bmp/lv_bmp.c
+++ b/src/libs/bmp/lv_bmp.c
@@ -205,7 +205,7 @@ static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         lv_draw_buf_t * reshaped = lv_draw_buf_reshape(decoded, dsc->header.cf, w_px, 1, LV_STRIDE_AUTO);
         if(reshaped == NULL) {
             if(decoded != NULL) {
-                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+                lv_draw_buf_destroy(decoded);
                 decoded = NULL;
                 dsc->decoded = NULL;
             }
@@ -246,7 +246,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
     bmp_dsc_t * b = dsc->user_data;
     lv_fs_close(&b->f);
     lv_free(dsc->user_data);
-    if(dsc->decoded) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (void *)dsc->decoded);
+    if(dsc->decoded) lv_draw_buf_destroy((void *)dsc->decoded);
 
 }
 

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -155,7 +155,7 @@ static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void
     uint16_t box_w = glyph_bitmap->bitmap.width;        /*Width of the bitmap in [px]*/
 
     uint32_t stride = lv_draw_buf_width_to_stride(box_w, LV_COLOR_FORMAT_A8);
-    data->draw_buf = lv_draw_buf_create_user(font_draw_buf_handlers, box_w, box_h, LV_COLOR_FORMAT_A8, stride);
+    data->draw_buf = lv_draw_buf_create_ex(font_draw_buf_handlers, box_w, box_h, LV_COLOR_FORMAT_A8, stride);
 
     for(int y = 0; y < box_h; ++y) {
         lv_memcpy((uint8_t *)(data->draw_buf->data) + y * stride, glyph_bitmap->bitmap.buffer + y * box_w,

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -171,7 +171,7 @@ static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void
 static void freetype_image_free_cb(lv_freetype_image_cache_data_t * data, void * user_data)
 {
     LV_UNUSED(user_data);
-    lv_draw_buf_destroy_user(font_draw_buf_handlers, data->draw_buf);
+    lv_draw_buf_destroy(data->draw_buf);
 }
 static lv_cache_compare_res_t freetype_image_compare_cb(const lv_freetype_image_cache_data_t * lhs,
                                                         const lv_freetype_image_cache_data_t * rhs)

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -186,7 +186,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(decoder, &search_key, decoded, NULL);
 
         if(entry == NULL) {
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
             return LV_RESULT_INVALID;
         }
         dsc->cache_entry = entry;
@@ -204,7 +204,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
     LV_UNUSED(decoder); /*Unused*/
 
     if(dsc->args.no_cache ||
-       !lv_image_cache_is_enabled()) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (lv_draw_buf_t *)dsc->decoded);
+       !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
 }
 
 static uint8_t * read_file(const char * filename, uint32_t * size)
@@ -306,7 +306,7 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
         LV_LOG_WARN("decoding error");
 
         if(decoded) {
-            lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+            lv_draw_buf_destroy(decoded);
         }
 
         /* If we get here, the JPEG code has signaled an error.

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -368,8 +368,8 @@ static lv_draw_buf_t * decode_jpeg_file(const char * filename)
              ((j_common_ptr) &cinfo, JPOOL_IMAGE, row_stride, 1);
     uint32_t buf_width = (image_angle % 180) ? cinfo.output_height : cinfo.output_width;
     uint32_t buf_height = (image_angle % 180) ? cinfo.output_width : cinfo.output_height;
-    decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, buf_width, buf_height, LV_COLOR_FORMAT_RGB888,
-                                      LV_STRIDE_AUTO);
+    decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, buf_width, buf_height, LV_COLOR_FORMAT_RGB888,
+                                    LV_STRIDE_AUTO);
     if(decoded != NULL) {
         uint32_t line_index = 0;
         /* while (scan lines remain to be read) */

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -297,7 +297,7 @@ static lv_draw_buf_t * decode_png(lv_image_decoder_dsc_t * dsc)
 
     /*Alloc image buffer*/
     lv_draw_buf_t * decoded;
-    decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, image.width, image.height, cf, LV_STRIDE_AUTO);
+    decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, image.width, image.height, cf, LV_STRIDE_AUTO);
     if(decoded == NULL) {
 
         if(dsc->src_type == LV_IMAGE_SRC_FILE) {

--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5790,7 +5790,7 @@ static void decodeGeneric(unsigned char ** out, unsigned * w, unsigned * h,
     lodepng_free(idat);
 
     if(!state->error) {
-        lv_draw_buf_t * decoded = lv_draw_buf_create_user(image_cache_draw_buf_handlers, *w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
+        lv_draw_buf_t * decoded = lv_draw_buf_create_ex(image_cache_draw_buf_handlers, *w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
         if(decoded) {
             *out = (unsigned char*)decoded;
             outsize = decoded->data_size;

--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5840,13 +5840,13 @@ unsigned lodepng_decode(unsigned char ** out, unsigned * w, unsigned * h,
                                             &state->info_raw, &state->info_png.color, *w, *h);
 
             if (state->error) {
-                lv_draw_buf_destroy_user(image_cache_draw_buf_handlers,new_buf);
+                lv_draw_buf_destroy(new_buf);
                 new_buf = NULL;
             }
         }
 
         *out = (unsigned char*)new_buf;
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers,old_buf);
+        lv_draw_buf_destroy(old_buf);
     }
     return state->error;
 }

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -176,13 +176,13 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     lv_draw_buf_t * adjusted = lv_image_decoder_post_process(dsc, decoded);
     if(adjusted == NULL) {
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+        lv_draw_buf_destroy(decoded);
         return LV_RESULT_INVALID;
     }
 
     /*The adjusted draw buffer is newly allocated.*/
     if(adjusted != decoded) {
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+        lv_draw_buf_destroy(decoded);
         decoded = adjusted;
     }
 
@@ -220,7 +220,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
     LV_UNUSED(decoder);
 
     if(dsc->args.no_cache ||
-       !lv_image_cache_is_enabled()) lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, (lv_draw_buf_t *)dsc->decoded);
+       !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
 }
 
 static lv_draw_buf_t * decode_png_data(const void * png_data, size_t png_data_size)

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -519,7 +519,7 @@ static bool tiny_ttf_draw_data_cache_create_cb(tiny_ttf_cache_data_t * node, voi
     w = x2 - x1 + 1;
     h = y2 - y1 + 1;
 
-    lv_draw_buf_t * draw_buf = lv_draw_buf_create_user(font_draw_buf_handlers, w, h, LV_COLOR_FORMAT_A8, LV_STRIDE_AUTO);
+    lv_draw_buf_t * draw_buf = lv_draw_buf_create_ex(font_draw_buf_handlers, w, h, LV_COLOR_FORMAT_A8, LV_STRIDE_AUTO);
     if(NULL == draw_buf) {
         LV_LOG_ERROR("tiny_ttf: out of memory");
         return false;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -538,7 +538,7 @@ static void tiny_ttf_draw_data_cache_free_cb(tiny_ttf_cache_data_t * node, void 
 {
     LV_UNUSED(user_data);
 
-    lv_draw_buf_destroy_user(font_draw_buf_handlers, node->draw_buf);
+    lv_draw_buf_destroy(node->draw_buf);
 }
 
 static lv_cache_compare_res_t tiny_ttf_draw_data_cache_compare_cb(const tiny_ttf_cache_data_t * lhs,

--- a/src/lv_api_map_v9_0.h
+++ b/src/lv_api_map_v9_0.h
@@ -42,6 +42,15 @@ extern "C" {
 #define LV_DRAW_BUF_DEFINE               LV_DRAW_BUF_DEFINE_STATIC
 
 #define _lv_utils_bsearch                lv_utils_bsearch
+#define lv_draw_buf_align_user           lv_draw_buf_align_ex
+#define lv_draw_buf_create_user          lv_draw_buf_create_ex
+#define lv_draw_buf_width_to_stride_user lv_draw_buf_width_to_stride_ex
+#define lv_draw_buf_dup_user             lv_draw_buf_dup_ex
+
+#define lv_draw_buf_invalidate_cache_user(handlers, drawbuf, area)  lv_draw_buf_invalidate_cache(drawbuf, area)
+#define lv_draw_buf_flush_cache_user(handlers, drawbuf, area)       lv_draw_buf_flush_cache(drawbuf, area)
+#define lv_draw_buf_destroy_user(handlers, drawbuf)                 lv_draw_buf_destroy(drawbuf)
+
 /**********************
  *      MACROS
  **********************/

--- a/src/misc/cache/lv_image_cache.c
+++ b/src/misc/cache/lv_image_cache.c
@@ -137,7 +137,7 @@ static void image_cache_free_cb(lv_image_cache_data_t * entry, void * user_data)
     /* Destroy the decoded draw buffer if necessary. */
     lv_draw_buf_t * decoded = (lv_draw_buf_t *)entry->decoded;
     if(lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_ALLOCATED)) {
-        lv_draw_buf_destroy_user(image_cache_draw_buf_handlers, decoded);
+        lv_draw_buf_destroy(decoded);
     }
 
     /*Free the duplicated file name*/

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -326,6 +326,8 @@ typedef struct lv_glfw_texture_t lv_glfw_texture_t;
 
 typedef uint32_t lv_prop_id_t;
 
+typedef struct lv_draw_buf_t lv_draw_buf_t;
+
 #if LV_USE_OBJ_PROPERTY
 typedef struct lv_property_name_t lv_property_name_t;
 #endif

--- a/src/others/vg_lite_tvg/vg_lite.h
+++ b/src/others/vg_lite_tvg/vg_lite.h
@@ -574,7 +574,7 @@ typedef unsigned int        vg_lite_color_t;
     typedef enum vg_lite_index_endian
     {
         VG_LITE_INDEX_LITTLE_ENDIAN,            /*! Parse the index pixel from low to high,
-                                                 *! when using index1, the parsing order is bit0~bit7. 
+                                                 *! when using index1, the parsing order is bit0~bit7.
                                                  *! when using index2, the parsing order is bit0:1,bit2:3,bit4:5.bit6:7.
                                                  *! when using index4, the parsing order is bit0:3,bit4:7.
                                                  */


### PR DESCRIPTION


### Description of the feature or fix

This is important because once we require to use correct APIs for different kinds of draw buffers, it can be easily misused.
Specially for create/destroy API, misuse it can lead to memory leak if different heap is used.

Add a handler pointer to lv_draw_buf_t so later operations for it can use same set of draw buf APIs. 4bytes compared to image data should be acceptable.

Rename the `_user` suffix to `_ex`, which means an extended sets of API.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
