### PR TITLE
fix(sdl): make sure minimal alignment is sizeof(void*) for aligned alloc

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -451,7 +451,9 @@ static void * sdl_draw_buf_realloc_aligned(void * ptr, size_t new_size)
 
 #ifndef _WIN32
     /* Size must be multiple of align, See: https://en.cppreference.com/w/c/memory/aligned_alloc */
-    return aligned_alloc(LV_DRAW_BUF_ALIGN, LV_ALIGN_UP(new_size, LV_DRAW_BUF_ALIGN));
+
+#define BUF_ALIGN (LV_DRAW_BUF_ALIGN < sizeof(void *) ? sizeof(void *) : LV_DRAW_BUF_ALIGN)
+    return aligned_alloc(BUF_ALIGN, LV_ALIGN_UP(new_size, BUF_ALIGN));
 #else
     return _aligned_malloc(LV_ALIGN_UP(new_size, LV_DRAW_BUF_ALIGN), LV_DRAW_BUF_ALIGN);
 #endif /* _WIN32 */


### PR DESCRIPTION

### Description of the feature or fix

Although it's implementation defined, set the minimal alignment to sizeof(void*) is required for posix_memalign. Test on my apple silicon mac shows that alignment to 4byte is not working, errno is set to EINVAL: invalid arguments.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
