### PR TITLE
feat(tests): add performance report action cleanup and refactor

### DIFF
--- a/.github/workflows/check_perf.yml
+++ b/.github/workflows/check_perf.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Find previous successful run
         id: prev_success_run
         run: |
-          wget ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/52959381/runs
+          wget ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/53635437/runs
           echo "ID=$(python3 lvgl/scripts/last_success_run_id.py runs)" >> "$GITHUB_OUTPUT"
 
       - name: Retrieve previous successful run performance data

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -1,11 +1,12 @@
 
 include_directories(.)
 
-add_executable(prof_test.elf prof_test.c)
+add_executable(prof_test.elf prof_test.c instr_func.c)
 target_compile_options(prof_test.elf PUBLIC -g)
 
 add_library(prof_test_p.a STATIC prof_test_p.c)
-target_compile_options(prof_test_p.a PRIVATE -pg)
+target_compile_options(prof_test_p.a PRIVATE -g)
+target_compile_options(prof_test_p.a PRIVATE -finstrument-functions)
 
 target_link_libraries(prof_test.elf c)
 target_link_libraries(prof_test.elf prof_test_p.a)

--- a/tests/perf/instr_func.c
+++ b/tests/perf/instr_func.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <time.h>
+
+void __cyg_profile_func_enter (void *this_fn, void *call_site)
+{
+    struct timespec ts;
+	// Get timestamp
+	clock_gettime(CLOCK_REALTIME, &ts);
+	// Write timestamp with identifier
+	printf("prof > %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
+}
+
+void __cyg_profile_func_exit  (void *this_fn, void *call_site)
+{
+    struct timespec ts;
+	// Get timestamp
+	clock_gettime(CLOCK_REALTIME, &ts);
+	// Write timestamp with identifier
+	printf("prof < %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
+}

--- a/tests/perf/instr_func.c
+++ b/tests/perf/instr_func.c
@@ -3,6 +3,15 @@
 #include <stdint.h>
 #include <time.h>
 
+/**
+ * Entry function for function instrumentation
+ * This functions will be called at the start of an instrumented function's execution 
+ * (see gcc's "-finstrument functions" flag) and provided with the address
+ * of the instrumented function (this_fn) and the address where this function
+ * was called from in the parent function (call_site)
+ * 
+ * Prints a message to timestamp the entry time of the instrumented function
+ */
 void __cyg_profile_func_enter(void * this_fn, void * call_site)
 {
     struct timespec ts;
@@ -12,6 +21,15 @@ void __cyg_profile_func_enter(void * this_fn, void * call_site)
     printf("prof > %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
 }
 
+/**
+ * Exit function for function instrumentation
+ * This functions will be called at the end of an instrumented function's execution
+ * (see gcc's "-finstrument functions" flag) and provided with the address
+ * of the instrumented function (this_fn) and the address where this function
+ * was called from in the parent function (call_site)
+ * 
+ * Prints a message to timestamp the exit time of the instrumented function
+ */
 void __cyg_profile_func_exit(void * this_fn, void * call_site)
 {
     struct timespec ts;

--- a/tests/perf/instr_func.c
+++ b/tests/perf/instr_func.c
@@ -5,11 +5,11 @@
 
 /**
  * Entry function for function instrumentation
- * This functions will be called at the start of an instrumented function's execution 
+ * This functions will be called at the start of an instrumented function's execution
  * (see gcc's "-finstrument functions" flag) and provided with the address
  * of the instrumented function (this_fn) and the address where this function
  * was called from in the parent function (call_site)
- * 
+ *
  * Prints a message to timestamp the entry time of the instrumented function
  */
 void __cyg_profile_func_enter(void * this_fn, void * call_site)
@@ -27,7 +27,7 @@ void __cyg_profile_func_enter(void * this_fn, void * call_site)
  * (see gcc's "-finstrument functions" flag) and provided with the address
  * of the instrumented function (this_fn) and the address where this function
  * was called from in the parent function (call_site)
- * 
+ *
  * Prints a message to timestamp the exit time of the instrumented function
  */
 void __cyg_profile_func_exit(void * this_fn, void * call_site)

--- a/tests/perf/instr_func.c
+++ b/tests/perf/instr_func.c
@@ -3,20 +3,20 @@
 #include <stdint.h>
 #include <time.h>
 
-void __cyg_profile_func_enter (void *this_fn, void *call_site)
+void __cyg_profile_func_enter(void * this_fn, void * call_site)
 {
     struct timespec ts;
-	// Get timestamp
-	clock_gettime(CLOCK_REALTIME, &ts);
-	// Write timestamp with identifier
-	printf("prof > %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
+    // Get timestamp
+    clock_gettime(CLOCK_REALTIME, &ts);
+    // Write timestamp with identifier
+    printf("prof > %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
 }
 
-void __cyg_profile_func_exit  (void *this_fn, void *call_site)
+void __cyg_profile_func_exit(void * this_fn, void * call_site)
 {
     struct timespec ts;
-	// Get timestamp
-	clock_gettime(CLOCK_REALTIME, &ts);
-	// Write timestamp with identifier
-	printf("prof < %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
+    // Get timestamp
+    clock_gettime(CLOCK_REALTIME, &ts);
+    // Write timestamp with identifier
+    printf("prof < %lx: %llu.%llu\n", call_site, ts.tv_sec, ts.tv_nsec);
 }

--- a/tests/perf/prof_test.c
+++ b/tests/perf/prof_test.c
@@ -1,9 +1,9 @@
 /**
  * This file contains the main function for the profiling program. It initialises the resources
- * and calls the profiling functions with those resources. Other functions and files may be used 
+ * and calls the profiling functions with those resources. Other functions and files may be used
  * to implement the desired procedures but the calling of the profiling function must be done in main.
  * This can be changed but it necessitates modifications in the script that calculates the execution
- * times and maps the addresses to the function names (found in SO3). However this hurts performance 
+ * times and maps the addresses to the function names (found in SO3). However this hurts performance
  * a lot (analysis goes from taking seconds to several minutes)
  */
 

--- a/tests/perf/prof_test.c
+++ b/tests/perf/prof_test.c
@@ -1,3 +1,12 @@
+/**
+ * This file contains the main function for the profiling program. It initialises the resources
+ * and calls the profiling functions with those resources. Other functions and files may be used 
+ * to implement the desired procedures but the calling of the profiling function must be done in main.
+ * This can be changed but it necessitates modifications in the script that calculates the execution
+ * times and maps the addresses to the function names (found in SO3). However this hurts performance 
+ * a lot (analysis goes from taking seconds to several minutes)
+ */
+
 #include "prof_test_p.h"
 #include <stdio.h>
 

--- a/tests/perf/prof_test.c
+++ b/tests/perf/prof_test.c
@@ -1,52 +1,52 @@
 #include "prof_test_p.h"
 #include <stdio.h>
 
-int main(int argc, char const *argv[])
+int main(int argc, char const * argv[])
 {
-	uint32_t t = 256,
-		u0 = 0,
-		u1 = 50,
-		u2 = 954,
-		u3 = LV_BEZIER_VAL_MAX,
-		bezier_res1,
-		bezier_res2;
-	lv_area_t intersect_res1, 
-		intersect_res2,
-		a1 = {0, 0, 4, 3}, 
-		a2 = {3, 1, 6, 4};
+    uint32_t t = 256,
+             u0 = 0,
+             u1 = 50,
+             u2 = 954,
+             u3 = LV_BEZIER_VAL_MAX,
+             bezier_res1,
+             bezier_res2;
+    lv_area_t intersect_res1,
+              intersect_res2,
+              a1 = {0, 0, 4, 3},
+              a2 = {3, 1, 6, 4};
 
-	printf("Profiling LVGL\n");
-	printf("\tProfiling lv_bezier3\n");
-	printf("\t\tCubic bezier curve with parameters (%d;%d;%d;%d), t = %d\n", u0, u1, u2, u3, t);
-	bezier_res1 = lv_bezier3(t, u0, u1, u2, u3);
-	printf("\t\tWithout profiling: res = %d\n", bezier_res1);
-	bezier_res2 = prof_lv_bezier3(t, u0, u1, u2, u3);
-	printf("\t\tWith profiling: res = %d\n", bezier_res2);
-	
-	printf("\tProfiling _lv_area_intersect\n");
-	printf("\t\tArea a1 (%d;%d)->(%d;%d)\n", 
-		(int)(a1.x1), 
-		(int)(a1.y1),
-		(int)(a1.x2),
-		(int)(a1.y2));
-	printf("\t\tArea a2 (%d;%d)->(%d;%d)\n", 
-		(int)(a2.x1), 
-		(int)(a2.y1),
-		(int)(a2.x2),
-		(int)(a2.y2));
-	printf("\t\tCalculating intersection\n");
-	_lv_area_intersect(&intersect_res1, &a1, &a2);
-	printf("\t\tWithout profiling: res = (%d;%d)->(%d;%d)\n",
-		(int)(intersect_res1.x1), 
-		(int)(intersect_res1.y1),
-		(int)(intersect_res1.x2),
-		(int)(intersect_res1.y2));
-	prof_lv_area_intersect(&intersect_res2, &a1, &a2);
-	printf("\t\tWith profiling: res = (%d;%d)->(%d;%d)\n",
-		(int)(intersect_res2.x1), 
-		(int)(intersect_res2.y1),
-		(int)(intersect_res2.x2),
-		(int)(intersect_res2.y2));
+    printf("Profiling LVGL\n");
+    printf("\tProfiling lv_bezier3\n");
+    printf("\t\tCubic bezier curve with parameters (%d;%d;%d;%d), t = %d\n", u0, u1, u2, u3, t);
+    bezier_res1 = lv_bezier3(t, u0, u1, u2, u3);
+    printf("\t\tWithout profiling: res = %d\n", bezier_res1);
+    bezier_res2 = prof_lv_bezier3(t, u0, u1, u2, u3);
+    printf("\t\tWith profiling: res = %d\n", bezier_res2);
 
-	return 0;
+    printf("\tProfiling _lv_area_intersect\n");
+    printf("\t\tArea a1 (%d;%d)->(%d;%d)\n",
+           (int)(a1.x1),
+           (int)(a1.y1),
+           (int)(a1.x2),
+           (int)(a1.y2));
+    printf("\t\tArea a2 (%d;%d)->(%d;%d)\n",
+           (int)(a2.x1),
+           (int)(a2.y1),
+           (int)(a2.x2),
+           (int)(a2.y2));
+    printf("\t\tCalculating intersection\n");
+    _lv_area_intersect(&intersect_res1, &a1, &a2);
+    printf("\t\tWithout profiling: res = (%d;%d)->(%d;%d)\n",
+           (int)(intersect_res1.x1),
+           (int)(intersect_res1.y1),
+           (int)(intersect_res1.x2),
+           (int)(intersect_res1.y2));
+    prof_lv_area_intersect(&intersect_res2, &a1, &a2);
+    printf("\t\tWith profiling: res = (%d;%d)->(%d;%d)\n",
+           (int)(intersect_res2.x1),
+           (int)(intersect_res2.y1),
+           (int)(intersect_res2.x2),
+           (int)(intersect_res2.y2));
+
+    return 0;
 }

--- a/tests/perf/prof_test_p.c
+++ b/tests/perf/prof_test_p.c
@@ -1,6 +1,6 @@
 /**
  * This file contains the profiling functions. Those functions may contain simple calls to functions
- * or more complex procedure depending on what needs to be profiled. Do not use these functions to 
+ * or more complex procedure depending on what needs to be profiled. Do not use these functions to
  * initialise structures or resources that you do not want to profile. Initialise them in another
  * file and use the functions' parameters to provide the necessary resources. This file is compiled
  * using the "-finstrument-functions" GCC flag. More than one file can be used but they all should

--- a/tests/perf/prof_test_p.c
+++ b/tests/perf/prof_test_p.c
@@ -1,3 +1,12 @@
+/**
+ * This file contains the profiling functions. Those functions may contain simple calls to functions
+ * or more complex procedure depending on what needs to be profiled. Do not use these functions to 
+ * initialise structures or resources that you do not want to profile. Initialise them in another
+ * file and use the functions' parameters to provide the necessary resources. This file is compiled
+ * using the "-finstrument-functions" GCC flag. More than one file can be used but they all should
+ * be compiled with the flag
+ */
+
 #include <lvgl.h>
 
 uint32_t prof_lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3)

--- a/tests/perf/prof_test_p.c
+++ b/tests/perf/prof_test_p.c
@@ -2,10 +2,10 @@
 
 uint32_t prof_lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3)
 {
-	return lv_bezier3(t, u0, u1, u2, u3);
+    return lv_bezier3(t, u0, u1, u2, u3);
 }
 
-bool prof_lv_area_intersect(lv_area_t *res_p, lv_area_t *a1_p, lv_area_t *a2_p)
+bool prof_lv_area_intersect(lv_area_t * res_p, lv_area_t * a1_p, lv_area_t * a2_p)
 {
-	return _lv_area_intersect(res_p, a1_p, a2_p);
+    return _lv_area_intersect(res_p, a1_p, a2_p);
 }

--- a/tests/perf/prof_test_p.h
+++ b/tests/perf/prof_test_p.h
@@ -1,4 +1,4 @@
 #include <lvgl.h>
 
 uint32_t prof_lv_bezier3(uint32_t t, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3);
-bool prof_lv_area_intersect(lv_area_t *res_p, lv_area_t *a1_p, lv_area_t *a2_p);
+bool prof_lv_area_intersect(lv_area_t * res_p, lv_area_t * a1_p, lv_area_t * a2_p);


### PR DESCRIPTION
### Description of the feature or fix

- [x] The job ID is used by the action to retrieve the execution time data from the last successful run and isn't the same in the forked and original repo so it had to be changed
- [x]  GCC features a compilation flag that instruments function calls to call other functions at entry and exit. Using it (if possible) would mean fewer caveats (ARM64 only, limited arguments) and more control over instrumentation functions features compared to current home-made solution 

### Notes

- [x] Update Documentation
- [x] Update Examples
- [x] Fix code style errors
