### PR TITLE
Revert "perf(draw): skip empty draw tasks (#6720)"

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -179,8 +179,7 @@ void lv_draw_dispatch(void)
     while(disp) {
         lv_layer_t * layer = disp->layer_head;
         while(layer) {
-            /* If there are no tasks in the layer, skip it */
-            if(layer->draw_task_head && lv_draw_dispatch_layer(disp, layer))
+            if(lv_draw_dispatch_layer(disp, layer))
                 task_dispatched = true;
             layer = layer->next;
         }


### PR DESCRIPTION
This reverts commit ed4cb1992628f750053f0641435f064a94ee6971.

After stress testing, it was found that `lv_draw_dispatch_layer` cannot be simply executed by checking whether `layer->draw_task_head` is empty.

After the task type is `LV_DRAW_TASK_TYPE_LAYER`, it may be necessary to execute `lv_draw_dispatch_layer` once more to switch it from `LV_DRAW_TASK_STATE_WAITING` state to `LV_DRAW_TASK_STATE_QUEUED` state, see function `lv_draw_dispatch_layer`:

```c
bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
{
    ...
    /*This layer is ready, enable blending its buffer*/
    if(layer->parent && layer->all_tasks_added && layer->draw_task_head == NULL) {
        /*Find a draw task with TYPE_LAYER in the layer where the src is this layer*/
        lv_draw_task_t * t_src = layer->parent->draw_task_head;
        while(t_src) {
            if(t_src->type == LV_DRAW_TASK_TYPE_LAYER && t_src->state == LV_DRAW_TASK_STATE_WAITING) {
                lv_draw_image_dsc_t * draw_dsc = t_src->draw_dsc;
                if(draw_dsc->src == layer) {
                    t_src->state = LV_DRAW_TASK_STATE_QUEUED;
                    lv_draw_dispatch_request();
                    break;
                }
            }
            t_src = t_src->next;
        }
    }
    ...
}
```

Otherwise, the `lv_draw_dispatch` function execution may cause a busy loop. Because there is a task of `LV_DRAW_TASK_TYPE_LAYER` left in the drawing queue, and this task is always in the `WAITING` state.

No case that can reproduce the problem independently has been found yet, so revert is performed first.

Can this be modified and merged into release v9.2? @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
