### PR TITLE
fix(cmake): generate lvgl.pc in CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -133,8 +133,8 @@ if(NOT LV_CONF_BUILD_DISABLE_DEMOS)
 endif()
 
 
-configure_file("${LVGL_ROOT_DIR}/lvgl.pc.in" ${CMAKE_BINARY_DIR}/lvgl.pc @ONLY)
-configure_file("${LVGL_ROOT_DIR}/lv_version.h.in" ${CMAKE_BINARY_DIR}/lv_version.h @ONLY)
+configure_file("${LVGL_ROOT_DIR}/lvgl.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/lvgl.pc @ONLY)
+configure_file("${LVGL_ROOT_DIR}/lv_version.h.in" ${CMAKE_CURRENT_BINARY_DIR}/lv_version.h @ONLY)
 
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/lvgl.pc"


### PR DESCRIPTION
Fixes file configured at `${CMAKE_BINARY_DIR}/lvgl.pc` but later installed from

```cmake
install(
  FILES "${CMAKE_CURRENT_BINARY_DIR}/lvgl.pc" # <--
  DESTINATION "${LIB_INSTALL_DIR}/pkgconfig/")
```

leading to

```
CMake Error at ThirdParty/_lvgl/cmake_install.cmake:58 (file):
  file INSTALL cannot find
  "/_build/<subdir>/lvgl/lvgl.pc": No such file or
  directory.
Call Stack (most recent call first):
  cmake_install.cmake:47 (include)
```

in multi-directory projects.

Originally introduced via 559618d9d2c66069f61ba673b7bce6bf3e7eb036. Works for me, now, but did I choose the right way to fix this?