### PR TITLE
feat(style): add a "set all" function for margin

### DIFF
--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -584,6 +584,14 @@ static inline void lv_style_set_pad_gap(lv_style_t * style, int32_t value)
     lv_style_set_pad_column(style, value);
 }
 
+static inline void lv_style_set_margin_all(lv_style_t * style, int32_t value)
+{
+    lv_style_set_margin_left(style, value);
+    lv_style_set_margin_right(style, value);
+    lv_style_set_margin_top(style, value);
+    lv_style_set_margin_bottom(style, value);
+}
+
 static inline void lv_style_set_transform_scale(lv_style_t * style, int32_t value)
 {
     lv_style_set_transform_scale_x(style, value);


### PR DESCRIPTION
New function, `lv_style_set_margin_all`.
Exactly like `lv_style_set_pad_all` except for the margins.
Convenience function.