### PR TITLE
fix: added bounds check in gif decoder

### DIFF
--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -113,9 +113,17 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     /* Aspect Ratio */
     f_gif_read(gif_base, &aspect, 1);
     /* Create gd_GIF Structure. */
-#if LV_GIF_CACHE_DECODE_DATA
+    #if LV_GIF_CACHE_DECODE_DATA
+    if(0 == (INT_MAX - sizeof(gd_GIF) - LZW_CACHE_SIZE) / width / height / 5){
+        LV_LOG_WARN("Image dimensions are too large");
+        goto fail;
+    } 
     gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height + LZW_CACHE_SIZE);
     #else
+    if(0 == (INT_MAX - sizeof(gd_GIF)) / width / height / 5){
+        LV_LOG_WARN("Image dimensions are too large");
+        goto fail;
+    } 
     gif = lv_malloc(sizeof(gd_GIF) + 5 * width * height);
     #endif
     if(!gif) goto fail;
@@ -318,6 +326,8 @@ get_key(gd_GIF *gif, int key_size, uint8_t *sub_len, uint8_t *shift, uint8_t *by
 }
 
 #if LV_GIF_CACHE_DECODE_DATA
+/* Decompress image pixels.
+ * Return 0 on success or -1 on out-of-memory or parse errror (w.r.t. LZW code table). */
 static int
 read_image_data(gd_GIF *gif, int interlace)
 {
@@ -375,6 +385,10 @@ read_image_data(gd_GIF *gif, int interlace)
     while (frm_off < frm_size) {
         /* copy data to frame buffer */
         while (sp > p_stack) {
+            if(frm_off >= frm_size){
+                LV_LOG_WARN("LZW table token overflows the frame buffer");
+                return -1;
+            }
             *ptr++ = *(--sp);
             frm_off += 1;
             /* read one line */
@@ -526,7 +540,7 @@ interlaced_line_index(int h, int y)
 }
 
 /* Decompress image pixels.
- * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table). */
+ * Return 0 on success or -1 on out-of-memory or parse errror (w.r.t. LZW code table). */
 static int
 read_image_data(gd_GIF * gif, int interlace)
 {
@@ -578,6 +592,10 @@ read_image_data(gd_GIF * gif, int interlace)
         if(ret == 1) key_size++;
         entry = table->entries[key];
         str_len = entry.length;
+	if(frm_off + str_len >= frm_size){
+		LV_LOG_WARN("LZW table token overflows the frame buffer");
+		return -1;
+	}
         for(i = 0; i < str_len; i++) {
             p = frm_off + entry.length - 1;
             x = p % gif->fw;
@@ -603,7 +621,7 @@ read_image_data(gd_GIF * gif, int interlace)
 #endif
 
 /* Read image.
- * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table). */
+ * Return 0 on success or -1 on out-of-memory or parse error (w.r.t. LZW code table). */
 static int
 read_image(gd_GIF * gif)
 {
@@ -615,6 +633,10 @@ read_image(gd_GIF * gif)
     gif->fy = read_num(gif);
     gif->fw = read_num(gif);
     gif->fh = read_num(gif);
+    if(gif->fx + gif->fw > gif->width || gif->fy + gif->fh > gif->height){
+        LV_LOG_WARN("Frame coordinates out of image bounds");
+        return -1;
+    }
     f_gif_read(gif, &fisrz, 1);
     interlace = fisrz & 0x40;
     /* Ignore Sort Flag. */

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -113,6 +113,10 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     /* Aspect Ratio */
     f_gif_read(gif_base, &aspect, 1);
     /* Create gd_GIF Structure. */
+    if(0 == width || 0 == height){
+    	LV_LOG_WARN("Zero size image");
+	goto fail;
+    }
     #if LV_GIF_CACHE_DECODE_DATA
     if(0 == (INT_MAX - sizeof(gd_GIF) - LZW_CACHE_SIZE) / width / height / 5){
         LV_LOG_WARN("Image dimensions are too large");

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -327,7 +327,7 @@ get_key(gd_GIF *gif, int key_size, uint8_t *sub_len, uint8_t *shift, uint8_t *by
 
 #if LV_GIF_CACHE_DECODE_DATA
 /* Decompress image pixels.
- * Return 0 on success or -1 on out-of-memory or parse errror (w.r.t. LZW code table). */
+ * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table) or parse error. */
 static int
 read_image_data(gd_GIF *gif, int interlace)
 {
@@ -540,7 +540,7 @@ interlaced_line_index(int h, int y)
 }
 
 /* Decompress image pixels.
- * Return 0 on success or -1 on out-of-memory or parse errror (w.r.t. LZW code table). */
+ * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table) or parse error. */
 static int
 read_image_data(gd_GIF * gif, int interlace)
 {
@@ -621,7 +621,7 @@ read_image_data(gd_GIF * gif, int interlace)
 #endif
 
 /* Read image.
- * Return 0 on success or -1 on out-of-memory or parse error (w.r.t. LZW code table). */
+ * Return 0 on success or -1 on out-of-memory (w.r.t. LZW code table) or parse error. */
 static int
 read_image(gd_GIF * gif)
 {

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -114,8 +114,8 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     f_gif_read(gif_base, &aspect, 1);
     /* Create gd_GIF Structure. */
     if(0 == width || 0 == height){
-    	LV_LOG_WARN("Zero size image");
-	goto fail;
+        LV_LOG_WARN("Zero size image");
+        goto fail;
     }
     #if LV_GIF_CACHE_DECODE_DATA
     if(0 == (INT_MAX - sizeof(gd_GIF) - LZW_CACHE_SIZE) / width / height / 5){

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -637,7 +637,7 @@ read_image(gd_GIF * gif)
     gif->fy = read_num(gif);
     gif->fw = read_num(gif);
     gif->fh = read_num(gif);
-    if(gif->fx + gif->fw > gif->width || gif->fy + gif->fh > gif->height){
+    if(gif->fx + (uint32_t)gif->fw > gif->width || gif->fy + (uint32_t)gif->fh > gif->height){
         LV_LOG_WARN("Frame coordinates out of image bounds");
         return -1;
     }

--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -117,7 +117,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         LV_LOG_WARN("Zero size image");
         goto fail;
     }
-    #if LV_GIF_CACHE_DECODE_DATA
+#if LV_GIF_CACHE_DECODE_DATA
     if(0 == (INT_MAX - sizeof(gd_GIF) - LZW_CACHE_SIZE) / width / height / 5){
         LV_LOG_WARN("Image dimensions are too large");
         goto fail;


### PR DESCRIPTION
Added bound check in the gif header  parsing functions to avoid integer overflow with subsequent allocation of wrongly-sized-buffer;
Also, added checks to avoid buffer overruns in the image parsing functions. 
