### PR TITLE
fix(indev): don't reset all indevs if an object is set disabled

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -309,11 +309,6 @@ void lv_obj_add_state(lv_obj_t * obj, lv_state_t state)
 
     lv_state_t new_state = obj->state | state;
     if(obj->state != new_state) {
-
-        if(new_state & ~obj->state & LV_STATE_DISABLED) {
-            lv_indev_reset(NULL, obj);
-        }
-
         update_obj_state(obj, new_state);
     }
 }


### PR DESCRIPTION
Fixes #7152 