### PR TITLE
fix(vg_lite): fix thorvg 32bit rendering test coordinate calculation overflow

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -25,9 +25,19 @@
  *      DEFINES
  *********************/
 
-/* Since thorvg has an upper limit on coordinates, choose a suitable value here */
-#define PATH_COORD_MAX (1 << 18)
-#define PATH_COORD_MIN (-PATH_COORD_MAX)
+#if LV_USE_VG_LITE_THORVG
+    /**
+    * It is found that thorvg cannot handle large coordinates well.
+    * When the coordinates are larger than 4096, the calculation of tvgSwRle module will overflow in 32-bit system.
+    * So we use FLT_MAX and FLT_MIN to write the mark to bonding_box to tell vg_lite_tvg not to add clip path to the current path.
+    */
+    #define PATH_COORD_MAX FLT_MAX
+    #define PATH_COORD_MIN FLT_MIN
+#else
+    /*  18 bits is enough to represent the coordinates of path bounding box */
+    #define PATH_COORD_MAX (1 << 18)
+    #define PATH_COORD_MIN (-PATH_COORD_MAX)
+#endif
 
 /**********************
  *      TYPEDEFS


### PR DESCRIPTION
It is found that thorvg cannot handle large coordinates well. When the coordinates are larger than 4096, the calculation of tvgSwRle module will overflow in 32-bit system. Report by PR: https://github.com/lvgl/lvgl/pull/6845

```bash
98/98 Test  #6: test_draw_svg ....................***Timeout 300.06 sec
[4664](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4665)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:583:28: runtime error: signed integer overflow: -94906264 * 76 cannot be represented in type 'long int'
[4665](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4666)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:583:44: runtime error: signed integer overflow: 94906260 * 152 cannot be represented in type 'long int'
[4666](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4667)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:594:18: runtime error: signed integer overflow: -94906264 * 256 cannot be represented in type 'long int'
[4667](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4668)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:595:18: runtime error: signed integer overflow: 94906260 * 256 cannot be represented in type 'long int'
[4668](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4669)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:606:52: runtime error: signed integer overflow: -1473801216 + -1637591296 cannot be represented in type 'long int'
[4669](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4670)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:598:35: runtime error: signed integer overflow: -1637591296 - 1473800192 cannot be represented in type 'long int'
[4670](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4671)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:600:22: runtime error: signed integer overflow: -1257966848 - 1473801216 cannot be represented in type 'long int'
[4671](https://github.com/lvgl/lvgl/actions/runs/11301791102/job/31436699319?pr=6845#step:7:4672)/home/runner/work/lvgl/lvgl/src/libs/thorvg/tvgSwRle.cpp:624:22: runtime error: signed integer overflow: 1563199232 + 1473800192 cannot be represented in type 'long int'
```

So we use `FLT_MAX` and `FLT_MIN` to write the mark to `bonding_box` to tell `vg_lite_tvg` not to add clip path to the current path.

![image](https://github.com/user-attachments/assets/8693469c-5229-4b4b-9059-5d593577f5df)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
