### PR TITLE
fix(decoder): use unsigned format spec with uint32_t's

### DIFF
--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -126,11 +126,11 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     /* Flush the D-Cache if enabled and the image was successfully opened */
     if(dsc->args.flush_cache && res == LV_RESULT_OK && dsc->decoded != NULL) {
         lv_draw_buf_flush_cache(dsc->decoded, NULL);
-        LV_LOG_INFO("Flushed D-cache: src %p (%s) (W%" LV_PRIu32 " x H%" LV_PRIu32 ", data: %p cf: %d)",
+        LV_LOG_INFO("Flushed D-cache: src %p (%s) (W%d x H%d, data: %p cf: %d)",
                     src,
                     dsc->src_type == LV_IMAGE_SRC_FILE ? (const char *)src : "c-array",
-                    (uint32_t)dsc->decoded->header.w,
-                    (uint32_t)dsc->decoded->header.h,
+                    dsc->decoded->header.w,
+                    dsc->decoded->header.h,
                     (void *)dsc->decoded->data,
                     dsc->decoded->header.cf);
     }

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -126,11 +126,11 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     /* Flush the D-Cache if enabled and the image was successfully opened */
     if(dsc->args.flush_cache && res == LV_RESULT_OK && dsc->decoded != NULL) {
         lv_draw_buf_flush_cache(dsc->decoded, NULL);
-        LV_LOG_INFO("Flushed D-cache: src %p (%s) (W%" LV_PRId32 " x H%" LV_PRId32 ", data: %p cf: %d)",
+        LV_LOG_INFO("Flushed D-cache: src %p (%s) (W%" LV_PRIu32 " x H%" LV_PRIu32 ", data: %p cf: %d)",
                     src,
                     dsc->src_type == LV_IMAGE_SRC_FILE ? (const char *)src : "c-array",
-                    dsc->decoded->header.w,
-                    dsc->decoded->header.h,
+                    (uint32_t)dsc->decoded->header.w,
+                    (uint32_t)dsc->decoded->header.h,
                     (void *)dsc->decoded->data,
                     dsc->decoded->header.cf);
     }


### PR DESCRIPTION
This fixes a pair of incorrect format specifiers introduced with
447f9b8f. The arguments in question — `w` and `h` (members of
`lv_image_header_t`) — are both uint32_t. The incorrect specifiers are
for signed integers.

This caused a compilation failure (`-Werror`) when building with
PlatformIO and the `espidf` framework for ESP32 with LV_LOG_LEVEL_TRACE.

However, I'm a little baffled why the typecasts are necessary. It seems
like these `uint32_t` variables are degrading to `int` after being
rolled up into the `__VA_ARGS__` macro? This may be why no warnings were
triggered with the original specifiers in most other compilers.
Someone more fluent in C would have to explain that one for me.

 #### Environment

```
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp323248s035c.html
PLATFORM: Espressif 32 (6.7.0) > esp323248s035c
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES:
 - framework-espidf @ 3.50201.240515 (5.2.1)
 - tool-cmake @ 3.16.4
 - tool-esptoolpy @ 1.40501.0 (4.5.1)
 - tool-ninja @ 1.7.1
 - tool-riscv32-esp-elf-gdb @ 12.1.0+20221002
 - tool-xtensa-esp-elf-gdb @ 12.1.0+20221002
 - toolchain-esp32ulp @ 1.23500.220830 (2.35.0)
 - toolchain-xtensa-esp-elf @ 13.2.0+20230928
```
