### PR TITLE
fix(script): add ending for raw loader of ThorVG

### DIFF
--- a/docs/details/libs/rlottie.rst
+++ b/docs/details/libs/rlottie.rst
@@ -81,13 +81,9 @@ array. E.g.:
 
 .. code-block:: shell
 
-   ./filetohex.py path/to/lottie.json > out.txt
-
-``lvgl/scripts/filetohex.py`` only support one-character string. And it is recommended to end with a null terminate to avoid rendering issues. E.g.:
-
-.. code-block:: shell
-
    ./filetohex.py path/to/lottie.json --filter-character --null-terminate > out.txt
+
+``--filter-character`` filters out non-ASCII characters and ``--null-terminate`` makes sure that a trailing zero is appended to properly close the string.
 
 To create an animation from raw data:
 

--- a/docs/details/libs/rlottie.rst
+++ b/docs/details/libs/rlottie.rst
@@ -83,6 +83,12 @@ array. E.g.:
 
    ./filetohex.py path/to/lottie.json > out.txt
 
+``lvgl/scripts/filetohex.py`` only support one-character string. And it is recommended to end with a null terminate to avoid rendering issues. E.g.:
+
+.. code-block:: shell
+
+   ./filetohex.py path/to/lottie.json --filter-character --null-terminate > out.txt
+
 To create an animation from raw data:
 
 .. code-block:: c

--- a/docs/details/widgets/lottie.rst
+++ b/docs/details/widgets/lottie.rst
@@ -68,13 +68,9 @@ array. E.g.:
 
 .. code-block:: shell
 
-   ./filetohex.py path/to/lottie.json > out.txt
-
-``lvgl/scripts/filetohex.py`` only support one-character string. And it is recommended to end with a null terminate to avoid rendering issues. E.g.:
-
-.. code-block:: shell
-
    ./filetohex.py path/to/lottie.json --filter-character --null-terminate > out.txt
+
+``--filter-character`` filters out non-ASCII characters and ``--null-terminate`` makes sure that a trailing zero is appended to properly close the string.
 
 To create an animation from data use
 :cpp:expr:`lv_lottie_set_src_data(lottie, data, sizeof(data))`

--- a/docs/details/widgets/lottie.rst
+++ b/docs/details/widgets/lottie.rst
@@ -70,6 +70,12 @@ array. E.g.:
 
    ./filetohex.py path/to/lottie.json > out.txt
 
+``lvgl/scripts/filetohex.py`` only support one-character string. And it is recommended to end with a null terminate to avoid rendering issues. E.g.:
+
+.. code-block:: shell
+
+   ./filetohex.py path/to/lottie.json --filter-character --null-terminate > out.txt
+
 To create an animation from data use
 :cpp:expr:`lv_lottie_set_src_data(lottie, data, sizeof(data))`
 

--- a/scripts/filetohex.py
+++ b/scripts/filetohex.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 import sys
+import textwrap
+import re
 
 with open(sys.argv[1], 'r') as file:
     s = file.read()
 
 b = bytearray()
+
+if '--filter-character' in sys.argv:
+    s = re.sub(r'[^\x00-\xff]', '', s)
+if '--null-terminate' in sys.argv:
+    s += '\x00'
+
 b.extend(map(ord, s))
-b.append(0x00)
 
-for a in b: print(hex(a), end =", ")
-
+print(textwrap.fill(', '.join([hex(a) for a in b]), 96))

--- a/scripts/filetohex.py
+++ b/scripts/filetohex.py
@@ -6,6 +6,7 @@ with open(sys.argv[1], 'r') as file:
 
 b = bytearray()
 b.extend(map(ord, s))
+b.append(0x00)
 
 for a in b: print(hex(a), end =", ")
 


### PR DESCRIPTION
The Lottie file exported from AE does not display correctly after running filetohex.py. It only displays properly if 0x00 is added at the end.