### PR TITLE
chore: make lv_utils as public and align function prototype with stdlib

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -32,6 +32,7 @@ extern "C" {
 #include "src/misc/lv_anim_timeline.h"
 #include "src/misc/lv_profiler_builtin.h"
 #include "src/misc/lv_rb.h"
+#include "src/misc/lv_utils.h"
 
 #include "src/tick/lv_tick.h"
 

--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -142,13 +142,13 @@ lv_prop_id_t lv_obj_property_get_id(const lv_obj_t * obj, const char * name)
             continue;
         }
 
-        found = _lv_utils_bsearch(name, names, clz->names_count, sizeof(lv_property_name_t), property_name_compare);
+        found = lv_utils_bsearch(name, names, clz->names_count, sizeof(lv_property_name_t), property_name_compare);
         if(found) return found->id;
     }
 
     /*Check style property*/
-    found = _lv_utils_bsearch(name, lv_style_property_names, sizeof(lv_style_property_names) / sizeof(lv_property_name_t),
-                              sizeof(lv_property_name_t), property_name_compare);
+    found = lv_utils_bsearch(name, lv_style_property_names, sizeof(lv_style_property_names) / sizeof(lv_property_name_t),
+                             sizeof(lv_property_name_t), property_name_compare);
     if(found) return found->id;
 #else
     LV_UNUSED(obj);
@@ -254,7 +254,7 @@ static lv_result_t obj_property(lv_obj_t * obj, lv_prop_id_t id, lv_property_t *
     return LV_RESULT_INVALID;
 }
 
-static int32_t property_name_compare(const void * ref, const void * element)
+static int property_name_compare(const void * ref, const void * element)
 {
     const lv_property_name_t * prop = element;
     return lv_strcmp(ref, prop->name);

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -35,9 +35,9 @@ typedef struct {
  **********************/
 static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter);
 static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t gid_right);
-static int32_t unicode_list_compare(const void * ref, const void * element);
-static int32_t kern_pair_8_compare(const void * ref, const void * element);
-static int32_t kern_pair_16_compare(const void * ref, const void * element);
+static int unicode_list_compare(const void * ref, const void * element);
+static int kern_pair_8_compare(const void * ref, const void * element);
+static int kern_pair_16_compare(const void * ref, const void * element);
 
 #if LV_USE_FONT_COMPRESSED
     static void decompress(const uint8_t * in, uint8_t * out, int32_t w, int32_t h, uint8_t bpp, bool prefilter);
