### PR TITLE
fix(env_support/cmake): If LV_CONF_PATH is set, install the indicated config instead of the default one.

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -80,8 +80,13 @@ file(GLOB LVGL_PUBLIC_HEADERS
     "${LVGL_ROOT_DIR}/lv_version.h")
 
 if(NOT LV_CONF_SKIP)
-	list(APPEND LVGL_PUBLIC_HEADERS
-		"${CMAKE_SOURCE_DIR}/lv_conf.h")
+  if (LV_CONF_PATH)
+    list(APPEND LVGL_PUBLIC_HEADERS
+    ${LV_CONF_PATH})
+  else()
+    list(APPEND LVGL_PUBLIC_HEADERS
+    "${CMAKE_SOURCE_DIR}/lv_conf.h")
+  endif()
 endif()
 
 if("${LIB_INSTALL_DIR}" STREQUAL "")


### PR DESCRIPTION
### Description of the feature or fix

When using CMake as build system, if `LV_CONF_PATH` is set, install the one pointed as public header instead of trying to install the config from the default location.
