### PR TITLE
fix(table): mark clicks as 'Invalid' when clicking on empty spaces

### DIFF
--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -1001,16 +1001,16 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
     lv_area_t area;
     lv_obj_get_coords(obj, &area);
 
-    uint8_t idx = 0;
+    uint32_t idx = 0;
     int32_t total_row_height = 0;
     int32_t total_column_width = 0;
 
     for(idx = 0; idx < table->row_cnt; ++idx) {
-        total_row_height += *(table->row_h);
+        total_row_height += table->row_h[idx];
     }
 
     for(idx = 0; idx < table->col_cnt; ++idx) {
-        total_column_width += *(table->col_w);
+        total_column_width += table->col_w[idx];
     }
 
     /* Clicked outside rows on empty space */
@@ -1025,7 +1025,6 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
         if(row) *row = LV_TABLE_CELL_NONE;
         return LV_RESULT_INVALID;
     }
-    else { /*Nothing to do*/ }
 
     int32_t tmp;
     if(col) {

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -1003,9 +1003,14 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
 
     uint8_t idx = 0;
     int32_t total_row_height = 0;
+    int32_t total_column_width = 0;
 
     for(idx = 0; idx < table->row_cnt; ++idx) {
         total_row_height += *(table->row_h);
+    }
+
+    for(idx = 0; idx < table->col_cnt; ++idx) {
+        total_column_width += *(table->col_w);
     }
 
     /* Clicked outside rows on empty space */
@@ -1014,6 +1019,13 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
         if(row) *row = LV_TABLE_CELL_NONE;
         return LV_RESULT_INVALID;
     }
+    /* Clicked outside columns on empty space */
+    else if(p.x > (total_column_width + area.x1)) {
+        if(col) *col = LV_TABLE_CELL_NONE;
+        if(row) *row = LV_TABLE_CELL_NONE;
+        return LV_RESULT_INVALID;
+    }
+    else { /*Nothing to do*/ }
 
     int32_t tmp;
     if(col) {

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -997,6 +997,24 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
     lv_point_t p;
     lv_indev_get_point(lv_indev_active(), &p);
 
+    /* Calculate total height of rows so we know if the click was outside them */
+    lv_area_t area;
+    lv_obj_get_coords(obj, &area);
+
+    uint8_t idx = 0;
+    int32_t total_row_height = 0;
+
+    for(idx = 0; idx < table->row_cnt; ++idx) {
+        total_row_height += *(table->row_h);
+    }
+
+    /* Clicked outside rows on empty space */
+    if(p.y > (total_row_height + area.y1)) {
+        if(col) *col = LV_TABLE_CELL_NONE;
+        if(row) *row = LV_TABLE_CELL_NONE;
+        return LV_RESULT_INVALID;
+    }
+
     int32_t tmp;
     if(col) {
         int32_t x = p.x + lv_obj_get_scroll_x(obj);

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -521,6 +521,8 @@ static void lv_table_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     table->row_h[0] = LV_DPI_DEF;
     table->cell_data = lv_realloc(table->cell_data, table->row_cnt * table->col_cnt * sizeof(lv_table_cell_t *));
     table->cell_data[0] = NULL;
+    table->row_act = LV_TABLE_CELL_NONE;
+    table->col_act = LV_TABLE_CELL_NONE;
 
     LV_TRACE_OBJ_CREATE("finished");
 }

--- a/tests/src/test_cases/test_file_explorer.c
+++ b/tests/src/test_cases/test_file_explorer.c
@@ -27,7 +27,7 @@ void tearDown(void)
 
 void test_file_explorer_read_dir(void)
 {
-    uint8_t back_row = 0, dev_row = 0, shm_row = 0, home_row = 0, user_row = 0;
+    // uint8_t back_row = 0, dev_row = 0, shm_row = 0, home_row = 0, user_row = 0;
 
     mkdir("src/test_files/test_file_explorer_folder", 0777);
     mkdir("src/test_files/test_file_explorer_folder/dev", 0777);
@@ -39,7 +39,8 @@ void test_file_explorer_read_dir(void)
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    /* Iterate the table rows, get their content and store the index when matching Back, dev and home dirs */
+    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_LEFT "  Back") == 0) {
             back_row = i;
         }
@@ -49,47 +50,52 @@ void test_file_explorer_read_dir(void)
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  home") == 0) {
             home_row = i;
         }
-    }
+    }*/
 
-    file_table->row_act = dev_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    // file_table->row_act = dev_row;
+    // lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/");
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  shm") == 0) {
             shm_row = i;
         }
-    }
+    }*/
 
-    file_table->row_act = shm_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/shm");
+    // lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/shm/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    file_table->row_act = back_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    // file_table->row_act = back_row;
+    // lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/");
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    file_table->row_act = back_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    //file_table->row_act = back_row;
+    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/");
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    file_table->row_act = home_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    //file_table->row_act = home_row;
+    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/home/");
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/home/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  web_user") == 0) {
             user_row = i;
         }
-    }
+    }*/
 
-    file_table->row_act = user_row;
-    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    //file_table->row_act = user_row;
+    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/home/web_user/");
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/home/web_user/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 

--- a/tests/src/test_cases/test_file_explorer.c
+++ b/tests/src/test_cases/test_file_explorer.c
@@ -51,6 +51,8 @@ void test_file_explorer_read_dir(void)
         }
     }
 
+    /* Since the default table->col_act = LV_TABLE_CELL_NONE, it is necessary to specify file_table->col_act = 0 */
+    file_table->col_act = 0;
     file_table->row_act = dev_row;
     lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/",

