### PR TITLE
fix(ffmpeg): add native filesystem API support for FFmpeg image decoder

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1377,7 +1377,7 @@ menu "LVGL configuration"
 			depends on LV_USE_FFMPEG
 			default n
 			help
-    			You won't be able to open URLs after enabling this feature.
+				You won't be able to open URLs after enabling this feature.
 				Note that FFmpeg image decoder will always use lvgl file system. 
 	endmenu
 

--- a/Kconfig
+++ b/Kconfig
@@ -1372,6 +1372,13 @@ menu "LVGL configuration"
 			bool "Dump format"
 			depends on LV_USE_FFMPEG
 			default n
+		config LV_FFMPEG_PLAYER_USE_LV_FS
+			bool "Use lvgl file path in FFmpeg Player widget"
+			depends on LV_USE_FFMPEG
+			default n
+			help
+    			You won't be able to open URLs after enabling this feature.
+				Note that FFmpeg image decoder will always use lvgl file system. 
 	endmenu
 
 	menu "Others"

--- a/docs/details/libs/ffmpeg.rst
+++ b/docs/details/libs/ffmpeg.rst
@@ -33,9 +33,7 @@ Enable :c:macro:`LV_USE_FFMPEG` in ``lv_conf.h``.
 
 See the examples below.
 
-:note: FFmpeg extension doesn't use LVGL's file system. You can
-       simply pass the path to the image or video as usual on your operating
-       system or platform.
+:note: Enable :c:macro:`LV_FFMPEG_PLAYER_USE_LV_FS` in ``lv_conf.h`` if you want to integrate the lvgl file system into FFmpeg.
 
 
 .. _ffmpeg_example:

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -924,6 +924,10 @@
 #if LV_USE_FFMPEG
     /** Dump input information to stderr */
     #define LV_FFMPEG_DUMP_FORMAT 0
+    /** Use lvgl file path in FFmpeg Player widget 
+     *  You won't be able to open URLs after enabling this feature.
+     *  Note that FFmpeg image decoder will always use lvgl file system. */
+    #define LV_FFMPEG_PLAYER_USE_LV_FS 0
 #endif
 
 /*==================

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -135,7 +135,7 @@ void lv_ffmpeg_init(void)
 int lv_ffmpeg_get_frame_num(const char * path)
 {
     int ret = -1;
-    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, false);
+    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS);
 
     if(ffmpeg_ctx) {
         ret = ffmpeg_ctx->video_stream->nb_frames;
@@ -166,7 +166,7 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
 
     lv_timer_pause(player->timer);
 
-    player->ffmpeg_ctx = ffmpeg_open_file(path, false);
+    player->ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS);
 
     if(!player->ffmpeg_ctx) {
         LV_LOG_ERROR("ffmpeg file open failed: %s", path);

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -267,7 +267,6 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
     LV_UNUSED(decoder);
 
     /* Get the source type */
