### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/others/monkey.rst
+++ b/docs/others/monkey.rst
@@ -14,7 +14,7 @@ Usage
 Enable :c:macro:`LV_USE_MONKEY` in ``lv_conf.h``.
 
 First configure monkey, use :c:struct:`lv_monkey_config_t` to define the
-configuration structure, set the ``type`` (check `input devices </overview/indev>`__ for the supported types), and then set the
+configuration structure, set the ``type`` (check `input devices <overview/indev>`__ for the supported types), and then set the
 range of ``period_range`` and ``input_range``, the monkey will output
 random operations at random times within this range. Call
 :cpp:func:`lv_monkey_create` to create monkey. Finally call

--- a/docs/overview/indev.rst
+++ b/docs/overview/indev.rst
@@ -11,7 +11,7 @@ An input device usually means:
 - Encoders with left/right turn and push options
 - External hardware buttons which are assigned to specific points on the screen
 
-:important: Before reading further, please read the `Porting </porting/indev>`__ section of Input devices
+:important: Before reading further, please read the `Porting <porting/indev>`__ section of Input devices
 
 Pointers
 ********

--- a/docs/overview/renderers/vg_lite.rst
+++ b/docs/overview/renderers/vg_lite.rst
@@ -58,4 +58,4 @@ VG-Lite Simulator
 
 LVGL integrates a VG-Lite simulator based on ThorVG.
 Its purpose is to simplify the debugging of VG-Lite adaptation and reduce the time of debugging and locating problems on hardware devices.
-For detailed instructions, see `VG-Lite Simulator </overview/vg_lite_tvg>`__.
+For detailed instructions, see `VG-Lite Simulator <overview/vg_lite_tvg>`__.

--- a/docs/overview/timer.rst
+++ b/docs/overview/timer.rst
@@ -7,7 +7,7 @@ Timers
 LVGL has a built-in timer system. You can register a function to have it
 be called periodically. The timers are handled and called in
 :cpp:func:`lv_timer_handler`, which needs to be called every few milliseconds.
-See `Porting </porting/timer-handler>`__ for more information.
+See `Porting <porting/timer-handler>`__ for more information.
 
 Timers are non-preemptive, which means a timer cannot interrupt another
 timer. Therefore, you can call any LVGL related function in a timer.

--- a/docs/overview/vg_lite_tvg.rst
+++ b/docs/overview/vg_lite_tvg.rst
@@ -18,7 +18,7 @@ and simulate the same rendering images as the real hardware on the simulator.
 Configuration
 *************
 
-1. Enable VG-Lite rendering backend, see `VG-Lite Rendering Backend </overview/renderers/vg_lite>`__.
+1. Enable VG-Lite rendering backend, see `VG-Lite Rendering Backend <overview/renderers/vg_lite>`__.
 
 2. Enable ThorVG and turn on the configuration :c:macro:`LV_USE_THORVG_INTERNAL` or :c:macro:`LV_USE_THORVG_EXTERNAL`.
 It is recommended to use the internal ThorVG library to ensure uniform rendering results.

--- a/docs/porting/project.rst
+++ b/docs/porting/project.rst
@@ -39,12 +39,12 @@ main Makefile:
    include $(LVGL_DIR)/$(LVGL_DIR_NAME)/lvgl.mk
 
 For integration with CMake take a look this section of the
-`Documentation </integration/build/cmake>`__.
+`Documentation <integration/build/cmake>`__.
 
 Other platforms and tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `Get started </integration/index>`__ section contains many platform
+The `Get started <integration/index>`__ section contains many platform
 specific descriptions e.g. for ESP32, Arduino, NXP, RT-Thread, NuttX,
 etc.
 
@@ -131,9 +131,9 @@ components. The order of the initialization is:
 1. Call :cpp:func:`lv_init`.
 2. Initialize your drivers.
 3. Register the display and input devices drivers in LVGL. Learn more
-   about `Display </porting/display>`__ and `Input
-   device </porting/indev>`__ registration.
+   about `Display <porting/display>`__ and `Input
+   device <porting/indev>`__ registration.
 4. Call :cpp:expr:`lv_tick_inc(x)` every ``x`` milliseconds in an interrupt to
-   report the elapsed time to LVGL. `Learn more </porting/tick>`__.
+   report the elapsed time to LVGL. `Learn more <porting/tick>`__.
 5. Call :cpp:func:`lv_timer_handler` every few milliseconds to handle LVGL
