### PR TITLE
fix(draw): add assertion checks for malloc return values

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -11,6 +11,7 @@
  *      INCLUDES
  *********************/
 #include "../misc/lv_area_private.h"
+#include "../misc/lv_assert.h"
 #include "lv_draw_private.h"
 #include "sw/lv_draw_sw.h"
 #include "../display/lv_display_private.h"
@@ -79,7 +80,7 @@ void lv_draw_deinit(void)
 void * lv_draw_create_unit(size_t size)
 {
     lv_draw_unit_t * new_unit = lv_malloc_zeroed(size);
-
+    LV_ASSERT_MALLOC(new_unit);
     new_unit->next = _draw_info.unit_head;
     _draw_info.unit_head = new_unit;
     _draw_info.unit_cnt++;
@@ -91,7 +92,7 @@ lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords)
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * new_task = lv_malloc_zeroed(sizeof(lv_draw_task_t));
-
+    LV_ASSERT_MALLOC(new_task);
     new_task->area = *coords;
     new_task->_real_area = *coords;
     new_task->clip_area = layer->_clip_area;

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -65,6 +65,7 @@ void lv_draw_arc(lv_layer_t * layer, const lv_draw_arc_dsc_t * dsc)
     lv_draw_task_t * t = lv_draw_add_task(layer, &a);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_ARC;
 

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -75,6 +75,7 @@ void lv_draw_layer(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     lv_draw_task_t * t = lv_draw_add_task(layer, coords);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_LAYER;
     t->state = LV_DRAW_TASK_STATE_WAITING;
@@ -107,6 +108,7 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_image_dsc_t * new_image_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(new_image_dsc);
     lv_memcpy(new_image_dsc, dsc, sizeof(*dsc));
     lv_result_t res = lv_image_decoder_get_info(new_image_dsc->src, &new_image_dsc->header);
     if(res != LV_RESULT_OK) {

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -100,6 +100,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_layer_t * layer, const lv_draw_label
     lv_draw_task_t * t = lv_draw_add_task(layer, coords);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_LABEL;
 

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -66,6 +66,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_line(lv_layer_t * layer, const lv_draw_line_d
     lv_draw_task_t * t = lv_draw_add_task(layer, &a);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_LINE;
 

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -58,6 +58,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_mask_rect(lv_layer_t * layer, const lv_draw_m
     lv_draw_task_t * t = lv_draw_add_task(layer, &layer->buf_area);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_MASK_RECTANGLE;
 

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -147,6 +147,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         /*Check whether the shadow is visible*/
         t = lv_draw_add_task(layer, coords);
         lv_draw_box_shadow_dsc_t * shadow_dsc = lv_malloc(sizeof(lv_draw_box_shadow_dsc_t));
+        LV_ASSERT_MALLOC(shadow_dsc);
         t->draw_dsc = shadow_dsc;
         lv_area_increase(&t->_real_area, dsc->shadow_spread, dsc->shadow_spread);
         lv_area_increase(&t->_real_area, dsc->shadow_width, dsc->shadow_width);
@@ -178,6 +179,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
 
         t = lv_draw_add_task(layer, &bg_coords);
         lv_draw_fill_dsc_t * bg_dsc = lv_malloc(sizeof(lv_draw_fill_dsc_t));
+        LV_ASSERT_MALLOC(bg_dsc);
         lv_draw_fill_dsc_init(bg_dsc);
         t->draw_dsc = bg_dsc;
         bg_dsc->base = dsc->base;
@@ -219,6 +221,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                 }
 
                 lv_draw_image_dsc_t * bg_image_dsc = lv_malloc(sizeof(lv_draw_image_dsc_t));
+                LV_ASSERT_MALLOC(bg_image_dsc);
                 lv_draw_image_dsc_init(bg_image_dsc);
                 t->draw_dsc = bg_image_dsc;
                 bg_image_dsc->base = dsc->base;
@@ -242,6 +245,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                 t = lv_draw_add_task(layer, &a);
 
                 lv_draw_label_dsc_t * bg_label_dsc = lv_malloc(sizeof(lv_draw_label_dsc_t));
+                LV_ASSERT_MALLOC(bg_label_dsc);
                 lv_draw_label_dsc_init(bg_label_dsc);
                 t->draw_dsc = bg_label_dsc;
                 bg_label_dsc->base = dsc->base;
@@ -259,6 +263,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
     if(has_border) {
         t = lv_draw_add_task(layer, coords);
         lv_draw_border_dsc_t * border_dsc = lv_malloc(sizeof(lv_draw_border_dsc_t));
+        LV_ASSERT_MALLOC(border_dsc);
         t->draw_dsc = border_dsc;
         border_dsc->base = dsc->base;
         border_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
@@ -277,6 +282,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         lv_area_increase(&outline_coords, dsc->outline_width + dsc->outline_pad, dsc->outline_width + dsc->outline_pad);
         t = lv_draw_add_task(layer, &outline_coords);
         lv_draw_border_dsc_t * outline_dsc = lv_malloc(sizeof(lv_draw_border_dsc_t));
+        LV_ASSERT_MALLOC(outline_dsc);
         t->draw_dsc = outline_dsc;
         lv_area_increase(&t->_real_area, dsc->outline_width, dsc->outline_width);
         lv_area_increase(&t->_real_area, dsc->outline_pad, dsc->outline_pad);

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -72,6 +72,7 @@ void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
     lv_draw_task_t * t = lv_draw_add_task(layer, &a);
 
     t->draw_dsc = lv_malloc(sizeof(*dsc));
+    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
     t->type = LV_DRAW_TASK_TYPE_TRIANGLE;
 


### PR DESCRIPTION
Fixes: #6877
LV_ASSERT_MALLOC() checks added after malloc calls in the draw routines.

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
