### PR TITLE
feat(textarea): make textarea editable

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -72,6 +72,7 @@ const lv_obj_class_t lv_textarea_class = {
     .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE,
     .width_def = LV_DPI_DEF * 2,
     .height_def = LV_DPI_DEF,
+    .editable = LV_OBJ_CLASS_EDITABLE_TRUE,
     .instance_size = sizeof(lv_textarea_t),
     .base_class = &lv_obj_class,
     .name = "textarea",


### PR DESCRIPTION
Although currently the textarea is editable, the flag is by default set to LV_OBJ_CLASS_EDITABLE_FALSE.  the problem is that we have a weird (horizontal in our experience) scroll jump in textarea when we move cursor one character to the left or right. This weird behavior comes from the fact that it enters to this block of code:  https://github.com/lvgl/lvgl/blob/c3d4510f843b40d74e2b42ca9ba790892084288e/src/core/lv_obj.c#L652C8-L652C26 which in my opinion should not.
