### PR TITLE
fix(Kconfig): Fix non existant LV_STDLIB_BUILTIN

### DIFF
--- a/.github/workflows/verify_kconfig.yml
+++ b/.github/workflows/verify_kconfig.yml
@@ -1,0 +1,22 @@
+name: Verify Kconfig
+on:
+  push:
+  pull_request:
+
+jobs:
+  verify-kconfig:
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.7
+      - name: Run kconfig_verify.py
+        run: python3 -m pip install kconfiglib && python kconfig_verify.py ../Kconfig
+        working-directory: scripts

--- a/Kconfig
+++ b/Kconfig
@@ -1384,7 +1384,7 @@ menu "LVGL configuration"
 		config LV_USE_MEM_MONITOR
 			bool "Show the used memory and the memory fragmentation"
 			default n
-			depends on LV_STDLIB_BUILTIN && LV_USE_SYSMON
+			depends on LV_USE_BUILTIN_MALLOC && LV_USE_SYSMON
 
 		choice
 			prompt "Memory monitor position"

--- a/Kconfig
+++ b/Kconfig
@@ -445,12 +445,12 @@ menu "LVGL configuration"
 				Accelerate blends, fills, image decoding, etc. with STM32 DMA2D.
 
 		config LV_DRAW_DMA2D_HAL_INCLUDE
-			int "the header file for LVGL to include for DMA2D"
+			string "the header file for LVGL to include for DMA2D"
 			default "stm32h7xx_hal.h"
 			depends on LV_USE_DRAW_DMA2D
 
 		config LV_USE_DRAW_DMA2D_INTERRUPT
-			int "use the DMA2D transfer complete interrupt"
+			bool "use the DMA2D transfer complete interrupt"
 			default n
 			depends on LV_USE_DRAW_DMA2D
 			help

--- a/scripts/install-prerequisites.bat
+++ b/scripts/install-prerequisites.bat
@@ -1,4 +1,4 @@
 vcpkg install vcpkg-tool-ninja libpng freetype opengl glfw3 glew
 if %errorlevel% neq 0 exit /b %errorlevel%
-pip install pypng lz4
+pip install pypng lz4 kconfiglib
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -14,4 +14,4 @@ sudo apt install gcc gcc-multilib g++-multilib ninja-build \
     ruby-full gcovr cmake  python3 pngquant libinput-dev libxkbcommon-dev \
     libdrm-dev pkg-config wayland-protocols libwayland-dev libwayland-bin \
     libwayland-dev:i386 libxkbcommon-dev:i386
-pip3 install pypng lz4
+pip3 install pypng lz4 kconfiglib

--- a/scripts/kconfig_verify.py
+++ b/scripts/kconfig_verify.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import sys
+
+try:
+    import kconfiglib
+except ImportError:
+    print("Need kconfiglib package, do `pip3 install kconfiglib`")
+    sys.exit(1)
+
+
+def verify_kconfig(kconfig_file):
+    kconf = kconfiglib.Kconfig(kconfig_file)
+
+    if kconf.warnings:
+        print("Warnings found:")
+        for warning in kconf.warnings:
+            print(warning)
+        sys.exit(1)
+    else:
+        print("No warnings found.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python check_kconfig.py <Kconfig_file>")
+        sys.exit(1)
+
+    verify_kconfig(sys.argv[1])


### PR DESCRIPTION
LV_USE_MEM_MONITOR depends on LV_STDLIB_BUILTIN which does not exist in the kconfig, therefore generating warnings.

Resolves #6797.

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
