### PR TITLE
chore(Kconfig): add version info to Kconfig file to check mismatch

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1464,6 +1464,16 @@ menu "LVGL configuration"
 			default y
 			help
 				This can save some memory, but not much. After the quick access bar is created, it can be hidden by clicking the button at the top left corner of the browsing area, which is very useful for small screen devices.
+
+		config LVGL_VERSION_MAJOR
+			int
+			default 9 # LVGL_VERSION_MAJOR
+		config LVGL_VERSION_MINOR
+			int
+			default 2 # LVGL_VERSION_MINOR
+		config LVGL_VERSION_PATCH
+			int
+			default 0 # LVGL_VERSION_PATCH
 	endmenu
 
 	menu "Devices"

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -121,6 +121,35 @@ class CmakeReplacer(MacroReplacer):
     def getReplacement(self, val: str):
         return r'\g<1>' + val + r'\g<3>'
 
+class KconfigReplacer(RepoFileVersionReplacer):
+    """Replace version info in Kconfig file"""
+
+    def __init__(self, relative_path_segments: List[str]):
+        super().__init__(relative_path_segments, 3)
+
+    def applyVersionToLine(self, line: str, version: Version):
+        targets = {
+            'LVGL_VERSION_MAJOR': version.major,
+            'LVGL_VERSION_MINOR': version.minor,
+            'LVGL_VERSION_PATCH': version.patch,
+        }
+
+        for key, val in targets.items():
+            pattern = self.getPattern(key)
+            repl = self.getReplacement(val)
+            replaced, n = re.subn(pattern, repl, line)
+            if n > 0:
+                return replaced
+
+        return None
+    def getPattern(self, key: str):
+        # Match the version fields in Kconfig file
+        return rf'(^\s+default\s+)(\d+) # ({key})'
+
+    def getReplacement(self, val: str):
+        # Replace the version value
+        return r'\g<1>' + val + r' # \g<3>'
+
 
 if __name__ == '__main__':
     args = get_arg()
@@ -132,6 +161,7 @@ if __name__ == '__main__':
         MacroReplacer(['lv_version.h']),
         CmakeReplacer(['env_support', 'cmake', 'version.cmake']),
         PrefixReplacer(['lv_conf_template.h'], 'Configuration file for v'),
+        KconfigReplacer(['Kconfig']),
     ]
 
     if version.is_release:

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -18,6 +18,16 @@ extern "C" {
 
 #  ifdef __NuttX__
 #    include <nuttx/config.h>
+/*
+ * Make sure version number in Kconfig file is correctly set.
+ * Mismatch can happen when user manually copy lvgl/Kconfig file to their project, like what NuttX does.
+ */
+#    include "../lv_version.h"
+
+#    if CONFIG_LVGL_VERSION_MAJOR != LVGL_VERSION_MAJOR || CONFIG_LVGL_VERSION_MINOR != LVGL_VERSION_MINOR \
+        || CONFIG_LVGL_VERSION_PATCH != LVGL_VERSION_PATCH
+#        warning "Version mismatch between Kconfig and lvgl/lv_version.h"
+#    endif
 #  elif defined(__RTTHREAD__)
 #    define LV_CONF_INCLUDE_SIMPLE
 #    include <lv_rt_thread_conf.h>


### PR DESCRIPTION
Pick to release v9.2

For NuttX, lvgl/Kconfig file is copied out, add version info in Kconfig file to detect if the Kconfig is out of sync with source code.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
