### PR TITLE
feat(scripts/gdb): add draw unit debug info support

### DIFF
--- a/scripts/gdb/lvgl.py
+++ b/scripts/gdb/lvgl.py
@@ -323,8 +323,7 @@ class InfoDrawUnit(gdb.Command):
 
     def dump_draw_unit(self, draw_unit:gdb.Value):
         # Dereference to get the string content of the name from draw_unit
-        name_address = draw_unit["name"]
-        name = name_address.string()
+        name = draw_unit["name"].string()
 
         # Print draw_unit information and the name
         print(f"Draw Unit: {draw_unit}, Name: {name}")

--- a/scripts/gdb/lvgl.py
+++ b/scripts/gdb/lvgl.py
@@ -188,9 +188,13 @@ class LVGL:
         disp = self.lv_global["disp_default"]
         return disp["act_scr"] if disp else None
 
-    def draw_info(self):
-        return self.lv_global["draw_info"]
+    def draw_units(self):
+        unit = self.lv_global["draw_info"]["unit_head"]
 
+        # Iterate through all draw units
+        while unit: 
+            yield unit
+            unit = unit["next"]
 
 def set_lvgl_instance(lv_global: gdb.Value):
     global g_lvgl_instance
@@ -326,46 +330,30 @@ class InfoDrawUnit(gdb.Command):
         print(f"Draw Unit: {draw_unit}, Name: {name}")
 
         # Handle different draw_units based on the name