-    const void * src = dsc->src;
     lv_image_src_t src_type = dsc->src_type;
 
     if(src_type == LV_IMAGE_SRC_FILE) {
@@ -684,7 +683,7 @@ static int ffmpeg_update_next_frame(struct ffmpeg_context_s * ffmpeg_ctx)
 static int ffmpeg_lvfs_read(void * ptr, uint8_t * buf, int buf_size)
 {
     lv_fs_file_t * file = ptr;
-    int bytesRead = 0;
+    uint32_t bytesRead = 0;
     lv_fs_res_t res = lv_fs_read(file, buf, buf_size, &bytesRead);
     if(bytesRead == 0)
         return AVERROR_EOF;  /* Let FFmpeg know that we have reached eof */

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -38,10 +38,14 @@
 
 #define FRAME_DEF_REFR_PERIOD   33  /*[ms]*/
 
+#define DECODER_BUFFER_SIZE (8 * 1024)
+
 /**********************
  *      TYPEDEFS
  **********************/
 struct ffmpeg_context_s {
+    AVIOContext * io_ctx;
+    lv_fs_file_t lv_file;
     AVFormatContext * fmt_ctx;
     AVCodecContext * video_dec_ctx;
     AVStream * video_stream;
@@ -75,12 +79,15 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
 
-static struct ffmpeg_context_s * ffmpeg_open_file(const char * path);
+static int ffmpeg_lvfs_read(void * ptr, uint8_t * buf, int buf_size);
+static int64_t ffmpeg_lvfs_seek(void * ptr, int64_t pos, int whence);
+static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file);
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path);
 static void ffmpeg_close(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_src_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_dst_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
 static int ffmpeg_image_allocate(struct ffmpeg_context_s * ffmpeg_ctx);
-static int ffmpeg_get_image_header(const char * path, lv_image_header_t * header);
+static int ffmpeg_get_image_header(lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 static int ffmpeg_get_frame_refr_period(struct ffmpeg_context_s * ffmpeg_ctx);
 static uint8_t * ffmpeg_get_image_data(struct ffmpeg_context_s * ffmpeg_ctx);
 static int ffmpeg_update_next_frame(struct ffmpeg_context_s * ffmpeg_ctx);
@@ -128,7 +135,7 @@ void lv_ffmpeg_init(void)
 int lv_ffmpeg_get_frame_num(const char * path)
 {
     int ret = -1;
-    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path);
+    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, false);
 
     if(ffmpeg_ctx) {
         ret = ffmpeg_ctx->video_stream->nb_frames;
@@ -159,7 +166,7 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
 
     lv_timer_pause(player->timer);
 
-    player->ffmpeg_ctx = ffmpeg_open_file(path);
+    player->ffmpeg_ctx = ffmpeg_open_file(path, false);
 
     if(!player->ffmpeg_ctx) {
         LV_LOG_ERROR("ffmpeg file open failed: %s", path);
@@ -264,9 +271,7 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
     lv_image_src_t src_type = dsc->src_type;
 
     if(src_type == LV_IMAGE_SRC_FILE) {
-        const char * fn = src;
-
-        if(ffmpeg_get_image_header(fn, header) < 0) {
+        if(ffmpeg_get_image_header(dsc, header) < 0) {
             LV_LOG_ERROR("ffmpeg can't get image header");
             return LV_RESULT_INVALID;
         }
@@ -291,7 +296,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * path = dsc->src;
 
-        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path);
+        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, &dsc->file);
 
         if(ffmpeg_ctx == NULL) {
             return LV_RESULT_INVALID;
@@ -564,18 +569,33 @@ static int ffmpeg_open_codec_context(int * stream_idx,
     return 0;
 }
 
-static int ffmpeg_get_image_header(const char * filepath,
+static int ffmpeg_get_image_header(lv_image_decoder_dsc_t * dsc,
                                    lv_image_header_t * header)
 {
     int ret = -1;
 
     AVFormatContext * fmt_ctx = NULL;
     AVCodecContext * video_dec_ctx = NULL;
+    AVIOContext * io_ctx = NULL;
     int video_stream_idx;
 
+    io_ctx = ffmpeg_open_io_context(&dsc->file);
+    if(io_ctx == NULL) {
+        LV_LOG_ERROR("io_ctx malloc failed");
+        return ret;
+    }
+
+    fmt_ctx = avformat_alloc_context();
+    if(fmt_ctx == NULL) {
+        LV_LOG_ERROR("fmt_ctx malloc failed");
+        goto failed;
+    }
+    fmt_ctx->pb = io_ctx;
+    fmt_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
     /* open input file, and allocate format context */
-    if(avformat_open_input(&fmt_ctx, filepath, NULL, NULL) < 0) {
-        LV_LOG_ERROR("Could not open source file %s", filepath);
+    if(avformat_open_input(&fmt_ctx, (const char *)dsc->src, NULL, NULL) < 0) {
+        LV_LOG_ERROR("Could not open source file %s", (const char *)dsc->src);
         goto failed;
     }
 
@@ -602,7 +622,10 @@ static int ffmpeg_get_image_header(const char * filepath,
 failed:
     avcodec_free_context(&video_dec_ctx);
     avformat_close_input(&fmt_ctx);
-
+    if(io_ctx != NULL) {
+        av_free(io_ctx->buffer);
+        av_free(io_ctx);
+    }
     return ret;
 }
 
@@ -658,7 +681,48 @@ static int ffmpeg_update_next_frame(struct ffmpeg_context_s * ffmpeg_ctx)
     return ret;
 }
 
-struct ffmpeg_context_s * ffmpeg_open_file(const char * path)
+static int ffmpeg_lvfs_read(void * ptr, uint8_t * buf, int buf_size)
+{
+    lv_fs_file_t * file = ptr;
+    int bytesRead = 0;
+    lv_fs_res_t res = lv_fs_read(file, buf, buf_size, &bytesRead);
+    if(bytesRead == 0)
+        return AVERROR_EOF;  /* Let FFmpeg know that we have reached eof */
+    if(res != LV_FS_RES_OK)
+        return AVERROR_EOF;
+    return bytesRead;
+}
+
+static int64_t ffmpeg_lvfs_seek(void * ptr, int64_t pos, int whence)
+{
+    lv_fs_file_t * file = ptr;
+    if(whence == SEEK_SET && lv_fs_seek(file, pos, SEEK_SET) == LV_FS_RES_OK) {
+        return pos;
+    }
+    return -1;
+}
+
+static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file)
+{
+    uint8_t * iBuffer = av_malloc(DECODER_BUFFER_SIZE);
+    if(iBuffer == NULL) {
+        LV_LOG_ERROR("iBuffer malloc failed");
+        return NULL;
+    }
+    AVIOContext * pIOCtx = avio_alloc_context(iBuffer, DECODER_BUFFER_SIZE,   /* internal Buffer and its size */
+                                              0,                                   /* bWriteable (1=true,0=false) */
+                                              file,                                /* user data ; will be passed to our callback functions */
+                                              ffmpeg_lvfs_read,                    /* Read callback function */
+                                              0,                                   /* Write callback function */
+                                              ffmpeg_lvfs_seek);                   /* Seek callback function */
+    if(pIOCtx == NULL) {
+        av_free(iBuffer);
+        return NULL;
+    }
+    return pIOCtx;
+}
+
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path)
 {
     if(path == NULL || lv_strlen(path) == 0) {
         LV_LOG_ERROR("file path is empty");
@@ -670,6 +734,25 @@ struct ffmpeg_context_s * ffmpeg_open_file(const char * path)
     if(ffmpeg_ctx == NULL) {
         LV_LOG_ERROR("ffmpeg_ctx malloc failed");
         goto failed;
+    }
+
+    if(is_lv_fs_path) {
+        lv_fs_open(&(ffmpeg_ctx->lv_file), path, LV_FS_MODE_RD);    /* image_decoder_get_info says the file truly exists. */
+
+        ffmpeg_ctx->io_ctx = ffmpeg_open_io_context(&(ffmpeg_ctx->lv_file));     /* Save the buffer pointer to free it later */
+
+        if(ffmpeg_ctx->io_ctx == NULL) {
+            LV_LOG_ERROR("io_ctx malloc failed");
+            goto failed;
+        }
+
+        ffmpeg_ctx->fmt_ctx = avformat_alloc_context();
+        if(ffmpeg_ctx->fmt_ctx == NULL) {
+            LV_LOG_ERROR("fmt_ctx malloc failed");
+            goto failed;
+        }
+        ffmpeg_ctx->fmt_ctx->pb = ffmpeg_ctx->io_ctx;
+        ffmpeg_ctx->fmt_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
     }
 
     /* open input file, and allocate format context */
@@ -799,6 +882,11 @@ static void ffmpeg_close(struct ffmpeg_context_s * ffmpeg_ctx)
     sws_freeContext(ffmpeg_ctx->sws_ctx);
     ffmpeg_close_src_ctx(ffmpeg_ctx);
     ffmpeg_close_dst_ctx(ffmpeg_ctx);
+    if(ffmpeg_ctx->io_ctx != NULL) {
+        av_free(ffmpeg_ctx->io_ctx->buffer);
+        av_free(ffmpeg_ctx->io_ctx);
+        lv_fs_close(&(ffmpeg_ctx->lv_file));
+    }
     free(ffmpeg_ctx);
 
     LV_LOG_INFO("ffmpeg_ctx closed");

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -295,7 +295,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * path = dsc->src;
 
-        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, &dsc->file);
+        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, true);
 
         if(ffmpeg_ctx == NULL) {
             return LV_RESULT_INVALID;

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -60,7 +60,6 @@ lv_obj_t * lv_ffmpeg_player_create(lv_obj_t * parent);
 
 /**
  * Set the path of the file to be played.
- * FFmpeg player doesn't use LVGL's File System API.
  * @param obj pointer to a ffmpeg_player object
  * @param path video file path
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info.

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -59,7 +59,8 @@ int lv_ffmpeg_get_frame_num(const char * path);
 lv_obj_t * lv_ffmpeg_player_create(lv_obj_t * parent);
 
 /**
- * Set the path of the file to be played
+ * Set the path of the file to be played.
+ * FFmpeg player doesn't use LVGL's File System API.
  * @param obj pointer to a ffmpeg_player object
  * @param path video file path
  * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't get the info.

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2956,6 +2956,20 @@
             #define LV_FFMPEG_DUMP_FORMAT 0
         #endif
     #endif
+    /** Use lvgl file path in FFmpeg Player widget 
+     *  You won't be able to open URLs after enabling this feature.
+     *  Note that FFmpeg image decoder will always use lvgl file system. */
+    #ifndef LV_FFMPEG_PLAYER_USE_LV_FS
+        #ifdef LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
+                #define LV_FFMPEG_PLAYER_USE_LV_FS CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
+            #else
+                #define LV_FFMPEG_PLAYER_USE_LV_FS 0
+            #endif
+        #else
+            #define LV_FFMPEG_PLAYER_USE_LV_FS 0
+        #endif
+    #endif
 #endif
 
 /*==================

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -2960,12 +2960,8 @@
      *  You won't be able to open URLs after enabling this feature.
      *  Note that FFmpeg image decoder will always use lvgl file system. */
     #ifndef LV_FFMPEG_PLAYER_USE_LV_FS
-        #ifdef LV_KCONFIG_PRESENT
-            #ifdef CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
-                #define LV_FFMPEG_PLAYER_USE_LV_FS CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
-            #else
-                #define LV_FFMPEG_PLAYER_USE_LV_FS 0
-            #endif
+        #ifdef CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
+            #define LV_FFMPEG_PLAYER_USE_LV_FS CONFIG_LV_FFMPEG_PLAYER_USE_LV_FS
         #else
             #define LV_FFMPEG_PLAYER_USE_LV_FS 0
         #endif


### PR DESCRIPTION
#7191 , but use AVIO for better compatibility.  

@FASTSHIFT 

**Edit:**
Tested with .jpg .png on linux 5.10 
| library | version |
|---|---|
| libavutil | 56.70.100 |
| libavcodec | 58.134.100 |
| libavformat | 58.76.100 |
| libswscale | 5.9.100 |


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
