### PR TITLE
fix(nuttx): fix framebuffer driver render artefacts

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1625,7 +1625,7 @@ menu "LVGL configuration"
 
 		choice
 			prompt "NuttX LCD buffer size"
-			depends on LV_USE_NUTTX_LCD
+			depends on LV_USE_NUTTX_LCD && LV_USE_NUTTX
 			default LV_NUTTX_LCD_SINGLE_BUFFER
 
 			config LV_NUTTX_LCD_SINGLE_BUFFER
@@ -1641,15 +1641,39 @@ menu "LVGL configuration"
 
 		config LV_NUTTX_LCD_BUFFER_COUNT
 			int
-			depends on LV_USE_NUTTX_LCD
+			depends on LV_USE_NUTTX_LCD && LV_USE_NUTTX
 			default 0 if LV_NUTTX_LCD_CUSTOM_BUFFER
 			default 1 if LV_NUTTX_LCD_SINGLE_BUFFER
 			default 2 if LV_NUTTX_LCD_DOUBLE_BUFFER
 
 		config LV_NUTTX_LCD_BUFFER_SIZE
 			int "Custom partial buffer size (in number of rows)"
-			depends on LV_USE_NUTTX_LCD && LV_NUTTX_LCD_CUSTOM_BUFFER
+			depends on LV_USE_NUTTX_LCD && LV_NUTTX_LCD_CUSTOM_BUFFER && LV_USE_NUTTX
 			default 60
+
+		config LV_USE_NUTTX_FBDEV
+			bool "Use NuttX LCD Framebuffer"
+			depends on LV_USE_NUTTX
+			default n
+
+		choice
+			prompt "Framebuffer size"
+			depends on LV_USE_NUTTX && LV_USE_NUTTX_FBDEV
+			default LV_NUTTX_FBDEV_SINGLE_BUFFER
+
+			config LV_NUTTX_FBDEV_SINGLE_BUFFER
+				bool "One screen-sized buffer"
+
+			config LV_NUTTX_FBDEV_DOUBLE_BUFFER
+				bool "Two screen-sized buffer"
+
+		endchoice
+
+		config LV_NUTTX_FBDEV_BUFFER_COUNT
+			int
+			depends on LV_USE_NUTTX_FBDEV
+			default 1 if LV_NUTTX_FBDEV_SINGLE_BUFFER
+			default 2 if LV_NUTTX_FBDEV_DOUBLE_BUFFER
 
 		config LV_USE_NUTTX_TOUCHSCREEN
 			bool "Use NuttX touchscreen driver"

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3186,6 +3186,7 @@
             #define LV_USE_NUTTX_LCD      0
         #endif
     #endif
+
     #if LV_USE_NUTTX_LCD
         #ifndef LV_NUTTX_LCD_BUFFER_COUNT
             #ifdef CONFIG_LV_NUTTX_LCD_BUFFER_COUNT
@@ -3199,6 +3200,25 @@
                 #define LV_NUTTX_LCD_BUFFER_SIZE CONFIG_LV_NUTTX_LCD_BUFFER_SIZE
             #else
                 #define LV_NUTTX_LCD_BUFFER_SIZE     60
+            #endif
+        #endif
+    #endif
+
+    /*Driver for /dev/fb0*/
+    #ifndef LV_USE_NUTTX_FBDEV
+        #ifdef CONFIG_LV_USE_NUTTX_FBDEV
+            #define LV_USE_NUTTX_FBDEV CONFIG_LV_USE_NUTTX_FBDEV
+        #else
+            #define LV_USE_NUTTX_FBDEV      0
+        #endif
+    #endif
+
+    #ifdef LV_USE_NUTTX_FBDEV
+        #ifndef LV_NUTTX_FBDEV_BUFFER_COUNT
+            #ifdef CONFIG_LV_NUTTX_FBDEV_BUFFER_COUNT
+                #define LV_NUTTX_FBDEV_BUFFER_COUNT CONFIG_LV_NUTTX_FBDEV_BUFFER_COUNT
+            #else
+                #define LV_NUTTX_FBDEV_BUFFER_COUNT  0
             #endif
         #endif
     #endif


### PR DESCRIPTION
### Fix Artefacts caused by NuttX framebuffer driver that currently allows rendering direct to hardware framebuffer

I found I was getting artefacts using LVGL V9 with a SAMA5D27 processor using the Nuttx framebuffer driver. This is becuase the LVGL driver passes the hardware MMAP'd framebuffer address as the address of the render buffer, whereas is should - I believe - be a MALLOC's local buffer, withe th flush routine copying the color_p buffer to the hardware framebuffer in flush_cb.

This amended code works, with no render artefacts, and a notable performance increase.

The driver (still) has a function `fbdev_init_mem2` the purpose of which is unclear to me. I seems perhaps to be related to a second video plane of some NuttX framebuffer device driver but I can't work it out.  I am wondering if it is an erroneous attempt at the usual LVGL double render buffer method? 

I have put code in for a second render buffer, but am not 100% sure if that "conflicts" in anyway with the purpose of `fbdev_init_mem2`? With Kconfig setup too.

My first LVGL commit - be kind, but I am expecting feedback and requests for change!!!