### PR TITLE
chore(display): prevent disp_refr from becoming a wild pointer

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -205,6 +205,10 @@ void lv_display_delete(lv_display_t * disp)
     lv_free(disp);
 
     if(was_default) lv_display_set_default(lv_ll_get_head(disp_ll_p));
+
+    if(disp == lv_refr_get_disp_refreshing()) {
+        lv_refr_set_disp_refreshing(lv_display_get_default());
+    }
 }
 
 void lv_display_set_default(lv_display_t * disp)

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -158,7 +158,9 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
 void lv_display_delete(lv_display_t * disp)
 {
     bool was_default = false;
+    bool was_refr = false;
     if(disp == lv_display_get_default()) was_default = true;
+    if(disp == lv_refr_get_disp_refreshing()) was_refr = true;
 
     lv_display_send_event(disp, LV_EVENT_DELETE, NULL);
     lv_event_remove_all(&(disp->event_list));
@@ -206,9 +208,7 @@ void lv_display_delete(lv_display_t * disp)
 
     if(was_default) lv_display_set_default(lv_ll_get_head(disp_ll_p));
 
-    if(disp == lv_refr_get_disp_refreshing()) {
-        lv_refr_set_disp_refreshing(lv_display_get_default());
-    }
+    if(was_refr) lv_refr_set_disp_refreshing(lv_ll_get_head(disp_ll_p));
 }
 
 void lv_display_set_default(lv_display_t * disp)

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -208,7 +208,7 @@ void lv_display_delete(lv_display_t * disp)
 
     if(was_default) lv_display_set_default(lv_ll_get_head(disp_ll_p));
 
-    if(was_refr) lv_refr_set_disp_refreshing(lv_ll_get_head(disp_ll_p));
+    if(was_refr) lv_refr_set_disp_refreshing(NULL);
 }
 
 void lv_display_set_default(lv_display_t * disp)


### PR DESCRIPTION
### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
