### PR TITLE
chore(scripts): allow to run update_version.py with python3.8

### DIFF
--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -3,6 +3,7 @@
 import os
 import re
 import argparse
+from typing import List, Union
 
 
 def get_arg():
@@ -43,12 +44,12 @@ class RepoFileVersionReplacer:
     DIR_SCRIPTS = os.path.dirname(__file__)
     DIR_REPO_ROOT = os.path.join(DIR_SCRIPTS, "..")
 
-    def __init__(self, relative_path_segments: list[str], expected_occurrences: int):
+    def __init__(self, relative_path_segments: List[str], expected_occurrences: int):
         self.path_relative = os.path.join(*relative_path_segments)
         self.path = os.path.join(self.DIR_REPO_ROOT, self.path_relative)
         self.expected_occurrences = expected_occurrences
 
-    def applyVersionToLine(self, line: str, version: Version) -> str | None:
+    def applyVersionToLine(self, line: str, version: Version) -> Union[str, None]:
         return None
 
     def applyVersion(self, version: Version):
@@ -72,7 +73,7 @@ class RepoFileVersionReplacer:
 
 class PrefixReplacer(RepoFileVersionReplacer):
 
-    def __init__(self, relative_path_segments: list[str], prefix: str, expected_occurrences=1):
+    def __init__(self, relative_path_segments: List[str], prefix: str, expected_occurrences=1):
         super().__init__(relative_path_segments, expected_occurrences)
         self.prefix = prefix
 
@@ -84,7 +85,7 @@ class PrefixReplacer(RepoFileVersionReplacer):
 
 
 class MacroReplacer(RepoFileVersionReplacer):
-    def __init__(self, relative_path_segments: list[str]):
+    def __init__(self, relative_path_segments: List[str]):
         super().__init__(relative_path_segments, 4)
 
     def applyVersionToLine(self, line: str, version: Version):


### PR DESCRIPTION
Type hinting generics is from python3.9

https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