-   related tasks. `Learn more </porting/timer-handler>`__.
+   related tasks. `Learn more <porting/timer-handler>`__.

--- a/docs/widgets/buttonmatrix.rst
+++ b/docs/widgets/buttonmatrix.rst
@@ -11,8 +11,8 @@ The Button Matrix object is a lightweight way to display multiple
 buttons in rows and columns. Lightweight because the buttons are not
 actually created but just virtually drawn on the fly. This way, one
 button use only eight extra bytes of memory instead of the ~100-150
-bytes a normal `Button </widgets/button>`__ object plus the 100 or so bytes
-for the `Label </widgets/label>`__ object.
+bytes a normal `Button <widgets/button>`__ object plus the 100 or so bytes
+for the `Label <widgets/label>`__ object.
 
 The Button matrix is added to the default group (if one is set). Besides
 the Button matrix is an editable object to allow selecting and clicking

--- a/docs/widgets/calendar.rst
+++ b/docs/widgets/calendar.rst
@@ -24,7 +24,7 @@ attached to the calendar.
 Parts and Styles
 ****************
 
-The calendar object uses the `Button matrix </widgets/buttonmatrix>`__
+The calendar object uses the `Button matrix <widgets/buttonmatrix>`__
 object under the hood to arrange the days into a matrix.
 
 - :cpp:enumerator:`LV_PART_MAIN` The background of the calendar. Uses all the background related style properties.

--- a/docs/widgets/chart.rst
+++ b/docs/widgets/chart.rst
@@ -173,7 +173,7 @@ Note that :cpp:enumerator:`LV_CHART_UPDATE_MODE_SHIFT` also changes the
 Tick marks and labels
 ---------------------
 
-With the help of `Scale </widgets/scale>`__, vertical and horizontal scales can be added in a very flexible way.
+With the help of `Scale <widgets/scale>`__, vertical and horizontal scales can be added in a very flexible way.
 See the example below to learn more.
 
 Zoom

--- a/docs/widgets/imagebutton.rst
+++ b/docs/widgets/imagebutton.rst
@@ -34,7 +34,7 @@ Image sources
 To set the image in a state, use the
 :cpp:expr:`lv_imagebutton_set_src(imagebutton, LV_IMAGEBUTTON_STATE_..., src_left, src_center, src_right)`.
 
-The image sources work the same as described in the `Image object </widgets/image>`__
+The image sources work the same as described in the `Image object <widgets/image>`__
 except that "Symbols" are not supported by the Image button. Any of the sources can ``NULL``.
 
 If only ``src_center`` is specified, the width of the widget will be set automatically to the

--- a/docs/widgets/slider.rst
+++ b/docs/widgets/slider.rst
@@ -7,7 +7,7 @@ Slider (lv_slider)
 Overview
 ********
 
-The Slider object looks like a `Bar </widgets/bar>`__ supplemented with
+The Slider object looks like a `Bar <widgets/bar>`__ supplemented with
 a knob. The knob can be dragged to set a value. Just like Bar, Slider
 can be vertical or horizontal.
 
@@ -80,7 +80,7 @@ Events
    being dragged.
 -  :cpp:enumerator:`LV_EVENT_RELEASED` Sent when the slider has just been released.
 
-See the events of the `Bar </widgets/bar>`__ too.
+See the events of the `Bar <widgets/bar>`__ too.
 
 Learn more about :ref:`events`.
 

--- a/docs/widgets/spinner.rst
+++ b/docs/widgets/spinner.rst
@@ -37,7 +37,7 @@ Events
 
 No special events are sent to the Spinner.
 
-See the events of the `Arc </widgets/arc>`__ too.
+See the events of the `Arc <widgets/arc>`__ too.
 
 Learn more about :ref:`events`.
 

--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -7,8 +7,8 @@ Text area (lv_textarea)
 Overview
 ********
 
-The Text Area is a `Base object </widgets/obj.html>`__ with a
-`Label </widgets/label.html>`__ and a cursor on it. Texts or characters
+The Text Area is a `Base object <widgets/obj.html>`__ with a
+`Label <widgets/label.html>`__ and a cursor on it. Texts or characters
 can be added to it. Long lines are wrapped and when the text becomes
 long enough the Text area can be scrolled.
 


### PR DESCRIPTION
`/` before these URLs leads to 404.

And here is an example that works fine:

https://github.com/lvgl/lvgl/blob/046d10bf7e489215b044190546589447aed336c1/docs/CODING_STYLE.rst?plain=1#L282