### PR TITLE
perf(draw): improve execute time of obj's transforming

### DIFF
--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -240,6 +240,7 @@ struct _lv_obj_t {
     uint16_t h_layout   : 1;
     uint16_t w_layout   : 1;
     uint16_t is_deleting : 1;
+    uint16_t transform_changed;
 };
 
 /**********************

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -338,7 +338,7 @@ void lv_obj_move_children_by(lv_obj_t * obj, int32_t x_diff, int32_t y_diff, boo
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
+void lv_obj_transform_point(lv_obj_t * obj, lv_point_t * p, bool recursive, bool inv);
 
 /**
  * Transform an area using the angle and zoom style properties of an object
@@ -347,7 +347,7 @@ void lv_obj_transform_point(const lv_obj_t * obj, lv_point_t * p, bool recursive
  * @param recursive     consider the transformation properties of the parents too
  * @param inv           do the inverse of the transformation (-angle and 1/zoom)
  */
-void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
+void lv_obj_get_transformed_area(lv_obj_t * obj, lv_area_t * area, bool recursive, bool inv);
 
 /**
  * Mark an area of an object as invalid.


### PR DESCRIPTION
Change-Id: Ic04d88aefce4b8c4fefeb2b419016ca7db0d0948

### Description of the feature or fix

I'm back again. 
please review this change.

I try to resolve the problems of first PR (https://github.com/lvgl/lvgl/pull/6327)
As I explain before, I want to reduce execute time of lv_obj_get_transformed_area(). 

the key of this solution, mark(increase) to object's transform_changed variable when parent has transform property, , object's childrens as well.

 - LV_STYLE_TRANSFORM_ROTATION
 - LV_STYLE_TRANSFORM_SCALE_X
 - LV_STYLE_TRANSFORM_SCALE_Y

If the transform_changed value of an object is not 0, it means that the transform property (scale, angle) of the parent of the object has changed.
That's why you need to change the object's scale or angle according to the scale and angle values ​​of the parent.

for example, 
  null
    |
    a ( a object's transform_changed is 0 )
    |
    b  ( _b has scale and angle property_, b object's transform_changed is 1 )
    | 
    c  ( _c has angle property_, c object's transform_changed is 2 )
    |
    d  ( object's transform_changed is 2 )


object d's transform_changed is 2. that means d's parent has transform property (scale, angle). 
so call lv_obj_transform_point() to check parent's transform property( scale, angle )
object c, d's parent, also is set to 2, so check c's parent one more time
object b, c's parent, is set to 1. however, parent(a)'s transform_changed set to 0. 
This means that there is no need to check the parent's attributes anymore.

In this way we can improve execution speed by reducing unnecessary recursive function calls.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
