### PR TITLE
feat(nuttx): move static var index to gloabl for gdb diagnostic

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -66,6 +66,8 @@ static void check_stack_size(void);
 
 #if LV_ENABLE_GLOBAL_CUSTOM
 
+static int lv_nuttx_tlskey = -1;
+
 static void lv_global_free(void * data)
 {
     if(data) {
@@ -75,18 +77,17 @@ static void lv_global_free(void * data)
 
 lv_global_t * lv_global_default(void)
 {
-    static int index = -1;
     lv_global_t * data = NULL;
 
-    if(index < 0) {
-        index = task_tls_alloc(lv_global_free);
+    if(lv_nuttx_tlskey < 0) {
+        lv_nuttx_tlskey = task_tls_alloc(lv_global_free);
     }
 
-    if(index >= 0) {
-        data = (lv_global_t *)task_tls_get_value(index);
+    if(lv_nuttx_tlskey >= 0) {
+        data = (lv_global_t *)task_tls_get_value(lv_nuttx_tlskey);
         if(data == NULL) {
             data = (lv_global_t *)calloc(1, sizeof(lv_global_t));
-            task_tls_set_value(index, (uintptr_t)data);
+            task_tls_set_value(lv_nuttx_tlskey, (uintptr_t)data);
         }
     }
     return data;


### PR DESCRIPTION
To support gdb debugging of lvgl objects, the global variable need to moved outside to facilitate Python gdb to locate the corresponding tls value.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
