### PR TITLE
fix(flex): Added null check around flex box pointer

### DIFF
--- a/src/extra/layouts/flex/lv_flex.c
+++ b/src/extra/layouts/flex/lv_flex.c
@@ -288,8 +288,12 @@ static void flex_update(lv_obj_t * cont, void * user_data)
         }
         children_repos(cont, &f, track_first_item, next_track_first_item, abs_x, abs_y, max_main_size, item_gap, &t);
         track_first_item = next_track_first_item;
-        lv_mem_buf_release(t.grow_dsc);
+
+        if(t.grow_dsc) {
+            lv_mem_buf_release(t.grow_dsc);
+        }
         t.grow_dsc = NULL;
+        
         if(rtl && !f.row) {
             *cross_pos -= gap + track_gap;
         }


### PR DESCRIPTION
Added null check around flex grow dsc pointer. This will stop showing 'p is not a known buffer' errors while using flex containers that aren't set to grow.

The better fix would be to add a null check to return immediately inside lv_mem_buf_release, but there are a lot more files that touch that function.