### PR TITLE
feat(nuttx): malloc second FB if driver only has one

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -39,6 +39,7 @@ typedef struct {
 
     void * mem;
     void * mem2;
+    void * mem_off_screen;
     uint32_t mem2_yoffset;
 
     lv_draw_buf_t buf1;
@@ -141,8 +142,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
     uint32_t data_size = h * stride;
     lv_draw_buf_init(&dsc->buf1, w, h, color_format, stride, dsc->mem, data_size);
 
-    /* double buffer mode */
-
+    /* Check buffer mode */
     bool double_buffer = dsc->pinfo.yres_virtual == (dsc->vinfo.yres * 2);
     if(double_buffer) {
         if((ret = fbdev_init_mem2(dsc)) < 0) {
@@ -150,9 +150,22 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         }
 
         lv_draw_buf_init(&dsc->buf2, w, h, color_format, stride, dsc->mem2, data_size);
+        lv_display_set_draw_buffers(disp, &dsc->buf1, &dsc->buf2);
+    }
+    else {
+        dsc->mem_off_screen = malloc(data_size);
+        LV_ASSERT_MALLOC(dsc->mem_off_screen);
+        if(!dsc->mem_off_screen) {
+            ret = -ENOMEM;
+            LV_LOG_ERROR("Failed to allocate memory for off-screen buffer");
+            goto errout;
+        }
+
+        LV_LOG_USER("Use off-screen mode, memory: %p, size: %" LV_PRIu32, dsc->mem_off_screen, data_size);
+        lv_draw_buf_init(&dsc->buf2, w, h, color_format, stride, dsc->mem_off_screen, data_size);
+        lv_display_set_draw_buffers(disp, &dsc->buf2, NULL);
     }
 
-    lv_display_set_draw_buffers(disp, &dsc->buf1, double_buffer ? &dsc->buf2 : NULL);
     lv_display_set_color_format(disp, color_format);
     lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_DIRECT);
     lv_display_set_resolution(disp, dsc->vinfo.xres, dsc->vinfo.yres);
@@ -223,18 +236,18 @@ static void display_refr_timer_cb(lv_timer_t * tmr)
 
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * color_p)
 {
+    LV_UNUSED(color_p);
     lv_nuttx_fb_t * dsc = lv_display_get_driver_data(disp);
+
+    if(dsc->mem_off_screen) {
+        /* When rendering in off-screen mode, copy the drawing buffer to fb */
+        /* buf2(off-screen buffer) -> buf1(fbmem)*/
+        lv_draw_buf_copy(&dsc->buf1, area, &dsc->buf2, area);
+    }
 
     /* Skip the non-last flush */
 
     if(!lv_display_flush_is_last(disp)) {
-        lv_display_flush_ready(disp);
-        return;
-    }
-
-    if(dsc->mem == NULL ||
-       area->x2 < 0 || area->y2 < 0 ||
-       area->x1 > (int32_t)dsc->vinfo.xres - 1 || area->y1 > (int32_t)dsc->vinfo.yres - 1) {
         lv_display_flush_ready(disp);
         return;
     }
@@ -379,6 +392,13 @@ static void display_release_cb(lv_event_t * e)
             close(dsc->fd);
             dsc->fd = -1;
         }
+
+        if(dsc->mem_off_screen) {
+            /* Free the off-screen buffer */
+            free(dsc->mem_off_screen);
+            dsc->mem_off_screen = NULL;
+        }
+
         lv_free(dsc);
     }
     LV_LOG_USER("Done");


### PR DESCRIPTION
### Description of the feature or fix

For fb devices with only a single frame buffer, a buffer is automatically created for drawing during initialization. It is copied to the fb display in flush_cb to avoid flickering.

For discussion, see: https://github.com/lvgl/lvgl/pull/6561

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
