### PR TITLE
perf(vg_lite): optimize label drawing efficiency

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -26,6 +26,14 @@
 
 #define PATH_QUALITY VG_LITE_HIGH
 #define PATH_DATA_COORD_FORMAT VG_LITE_S16
+
+#if LV_VG_LITE_FLUSH_MAX_COUNT > 0
+    #define PATH_FLUSH_COUNT_MAX 0
+#else
+    /* When using IDLE Flush mode, reduce the number of flushes */
+    #define PATH_FLUSH_COUNT_MAX 8
+#endif
+
 #define FT_F26DOT6_SHIFT 6
 
 /** After converting the font reference size, it is also necessary to scale the 26dot6 data
@@ -289,8 +297,11 @@ static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_
                                &draw_matrix, VG_LITE_BLEND_SRC_OVER, lv_vg_lite_color(dsc->color, dsc->opa, true)));
     LV_PROFILER_END_TAG("vg_lite_draw");
 
-    /* Flush in time to avoid accumulation of drawing commands */
-    lv_vg_lite_flush(u);
+    u->letter_count++;
+    if(u->letter_count > PATH_FLUSH_COUNT_MAX) {
+        /* Flush in time to avoid accumulation of drawing commands */
+        lv_vg_lite_flush(u);
+    }
 
     LV_PROFILER_END;
 }

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -145,6 +145,12 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
     if(fill_draw_dsc && fill_area) {
         lv_draw_vg_lite_fill(draw_unit, fill_draw_dsc, fill_area);
     }
+
+    /* Flush in time to avoid accumulation of drawing commands */
+    u->letter_count++;
+    if(u->letter_count > PATH_FLUSH_COUNT_MAX) {
+        lv_vg_lite_flush(u);
+    }
 }
 
 static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_dsc_t * dsc)
@@ -296,12 +302,6 @@ static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_
                                &u->target_buffer, vg_lite_path, VG_LITE_FILL_NON_ZERO,
                                &draw_matrix, VG_LITE_BLEND_SRC_OVER, lv_vg_lite_color(dsc->color, dsc->opa, true)));
     LV_PROFILER_END_TAG("vg_lite_draw");
-
-    u->letter_count++;
-    if(u->letter_count > PATH_FLUSH_COUNT_MAX) {
-        /* Flush in time to avoid accumulation of drawing commands */
-        lv_vg_lite_flush(u);
-    }
 
     LV_PROFILER_END;
 }

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -49,6 +49,7 @@ struct _lv_draw_vg_lite_unit_t {
     lv_cache_t * stroke_cache;
 
     uint16_t flush_count;
+    uint16_t letter_count;
     vg_lite_buffer_t target_buffer;
     vg_lite_matrix_t global_matrix;
     struct _lv_vg_lite_path_t * global_path;

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1195,7 +1195,6 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
 
     LV_VG_LITE_CHECK_ERROR(vg_lite_flush());
     u->flush_count = 0;
-    u->letter_count = 0;
     LV_PROFILER_END;
 }
 
@@ -1214,6 +1213,7 @@ void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u)
     /* Clear image decoder dsc reference */
     lv_vg_lite_pending_remove_all(u->image_dsc_pending);
     u->flush_count = 0;
+    u->letter_count = 0;
     LV_PROFILER_END;
 }
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1175,6 +1175,7 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
     LV_PROFILER_BEGIN;
 
     u->flush_count++;
+    u->letter_count = 0;
 
 #if LV_VG_LITE_FLUSH_MAX_COUNT
     if(u->flush_count < LV_VG_LITE_FLUSH_MAX_COUNT) {
@@ -1194,6 +1195,7 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
 
     LV_VG_LITE_CHECK_ERROR(vg_lite_flush());
     u->flush_count = 0;
+    u->letter_count = 0;
     LV_PROFILER_END;
 }
 


### PR DESCRIPTION
Since `vg_lite_flush` needs to flush the D-Cache which takes some time, slightly reduce the number of flushes when drawing text.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
