### PR TITLE
fix(docs): fix error blocking API-doc generation under Windows

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -80,7 +80,7 @@ def cmd(s):
 # Get the current branch name
 status, br = subprocess.getstatusoutput("git branch --show-current")
 _, gitcommit = subprocess.getstatusoutput("git rev-parse HEAD")
-br = re.sub('\* ', '', br)
+br = re.sub(r'\* ', '', br)
 
 
 urlpath = re.sub('release/', '', br)
@@ -141,7 +141,9 @@ print("Add translation")
 add_translation.exec(temp_directory)
 
 print("Running doxygen")
-cmd('cd "{temp_directory}" && doxygen Doxyfile'.format(temp_directory=temp_directory))
+os.chdir(temp_directory)
+cmd('doxygen Doxyfile')
+os.chdir(base_path)
 
 print('Reading Doxygen output')
 
@@ -205,11 +207,23 @@ else:
         f.write(index_data.encode('utf-8'))
 
 # BUILD HTML
-
-
+# This version of get_version() works correctly under Windows and Linux.
+# Credit:  @kdschlosser
 def get_version():
-    _, ver = subprocess.getstatusoutput("../scripts/find_version.sh")
-    return ver
+    path = os.path.join(project_path, 'lv_version.h')
+    with open(path, 'rb') as fle:
+        d = fle.read().decode('utf-8')
+
+    d = d.split('#define LVGL_VERSION_MAJOR', 1)[-1]
+    major, d = d.split('\n', 1)
+    d = d.split('#define LVGL_VERSION_MINOR', 1)[-1]
+    minor, d = d.split('\n', 1)
+
+    # d = d.split('#define LVGL_VERSION_PATCH', 1)[-1]
+    # patch, d = d.split('\n', 1)
+
+    return f'{major.strip()}.{minor.strip()}'
+
 
 cmd('sphinx-build -b html "{src}" "{dst}" -D version="{version}" -E -j {cpu}'.format(
     src=html_src_path,

--- a/docs/build.py
+++ b/docs/build.py
@@ -147,9 +147,7 @@ print("Add translation")
 add_translation.exec(temp_directory)
 
 print("Running doxygen")
-os.chdir(temp_directory)
-cmd('doxygen Doxyfile')
-os.chdir(base_path)
+cmd('doxygen Doxyfile', temp_directory)
 
 print('Reading Doxygen output')
 

--- a/docs/build.py
+++ b/docs/build.py
@@ -66,12 +66,18 @@ if len(args) >= 1:
         develop = True
 
 
-def cmd(s):
+def cmd(s, start_dir=None):
+    if start_dir is None:
+        start_dir = os.getcwd()
+
+    saved_dir = os.getcwd()
+    os.chdir(start_dir)
     print("")
     print(s)
     print("-------------------------------------")
-
     result = os.system(s)
+    os.chdir(saved_dir)
+
     if result != 0:
         print("Exit build due to previous error")
         sys.exit(result)
@@ -146,6 +152,8 @@ cmd('doxygen Doxyfile')
 os.chdir(base_path)
 
 print('Reading Doxygen output')
+
+doc_builder.EMIT_WARNINGS = False
 
 doc_builder.run(
     project_path,

--- a/docs/doc_builder.py
+++ b/docs/doc_builder.py
@@ -1134,6 +1134,11 @@ def iter_src(n, p):
 
 
 def clean_name(nme):
+    # Handle error:
+    #     AttributeError: 'NoneType' object has no attribute 'startswith'
+    if nme is None:
+        return nme
+
     if nme.startswith('_lv_'):
         nme = nme[4:]
     elif nme.startswith('lv_'):
@@ -1146,6 +1151,11 @@ def clean_name(nme):
 
 
 def is_name_match(item_name, obj_name):
+    # Handle error:
+    #     AttributeError: 'NoneType' object has no attribute 'split'
+    if obj_name is None:
+        return False
+
     u_num = item_name.count('_') + 1
 
     obj_name = obj_name.split('_')
@@ -1207,7 +1217,7 @@ class XMLSearch(object):
 
         status, br = subprocess.getstatusoutput("git branch")
         _, gitcommit = subprocess.getstatusoutput("git rev-parse HEAD")
-        br = re.sub('\* ', '', br)
+        br = re.sub(r'\* ', '', br)
 
         urlpath = re.sub('release/', '', br)
 
@@ -1292,6 +1302,7 @@ def run(project_path, temp_directory, *doc_paths):
     if not os.path.exists(api_path):
         os.makedirs(api_path)
 
+    # Generate .RST files for API pages.
     iter_src('API', '')
     index = load_xml('index')
 


### PR DESCRIPTION
...in the case where TMPDIR environment variable pointed to a drive different than the LVGL project directory.  (TMPDIR is used by Python `tempfile.mkdtemp()` used in `build.py`.)  The result was on Windows Doxygen was running in the LVGL project's `./docs/` directory instead of the temporary directory where it was intended to run, causing Doxygen to generate XML files for the API pages in in the wrong place. The solution was to replace the attempted `cd` with a cross-platform compatible `cd` built into Python's `os` library by temporarily having the `build.py` script change directories to where Doxygen should run and change back again after running it.

Additionally:

1.  Handled 2 Python warnings where a regex string was using an illegal escape sequence by making it a "raw" string, since the escape backslash needs to be passed un-interpreted to the regex.

2.  Replaced `build.py`s get_version() function with one that works on both Linux and Windows platforms.  Credit:  @kdschlosser.

Resolves #6924.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  n/a
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  @kisvegabor 
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
