### PR TITLE
feat(animimg): add getter function for underlying animation

### DIFF
--- a/docs/widgets/animimg.rst
+++ b/docs/widgets/animimg.rst
@@ -33,6 +33,16 @@ Image sources
 To set the image in a state, use the
 :cpp:expr:`lv_animimg_set_src(imagebutton, dsc[], num)`.
 
+Using the inner animation
+-------------------------
+
+For more advanced use cases, the animation internally used by the image can be
+retrieved using the :cpp:expr:`lv_animimg_get_anim(image)`. This way, the
+:ref:`Animation <animations>` functions can be used, for example to
+override the animation values using the
+:cpp:expr:`lv_anim_set_values(anim, start, end)` or to set a callback
+on the animation completed event.
+
 .. _lv_animimg_events:
 
 Events

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -134,6 +134,13 @@ uint32_t lv_animimg_get_repeat_count(lv_obj_t * obj)
     return lv_anim_get_repeat_count(&animimg->anim);
 }
 
+lv_anim_t * lv_animimg_get_anim(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return &animimg->anim;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../image/lv_image.h"
+#include "../../misc/lv_types.h"
 
 #if LV_USE_ANIMIMG != 0
 
@@ -111,6 +112,13 @@ uint32_t lv_animimg_get_duration(lv_obj_t * img);
  * @return      the repeat count
  */
 uint32_t lv_animimg_get_repeat_count(lv_obj_t * img);
+
+/**
+ * Get the image animation underlying animation.
+ * @param img   pointer to an animation image object
+ * @return      the animation reference
+ */
+lv_anim_t * lv_animimg_get_anim(lv_obj_t * img);
 
 #endif /*LV_USE_ANIMIMG*/
 


### PR DESCRIPTION
This PR adds a getter function for the animimage class to retrieve the underlying animation reference. This is needed when someone want to tweak the animation process (for example setting it reverse or with a custom range of values) without having to create a new image array.


