### PR TITLE
fix(perf): perf monitor FPS

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -355,7 +355,7 @@ void lv_display_refr_timer(lv_timer_t * tmr)
         /* Ensure the timer does not run again automatically.
          * This is done before refreshing in case refreshing invalidates something else.
          * However if the performance monitor is enabled keep the timer running to count the FPS.*/
-#if LV_USE_PERF_MONITOR
+#if !LV_USE_PERF_MONITOR
         lv_timer_pause(tmr);
 #endif
     }

--- a/tests/src/test_cases/widgets/test_arc.c
+++ b/tests/src/test_cases/widgets/test_arc.c
@@ -209,6 +209,8 @@ void test_arc_click_sustained_from_start_to_end_does_not_set_value_to_max(void)
 
     /* Click close to start angle */
     event_cnt = 0;
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
     lv_test_mouse_move_to(376, 285);
     lv_test_mouse_press();
     lv_test_indev_wait(500);
@@ -221,6 +223,8 @@ void test_arc_click_sustained_from_start_to_end_does_not_set_value_to_max(void)
     /* Click close to end angle */
     event_cnt = 0;
 
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
     lv_test_mouse_move_to(376, 285);
     lv_test_mouse_press();
     lv_test_indev_wait(500);
@@ -264,6 +268,8 @@ void test_two_overlapping_arcs_can_be_interacted_independently(void)
     event_cnt2 = 0;
 
     // Click on the position of the first arc (center)
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
     lv_test_mouse_move_to(400, 195);
     lv_test_mouse_press();
     lv_test_indev_wait(500);
@@ -275,6 +281,8 @@ void test_two_overlapping_arcs_can_be_interacted_independently(void)
     TEST_ASSERT_EQUAL_UINT32(1, event_cnt2);
 
     // click on the position of the second arc (center)
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
     lv_test_mouse_move_to(400, 285);
     lv_test_mouse_press();
     lv_test_indev_wait(500);


### PR DESCRIPTION
The logic for pausing the timer was accidentally inverted. It should not pause the timer if the perf monitor is enabled. Always try to achieve target FPS while perf monitor is enabled.

Should fix #6785

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
