### PR TITLE
fix(chart):  `lv_malloc()` was allocating double size needed

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -94,7 +94,7 @@ void lv_chart_set_type(lv_obj_t * obj, lv_chart_type_t type)
     if(type == LV_CHART_TYPE_SCATTER) {
         lv_chart_series_t * ser;
         LV_LL_READ_BACK(&chart->series_ll, ser) {
-            ser->x_points = lv_malloc(sizeof(lv_point_t) * chart->point_cnt);
+            ser->x_points = lv_malloc(sizeof(int32_t) * chart->point_cnt);
             LV_ASSERT_MALLOC(ser->x_points);
             if(ser->x_points == NULL) return;
         }


### PR DESCRIPTION
When a chart is a SCATTER type, each series must have both an array of X values in addition to a separate array of Y values (both having `chart->point_cnt` `int32_t` elements).  This call of `lv_malloc()`, occurring when the chart type was changed to SCATTER type, was allocating a space for an `lv_point_t` (2 `int32_t` values) instead of 1, for each X value -- double the amount actually needed.  No harm was done to the application except for wasting RAM.

No issue was created for this.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  n/a
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  n/a
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
