### PR TITLE
chore(lv_conf_internal): avoid LV_CONF_SKIP redefinition warning

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -54,7 +54,7 @@ fout.write(
 /** Handle special Kconfig options. */
 #ifndef LV_KCONFIG_IGNORE
     #include "lv_conf_kconfig.h"
-    #ifdef CONFIG_LV_CONF_SKIP
+    #if defined(CONFIG_LV_CONF_SKIP) && !defined(LV_CONF_SKIP)
         #define LV_CONF_SKIP
     #endif
 #endif

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -32,7 +32,7 @@
 /** Handle special Kconfig options. */
 #ifndef LV_KCONFIG_IGNORE
     #include "lv_conf_kconfig.h"
-    #ifdef CONFIG_LV_CONF_SKIP
+    #if defined(CONFIG_LV_CONF_SKIP) && !defined(LV_CONF_SKIP)
         #define LV_CONF_SKIP
     #endif
 #endif


### PR DESCRIPTION
When `LV_CONF_SKIP` is set from CMake, it is already defined at this point, triggering a warning.