### PR TITLE
feat(roller): set roller option with a string

### DIFF
--- a/docs/details/widgets/roller.rst
+++ b/docs/details/widgets/roller.rst
@@ -43,6 +43,10 @@ You can select an option manually with
 :cpp:expr:`lv_roller_set_selected(roller, id, LV_ANIM_ON)`,
 where *id* is the index of an option.
 
+If you don't know the index of an option can also select an option with
+:cpp:expr:`lv_roller_set_selected_str(roller, str, LV_ANIM_ON)`,
+where *str* is the string equal to one of the options.
+
 Get selected option
 -------------------
 

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -232,6 +232,16 @@ int lv_strcmp(const char * s1, const char * s2)
     return *(const unsigned char *)s1 - *(const unsigned char *)s2;
 }
 
+int lv_strncmp(const char * s1, const char * s2, size_t len)
+{
+    while(len > 0 && *s1 && (*s1 == *s2)) {
+        s1++;
+        s2++;
+        len--;
+    }
+    return *(const unsigned char *)s1 - *(const unsigned char *)s2;
+}
+
 char * lv_strdup(const char * src)
 {
     size_t len = lv_strlen(src) + 1;

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -235,9 +235,11 @@ int lv_strcmp(const char * s1, const char * s2)
 int lv_strncmp(const char * s1, const char * s2, size_t len)
 {
     while(len > 0 && *s1 && (*s1 == *s2)) {
+        if(--len == 0) {
+            return 0;
+        }
         s1++;
         s2++;
-        len--;
     }
     return *(const unsigned char *)s1 - *(const unsigned char *)s2;
 }

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -234,6 +234,10 @@ int lv_strcmp(const char * s1, const char * s2)
 
 int lv_strncmp(const char * s1, const char * s2, size_t len)
 {
+    if(len == 0) {
+        return 0;
+    }
+
     while(len > 0 && *s1 && (*s1 == *s2)) {
         if(--len == 0) {
             return 0;

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -86,6 +86,11 @@ int lv_strcmp(const char * s1, const char * s2)
     return strcmp(s1, s2);
 }
 
+int lv_strncmp(const char * s1, const char * s2, size_t len)
+{
+    return strncmp(s1, s2, len);
+}
+
 char * lv_strdup(const char * src)
 {
     /*strdup uses malloc, so use the lv_malloc when LV_USE_STDLIB_MALLOC is not LV_STDLIB_CLIB */

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -120,6 +120,15 @@ char * lv_strcpy(char * dst, const char * src);
 int lv_strcmp(const char * s1, const char * s2);
 
 /**
+ * @brief  This function will compare two strings up to the given length.
+ * @param s1    pointer to the first string
+ * @param s2    pointer to the second string
+ * @param len   the maximum amount of characters to compare
+ * @return      the difference between the value of the first unmatching character.
+ */
+int lv_strncmp(const char * s1, const char * s2, size_t len);
+
+/**
  * @brief Duplicate a string by allocating a new one and copying the content.
  * @param src Pointer to the source of data to be copied.
  * @return A pointer to the new allocated string. NULL if failed.

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -86,6 +86,11 @@ int lv_strcmp(const char * s1, const char * s2)
     return rt_strcmp(s1, s2);
 }
 
+int lv_strncmp(const char * s1, const char * s2, size_t len)
+{
+    return rt_strncmp(s1, s2, len);
+}
+
 char * lv_strdup(const char * src)
 {
     size_t len = lv_strlen(src) + 1;

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -275,6 +275,34 @@ void lv_roller_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf_s
     buf[c] = '\0';
 }
 
+bool lv_roller_set_selected_str(lv_obj_t * obj, const char * sel_opt, lv_anim_enable_t anim)
+{
+    const char * options = lv_roller_get_options(obj);
+    size_t options_len = lv_strlen(options);
+
+    bool option_found = false;
+
+    uint32_t current_option = 0;
+    size_t line_start = 0;
+
+    for(size_t i = 0; i < options_len; i++) {
+        if(options[i] == '\n') {
+            // See if this is the correct option
+            if(lv_strncmp(&options[line_start], sel_opt, i - line_start) == 0) {
+                lv_roller_set_selected(obj, current_option, anim);
+                option_found = true;
+                break;
+            }
+
+            current_option++;
+            line_start = i + 1;
+        }
+    }
+
+    return option_found;
+}
+
+
 /**
  * Get the options of a roller
  * @param roller pointer to roller object

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -287,7 +287,7 @@ bool lv_roller_set_selected_str(lv_obj_t * obj, const char * sel_opt, lv_anim_en
 
     for(size_t i = 0; i < options_len; i++) {
         if(options[i] == '\n') {
-            // See if this is the correct option
+            /* See if this is the correct option */
             if(lv_strncmp(&options[line_start], sel_opt, i - line_start) == 0) {
                 lv_roller_set_selected(obj, current_option, anim);
                 option_found = true;

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -106,6 +106,16 @@ uint32_t lv_roller_get_selected(const lv_obj_t * obj);
  */
 void lv_roller_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf_size);
 
+
+/**
+ * Sets the given string as the selection on the roller. Does not alter the current selection on failure.
+ * @param obj               pointer to roller object
+ * @param sel_opt   pointer to the string you want to set as an option
+ * @param anim          LV_ANIM_ON: set with animation; LV_ANOM_OFF set immediately
+ * @return                  `true` if set successfully and `false` if the given string does not exist as an option in the roller
+ */
+bool lv_roller_set_selected_str(lv_obj_t * obj, const char * sel_opt, lv_anim_enable_t anim);
+
 /**
  * Get the options of a roller
  * @param obj       pointer to roller object

--- a/tests/src/test_cases/widgets/test_roller.c
+++ b/tests/src/test_cases/widgets/test_roller.c
@@ -125,6 +125,25 @@ void test_roller_infinite_mode_get_selected_option(void)
     TEST_ASSERT_EQUAL_STRING("Two", actual_str);
 }
 
+void test_roller_set_selected_option_str(void)
+{
+    bool selected;
+    TEST_ASSERT_EQUAL(0, lv_roller_get_selected(roller));
+
+    /* Test an item that exists in the roller */
+    selected = lv_roller_set_selected_str(roller, "Two", LV_ANIM_OFF);
+    TEST_ASSERT_TRUE(selected);
+
+    TEST_ASSERT_EQUAL(1, lv_roller_get_selected(roller));
+
+    /* Try to select an item that does not exist in the roller */
+    selected = lv_roller_set_selected_str(roller, "No", LV_ANIM_OFF);
+    TEST_ASSERT_FALSE(selected);
+
+    /* Make sure that the selection did not change */
+    TEST_ASSERT_EQUAL(1, lv_roller_get_selected(roller));
+}
+
 void test_roller_keypad_events(void)
 {
     int16_t expected_index = 1;


### PR DESCRIPTION
This adds the ability to manually set an option in a roller using a string that corresponds to that option.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
