### PR TITLE
feat(display): add globle function lv_display_get_render_state

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -443,6 +443,12 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
     disp->render_mode = render_mode;
 }
 
+uint32_t lv_display_get_render_state(lv_display_t * disp);
+{
+    return disp->rendering_in_progress;
+}
+
+
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb)
 {
     if(disp == NULL) disp = lv_display_get_default();

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -443,7 +443,7 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
     disp->render_mode = render_mode;
 }
 
-uint32_t lv_display_get_render_state(lv_display_t * disp);
+uint32_t lv_display_get_render_state(lv_display_t * disp)
 {
     return disp->rendering_in_progress;
 }

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -448,7 +448,6 @@ uint32_t lv_display_get_render_state(lv_display_t * disp);
     return disp->rendering_in_progress;
 }
 
-
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb)
 {
     if(disp == NULL) disp = lv_display_get_default();

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -261,7 +261,6 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
  */
 uint32_t lv_display_get_render_state(lv_display_t * disp);
 
-
 /**
  * Set the flush callback which will be called to copy the rendered image to the display.
  * @param disp      pointer to a display

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -255,6 +255,14 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode);
 
 /**
+ * Get display render state
+ * @param disp              pointer to a display
+ * @return                  state of rendering_in_progress
+ */
+uint32_t lv_display_get_render_state(lv_display_t * disp);
+
+
+/**
  * Set the flush callback which will be called to copy the rendered image to the display.
  * @param disp      pointer to a display
  * @param flush_cb  the flush callback (`px_map` contains the rendered image as raw pixel map and it should be copied to `area` on the display)


### PR DESCRIPTION
### Description of the feature or fix
When I change screen really fast, I need to avoid ERROR Asserted at expression: !disp->rendering_in_progress (Invalidate area is not allowed during rendering.), I need to check rendering_in_progress state, but disp its in lv_display_private.h, if I want to access it without c hearder "lvgl/src/display/lv_display_private.h", it will show error: invalid use of incomplete.
so in this case I suggest to set a globle function 'lv_display_get_render_state' to get rendering_in_progress state


```
/**
 * Get display render state
 * @param disp              pointer to a display
 * @return                  state of rendering_in_progress
 */
uint32_t lv_display_get_render_state(lv_display_t * disp);
```

```
uint32_t lv_display_get_render_state(lv_display_t * disp)
{
    return disp->rendering_in_progress;
}
```
