### PR TITLE
fix(buttonmatrix):  fix 1-off error in `lv_buttonmatrix_get_button_text()`

### DIFF
--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -319,7 +319,7 @@ const char * lv_buttonmatrix_get_button_text(const lv_obj_t * obj, uint32_t btn_
     if(btn_id == LV_BUTTONMATRIX_BUTTON_NONE) return NULL;
 
     lv_buttonmatrix_t * btnm = (lv_buttonmatrix_t *)obj;
-    if(btn_id > btnm->btn_cnt) return NULL;
+    if(btn_id >= btnm->btn_cnt) return NULL;
 
     uint32_t txt_i = 0;
     uint32_t btn_i = 0;


### PR DESCRIPTION
I found a bug while proofreading/editing documentation on Button Matrix:

`lv_buttonmatrix_get_button_text()` function has this code in it to avoid attempting to use a user-provided `btn_id` value that will make the `while(btn_i != btn_id)` loop proceed past the end of the array of buttons. However, it has a 1-off error which does permit it to go 1 past the end of the array.  This PR fixes that error.

Resolves #7192

cc:  @kisvegabor

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
