### PR TITLE
feat(os): use recursive mutex by default

### DIFF
--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -364,7 +364,7 @@ static void prvRunThread(void * pxArg)
 
 static void prvMutexInit(lv_mutex_t * pxMutex)
 {
-    pxMutex->xMutex = xSemaphoreCreateMutex();
+    pxMutex->xMutex = xSemaphoreCreateRecursiveMutex();
 
     /* Ensure that the FreeRTOS mutex was successfully created. */
     if(pxMutex->xMutex == NULL) {

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -69,6 +69,7 @@ lv_result_t lv_mutex_init(lv_mutex_t * mutex)
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
     int ret = pthread_mutex_init(mutex, &attr);
+    pthread_mutexattr_destroy(&attr);
 
     if(ret) {
         LV_LOG_WARN("Error: %d", ret);

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -64,7 +64,12 @@ lv_result_t lv_thread_delete(lv_thread_t * thread)
 
 lv_result_t lv_mutex_init(lv_mutex_t * mutex)
 {
-    int ret = pthread_mutex_init(mutex, NULL);
+    pthread_mutexattr_t attr;
+
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    int ret = pthread_mutex_init(mutex, &attr);
+
     if(ret) {
         LV_LOG_WARN("Error: %d", ret);
         return LV_RESULT_INVALID;


### PR DESCRIPTION
### Description of the feature or fix

The problem to solve is that `lv_lock` can be called multiple times from nested user functions. Therefore the mutex it uses should be recursive. I've tried a few options and found that using recursive mutexes by default is the simplest way of handling this. In some OS-es (Windows, RT-Thread) there is no option for non-recursive mutex anyway. 

cc @espzav 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
