### PR TITLE
perf(vg_lite): balancing performance and memory consumption

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -24,6 +24,8 @@
 /* Magic number from https://spencermortensen.com/articles/bezier-circle/ */
 #define PATH_ARC_MAGIC 0.55191502449351f
 
+#define PATH_MEM_SIZE_MIN 128
+
 #define SIGN(x) (math_zero(x) ? 0 : ((x) > 0 ? 1 : -1))
 
 #define VLC_OP_ARG_LEN(OP, LEN) \
@@ -260,10 +262,11 @@ static void lv_vg_lite_path_append_data(lv_vg_lite_path_t * path, const void * d
 
     if(path->base.path_length + len > path->mem_size) {
         if(path->mem_size == 0) {
-            path->mem_size = len;
+            path->mem_size = LV_MAX(len, PATH_MEM_SIZE_MIN);
         }
         else {
-            path->mem_size *= 2;
+            /* Increase memory size by 1.5 times */
+            path->mem_size = path->mem_size * 3 / 2;
         }
         path->base.path = lv_realloc(path->base.path, path->mem_size);
         LV_ASSERT_MALLOC(path->base.path);


### PR DESCRIPTION
According to @W-Mai statistics, the initial memory of the path is 128 bytes and is expanded by 1.5 times, which can achieve a balance between performance and memory.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
