### PR TITLE
chore(Kconfig): add version info to Kconfig file to check mismatch

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1527,15 +1527,25 @@ menu "LVGL configuration"
 			default y
 			help
 				This can save some memory, but not much. After the quick access bar is created, it can be hidden by clicking the button at the top left corner of the browsing area, which is very useful for small screen devices.
-	
+
 		config LV_USE_FONT_MANAGER
 			bool "Enable freetype font manager"
 			depends on LV_USE_FREETYPE
-			default n			
+			default n
 		config LV_FONT_MANAGER_NAME_MAX_LEN
 			int "Font manager name max length"
 			depends on LV_USE_FONT_MANAGER
 			default 32
+
+		config LVGL_VERSION_MAJOR
+			int
+			default 9 # LVGL_VERSION_MAJOR
+		config LVGL_VERSION_MINOR
+			int
+			default 2 # LVGL_VERSION_MINOR
+		config LVGL_VERSION_PATCH
+			int
+			default 0 # LVGL_VERSION_PATCH
 	endmenu
 
 	menu "Devices"

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -18,6 +18,16 @@ extern "C" {
 
 #  ifdef __NuttX__
 #    include <nuttx/config.h>
+/*
+ * Make sure version number in Kconfig file is correctly set.
+ * Mismatch can happen when user manually copy lvgl/Kconfig file to their project, like what NuttX does.
+ */
+#    include "../lv_version.h"
+
+#    if CONFIG_LVGL_VERSION_MAJOR != LVGL_VERSION_MAJOR || CONFIG_LVGL_VERSION_MINOR != LVGL_VERSION_MINOR \
+        || CONFIG_LVGL_VERSION_PATCH != LVGL_VERSION_PATCH
+#        warning "Version mismatch between Kconfig and lvgl/lv_version.h"
+#    endif
 #  elif defined(__RTTHREAD__)
 #    define LV_CONF_INCLUDE_SIMPLE
 #    include <lv_rt_thread_conf.h>


### PR DESCRIPTION


For NuttX, lvgl/Kconfig file is copied out, add version info in Kconfig file to detect if the Kconfig is out of sync with source code.

Fix #6576

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
