### PR TITLE
chore(svg): LV_USE_SVG: document and enforce dependency on LV_USE_VECTOR_GRAPHIC

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -907,7 +907,8 @@
 /** Use external LZ4 library */
 #define LV_USE_LZ4_EXTERNAL  0
 
-/*SVG library*/
+/*SVG library
+ *  - Requires `LV_USE_VECTOR_GRAPHIC = 1` */
 #define LV_USE_SVG 0
 #define LV_USE_SVG_ANIMATION 0
 #define LV_USE_SVG_DEBUG 0

--- a/src/libs/svg/lv_svg_render.h
+++ b/src/libs/svg/lv_svg_render.h
@@ -11,7 +11,11 @@
  *********************/
 #include "../../lv_conf_internal.h"
 
-#if LV_USE_SVG && LV_USE_VECTOR_GRAPHIC
+#if LV_USE_SVG
+#if !LV_USE_VECTOR_GRAPHIC
+    #error "LV_USE_SVG requires LV_USE_VECTOR_GRAPHIC = 1"
+#endif
+
 #include "lv_svg.h"
 #include "../../misc/lv_types.h"
 #include "../../draw/lv_draw_vector_private.h"

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2900,7 +2900,8 @@
     #endif
 #endif
 
-/*SVG library*/
+/*SVG library
+ *  - Requires `LV_USE_VECTOR_GRAPHIC = 1` */
 #ifndef LV_USE_SVG
     #ifdef CONFIG_LV_USE_SVG
         #define LV_USE_SVG CONFIG_LV_USE_SVG


### PR DESCRIPTION
`LV_USE_VECTOR_GRAPHIC` needs some other flags, and this is documented in comments and enforced with clear `#error`.

`LV_USE_SVG` needs `LV_USE_VECTOR_GRAPHIC` but this is not made clear. This PR fixes that.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).

I ran lv_conf_internal_gen (second commit, let me know if you want a squash). The Kconfig already knew about the dep.

- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the 
[Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).

code-format updated more files than I touched. I only committed the formatting of my changes.

- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
