### PR TITLE
fix(sdl): check against NULL before using the driver data of a display

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -166,7 +166,7 @@ lv_display_t * lv_sdl_get_disp_from_win_id(uint32_t win_id)
 
     while(disp) {
         lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-        if(SDL_GetWindowID(dsc->window) == win_id) {
+        if(dsc != NULL && SDL_GetWindowID(dsc->window) == win_id) {
             return disp;
         }
         disp = lv_display_get_next(disp);


### PR DESCRIPTION
We are migrating from LVGL 8 to 9.2.

When we simulate our device's GUI, we embed the device GUI as a secondary display (draw-buffer-only) in an SDL display. The SDL display shows some hardware buttons around the device GUI. So it is a display in display.

In LVGL 9, all displays are assumed to be an SDL display. But this isn't the case. The simplest workaround that works for us is to check if the drive data is not null. 

It would be even better to check what type of display it is. Unfortunately, I don't see such an option yet.