### PR TITLE
fix(freertos): notifiy-based sync can be initialized from any task

### DIFF
--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -51,7 +51,7 @@ extern "C" {
 
 typedef struct {
     void (*pvStartRoutine)(void *);       /**< Application thread function. */
-    void * xTaskArg;                      /**< Arguments for application thread function. */
+    void * pTaskArg;                      /**< Arguments for application thread function. */
     TaskHandle_t xTaskHandle;             /**< FreeRTOS task handle. */
 } lv_thread_t;
 
@@ -61,12 +61,12 @@ typedef struct {
 } lv_mutex_t;
 
 typedef struct {
+    BaseType_t
+    xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
 #if USE_FREERTOS_TASK_NOTIFY
     TaskHandle_t xTaskToNotify;
     BaseType_t xSignalSent;
 #else
-    BaseType_t
-    xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
     SemaphoreHandle_t xCondWaitSemaphore; /**< Threads block on this semaphore in lv_thread_sync_wait. */
     uint32_t ulWaitingThreads;            /**< The number of threads currently waiting on this condition variable. */
     SemaphoreHandle_t xSyncMutex;         /**< Threads take this mutex before accessing the condition variable. */

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -63,14 +63,13 @@ typedef struct {
 typedef struct {
     BaseType_t
     xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
+    BaseType_t xSyncSignal;               /**< Set to pdTRUE if the thread is signaled, pdFALSE otherwise. */
 #if USE_FREERTOS_TASK_NOTIFY
-    TaskHandle_t xTaskToNotify;
-    BaseType_t xSignalSent;
+    TaskHandle_t xTaskToNotify;           /**< The task waiting to be signalled. NULL if nothing is waiting. */
 #else
     SemaphoreHandle_t xCondWaitSemaphore; /**< Threads block on this semaphore in lv_thread_sync_wait. */
     uint32_t ulWaitingThreads;            /**< The number of threads currently waiting on this condition variable. */
     SemaphoreHandle_t xSyncMutex;         /**< Threads take this mutex before accessing the condition variable. */
-    BaseType_t xSyncSignal;               /**< Set to pdTRUE if the thread is signaled, pdFALSE otherwise. */
 #endif
 } lv_thread_sync_t;
 

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -63,6 +63,7 @@ typedef struct {
 typedef struct {
 #if USE_FREERTOS_TASK_NOTIFY
     TaskHandle_t xTaskToNotify;
+    BaseType_t xSignalSent;
 #else
     BaseType_t
     xIsInitialized;                       /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */


### PR DESCRIPTION
### Description of the feature or fix

Fixes #6414

`lv_thread_sync_wait` can be called from a thread other than the one that called `lv_thread_sync_init`.

@nicusorcitu

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` ([astyle](http://astyle.sourceforge.net/install.html) version [v3.4.12](https://github.com/szepeviktor/astyle/releases/tag/v3.4.12) needs to be installed) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
