### PR TITLE
chore(scale): fix compile warning

### DIFF
--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -696,11 +696,9 @@ static void scale_calculate_main_compensation(lv_obj_t * obj)
     lv_obj_init_draw_line_dsc(obj, LV_PART_ITEMS, &minor_tick_dsc);
 
     uint32_t tick_idx = 0;
-    uint32_t major_tick_idx = 0;
     for(tick_idx = 0; tick_idx < total_tick_count; tick_idx++) {
 
         const bool is_major_tick = tick_idx % scale->major_tick_every == 0;
-        if(is_major_tick) major_tick_idx++;
 
         const int32_t tick_value = lv_map(tick_idx, 0U, total_tick_count - 1, scale->range_min, scale->range_max);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -198,7 +198,6 @@ if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
         -Werror=float-conversion
         -Werror=strict-aliasing
         -Wno-double-promotion
-        -Wno-unused-but-set-parameter
         -Wno-unreachable-code
     )
 else()


### PR DESCRIPTION


### Description of the feature or fix

```
/Users/neo/projects/lvgl/lv_port_pc_eclipse/lvgl/src/widgets/scale/lv_scale.c:699:14: error: variable 'major_tick_idx' set but not used [-Werror,-Wunused-but-set-variable]
    uint32_t major_tick_idx = 0;
             ^
1 error generated.
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
