### PR TITLE
fix(grid): fix naming conflicts

### DIFF
--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -115,7 +115,7 @@ static inline int32_t get_margin_ver(lv_obj_t * obj)
            + lv_obj_get_style_margin_bottom(obj, LV_PART_MAIN);
 }
 
-static inline int32_t div_round_closest(int32_t dividend, int32_t divisor)
+static inline int32_t lv_div_round_closest(int32_t dividend, int32_t divisor)
 {
     return (dividend + divisor / 2) / divisor;
 }
@@ -351,7 +351,7 @@ static void calc_cols(lv_obj_t * cont, lv_grid_calc_t * c)
         int32_t x = col_templ[i];
         if(IS_FR(x)) {
             int32_t f = GET_FR(x);
-            c->w[i] = div_round_closest(free_w * f, col_fr_cnt);
+            c->w[i] = lv_div_round_closest(free_w * f, col_fr_cnt);
             /*By updating remaining fr and width, we ensure f == col_fr_cnt
              *in the last loop iteration. That means the last iteration will
              *not have rounding errors and use all remaining space.*/
@@ -440,7 +440,7 @@ static void calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
         int32_t x = row_templ[i];
         if(IS_FR(x)) {
             int32_t f = GET_FR(x);
-            c->h[i] = div_round_closest(free_h * f, row_fr_cnt);
+            c->h[i] = lv_div_round_closest(free_h * f, row_fr_cnt);
             /*By updating remaining fr and height, we ensure f == row_fr_cnt
              *in the last loop iteration. That means the last iteration will
              *not have rounding errors and use all remaining space.*/


### PR DESCRIPTION
To avoid name collision when LVGL OS PThread is enabled

Fixes #6949 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
