### PR TITLE
fix(vg_lite_tvg): fix path structure is not fully initialized

### DIFF
--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -858,6 +858,8 @@ extern "C" {
             return VG_LITE_INVALID_ARGUMENT;
         }
 
+        lv_memzero(path, sizeof(vg_lite_path_t));
+
         path->format = data_format;
         path->quality = quality;
         path->bounding_box[0] = min_x;
@@ -2152,10 +2154,19 @@ static uint8_t vlc_op_arg_len(uint8_t vlc_op)
 
 static Result shape_set_stroke(std::unique_ptr<Shape> & shape, const vg_lite_path_t * path)
 {
-    /* if path is not a stroke, return */
-    if(path->path_type == VG_LITE_DRAW_ZERO
-       || path->path_type == VG_LITE_DRAW_FILL_PATH) {
-        return Result::Success;
+    switch(path->path_type) {
+        case VG_LITE_DRAW_ZERO:
+        case VG_LITE_DRAW_FILL_PATH:
+            /* if path is not a stroke, return */
+            return Result::Success;
+
+        case VG_LITE_DRAW_STROKE_PATH:
+        case VG_LITE_DRAW_FILL_STROKE_PATH:
+            break;
+
+        default:
+            LV_LOG_ERROR("unknown path type: %d", path->path_type);
+            return Result::InvalidArguments;
     }
 
     LV_ASSERT_NULL(path->stroke);


### PR DESCRIPTION
### Description of the feature or fix

Fixed the problem that the path structure was not fully initialized, causing path_type and stroke to be random values.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
