### PR TITLE
fix(docs):  trailing underscore looked like hyperlink to Sphinx

### DIFF
--- a/docs/details/base-widget/styles/style-properties.rst
+++ b/docs/details/base-widget/styles/style-properties.rst
@@ -409,7 +409,7 @@ Sets the padding between the columns. Used by the layouts.
 pad_radial
 ~~~~~~~~~~
 
-Pad text labels away from the scale ticks/remainder of the LV_PART_
+Pad text labels away from the scale ticks/remainder of the ``LV_PART_``
 
 .. raw:: html
 

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -121,7 +121,7 @@ props = [
 
 {'name': 'PAD_RADIAL',
 'style_type': 'num',   'var_type': 'int32_t' ,  'default':0, 'inherited': 0, 'layout': 0, 'ext_draw': 0,
- 'dsc': "Pad text labels away from the scale ticks/remainder of the LV_PART_"},
+ 'dsc': "Pad text labels away from the scale ticks/remainder of the ``LV_PART_``"},
 
 {'section': 'Margin', 'dsc' : "Properties to describe spacing around a Widget. Very similar to the margin properties in HTML."},
 {'name': 'MARGIN_TOP',


### PR DESCRIPTION
Inspection of docs-build errors revealed this one being caused by contents of `./scripts/style_api_gen.py`.  A trailing underscore was being interpreted by Sphinx as a hyperlink reference, wherease it was meant to only be a code reference to `LV_PART_...` enumeration value.  Solved by encapsulating code reference in reStructuredText `literal` syntax.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