@@ -236,8 +236,8 @@ static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter)
         }
         else if(fdsc->cmaps[i].type == LV_FONT_FMT_TXT_CMAP_SPARSE_TINY) {
             uint16_t key = rcp;
-            uint16_t * p = _lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
-                                             sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
+            uint16_t * p = lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
+                                            sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
 
             if(p) {
                 lv_uintptr_t ofs = p - fdsc->cmaps[i].unicode_list;
@@ -246,8 +246,8 @@ static uint32_t get_glyph_dsc_id(const lv_font_t * font, uint32_t letter)
         }
         else if(fdsc->cmaps[i].type == LV_FONT_FMT_TXT_CMAP_SPARSE_FULL) {
             uint16_t key = rcp;
-            uint16_t * p = _lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
-                                             sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
+            uint16_t * p = lv_utils_bsearch(&key, fdsc->cmaps[i].unicode_list, fdsc->cmaps[i].list_length,
+                                            sizeof(fdsc->cmaps[i].unicode_list[0]), unicode_list_compare);
 
             if(p) {
                 lv_uintptr_t ofs = p - fdsc->cmaps[i].unicode_list;
@@ -277,7 +277,7 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
              *The pairs are ordered left_id first, then right_id secondly.*/
             const uint16_t * g_ids = kdsc->glyph_ids;
             kern_pair_ref_t g_id_both = {gid_left, gid_right};
-            uint16_t * kid_p = _lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 2, kern_pair_8_compare);
+            uint16_t * kid_p = lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 2, kern_pair_8_compare);
 
             /*If the `g_id_both` were found get its index from the pointer*/
             if(kid_p) {
@@ -290,7 +290,7 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
              *The pairs are ordered left_id first, then right_id secondly.*/
             const uint32_t * g_ids = kdsc->glyph_ids;
             kern_pair_ref_t g_id_both = {gid_left, gid_right};
-            uint32_t * kid_p = _lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 4, kern_pair_16_compare);
+            uint32_t * kid_p = lv_utils_bsearch(&g_id_both, g_ids, kdsc->pair_cnt, 4, kern_pair_16_compare);
 
             /*If the `g_id_both` were found get its index from the pointer*/
             if(kid_p) {
@@ -319,25 +319,24 @@ static int8_t get_kern_value(const lv_font_t * font, uint32_t gid_left, uint32_t
     return value;
 }
 
-static int32_t kern_pair_8_compare(const void * ref, const void * element)
+static int kern_pair_8_compare(const void * ref, const void * element)
 {
     const kern_pair_ref_t * ref8_p = ref;
     const uint8_t * element8_p = element;
 
     /*If the MSB is different it will matter. If not return the diff. of the LSB*/
-    if(ref8_p->gid_left != element8_p[0]) return (int32_t) ref8_p->gid_left - element8_p[0];
-    else return (int32_t) ref8_p->gid_right - element8_p[1];
-
+    if(ref8_p->gid_left != element8_p[0]) return ref8_p->gid_left - element8_p[0];
+    else return ref8_p->gid_right - element8_p[1];
 }
 
-static int32_t kern_pair_16_compare(const void * ref, const void * element)
+static int kern_pair_16_compare(const void * ref, const void * element)
 {
     const kern_pair_ref_t * ref16_p = ref;
     const uint16_t * element16_p = element;
 
     /*If the MSB is different it will matter. If not return the diff. of the LSB*/
-    if(ref16_p->gid_left != element16_p[0]) return (int32_t) ref16_p->gid_left - element16_p[0];
-    else return (int32_t) ref16_p->gid_right - element16_p[1];
+    if(ref16_p->gid_left != element16_p[0]) return ref16_p->gid_left - element16_p[0];
+    else return ref16_p->gid_right - element16_p[1];
 }
 
 #if LV_USE_FONT_COMPRESSED
@@ -550,7 +549,7 @@ static inline uint8_t rle_next(void)
  *  @retval > 0   Reference is greater than element.
  *
  */
-static int32_t unicode_list_compare(const void * ref, const void * element)
+static int unicode_list_compare(const void * ref, const void * element)
 {
-    return ((int32_t)(*(uint16_t *)ref)) - ((int32_t)(*(uint16_t *)element));
+    return (*(uint16_t *)ref) - (*(uint16_t *)element);
 }

--- a/src/lv_api_map_v9_0.h
+++ b/src/lv_api_map_v9_0.h
@@ -41,6 +41,7 @@ extern "C" {
 
 #define LV_DRAW_BUF_DEFINE               LV_DRAW_BUF_DEFINE_STATIC
 
+#define _lv_utils_bsearch                lv_utils_bsearch
 /**********************
  *      MACROS
  **********************/

--- a/src/misc/lv_utils.c
+++ b/src/misc/lv_utils.c
@@ -35,8 +35,8 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void * _lv_utils_bsearch(const void * key, const void * base, uint32_t n, uint32_t size,
-                         int32_t (*cmp)(const void * pRef, const void * pElement))
+void * lv_utils_bsearch(const void * key, const void * base, size_t n, size_t size,
+                        int (*cmp)(const void * pRef, const void * pElement))
 {
     const char * middle;
     int32_t c;

--- a/src/misc/lv_utils.h
+++ b/src/misc/lv_utils.h
@@ -46,8 +46,8 @@ extern "C" {
  *
  * @return a pointer to a matching item, or NULL if none exists.
  */
-void * _lv_utils_bsearch(const void * key, const void * base, uint32_t n, uint32_t size,
-                         int32_t (*cmp)(const void * pRef, const void * pElement));
+void * lv_utils_bsearch(const void * key, const void * base, size_t n, size_t size,
+                        int (*cmp)(const void * pRef, const void * pElement));
 
 /**
  * Save a draw buf to a file

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -171,7 +171,7 @@ void * LV_ATTRIBUTE_FAST_MEM lv_memmove(void * dst, const void * src, size_t len
     return dst;
 }
 
-int32_t lv_memcmp(const void * p1, const void * p2, size_t len)
+int lv_memcmp(const void * p1, const void * p2, size_t len)
 {
     const char * s1 = (const char *) p1;
     const char * s2 = (const char *) p2;
@@ -223,7 +223,7 @@ char * lv_strcpy(char * dst, const char * src)
     return tmp;
 }
 
-int32_t lv_strcmp(const char * s1, const char * s2)
+int lv_strcmp(const char * s1, const char * s2)
 {
     while(*s1 && (*s1 == *s2)) {
         s1++;

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -50,7 +50,7 @@ void * LV_ATTRIBUTE_FAST_MEM lv_memmove(void * dst, const void * src, size_t len
     return memmove(dst, src, len);
 }
 
-int32_t lv_memcmp(const void * p1, const void * p2, size_t len)
+int lv_memcmp(const void * p1, const void * p2, size_t len)
 {
     return memcmp(p1, p2, len);
 }
@@ -81,7 +81,7 @@ char * lv_strcpy(char * dst, const char * src)
     return strcpy(dst, src);
 }
 
-int32_t lv_strcmp(const char * s1, const char * s2)
+int lv_strcmp(const char * s1, const char * s2)
 {
     return strcmp(s1, s2);
 }

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -63,7 +63,7 @@ void * lv_memmove(void * dst, const void * src, size_t len);
  * @param len Number of bytes to compare
  * @return The difference between the value of the first unmatching byte.
  */
-int32_t lv_memcmp(const void * p1, const void * p2, size_t len);
+int lv_memcmp(const void * p1, const void * p2, size_t len);
 
 /**
  * Same as `memset(dst, 0x00, len)`.
@@ -117,7 +117,7 @@ char * lv_strcpy(char * dst, const char * src);
  * @param s2    pointer to the second string
  * @return      the difference between the value of the first unmatching character.
  */
-int32_t lv_strcmp(const char * s1, const char * s2);
+int lv_strcmp(const char * s1, const char * s2);
 
 /**
  * @brief Duplicate a string by allocating a new one and copying the content.

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -55,7 +55,7 @@ size_t lv_strlen(const char * str)
     return rt_strlen(str);
 }
 
-int32_t lv_memcmp(const void * p1, const void * p2, size_t len)
+int lv_memcmp(const void * p1, const void * p2, size_t len)
 {
     return rt_memcmp(p1, p2, len);
 }
@@ -81,7 +81,7 @@ char * lv_strcpy(char * dst, const char * src)
     return rt_strcpy(dst, src);
 }
 
-int32_t lv_strcmp(const char * s1, const char * s2)
+int lv_strcmp(const char * s1, const char * s2)
 {
     return rt_strcmp(s1, s2);
 }


### PR DESCRIPTION
### Description of the feature or fix

1. chore(stdlib): use int as return type for strcmp and memcmp
    To keep the prototype same as stdlib
2.  chore(utils): make utils public
_lv_utils_bsearch has been renamed to lv_utils_bsearch for public usage. Function prototype is same as bsearch


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
