### PR TITLE
fix(assets): Add missing strides

### DIFF
--- a/demos/music/assets/img_lv_demo_music_cover_1.c
+++ b/demos/music/assets/img_lv_demo_music_cover_1.c
@@ -187,6 +187,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_cover_1_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_1 = {
     .header.w = 176,
     .header.h = 175,
+    .header.stride = 704,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_1_map,
     .data_size = sizeof(img_lv_demo_music_cover_1_map),

--- a/demos/music/assets/img_lv_demo_music_cover_1_large.c
+++ b/demos/music/assets/img_lv_demo_music_cover_1_large.c
@@ -448,6 +448,7 @@ img_lv_demo_music_cover_1_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_1 = {
     .header.w = 428,
     .header.h = 428,
+    .header.stride = 1712,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_1_map,
     .data_size = sizeof(img_lv_demo_music_cover_1_map),

--- a/demos/music/assets/img_lv_demo_music_cover_2.c
+++ b/demos/music/assets/img_lv_demo_music_cover_2.c
@@ -188,6 +188,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_cover_2_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_2 = {
     .header.w = 176,
     .header.h = 175,
+    .header.stride = 704,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_2_map,
     .data_size = sizeof(img_lv_demo_music_cover_2_map),

--- a/demos/music/assets/img_lv_demo_music_cover_2_large.c
+++ b/demos/music/assets/img_lv_demo_music_cover_2_large.c
@@ -448,6 +448,7 @@ img_lv_demo_music_cover_2_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_2 = {
     .header.w = 428,
     .header.h = 428,
+    .header.stride = 1712,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_2_map,
     .data_size = sizeof(img_lv_demo_music_cover_2_map),

--- a/demos/music/assets/img_lv_demo_music_cover_3.c
+++ b/demos/music/assets/img_lv_demo_music_cover_3.c
@@ -188,6 +188,7 @@ const LV_ATTRIBUTE_MEM_ALIGN uint8_t img_lv_demo_music_cover_3_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_3 = {
     .header.w = 176,
     .header.h = 175,
+    .header.stride = 704,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_3_map,
     .data_size = sizeof(img_lv_demo_music_cover_3_map),

--- a/demos/music/assets/img_lv_demo_music_cover_3_large.c
+++ b/demos/music/assets/img_lv_demo_music_cover_3_large.c
@@ -447,6 +447,7 @@ img_lv_demo_music_cover_3_map[] = {
 const lv_image_dsc_t img_lv_demo_music_cover_3 = {
     .header.w = 428,
     .header.h = 428,
+    .header.stride = 1712,
     .header.cf = LV_COLOR_FORMAT_ARGB8888,
     .data = img_lv_demo_music_cover_3_map,
     .data_size = sizeof(img_lv_demo_music_cover_3_map),

--- a/examples/assets/img_star.c
+++ b/examples/assets/img_star.c
@@ -58,6 +58,7 @@ const lv_image_dsc_t img_star = {
   .header.magic = LV_IMAGE_HEADER_MAGIC,
   .header.w = 30,
   .header.h = 29,
+  .header.stride = 120,
   .data_size = 870 * 4,
   .data = img_star_map,
 };


### PR DESCRIPTION
Add `.header.stride` where missing. Ignoring `examples/libs/gif/img_bulb_gif.c` and `examples/libs/lodepng/img_wink_png.c` because they are raw GIF and PNG.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
