### PR TITLE
fix(rtthread): display driver hang

### DIFF
--- a/env_support/rt-thread/lv_rt_thread_port.c
+++ b/env_support/rt-thread/lv_rt_thread_port.c
@@ -47,8 +47,9 @@ static struct rt_thread lvgl_thread;
 static rt_uint8_t lvgl_thread_stack[PKG_LVGL_THREAD_STACK_SIZE];
 
 #if LV_USE_LOG
-static void lv_rt_log(const char *buf)
+static void lv_rt_log(lv_log_level_t level, const char * buf)
 {
+    (void) level;
     LOG_I(buf);
 }
 #endif /* LV_USE_LOG */
@@ -66,11 +67,11 @@ static void lvgl_thread_entry(void *parameter)
     lv_log_register_print_cb(lv_rt_log);
 #endif /* LV_USE_LOG */
     lv_init();
+    lv_tick_set_cb(&rt_tick_get_millisecond);
     lv_port_disp_init();
     lv_port_indev_init();
     lv_user_gui_init();
 
-    lv_tick_set_cb(&rt_tick_get_millisecond);
 
 #ifdef PKG_USING_CPU_USAGE
     cpu_usage_init();


### PR DESCRIPTION
The lvgl 9.1 st7789 driver hangs on rt-thread. 
The reason is that the lv_lcd_generic_mipi display driver uses lv_delay_ms() before clock ticks are running.
Solution is moving lv_tick_set_cb() before lv_port_disp_init().

Also, update argument list of logger to lvgl 9.1.
