### PR TITLE
fix(image): backport lv_image_set_inner_align() behaviour with LV_IMAGE_ALIGN_…

### DIFF
--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -435,6 +435,11 @@ void lv_image_set_inner_align(lv_obj_t * obj, lv_image_align_t align)
     lv_image_t * img = (lv_image_t *)obj;
     if(align == img->align) return;
 
+    /*If we're removing STRETCH, reset the scale*/
+    if(img->align == LV_IMAGE_ALIGN_STRETCH) {
+        lv_image_set_scale(obj, LV_SCALE_NONE);
+    }
+
     img->align = align;
     update_align(obj);
 
@@ -849,9 +854,11 @@ static void update_align(lv_obj_t * obj)
     if(img->align == LV_IMAGE_ALIGN_STRETCH) {
         lv_image_set_rotation(obj, 0);
         lv_image_set_pivot(obj, 0, 0);
-        int32_t scale_x = lv_obj_get_width(obj) * LV_SCALE_NONE / img->w;
-        int32_t scale_y = lv_obj_get_height(obj) * LV_SCALE_NONE / img->h;
-        scale_update(obj, scale_x, scale_y);
+        if(img->w != 0 && img->h != 0) {
+            int32_t scale_x = lv_obj_get_width(obj) * LV_SCALE_NONE / img->w;
+            int32_t scale_y = lv_obj_get_height(obj) * LV_SCALE_NONE / img->h;
+            scale_update(obj, scale_x, scale_y);
+        }
     }
     else if(img->align == LV_IMAGE_ALIGN_TILE) {
         lv_image_set_rotation(obj, 0);


### PR DESCRIPTION
Backports the fixes contained in https://github.com/lvgl/lvgl/pull/6864 to v9.2.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
