### PR TITLE
fix(fs): backport add lv_fs_dir_t to lv_fs.h (#6925)

### DIFF
--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -91,6 +91,12 @@ typedef struct {
     lv_fs_file_cache_t * cache;
 } lv_fs_file_t;
 
+
+typedef struct {
+    void * dir_d;
+    lv_fs_drv_t * drv;
+} lv_fs_dir_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/misc/lv_fs_private.h
+++ b/src/misc/lv_fs_private.h
@@ -38,12 +38,6 @@ struct lv_fs_path_ex_t {
     uint32_t size;
 };
 
-struct lv_fs_dir_t {
-    void * dir_d;
-    lv_fs_drv_t * drv;
-};
-
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -139,8 +139,6 @@ typedef struct lv_fs_file_cache_t lv_fs_file_cache_t;
 
 typedef struct lv_fs_path_ex_t lv_fs_path_ex_t;
 
-typedef struct lv_fs_dir_t lv_fs_dir_t;
-
 typedef struct lv_image_decoder_args_t lv_image_decoder_args_t;
 
 typedef struct lv_image_cache_data_t lv_image_cache_data_t;


### PR DESCRIPTION
Backport [6925](https://github.com/lvgl/lvgl/pull/6925) to use `lv_fs_dir_t` without including "lv_fs_private.h"

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
