### PR TITLE
fix(buttonmatrix): add check for indev POINTER | BUTTON type

### DIFF
--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -456,14 +456,17 @@ static void lv_buttonmatrix_event(const lv_obj_class_t * class_p, lv_event_t * e
         }
     }
     else if(code == LV_EVENT_PRESSING) {
-        /*If a slid to a new button, discard the current button and don't press any buttons*/
         if(btnm->btn_id_sel != LV_BUTTONMATRIX_BUTTON_NONE) {
             lv_indev_t * indev = lv_event_get_indev(e);
-            lv_indev_get_point(indev, &p);
-            uint32_t btn_pr = get_button_from_point(obj, &p);
-            if(btn_pr != btnm->btn_id_sel) {
-                invalidate_button_area(obj, btnm->btn_id_sel); /*Invalidate the old area*/
-                btnm->btn_id_sel = LV_BUTTONMATRIX_BUTTON_NONE;
+            lv_indev_type_t indev_type = lv_indev_get_type(indev);
+            if(indev_type == LV_INDEV_TYPE_POINTER || indev_type == LV_INDEV_TYPE_BUTTON) {
+                /*If pointer device slid to a new button, discard the current button and don't press any buttons*/
+                lv_indev_get_point(indev, &p);
+                uint32_t btn_pr = get_button_from_point(obj, &p);
+                if(btn_pr != btnm->btn_id_sel) {
+                    invalidate_button_area(obj, btnm->btn_id_sel); /*Invalidate the old area*/
+                    btnm->btn_id_sel = LV_BUTTONMATRIX_BUTTON_NONE;
+                }
             }
         }
     }


### PR DESCRIPTION
Using Keypad indev with buttonmatrix and LV_BUTTONMATRIX_CTRL_CLICK_TRIG.
Sending of LV_EVENT_VALUE_CHANGE in buttonmatrix event handler on LV_EVENT_RELEASED never happens due to invalid check for clicked point and invalidation of clicked button in  LV_EVENT_PRESSING.

#7074 and #7009 explain the issue.

I'm creating this pull request as nobody is opposing this and this fixes the issue.
