### PR TITLE
feat(event): cache removed event

### DIFF
--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -107,7 +107,9 @@ typedef enum {
 
     LV_EVENT_VSYNC,
 
-    LV_EVENT_LAST,                 /** Number of default events*/
+    LV_EVENT_MARK_FREE,             /** Mark event slots as free, NOT an event*/
+
+    LV_EVENT_LAST,                  /** Number of default events*/
 
     LV_EVENT_PREPROCESS = 0x8000,   /** This is a flag that can be set with an event so it's processed
                                       before the class default event processing */


### PR DESCRIPTION
### Description of the feature or fix

This modification is similar to https://github.com/lvgl/lvgl/pull/6592. Both add a mark to the deleted event. This PR marks the event slot as pending reuse. This solution should be the most efficient because it saves the overhead introduced by the `realloc` operation of `lv_array`, and the changes to the current code are minimal. The disadvantage is that the insertion order cannot be guaranteed, which may affect the current APP that relies on the order of event sending.
The design of https://github.com/lvgl/lvgl/pull/6592 is to mark the deleted events as pending deletion and clean them up uniformly after the events are sent. The advantage is that it will not affect the event order and can ensure forward compatibility. The disadvantage is that it is necessary to introduce additional member variables to record whether event_list has been deleted.
Which option do you prefer?

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
