### PR TITLE
fix: the latest lvgl version of msinttypes in rt-thread caused compil…

### DIFF
--- a/env_support/rt-thread/SConscript
+++ b/env_support/rt-thread/SConscript
@@ -28,6 +28,8 @@ src = src + Glob(os.path.join(lvgl_src_cwd,'*.c'))
 for root, dirs, files in os.walk(lvgl_src_cwd):
     for dir in dirs:
         current_path = os.path.join(root, dir)
+        if current_path == os.path.join(lvgl_src_cwd, 'libs', 'thorvg', 'rapidjson', 'msinttypes'): # exclude the msinttypes folder
+            continue
         src = src + Glob(os.path.join(current_path,'*.c')) # add all .c files
         if check_h_hpp_exists(current_path): # add .h and .hpp path
             inc = inc + [current_path]


### PR DESCRIPTION
…ation errors

A clear and concise description of what the bug or new feature is.

Fixed an issue where the latest lvgl version of msinttypes in rt-thread caused compilation errors

<img width="425" alt="微信图片_20240924140930" src="https://github.com/user-attachments/assets/f4450ef1-d7c9-409a-b4f7-1369bf33dd0b">

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
