### PR TITLE
feat(ffmpeg): add playback complete event trigger

### DIFF
--- a/docs/details/libs/ffmpeg.rst
+++ b/docs/details/libs/ffmpeg.rst
@@ -40,6 +40,13 @@ See the examples below.
 
 .. _ffmpeg_example:
 
+Events
+------
+
+- :cpp:enumerator:`LV_EVENT_READY` Sent when playback is complete and auto-restart is not enabled.
+
+Learn more about :ref:`events`.
+
 Example
 -------
 

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -817,6 +817,9 @@ static void lv_ffmpeg_player_frame_update_cb(lv_timer_t * timer)
 
     if(has_next < 0) {
         lv_ffmpeg_player_set_cmd(obj, player->auto_restart ? LV_FFMPEG_PLAYER_CMD_START : LV_FFMPEG_PLAYER_CMD_STOP);
+        if(!player->auto_restart) {
+            lv_obj_send_event((lv_obj_t *)player, LV_EVENT_READY, NULL);
+        }
         return;
     }
 


### PR DESCRIPTION
I had a need to trigger an even when video playback completed. The comment for the `LV_EVENT_READY` event indicated that it fit this purpose, but I'm open to suggestions this warrants a different/new event code.