### PR TITLE
fix(sw_blend): add null pointer check for mask_area

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -162,6 +162,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         else image_dsc.mask_buf = blend_dsc->mask_buf;
 
         if(image_dsc.mask_buf) {
+            LV_ASSERT_NULL(blend_dsc->mask_area);
             image_dsc.mask_buf = blend_dsc->mask_buf;
             image_dsc.mask_stride = blend_dsc->mask_stride ? blend_dsc->mask_stride : lv_area_get_width(blend_dsc->mask_area);
             image_dsc.mask_buf += image_dsc.mask_stride * (blend_area.y1 - blend_dsc->mask_area->y1) +


### PR DESCRIPTION
In lv_draw_sw_blend(), the blend_dsc->mask_area can be NULL and it is being dereferenced before being checked.  Add a LV_ASSERT_NULL check to the blend_dsc->mask_area variable.
