### PR TITLE
ci(esp): add esp32s3 build workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -59,6 +59,21 @@ jobs:
       env:
         CC: cl
 
+  build-esp32s3:
+    runs-on: ubuntu-22.04
+    container: espressif/idf:v5.3.1
+    steps:
+    - name: Checkout LVGL
+      uses: actions/checkout@v4
+      with:
+        path: components/lvgl
+    - name: Copy IDF Project Example
+      run: . /opt/esp/idf/export.sh && cp -r $IDF_PATH/examples/get-started/hello_world/* .
+    - name: Set Target ESP32S3
+      run: . /opt/esp/idf/export.sh && idf.py set-target esp32s3
+    - name: Build
+      run: . /opt/esp/idf/export.sh && idf.py build
+
   test-native:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -61,9 +61,10 @@ jobs:
 
   build-esp32s3:
     runs-on: ubuntu-22.04
+    name: Build ESP IDF ESP32S3
     container: espressif/idf:v5.3.1
     steps:
-    - name: Checkout LVGL
+    - name: Clone LVGL as a Component
       uses: actions/checkout@v4
       with:
         path: components/lvgl


### PR DESCRIPTION
Catch build and Kconfig related issues such as #7154. See an failure in this branch that tested the workflow: https://github.com/liamHowatt/lvgl/actions/runs/11706872777/job/32604945034

It runs the GitHub Action inside the `espressif/idf` Docker container where all requirements are installed. LVGL is cloned into a `components/` folder where ESP-IDF will recognize it as a custom component. Copy an example IDF project into the working directory. LVGL will be built regardless of whether it's used by `main.c`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
