### PR TITLE
docs: update LV_OBJ_FLAG_OVERFLOW_VISIBLE usage

### DIFF
--- a/docs/details/base-widget/obj.rst
+++ b/docs/details/base-widget/obj.rst
@@ -191,7 +191,16 @@ outside will not be visible.
 
 This behavior can be overwritten with
 :cpp:expr:`lv_obj_add_flag(widget, LV_OBJ_FLAG_OVERFLOW_VISIBLE)` which allow the
-children to be drawn out of the parent.
+children to be drawn out of the parent. In addition to this, you must register
+the following event callback (this was not required in previous versions).
+
+.. code-block:: c
+
+    static void ext_draw_size_event_cb(lv_event_t * e)
+    {
+        lv_coord_t * cur_size = lv_event_get_param(e);
+        *cur_size = LV_MAX(*cur_size, LV_HOR_RES);
+    }
 
 Create and delete Widgets
 -------------------------

--- a/docs/details/base-widget/obj.rst
+++ b/docs/details/base-widget/obj.rst
@@ -194,12 +194,15 @@ This behavior can be overwritten with
 children to be drawn out of the parent. In addition to this, you must register
 the following event callback (this was not required in previous versions).
 
+Note: ``ext_width`` should be the maximum absolute width the children will be
+drawn within.
+
 .. code-block:: c
 
     static void ext_draw_size_event_cb(lv_event_t * e)
     {
         lv_coord_t * cur_size = lv_event_get_param(e);
-        *cur_size = LV_MAX(*cur_size, LV_HOR_RES);
+        *cur_size = LV_MAX(*cur_size, ext_width);
     }
 
 Create and delete Widgets

--- a/docs/details/base-widget/obj.rst
+++ b/docs/details/base-widget/obj.rst
@@ -201,8 +201,7 @@ drawn within.
 
     static void ext_draw_size_event_cb(lv_event_t * e)
     {
-        lv_coord_t * cur_size = lv_event_get_param(e);
-        *cur_size = LV_MAX(*cur_size, ext_width);
+        lv_event_set_ext_draw_size(e, 30); /*Set 30px extra draw area around the widget*/
     }
 
 Create and delete Widgets


### PR DESCRIPTION
Update usage of LV_OBJ_FLAG_OVERFLOW_VISIBLE which now requires a calculation during an extended draw callback event. See https://github.com/lvgl/lvgl/issues/7091 for details.

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
