### PR TITLE
perf(draw): skip empty draw tasks

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -160,16 +160,13 @@ void lv_draw_dispatch(void)
     bool render_running = false;
     lv_display_t * disp = lv_display_get_next(NULL);
     while(disp) {
-        /*If there are no redraw areas on the display, then skip drawing*/
-        if(disp->inv_p) {
-            lv_layer_t * layer = disp->layer_head;
-            while(layer) {
-                if(lv_draw_dispatch_layer(disp, layer))
-                    render_running = true;
-                layer = layer->next;
-            }
+        lv_layer_t * layer = disp->layer_head;
+        while(layer) {
+            /* If there are no tasks in the layer, skip it */
+            if(layer->draw_task_head && lv_draw_dispatch_layer(disp, layer))
+                render_running = true;
+            layer = layer->next;
         }
-
         if(!render_running) {
             lv_draw_dispatch_request();
         }

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -160,12 +160,16 @@ void lv_draw_dispatch(void)
     bool render_running = false;
     lv_display_t * disp = lv_display_get_next(NULL);
     while(disp) {
-        lv_layer_t * layer = disp->layer_head;
-        while(layer) {
-            if(lv_draw_dispatch_layer(disp, layer))
-                render_running = true;
-            layer = layer->next;
+        /*If there are no redraw areas on the display, then skip drawing*/
+        if(disp->inv_p) {
+            lv_layer_t * layer = disp->layer_head;
+            while(layer) {
+                if(lv_draw_dispatch_layer(disp, layer))
+                    render_running = true;
+                layer = layer->next;
+            }
         }
+
         if(!render_running) {
             lv_draw_dispatch_request();
         }

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -128,7 +128,7 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
 
     while(layer.draw_task_head) {
         lv_draw_dispatch_wait_for_request();
-        lv_draw_dispatch();
+        lv_draw_dispatch_layer(disp_new, &layer);
     }
 
     disp_new->layer_head = layer_old;

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -128,7 +128,7 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
 
     while(layer.draw_task_head) {
         lv_draw_dispatch_wait_for_request();
-        lv_draw_dispatch_layer(disp_new, &layer);
+        lv_draw_dispatch();
     }
 
     disp_new->layer_head = layer_old;


### PR DESCRIPTION
### Description of the feature or fix

If the drawing task is not found in the drawing task list of the layer, `lv_draw_dispatch_layer` will not be called, and an empty drawing request will not be triggered.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
