### PR TITLE
fix(kconfig): Do not set LV_CONF_SKIP by default

### DIFF
--- a/docs/porting/project.rst
+++ b/docs/porting/project.rst
@@ -90,7 +90,8 @@ will attempt to include ``lv_conf.h`` simply with
 
 You can even use a different name for ``lv_conf.h``. The custom path can
 be set via the :c:macro:`LV_CONF_PATH` define. For example
-``-DLV_CONF_PATH="/home/joe/my_project/my_custom_conf.h"``
+``-DLV_CONF_PATH="/home/joe/my_project/my_custom_conf.h"``. If this define
+is set :c:macro:`LV_CONF_SKIP` is assumed to be ``0``.
 
 If :c:macro:`LV_CONF_SKIP` is defined, LVGL will not try to include
 ``lv_conf.h``. Instead you can pass the config defines using build

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -69,7 +69,7 @@ fout.write(
 #endif
 
 /*If lv_conf.h is not skipped include it*/
-#ifndef LV_CONF_SKIP
+#if !defined(LV_CONF_SKIP) || defined(LV_CONF_PATH)
     #ifdef LV_CONF_PATH                           /*If there is a path defined for lv_conf.h use it*/
         #define __LV_TO_STR_AUX(x) #x
         #define __LV_TO_STR(x) __LV_TO_STR_AUX(x)

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -47,7 +47,7 @@
 #endif
 
 /*If lv_conf.h is not skipped include it*/
-#ifndef LV_CONF_SKIP
+#if !defined(LV_CONF_SKIP) || defined(LV_CONF_PATH)
     #ifdef LV_CONF_PATH                           /*If there is a path defined for lv_conf.h use it*/
         #define __LV_TO_STR_AUX(x) #x
         #define __LV_TO_STR(x) __LV_TO_STR_AUX(x)


### PR DESCRIPTION
Due to the way that Kconfig symbols work, this can not be turned off if it is defaulted to true.

### Description of the feature or fix

While rebasing the Zephyr integration I encountered the issue that the `lv_conf.h` that is used to point to the `malloc_core` etc. functions is not included correctly in the respective headers. Investigating the issue shows that since this symbol is defined with `default y` I can not turn it  off from my "third party" code. Having an unconditional `default y` in Kconfig essentially always enables the option since it can not be turned of. This should be avoided.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
