### PR TITLE
fix(image): lv_image_set_inner_align() behaviour with LV_IMAGE_ALIGN_STRETCH

### DIFF
--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -849,9 +849,11 @@ static void update_align(lv_obj_t * obj)
     if(img->align == LV_IMAGE_ALIGN_STRETCH) {
         lv_image_set_rotation(obj, 0);
         lv_image_set_pivot(obj, 0, 0);
-        int32_t scale_x = lv_obj_get_width(obj) * LV_SCALE_NONE / img->w;
-        int32_t scale_y = lv_obj_get_height(obj) * LV_SCALE_NONE / img->h;
-        scale_update(obj, scale_x, scale_y);
+        if(img->w != 0 && img->h != 0) {
+            int32_t scale_x = lv_obj_get_width(obj) * LV_SCALE_NONE / img->w;
+            int32_t scale_y = lv_obj_get_height(obj) * LV_SCALE_NONE / img->h;
+            scale_update(obj, scale_x, scale_y);
+        }
     }
     else if(img->align == LV_IMAGE_ALIGN_TILE) {
         lv_image_set_rotation(obj, 0);

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -435,6 +435,11 @@ void lv_image_set_inner_align(lv_obj_t * obj, lv_image_align_t align)
     lv_image_t * img = (lv_image_t *)obj;
     if(align == img->align) return;
 
+    /*If we're removing STRETCH, reset the scale*/
+    if(img->align == LV_IMAGE_ALIGN_STRETCH) {
+        lv_image_set_scale(obj, LV_SCALE_NONE);
+    }
+
     img->align = align;
     update_align(obj);
 


### PR DESCRIPTION
If you try to set the inner alignment of an image with `lv_image_set_inner_align` to `LV_IMAGE_ALIGN_STRETCH` when an image source for the widget is not yet set, lvgl will attempt a division by zero which results in a crash.