### PR TITLE
chore(vg_lite): remove YUV format processing of vg-lite decoder

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -39,10 +39,6 @@
  *      TYPEDEFS
  **********************/
 
-typedef struct {
-    lv_draw_buf_t yuv;  /*A draw buffer struct for yuv variable image*/
-} decoder_data_t;
-
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -159,10 +155,6 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, 
         return res;
     }
 
-    if(LV_COLOR_FORMAT_IS_YUV(header->cf)) {
-        return LV_RESULT_OK;
-    }
-
     if(!IS_CONV_INDEX_FORMAT(header->cf)) {
         return LV_RESULT_INVALID;
     }
@@ -191,44 +183,22 @@ static lv_result_t decoder_open_variable(lv_image_decoder_t * decoder, lv_image_
     int32_t width = dsc->header.w;
     int32_t height = dsc->header.h;
 
-    /*In case of uncompressed formats the image stored in the ROM/RAM.
-     *So simply give its pointer*/
-    const uint8_t * image_data = ((lv_image_dsc_t *)dsc->src)->data;
-    uint32_t image_data_size = ((lv_image_dsc_t *)dsc->src)->data_size;
-
-    /* if is YUV format, no need to copy */
-    if(LV_COLOR_FORMAT_IS_YUV(src_cf)) {
-        decoder_data_t * decoder_data = dsc->user_data;
-        if(decoder_data == NULL) {
-            decoder_data = lv_malloc_zeroed(sizeof(decoder_data_t));
-            LV_ASSERT_MALLOC(decoder_data);
-        }
-        lv_draw_buf_t * draw_buf = &decoder_data->yuv;
-        uint32_t stride = lv_draw_buf_width_to_stride(width, src_cf);
-        lv_draw_buf_init(draw_buf, width, height, src_cf, stride, (void *)image_data, image_data_size);
-
-        /* Use allocated bit to indicate we should not free the memory */
-        draw_buf->header.flags &= ~LV_IMAGE_FLAGS_ALLOCATED;
-
-        /* Do not add this kind of image to cache, since its life is managed by user. */
-        dsc->args.no_cache = true;
-
-        dsc->decoded = draw_buf;
-        return LV_RESULT_OK;
-    }
-
     /* create draw buf */
     lv_draw_buf_t * draw_buf = lv_draw_buf_create_user(image_cache_draw_buf_handlers, width, height, DEST_IMG_FORMAT,
                                                        LV_STRIDE_AUTO);
     if(draw_buf == NULL) {
         return LV_RESULT_INVALID;
     }
+
+    lv_draw_buf_clear(draw_buf, NULL);
     dsc->decoded = draw_buf;
 
     uint32_t src_stride = image_stride(&src_img_buf.header);
     uint32_t dest_stride = draw_buf->header.stride;
 
-    const uint8_t * src = image_data;
+    /*In case of uncompressed formats the image stored in the ROM/RAM.
+     *So simply give its pointer*/
+    const uint8_t * src = ((lv_image_dsc_t *)dsc->src)->data;
     uint8_t * dest = draw_buf->data;
 
     /* index format only */
@@ -292,6 +262,8 @@ static lv_result_t decoder_open_file(lv_image_decoder_t * decoder, lv_image_deco
         lv_fs_close(&file);
         return LV_RESULT_INVALID;
     }
+
+    lv_draw_buf_clear(draw_buf, NULL);
 
     /* get stride */
     uint32_t src_stride = image_stride(&src_header);
@@ -363,16 +335,6 @@ failed:
     return LV_RESULT_INVALID;
 }
 
-static void decoder_draw_buf_free(lv_draw_buf_t * draw_buf)
-{
-    if((draw_buf->header.flags & LV_IMAGE_FLAGS_ALLOCATED) == 0) {
-        /* This must be the yuv variable image. */
-        return;
-    }
-
-    lv_draw_buf_destroy(draw_buf);
-}
-
 /**
  * Decode an image using the vg_lite gpu.
  * @param decoder pointer to the decoder
@@ -409,7 +371,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(decoder, &search_key, dsc->decoded, NULL);
 
         if(entry == NULL) {
-            decoder_draw_buf_free((lv_draw_buf_t *)dsc->decoded);
+            lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
             dsc->decoded = NULL;
             return LV_RESULT_INVALID;
         }
@@ -423,9 +385,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 {
     LV_UNUSED(decoder); /*Unused*/
 
-    if(dsc->args.no_cache || !lv_image_cache_is_enabled()) decoder_draw_buf_free((lv_draw_buf_t *)dsc->decoded);
-
-    if(decoder->user_data) free(decoder->user_data);
+    if(dsc->args.no_cache || !lv_image_cache_is_enabled()) lv_draw_buf_destroy((lv_draw_buf_t *)dsc->decoded);
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/


### PR DESCRIPTION
### Description of the feature or fix

The bin decoder can directly pass through the YUV data structure, and the vg-lite decoder no longer needs to process it.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
