### PR TITLE
feat(nuttx): add memory dump for image cache heap

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -136,6 +136,19 @@ static bool defer_init(void)
     return true;
 }
 
+static void heap_memdump(struct mm_heap_s * heap)
+{
+    struct mm_memdump_s dump = {
+        PID_MM_ALLOC,
+#if CONFIG_MM_BACKTRACE >= 0
+        0,
+        ULONG_MAX
+#endif
+    };
+
+    mm_memdump(heap, &dump);
+}
+
 static void * malloc_cb(size_t size_bytes, lv_color_format_t color_format)
 {
     LV_UNUSED(color_format);
@@ -163,6 +176,7 @@ static void * malloc_cb(size_t size_bytes, lv_color_format_t color_format)
         bool evict_res = lv_cache_evict_one(img_cache_p, NULL);
         if(evict_res == false) {
             LV_LOG_ERROR("failed to evict one cache entry");
+            heap_memdump(ctx->heap);
             return NULL;
         }
     }


### PR DESCRIPTION
When allocation fails after all caches are removed from the image cache heap, print the current heap occupancy to check for memory leaks.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
