### PR TITLE
fix(property): fix style property

### DIFF
--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -59,7 +59,7 @@ lv_result_t lv_obj_set_property(lv_obj_t * obj, const lv_property_t * value)
     LV_ASSERT(obj && value);
 
     uint32_t index = LV_PROPERTY_ID_INDEX(value->id);
-    if(value->id == LV_PROPERTY_ID_INVALID || index < LV_PROPERTY_STYLE_START || index >= LV_PROPERTY_ID_BUILTIN_LAST) {
+    if(value->id == LV_PROPERTY_ID_INVALID || index >= LV_PROPERTY_ID_BUILTIN_LAST) {
         LV_LOG_WARN("Invalid property id set to %p", obj);
         return LV_RESULT_INVALID;
     }
@@ -90,7 +90,7 @@ lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id)
     lv_property_t value;
 
     uint32_t index = LV_PROPERTY_ID_INDEX(id);
-    if(id == LV_PROPERTY_ID_INVALID || index < LV_PROPERTY_STYLE_START || index >= LV_PROPERTY_ID_BUILTIN_LAST) {
+    if(id == LV_PROPERTY_ID_INVALID || index >= LV_PROPERTY_ID_BUILTIN_LAST) {
         LV_LOG_WARN("Invalid property id to get from %p", obj);
         value.id = LV_PROPERTY_ID_INVALID;
         value.num = 0;
@@ -114,8 +114,9 @@ lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id)
 lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, uint32_t selector)
 {
     lv_property_t value;
+    uint32_t index = LV_PROPERTY_ID_INDEX(id);
 
-    if(id == LV_PROPERTY_ID_INVALID || id >= LV_PROPERTY_ID_START) {
+    if(index == LV_PROPERTY_ID_INVALID || index >= LV_PROPERTY_ID_START) {
         LV_LOG_WARN("invalid style property id %d", id);
         value.id = LV_PROPERTY_ID_INVALID;
         value.num = 0;

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -56,15 +56,15 @@ enum {
     LV_PROPERTY_ID_INVALID      = 0,
 
     /*ID 0x01 to 0xff are style ID, check lv_style_prop_t*/
-    LV_PROPERTY_STYLE_START     = 0x01,
+    LV_PROPERTY_STYLE_START     = 0x00,
 
-    LV_PROPERTY_ID_START        = 0x100, /*ID little than 0xff is style ID*/
+    LV_PROPERTY_ID_START        = 0x0100, /*ID smaller than 0xff is style ID*/
     /*Define the property ID for every widget here. */
-    LV_PROPERTY_OBJ_START       = 0x100, /* lv_obj.c */
-    LV_PROPERTY_IMAGE_START     = 0x200, /* lv_image.c */
+    LV_PROPERTY_OBJ_START       = 0x0100, /* lv_obj.c */
+    LV_PROPERTY_IMAGE_START     = 0x0200, /* lv_image.c */
 
     /*Special ID, use it to extend ID and make sure it's unique and compile time determinant*/
-    LV_PROPERTY_ID_BUILTIN_LAST = 0x10000000,
+    LV_PROPERTY_ID_BUILTIN_LAST = 0xffff, /*ID of 0x10000 ~ 0xfffffff is reserved for user*/
 
     /*Special ID used by lvgl to intercept all setter/getter call.*/
     LV_PROPERTY_ID_ANY          = 0x7ffffffe,

--- a/tests/src/test_cases/widgets/test_obj_property.c
+++ b/tests/src/test_cases/widgets/test_obj_property.c
@@ -37,25 +37,25 @@ void test_obj_property_set_get_should_match(void)
 
     /* Style property should work */
     /* int type */
-    prop.id = LV_STYLE_X;
+    prop.id = LV_PROPERTY_STYLE_X;
     prop.num = 0xaabb;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_style_x(obj, 0));
-    TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_property(obj, LV_STYLE_X).num);
+    TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_property(obj, LV_PROPERTY_STYLE_X).num);
 
     /* color type */
-    prop.id = LV_STYLE_BG_COLOR;
+    prop.id = LV_PROPERTY_STYLE_BG_COLOR;
     prop.color = color;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_COLOR(color, lv_obj_get_style_bg_color(obj, LV_PART_MAIN));
-    TEST_ASSERT_EQUAL_COLOR(color, lv_obj_get_property(obj, LV_STYLE_BG_COLOR).color);
+    TEST_ASSERT_EQUAL_COLOR(color, lv_obj_get_property(obj, LV_PROPERTY_STYLE_BG_COLOR).color);
 
     /* pointer type */
-    prop.id = LV_STYLE_TEXT_FONT;
+    prop.id = LV_PROPERTY_STYLE_TEXT_FONT;
     prop.ptr = &lv_font_montserrat_26;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, lv_obj_get_style_text_font(obj, LV_PART_MAIN));
-    TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, lv_obj_get_property(obj, LV_STYLE_TEXT_FONT).ptr);
+    TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, lv_obj_get_property(obj, LV_PROPERTY_STYLE_TEXT_FONT).ptr);
 
     /* Object flags */
     prop.id = LV_PROPERTY_OBJ_FLAG_HIDDEN ;
@@ -101,20 +101,20 @@ void test_obj_property_style_selector(void)
     lv_property_t prop = { };
 
     /* Style property with default selector(0) should work */
-    prop.id = LV_STYLE_X;
+    prop.id = LV_PROPERTY_STYLE_X;
     prop.num = 0xaabb;  /* `num` shares same memory with `prop.style.value.num` */
     /* selector is initialed to zero when prop is defined. */
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_style_x(obj, 0));
-    TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_style_property(obj, LV_STYLE_X, 0).num);
+    TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_style_property(obj, LV_PROPERTY_STYLE_X, 0).num);
 
     lv_style_selector_t selector = LV_PART_MAIN | LV_STATE_PRESSED;
-    prop.id = LV_STYLE_X;
+    prop.id = LV_PROPERTY_STYLE_X;
     prop.num = 0x1122;
     prop.selector = selector;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT32(0x1122, lv_obj_get_style_x(obj, selector));
-    TEST_ASSERT_EQUAL_UINT32(0x1122, lv_obj_get_style_property(obj, LV_STYLE_X, selector).num);
+    TEST_ASSERT_EQUAL_UINT32(0x1122, lv_obj_get_style_property(obj, LV_PROPERTY_STYLE_X, selector).num);
 #endif
 }
 


### PR DESCRIPTION


### Description of the feature or fix

The test case is out of date, `prop.id` should not use LV_STYLE_xxx enum directly. 
Set builtin last property ID to 0xffff, leaving 0x10000 to 0xfffffff for user.

Fix #6551

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