-        types = {}
-        type_names = {
-            "DMA2D": "lv_draw_dma2d_unit_t",
-            "NEMA_GFX": "lv_draw_nema_gfx_unit_t",
-            "NXP_PXP": "lv_draw_pxp_unit_t",
-            "NXP_VGLITE": "lv_draw_vglite_unit_t",
-            "OPENGLES": "lv_draw_opengles_unit_t",
-            "DAVE2D": "lv_draw_dave2d_unit_t",
-            "SDL": "lv_draw_sdl_unit_t",
-            "SW": "lv_draw_sw_unit_t",
-            "VG_LITE": "lv_draw_vg_lite_unit_t",
+        def lookup_type(name):
+            try:
+                return gdb.lookup_type(name)
+            except gdb.error:
+                return None
+
+        types = {
+            "DMA2D": lookup_type("lv_draw_dma2d_unit_t"),
+            "NEMA_GFX": lookup_type("lv_draw_nema_gfx_unit_t"),
+            "NXP_PXP": lookup_type("lv_draw_pxp_unit_t"),
+            "NXP_VGLITE": lookup_type("lv_draw_vglite_unit_t"),
+            "OPENGLES": lookup_type("lv_draw_opengles_unit_t"),
+            "DAVE2D": lookup_type("lv_draw_dave2d_unit_t"),
+            "SDL": lookup_type("lv_draw_sdl_unit_t"),
+            "SW": lookup_type("lv_draw_sw_unit_t"),
+            "VG_LITE": lookup_type("lv_draw_vg_lite_unit_t"),
         }
 
-        # Scan available draw unit types
-        for index, type_name in type_names.items():
-            try:
-                types[index] = gdb.lookup_type(type_name)
-            except gdb.error:
-                pass
-
-        # Print the format string of the draw unit, if not found, use the default type
-        type = types.get(name, gdb.lookup_type("lv_draw_unit_t"))
+        type = types.get(name) or lookup_type("lv_draw_unit_t")
         print(draw_unit.cast(type.pointer()).dereference().format_string(pretty_structs=True, symbols=True))
 
     def invoke(self, args, from_tty):
-        try:
-            if g_lvgl_instance is None:
-                print("LVGL instance is not set.")
-                return
-
-            unit = g_lvgl_instance.draw_info()["unit_head"]
-
-            # Iterate through all draw units
-            while unit:
-                self.dump_draw_unit(unit)
-                unit = unit["next"]
-
-        except gdb.error as e:
-            print(f"Error: {e}")
-
+        for unit in g_lvgl_instance.draw_units():
+            self.dump_draw_unit(unit)
 
 DumpObj()
 InfoStyle()

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -64,6 +64,7 @@ void lv_draw_dma2d_init(void)
     draw_dma2d_unit->base_unit.evaluate_cb = evaluate_cb;
     draw_dma2d_unit->base_unit.dispatch_cb = dispatch_cb;
     draw_dma2d_unit->base_unit.delete_cb = delete_cb;
+    draw_dma2d_unit->base_unit.name = "DMA2D";
 
 #if LV_DRAW_DMA2D_ASYNC
     g_unit = draw_dma2d_unit;

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -92,6 +92,11 @@ struct _lv_draw_unit_t {
     const lv_area_t * clip_area;
 
     /**
+     * Name of the draw unit, for debugging purposes only.
+     */
+    const char * name;
+
+    /**
      * Called to try to assign a draw task to itself.
      * `lv_draw_get_next_available_task` can be used to get an independent draw task.
      * A draw task should be assign only if the draw unit can draw it too

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -104,6 +104,7 @@ void lv_draw_nema_gfx_init(void)
     draw_nema_gfx_unit->base_unit.dispatch_cb = nema_gfx_dispatch;
     draw_nema_gfx_unit->base_unit.evaluate_cb = nema_gfx_evaluate;
     draw_nema_gfx_unit->base_unit.delete_cb = nema_gfx_delete;
+    draw_nema_gfx_unit->base_unit.name = "NEMA_GFX";
     /*Create GPU Command List*/
     draw_nema_gfx_unit->cl = nema_cl_create();
     /*Bind Command List*/

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -92,6 +92,7 @@ void lv_draw_pxp_init(void)
     draw_pxp_unit->base_unit.evaluate_cb = _pxp_evaluate;
     draw_pxp_unit->base_unit.dispatch_cb = _pxp_dispatch;
     draw_pxp_unit->base_unit.delete_cb = _pxp_delete;
+    draw_pxp_unit->base_unit.name = "NXP_PXP";
 
 #if LV_USE_PXP_DRAW_THREAD
     lv_thread_init(&draw_pxp_unit->thread, LV_THREAD_PRIO_HIGH, _pxp_render_thread_cb, 2 * 1024, draw_pxp_unit);

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -115,6 +115,7 @@ void lv_draw_vglite_init(void)
     draw_vglite_unit->base_unit.wait_for_finish_cb = _vglite_wait_for_finish;
 #endif
     draw_vglite_unit->base_unit.delete_cb = _vglite_delete;
+    draw_vglite_unit->base_unit.name = "NXP_VGLITE";
 
 #if LV_USE_VGLITE_DRAW_THREAD
     lv_thread_init(&draw_vglite_unit->thread, LV_THREAD_PRIO_HIGH, _vglite_render_thread_cb, 2 * 1024, draw_vglite_unit);

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -94,6 +94,7 @@ void lv_draw_opengles_init(void)
     lv_draw_opengles_unit_t * draw_opengles_unit = lv_draw_create_unit(sizeof(lv_draw_opengles_unit_t));
     draw_opengles_unit->base_unit.dispatch_cb = dispatch;
     draw_opengles_unit->base_unit.evaluate_cb = evaluate;
+    draw_opengles_unit->base_unit.name = "OPENGLES";
     draw_opengles_unit->texture_cache = lv_cache_create(&lv_cache_class_lru_rb_count,
     sizeof(cache_data_t), 128, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t)opengles_texture_cache_compare_cb,

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -79,6 +79,7 @@ void lv_draw_dave2d_init(void)
     lv_draw_dave2d_unit_t * draw_dave2d_unit = lv_draw_create_unit(sizeof(lv_draw_dave2d_unit_t));
     draw_dave2d_unit->base_unit.dispatch_cb = lv_draw_dave2d_dispatch;
     draw_dave2d_unit->base_unit.evaluate_cb = _dave2d_evaluate;
+    draw_dave2d_unit->base_unit.name = "DAVE2D";
     draw_dave2d_unit->idx = DRAW_UNIT_ID_DAVE2D;
 
     result = lv_dave2d_init();

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -111,6 +111,7 @@ void lv_draw_sdl_init(void)
     lv_draw_sdl_unit_t * draw_sdl_unit = lv_draw_create_unit(sizeof(lv_draw_sdl_unit_t));
     draw_sdl_unit->base_unit.dispatch_cb = dispatch;
     draw_sdl_unit->base_unit.evaluate_cb = evaluate;
+    draw_sdl_unit->base_unit.name = "SDL";
     draw_sdl_unit->texture_cache = lv_cache_create(&lv_cache_class_lru_rb_count,
     sizeof(cache_data_t), 128, (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t)sdl_texture_cache_compare_cb,

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -175,6 +175,7 @@ void lv_draw_sw_init(void)
         draw_sw_unit->base_unit.evaluate_cb = evaluate;
         draw_sw_unit->idx = i;
         draw_sw_unit->base_unit.delete_cb = LV_USE_OS ? lv_draw_sw_delete : NULL;
+        draw_sw_unit->base_unit.name = "SW";
 
 #if LV_USE_OS
         lv_thread_init(&draw_sw_unit->thread, LV_THREAD_PRIO_HIGH, render_thread_cb, LV_DRAW_THREAD_STACK_SIZE, draw_sw_unit);

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -71,6 +71,7 @@ void lv_draw_vg_lite_init(void)
     unit->base_unit.dispatch_cb = draw_dispatch;
     unit->base_unit.evaluate_cb = draw_evaluate;
     unit->base_unit.delete_cb = draw_delete;
+    unit->base_unit.name = "VG_LITE";
 
     lv_vg_lite_image_dsc_init(unit);
 #if LV_USE_VECTOR_GRAPHIC


### PR DESCRIPTION
1. Add name field to `lv_draw_unit_t`
2. Add add drawing unit structure parsing.

```bash
-exec info draw_unit
Draw Unit: 0x614000000040, Name: VG_LITE
{
  base_unit = {
    next = 0x607000000100,
    target_layer = 0x60d00000c4e0,
    clip_area = 0x60d0000e471c,
    name = 0x555556b655e0 "VG_LITE",
    dispatch_cb = 0x5555564abca6 <draw_dispatch>,
    evaluate_cb = 0x5555564ac250 <draw_evaluate>,
    wait_for_finish_cb = 0x0,
    delete_cb = 0x5555564ac656 <draw_delete>
  },
  task_act = 0x60d0000e46e0,
  image_dsc_pending = 0x6040000000d0,
  grad_cache = 0x60c0000001c0,
  grad_pending = 0x604000000110,
  stroke_cache = 0x60c000000280,
  flush_count = 0,
  letter_count = 0,
  target_buffer = {
    width = 480,
    height = 480,
    stride = 1920,
    tiled = VG_LITE_LINEAR,
    format = VG_LITE_BGRX8888,
    handle = 0x0,
    memory = 0x7fffde033800,
    address = 3724752896,
    yuv = {
      swizzle = VG_LITE_SWIZZLE_UV,
      yuv2rgb = VG_LITE_YUV601,
      uv_planar = 0,
      v_planar = 0,
      alpha_planar = 0,
      uv_stride = 0,
      v_stride = 0,
      alpha_stride = 0,
      uv_height = 0,
      v_height = 0,
      uv_memory = 0x0,
      v_memory = 0x0,
      uv_handle = 0x0,
      v_handle = 0x0
    },
    image_mode = VG_LITE_NORMAL_IMAGE_MODE,
    transparency_mode = VG_LITE_IMAGE_OPAQUE,
    fc_buffer = {{
        width = 0,
        height = 0,
        stride = 0,
        handle = 0x0,
        memory = 0x0,
        address = 0,
        color = 0
      }, {
        width = 0,
        height = 0,
        stride = 0,
        handle = 0x0,
        memory = 0x0,
        address = 0,
        color = 0
      }, {
        width = 0,
        height = 0,
        stride = 0,
        handle = 0x0,
        memory = 0x0,
        address = 0,
        color = 0
      }},
    compress_mode = VG_LITE_DEC_DISABLE,
    index_endian = VG_LITE_INDEX_LITTLE_ENDIAN,
    paintType = VG_LITE_PAINT_ZERO,
    fc_enable = 0 '\000',
    scissor_layer = 0 '\000',
    premultiplied = 0 '\000'
  },
  global_matrix = {
    m = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
    scaleX = 5.73831721e-42,
    scaleY = -nan(0x7fc2c0),
    angle = 4.59163468e-41
  },
  global_path = 0x60f000000040,
  path_in_use = true
}
Draw Unit: 0x607000000100, Name: SW
{
  base_unit = {
    next = 0x0,
    target_layer = 0x0,
    clip_area = 0x0,
    name = 0x555556b545c0 "SW",
    dispatch_cb = 0x55555645d779 <dispatch>,
    evaluate_cb = 0x55555645d093 <evaluate>,
    wait_for_finish_cb = 0x0,
    delete_cb = 0x0
  },
  task_act = 0x0,
  idx = 0
}
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
