### PR TITLE
fix(indev): keep pointer movement even if previous object has been lost duo to missing press lock

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1197,8 +1197,11 @@ static void indev_proc_press(lv_indev_t * indev)
 
     /*If a new object was found reset some variables and send a pressed event handler*/
     if(indev_obj_act != indev->pointer.act_obj) {
-        indev->pointer.last_point.x = indev->pointer.act_point.x;
-        indev->pointer.last_point.y = indev->pointer.act_point.y;
+        /*If a no previous object was lost, overwrite the last point.*/
+        if(indev->pointer.act_obj == NULL) {
+            indev->pointer.last_point.x = indev->pointer.act_point.x;
+            indev->pointer.last_point.y = indev->pointer.act_point.y;
+        }
 
         /*Without `LV_OBJ_FLAG_PRESS_LOCK` new widget can be found while pressing.*/
         if(indev->pointer.last_hovered && indev->pointer.last_hovered != indev_obj_act) {


### PR DESCRIPTION
I think this change here https://github.com/lvgl/lvgl/commit/ecf1ea4d37833cd1b7b3f5d9fb6fabc5acb9850b (from https://github.com/lvgl/lvgl/issues/4328) went in a good direction to not fire LV_EVENT_CLICKED.

But IMHO, one thing is missing. Since there was already an active object, the new position should still be recognized as a movement of the pointer rather than the start of a new movement.

We have a case where a scroll event isn’t recognized because the press event slips from one small object to another, and so on.