### PR TITLE
fix(ffmpeg): fix FFmpeg as image decoder 'File open failed' error

### DIFF
--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -332,7 +332,7 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(src_type == LV_IMAGE_SRC_FILE) {
         char * fn = ffmpeg_resolve_path(src);
         if(fn == NULL) {
-            /*Maybe other decoder can handle it, so keep silence here*/
+            /*Maybe other decoder can handle it, so keep silent here*/
             return LV_RESULT_INVALID;
         }
 
@@ -363,7 +363,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         char * path = ffmpeg_resolve_path(dsc->src);
         if(path == NULL) {
-            /*Maybe other decoder can handle it, so keep silence here*/
+            /*Maybe other decoder can handle it, so keep silent here*/
             return LV_RESULT_INVALID;
         }
 

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -311,6 +311,7 @@ static char * ffmpeg_resolve_path(const char * path)
     size_t prefix_len = lv_strlen(prefix);
 
     char * res = lv_malloc(prefix_len + path_len + 1);
+    if(res == NULL) return NULL;
     lv_memcpy(res, prefix, prefix_len);
     lv_memcpy(res + prefix_len, path, path_len + 1);
 

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -59,7 +59,8 @@ int lv_ffmpeg_get_frame_num(const char * path);
 lv_obj_t * lv_ffmpeg_player_create(lv_obj_t * parent);
 
 /**
- * Set the path of the file to be played
+ * Set the path of the file to be played.
+ * FFmpeg player doesn't use LVGL's File System API.
  * @param obj pointer to a ffmpeg_player object
  * @param path video file path
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info.


### PR DESCRIPTION
The FFmpeg image decoder can't recognize lvgl's driver letter. And here is my workaround for it.  

**The problem is**, for example, after enabling `LV_USE_FFMPEG`, if we have a image located at `"/tmp/3dmodel.png"` as **image** src, like this:  
```c
    lv_obj_t *image = lv_image_create(parent);
    lv_image_set_src(image , "/tmp/3dmodel.png");
```
Log will report:  
```
[Warn]  (170764.186, +170764186)         lv_fs_open: Can't open file (/tmp/3dmodel.png): unknown driver letter lv_fs.c:88
[Error] (170764.186, +0)         image_decoder_get_info: File open failed: 3 lv_image_decoder.c:332
[Warn]  (170764.186, +0)         lv_draw_image: Couldn't get info about the image lv_draw_image.c:109
```
Or if we pass `"A:/tmp/3dmodel.png"`, because FFmpeg have higher priority, it will report:
```
[Error] (172891.877, +0)         ffmpeg_get_image_header: Could not open source file A:/tmp/3dmodel.png lv_ffmpeg.c:578
[Error] (172891.877, +0)         decoder_info: ffmpeg can't get image header lv_ffmpeg.c:270
...(repeat every LV_DEF_REFR_PERIOD)
```

**My solution**: every time when FFmpeg wrapper can't find the file, I simply let it try again with driver letter removed. This modification will only affect FFmpeg as image decoder.  

**Known issue**: Relative paths are accepted here, but `LV_FS_STDIO_PATH` needs to be empty string. Modify [lv_image_decoder.c](https://github.com/lvgl/lvgl/blob/a4f66606fab2726534dd8c99cea4a6de7f1e7223/src/draw/lv_image_decoder.c#L329-L335) to check if FFmpeg is enabled **might** solve this, but it will cause more coupling. So I didn't do that.  

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
