### PR TITLE
perf(image_decoder): refactor image decoder to reduce file operation on get_info

### DIFF
--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -147,6 +147,8 @@ struct _lv_image_decoder_dsc_t {
     /**Type of the source: file or variable. Can be set in `open` function if required*/
     lv_image_src_t src_type;
 
+    lv_fs_file_t * fp;
+
     /**Info about the opened image: color format, size, etc. MUST be set in `open` function*/
     lv_image_header_t header;
 

--- a/src/draw/lv_image_decoder.h
+++ b/src/draw/lv_image_decoder.h
@@ -72,7 +72,7 @@ typedef struct _lv_image_decoder_args_t {
  * @param header store the info here
  * @return LV_RESULT_OK: info written correctly; LV_RESULT_INVALID: failed
  */
-typedef lv_result_t (*lv_image_decoder_info_f_t)(lv_image_decoder_t * decoder, const void * src,
+typedef lv_result_t (*lv_image_decoder_info_f_t)(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
                                                  lv_image_header_t * header);
 
 /**
@@ -147,7 +147,7 @@ struct _lv_image_decoder_dsc_t {
     /**Type of the source: file or variable. Can be set in `open` function if required*/
     lv_image_src_t src_type;
 
-    lv_fs_file_t * fp;
+    lv_fs_file_t file;
 
     /**Info about the opened image: color format, size, etc. MUST be set in `open` function*/
     lv_image_header_t header;

--- a/src/draw/vg_lite/lv_vg_lite_decoder.c
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.c
@@ -43,7 +43,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void image_color32_pre_mul(lv_color32_t * img_data, uint32_t px_size);
@@ -148,9 +148,9 @@ static void image_decode_to_index8_line(uint8_t * dest, const uint8_t * src, int
     }
 }
 
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
-    lv_result_t res = lv_bin_decoder_info(decoder, src, header);
+    lv_result_t res = lv_bin_decoder_info(decoder, dsc, header);
     if(res != LV_RESULT_OK) {
         return res;
     }

--- a/src/libs/bin_decoder/lv_bin_decoder.h
+++ b/src/libs/bin_decoder/lv_bin_decoder.h
@@ -35,11 +35,11 @@ void lv_bin_decoder_init(void);
 /**
  * Get info about a lvgl binary image
  * @param decoder the decoder where this function belongs
- * @param src the image source: pointer to an `lv_image_dsc_t` variable, a file path or a symbol
+ * @param dsc image descriptor containing the source and type of the image and other info.
  * @param header store the image data here
  * @return LV_RESULT_OK: the info is successfully stored in `header`; LV_RESULT_INVALID: unknown format or other error.
  */
-lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 
 lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
                                     const lv_area_t * full_area, lv_area_t * decoded_area);

--- a/src/libs/bmp/lv_bmp.c
+++ b/src/libs/bmp/lv_bmp.c
@@ -35,7 +35,7 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 
 static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,
@@ -82,34 +82,31 @@ void lv_bmp_deinit(void)
 
 /**
  * Get info about a BMP image
- * @param src can be file name or pointer to a C array
+ * @param dsc image descriptor containing the source and type of the image and other info.
  * @param header store the info here
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
  */
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
     LV_UNUSED(decoder);
 
-    lv_image_src_t src_type = lv_image_src_get_type(src);          /*Get the source type*/
+    const void * src = dsc->src;
+    lv_image_src_t src_type = dsc->src_type;          /*Get the source type*/
 
     /*If it's a BMP file...*/
     if(src_type == LV_IMAGE_SRC_FILE) {
         const char * fn = src;
         if(lv_strcmp(lv_fs_get_ext(fn), "bmp") == 0) {              /*Check the extension*/
             /*Save the data in the header*/
-            lv_fs_file_t f;
-            lv_fs_res_t res = lv_fs_open(&f, src, LV_FS_MODE_RD);
-            if(res != LV_FS_RES_OK) return LV_RESULT_INVALID;
             uint8_t headers[54];
 
-            lv_fs_read(&f, headers, 54, NULL);
+            lv_fs_read(&dsc->file, headers, 54, NULL);
             uint32_t w;
             uint32_t h;
             lv_memcpy(&w, headers + 18, 4);
             lv_memcpy(&h, headers + 22, 4);
             header->w = w;
             header->h = h;
-            lv_fs_close(&f);
 
             uint16_t bpp;
             lv_memcpy(&bpp, headers + 28, 2);

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -69,7 +69,7 @@ struct lv_image_pixel_color_s {
  *  STATIC PROTOTYPES
  **********************/
 
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
 
@@ -253,12 +253,13 @@ void lv_ffmpeg_player_set_auto_restart(lv_obj_t * obj, bool en)
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
     LV_UNUSED(decoder);
 
     /* Get the source type */
-    lv_image_src_t src_type = lv_image_src_get_type(src);
+    const void * src = dsc->src;
+    lv_image_src_t src_type = dsc->src_type;
 
     if(src_type == LV_IMAGE_SRC_FILE) {
         const char * fn = src;

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -38,7 +38,7 @@ typedef struct error_mgr_s {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static lv_draw_buf_t * decode_jpeg_file(const char * filename);
@@ -98,42 +98,34 @@ void lv_libjpeg_turbo_deinit(void)
 
 /**
  * Get info about a JPEG image
- * @param src can be file name or pointer to a C array
+ * @param dsc image descriptor containing the source and type of the image and other info.
  * @param header store the info here
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
  */
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
     LV_UNUSED(decoder); /*Unused*/
-    lv_image_src_t src_type = lv_image_src_get_type(src);          /*Get the source type*/
+    lv_image_src_t src_type = dsc->src_type;          /*Get the source type*/
 
     /*If it's a JPEG file...*/
     if(src_type == LV_IMAGE_SRC_FILE) {
-        const char * fn = src;
-
-        lv_fs_file_t f;
-        lv_fs_res_t res = lv_fs_open(&f, fn, LV_FS_MODE_RD);
-        if(res != LV_FS_RES_OK) {
-            LV_LOG_WARN("Can't open file: %s", fn);
-            return LV_RESULT_INVALID;
-        }
-
+        const char * src = dsc->src;
         uint32_t jpg_signature = 0;
         uint32_t rn;
-        lv_fs_read(&f, &jpg_signature, sizeof(jpg_signature), &rn);
-        lv_fs_close(&f);
+        lv_fs_read(&dsc->file, &jpg_signature, sizeof(jpg_signature), &rn);
 
         if(rn != sizeof(jpg_signature)) {
-            LV_LOG_WARN("file: %s signature len = %" LV_PRIu32 " error", fn, rn);
+            LV_LOG_WARN("file: %s signature len = %" LV_PRIu32 " error", src, rn);
             return LV_RESULT_INVALID;
         }
 
-        bool is_jpeg_ext = (lv_strcmp(lv_fs_get_ext(fn), "jpg") == 0)
-                           || (lv_strcmp(lv_fs_get_ext(fn), "jpeg") == 0);
+        const char * ext = lv_fs_get_ext(src);
+        bool is_jpeg_ext = (lv_strcmp(ext, "jpg") == 0)
+                           || (lv_strcmp(ext, "jpeg") == 0);
 
         if(!IS_JPEG_SIGNATURE(jpg_signature)) {
             if(is_jpeg_ext) {
-                LV_LOG_WARN("file: %s signature = 0X%" LV_PRIX32 " error", fn, jpg_signature);
+                LV_LOG_WARN("file: %s signature = 0X%" LV_PRIX32 " error", src, jpg_signature);
             }
             return LV_RESULT_INVALID;
         }
@@ -142,7 +134,7 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, 
         uint32_t height;
         uint32_t orientation = 0;
 
-        if(!get_jpeg_head_info(fn, &width, &height, &orientation)) {
+        if(!get_jpeg_head_info(src, &width, &height, &orientation)) {
             return LV_RESULT_INVALID;
         }
 

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -28,7 +28,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static lv_draw_buf_t * decode_png_file(lv_image_decoder_dsc_t * dsc, const char * filename);
@@ -75,31 +75,25 @@ void lv_libpng_deinit(void)
 
 /**
  * Get info about a PNG image
- * @param src can be file name or pointer to a C array
+ * @param dsc can be file name or pointer to a C array
  * @param header store the info here
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
  */
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
     LV_UNUSED(decoder); /*Unused*/
-    lv_image_src_t src_type = lv_image_src_get_type(src);          /*Get the source type*/
+
+    lv_image_src_t src_type = dsc->src_type;          /*Get the source type*/
 
     /*If it's a PNG file...*/
     if(src_type == LV_IMAGE_SRC_FILE) {
-        const char * fn = src;
-
-        lv_fs_file_t f;
-        lv_fs_res_t res = lv_fs_open(&f, fn, LV_FS_MODE_RD);
-        if(res != LV_FS_RES_OK) return LV_RESULT_INVALID;
-
         /* Read the width and height from the file. They have a constant location:
          * [16..19]: width
          * [20..23]: height
          */
         uint8_t buf[24];
         uint32_t rn;
-        lv_fs_read(&f, buf, sizeof(buf), &rn);
-        lv_fs_close(&f);
+        lv_fs_read(&dsc->file, buf, sizeof(buf), &rn);
 
         if(rn != sizeof(buf)) return LV_RESULT_INVALID;
 

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -28,7 +28,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
 static void convert_color_depth(uint8_t * img_p, uint32_t px_cnt);
@@ -76,14 +76,16 @@ void lv_lodepng_deinit(void)
 /**
  * Get info about a PNG image
  * @param decoder   pointer to the decoder where this function belongs
- * @param src       can be file name or pointer to a C array
+ * @param dsc       image descriptor containing the source and type of the image and other info.
  * @param header    image information is set in header parameter
  * @return          LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info
  */
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, lv_image_header_t * header)
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header)
 {
     LV_UNUSED(decoder); /*Unused*/
-    lv_image_src_t src_type = lv_image_src_get_type(src);          /*Get the source type*/
+
+    const void * src = dsc->src;
+    lv_image_src_t src_type = dsc->src_type;          /*Get the source type*/
 
     /*If it's a PNG file...*/
     if(src_type == LV_IMAGE_SRC_FILE) {
@@ -95,15 +97,10 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, const void * src, 
              * [24..27]: height
              */
             uint32_t size[2];
-            lv_fs_file_t f;
-            lv_fs_res_t res = lv_fs_open(&f, fn, LV_FS_MODE_RD);
-            if(res != LV_FS_RES_OK) return LV_RESULT_INVALID;
-
-            lv_fs_seek(&f, 16, LV_FS_SEEK_SET);
-
             uint32_t rn;
-            lv_fs_read(&f, &size, 8, &rn);
-            lv_fs_close(&f);
+
+            lv_fs_seek(&dsc->file, 16, LV_FS_SEEK_SET);
+            lv_fs_read(&dsc->file, &size, 8, &rn);
 
             if(rn != 8) return LV_RESULT_INVALID;
 


### PR DESCRIPTION
### Description of the feature or fix

The original LVGL Image Decoder process is (pseudo-code)

```python
for decoder in decoder_list:
    img_info = decoder.get_info(img)
    if img_info:
        return decoder, img_info
return None
```

```python
def get_info(img):
    f = open(img)
    # read image info
    close(f)
    return img_info
```

Among them, each decoder in the original scheme needs to reopen/close the image file when obtaining image information. Such frequent open/close files will cause extra time and Calculation cost.

The new process is:

```python
f = open(img)
for decoder in decoder_list:
    img_info = decoder.get_info(f)
    if img_info:
        close(f)
        return decoder, img_info
close(f)
return None
```

Among them, the open/close of files is reduced to one time, reducing the overhead of additional file open/close.

Among them, the reading and writing part of the file increases the cache of the read and written content of the file, reducing the overhead of reading data from the disk.

On our devices, this optimization increases the open speed by n times (n = decoder nums) 🚀

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
