### PR TITLE
fix(API): keep ime struct lv_pinyin_dict_t public

### DIFF
--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -257,8 +257,6 @@ typedef struct lv_observer_t lv_observer_t;
 
 typedef struct lv_monkey_config_t lv_monkey_config_t;
 
-typedef struct lv_pinyin_dict_t lv_pinyin_dict_t;
-
 typedef struct lv_ime_pinyin_t lv_ime_pinyin_t;
 
 typedef struct lv_file_explorer_t lv_file_explorer_t;

--- a/src/others/ime/lv_ime_pinyin.h
+++ b/src/others/ime/lv_ime_pinyin.h
@@ -32,6 +32,12 @@ typedef enum {
     LV_IME_PINYIN_MODE_K9_NUMBER,
 } lv_ime_pinyin_mode_t;
 
+/*Data of pinyin_dict*/
+typedef struct {
+    const char * const py;
+    const char * const py_mb;
+} lv_pinyin_dict_t;
+
 /*Data of 9-key input(k9) mode*/
 typedef struct {
     char py_str[7];

--- a/src/others/ime/lv_ime_pinyin_private.h
+++ b/src/others/ime/lv_ime_pinyin_private.h
@@ -27,12 +27,6 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-/*Data of pinyin_dict*/
-struct lv_pinyin_dict_t {
-    const char * const py;
-    const char * const py_mb;
-};
-
 /*Data of lv_ime_pinyin*/
 struct lv_ime_pinyin_t {
     lv_obj_t obj;


### PR DESCRIPTION
### Description of the feature or fix

cc @liamHowatt 

fix(API): keep ime struct lv_pinyin_dict_t public

The following two APIs require this structure, otherwise using them will result in errors.

```c
void lv_ime_pinyin_set_dict(lv_obj_t * obj, lv_pinyin_dict_t * dict);

const lv_pinyin_dict_t * lv_ime_pinyin_get_dict(lv_obj_t * obj);
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
