### PR TITLE
fix(vg_lite): fix path bonding box coordinate overflow

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -25,6 +25,10 @@
  *      DEFINES
  *********************/
 
+/* Since thorvg has an upper limit on coordinates, choose a suitable value here */
+#define PATH_COORD_MAX (1 << 18)
+#define PATH_COORD_MIN (-PATH_COORD_MAX)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -181,8 +185,8 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
 
         /* no bonding box */
         lv_vg_lite_path_set_bonding_box(lv_vg_path,
-                                        (float)LV_COORD_MIN, (float)LV_COORD_MIN,
-                                        (float)LV_COORD_MAX, (float)LV_COORD_MAX);
+                                        (float)PATH_COORD_MIN, (float)PATH_COORD_MIN,
+                                        (float)PATH_COORD_MAX, (float)PATH_COORD_MAX);
     }
     else {
         /* calc inverse matrix */


### PR DESCRIPTION
Since the coordinate algorithm of thorvg has a coordinate upper limit, `LV_COORD_MAX` (1 << 29) cannot be used directly. Reselect the appropriate boundary value.

![1728571502235](https://github.com/user-attachments/assets/23a57086-2cd3-4162-ac0e-e8404617a2f3)

cc @onecoolx You can continue your PR: https://github.com/lvgl/lvgl/pull/6845 with the changes of this PR.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
