### PR TITLE
fix(obj): fix crash during multiple screen loader 

### DIFF
--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -310,7 +310,7 @@ void lv_obj_refresh_ext_draw_size(lv_obj_t * obj)
 
 int32_t lv_obj_get_ext_draw_size(const lv_obj_t * obj)
 {
-    if(obj->spec_attr) return obj->spec_attr->ext_draw_size;
+    if(obj!=NULL && obj->spec_attr) return obj->spec_attr->ext_draw_size;
     else return 0;
 }
 


### PR DESCRIPTION

fix(lv_obj_draw): Update lv_obj_draw.c to avoid crash during multiple screen loader 