### PR TITLE
perf(label): simplify handling of bytes overwritten with dots

### DIFF
--- a/src/widgets/label/lv_label_private.h
+++ b/src/widgets/label/lv_label_private.h
@@ -31,11 +31,8 @@ extern "C" {
 struct _lv_label_t {
     lv_obj_t obj;
     char * text;
-    union {
-        char * tmp_ptr; /**< Pointer to the allocated memory containing the character replaced by dots */
-        char tmp[LV_LABEL_DOT_NUM + 1]; /**< Directly store the characters if <=4 characters */
-    } dot;
-    uint32_t dot_end;  /**< The real text length, used in dot mode */
+    char dot[LV_LABEL_DOT_NUM + 1]; /**< Bytes that have been replaced with dots */
+    uint32_t dot_begin;  /**< Offset where bytes have been replaced with dots */
 
 #if LV_LABEL_LONG_TXT_HINT
     lv_draw_label_hint_t hint;
@@ -52,7 +49,6 @@ struct _lv_label_t {
     uint8_t static_txt : 1;             /**< Flag to indicate the text is static */
     uint8_t recolor : 1;                /**< Enable in-line letter re-coloring*/
     uint8_t expand : 1;                 /**< Ignore real width (used by the library with LV_LABEL_LONG_SCROLL) */
-    uint8_t dot_tmp_alloc : 1;          /**< 1: dot is allocated, 0: dot directly holds up to 4 chars */
     uint8_t invalid_size_cache : 1;     /**< 1: Recalculate size and update cache */
 };
 


### PR DESCRIPTION
Dots and null terminator will overwrite at most LV_LABEL_DOT_NUM + 1 bytes, and there will always be a null terminator after the dots. So we do not need to worry about how many characters those bytes represent, or even if we overwrite a multi-byte character partially. Therefore the dynamic memory allocation path for replaced characters can be simplified away.

Use the new fast revert/set to ensure that self size calculations and placing new dots always happens based on text without dots.
