### PR TITLE
fix(anim): fix deleted_cb not called in lv_anim_delete_all

### DIFF
--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -39,6 +39,7 @@ static int32_t lv_anim_path_cubic_bezier(const lv_anim_t * a, int32_t x1,
 static uint32_t convert_speed_to_time(uint32_t speed, int32_t start, int32_t end);
 static void resolve_time(lv_anim_t * a);
 static bool remove_concurrent_anims(lv_anim_t * a_current);
+static void remove_anim(void * a);
 
 /**********************
  *  STATIC VARIABLES
@@ -149,9 +150,7 @@ bool lv_anim_delete(void * var, lv_anim_exec_xcb_t exec_cb)
     while(a != NULL) {
         bool del = false;
         if((a->var == var || var == NULL) && (a->exec_cb == exec_cb || exec_cb == NULL)) {
-            _lv_ll_remove(anim_ll_p, a);
-            if(a->deleted_cb != NULL) a->deleted_cb(a);
-            lv_free(a);
+            remove_anim(a);
             anim_mark_list_change(); /*Read by `anim_timer`. It need to know if a delete occurred in
                                        the linked list*/
             del_any = true;
@@ -168,13 +167,7 @@ bool lv_anim_delete(void * var, lv_anim_exec_xcb_t exec_cb)
 
 void lv_anim_delete_all(void)
 {
-    lv_anim_t * a = _lv_ll_get_head(anim_ll_p);
-    while(a != NULL) {
-        _lv_ll_remove(anim_ll_p, a);
-        if(a->deleted_cb != NULL) a->deleted_cb(a);
-        lv_free(a);
-        a = _lv_ll_get_head(anim_ll_p);
-    }
+    _lv_ll_clear_custom(anim_ll_p, remove_anim);
     anim_mark_list_change();
 }
 
@@ -556,4 +549,12 @@ static bool remove_concurrent_anims(lv_anim_t * a_current)
     }
 
     return del_any;
+}
+
+static void remove_anim(void * a)
+{
+    lv_anim_t * anim = a;
+    _lv_ll_remove(anim_ll_p, a);
+    if(anim->deleted_cb != NULL) anim->deleted_cb(anim);
+    lv_free(a);
 }

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -168,7 +168,13 @@ bool lv_anim_delete(void * var, lv_anim_exec_xcb_t exec_cb)
 
 void lv_anim_delete_all(void)
 {
-    _lv_ll_clear(anim_ll_p);
+    lv_anim_t * a = _lv_ll_get_head(anim_ll_p);
+    while(a != NULL) {
+        _lv_ll_remove(anim_ll_p, a);
+        if(a->deleted_cb != NULL) a->deleted_cb(a);
+        lv_free(a);
+        a = _lv_ll_get_head(anim_ll_p);
+    }
     anim_mark_list_change();
 }
 


### PR DESCRIPTION

### Description of the feature or fix

Fixed the issue that deleting all animated objects would not call the animation object deletion callback

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
