### PR TITLE
fix(imagebutton): warn if middle image is not set

### DIFF
--- a/docs/details/widgets/imagebutton.rst
+++ b/docs/details/widgets/imagebutton.rst
@@ -12,7 +12,7 @@ The Image Button is very similar to the simple 'Button' Widget. The only
 difference is that it displays user-defined images for each state instead
 of drawing a rectangle.  The list of states is covered below.
 
-You can set a left, right and center image, and the center image will be
+You can set a left, right and middle image, and the middle image will be
 repeated to match the width of the Widget.
 
 
@@ -34,16 +34,16 @@ Usage
 Image sources
 -------------
 
-To set the image for a particular state, use
-:cpp:expr:`lv_imagebutton_set_src(imagebutton, LV_IMAGEBUTTON_STATE_..., src_left, src_center, src_right)`.
+To set the image in a state, use the
+:cpp:expr:`lv_imagebutton_set_src(imagebutton, LV_IMAGEBUTTON_STATE_..., src_left, src_mid, src_right)`.
 
-The image sources work the same as described in :ref:`Image Widget <lv_image>`
-except that "Symbols" are not supported by the Image Button. ``NULL`` can be passed
-for any of the sources.
+The image sources work the same as described in the :ref:`Image Widget <lv_image>`
+except that "Symbols" are not supported by the Image button. Any of the sources can ``NULL``.
+Typically the middle image should be one of the set image sources.
 
-If only ``src_center`` is specified, the width of the Widget will be set automatically to the
+If only ``src_mid`` is specified, the width of the widget will be set automatically to the
 width of the image. However, if all three sources are set, the width needs to be set by the user
-(using e.g. :cpp:func:`lv_obj_set_width`) and the center image will be tiled as needed to fill the given size.
+(using e.g. :cpp:expr:`lv_obj_set_width`) and the middle image will be tiled to fill the given size.
 
 The possible states are:
 

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -253,11 +253,14 @@ static void refr_image(lv_obj_t * obj)
     lv_imagebutton_t * imagebutton = (lv_imagebutton_t *)obj;
     lv_imagebutton_state_t state  = suggest_state(obj, get_state(obj));
 
-    const void * src = imagebutton->src_mid[state].img_src;
-    if(src == NULL) return;
+    lv_imagebutton_src_info_t * src_left = &imagebutton->src_left[state];
+    lv_imagebutton_src_info_t * src_mid = &imagebutton->src_mid[state];
+    lv_imagebutton_src_info_t * src_right = &imagebutton->src_right[state];
+    if(src_left->img_src == NULL && src_mid->img_src == NULL && src_right->img_src == NULL) return;
 
     lv_obj_refresh_self_size(obj);
-    lv_obj_set_height(obj, imagebutton->src_mid[state].header.h); /*Keep the user defined width*/
+    lv_obj_set_height(obj, LV_MAX3(src_left->header.h, src_mid->header.h,
+                                   src_right->header.h)); /*Keep the user defined height*/
 
     lv_obj_invalidate(obj);
 }

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -79,6 +79,10 @@ void lv_imagebutton_set_src(lv_obj_t * obj, lv_imagebutton_state_t state, const 
 
     lv_imagebutton_t * imagebutton = (lv_imagebutton_t *)obj;
 
+    if((src_left || src_right) && !src_mid) {
+        LV_LOG_WARN("middle image source is not set while left and/or right image sources are");
+    }
+
     update_src_info(&imagebutton->src_left[state], src_left);
     update_src_info(&imagebutton->src_mid[state], src_mid);
     update_src_info(&imagebutton->src_right[state], src_right);
@@ -253,14 +257,11 @@ static void refr_image(lv_obj_t * obj)
     lv_imagebutton_t * imagebutton = (lv_imagebutton_t *)obj;
     lv_imagebutton_state_t state  = suggest_state(obj, get_state(obj));
 
-    lv_imagebutton_src_info_t * src_left = &imagebutton->src_left[state];
-    lv_imagebutton_src_info_t * src_mid = &imagebutton->src_mid[state];
-    lv_imagebutton_src_info_t * src_right = &imagebutton->src_right[state];
-    if(src_left->img_src == NULL && src_mid->img_src == NULL && src_right->img_src == NULL) return;
+    const void * src = imagebutton->src_mid[state].img_src;
+    if(src == NULL) return;
 
     lv_obj_refresh_self_size(obj);
-    lv_obj_set_height(obj, LV_MAX3(src_left->header.h, src_mid->header.h,
-                                   src_right->header.h)); /*Keep the user defined height*/
+    lv_obj_set_height(obj, imagebutton->src_mid[state].header.h); /*Keep the user defined width*/
 
     lv_obj_invalidate(obj);
 }


### PR DESCRIPTION
Fixes #7203

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
