### PR TITLE
refact(draw): use task instead of draw_unit as argument to draw functions

### DIFF
--- a/docs/details/integration/chip/nxp.rst
+++ b/docs/details/integration/chip/nxp.rst
@@ -108,13 +108,13 @@ Supported draw tasks are available in "src/draw/nxp/pxp/lv_draw_pxp.c":
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_pxp_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_pxp_img(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_img(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_pxp_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_layer(t, t->draw_dsc, &t->area);
             break;
         default:
             break;
@@ -333,28 +333,28 @@ Supported draw tasks are available in "src/draw/nxp/pxp/lv_draw_vglite.c":
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_vglite_label(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_vglite_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_vglite_border(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_border(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_vglite_img(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_img(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_vglite_arc(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_arc(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_vglite_line(draw_unit, t->draw_dsc);
+            lv_draw_vglite_line(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_vglite_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_vglite_triangle(draw_unit, t->draw_dsc);
+            lv_draw_vglite_triangle(t, t->draw_dsc);
             break;
         default:
             break;

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -360,15 +360,13 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_dma2d_unit->base_unit.target_layer = layer;
-    draw_dma2d_unit->base_unit.clip_area = &t->clip_area;
     draw_dma2d_unit->task_act = t;
 
     if(t->type == LV_DRAW_TASK_TYPE_FILL) {
         lv_draw_fill_dsc_t * dsc = t->draw_dsc;
         const lv_area_t * coords = &t->area;
         lv_area_t clipped_coords;
-        if(!lv_area_intersect(&clipped_coords, coords, draw_dma2d_unit->base_unit.clip_area)) {
+        if(!lv_area_intersect(&clipped_coords, coords, &t->clip_area)) {
             return LV_DRAW_UNIT_IDLE;
         }
 
@@ -377,14 +375,14 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
                                              clipped_coords.y1 - layer->buf_area.y1);
 
         if(dsc->opa >= LV_OPA_MAX) {
-            lv_draw_dma2d_opaque_fill(draw_dma2d_unit,
+            lv_draw_dma2d_opaque_fill(t,
                                       dest,
                                       lv_area_get_width(&clipped_coords),
                                       lv_area_get_height(&clipped_coords),
                                       lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), dsc->base.layer->color_format));
         }
         else {
-            lv_draw_dma2d_fill(draw_dma2d_unit,
+            lv_draw_dma2d_fill(t,
                                dest,
                                lv_area_get_width(&clipped_coords),
                                lv_area_get_height(&clipped_coords),
@@ -395,7 +393,7 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         lv_draw_image_dsc_t * dsc = t->draw_dsc;
         const lv_area_t * coords = &t->area;
         lv_area_t clipped_coords;
-        if(!lv_area_intersect(&clipped_coords, coords, draw_dma2d_unit->base_unit.clip_area)) {
+        if(!lv_area_intersect(&clipped_coords, coords, &t->clip_area)) {
             return LV_DRAW_UNIT_IDLE;
         }
 
@@ -405,14 +403,14 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
         if(dsc->opa >= LV_OPA_MAX) {
             lv_draw_dma2d_opaque_image(
-                draw_dma2d_unit,
+                t,
                 dest,
                 &clipped_coords,
                 lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), dsc->base.layer->color_format));
         }
         else {
             lv_draw_dma2d_image(
-                draw_dma2d_unit,
+                t,
                 dest,
                 &clipped_coords,
                 lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), dsc->base.layer->color_format));

--- a/src/draw/dma2d/lv_draw_dma2d_fill.c
+++ b/src/draw/dma2d/lv_draw_dma2d_fill.c
@@ -34,9 +34,9 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_dma2d_opaque_fill(lv_draw_dma2d_unit_t * u, void * first_pixel, int32_t w, int32_t h, int32_t stride)
+void lv_draw_dma2d_opaque_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride)
 {
-    lv_draw_fill_dsc_t * dsc = u->task_act->draw_dsc;
+    lv_draw_fill_dsc_t * dsc = t->draw_dsc;
     lv_color_format_t cf = dsc->base.layer->color_format;
 
     lv_draw_dma2d_output_cf_t output_cf = lv_draw_dma2d_cf_to_dma2d_output_cf(cf);
@@ -67,9 +67,9 @@ void lv_draw_dma2d_opaque_fill(lv_draw_dma2d_unit_t * u, void * first_pixel, int
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }
 
-void lv_draw_dma2d_fill(lv_draw_dma2d_unit_t * u, void * first_pixel, int32_t w, int32_t h, int32_t stride)
+void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride)
 {
-    lv_draw_fill_dsc_t * dsc = u->task_act->draw_dsc;
+    lv_draw_fill_dsc_t * dsc = t->draw_dsc;
     lv_color_t color = dsc->color;
     lv_color_format_t cf = dsc->base.layer->color_format;
     lv_opa_t opa = dsc->opa;

--- a/src/draw/dma2d/lv_draw_dma2d_img.c
+++ b/src/draw/dma2d/lv_draw_dma2d_img.c
@@ -34,13 +34,13 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_dma2d_opaque_image(lv_draw_dma2d_unit_t * u, void * dest_first_pixel, lv_area_t * clipped_coords,
+void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
                                 int32_t dest_stride)
 {
     int32_t w = lv_area_get_width(clipped_coords);
     int32_t h = lv_area_get_height(clipped_coords);
 
-    lv_draw_image_dsc_t * dsc = u->task_act->draw_dsc;
+    lv_draw_image_dsc_t * dsc = t->draw_dsc;
     lv_color_format_t output_cf = dsc->base.layer->color_format;
     lv_color_format_t image_cf = dsc->header.cf;
 
@@ -120,13 +120,13 @@ void lv_draw_dma2d_opaque_image(lv_draw_dma2d_unit_t * u, void * dest_first_pixe
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }
 
-void lv_draw_dma2d_image(lv_draw_dma2d_unit_t * u, void * dest_first_pixel, lv_area_t * clipped_coords,
+void lv_draw_dma2d_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
                          int32_t dest_stride)
 {
     int32_t w = lv_area_get_width(clipped_coords);
     int32_t h = lv_area_get_height(clipped_coords);
 
-    lv_draw_image_dsc_t * dsc = u->task_act->draw_dsc;
+    lv_draw_image_dsc_t * dsc = t->draw_dsc;
     lv_color_format_t output_cf = dsc->base.layer->color_format;
     lv_color_format_t image_cf = dsc->header.cf;
     lv_opa_t opa = dsc->opa;

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -129,11 +129,11 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_draw_dma2d_opaque_fill(lv_draw_dma2d_unit_t * u, void * first_pixel, int32_t w, int32_t h, int32_t stride);
-void lv_draw_dma2d_fill(lv_draw_dma2d_unit_t * u, void * first_pixel, int32_t w, int32_t h, int32_t stride);
-void lv_draw_dma2d_opaque_image(lv_draw_dma2d_unit_t * u, void * dest_first_pixel, lv_area_t * clipped_coords,
+void lv_draw_dma2d_opaque_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride);
+void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride);
+void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
                                 int32_t dest_stride);
-void lv_draw_dma2d_image(lv_draw_dma2d_unit_t * u, void * dest_first_pixel, lv_area_t * clipped_coords,
+void lv_draw_dma2d_image(lv_draw_task_t_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
                          int32_t dest_stride);
 lv_draw_dma2d_output_cf_t lv_draw_dma2d_cf_to_dma2d_output_cf(lv_color_format_t cf);
 uint32_t lv_draw_dma2d_color_to_dma2d_color(lv_draw_dma2d_output_cf_t cf, lv_color_t color);

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -80,8 +80,11 @@ void * lv_draw_create_unit(size_t size)
     lv_draw_unit_t * new_unit = lv_malloc_zeroed(size);
     LV_ASSERT_MALLOC(new_unit);
     new_unit->next = _draw_info.unit_head;
+
     _draw_info.unit_head = new_unit;
     _draw_info.unit_cnt++;
+
+    new_unit->idx = _draw_info.unit_cnt;
 
     return new_unit;
 }

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -96,6 +96,7 @@ lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords)
     LV_ASSERT_MALLOC(new_task);
     new_task->area = *coords;
     new_task->_real_area = *coords;
+    new_task->target_layer = layer;
     new_task->clip_area = layer->_clip_area;
 #if LV_DRAW_TRANSFORM_USE_MATRIX
     new_task->matrix = layer->matrix;

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -29,7 +29,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void img_decode_and_draw(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void img_decode_and_draw(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                 lv_image_decoder_dsc_t * decoder_dsc, lv_area_t * relative_decoded_area,
                                 const lv_area_t * img_area, const lv_area_t * clipped_img_area,
                                 lv_draw_image_core_cb draw_core_cb);
@@ -147,7 +147,7 @@ lv_image_src_t lv_image_src_get_type(const void * src)
     }
 }
 
-void lv_draw_image_normal_helper(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_image_normal_helper(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_area_t * coords, lv_draw_image_core_cb draw_core_cb)
 {
     if(draw_core_cb == NULL) {
@@ -171,7 +171,7 @@ void lv_draw_image_normal_helper(lv_draw_unit_t * draw_unit, const lv_draw_image
     }
 
     lv_area_t clipped_img_area;
-    if(!lv_area_intersect(&clipped_img_area, &draw_area, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&clipped_img_area, &draw_area, &t->clip_area)) {
         return;
     }
 
@@ -182,12 +182,12 @@ void lv_draw_image_normal_helper(lv_draw_unit_t * draw_unit, const lv_draw_image
         return;
     }
 
-    img_decode_and_draw(draw_unit, draw_dsc, &decoder_dsc, NULL, coords, &clipped_img_area, draw_core_cb);
+    img_decode_and_draw(t, draw_dsc, &decoder_dsc, NULL, coords, &clipped_img_area, draw_core_cb);
 
     lv_image_decoder_close(&decoder_dsc);
 }
 
-void lv_draw_image_tiled_helper(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_image_tiled_helper(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                 const lv_area_t * coords, lv_draw_image_core_cb draw_core_cb)
 {
     if(draw_core_cb == NULL) {
@@ -229,7 +229,7 @@ void lv_draw_image_tiled_helper(lv_draw_unit_t * draw_unit, const lv_draw_image_
 
             lv_area_t clipped_img_area;
             if(lv_area_intersect(&clipped_img_area, &tile_area, coords)) {
-                img_decode_and_draw(draw_unit, draw_dsc, &decoder_dsc, &relative_decoded_area, &tile_area, &clipped_img_area,
+                img_decode_and_draw(t, draw_dsc, &decoder_dsc, &relative_decoded_area, &tile_area, &clipped_img_area,
                                     draw_core_cb);
             }
 
@@ -277,7 +277,7 @@ void lv_image_buf_get_transformed_area(lv_area_t * res, int32_t w, int32_t h, in
  *   STATIC FUNCTIONS
  **********************/
 
-static void img_decode_and_draw(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void img_decode_and_draw(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                 lv_image_decoder_dsc_t * decoder_dsc, lv_area_t * relative_decoded_area,
                                 const lv_area_t * img_area, const lv_area_t * clipped_img_area,
                                 lv_draw_image_core_cb draw_core_cb)
@@ -289,7 +289,7 @@ static void img_decode_and_draw(lv_draw_unit_t * draw_unit, const lv_draw_image_
 
     /*The whole image is available, just draw it*/
     if(decoder_dsc->decoded && (relative_decoded_area == NULL || relative_decoded_area->x1 == LV_COORD_MIN)) {
-        draw_core_cb(draw_unit, draw_dsc, decoder_dsc, &sup, img_area, clipped_img_area);
+        draw_core_cb(t, draw_dsc, decoder_dsc, &sup, img_area, clipped_img_area);
     }
     /*Draw in smaller pieces*/
     else {
@@ -312,7 +312,7 @@ static void img_decode_and_draw(lv_draw_unit_t * draw_unit, const lv_draw_image_
                 /*Limit draw area to the current decoded area and draw the image*/
                 lv_area_t clipped_img_area_sub;
                 if(lv_area_intersect(&clipped_img_area_sub, clipped_img_area, &absolute_decoded_area)) {
-                    draw_core_cb(draw_unit, draw_dsc, decoder_dsc, &sup,
+                    draw_core_cb(t, draw_dsc, decoder_dsc, &sup,
                                  &absolute_decoded_area, &clipped_img_area_sub);
                 }
             }

--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -63,14 +63,14 @@ typedef struct _lv_draw_image_dsc_t {
 
 /**
  * PErform the actual rendering of a decoded image
- * @param draw_unit         pointer to a draw unit
+ * @param t                 pointer to a draw task
  * @param draw_dsc          the draw descriptor of the image
  * @param decoder_dsc       pointer to the decoded image's descriptor
  * @param sup               supplementary data
  * @param img_coords        the absolute coordinates of the image
  * @param clipped_img_area  the absolute clip coordinates
  */
-typedef void (*lv_draw_image_core_cb)(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+typedef void (*lv_draw_image_core_cb)(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                       const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                                       const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 

--- a/src/draw/lv_draw_image_private.h
+++ b/src/draw/lv_draw_image_private.h
@@ -42,23 +42,23 @@ struct _lv_draw_image_sup_t {
 /**
  * Can be used by draw units to handle the decoding and
  * prepare everything for the actual image rendering
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param draw_dsc      the draw descriptor of the image
  * @param coords        the absolute coordinates of the image
  * @param draw_core_cb  a callback to perform the actual rendering
  */
-void lv_draw_image_normal_helper(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_image_normal_helper(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_area_t * coords, lv_draw_image_core_cb draw_core_cb);
 
 /**
  * Can be used by draw units for TILED images to handle the decoding and
  * prepare everything for the actual image rendering
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param draw_dsc      the draw descriptor of the image
  * @param coords        the absolute coordinates of the image
  * @param draw_core_cb  a callback to perform the actual rendering
  */
-void lv_draw_image_tiled_helper(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_image_tiled_helper(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                 const lv_area_t * coords, lv_draw_image_core_cb draw_core_cb);
 
 /**

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -85,7 +85,7 @@ typedef struct {
 /**
  * Passed as a parameter to `lv_draw_label_iterate_characters` to
  * draw the characters one by one
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           pointer to `lv_draw_glyph_dsc_t` to describe the character to draw
  *                      if NULL don't draw character
  * @param fill_dsc      pointer to a fill descriptor to draw a background for the character or
@@ -94,7 +94,7 @@ typedef struct {
  * @param fill_area     the area to fill
  *                      if NULL do not fill anything
  */
-typedef void(*lv_draw_glyph_cb_t)(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc, lv_draw_fill_dsc_t * fill_dsc,
+typedef void(*lv_draw_glyph_cb_t)(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc, lv_draw_fill_dsc_t * fill_dsc,
                                   const lv_area_t * fill_area);
 
 /**********************
@@ -154,12 +154,12 @@ void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_letter(lv_layer_t * layer, lv_draw_lett
 /**
  * Should be used during rendering the characters to get the position and other
  * parameters of the characters
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           pointer to draw descriptor
  * @param coords        coordinates of the label
  * @param cb            a callback to call to draw each glyphs one by one
  */
-void lv_draw_label_iterate_characters(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                                       const lv_area_t * coords, lv_draw_glyph_cb_t cb);
 
 /**
@@ -171,14 +171,14 @@ void lv_draw_label_iterate_characters(lv_draw_unit_t * draw_unit, const lv_draw_
  * and invokes the callback (`cb`) to render the glyph at the specified position (`pos`)
  * using the given font (`font`).
  *
- * @param draw_unit     Pointer to the drawing unit handling the rendering context.
+ * @param t             Pointer to the drawing task.
  * @param dsc           Pointer to the descriptor containing styling for the glyph to be drawn.
  * @param pos           Pointer to the point coordinates where the letter should be drawn.
  * @param font          Pointer to the font containing the glyph.
  * @param letter        The Unicode code point of the letter to be drawn.
  * @param cb            Callback function to execute the actual rendering of the glyph.
  */
-void lv_draw_unit_draw_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * dsc,  const lv_point_t * pos,
+void lv_draw_unit_draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  const lv_point_t * pos,
                               const lv_font_t * font, uint32_t letter, lv_draw_glyph_cb_t cb);
 
 /***********************

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -94,9 +94,10 @@ struct _lv_draw_unit_t {
     const lv_area_t * clip_area;
 
     /**
-     * Name of the draw unit, for debugging purposes only.
+     * Name and ID of the draw unit, for debugging purposes only.
      */
     const char * name;
+    int32_t idx;
 
     /**
      * Called to try to assign a draw task to itself.

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -54,11 +54,15 @@ struct _lv_draw_task_t {
      * Therefore during drawing the layer's clip area shouldn't be used as it might be already changed for other draw tasks.
      */
     lv_area_t clip_area;
+    lv_layer_t * target_layer;
 
 #if LV_DRAW_TRANSFORM_USE_MATRIX
     /** Transform matrix to be applied when rendering the layer */
     lv_matrix_t matrix;
 #endif
+
+    /* Reference to the draw unit for debug or draw context purposes */
+    lv_draw_unit_t * draw_unit;
 
     volatile int state;              /** int instead of lv_draw_task_state_t to be sure its atomic */
 
@@ -85,13 +89,6 @@ struct _lv_draw_mask_t {
 
 struct _lv_draw_unit_t {
     lv_draw_unit_t * next;
-
-    /**
-     * The target_layer on which drawing should happen
-     */
-    lv_layer_t * target_layer;
-
-    const lv_area_t * clip_area;
 
     /**
      * Name and ID of the draw unit, for debugging purposes only.

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -287,34 +287,35 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
-    lv_draw_unit_t * draw_unit = (lv_draw_unit_t *)u;
+    /* remember draw unit for access to unit's context */
+    t->draw_unit = (lv_draw_unit_t *)u;
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_nema_gfx_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_nema_gfx_img(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_img(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_nema_gfx_triangle(draw_unit, t->draw_dsc);
+            lv_draw_nema_gfx_triangle(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_nema_gfx_label(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_nema_gfx_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_nema_gfx_line(draw_unit, t->draw_dsc);
+            lv_draw_nema_gfx_line(t, t->draw_dsc);
             break;
 #if LV_USE_NEMA_VG
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_nema_gfx_arc(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_arc(t, t->draw_dsc, &t->area);
             break;
 #endif
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_nema_gfx_border(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_nema_gfx_border(t, t->draw_dsc, &t->area);
             break;
         default:
             break;

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.h
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.h
@@ -86,28 +86,28 @@ void lv_draw_nema_gfx_init(void);
 
 void lv_draw_nema_gfx_deinit(void);
 
-void lv_draw_nema_gfx_fill(lv_draw_unit_t * draw_unit,
+void lv_draw_nema_gfx_fill(lv_draw_task_t * t,
                            const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
 
-void lv_draw_nema_gfx_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc);
+void lv_draw_nema_gfx_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc);
 
-void lv_draw_nema_gfx_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                           const lv_area_t * coords);
 
-void lv_draw_nema_gfx_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_nema_gfx_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                             const lv_area_t * coords);
 
 void lv_draw_nema_gfx_label_init(lv_draw_unit_t * draw_unit);
 
-void lv_draw_nema_gfx_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_nema_gfx_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                             const lv_area_t * coords);
 
-void lv_draw_nema_gfx_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+void lv_draw_nema_gfx_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
-void lv_draw_nema_gfx_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_nema_gfx_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                              const lv_area_t * coords);
 
-void lv_draw_nema_gfx_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
+void lv_draw_nema_gfx_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                           const lv_area_t * coords);
 
 

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c
@@ -39,7 +39,7 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_nema_gfx_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
 {
 
     LV_UNUSED(coords);
@@ -51,13 +51,13 @@ void lv_draw_nema_gfx_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * 
     if(dsc->start_angle == dsc->end_angle)
         return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_point_t center = {dsc->center.x - layer->buf_area.x1, dsc->center.y - layer->buf_area.y1};
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     nema_set_clip(clip_area.x1, clip_area.y1, lv_area_get_width(&clip_area), lv_area_get_height(&clip_area));

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_border.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_border.c
@@ -40,7 +40,7 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_nema_gfx_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN)
         return;
@@ -49,9 +49,9 @@ void lv_draw_nema_gfx_border(lv_draw_unit_t * draw_unit, const lv_draw_border_ds
     if(dsc->side == LV_BORDER_SIDE_NONE)
         return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t inward_coords;
     int32_t width = dsc->width;
 
@@ -64,7 +64,7 @@ void lv_draw_nema_gfx_border(lv_draw_unit_t * draw_unit, const lv_draw_border_ds
     lv_area_move(&inward_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     nema_set_clip(clip_area.x1, clip_area.y1, lv_area_get_width(&clip_area), lv_area_get_height(&clip_area));

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -39,13 +39,13 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t rel_coords;
     lv_area_copy(&rel_coords, coords);
     lv_area_move(&rel_coords, -layer->buf_area.x1, -layer->buf_area.y1);

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
@@ -41,9 +41,9 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void _draw_nema_gfx_tile(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
+static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
-static void _draw_nema_gfx_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
+static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
 
 static uint32_t lv_nemagfx_mask_cf_to_nema(lv_color_format_t cf);
 
@@ -51,7 +51,7 @@ static uint32_t lv_nemagfx_mask_cf_to_nema(lv_color_format_t cf);
  *  STATIC FUNCTIONS
  **********************/
 
-static void _draw_nema_gfx_tile(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
+static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
 {
 
     lv_image_decoder_dsc_t decoder_dsc;
@@ -76,11 +76,11 @@ static void _draw_nema_gfx_tile(lv_draw_unit_t * draw_unit, const lv_draw_image_
 
     int32_t tile_x_start = tile_area.x1;
 
-    while(tile_area.y1 <= draw_unit->clip_area->y2) {
-        while(tile_area.x1 <= draw_unit->clip_area->x2) {
+    while(tile_area.y1 <= t->clip_area->y2) {
+        while(tile_area.x1 <= t->clip_area->x2) {
 
             lv_area_t clipped_img_area;
-            if(lv_area_intersect(&clipped_img_area, &tile_area, draw_unit->clip_area)) {
+            if(lv_area_intersect(&clipped_img_area, &tile_area, &t->clip_area)) {
                 _draw_nema_gfx_img(draw_unit, dsc, &tile_area);
             }
 
@@ -97,24 +97,24 @@ static void _draw_nema_gfx_tile(lv_draw_unit_t * draw_unit, const lv_draw_image_
     lv_image_decoder_close(&decoder_dsc);
 }
 
-static void _draw_nema_gfx_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
+static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     const lv_image_dsc_t * img_dsc = dsc->src;
 
     bool masked = dsc->bitmap_mask_src != NULL;
 
     lv_area_t blend_area;
     /*Let's get the blend area which is the intersection of the area to fill and the clip area.*/
-    if(!lv_area_intersect(&blend_area, coords, draw_unit->clip_area))
+    if(!lv_area_intersect(&blend_area, coords, &t->clip_area))
         return; /*Fully clipped, nothing to do*/
 
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, draw_unit->clip_area);
+    lv_area_copy(&rel_clip_area, &t->clip_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     bool has_transform = (dsc->rotation != 0 || dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE);
@@ -260,14 +260,14 @@ static uint32_t lv_nemagfx_mask_cf_to_nema(lv_color_format_t cf)
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
 {
 
     if(!dsc->tile) {
-        _draw_nema_gfx_img(draw_unit, dsc, coords);
+        _draw_nema_gfx_img(t, dsc, coords);
     }
     else {
-        _draw_nema_gfx_tile(draw_unit, dsc, coords);
+        _draw_nema_gfx_tile(t, dsc, coords);
     }
 
 }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c
@@ -40,7 +40,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_nema_gfx_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords)
+void lv_draw_nema_gfx_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords)
 {
     lv_layer_t * layer_to_draw = (lv_layer_t *)draw_dsc->src;
 
@@ -51,7 +51,7 @@ void lv_draw_nema_gfx_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = layer_to_draw->draw_buf;
 
-    lv_draw_nema_gfx_img(draw_unit, &new_draw_dsc, coords);
+    lv_draw_nema_gfx_img(t, &new_draw_dsc, coords);
 }
 
 #endif /*LV_USE_NEMA_GFX*/

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_line.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_line.c
@@ -39,7 +39,7 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+void lv_draw_nema_gfx_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
     if(dsc->width == 0)
         return;
@@ -48,16 +48,16 @@ void lv_draw_nema_gfx_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t 
     if(dsc->p1.x == dsc->p2.x && dsc->p1.y == dsc->p2.y)
         return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t clip_area;
     clip_area.x1 = LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width / 2;
     clip_area.x2 = LV_MAX(dsc->p1.x, dsc->p2.x) + dsc->width / 2;
     clip_area.y1 = LV_MIN(dsc->p1.y, dsc->p2.y) - dsc->width / 2;
     clip_area.y2 = LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width / 2;
 
-    if(!lv_area_intersect(&clip_area, &clip_area, draw_unit->clip_area))
+    if(!lv_area_intersect(&clip_area, &clip_area, &t->clip_area))
         return; /*Fully clipped, nothing to do*/
 
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c
@@ -39,16 +39,16 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_nema_gfx_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_nema_gfx_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
 {
     if(dsc->bg_opa <= LV_OPA_MIN) return;
 
-    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)draw_unit;
+    lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
 
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, draw_unit->clip_area);
+    lv_area_copy(&rel_clip_area, &t->clip_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t coords;

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -412,12 +412,8 @@ static void _pxp_execute_drawing(lv_draw_pxp_unit_t * u)
         if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area))
             return;
 
-        int32_t idx = 0;
-        lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-        while(draw_unit_tmp != (lv_draw_unit_t *)u) {
-            draw_unit_tmp = draw_unit_tmp->next;
-            idx++;
-        }
+        int32_t idx = u->base_unit.idx;
+
         lv_draw_rect_dsc_t rect_dsc;
         lv_draw_rect_dsc_init(&rect_dsc);
         rect_dsc.bg_color = lv_palette_main(idx % LV_PALETTE_LAST);

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -332,8 +332,6 @@ static int32_t _pxp_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_pxp_unit->base_unit.target_layer = layer;
-    draw_pxp_unit->base_unit.clip_area = &t->clip_area;
     draw_pxp_unit->task_act = t;
 
 #if LV_USE_PXP_DRAW_THREAD
@@ -378,11 +376,11 @@ static void _pxp_execute_drawing(lv_draw_pxp_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
     lv_draw_unit_t * draw_unit = (lv_draw_unit_t *)u;
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_draw_buf_t * draw_buf = layer->draw_buf;
 
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &t->area, draw_unit->clip_area))
+    if(!lv_area_intersect(&draw_area, &t->area, &t->clip_area))
         return; /*Fully clipped, nothing to do*/
 
     /* Make area relative to the buffer */
@@ -391,15 +389,19 @@ static void _pxp_execute_drawing(lv_draw_pxp_unit_t * u)
     /* Invalidate only the drawing area */
     lv_draw_buf_invalidate_cache(draw_buf, &draw_area);
 
+#if LV_USE_PARALLEL_DRAW_DEBUG
+    t->draw_unit = &u->base_unit;
+#endif
+
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_pxp_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_pxp_img(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_img(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_pxp_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_pxp_layer(t, t->draw_dsc, &t->area);
             break;
         default:
             break;
@@ -409,7 +411,7 @@ static void _pxp_execute_drawing(lv_draw_pxp_unit_t * u)
     /*Layers manage it for themselves*/
     if(t->type != LV_DRAW_TASK_TYPE_LAYER) {
         lv_area_t draw_area;
-        if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area))
+        if(!lv_area_intersect(&draw_area, &t->area, &t->clip_area))
             return;
 
         int32_t idx = u->base_unit.idx;

--- a/src/draw/nxp/pxp/lv_draw_pxp.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp.h
@@ -62,13 +62,13 @@ void lv_draw_pxp_rotate(const void * src_buf, void * dest_buf, int32_t src_width
 #if LV_USE_DRAW_PXP
 void lv_draw_buf_pxp_init_handlers(void);
 
-void lv_draw_pxp_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc,
+void lv_draw_pxp_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                       const lv_area_t * coords);
 
-void lv_draw_pxp_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_pxp_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                      const lv_area_t * coords);
 
-void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_pxp_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                        const lv_area_t * coords);
 
 /**********************

--- a/src/draw/nxp/pxp/lv_draw_pxp_fill.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_fill.c
@@ -47,13 +47,13 @@ static void _pxp_fill(uint8_t * dest_buf, const lv_area_t * dest_area, int32_t d
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_pxp_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc,
+void lv_draw_pxp_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                       const lv_area_t * coords)
 {
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_draw_buf_t * draw_buf = layer->draw_buf;
 
     lv_area_t rel_coords;
@@ -61,7 +61,7 @@ void lv_draw_pxp_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc
     lv_area_move(&rel_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, draw_unit->clip_area);
+    lv_area_copy(&rel_clip_area, &t->clip_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t blend_area;

--- a/src/draw/nxp/pxp/lv_draw_pxp_img.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_img.c
@@ -61,13 +61,13 @@ static void _pxp_blit(uint8_t * dest_buf, const lv_area_t * dest_area, int32_t d
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_pxp_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_pxp_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                      const lv_area_t * coords)
 {
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_draw_buf_t * draw_buf = layer->draw_buf;
     const lv_image_dsc_t * img_dsc = dsc->src;
 
@@ -76,7 +76,7 @@ void lv_draw_pxp_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc
     lv_area_move(&rel_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, draw_unit->clip_area);
+    lv_area_copy(&rel_clip_area, &t->clip_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t blend_area;

--- a/src/draw/nxp/pxp/lv_draw_pxp_layer.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_layer.c
@@ -51,7 +51,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_pxp_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                        const lv_area_t * coords)
 {
     lv_layer_t * layer_to_draw = (lv_layer_t *)draw_dsc->src;
@@ -73,7 +73,7 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
 
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = draw_buf;
-    lv_draw_pxp_img(draw_unit, &new_draw_dsc, coords);
+    lv_draw_pxp_img(t, &new_draw_dsc, coords);
 
 #if LV_USE_LAYER_DEBUG || LV_USE_PARALLEL_DRAW_DEBUG
     lv_area_t area_rot;
@@ -91,7 +91,7 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
         area_rot.y2 += coords->y1;
     }
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &area_rot, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &area_rot, &t->clip_area)) return;
 #endif
 
 #if LV_USE_LAYER_DEBUG
@@ -99,32 +99,32 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
     fill_dsc.opa = LV_OPA_20;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = fill_dsc.color;
     border_dsc.opa = LV_OPA_60;
     border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    int32_t idx = draw_unit->idx;
+    int32_t idx = t->draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_rect_dsc_init(&fill_dsc);
     fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     fill_dsc.opa = LV_OPA_10;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     border_dsc.opa = LV_OPA_100;
     border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
     lv_point_t txt_size;
     lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -137,7 +137,7 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
 
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_black();
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &txt_area);
+    lv_draw_sw_fill(t, &fill_dsc, &txt_area);
 
     char buf[8];
     lv_snprintf(buf, sizeof(buf), "%d", idx);
@@ -145,7 +145,7 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
     lv_draw_label_dsc_init(&label_dsc);
     label_dsc.color = lv_color_white();
     label_dsc.text = buf;
-    lv_draw_sw_label(draw_unit, &label_dsc, &txt_area);
+    lv_draw_sw_label(t, &label_dsc, &txt_area);
 #endif
 }
 

--- a/src/draw/nxp/pxp/lv_draw_pxp_layer.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_layer.c
@@ -111,12 +111,7 @@ void lv_draw_pxp_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * d
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    uint32_t idx = 0;
-    lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-    while(draw_unit_tmp != draw_unit) {
-        draw_unit_tmp = draw_unit_tmp->next;
-        idx++;
-    }
+    int32_t idx = draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_rect_dsc_init(&fill_dsc);

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -445,12 +445,8 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
         if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area))
             return;
 
-        int32_t idx = 0;
-        lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-        while(draw_unit_tmp != (lv_draw_unit_t *)u) {
-            draw_unit_tmp = draw_unit_tmp->next;
-            idx++;
-        }
+        int32_t idx = u->base_unit.idx;
+
         lv_draw_rect_dsc_t rect_dsc;
         lv_draw_rect_dsc_init(&rect_dsc);
         rect_dsc.bg_color = lv_palette_main(idx % LV_PALETTE_LAST);

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -314,10 +314,7 @@ static int32_t _vglite_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
-
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_vglite_unit->base_unit.target_layer = layer;
-    draw_vglite_unit->base_unit.clip_area = &t->clip_area;
     draw_vglite_unit->task_act = t;
 
 #if LV_USE_VGLITE_DRAW_THREAD
@@ -378,8 +375,7 @@ static int32_t _vglite_delete(lv_draw_unit_t * draw_unit)
 static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
-    lv_draw_unit_t * draw_unit = (lv_draw_unit_t *)u;
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_draw_buf_t * draw_buf = layer->draw_buf;
 
     /* Set target buffer */
@@ -387,7 +383,7 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
                         draw_buf->header.cf);
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t draw_area;
@@ -400,6 +396,11 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
     if(_draw_info.unit_cnt > 1)
         lv_draw_buf_invalidate_cache(draw_buf, &draw_area);
 
+#if LV_USE_PARALLEL_DRAW_DEBUG
+    /* remember draw unit for debug purposes */
+    t->draw_unit = &u->base_unit;
+#endif
+
     /* Set scissor area, excluding the split blit case */
 #if LV_USE_VGLITE_BLIT_SPLIT
     if(t->type != LV_DRAW_TASK_TYPE_IMAGE || t->type != LV_DRAW_TASK_TYPE_LAYER)
@@ -408,28 +409,28 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_vglite_label(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_vglite_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_vglite_border(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_border(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_vglite_img(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_img(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_vglite_arc(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_arc(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_vglite_line(draw_unit, t->draw_dsc);
+            lv_draw_vglite_line(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_vglite_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vglite_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_vglite_triangle(draw_unit, t->draw_dsc);
+            lv_draw_vglite_triangle(t, t->draw_dsc);
             break;
         default:
             break;
@@ -442,7 +443,7 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
     /*Layers manage it for themselves*/
     if(t->type != LV_DRAW_TASK_TYPE_LAYER) {
         lv_area_t draw_area;
-        if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area))
+        if(!lv_area_intersect(&draw_area, &t->area, &t->clip_area))
             return;
 
         int32_t idx = u->base_unit.idx;
@@ -454,7 +455,7 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
         rect_dsc.bg_opa = LV_OPA_10;
         rect_dsc.border_opa = LV_OPA_80;
         rect_dsc.border_width = 1;
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &draw_area);
+        lv_draw_sw_fill(t, &rect_dsc, &draw_area);
 
         lv_point_t txt_size;
         lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -467,7 +468,7 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
 
         lv_draw_rect_dsc_init(&rect_dsc);
         rect_dsc.bg_color = lv_color_white();
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &txt_area);
+        lv_draw_sw_fill(t, &rect_dsc, &txt_area);
 
         char buf[8];
         lv_snprintf(buf, sizeof(buf), "%d", idx);
@@ -475,7 +476,7 @@ static void _vglite_execute_drawing(lv_draw_vglite_unit_t * u)
         lv_draw_label_dsc_init(&label_dsc);
         label_dsc.color = lv_color_black();
         label_dsc.text = buf;
-        lv_draw_sw_label((lv_draw_unit_t *)u, &label_dsc, &txt_area);
+        lv_draw_sw_label(t, &label_dsc, &txt_area);
     }
 #endif
 }

--- a/src/draw/nxp/vglite/lv_draw_vglite.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite.h
@@ -65,27 +65,27 @@ void lv_draw_vglite_init(void);
 
 void lv_draw_vglite_deinit(void);
 
-void lv_draw_vglite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
+void lv_draw_vglite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                         const lv_area_t * coords);
 
-void lv_draw_vglite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_vglite_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                            const lv_area_t * coords);
 
-void lv_draw_vglite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc,
+void lv_draw_vglite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                          const lv_area_t * coords);
 
-void lv_draw_vglite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_vglite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                         const lv_area_t * coords);
 
-void lv_draw_vglite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_vglite_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                           const lv_area_t * coords);
 
-void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_vglite_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_area_t * coords);
 
-void lv_draw_vglite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+void lv_draw_vglite_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
-void lv_draw_vglite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc);
+void lv_draw_vglite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/nxp/vglite/lv_draw_vglite_arc.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_arc.c
@@ -96,7 +96,7 @@ static void _vglite_draw_arc(const lv_point_t * center, const lv_area_t * clip_a
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
+void lv_draw_vglite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                         const lv_area_t * coords)
 {
     LV_UNUSED(coords);
@@ -108,11 +108,11 @@ void lv_draw_vglite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * ds
     if(dsc->start_angle == dsc->end_angle)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_point_t center = {dsc->center.x - layer->buf_area.x1, dsc->center.y - layer->buf_area.y1};
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     _vglite_draw_arc(&center, &clip_area, dsc);

--- a/src/draw/nxp/vglite/lv_draw_vglite_border.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_border.c
@@ -64,7 +64,7 @@ static void _vglite_draw_border(const lv_area_t * coords, const lv_area_t * clip
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_vglite_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                            const lv_area_t * coords)
 {
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
@@ -74,7 +74,7 @@ void lv_draw_vglite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_
     if(dsc->side == (lv_border_side_t)LV_BORDER_SIDE_NONE)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t inward_coords;
     int32_t width = dsc->width;
 
@@ -87,7 +87,7 @@ void lv_draw_vglite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_
     lv_area_move(&inward_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clipped_coords;

--- a/src/draw/nxp/vglite/lv_draw_vglite_fill.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_fill.c
@@ -66,19 +66,19 @@ static void _vglite_draw_rect(const lv_area_t * coords, const lv_area_t * clip_a
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc,
+void lv_draw_vglite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                          const lv_area_t * coords)
 {
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t relative_coords;
     lv_area_copy(&relative_coords, coords);
     lv_area_move(&relative_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clipped_coords;

--- a/src/draw/nxp/vglite/lv_draw_vglite_img.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_img.c
@@ -125,13 +125,13 @@ static vg_lite_color_t _vglite_recolor(const lv_draw_image_dsc_t * dsc);
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_vglite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                         const lv_area_t * coords)
 {
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     const lv_image_dsc_t * img_dsc = dsc->src;
 
     lv_area_t relative_coords;
@@ -139,7 +139,7 @@ void lv_draw_vglite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * 
     lv_area_move(&relative_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t blend_area;

--- a/src/draw/nxp/vglite/lv_draw_vglite_label.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_label.c
@@ -35,7 +35,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void _draw_vglite_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                 lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
 
 /**
@@ -64,19 +64,19 @@ static void _vglite_draw_letter(const lv_area_t * mask_area, lv_color_t color, l
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_vglite_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                           const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    lv_draw_label_iterate_characters(draw_unit, dsc, coords, _draw_vglite_letter);
+    lv_draw_label_iterate_characters(t, dsc, coords, _draw_vglite_letter);
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void _draw_vglite_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                 lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
     if(glyph_draw_dsc) {
@@ -91,7 +91,7 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
                     border_draw_dsc.opa = glyph_draw_dsc->opa;
                     border_draw_dsc.color = glyph_draw_dsc->color;
                     border_draw_dsc.width = 1;
-                    lv_draw_vglite_border(draw_unit, &border_draw_dsc, glyph_draw_dsc->bg_coords);
+                    lv_draw_vglite_border(t, &border_draw_dsc, glyph_draw_dsc->bg_coords);
 #endif
                 }
                 break;
@@ -100,10 +100,10 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
                     if(glyph_draw_dsc->opa <= LV_OPA_MIN)
                         return;
 
-                    lv_layer_t * layer = draw_unit->target_layer;
+                    lv_layer_t * layer = t->target_layer;
 
                     lv_area_t blend_area;
-                    if(!lv_area_intersect(&blend_area, glyph_draw_dsc->letter_coords, draw_unit->clip_area))
+                    if(!lv_area_intersect(&blend_area, glyph_draw_dsc->letter_coords, &t->clip_area))
                         return;
                     lv_area_move(&blend_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
@@ -148,7 +148,7 @@ static void _draw_vglite_letter(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t 
     }
 
     if(fill_draw_dsc && fill_area) {
-        lv_draw_vglite_fill(draw_unit, fill_draw_dsc, fill_area);
+        lv_draw_vglite_fill(t, fill_draw_dsc, fill_area);
     }
 }
 

--- a/src/draw/nxp/vglite/lv_draw_vglite_layer.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_layer.c
@@ -111,12 +111,7 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    uint32_t idx = 0;
-    lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-    while(draw_unit_tmp != draw_unit) {
-        draw_unit_tmp = draw_unit_tmp->next;
-        idx++;
-    }
+    int32_t idx = draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_rect_dsc_init(&fill_dsc);

--- a/src/draw/nxp/vglite/lv_draw_vglite_layer.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_layer.c
@@ -46,7 +46,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_vglite_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_area_t * coords)
 {
     lv_layer_t * layer_to_draw = (lv_layer_t *)draw_dsc->src;
@@ -70,7 +70,7 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
 
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = draw_buf;
-    lv_draw_vglite_img(draw_unit, &new_draw_dsc, coords);
+    lv_draw_vglite_img(t, &new_draw_dsc, coords);
 
 #if LV_USE_LAYER_DEBUG || LV_USE_PARALLEL_DRAW_DEBUG
     lv_area_t area_rot;
@@ -91,7 +91,7 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
         area_rot.y2 += coords->y1;
     }
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &area_rot, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &area_rot, &t->clip_area)) return;
 #endif
 
 #if LV_USE_LAYER_DEBUG
@@ -99,32 +99,32 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
     fill_dsc.opa = LV_OPA_20;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = fill_dsc.color;
     border_dsc.opa = LV_OPA_60;
     border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    int32_t idx = draw_unit->idx;
+    int32_t idx = t->draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_rect_dsc_init(&fill_dsc);
     fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     fill_dsc.opa = LV_OPA_10;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     border_dsc.opa = LV_OPA_100;
     border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
     lv_point_t txt_size;
     lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -137,7 +137,7 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
 
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_black();
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &txt_area);
+    lv_draw_sw_fill(t, &fill_dsc, &txt_area);
 
     char buf[8];
     lv_snprintf(buf, sizeof(buf), "%d", idx);
@@ -145,7 +145,7 @@ void lv_draw_vglite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
     lv_draw_label_dsc_init(&label_dsc);
     label_dsc.color = lv_color_white();
     label_dsc.text = buf;
-    lv_draw_sw_label(draw_unit, &label_dsc, &txt_area);
+    lv_draw_sw_label(t, &label_dsc, &txt_area);
 #endif
 }
 

--- a/src/draw/nxp/vglite/lv_draw_vglite_line.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_line.c
@@ -55,7 +55,7 @@ static void _vglite_draw_line(const lv_point_t * point1, const lv_point_t * poin
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+void lv_draw_vglite_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
     if(dsc->width == 0)
         return;
@@ -64,14 +64,14 @@ void lv_draw_vglite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * 
     if(dsc->p1.x == dsc->p2.x && dsc->p1.y == dsc->p2.y)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t clip_area;
     clip_area.x1 = LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width / 2;
     clip_area.x2 = LV_MAX(dsc->p1.x, dsc->p2.x) + dsc->width / 2;
     clip_area.y1 = LV_MIN(dsc->p1.y, dsc->p2.y) - dsc->width / 2;
     clip_area.y2 = LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width / 2;
 
-    if(!lv_area_intersect(&clip_area, &clip_area, draw_unit->clip_area))
+    if(!lv_area_intersect(&clip_area, &clip_area, &t->clip_area))
         return; /*Fully clipped, nothing to do*/
 
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);

--- a/src/draw/nxp/vglite/lv_draw_vglite_triangle.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_triangle.c
@@ -57,14 +57,14 @@ static void _vglite_draw_triangle(const lv_area_t * coords, const lv_area_t * cl
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vglite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_vglite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
 {
     if(dsc->bg_opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t clip_area;
-    lv_area_copy(&clip_area, draw_unit->clip_area);
+    lv_area_copy(&clip_area, &t->clip_area);
     lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t coords;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -397,8 +397,6 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
 #endif
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_dave2d_unit->base_unit.target_layer = layer;
-    draw_dave2d_unit->base_unit.clip_area = &t->clip_area;
     draw_dave2d_unit->task_act = t;
 
 #if LV_USE_OS
@@ -449,14 +447,17 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u)
     /*Render the draw task*/
     lv_draw_task_t * t = u->task_act;
 
+    /* remember draw unit for access to unit's context */
+    t->draw_unit = (lv_draw_unit_t *)u;
+
 #if defined(RENESAS_CORTEX_M85)
 #if (BSP_CFG_DCACHE_ENABLED)
-    lv_layer_t * layer = u->base_unit.target_layer;
+    lv_layer_t * layer = t->target_layer;
     lv_area_t clipped_area;
     int32_t x;
     int32_t y;
 
-    lv_area_intersect(&clipped_area,  &t->area, u->base_unit.clip_area);
+    lv_area_intersect(&clipped_area,  &t->area, &t->clip_area);
 
     x = 0 - u->base_unit.target_layer->buf_area.x1;
     y = 0 - u->base_unit.target_layer->buf_area.y1;
@@ -470,39 +471,39 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u)
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_dave2d_fill(u, t->draw_dsc, &t->area);
+            lv_draw_dave2d_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_dave2d_border(u, t->draw_dsc, &t->area);
+            lv_draw_dave2d_border(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BOX_SHADOW:
-            //lv_draw_dave2d_box_shadow(u, t->draw_dsc, &t->area);
+            //lv_draw_dave2d_box_shadow(t, t->draw_dsc, &t->area);
             break;
 #if 0
         case LV_DRAW_TASK_TYPE_BG_IMG:
-            //lv_draw_dave2d_bg_image(u, t->draw_dsc, &t->area);
+            //lv_draw_dave2d_bg_image(t, t->draw_dsc, &t->area);
             break;
 #endif
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_dave2d_label(u, t->draw_dsc, &t->area);
+            lv_draw_dave2d_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_dave2d_image(u, t->draw_dsc, &t->area);
+            lv_draw_dave2d_image(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_dave2d_line(u, t->draw_dsc);
+            lv_draw_dave2d_line(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_dave2d_arc(u, t->draw_dsc, &t->area);
+            lv_draw_dave2d_arc(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_dave2d_triangle(u, t->draw_dsc);
+            lv_draw_dave2d_triangle(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            //lv_draw_dave2d_layer(u, t->draw_dsc, &t->area);
+            //lv_draw_dave2d_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
-            //lv_draw_dave2d_mask_rect(u, t->draw_dsc, &t->area);
+            //lv_draw_dave2d_mask_rect(t, t->draw_dsc, &t->area);
             break;
         default:
             break;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -60,32 +60,32 @@ typedef struct {
 
 void lv_draw_dave2d_init(void);
 
-void lv_draw_dave2d_image(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_dave2d_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_area_t * coords);
 
-void lv_draw_dave2d_fill(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_dave2d_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
 
-void lv_draw_dave2d_border(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_dave2d_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                            const lv_area_t * coords);
 
-void lv_draw_dave2d_box_shadow(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_box_shadow_dsc_t * dsc,
+void lv_draw_dave2d_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_t * dsc,
                                const lv_area_t * coords);
 
-void lv_draw_dave2d_label(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_dave2d_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords);
 
-void lv_draw_dave2d_arc(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_dave2d_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords);
 
-void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+void lv_draw_dave2d_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
-void lv_draw_dave2d_layer(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_dave2d_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_area_t * coords);
 
-void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc);
+void lv_draw_dave2d_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc);
 
-void lv_draw_dave2d_mask_rect(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_mask_rect_dsc_t * dsc,
+void lv_draw_dave2d_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * dsc,
                               const lv_area_t * coords);
 
-void lv_draw_dave2d_transform(lv_draw_dave2d_unit_t * draw_unit, const lv_area_t * dest_area, const void * src_buf,
+void lv_draw_dave2d_transform(lv_draw_task_t * t, const lv_area_t * dest_area, const void * src_buf,
                               int32_t src_w, int32_t src_h, int32_t src_stride,
                               const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t cf, void * dest_buf);
 

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
@@ -3,7 +3,7 @@
 
 #include "../../../misc/lv_area_private.h"
 
-void lv_draw_dave2d_arc(lv_draw_dave2d_unit_t * u, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_dave2d_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
 {
 
     uint32_t                flags = 0;
@@ -17,13 +17,14 @@ void lv_draw_dave2d_arc(lv_draw_dave2d_unit_t * u, const lv_draw_arc_dsc_t * dsc
     lv_point_t arc_centre;
     int32_t x;
     int32_t y;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
-    if(!lv_area_intersect(&clipped_area, coords, u->base_unit.clip_area)) return;
+    if(!lv_area_intersect(&clipped_area, coords, &t->clip_area)) return;
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
-    buffer_area = u->base_unit.target_layer->buf_area;
+    buffer_area = t->target_layer->buf_area;
 
     arc_centre = dsc->center;
     arc_centre.x = arc_centre.x - buffer_area.x1;
@@ -52,7 +53,7 @@ void lv_draw_dave2d_arc(lv_draw_dave2d_unit_t * u, const lv_draw_arc_dsc_t * dsc
     //
     // Generate render operations
     //
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_setalpha(u->d2_handle, dsc->opa);
 

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
@@ -3,15 +3,15 @@
 
 #include "../../../misc/lv_area_private.h"
 
-static void dave2d_draw_border_complex(lv_draw_dave2d_unit_t * draw_unit, const lv_area_t * outer_area,
+static void dave2d_draw_border_complex(lv_draw_task_t * t, const lv_area_t * outer_area,
                                        const lv_area_t * inner_area,
                                        int32_t rout, int32_t rin, lv_color_t color, lv_opa_t opa);
 
-static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * draw_unit, const lv_area_t * outer_area,
+static void dave2d_draw_border_simple(lv_draw_task_t * t, const lv_area_t * outer_area,
                                       const lv_area_t * inner_area,
                                       lv_color_t color, lv_opa_t opa);
 
-void lv_draw_dave2d_border(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_dave2d_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                            const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -36,15 +36,15 @@ void lv_draw_dave2d_border(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_bord
     if(rin < 0) rin = 0;
 
     if(rout == 0 && rin == 0) {
-        dave2d_draw_border_simple(draw_unit, coords, &area_inner, dsc->color, dsc->opa);
+        dave2d_draw_border_simple(t, coords, &area_inner, dsc->color, dsc->opa);
     }
     else {
-        dave2d_draw_border_complex(draw_unit, coords, &area_inner, rout, rin, dsc->color, dsc->opa);
+        dave2d_draw_border_complex(t, coords, &area_inner, rout, rin, dsc->color, dsc->opa);
     }
 
 }
 
-static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * u, const lv_area_t * outer_area,
+static void dave2d_draw_border_simple(lv_draw_task_t * t, const lv_area_t * outer_area,
                                       const lv_area_t * inner_area,
                                       lv_color_t color, lv_opa_t opa)
 
@@ -57,8 +57,10 @@ static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * u, const lv_area_t
     int32_t y;
     bool is_common;
 
-    is_common = lv_area_intersect(&clip_area, outer_area, u->base_unit.clip_area);
+    is_common = lv_area_intersect(&clip_area, outer_area, &t->clip_area);
     if(!is_common) return;
+
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
 #if LV_USE_OS
     lv_result_t  status;
@@ -69,8 +71,8 @@ static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * u, const lv_area_t
     local_outer_area = *outer_area;
     local_inner_area = *inner_area;
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&clip_area, x, y);
     lv_area_move(&local_outer_area, x, y);
@@ -83,7 +85,7 @@ static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * u, const lv_area_t
     // Generate render operations
     //
 
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_setcolor(u->d2_handle, 0, lv_draw_dave2d_lv_colour_to_d2_colour(color));
     d2_setalpha(u->d2_handle, opa);
@@ -155,7 +157,7 @@ static void dave2d_draw_border_simple(lv_draw_dave2d_unit_t * u, const lv_area_t
 #endif
 }
 
-static void dave2d_draw_border_complex(lv_draw_dave2d_unit_t * u, const lv_area_t * orig_outer_area,
+static void dave2d_draw_border_complex(lv_draw_task_t * t, const lv_area_t * orig_outer_area,
                                        const lv_area_t * orig_inner_area,
                                        int32_t rout, int32_t rin, lv_color_t color, lv_opa_t opa)
 {
@@ -171,8 +173,9 @@ static void dave2d_draw_border_complex(lv_draw_dave2d_unit_t * u, const lv_area_
 
     outer_area = *orig_outer_area;
     inner_area = *orig_inner_area;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
-    if(!lv_area_intersect(&draw_area, &outer_area, u->base_unit.clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &outer_area, &t->clip_area)) return;
 
 #if LV_USE_OS
     lv_result_t  status;
@@ -180,8 +183,8 @@ static void dave2d_draw_border_complex(lv_draw_dave2d_unit_t * u, const lv_area_
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&draw_area, x, y);
     lv_area_move(&outer_area, x, y);
@@ -194,7 +197,7 @@ static void dave2d_draw_border_complex(lv_draw_dave2d_unit_t * u, const lv_area_
     // Generate render operations
     //
 
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_setcolor(u->d2_handle, 0, lv_draw_dave2d_lv_colour_to_d2_colour(color));
     d2_setalpha(u->d2_handle, opa);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
@@ -3,7 +3,7 @@
 
 #include "../../../misc/lv_area_private.h"
 
-void lv_draw_dave2d_fill(lv_draw_dave2d_unit_t * u, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_dave2d_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
 {
     lv_area_t draw_area;
     lv_area_t coordinates;
@@ -15,8 +15,9 @@ void lv_draw_dave2d_fill(lv_draw_dave2d_unit_t * u, const lv_draw_fill_dsc_t * d
     d2_u32 flags = 0;
 
     lv_point_t arc_centre;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
-    is_common = lv_area_intersect(&draw_area, coords, u->base_unit.clip_area);
+    is_common = lv_area_intersect(&draw_area, coords, &t->clip_area);
     if(!is_common) return;
 
 #if LV_USE_OS
@@ -27,8 +28,8 @@ void lv_draw_dave2d_fill(lv_draw_dave2d_unit_t * u, const lv_draw_fill_dsc_t * d
 
     lv_area_copy(&coordinates, coords);
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&draw_area, x, y);
     lv_area_move(&coordinates, x, y);
@@ -40,7 +41,7 @@ void lv_draw_dave2d_fill(lv_draw_dave2d_unit_t * u, const lv_draw_fill_dsc_t * d
     d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
 #endif
 
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     if(LV_GRAD_DIR_NONE != dsc->grad.dir) {
         float a1;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -23,7 +23,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * draw_dsc,
+static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                           const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
@@ -39,14 +39,14 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_dave2d_image(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_dave2d_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_area_t * coords)
 {
     if(!draw_dsc->tile) {
-        lv_draw_image_normal_helper((lv_draw_unit_t *)draw_unit, draw_dsc, coords, img_draw_core);
+        lv_draw_image_normal_helper(t, draw_dsc, coords, img_draw_core);
     }
     else {
-        lv_draw_image_tiled_helper((lv_draw_unit_t *)draw_unit, draw_dsc, coords, img_draw_core);
+        lv_draw_image_tiled_helper(t, draw_dsc, coords, img_draw_core);
     }
 }
 
@@ -54,12 +54,12 @@ void lv_draw_dave2d_image(lv_draw_dave2d_unit_t * draw_unit, const lv_draw_image
  *   STATIC FUNCTIONS
  **********************/
 
-static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * draw_dsc,
+static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                           const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
 
-    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)u_base;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
     (void)sup; //remove warning about unused parameter
 
@@ -91,12 +91,12 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-    buffer_area = u->base_unit.target_layer->buf_area;
+    buffer_area = t->target_layer->buf_area;
     draw_area = *img_coords;
     clipped_area = *clipped_img_area;
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&draw_area, x, y);
     lv_area_move(&buffer_area, x, y);
@@ -203,7 +203,7 @@ static void img_draw_core(lv_draw_unit_t * u_base, const lv_draw_image_dsc_t * d
 
     }
 
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_cliprect(u->d2_handle, (d2_border)clipped_area.x1, (d2_border)clipped_area.y1, (d2_border)clipped_area.x2,
                 (d2_border)clipped_area.y2);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
@@ -4,22 +4,20 @@
 #include "../../lv_draw_label_private.h"
 #include "../../../misc/lv_area_private.h"
 
-static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void lv_draw_dave2d_draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                           lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
 
 static lv_draw_dave2d_unit_t * unit = NULL;
 
-void lv_draw_dave2d_label(lv_draw_dave2d_unit_t * u, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_dave2d_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    unit = u;
-
-    lv_draw_label_iterate_characters(&u->base_unit, dsc, coords, lv_draw_dave2d_draw_letter_cb);
+    lv_draw_label_iterate_characters(t, dsc, coords, lv_draw_dave2d_draw_letter_cb);
 
 }
 
-static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void lv_draw_dave2d_draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                           lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
 
@@ -31,13 +29,14 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
     int32_t y;
 
     letter_coords = *glyph_draw_dsc->letter_coords;
+    lv_draw_vg_lite_unit_t * unit = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     bool is_common;
-    is_common = lv_area_intersect(&clip_area, glyph_draw_dsc->letter_coords, u->clip_area);
+    is_common = lv_area_intersect(&clip_area, glyph_draw_dsc->letter_coords, &t->clip_area);
     if(!is_common) return;
 
-    x = 0 - unit->base_unit.target_layer->buf_area.x1;
-    y = 0 - unit->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&clip_area, x, y);
     lv_area_move(&letter_coords, x, y);
@@ -56,7 +55,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
     // Generate render operations
     //
 
-    d2_framebuffer_from_layer(unit->d2_handle, unit->base_unit.target_layer);
+    d2_framebuffer_from_layer(unit->d2_handle, t->target_layer);
 
     current_fillmode = d2_getfillmode(unit->d2_handle);
 
@@ -74,7 +73,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
                     border_draw_dsc.color = glyph_draw_dsc->color;
                     border_draw_dsc.width = 1;
                     //lv_draw_sw_border(u, &border_draw_dsc, glyph_draw_dsc->bg_coords);
-                    lv_draw_dave2d_border(unit, &border_draw_dsc, glyph_draw_dsc->bg_coords);
+                    lv_draw_dave2d_border(t, &border_draw_dsc, glyph_draw_dsc->bg_coords);
 #endif
                 }
                 break;
@@ -134,7 +133,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
                     img_dsc.scale_y = LV_SCALE_NONE;
                     img_dsc.opa = glyph_draw_dsc->opa;
                     img_dsc.src = glyph_draw_dsc->glyph_data;
-                    //lv_draw_sw_image(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
+                    //lv_draw_sw_image(t, &img_dsc, glyph_draw_dsc->letter_coords);
 #endif
                 }
                 break;
@@ -153,7 +152,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_unit_t * u, lv_draw_glyph_dsc_
 
     if(fill_draw_dsc && fill_area) {
         //lv_draw_sw_fill(u, fill_draw_dsc, fill_area);
-        lv_draw_dave2d_fill(unit, fill_draw_dsc, fill_area);
+        lv_draw_dave2d_fill(t, fill_draw_dsc, fill_area);
     }
 
 #if LV_USE_OS

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
@@ -3,7 +3,7 @@
 
 #include "../../../misc/lv_area_private.h"
 
-void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * u, const lv_draw_line_dsc_t * dsc)
+void lv_draw_dave2d_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
 
     lv_area_t clip_line;
@@ -15,6 +15,7 @@ void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * u, const lv_draw_line_dsc_t * d
     lv_value_precise_t p2_y;
     int32_t x;
     int32_t y;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
     clip_line.x1 = LV_MIN(dsc->p1.x, dsc->p2.x) - dsc->width / 2;
     clip_line.x2 = LV_MAX(dsc->p1.x, dsc->p2.x) + dsc->width / 2;
@@ -22,7 +23,7 @@ void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * u, const lv_draw_line_dsc_t * d
     clip_line.y2 = LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width / 2;
 
     bool is_common;
-    is_common = lv_area_intersect(&clip_line, &clip_line, u->base_unit.clip_area);
+    is_common = lv_area_intersect(&clip_line, &clip_line, &t->clip_area);
     if(!is_common) return;
 
 #if LV_USE_OS
@@ -31,14 +32,14 @@ void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * u, const lv_draw_line_dsc_t * d
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-    buffer_area = u->base_unit.target_layer->buf_area;
+    buffer_area = t->target_layer->buf_area;
     p1_x = dsc->p1.x - buffer_area.x1;
     p1_y = dsc->p1.y - buffer_area.y1;
     p2_x = dsc->p2.x - buffer_area.x1;
     p2_y = dsc->p2.y - buffer_area.y1;
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&clip_line, x, y);
     lv_area_move(&buffer_area, x, y);
@@ -56,7 +57,7 @@ void lv_draw_dave2d_line(lv_draw_dave2d_unit_t * u, const lv_draw_line_dsc_t * d
     //
     // Generate render operations
     //
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_setcolor(u->d2_handle, 0, lv_draw_dave2d_lv_colour_to_d2_colour(dsc->color));
 

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
@@ -3,13 +3,14 @@
 
 #include "../../../misc/lv_area_private.h"
 
-void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * u, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_dave2d_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
 {
     lv_area_t clipped_area;
     d2_u32      flags = 0;
     d2_u8 current_alpha_mode = 0;
     int32_t x;
     int32_t y;
+    lv_draw_dave2d_unit_t * u = (lv_draw_dave2d_unit_t *)t->draw_unit;
 
     lv_area_t tri_area;
     tri_area.x1 = LV_MIN3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
@@ -17,7 +18,7 @@ void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * u, const lv_draw_triangle_d
     tri_area.x2 = LV_MAX3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
     tri_area.y2 = LV_MAX3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);
 
-    if(!lv_area_intersect(&clipped_area, &tri_area, u->base_unit.clip_area)) return;
+    if(!lv_area_intersect(&clipped_area, &tri_area, &t->clip_area)) return;
 
 #if LV_USE_OS
     lv_result_t  status;
@@ -25,8 +26,8 @@ void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * u, const lv_draw_triangle_d
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-    x = 0 - u->base_unit.target_layer->buf_area.x1;
-    y = 0 - u->base_unit.target_layer->buf_area.y1;
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
 
     lv_area_move(&clipped_area, x, y);
 
@@ -78,13 +79,13 @@ void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * u, const lv_draw_triangle_d
         }
     }
 
-    p[0].x -= u->base_unit.target_layer->buf_area.x1;
-    p[1].x -= u->base_unit.target_layer->buf_area.x1;
-    p[2].x -= u->base_unit.target_layer->buf_area.x1;
+    p[0].x -= t->target_layer->buf_area.x1;
+    p[1].x -= t->target_layer->buf_area.x1;
+    p[2].x -= t->target_layer->buf_area.x1;
 
-    p[0].y -= u->base_unit.target_layer->buf_area.y1;
-    p[1].y -= u->base_unit.target_layer->buf_area.y1;
-    p[2].y -= u->base_unit.target_layer->buf_area.y1;
+    p[0].y -= t->target_layer->buf_area.y1;
+    p[1].y -= t->target_layer->buf_area.y1;
+    p[2].y -= t->target_layer->buf_area.y1;
 
     p[1].y -= 1;
     p[2].y -= 1;
@@ -142,7 +143,7 @@ void lv_draw_dave2d_triangle(lv_draw_dave2d_unit_t * u, const lv_draw_triangle_d
 
     }
 
-    d2_framebuffer_from_layer(u->d2_handle, u->base_unit.target_layer);
+    d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_cliprect(u->d2_handle, (d2_border)clipped_area.x1, (d2_border)clipped_area.y1, (d2_border)clipped_area.x2,
                 (d2_border)clipped_area.y2);

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -53,17 +53,17 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t * blend_dsc)
+void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * blend_dsc)
 {
     /*Do not draw transparent things*/
     if(blend_dsc->opa <= LV_OPA_MIN) return;
     if(blend_dsc->mask_buf && blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_TRANSP) return;
 
     lv_area_t blend_area;
-    if(!lv_area_intersect(&blend_area, blend_dsc->blend_area, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&blend_area, blend_dsc->blend_area, &t->clip_area)) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
     uint32_t layer_stride_byte = layer->draw_buf->header.stride;
 
     if(blend_dsc->src_buf == NULL) {

--- a/src/draw/sw/blend/lv_draw_sw_blend.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param draw_unit     pointer to a draw unit
  * @param dsc           pointer to an initialized blend descriptor
  */
-void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t * dsc);
+void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * dsc);
 
 /**********************
  *      MACROS

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -201,8 +201,6 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_sw_unit->base_unit.target_layer = layer;
-    draw_sw_unit->base_unit.clip_area = &t->clip_area;
     draw_sw_unit->task_act = t;
 
 #if LV_USE_OS
@@ -250,43 +248,46 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
     LV_PROFILER_DRAW_BEGIN;
     /*Render the draw task*/
     lv_draw_task_t * t = u->task_act;
+#if LV_USE_PARALLEL_DRAW_DEBUG
+    t->draw_unit = &u->base_unit;
+#endif
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_sw_fill((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_sw_border((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_border(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BOX_SHADOW:
-            lv_draw_sw_box_shadow((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_box_shadow(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LETTER:
-            lv_draw_sw_letter((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_letter(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_sw_label((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_sw_image((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_image(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_sw_arc((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_arc(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_sw_line((lv_draw_unit_t *)u, t->draw_dsc);
+            lv_draw_sw_line(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_sw_triangle((lv_draw_unit_t *)u, t->draw_dsc);
+            lv_draw_sw_triangle(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_sw_layer((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
-            lv_draw_sw_mask_rect((lv_draw_unit_t *)u, t->draw_dsc, &t->area);
+            lv_draw_sw_mask_rect(t, t->draw_dsc);
             break;
 #if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
         case LV_DRAW_TASK_TYPE_VECTOR:
-            lv_draw_sw_vector((lv_draw_unit_t *)u, t->draw_dsc);
+            lv_draw_sw_vector(t, t->draw_dsc);
             break;
 #endif
         default:
@@ -297,7 +298,7 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
     /*Layers manage it for themselves*/
     if(t->type != LV_DRAW_TASK_TYPE_LAYER) {
         lv_area_t draw_area;
-        if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area)) return;
+        if(!lv_area_intersect(&draw_area, &t->area, &t->clip_area)) return;
 
         int32_t idx = u->base_unit.idx;
 
@@ -305,14 +306,14 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         lv_draw_fill_dsc_init(&fill_dsc);
         fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
         fill_dsc.opa = LV_OPA_10;
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &fill_dsc, &draw_area);
+        lv_draw_sw_fill(t, &fill_dsc, &draw_area);
 
         lv_draw_border_dsc_t border_dsc;
         lv_draw_border_dsc_init(&border_dsc);
         border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
         border_dsc.opa = LV_OPA_60;
         border_dsc.width = 1;
-        lv_draw_sw_border((lv_draw_unit_t *)u, &border_dsc, &draw_area);
+        lv_draw_sw_border(t, &border_dsc, &draw_area);
 
         lv_point_t txt_size;
         lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -325,7 +326,7 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
 
         lv_draw_fill_dsc_init(&fill_dsc);
         fill_dsc.color = lv_color_white();
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &fill_dsc, &txt_area);
+        lv_draw_sw_fill(t, &fill_dsc, &txt_area);
 
         char buf[8];
         lv_snprintf(buf, sizeof(buf), "%d", idx);
@@ -333,7 +334,7 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         lv_draw_label_dsc_init(&label_dsc);
         label_dsc.color = lv_color_black();
         label_dsc.text = buf;
-        lv_draw_sw_label((lv_draw_unit_t *)u, &label_dsc, &txt_area);
+        lv_draw_sw_label(t, &label_dsc, &txt_area);
     }
 #endif
     LV_PROFILER_DRAW_END;

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -80,7 +80,6 @@ void lv_draw_sw_init(void)
         lv_draw_sw_unit_t * draw_sw_unit = lv_draw_create_unit(sizeof(lv_draw_sw_unit_t));
         draw_sw_unit->base_unit.dispatch_cb = dispatch;
         draw_sw_unit->base_unit.evaluate_cb = evaluate;
-        draw_sw_unit->idx = i;
         draw_sw_unit->base_unit.delete_cb = LV_USE_OS ? lv_draw_sw_delete : NULL;
         draw_sw_unit->base_unit.name = "SW";
 
@@ -300,12 +299,8 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         lv_area_t draw_area;
         if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area)) return;
 
-        int32_t idx = 0;
-        lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-        while(draw_unit_tmp != (lv_draw_unit_t *)u) {
-            draw_unit_tmp = draw_unit_tmp->next;
-            idx++;
-        }
+        int32_t idx = u->base_unit.idx;
+
         lv_draw_fill_dsc_t fill_dsc;
         lv_draw_fill_dsc_init(&fill_dsc);
         fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -50,88 +50,87 @@ void lv_draw_sw_deinit(void);
 
 /**
  * Fill an area using SW render. Handle gradient and radius.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the rectangle
  */
-void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_fill(lv_draw_task_t * t, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw border with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the rectangle
  */
-void lv_draw_sw_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw box shadow with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the rectangle for which the box shadow should be drawn
  */
-void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw an image with SW render. It handles image decoding, tiling, transformations, and recoloring.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param draw_dsc      the draw descriptor
  * @param coords        the coordinates of the image
  */
-void lv_draw_sw_image(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_sw_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                       const lv_area_t * coords);
 
-void lv_draw_sw_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_letter(lv_draw_task_t * t, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw a label with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the label
  */
-void lv_draw_sw_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw an arc with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the arc
  */
-void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords);
 
 /**
  * Draw a line with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  */
-void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+void lv_draw_sw_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
 /**
  * Blend a layer with SW render
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param draw_dsc      the draw descriptor
  * @param coords        the coordinates of the layer
  */
-void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords);
+void lv_draw_sw_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords);
 
 /**
  * Draw a triangle with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  */
-void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc);
+void lv_draw_sw_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc);
 
 /**
  * Mask out a rectangle with radius from a current layer
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  * @param coords        the coordinates of the mask
  */
-void lv_draw_sw_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_rect_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_sw_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * dsc);
 
 /**
  * Used internally to get a transformed are of an image
- * @param draw_unit     pointer to a draw unit
  * @param dest_area     area to calculate, i.e. get this area from the transformed image
  * @param src_buf       source buffer
  * @param src_w         source buffer width in pixels
@@ -142,17 +141,17 @@ void lv_draw_sw_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_rect_ds
  * @param cf            color format of the source buffer
  * @param dest_buf      the destination buffer
  */
-void lv_draw_sw_transform(lv_draw_unit_t * draw_unit, const lv_area_t * dest_area, const void * src_buf,
+void lv_draw_sw_transform(const lv_area_t * dest_area, const void * src_buf,
                           int32_t src_w, int32_t src_h, int32_t src_stride,
                           const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t cf, void * dest_buf);
 
 #if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
 /**
  * Draw vector graphics with SW render.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
  */
-void lv_draw_sw_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc_t * dsc);
+void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc);
 #endif
 
 /***********************

--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -50,7 +50,7 @@ static void get_rounded_area(int16_t angle, int32_t radius, uint8_t thickness, l
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_area_t * coords)
 {
 #if LV_DRAW_SW_COMPLEX
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -62,7 +62,7 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
 
     lv_area_t area_out = *coords;
     lv_area_t clipped_area;
-    if(!lv_area_intersect(&clipped_area, &area_out, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&clipped_area, &area_out, &t->clip_area)) return;
 
     /*Draw a full ring*/
     if(dsc->img_src == NULL &&
@@ -74,7 +74,7 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
         cir_dsc.width = width;
         cir_dsc.radius = LV_RADIUS_CIRCLE;
         cir_dsc.side = LV_BORDER_SIDE_FULL;
-        lv_draw_sw_border(draw_unit, &cir_dsc, &area_out);
+        lv_draw_sw_border(t, &cir_dsc, &area_out);
         return;
     }
 
@@ -217,7 +217,7 @@ void lv_draw_sw_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc, c
             }
         }
 
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
 
         blend_area.y1 ++;
         blend_area.y2 ++;

--- a/src/draw/sw/lv_draw_sw_border.c
+++ b/src/draw/sw/lv_draw_sw_border.c
@@ -33,10 +33,10 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_area, const lv_area_t * inner_area,
+static void draw_border_complex(lv_draw_task_t * t, const lv_area_t * outer_area, const lv_area_t * inner_area,
                                 int32_t rout, int32_t rin, lv_color_t color, lv_opa_t opa);
 
-static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * outer_area, const lv_area_t * inner_area,
+static void draw_border_simple(lv_draw_task_t * t, const lv_area_t * outer_area, const lv_area_t * inner_area,
                                lv_color_t color, lv_opa_t opa);
 
 /**********************
@@ -51,7 +51,7 @@ static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * out
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
     if(dsc->width == 0) return;
@@ -75,10 +75,10 @@ void lv_draw_sw_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * 
     if(rin < 0) rin = 0;
 
     if(rout == 0 && rin == 0) {
-        draw_border_simple(draw_unit, coords, &area_inner, dsc->color, dsc->opa);
+        draw_border_simple(t, coords, &area_inner, dsc->color, dsc->opa);
     }
     else {
-        draw_border_complex(draw_unit, coords, &area_inner, rout, rin, dsc->color, dsc->opa);
+        draw_border_complex(t, coords, &area_inner, rout, rin, dsc->color, dsc->opa);
     }
 
 }
@@ -87,14 +87,14 @@ void lv_draw_sw_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * 
  *   STATIC FUNCTIONS
  **********************/
 
-void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_area, const lv_area_t * inner_area,
+void draw_border_complex(lv_draw_task_t * t, const lv_area_t * outer_area, const lv_area_t * inner_area,
                          int32_t rout, int32_t rin, lv_color_t color, lv_opa_t opa)
 {
 #if LV_DRAW_SW_COMPLEX
     /*Get clipped draw area which is the real draw area.
      *It is always the same or inside `coords`*/
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, outer_area, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, outer_area, &t->clip_area)) return;
     int32_t draw_area_w = lv_area_get_width(&draw_area);
 
     lv_draw_sw_blend_dsc_t blend_dsc;
@@ -151,7 +151,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
         blend_area.x2 = core_area.x2;
         blend_area.y1 = outer_area->y1;
         blend_area.y2 = inner_area->y1 - 1;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     if(bottom_side && split_hor) {
@@ -159,7 +159,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
         blend_area.x2 = core_area.x2;
         blend_area.y1 = inner_area->y2 + 1;
         blend_area.y2 = outer_area->y2;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     /*If the border is very thick and the vertical sides overlap horizontally draw a single rectangle*/
@@ -168,7 +168,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
         blend_area.x2 = outer_area->x2;
         blend_area.y1 = core_area.y1;
         blend_area.y2 = core_area.y2;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     else {
         if(left_side) {
@@ -176,7 +176,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
             blend_area.x2 = inner_area->x1 - 1;
             blend_area.y1 = core_area.y1;
             blend_area.y2 = core_area.y2;
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
         }
 
         if(right_side) {
@@ -184,7 +184,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
             blend_area.x2 = outer_area->x2;
             blend_area.y1 = core_area.y1;
             blend_area.y2 = core_area.y2;
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
         }
     }
 
@@ -208,13 +208,13 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
             if(top_y >= draw_area.y1) {
                 blend_area.y1 = top_y;
                 blend_area.y2 = top_y;
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
             }
 
             if(bottom_y <= draw_area.y2) {
                 blend_area.y1 = bottom_y;
                 blend_area.y2 = bottom_y;
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
             }
         }
     }
@@ -231,7 +231,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
 
                     lv_memset(mask_buf, 0xff, blend_w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(mask_list, mask_buf, blend_area.x1, h, blend_w);
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
             }
 
@@ -242,7 +242,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
 
                     lv_memset(mask_buf, 0xff, blend_w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(mask_list, mask_buf, blend_area.x1, h, blend_w);
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
             }
         }
@@ -262,7 +262,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
 
                     lv_memset(mask_buf, 0xff, blend_w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(mask_list, mask_buf, blend_area.x1, h, blend_w);
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
             }
 
@@ -273,7 +273,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
 
                     lv_memset(mask_buf, 0xff, blend_w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(mask_list, mask_buf, blend_area.x1, h, blend_w);
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
             }
         }
@@ -285,7 +285,7 @@ void draw_border_complex(lv_draw_unit_t * draw_unit, const lv_area_t * outer_are
 
 #endif /*LV_DRAW_SW_COMPLEX*/
 }
-static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * outer_area, const lv_area_t * inner_area,
+static void draw_border_simple(lv_draw_task_t * t, const lv_area_t * outer_area, const lv_area_t * inner_area,
                                lv_color_t color, lv_opa_t opa)
 {
     lv_area_t a;
@@ -306,14 +306,14 @@ static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * out
     a.y1 = outer_area->y1;
     a.y2 = inner_area->y1 - 1;
     if(top_side) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     /*Bottom*/
     a.y1 = inner_area->y2 + 1;
     a.y2 = outer_area->y2;
     if(bottom_side) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     /*Left*/
@@ -322,14 +322,14 @@ static void draw_border_simple(lv_draw_unit_t * draw_unit, const lv_area_t * out
     a.y1 = (top_side) ? inner_area->y1 : outer_area->y1;
     a.y2 = (bottom_side) ? inner_area->y2 : outer_area->y2;
     if(left_side) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     /*Right*/
     a.x1 = inner_area->x2 + 1;
     a.x2 = outer_area->x2;
     if(right_side) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 }
 

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -55,7 +55,7 @@ static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_blur_corner(int32_t size, int32_t
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_t * dsc, const lv_area_t * coords)
 {
     /*Calculate the rectangle which is blurred to get the shadow in `shadow_area`*/
     lv_area_t core_area;
@@ -77,7 +77,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     /*Get clipped draw area which is the real draw area.
      *It is always the same or inside `shadow_area`*/
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &shadow_area, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &shadow_area, &t->clip_area)) return;
 
     /*Consider 1 px smaller bg to be sure the edge will be covered by the shadow*/
     lv_area_t bg_area;
@@ -167,7 +167,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.x1 = LV_MAX(blend_area.x1, w_half);
     blend_area.y2 = LV_MIN(blend_area.y2, h_half);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -194,7 +194,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                 else {
                     blend_dsc.mask_buf = sh_buf_tmp;
                 }
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
                 sh_buf_tmp += corner_size;
             }
         }
@@ -210,7 +210,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.x1 = LV_MAX(blend_area.x1, w_half);
     blend_area.y1 = LV_MAX(blend_area.y1, h_half + 1);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -237,7 +237,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                 else {
                     blend_dsc.mask_buf = sh_buf_tmp;
                 }
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
                 sh_buf_tmp += corner_size;
             }
         }
@@ -250,7 +250,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y2 = shadow_area.y1 + corner_size - 1;
     blend_area.y2 = LV_MIN(blend_area.y2, h_half);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -278,11 +278,11 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                     lv_memset(mask_buf, sh_buf_tmp[0], w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(masks, mask_buf, clip_area_sub.x1, y, w);
                     if(blend_dsc.mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
                 else {
                     blend_dsc.opa = opa == LV_OPA_COVER ? sh_buf_tmp[0] : LV_OPA_MIX2(sh_buf_tmp[0], dsc->opa);
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
                 sh_buf_tmp += corner_size;
             }
@@ -297,7 +297,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y2 = shadow_area.y2;
     blend_area.y1 = LV_MAX(blend_area.y1, h_half + 1);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -328,11 +328,11 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                     lv_memset(mask_buf, sh_buf_tmp[0], w);
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(masks, mask_buf, clip_area_sub.x1, y, w);
                     if(blend_dsc.mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
                 }
                 else {
                     blend_dsc.opa = opa == LV_OPA_COVER ? sh_buf_tmp[0] : (sh_buf_tmp[0] * dsc->opa) >> 8;
-                    lv_draw_sw_blend(draw_unit, &blend_dsc);
+                    lv_draw_sw_blend(t, &blend_dsc);
 
                 }
                 sh_buf_tmp += corner_size;
@@ -352,7 +352,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y2 = LV_MAX(blend_area.y2, h_half);
     blend_area.x1 = LV_MAX(blend_area.x1, w_half);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -377,7 +377,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                     blend_dsc.mask_res = lv_draw_sw_mask_apply(masks, mask_buf, clip_area_sub.x1, y, w);
                     if(blend_dsc.mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
                 }
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
             }
         }
     }
@@ -409,7 +409,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y2 = LV_MAX(blend_area.y2, h_half);
     blend_area.x2 = LV_MIN(blend_area.x2, w_half - 1);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -434,7 +434,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                     if(blend_dsc.mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
                 }
 
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
             }
         }
     }
@@ -448,7 +448,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.x2 = LV_MIN(blend_area.x2, w_half - 1);
     blend_area.y2 = LV_MIN(blend_area.y2, h_half);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -477,7 +477,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                     blend_dsc.mask_buf = sh_buf_tmp;
                 }
 
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
                 sh_buf_tmp += corner_size;
             }
         }
@@ -493,7 +493,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y1 = LV_MAX(blend_area.y1, h_half + 1);
     blend_area.x2 = LV_MIN(blend_area.x2, w_half - 1);
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         sh_buf_tmp = sh_buf;
@@ -520,7 +520,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
                 else {
                     blend_dsc.mask_buf = sh_buf_tmp;
                 }
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
                 sh_buf_tmp += corner_size;
             }
         }
@@ -535,7 +535,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
     blend_area.y2 = LV_MAX(blend_area.y2, h_half);
     blend_dsc.mask_buf = mask_buf;
 
-    if(lv_area_intersect(&clip_area_sub, &blend_area, draw_unit->clip_area) &&
+    if(lv_area_intersect(&clip_area_sub, &blend_area, &t->clip_area) &&
        !lv_area_is_in(&clip_area_sub, &bg_area, r_bg)) {
         int32_t w = lv_area_get_width(&clip_area_sub);
         if(w > 0) {
@@ -547,7 +547,7 @@ void lv_draw_sw_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_
 
                 lv_memset(mask_buf, 0xff, w);
                 blend_dsc.mask_res = lv_draw_sw_mask_apply(masks, mask_buf, clip_area_sub.x1, y, w);
-                lv_draw_sw_blend(draw_unit, &blend_dsc);
+                lv_draw_sw_blend(t, &blend_dsc);
             }
         }
     }

--- a/src/draw/sw/lv_draw_sw_fill.c
+++ b/src/draw/sw/lv_draw_sw_fill.c
@@ -45,7 +45,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_fill(lv_draw_task_t * t, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
@@ -53,7 +53,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
     lv_area_copy(&bg_coords, coords);
 
     lv_area_t clipped_coords;
-    if(!lv_area_intersect(&clipped_coords, &bg_coords, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&clipped_coords, &bg_coords, &t->clip_area)) return;
 
     lv_grad_dir_t grad_dir = dsc->grad.dir;
     lv_color_t bg_color    = grad_dir == LV_GRAD_DIR_NONE ? dsc->color : dsc->grad.stops[0].color;
@@ -65,7 +65,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
     if(dsc->radius == 0 && (grad_dir == LV_GRAD_DIR_NONE)) {
         blend_dsc.blend_area = &bg_coords;
         blend_dsc.opa = dsc->opa;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
         return;
     }
 
@@ -203,7 +203,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
                 }
                 blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
             }
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
         }
 
         if(bottom_y <= clipped_coords.y2) {
@@ -250,7 +250,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
                 }
                 blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
             }
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
         }
     }
 
@@ -262,7 +262,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
         blend_area.y2 = bg_coords.y2 - rout;
         blend_dsc.opa = opa;
         blend_dsc.mask_buf = NULL;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     /*With gradient draw line by line*/
     else {
@@ -312,7 +312,7 @@ void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const
                 default:
                     break;
             }
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
         }
     }
 

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -145,12 +145,7 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    uint32_t idx = 0;
-    lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-    while(draw_unit_tmp != draw_unit) {
-        draw_unit_tmp = draw_unit_tmp->next;
-        idx++;
-    }
+    int32_t idx = draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_fill_dsc_init(&fill_dsc);

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -55,20 +55,20 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                           const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
 
-static void radius_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void radius_only(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                         const lv_image_decoder_dsc_t * decoder_dsc,
                         const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
-static void recolor_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void recolor_only(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                          const lv_image_decoder_dsc_t * decoder_dsc,
                          const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
-static void transform_and_recolor(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void transform_and_recolor(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                   const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                                   const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
@@ -91,7 +91,7 @@ static bool apply_mask(const lv_draw_image_dsc_t * draw_dsc);
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords)
+void lv_draw_sw_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc, const lv_area_t * coords)
 {
     lv_layer_t * layer_to_draw = (lv_layer_t *)draw_dsc->src;
 
@@ -108,7 +108,8 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = layer_to_draw->draw_buf;
 
-    lv_draw_sw_image(draw_unit, &new_draw_dsc, coords);
+    lv_draw_sw_image(t, &new_draw_dsc, coords);
+
 #if LV_USE_LAYER_DEBUG || LV_USE_PARALLEL_DRAW_DEBUG
     lv_area_t area_rot;
     lv_area_copy(&area_rot, coords);
@@ -125,7 +126,7 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
         area_rot.y2 += coords->y1;
     }
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &area_rot, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &area_rot, &t->clip_area)) return;
 #endif
 
 #if LV_USE_LAYER_DEBUG
@@ -133,32 +134,32 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
     fill_dsc.opa = LV_OPA_20;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = fill_dsc.color;
     border_dsc.opa = LV_OPA_60;
     border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    int32_t idx = draw_unit->idx;
+    int32_t idx = t->draw_unit->idx;
 
     lv_draw_fill_dsc_t fill_dsc;
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     fill_dsc.opa = LV_OPA_10;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
     lv_draw_border_dsc_t border_dsc;
     lv_draw_border_dsc_init(&border_dsc);
     border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
     border_dsc.opa = LV_OPA_60;
     border_dsc.width = 1;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    lv_draw_sw_border(t, &border_dsc, &area_rot);
 
     lv_point_t txt_size;
     lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -171,7 +172,7 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
 
     lv_draw_fill_dsc_init(&fill_dsc);
     fill_dsc.color = lv_color_black();
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &txt_area);
+    lv_draw_sw_fill(t, &fill_dsc, &txt_area);
 
     char buf[8];
     lv_snprintf(buf, sizeof(buf), "%d", idx);
@@ -179,18 +180,18 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
     lv_draw_label_dsc_init(&label_dsc);
     label_dsc.color = lv_color_white();
     label_dsc.text = buf;
-    lv_draw_sw_label(draw_unit, &label_dsc, &txt_area);
+    lv_draw_sw_label(t, &label_dsc, &txt_area);
 #endif
 }
 
-void lv_draw_sw_image(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_sw_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                       const lv_area_t * coords)
 {
     if(!draw_dsc->tile) {
-        lv_draw_image_normal_helper(draw_unit, draw_dsc, coords, img_draw_core);
+        lv_draw_image_normal_helper(t, draw_dsc, coords, img_draw_core);
     }
     else {
-        lv_draw_image_tiled_helper(draw_unit, draw_dsc, coords, img_draw_core);
+        lv_draw_image_tiled_helper(t, draw_dsc, coords, img_draw_core);
     }
 }
 
@@ -198,7 +199,7 @@ void lv_draw_sw_image(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
  *   STATIC FUNCTIONS
  **********************/
 
-static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                           const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                           const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
@@ -221,7 +222,7 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
 
     if(!transformed && !radius && cf == LV_COLOR_FORMAT_A8) {
         lv_area_t clipped_coords;
-        if(!lv_area_intersect(&clipped_coords, img_coords, draw_unit->clip_area)) return;
+        if(!lv_area_intersect(&clipped_coords, img_coords, &t->clip_area)) return;
 
         blend_dsc.mask_buf = (lv_opa_t *)src_buf;
         blend_dsc.mask_area = img_coords;
@@ -231,7 +232,7 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
         blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
 
         blend_dsc.blend_area = img_coords;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     else if(!transformed && !radius && cf == LV_COLOR_FORMAT_RGB565A8 && draw_dsc->recolor_opa <= LV_OPA_MIN) {
         int32_t src_h = lv_area_get_height(img_coords);
@@ -250,14 +251,14 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
         blend_dsc.mask_area = img_coords;
         blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
         blend_dsc.src_color_format = LV_COLOR_FORMAT_RGB565;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     else if(!transformed && !radius && (cf == LV_COLOR_FORMAT_L8 || cf == LV_COLOR_FORMAT_AL88)) {
         blend_dsc.src_area = img_coords;
         blend_dsc.src_buf = src_buf;
         blend_dsc.blend_area = img_coords;
         blend_dsc.src_color_format = cf;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     /*The simplest case just copy the pixels into the draw_buf. Blending will convert the colors if needed*/
     else if(!transformed && !radius && draw_dsc->recolor_opa <= LV_OPA_MIN) {
@@ -265,14 +266,14 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
         blend_dsc.src_buf = src_buf;
         blend_dsc.blend_area = img_coords;
         blend_dsc.src_color_format = cf;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
     else if(!transformed && !radius && draw_dsc->recolor_opa > LV_OPA_MIN) {
-        recolor_only(draw_unit, draw_dsc, decoder_dsc, img_coords,  clipped_img_area);
+        recolor_only(t, draw_dsc, decoder_dsc, img_coords,  clipped_img_area);
     }
     /*Handle masked RGB565, RGB888, XRGB888, or ARGB8888 images*/
     else if(!transformed && radius && draw_dsc->recolor_opa <= LV_OPA_MIN) {
-        radius_only(draw_unit, draw_dsc, decoder_dsc, img_coords,  clipped_img_area);
+        radius_only(t, draw_dsc, decoder_dsc, img_coords,  clipped_img_area);
     }
     /* check whether it is possible to accelerate the operation in synchronous mode */
     else if(LV_RESULT_INVALID == LV_DRAW_SW_IMAGE(transformed,      /* whether require transform */
@@ -284,11 +285,11 @@ static void img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t 
                                                   draw_unit,        /* target buffer, buffer width, buffer height, buffer stride */
                                                   draw_dsc)) {      /* opa, recolour_opa and colour */
         /*In the other cases every pixel need to be checked one-by-one*/
-        transform_and_recolor(draw_unit, draw_dsc, decoder_dsc, sup, img_coords, clipped_img_area);
+        transform_and_recolor(t, draw_dsc, decoder_dsc, sup, img_coords, clipped_img_area);
 
     }
 }
-static void radius_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void radius_only(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                         const lv_image_decoder_dsc_t * decoder_dsc,
                         const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
@@ -358,7 +359,7 @@ static void radius_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * 
         }
 
         /*Blend*/
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
 
         /*Go to the next area*/
         blend_area.y1 ++;
@@ -367,7 +368,7 @@ static void radius_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * 
     lv_free(mask_buf);
 
 }
-static void recolor_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void recolor_only(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                          const lv_image_decoder_dsc_t * decoder_dsc,
                          const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
@@ -415,7 +416,7 @@ static void recolor_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
         lv_area_move(&relative_area, -img_coords->x1, -img_coords->y1);
         recolor(relative_area, decoded->data, tmp_buf, img_stride, blend_dsc.src_color_format, draw_dsc);
 
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
 
         /*Go to the next area*/
         blend_area.y1 = blend_area.y2 + 1;
@@ -430,7 +431,7 @@ static void recolor_only(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
 
 }
 
-static void transform_and_recolor(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+static void transform_and_recolor(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                   const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                                   const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 
@@ -510,7 +511,7 @@ static void transform_and_recolor(lv_draw_unit_t * draw_unit, const lv_draw_imag
         lv_area_t relative_area;
         lv_area_copy(&relative_area, &blend_area);
         lv_area_move(&relative_area, -img_coords->x1, -img_coords->y1);
-        lv_draw_sw_transform(draw_unit, &relative_area, src_buf, src_w, src_h, img_stride,
+        lv_draw_sw_transform(&relative_area, src_buf, src_w, src_h, img_stride,
                              draw_dsc, sup, cf, transformed_buf);
 
         if(do_recolor) {
@@ -521,7 +522,7 @@ static void transform_and_recolor(lv_draw_unit_t * draw_unit, const lv_draw_imag
         }
 
         /*Blend*/
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
 
         /*Go to the next area*/
         blend_area.y1 = blend_area.y2 + 1;

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -32,7 +32,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void /* LV_ATTRIBUTE_FAST_MEM */ draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                                        lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
 
 /**********************
@@ -51,7 +51,7 @@ static void /* LV_ATTRIBUTE_FAST_MEM */ draw_letter_cb(lv_draw_unit_t * draw_uni
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_letter(lv_draw_task_t * t, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN)
         return;
@@ -65,7 +65,7 @@ void lv_draw_sw_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * 
     glyph_dsc.pivot = dsc->pivot;
 
     LV_PROFILER_BEGIN;
-    lv_draw_unit_draw_letter(draw_unit, &glyph_dsc, &(lv_point_t) {
+    lv_draw_unit_draw_letter(t, &glyph_dsc, &(lv_point_t) {
         .x = coords->x1, .y = coords->y1
     },
     dsc->font, dsc->unicode, draw_letter_cb);
@@ -77,12 +77,12 @@ void lv_draw_sw_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * 
     }
 }
 
-void lv_draw_sw_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_label_iterate_characters(draw_unit, dsc, coords, draw_letter_cb);
+    lv_draw_label_iterate_characters(t, dsc, coords, draw_letter_cb);
     LV_PROFILER_DRAW_END;
 }
 
@@ -90,7 +90,7 @@ void lv_draw_sw_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * ds
  *   STATIC FUNCTIONS
  **********************/
 
-static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                                                  lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
     if(glyph_draw_dsc) {
@@ -103,7 +103,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
                     border_draw_dsc.opa = glyph_draw_dsc->opa;
                     border_draw_dsc.color = glyph_draw_dsc->color;
                     border_draw_dsc.width = 1;
-                    lv_draw_sw_border(draw_unit, &border_draw_dsc, glyph_draw_dsc->bg_coords);
+                    lv_draw_sw_border(t, &border_draw_dsc, glyph_draw_dsc->bg_coords);
 #endif
                 }
                 break;
@@ -131,7 +131,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
                         blend_dsc.mask_stride = draw_buf->header.stride;
                         blend_dsc.blend_area = glyph_draw_dsc->letter_coords;
                         blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
-                        lv_draw_sw_blend(draw_unit, &blend_dsc);
+                        lv_draw_sw_blend(t, &blend_dsc);
                     }
                     else {
                         glyph_draw_dsc->glyph_data = lv_font_get_glyph_bitmap(glyph_draw_dsc->g, glyph_draw_dsc->_draw_buf);
@@ -147,7 +147,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
                             .x = glyph_draw_dsc->pivot.x,
                             .y = glyph_draw_dsc->g->box_h + glyph_draw_dsc->g->ofs_y
                         };
-                        lv_draw_sw_image(draw_unit, &img_dsc, glyph_draw_dsc->letter_coords);
+                        lv_draw_sw_image(t, &img_dsc, glyph_draw_dsc->letter_coords);
                     }
                     break;
                 }
@@ -157,7 +157,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_unit_t * draw_unit, lv_
     }
 
     if(fill_draw_dsc && fill_area) {
-        lv_draw_sw_fill(draw_unit, fill_draw_dsc, fill_area);
+        lv_draw_sw_fill(t, fill_draw_dsc, fill_area);
     }
 }
 

--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -31,9 +31,9 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_skew(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
-static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_hor(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
-static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_ver(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_skew(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_hor(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
+static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_ver(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
 /**********************
  *  STATIC VARIABLES
@@ -47,7 +47,7 @@ static void /* LV_ATTRIBUTE_FAST_MEM */ draw_line_ver(lv_draw_unit_t * draw_unit
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+void lv_draw_sw_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
     if(dsc->width == 0) return;
     if(dsc->opa <= LV_OPA_MIN) return;
@@ -61,13 +61,13 @@ void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
     clip_line.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width / 2;
 
     bool is_common;
-    is_common = lv_area_intersect(&clip_line, &clip_line, draw_unit->clip_area);
+    is_common = lv_area_intersect(&clip_line, &clip_line, &t->clip_area);
     if(!is_common) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    if((int32_t)dsc->p1.y == (int32_t)dsc->p2.y) draw_line_hor(draw_unit, dsc);
-    else if((int32_t)dsc->p1.x == (int32_t)dsc->p2.x) draw_line_ver(draw_unit, dsc);
-    else draw_line_skew(draw_unit, dsc);
+    if((int32_t)dsc->p1.y == (int32_t)dsc->p2.y) draw_line_hor(t, dsc);
+    else if((int32_t)dsc->p1.x == (int32_t)dsc->p2.x) draw_line_ver(t, dsc);
+    else draw_line_skew(t, dsc);
 
     if(dsc->round_end || dsc->round_start) {
         lv_draw_fill_dsc_t cir_dsc;
@@ -85,7 +85,7 @@ void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
             cir_area.y1 = (int32_t)dsc->p1.y - r;
             cir_area.x2 = (int32_t)dsc->p1.x + r - r_corr;
             cir_area.y2 = (int32_t)dsc->p1.y + r - r_corr ;
-            lv_draw_sw_fill(draw_unit, &cir_dsc, &cir_area);
+            lv_draw_sw_fill(t, &cir_dsc, &cir_area);
         }
 
         if(dsc->round_end) {
@@ -93,7 +93,7 @@ void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
             cir_area.y1 = (int32_t)dsc->p2.y - r;
             cir_area.x2 = (int32_t)dsc->p2.x + r - r_corr;
             cir_area.y2 = (int32_t)dsc->p2.y + r - r_corr ;
-            lv_draw_sw_fill(draw_unit, &cir_dsc, &cir_area);
+            lv_draw_sw_fill(t, &cir_dsc, &cir_area);
         }
     }
     LV_PROFILER_DRAW_END;
@@ -102,7 +102,7 @@ void lv_draw_sw_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -115,7 +115,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_unit_t * draw_unit, cons
     blend_area.y2 = (int32_t)dsc->p1.y + w_half0;
 
     bool is_common;
-    is_common = lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
+    is_common = lv_area_intersect(&blend_area, &blend_area, &t->clip_area);
     if(!is_common) return;
 
     bool dashed = dsc->dash_gap && dsc->dash_width;
@@ -128,7 +128,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_unit_t * draw_unit, cons
 
     /*If there is no mask then simply draw a rectangle*/
     if(!dashed) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 #if LV_DRAW_SW_COMPLEX
     /*If there other mask apply it*/
@@ -167,7 +167,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_unit_t * draw_unit, cons
                 blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
             }
 
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
 
             blend_area.y1++;
             blend_area.y2++;
@@ -177,7 +177,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_hor(lv_draw_unit_t * draw_unit, cons
 #endif /*LV_DRAW_SW_COMPLEX*/
 }
 
-static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
     int32_t w = dsc->width - 1;
     int32_t w_half0 = w >> 1;
@@ -190,7 +190,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_unit_t * draw_unit, cons
     blend_area.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) - 1;
 
     bool is_common;
-    is_common = lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
+    is_common = lv_area_intersect(&blend_area, &blend_area, &t->clip_area);
     if(!is_common) return;
 
     bool dashed = dsc->dash_gap && dsc->dash_width;
@@ -203,7 +203,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_unit_t * draw_unit, cons
 
     /*If there is no mask then simply draw a rectangle*/
     if(!dashed) {
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
 #if LV_DRAW_SW_COMPLEX
@@ -238,7 +238,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_unit_t * draw_unit, cons
             }
             dash_cnt ++;
 
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
 
             blend_area.y1++;
             blend_area.y2++;
@@ -248,7 +248,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_ver(lv_draw_unit_t * draw_unit, cons
 #endif /*LV_DRAW_SW_COMPLEX*/
 }
 
-static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
 #if LV_DRAW_SW_COMPLEX
     /*Keep the great y in p1*/
@@ -293,7 +293,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_unit_t * draw_unit, con
     /*Get the union of `coords` and `clip`*/
     /*`clip` is already truncated to the `draw_buf` size
      *in 'lv_refr_area' function*/
-    bool is_common = lv_area_intersect(&blend_area, &blend_area, draw_unit->clip_area);
+    bool is_common = lv_area_intersect(&blend_area, &blend_area, &t->clip_area);
     if(is_common == false) return;
 
     lv_draw_sw_mask_line_param_t mask_left_param;
@@ -374,7 +374,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_unit_t * draw_unit, con
         }
         else {
             blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
-            lv_draw_sw_blend(draw_unit, &blend_dsc);
+            lv_draw_sw_blend(t, &blend_dsc);
 
             blend_area.y1 = blend_area.y2 + 1;
             blend_area.y2 = blend_area.y1;
@@ -387,7 +387,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_unit_t * draw_unit, con
     if(blend_area.y1 != blend_area.y2) {
         blend_area.y2--;
         blend_dsc.mask_res = LV_DRAW_SW_MASK_RES_CHANGED;
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     lv_free(mask_buf);

--- a/src/draw/sw/lv_draw_sw_mask_rect.c
+++ b/src/draw/sw/lv_draw_sw_mask_rect.c
@@ -43,40 +43,38 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_rect_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_sw_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * dsc)
 {
-    LV_UNUSED(coords);
-
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &dsc->area, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&draw_area, &dsc->area, &t->clip_area)) {
         return;
     }
 
-    lv_layer_t * target_layer = draw_unit->target_layer;
+    lv_layer_t * target_layer = t->target_layer;
     lv_area_t * buf_area = &target_layer->buf_area;
     lv_area_t clear_area;
 
     void * draw_buf = target_layer->draw_buf;
 
     /*Clear the top part*/
-    lv_area_set(&clear_area, draw_unit->clip_area->x1, draw_unit->clip_area->y1, draw_unit->clip_area->x2,
+    lv_area_set(&clear_area, t->clip_area.x1, t->clip_area.y1, t->clip_area.x2,
                 dsc->area.y1 - 1);
     lv_area_move(&clear_area, -buf_area->x1, -buf_area->y1);
     lv_draw_buf_clear(draw_buf, &clear_area);
 
     /*Clear the bottom part*/
-    lv_area_set(&clear_area, draw_unit->clip_area->x1, dsc->area.y2 + 1, draw_unit->clip_area->x2,
-                draw_unit->clip_area->y2);
+    lv_area_set(&clear_area, t->clip_area.x1, dsc->area.y2 + 1, t->clip_area.x2,
+                t->clip_area.y2);
     lv_area_move(&clear_area, -buf_area->x1, -buf_area->y1);
     lv_draw_buf_clear(draw_buf, &clear_area);
 
     /*Clear the left part*/
-    lv_area_set(&clear_area, draw_unit->clip_area->x1, dsc->area.y1, dsc->area.x1 - 1, dsc->area.y2);
+    lv_area_set(&clear_area, t->clip_area.x1, dsc->area.y1, dsc->area.x1 - 1, dsc->area.y2);
     lv_area_move(&clear_area, -buf_area->x1, -buf_area->y1);
     lv_draw_buf_clear(draw_buf, &clear_area);
 
     /*Clear the right part*/
-    lv_area_set(&clear_area, dsc->area.x2 + 1, dsc->area.y1, draw_unit->clip_area->x2, dsc->area.y2);
+    lv_area_set(&clear_area, dsc->area.x2 + 1, dsc->area.y1, t->clip_area.x2, dsc->area.y2);
     lv_area_move(&clear_area, -buf_area->x1, -buf_area->y1);
     lv_draw_buf_clear(draw_buf, &clear_area);
 

--- a/src/draw/sw/lv_draw_sw_private.h
+++ b/src/draw/sw/lv_draw_sw_private.h
@@ -40,7 +40,6 @@ struct _lv_draw_sw_unit_t {
     volatile bool inited;
     volatile bool exit_status;
 #endif
-    uint32_t idx;
 };
 
 #if LV_DRAW_SW_SHADOW_CACHE_SIZE

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -95,11 +95,10 @@ static void transform_l8_to_al88(const uint8_t * src, int32_t src_w, int32_t src
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_transform(lv_draw_unit_t * draw_unit, const lv_area_t * dest_area, const void * src_buf,
+void lv_draw_sw_transform(const lv_area_t * dest_area, const void * src_buf,
                           int32_t src_w, int32_t src_h, int32_t src_stride,
                           const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t src_cf, void * dest_buf)
 {
-    LV_UNUSED(draw_unit);
     LV_UNUSED(sup);
 
     point_transform_dsc_t tr_dsc;

--- a/src/draw/sw/lv_draw_sw_triangle.c
+++ b/src/draw/sw/lv_draw_sw_triangle.c
@@ -44,7 +44,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_sw_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
 {
 #if LV_DRAW_SW_COMPLEX
     lv_area_t tri_area;
@@ -55,7 +55,7 @@ void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_
 
     bool is_common;
     lv_area_t draw_area;
-    is_common = lv_area_intersect(&draw_area, &tri_area, draw_unit->clip_area);
+    is_common = lv_area_intersect(&draw_area, &tri_area, &t->clip_area);
     if(!is_common) return;
 
     lv_point_t p[3];
@@ -175,7 +175,7 @@ void lv_draw_sw_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_
                 }
             }
         }
-        lv_draw_sw_blend(draw_unit, &blend_dsc);
+        lv_draw_sw_blend(t, &blend_dsc);
     }
 
     lv_free(mask_buf);

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -405,10 +405,8 @@ static void _task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_ve
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_sw_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc_t * dsc)
+void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc)
 {
-    LV_UNUSED(draw_unit);
-
     if(dsc->task_list == NULL)
         return;
 
@@ -433,7 +431,7 @@ void lv_draw_sw_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc
     tvg_swcanvas_set_target(canvas, buf, stride / 4, width, height, TVG_COLORSPACE_ARGB8888);
 
     _tvg_rect rc;
-    lv_area_to_tvg(&rc, draw_unit->clip_area);
+    lv_area_to_tvg(&rc, &t->clip_area);
     tvg_canvas_set_viewport(canvas, (int32_t)rc.x, (int32_t)rc.y, (int32_t)rc.w, (int32_t)rc.h);
 
     lv_ll_t * task_list = dsc->task_list;

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -51,7 +51,6 @@ static int32_t draw_delete(lv_draw_unit_t * draw_unit);
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
 void lv_draw_vg_lite_init(void)
 {
 #if LV_VG_LITE_USE_GPU_INIT
@@ -115,9 +114,10 @@ static bool check_arc_is_supported(const lv_draw_arc_dsc_t * dsc)
 static void draw_execute(lv_draw_vg_lite_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
-    lv_draw_unit_t * draw_unit = (lv_draw_unit_t *)u;
+    lv_layer_t * layer = t->target_layer;
 
-    lv_layer_t * layer = u->base_unit.target_layer;
+    /* remember draw unit for access to unit's context */
+    t->draw_unit = (lv_draw_unit_t *)u;
 
     lv_vg_lite_buffer_from_draw_buf(&u->target_buffer, layer->draw_buf);
 
@@ -144,41 +144,41 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_LETTER:
-            lv_draw_vg_lite_letter(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_letter(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LABEL:
-            lv_draw_vg_lite_label(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_label(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_FILL:
-            lv_draw_vg_lite_fill(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_fill(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BORDER:
-            lv_draw_vg_lite_border(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_border(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_BOX_SHADOW:
-            lv_draw_vg_lite_box_shadow(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_box_shadow(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_vg_lite_img(draw_unit, t->draw_dsc, &t->area, false);
+            lv_draw_vg_lite_img(t, t->draw_dsc, &t->area, false);
             break;
         case LV_DRAW_TASK_TYPE_ARC:
-            lv_draw_vg_lite_arc(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_arc(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_LINE:
-            lv_draw_vg_lite_line(draw_unit, t->draw_dsc);
+            lv_draw_vg_lite_line(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_LAYER:
-            lv_draw_vg_lite_layer(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_layer(t, t->draw_dsc, &t->area);
             break;
         case LV_DRAW_TASK_TYPE_TRIANGLE:
-            lv_draw_vg_lite_triangle(draw_unit, t->draw_dsc);
+            lv_draw_vg_lite_triangle(t, t->draw_dsc);
             break;
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
-            lv_draw_vg_lite_mask_rect(draw_unit, t->draw_dsc, &t->area);
+            lv_draw_vg_lite_mask_rect(t, t->draw_dsc, &t->area);
             break;
 #if LV_USE_VECTOR_GRAPHIC
         case LV_DRAW_TASK_TYPE_VECTOR:
-            lv_draw_vg_lite_vector(draw_unit, t->draw_dsc);
+            lv_draw_vg_lite_vector(t, t->draw_dsc);
             break;
 #endif
         default:
@@ -217,8 +217,6 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    u->base_unit.target_layer = layer;
-    u->base_unit.clip_area = &t->clip_area;
     u->task_act = t;
 
     draw_execute(u);

--- a/src/draw/vg_lite/lv_draw_vg_lite.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite.h
@@ -13,11 +13,9 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-
 #include "../../lv_conf_internal.h"
 
 #if LV_USE_DRAW_VG_LITE
-
 #include "../lv_draw.h"
 #include "../../draw/lv_draw_vector.h"
 #include "../../draw/lv_draw_arc.h"
@@ -38,47 +36,46 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
 void lv_draw_buf_vg_lite_init_handlers(void);
 
 void lv_draw_vg_lite_init(void);
 
 void lv_draw_vg_lite_deinit(void);
 
-void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
+void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                          const lv_area_t * coords);
 
-void lv_draw_vg_lite_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_dsc_t * dsc,
+void lv_draw_vg_lite_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_t * dsc,
                                 const lv_area_t * coords);
 
-void lv_draw_vg_lite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_vg_lite_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                             const lv_area_t * coords);
 
-void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc,
+void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                           const lv_area_t * coords);
 
-void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                          const lv_area_t * coords, bool no_cache);
 
 void lv_draw_vg_lite_label_init(lv_draw_unit_t * draw_unit);
 
-void lv_draw_vg_lite_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords);
+void lv_draw_vg_lite_letter(lv_draw_task_t * t, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords);
 
-void lv_draw_vg_lite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_vg_lite_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                            const lv_area_t * coords);
 
-void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_vg_lite_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                            const lv_area_t * coords);
 
-void lv_draw_vg_lite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc);
+void lv_draw_vg_lite_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc);
 
-void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc);
+void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc);
 
-void lv_draw_vg_lite_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_rect_dsc_t * dsc,
+void lv_draw_vg_lite_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * dsc,
                                const lv_area_t * coords);
 
 #if LV_USE_VECTOR_GRAPHIC
-void lv_draw_vg_lite_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc_t * dsc);
+void lv_draw_vg_lite_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc);
 #endif
 
 /**********************

--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -51,14 +51,13 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * dsc,
+void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                          const lv_area_t * coords)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     lv_area_t clip_area;
-    if(!lv_area_intersect(&clip_area, coords, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&clip_area, coords, &t->clip_area)) {
         /*Fully clipped, nothing to do*/
         return;
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite_border.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_border.c
@@ -48,14 +48,13 @@ static vg_lite_fill_t path_append_inner_rect(lv_vg_lite_path_t * path,
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_border(lv_draw_unit_t * draw_unit, const lv_draw_border_dsc_t * dsc,
+void lv_draw_vg_lite_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc,
                             const lv_area_t * coords)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     lv_area_t clip_area;
-    if(!lv_area_intersect(&clip_area, coords, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&clip_area, coords, &t->clip_area)) {
         /*Fully clipped, nothing to do*/
         return;
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c
@@ -38,7 +38,7 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_vg_lite_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_shadow_dsc_t * dsc,
+void lv_draw_vg_lite_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_t * dsc,
                                 const lv_area_t * coords)
 {
     /*Calculate the rectangle which is blurred to get the shadow in `shadow_area`*/
@@ -58,7 +58,7 @@ void lv_draw_vg_lite_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_sh
     /*Get clipped draw area which is the real draw area.
      *It is always the same or inside `shadow_area`*/
     lv_area_t draw_area;
-    if(!lv_area_intersect(&draw_area, &shadow_area, draw_unit->clip_area)) return;
+    if(!lv_area_intersect(&draw_area, &shadow_area, &t->clip_area)) return;
 
     LV_PROFILER_DRAW_BEGIN;
 
@@ -76,7 +76,7 @@ void lv_draw_vg_lite_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_sh
         border_dsc.opa = lv_map(w, 0, half_w, dsc->opa / 4, LV_OPA_0);
         border_dsc.radius++;
         lv_area_increase(&draw_area, 1, 1);
-        lv_draw_vg_lite_border(draw_unit, &border_dsc, &draw_area);
+        lv_draw_vg_lite_border(t, &border_dsc, &draw_area);
 
         /* fill center */
         if(dsc->ofs_x || dsc->ofs_y) {
@@ -85,7 +85,7 @@ void lv_draw_vg_lite_box_shadow(lv_draw_unit_t * draw_unit, const lv_draw_box_sh
             fill_dsc.radius = dsc->radius;
             fill_dsc.opa = dsc->opa;
             fill_dsc.color = dsc->color;
-            lv_draw_vg_lite_fill(draw_unit, &fill_dsc, &core_area);
+            lv_draw_vg_lite_fill(t, &fill_dsc, &core_area);
         }
     }
     LV_PROFILER_DRAW_END;

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -44,13 +44,12 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_fill(lv_draw_unit_t * draw_unit, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, const lv_area_t * coords)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     lv_area_t clip_area;
-    if(!lv_area_intersect(&clip_area, coords, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&clip_area, coords, &t->clip_area)) {
         /*Fully clipped, nothing to do*/
         return;
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -44,11 +44,10 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dsc,
+void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                          const lv_area_t * coords, bool no_cache)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     /* The coordinates passed in by coords are not transformed,
      * so the transformed area needs to be calculated once.
@@ -65,7 +64,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
     lv_area_move(&image_tf_area, coords->x1, coords->y1);
 
     lv_area_t clip_area;
-    if(!lv_area_intersect(&clip_area, &image_tf_area, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&clip_area, &image_tf_area, &t->clip_area)) {
         /*Fully clipped, nothing to do*/
         return;
     }
@@ -105,7 +104,7 @@ void lv_draw_vg_lite_img(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t *
     vg_lite_filter_t filter = no_transform ? VG_LITE_FILTER_POINT : VG_LITE_FILTER_BI_LINEAR;
 
     /* If clipping is not required, blit directly */
-    if(lv_area_is_in(&image_tf_area, draw_unit->clip_area, false) && dsc->clip_radius <= 0) {
+    if(lv_area_is_in(&image_tf_area, &t->clip_area, false) && dsc->clip_radius <= 0) {
         /* rect is used to crop the pixel-aligned padding area */
         vg_lite_rectangle_t rect = {
             .x = 0,

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -49,14 +49,14 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                            lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
 
-static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_dsc_t * dsc);
+static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * dsc);
 
 #if LV_USE_FREETYPE
     static void freetype_outline_event_cb(lv_event_t * e);
-    static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_dsc_t * dsc);
+    static void draw_letter_outline(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * dsc);
 #endif /* LV_USE_FREETYPE */
 
 /**********************
@@ -70,7 +70,6 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
 void lv_draw_vg_lite_label_init(lv_draw_unit_t * draw_unit)
 {
 #if LV_USE_FREETYPE
@@ -81,7 +80,7 @@ void lv_draw_vg_lite_label_init(lv_draw_unit_t * draw_unit)
 #endif /* LV_USE_FREETYPE */
 }
 
-void lv_draw_vg_lite_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords)
+void lv_draw_vg_lite_letter(lv_draw_task_t * t, const lv_draw_letter_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->opa <= LV_OPA_MIN)
         return;
@@ -95,7 +94,7 @@ void lv_draw_vg_lite_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc
     glyph_dsc.pivot = dsc->pivot;
 
     LV_PROFILER_BEGIN;
-    lv_draw_unit_draw_letter(draw_unit, &glyph_dsc, &(lv_point_t) {
+    lv_draw_unit_draw_letter(t, &glyph_dsc, &(lv_point_t) {
         .x = coords->x1, .y = coords->y1
     },
     dsc->font, dsc->unicode, draw_letter_cb);
@@ -107,11 +106,11 @@ void lv_draw_vg_lite_letter(lv_draw_unit_t * draw_unit, const lv_draw_letter_dsc
     }
 }
 
-void lv_draw_vg_lite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t * dsc,
+void lv_draw_vg_lite_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
                            const lv_area_t * coords)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_label_iterate_characters(draw_unit, dsc, coords, draw_letter_cb);
+    lv_draw_label_iterate_characters(t, dsc, coords, draw_letter_cb);
     LV_PROFILER_DRAW_END;
 }
 
@@ -119,10 +118,10 @@ void lv_draw_vg_lite_label(lv_draw_unit_t * draw_unit, const lv_draw_label_dsc_t
  *   STATIC FUNCTIONS
  **********************/
 
-static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+static void draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyph_draw_dsc,
                            lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
 {
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
     if(glyph_draw_dsc) {
         switch(glyph_draw_dsc->format) {
             case LV_FONT_GLYPH_FORMAT_A1:
@@ -135,7 +134,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
             case LV_FONT_GLYPH_FORMAT_A4_ALIGNED:
             case LV_FONT_GLYPH_FORMAT_A8_ALIGNED: {
                     glyph_draw_dsc->glyph_data = lv_font_get_glyph_bitmap(glyph_draw_dsc->g, glyph_draw_dsc->_draw_buf);
-                    draw_letter_bitmap(u, glyph_draw_dsc);
+                    draw_letter_bitmap(t, glyph_draw_dsc);
                 }
                 break;
 
@@ -143,7 +142,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
             case LV_FONT_GLYPH_FORMAT_VECTOR: {
                     if(lv_freetype_is_outline_font(glyph_draw_dsc->g->resolved_font)) {
                         glyph_draw_dsc->glyph_data = lv_font_get_glyph_bitmap(glyph_draw_dsc->g, glyph_draw_dsc->_draw_buf);
-                        draw_letter_outline(u, glyph_draw_dsc);
+                        draw_letter_outline(t, glyph_draw_dsc);
                     }
                 }
                 break;
@@ -156,7 +155,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
                     image_dsc.opa = glyph_draw_dsc->opa;
                     image_dsc.src = glyph_draw_dsc->glyph_data;
                     image_dsc.rotation = glyph_draw_dsc->rotation;
-                    lv_draw_vg_lite_img(draw_unit, &image_dsc, glyph_draw_dsc->letter_coords, false);
+                    lv_draw_vg_lite_img(t, &image_dsc, glyph_draw_dsc->letter_coords, false);
                 }
                 break;
 
@@ -168,7 +167,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
                     border_draw_dsc.opa = glyph_draw_dsc->opa;
                     border_draw_dsc.color = glyph_draw_dsc->color;
                     border_draw_dsc.width = 1;
-                    lv_draw_vg_lite_border(draw_unit, &border_draw_dsc, glyph_draw_dsc->bg_coords);
+                    lv_draw_vg_lite_border(t, &border_draw_dsc, glyph_draw_dsc->bg_coords);
                 }
                 break;
 #endif /* LV_USE_FONT_PLACEHOLDER */
@@ -179,7 +178,7 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
     }
 
     if(fill_draw_dsc && fill_area) {
-        lv_draw_vg_lite_fill(draw_unit, fill_draw_dsc, fill_area);
+        lv_draw_vg_lite_fill(t, fill_draw_dsc, fill_area);
     }
 
     /* Flush in time to avoid accumulation of drawing commands */
@@ -189,10 +188,11 @@ static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * gly
     }
 }
 
-static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_dsc_t * dsc)
+static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * dsc)
 {
     lv_area_t clip_area;
-    if(!lv_area_intersect(&clip_area, u->base_unit.clip_area, dsc->letter_coords)) {
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
+    if(!lv_area_intersect(&clip_area, &t->clip_area, dsc->letter_coords)) {
         return;
     }
 
@@ -223,7 +223,7 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
     LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
 
     /* If clipping is not required, blit directly */
-    if(lv_area_is_in(&image_area, u->base_unit.clip_area, false)) {
+    if(lv_area_is_in(&image_area, &t->clip_area, false)) {
         /* rect is used to crop the pixel-aligned padding area */
         vg_lite_rectangle_t rect = {
             .x = 0,
@@ -288,11 +288,12 @@ static void draw_letter_bitmap(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_d
 
 #if LV_USE_FREETYPE
 
-static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_dsc_t * dsc)
+static void draw_letter_outline(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * dsc)
 {
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
     /* get clip area */
     lv_area_t path_clip_area;
-    if(!lv_area_intersect(&path_clip_area, u->base_unit.clip_area, dsc->letter_coords)) {
+    if(!lv_area_intersect(&path_clip_area, &t->clip_area, dsc->letter_coords)) {
         return;
     }
 
@@ -325,7 +326,7 @@ static void draw_letter_outline(lv_draw_vg_lite_unit_t * u, const lv_draw_glyph_
 
     if(vg_lite_query_feature(gcFEATURE_BIT_VG_SCISSOR)) {
         /* set scissor area */
-        lv_vg_lite_set_scissor_area(u->base_unit.clip_area);
+        lv_vg_lite_set_scissor_area(&t->clip_area);
 
         /* no bounding box */
         lv_vg_lite_path_set_bounding_box(outline,

--- a/src/draw/vg_lite/lv_draw_vg_lite_layer.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_layer.c
@@ -11,8 +11,9 @@
 
 #if LV_USE_DRAW_VG_LITE
 
-#include "lv_vg_lite_utils.h"
 #include "lv_draw_vg_lite_type.h"
+#include "lv_vg_lite_utils.h"
+#include "lv_vg_lite_path.h"
 
 /*********************
  *      DEFINES
@@ -37,12 +38,11 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+void lv_draw_vg_lite_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                            const lv_area_t * coords)
 {
     lv_layer_t * layer = (lv_layer_t *)draw_dsc->src;
-    struct _lv_draw_vg_lite_unit_t * u = (struct _lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     /*It can happen that nothing was draw on a layer and therefore its buffer is not allocated.
      *In this case just return. */
@@ -58,7 +58,7 @@ void lv_draw_vg_lite_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t
 
     lv_draw_image_dsc_t new_draw_dsc = *draw_dsc;
     new_draw_dsc.src = layer->draw_buf;
-    lv_draw_vg_lite_img(draw_unit, &new_draw_dsc, coords, true);
+    lv_draw_vg_lite_img(t, &new_draw_dsc, coords, true);
 
     /* Wait for the GPU drawing to complete here,
      * otherwise it may cause the drawing to fail. */

--- a/src/draw/vg_lite/lv_draw_vg_lite_line.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_line.c
@@ -42,9 +42,10 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t * dsc)
+void lv_draw_vg_lite_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 {
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
+
     float p1_x = dsc->p1.x;
     float p1_y = dsc->p1.y;
     float p2_x = dsc->p2.x;
@@ -61,13 +62,11 @@ void lv_draw_vg_lite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t *
     rel_clip_area.y1 = (int32_t)(LV_MIN(p1_y, p2_y) - half_w);
     rel_clip_area.y2 = (int32_t)(LV_MAX(p1_y, p2_y) + half_w);
 
-    if(!lv_area_intersect(&rel_clip_area, &rel_clip_area, draw_unit->clip_area)) {
+    if(!lv_area_intersect(&rel_clip_area, &rel_clip_area, &t->clip_area)) {
         return; /*Fully clipped, nothing to do*/
     }
 
     LV_PROFILER_DRAW_BEGIN;
-
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
 
     int32_t dash_width = dsc->dash_width;
     int32_t dash_gap = dsc->dash_gap;

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -40,8 +40,7 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
 {
     lv_area_t tri_area;
     tri_area.x1 = (int32_t)LV_MIN3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
@@ -51,12 +50,12 @@ void lv_draw_vg_lite_triangle(lv_draw_unit_t * draw_unit, const lv_draw_triangle
 
     bool is_common;
     lv_area_t clip_area;
-    is_common = lv_area_intersect(&clip_area, &tri_area, draw_unit->clip_area);
+    is_common = lv_area_intersect(&clip_area, &tri_area, &t->clip_area);
     if(!is_common) return;
 
     LV_PROFILER_DRAW_BEGIN;
 
-    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)draw_unit;
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
     lv_vg_lite_path_set_bounding_box_area(path, &clip_area);

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -53,8 +53,7 @@ static vg_lite_fill_t lv_fill_to_vg(lv_vector_fill_t fill_rule);
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-
-void lv_draw_vg_lite_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_task_dsc_t * dsc)
+void lv_draw_vg_lite_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc)
 {
     if(dsc->task_list == NULL)
         return;
@@ -63,8 +62,10 @@ void lv_draw_vg_lite_vector(lv_draw_unit_t * draw_unit, const lv_draw_vector_tas
     if(layer->draw_buf == NULL)
         return;
 
+    lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
+
     LV_PROFILER_DRAW_BEGIN;
-    lv_vector_for_each_destroy_tasks(dsc->task_list, task_draw_cb, draw_unit);
+    lv_vector_for_each_destroy_tasks(dsc->task_list, task_draw_cb, u);
     LV_PROFILER_DRAW_END;
 }
 


### PR DESCRIPTION
This patch relieves draw unit structure from records related to the current task (clip_area and target layer) and puts them back with the task where they belong

This simplifies the signatures of draw functions and permits implementations of different dispatch mechanisms (for example with more than one task given in bulk to be executed by a draw_unit)

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- [x] Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
