### PR TITLE
fix(display) remove lv_display_set_buffers_with_stride function

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -444,31 +444,6 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_display_set_render_mode(disp, render_mode);
 }
 
-void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
-                                        uint32_t stride, lv_display_render_mode_t render_mode)
-{
-    LV_ASSERT_MSG(buf1 != NULL, "Null buffer");
-    lv_color_format_t cf = lv_display_get_color_format(disp);
-    uint32_t w = lv_display_get_horizontal_resolution(disp);
-    uint32_t h = lv_display_get_vertical_resolution(disp);
-    LV_ASSERT_MSG(w != 0 && h != 0, "display resolution is 0");
-
-    if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        /* for partial mode, we calculate the height based on the buf_size and stride */
-        h = buf_size / stride;
-        LV_ASSERT_MSG(h != 0, "the buffer is too small");
-    }
-    else {
-        LV_ASSERT_FORMAT_MSG(stride * h <= buf_size, "%s mode requires screen sized buffer(s)",
-                             render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
-    }
-
-    lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
-    lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
-    lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
-    lv_display_set_render_mode(disp, render_mode);
-}
-
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode)
 {
     if(disp == NULL) disp = lv_display_get_default();

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -240,21 +240,6 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
                             lv_display_render_mode_t render_mode);
 
 /**
- * Set the frame buffers for a display, similarly to `lv_display_set_buffers`, but allow
- * for a custom stride as required by a display controller.
- * This allows the frame buffers to have a stride alignment different from the rest of
- * the buffers`
- * @param disp              pointer to a display
- * @param buf1              first buffer
- * @param buf2              second buffer (can be `NULL`)
- * @param buf_size          buffer size in byte
- * @param stride            buffer stride in bytes
- * @param render_mode       LV_DISPLAY_RENDER_MODE_PARTIAL/DIRECT/FULL
- */
-void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
-                                        uint32_t stride, lv_display_render_mode_t render_mode);
-
-/**
  * Set the buffers for a display, accept a draw buffer pointer.
  * Normally use `lv_display_set_buffers` is enough for most cases.
  * Use this function when an existing lv_draw_buf_t is available.


### PR DESCRIPTION
This function is a recent addition to framebuffer initialization API. Remove it from v9.2 branch as innapropriate for a maintenance release

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- [x] Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
