### PR TITLE
chore(fs): treat '/' as valid driver letter 

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -163,7 +163,7 @@ for line in fin.read().splitlines():
     fout.write(f'{line}\n')
 
 fout.write(
-'''
+r'''
 
 /*----------------------------------
  * End of parsing lv_conf_template.h
@@ -213,6 +213,9 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
         #define LV_DRAW_THREAD_STACK_SIZE LV_DRAW_THREAD_STACKSIZE
     #endif
 #endif
+
+/*Allow only upper case letters and '/'  ('/' is a special case for backward compatibility)*/
+#define LV_FS_IS_VALID_LETTER(l) ((l) == '/' || ((l) >= 'A' && (l) <= 'Z'))
 
 /* If running without lv_conf.h, add typedefs with default value. */
 #ifdef LV_CONF_SKIP

--- a/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp
+++ b/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp
@@ -4,17 +4,8 @@
 #include "../../core/lv_global.h"
 #include "LittleFS.h"
 
-#if LV_FS_ARDUINO_ESP_LITTLEFS_LETTER == '\0'
-    #error "LV_FS_ARDUINO_ESP_LITTLEFS_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_ARDUINO_ESP_LITTLEFS_LETTER < 'A') || (LV_FS_ARDUINO_ESP_LITTLEFS_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_ARDUINO_ESP_LITTLEFS_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_ARDUINO_ESP_LITTLEFS_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+#if !LV_FS_IS_VALID_LETTER(LV_FS_ARDUINO_ESP_LITTLEFS_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 typedef struct ArduinoEspLittleFile {
@@ -198,4 +189,3 @@ static lv_fs_res_t fs_tell(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p)
 #endif
 
 #endif /*LV_USE_FS_ARDUINO_ESP_LITTLEFS*/
-

--- a/src/libs/fsdrv/lv_fs_arduino_sd.cpp
+++ b/src/libs/fsdrv/lv_fs_arduino_sd.cpp
@@ -5,17 +5,8 @@
 #include <SPI.h>
 #include "SD.h"
 
-#if LV_FS_ARDUINO_SD_LETTER == '\0'
-    #error "LV_FS_ARDUINO_SD_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_ARDUINO_SD_LETTER < 'A') || (LV_FS_ARDUINO_SD_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_ARDUINO_SD_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_ARDUINO_SD_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+#if !LV_FS_IS_VALID_LETTER(LV_FS_ARDUINO_SD_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 typedef struct SdFile {

--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -20,17 +20,8 @@
     #define DIR FF_DIR  /* ESP IDF typedefs `DIR` as `FF_DIR` in its version of ff.h. Use `FF_DIR` in LVGL too */
 #endif
 
-#if LV_FS_FATFS_LETTER == '\0'
-    #error "LV_FS_FATFS_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_FATFS_LETTER < 'A') || (LV_FS_FATFS_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_FATFS_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_FATFS_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+#if !LV_FS_IS_VALID_LETTER(LV_FS_FATFS_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -4,17 +4,8 @@
 #include "lfs.h"
 #include "../../core/lv_global.h"
 
-#if LV_FS_LITTLEFS_LETTER == '\0'
-    #error "LV_FS_LITTLEFS_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_LITTLEFS_LETTER < 'A') || (LV_FS_LITTLEFS_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_LITTLEFS_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_LITTLEFS_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+#if !LV_FS_IS_VALID_LETTER(LV_FS_LITTLEFS_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 typedef struct LittleFile {

--- a/src/libs/fsdrv/lv_fs_memfs.c
+++ b/src/libs/fsdrv/lv_fs_memfs.c
@@ -47,17 +47,9 @@
 /*********************
  *      DEFINES
  *********************/
-#if LV_FS_MEMFS_LETTER == '\0'
-    #error "LV_FS_MEMFS_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_MEMFS_LETTER < 'A') || (LV_FS_MEMFS_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_MEMFS_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_MEMFS_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+
+#if !LV_FS_IS_VALID_LETTER(LV_FS_MEMFS_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_posix.c
+++ b/src/libs/fsdrv/lv_fs_posix.c
@@ -22,17 +22,8 @@
  *      DEFINES
  *********************/
 
-#if LV_FS_POSIX_LETTER == '\0'
-    #error "LV_FS_POSIX_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_POSIX_LETTER < 'A') || (LV_FS_POSIX_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_POSIX_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_POSIX_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+#if !LV_FS_IS_VALID_LETTER(LV_FS_POSIX_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 /** The reason for 'fd + 1' is because open() may return a legal fd with a value of 0,

--- a/src/libs/fsdrv/lv_fs_stdio.c
+++ b/src/libs/fsdrv/lv_fs_stdio.c
@@ -21,17 +21,9 @@
 /*********************
  *      DEFINES
  *********************/
-#if LV_FS_STDIO_LETTER == '\0'
-    #error "LV_FS_STDIO_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_STDIO_LETTER < 'A') || (LV_FS_STDIO_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_STDIO_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_STDIO_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+
+#if !LV_FS_IS_VALID_LETTER(LV_FS_STDIO_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 #define MAX_PATH_LEN 256

--- a/src/libs/fsdrv/lv_fs_win32.c
+++ b/src/libs/fsdrv/lv_fs_win32.c
@@ -17,17 +17,9 @@
 /*********************
  *      DEFINES
  *********************/
-#if LV_FS_WIN32_LETTER == '\0'
-    #error "LV_FS_WIN32_LETTER must be set to a valid value"
-#else
-    #if (LV_FS_WIN32_LETTER < 'A') || (LV_FS_WIN32_LETTER > 'Z')
-        #if LV_FS_DEFAULT_DRIVE_LETTER != '\0' /*When using default drive letter, strict format (X:) is mandatory*/
-            #error "LV_FS_WIN32_LETTER must be an upper case ASCII letter"
-        #else /*Lean rules for backward compatibility*/
-            #warning LV_FS_WIN32_LETTER should be an upper case ASCII letter. \
-            Using a slash symbol as drive letter should be replaced with LV_FS_DEFAULT_DRIVE_LETTER mechanism
-        #endif
-    #endif
+
+#if !LV_FS_IS_VALID_LETTER(LV_FS_WIN32_LETTER)
+    #error "Invalid drive letter"
 #endif
 
 #define MAX_PATH_LEN 256

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4078,6 +4078,9 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #endif
 #endif
 
+/*Allow only upper case letters and '/'  ('/' is a special case for backward compatibility)*/
+#define LV_FS_IS_VALID_LETTER(l) ((l) == '/' || ((l) >= 'A' && (l) <= 'Z'))
+
 /* If running without lv_conf.h, add typedefs with default value. */
 #ifdef LV_CONF_SKIP
     #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/


### PR DESCRIPTION
When set `LV_FS_POSIX_LETTER = '/'`, do not generate warnings.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
