### PR TITLE
bugfix for fatfs freetype fps

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -61,7 +61,7 @@ else()
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
       INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../
                    ${LVGL_ROOT_DIR}/examples ${LVGL_ROOT_DIR}/demos
-      REQUIRES esp_timer)
+      REQUIRES esp_timer fatfs freetype)
 endif()
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_CONF_INCLUDE_SIMPLE")

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -420,6 +420,14 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
     disp->buf_act = disp->buf_1;
 }
 
+void lv_display_get_buffers(lv_display_t * disp, void ** buf1, void ** buf2)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return;
+    *buf1 = disp->_static_buf1.data;
+    *buf2 = disp->_static_buf2.data;
+}
+
 void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
                             lv_display_render_mode_t render_mode)
 {
@@ -481,6 +489,13 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
     if(disp == NULL) disp = lv_display_get_default();
     if(disp == NULL) return;
     disp->render_mode = render_mode;
+}
+
+lv_display_render_mode_t lv_display_get_render_mode(lv_display_t * disp)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return LV_DISPLAY_RENDER_MODE_PARTIAL;
+    return disp->render_mode;
 }
 
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb)

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -255,6 +255,14 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
                                         uint32_t stride, lv_display_render_mode_t render_mode);
 
 /**
+ * Get the raw buffer pointers for a display.
+ * @param disp              pointer to a display
+ * @param buf1              first buffer
+ * @param buf2              second buffer (can be `NULL`)
+ */
+void lv_display_get_buffers(lv_display_t * disp, void ** buf1, void ** buf2);
+
+/**
  * Set the buffers for a display, accept a draw buffer pointer.
  * Normally use `lv_display_set_buffers` is enough for most cases.
  * Use this function when an existing lv_draw_buf_t is available.
@@ -270,6 +278,13 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
  * @param render_mode       LV_DISPLAY_RENDER_MODE_PARTIAL/DIRECT/FULL
  */
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode);
+
+/**
+ * Get display render mode
+ * @param disp              pointer to a display
+ * @return                  the render mode
+ */
+lv_display_render_mode_t lv_display_get_render_mode(lv_display_t * disp);
 
 /**
  * Set the flush callback which will be called to copy the rendered image to the display.

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -242,7 +242,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     lv_timer_t * disp_refr_timer = lv_display_get_refr_timer(NULL);
     uint32_t disp_refr_period = disp_refr_timer->period;
 
-    info->calculated.fps = info->measured.refr_interval_sum ? (1000 * info->measured.refr_cnt / time_since_last_report) : 0;
+    info->calculated.fps = info->measured.refr_interval_sum ? (uint32_t)(1000.0 * info->measured.refr_cnt / time_since_last_report + 0.5) : 0;
     info->calculated.fps = LV_MIN(info->calculated.fps,
                                   1000 / disp_refr_period);   /*Limit due to possible off-by-one error*/
 


### PR DESCRIPTION
1. when use freetype and fatfs for esp32, then will compilation failed
2. When calculating fps, direct shaping and discarding may result in a significant difference from the actual frame rate. Therefore, rounding should be used more reasonably