### PR TITLE
fix(refr): eliminate side effect in assert

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -590,7 +590,7 @@ static void layer_reshape_draw_buf(lv_layer_t * layer)
                               lv_area_get_width(&layer->buf_area),
                               lv_area_get_height(&layer->buf_area),
                               0);
-    (void)ret; /* Unused if LV_USE_ASSERT_NULL is disabled */
+    LV_UNUSED(ret);
     LV_ASSERT_NULL(ret);
 }
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -584,13 +584,13 @@ static void refr_invalid_areas(void)
  */
 static void layer_reshape_draw_buf(lv_layer_t * layer)
 {
-    LV_ASSERT(lv_draw_buf_reshape(
-                  layer->draw_buf,
-                  layer->color_format,
-                  lv_area_get_width(&layer->buf_area),
-                  lv_area_get_height(&layer->buf_area),
-                  0)
-              != NULL);
+    lv_draw_buf_t *ret = lv_draw_buf_reshape(
+        layer->draw_buf,
+        layer->color_format,
+        lv_area_get_width(&layer->buf_area),
+        lv_area_get_height(&layer->buf_area),
+        0);
+    LV_ASSERT_NULL(ret);
 }
 
 /**

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -584,12 +584,13 @@ static void refr_invalid_areas(void)
  */
 static void layer_reshape_draw_buf(lv_layer_t * layer)
 {
-    lv_draw_buf_t *ret = lv_draw_buf_reshape(
-        layer->draw_buf,
-        layer->color_format,
-        lv_area_get_width(&layer->buf_area),
-        lv_area_get_height(&layer->buf_area),
-        0);
+    lv_draw_buf_t * ret = lv_draw_buf_reshape(
+                              layer->draw_buf,
+                              layer->color_format,
+                              lv_area_get_width(&layer->buf_area),
+                              lv_area_get_height(&layer->buf_area),
+                              0);
+    (void)ret; /* Unused if LV_USE_ASSERT_NULL is disabled */
     LV_ASSERT_NULL(ret);
 }
 


### PR DESCRIPTION
fixes #6497

### Description of the fix

Refactor `layer_reshape_draw_buf` to move the call to `lv_draw_buf_reshape` outside the `ASSERT` macro, so it can be safely eliminated from non-debug builds.

### Notes
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
