### PR TITLE
fix(test): fix filter option dot escape by setting regexp string

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -139,7 +139,7 @@ def generate_code_coverage_report():
     cmd = ['gcovr', '--root', root_dir, '--html-details', '--output',
            html_report_file, '--xml', 'report/coverage.xml',
            '-j', str(os.cpu_count()), '--print-summary',
-           '--html-title', 'LVGL Test Coverage', '--filter', '../src/.*/lv_.*\.c']
+           '--html-title', 'LVGL Test Coverage', '--filter', r'../src/.*/lv_.*\.c']
 
     subprocess.check_call(cmd)
     print("Done: See %s" % html_report_file, flush=True)


### PR DESCRIPTION
### Description of the feature or fix

While running tests on Ubuntu 24.04 a warning is emitted:

```bash
./main.py:142: SyntaxWarning: invalid escape sequence '\.'
  '--html-title', 'LVGL Test Coverage', '--filter', '../src/.*/lv_.*\.c']
```

This is due to the fact that Ubuntu 24.04 includes Python 3.12 and from this version [a SyntaxWarning is emitted](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes) (it is also state that it will eventually become a SyntaxError) for invalid escape sequences.
