### PR TITLE
docs(label):  fix unintentional definition list in parts and styles section

### DIFF
--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -15,13 +15,13 @@ Parts and Styles
 ****************
 
 - :cpp:enumerator:`LV_PART_MAIN` Uses all the typical background properties and the
-   text properties. The padding values can be used to add space between
-   the text and the background.
+  text properties. The padding values can be used to add space between
+  the text and the background.
 - :cpp:enumerator:`LV_PART_SCROLLBAR` The scrollbar that is shown when the text is
-   larger than the widget's size.
-- :cpp:enumerator:`LV_PART_SELECTED` Tells the style of the 
+  larger than the widget's size.
+- :cpp:enumerator:`LV_PART_SELECTED` Tells the style of the
   :ref:`selected text <lv_label_text_selection>`. Only ``text_color`` and ``bg_color`` style
-   properties can be used.
+  properties can be used.
 
 .. _lv_label_usage:
 


### PR DESCRIPTION
An indentation error in a bullet list was causing something in the docs data-processing chain to interpret the items in the label documentation's ["Parts and Styles" section](https://docs.lvgl.io/master/widgets/label.html#parts-and-styles) as a "definition list"  (referring to the HTML \<dl\>...\</dt\> element).

This addresses issue #6734.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
