### PR TITLE
docs: fix 'my_disp_flush' in quick-overview

### DIFF
--- a/docs/get-started/quick-overview.rst
+++ b/docs/get-started/quick-overview.rst
@@ -65,15 +65,15 @@ If you would rather try LVGL on your own project follow these steps:
 
      lv_display_set_flush_cb(display, my_disp_flush);
 
-     void my_disp_flush(lv_display_t * disp, const lv_area_t * area, lv_color_t * color_p)
+     void my_disp_flush(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
      {
          int32_t x, y;
          /*It's a very slow but simple implementation.
-          *`set_pixel` needs to be written by you to a set pixel on the screen*/
+          *`put_px` needs to be written by you to put a pixel on the screen*/
          for(y = area->y1; y <= area->y2; y++) {
              for(x = area->x1; x <= area->x2; x++) {
-                 set_pixel(x, y, *color_p);
-                 color_p++;
+                 put_px(x, y, *px_map);
+                 px_map++;
              }
          }
 


### PR DESCRIPTION
Fix 'my_disp_flush' in quick-overview. In parallel rendering architecture, `lv_color_t*` in `lv_display_flush_cb_t` has been changed to `uint8_t*`.

Related code:

https://github.com/lvgl/lvgl/blob/a853a1289ae40898122d83be1842d0b61c56b15d/src/display/lv_display.h#L81

https://github.com/lvgl/lvgl/blob/a853a1289ae40898122d83be1842d0b61c56b15d/examples/porting/lv_port_disp_template.c#L124-L138


