### PR TITLE
fix(indev): fix hovering disabled obj resets indev

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -306,7 +306,7 @@ void lv_obj_add_state(lv_obj_t * obj, lv_state_t state)
     lv_state_t new_state = obj->state | state;
     if(obj->state != new_state) {
 
-        if(new_state & LV_STATE_DISABLED) {
+        if(new_state & ~obj->state & LV_STATE_DISABLED) {
             lv_indev_reset(NULL, obj);
         }
 


### PR DESCRIPTION
d11171d2bd291cad47d45f55ebc80d3985005730 introduced a check to reset input devices when an element is disabled. However, this also triggers when changing the state of an element that is already disabled. Fix that.

To reproduce, try scrolling in my current favorite example:

```c
static void demo()
{
    lv_obj_t * screen = lv_obj_create(NULL);
    lv_obj_set_size(screen, 512, 600);
    lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);

    for(int i = 0; i < 150; i++) {
        lv_obj_t * btn = lv_btn_create(screen);
        lv_obj_set_size(btn, lv_pct(100), LV_SIZE_CONTENT);

        if(i > 75) {
            lv_obj_add_state(btn, LV_STATE_DISABLED);
        }
    }

    lv_screen_load(screen);
}
```

Note how scroll momentum is frequently interrupted when scrolling the lower half with the disabled buttons.