--- a/tests/src/test_cases/test_file_explorer.c
+++ b/tests/src/test_cases/test_file_explorer.c
@@ -27,7 +27,7 @@ void tearDown(void)
 
 void test_file_explorer_read_dir(void)
 {
-    // uint8_t back_row = 0, dev_row = 0, shm_row = 0, home_row = 0, user_row = 0;
+    uint8_t back_row = 0, dev_row = 0, shm_row = 0, home_row = 0, user_row = 0;
 
     mkdir("src/test_files/test_file_explorer_folder", 0777);
     mkdir("src/test_files/test_file_explorer_folder/dev", 0777);
@@ -39,8 +39,7 @@ void test_file_explorer_read_dir(void)
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    /* Iterate the table rows, get their content and store the index when matching Back, dev and home dirs */
-    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_LEFT "  Back") == 0) {
             back_row = i;
         }
@@ -50,52 +49,47 @@ void test_file_explorer_read_dir(void)
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  home") == 0) {
             home_row = i;
         }
-    }*/
+    }
 
-    // file_table->row_act = dev_row;
-    // lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/");
+    file_table->row_act = dev_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  shm") == 0) {
             shm_row = i;
         }
-    }*/
+    }
 
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/shm");
-    // lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
+    file_table->row_act = shm_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/shm/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    // file_table->row_act = back_row;
-    // lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/dev/");
+    file_table->row_act = back_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/dev/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    //file_table->row_act = back_row;
-    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/");
+    file_table->row_act = back_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    //file_table->row_act = home_row;
-    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/home/");
+    file_table->row_act = home_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/home/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 
-    /*for(uint8_t i = 0; i < file_table->row_cnt; i++) {
+    for(uint8_t i = 0; i < file_table->row_cnt; i++) {
         if(lv_strcmp(lv_table_get_cell_value(file_explorer->file_table, i, 0), LV_SYMBOL_DIRECTORY "  web_user") == 0) {
             user_row = i;
         }
-    }*/
+    }
 
-    //file_table->row_act = user_row;
-    //lv_obj_send_event(file_explorer_obj, LV_EVENT_VALUE_CHANGED, NULL);
-    lv_file_explorer_open_dir(file_explorer_obj, "A:src/test_files/test_file_explorer_folder/home/web_user/");
+    file_table->row_act = user_row;
+    lv_obj_send_event(file_explorer->file_table, LV_EVENT_VALUE_CHANGED, NULL);
     TEST_ASSERT_EQUAL_STRING("A:src/test_files/test_file_explorer_folder/home/web_user/",
                              lv_file_explorer_get_current_path(file_explorer_obj));
 

--- a/tests/src/test_cases/widgets/test_table.c
+++ b/tests/src/test_cases/widgets/test_table.c
@@ -309,8 +309,8 @@ void test_table_cell_select_should_not_allow_set_on_table_with_no_rows(void)
 
     lv_table_get_selected_cell(table, &selected_row, &selected_column);
 
-    TEST_ASSERT_EQUAL_UINT32(0, selected_row);
-    TEST_ASSERT_EQUAL_UINT32(0, selected_column);
+    TEST_ASSERT_EQUAL_UINT32(LV_TABLE_CELL_NONE, selected_row);
+    TEST_ASSERT_EQUAL_UINT32(LV_TABLE_CELL_NONE, selected_column);
 }
 
 #endif


### PR DESCRIPTION
Fixes one part of #7132 

Before this change when clicking in a table empty space (this happens when the table size is bigger than the total size of the rows and columns) the returned columns and rows were the total table cols and rows plus 1.
With this change we return an invalid click, so the click is 'ignored'.

This is my test case, taken from the `lv_example_table_1` example:
```c
    lv_obj_t * table = lv_table_create(lv_screen_active());

    /*Fill the first column*/
    lv_table_set_cell_value(table, 0, 0, "Name");
    lv_table_set_cell_value(table, 1, 0, "Apple");
    lv_table_set_cell_value(table, 2, 0, "Banana");

    /*Fill the second column*/
    lv_table_set_cell_value(table, 0, 1, "Price");
    lv_table_set_cell_value(table, 1, 1, "$7");
    lv_table_set_cell_value(table, 2, 1, "$4");

    /*Set a smaller height to the table. It'll make it scrollable*/
    lv_obj_set_height(table, 400); /* Make the table bigger */
    lv_obj_center(table);
```
And I've added this log to the table event handler to print out the selected cell:
```patch
diff --git a/src/widgets/table/lv_table.c b/src/widgets/table/lv_table.c
index b1553506d..d5caa99be 100644
--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -582,6 +582,7 @@ static void lv_table_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_result_t pr_res = get_pressed_cell(obj, &row, &col);
 
         if(pr_res == LV_RESULT_OK && (table->col_act != col || table->row_act != row)) {
+            LV_LOG_USER("Row: %d, Col: %d", row, col);
             table->col_act = col;
             table->row_act = row;
             lv_obj_invalidate(obj);
```

Then click into the empty space and print the rows and cols only when clicking inside them, not when clicking in the empty space.

This video is before the change:
[Screencast from 27-10-24 23:26:16.webm](https://github.com/user-attachments/assets/3410acfb-c5fd-47af-85e2-70411914dcae)

This other video is with the change:
[Screencast from 27-10-24 23:25:25.webm](https://github.com/user-attachments/assets/566e69d7-6a0c-4d3e-81db-29f4f6bacc4d)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
