### PR TITLE
fix(evdev): not transmitting events for btn mouse and btn touch

### DIFF
--- a/docs/porting/indev.rst
+++ b/docs/porting/indev.rst
@@ -194,10 +194,12 @@ assigned to specific coordinates of the screen. If a button is pressed
 it will simulate the pressing on the assigned coordinate. (Similarly to a touchpad)
 
 To assign buttons to coordinates use ``lv_indev_set_button_points(my_indev, points_array)``. ``points_array``
-should look like ``const lv_point_t points_array[] = { {12,30},{60,90}, ...}``
+should look like ``const lv_point_t points_array[] = { {12,30},{60,90}, ...}``.
+Depending on the input device driver used, make sure to supply enough points
+in the ``points_array``.
 
 :important: The points_array can't go out of scope. Either declare it as a global variable
-            or as a static variable inside a function.`
+            or as a static variable inside a function.
 
 .. code:: c
 

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -150,6 +150,10 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
             data->state = dsc->state;
             data->key = dsc->key;
             break;
+        case LV_INDEV_TYPE_BUTTON:
+            data->state = dsc->state;
+            data->btn_id = (dsc->state == LV_INDEV_STATE_PRESSED) ? 0 : 1;
+            break;
         case LV_INDEV_TYPE_POINTER:
             data->state = dsc->state;
             data->point = _evdev_process_pointer(indev, dsc->root_x, dsc->root_y);


### PR DESCRIPTION
### Description of the feature or fix

Button state and ID are now properly handled when evdev driver with `LV_INDEV_TYPE_BUTTON` device type and event code `BTN_MOUSE` or `BTN_TOUCH` is used.

Fixes issue #6519 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
