### PR TITLE
fix(sw_blend): only assign to mask_stride when it is initialized

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c
@@ -200,7 +200,6 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_al88(lv_draw_sw_blend_fill_
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t dest_stride = dsc->dest_stride;
 
     lv_color_mix_alpha_cache_t cache;
@@ -208,15 +207,6 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_al88(lv_draw_sw_blend_fill_
 
     int32_t x;
     int32_t y;
-
-    LV_UNUSED(w);
-    LV_UNUSED(h);
-    LV_UNUSED(x);
-    LV_UNUSED(y);
-    LV_UNUSED(opa);
-    LV_UNUSED(mask);
-    LV_UNUSED(mask_stride);
-    LV_UNUSED(dest_stride);
 
     /*Simple fill*/
     if(mask == NULL && opa >= LV_OPA_MAX) {
@@ -273,6 +263,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_al88(lv_draw_sw_blend_fill_
     }
     /*Masked with full opacity*/
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_AL88_WITH_MASK(dsc)) {
             lv_color16a_t color16a;
             color16a.lumi = lv_color_luminance(dsc->color);
@@ -290,6 +281,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_al88(lv_draw_sw_blend_fill_
     }
     /*Masked with opacity*/
     else {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_AL88_MIX_MASK_OPA(dsc)) {
             lv_color16a_t color16a;
             color16a.lumi = lv_color_luminance(dsc->color);
@@ -362,7 +354,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -397,6 +388,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -412,6 +404,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -427,6 +420,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             for(y = 0; y < h; y++) {
                 for(x = 0; x < w; x++) {
                     lv_color16a_t src_color;
@@ -455,7 +449,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -490,6 +483,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -505,6 +499,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -529,7 +524,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_color.alpha = LV_OPA_MIX2(mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_al88[x], src_color, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_al88 = drawbuf_next_row(dest_buf_al88, dest_stride);
             src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
         }
@@ -548,7 +543,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -581,6 +575,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -595,6 +590,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -617,7 +613,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
                 else src_color.alpha = LV_OPA_MIX3(src_color.alpha, mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_al88[x], src_color, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_al88 = drawbuf_next_row(dest_buf_al88, dest_stride);
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
         }
@@ -636,7 +632,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const lv_color16_t * src_buf_c16 = (const lv_color16_t *)dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -671,6 +666,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -686,6 +682,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -710,7 +707,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
                 else src_color.alpha = LV_OPA_MIX2(mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_al88[x], src_color, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_al88 = drawbuf_next_row(dest_buf_al88, dest_stride);
             src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
         }
@@ -732,7 +729,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -770,6 +766,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -786,6 +783,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -812,7 +810,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
                 blend_non_normal_pixel(&dest_buf_al88[dest_x], src_color, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_al88 = drawbuf_next_row(dest_buf_al88, dest_stride);
             src_buf_u8 += src_stride;
         }
@@ -833,7 +831,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const lv_color32_t * src_buf_c32 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color_mix_alpha_cache_t cache;
     lv_color_mix_with_alpha_cache_init(&cache);
@@ -871,6 +868,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_AL88_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -886,6 +884,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_AL88_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -911,7 +910,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 else src_color.alpha = LV_OPA_MIX3(src_color.alpha, mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_al88[x], src_color, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_al88 = drawbuf_next_row(dest_buf_al88, dest_stride);
             src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
         }

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
@@ -212,7 +212,6 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_argb8888(lv_draw_sw_blend_f
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t dest_stride = dsc->dest_stride;
 
     lv_color_mix_alpha_cache_t cache;
@@ -220,15 +219,6 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_argb8888(lv_draw_sw_blend_f
 
     int32_t x;
     int32_t y;
-
-    LV_UNUSED(w);
-    LV_UNUSED(h);
-    LV_UNUSED(x);
-    LV_UNUSED(y);
-    LV_UNUSED(opa);
-    LV_UNUSED(mask);
-    LV_UNUSED(mask_stride);
-    LV_UNUSED(dest_stride);
 
     /*Simple fill*/
     if(mask == NULL && opa >= LV_OPA_MAX) {
@@ -283,6 +273,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_argb8888(lv_draw_sw_blend_f
     }
     /*Masked with full opacity*/
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_ARGB8888_WITH_MASK(dsc)) {
             lv_color32_t color_argb = lv_color_to_32(dsc->color, 0xff);
             lv_color32_t * dest_buf = dsc->dest_buf;
@@ -300,6 +291,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_argb8888(lv_draw_sw_blend_f
     }
     /*Masked with opacity*/
     else {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
             lv_color32_t color_argb = lv_color_to_32(dsc->color, opa);
             lv_color32_t * dest_buf = dsc->dest_buf;
@@ -372,7 +364,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -407,6 +398,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -420,6 +412,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -446,7 +439,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_c32[dest_x], src_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf_i1 = drawbuf_next_row(src_buf_i1, src_stride);
         }
@@ -465,7 +458,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -501,6 +493,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -514,6 +507,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -540,7 +534,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
                 else src_argb.alpha = LV_OPA_MIX3(src_buf_al88[src_x].alpha, mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_c32[dest_x], src_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
         }
@@ -561,7 +555,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -594,6 +587,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -606,6 +600,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -631,7 +626,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_c32[dest_x], src_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
         }
@@ -652,7 +647,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const lv_color16_t * src_buf_c16 = (const lv_color16_t *) dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color32_t color_argb;
     lv_color_mix_alpha_cache_t cache;
@@ -687,6 +681,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -703,6 +698,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -730,7 +726,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_c32[x], src_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
         }
@@ -752,7 +748,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color32_t color_argb;
     lv_color_mix_alpha_cache_t cache;
@@ -808,6 +803,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
         }
         if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc, src_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
@@ -824,6 +820,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc, src_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
@@ -852,7 +849,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
                 blend_non_normal_pixel(&dest_buf_c32[dest_x], src_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf = drawbuf_next_row(src_buf, src_stride);
         }
@@ -871,7 +868,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const lv_color32_t * src_buf_c32 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     lv_color32_t color_argb;
     lv_color_mix_alpha_cache_t cache;
@@ -906,6 +902,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_ARGB8888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -920,6 +917,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_ARGB8888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -942,7 +940,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 else color_argb.alpha = LV_OPA_MIX3(color_argb.alpha, mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_c32[x], color_argb, dsc->blend_mode, &cache);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_c32 = drawbuf_next_row(dest_buf_c32, dest_stride);
             src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
         }

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
@@ -206,7 +206,6 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_i1(lv_draw_sw_blend_fill_ds
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t dest_stride = dsc->dest_stride;
 
     uint8_t src_color = lv_color_luminance(dsc->color) / (I1_LUM_THRESHOLD + 1);
@@ -251,6 +250,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_i1(lv_draw_sw_blend_fill_ds
     }
     /* Masked with full opacity */
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_I1_WITH_MASK(dsc)) {
             for(int32_t y = 0; y < h; y++) {
                 for(int32_t x = 0; x < w; x++) {
@@ -283,6 +283,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_i1(lv_draw_sw_blend_fill_ds
     }
     /* Masked with opacity */
     else {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_I1_MIX_MASK_OPA(dsc)) {
             for(int32_t y = 0; y < h; y++) {
                 for(int32_t x = 0; x < w; x++) {
@@ -362,7 +363,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -407,6 +407,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -428,6 +429,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -462,7 +464,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(dest_buf_i1, dest_x + bit_ofs, src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_i1 = drawbuf_next_row(dest_buf_i1, dest_stride);
             src_buf_i1 = drawbuf_next_row(src_buf_i1, src_stride);
         }
@@ -480,7 +482,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t src_x, dest_x;
     int32_t y;
@@ -523,6 +524,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -543,6 +545,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -574,7 +577,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[src_x], opa);
                 blend_non_normal_pixel(dest_buf_i1, src_x + bit_ofs, src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_i1 = drawbuf_next_row(dest_buf_i1, dest_stride);
             src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
         }
@@ -593,7 +596,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -639,6 +641,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -658,6 +661,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -688,7 +692,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
                 else src_argb.alpha = LV_OPA_MIX3(src_buf_al88[src_x].alpha, mask_buf[src_x], opa);
                 blend_non_normal_pixel(dest_buf_i1, dest_x + bit_ofs, src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_i1 = drawbuf_next_row(dest_buf_i1, dest_stride);
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
         }
@@ -707,7 +711,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const lv_color32_t * src_buf_c32 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t x;
     int32_t y;
@@ -754,6 +757,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -774,6 +778,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -802,7 +807,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 else color_argb.alpha = LV_OPA_MIX3(color_argb.alpha, mask_buf[x], opa);
                 blend_non_normal_pixel(dest_buf_i1, x + bit_ofs, color_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_i1 = drawbuf_next_row(dest_buf_i1, dest_stride);
             src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
         }
@@ -822,7 +827,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf_rgb888 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -870,6 +874,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -891,6 +896,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -923,7 +929,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
                     blend_non_normal_pixel(dest_buf_i1, dest_x + bit_ofs, src_argb, dsc->blend_mode);
                 }
-                if(mask_buf) mask_buf += mask_stride;
+                if(mask_buf) mask_buf += dsc->mask_stride;
                 dest_buf_i1 = drawbuf_next_row(dest_buf_i1, dest_stride);
                 src_buf_rgb888 = drawbuf_next_row(src_buf_rgb888, src_stride);
             }
@@ -943,7 +949,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const lv_color16_t * src_buf_c16 = (const lv_color16_t *)dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t bit_ofs = dsc->relative_area.x1 % 8;
 
     int32_t src_x;
@@ -988,6 +993,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_I1_WITH_MASK(dsc)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -1009,6 +1015,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX)  {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_I1_MIX_MASK_OPA(dsc)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -1042,7 +1049,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
 
                 blend_non_normal_pixel(dest_buf_u8, dest_x + bit_ofs, src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 = drawbuf_next_row(dest_buf_u8, dest_stride);
             src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
         }

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
@@ -184,20 +184,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_l8(lv_draw_sw_blend_fill_ds
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t dest_stride = dsc->dest_stride;
 
     int32_t x;
     int32_t y;
-
-    LV_UNUSED(w);
-    LV_UNUSED(h);
-    LV_UNUSED(x);
-    LV_UNUSED(y);
-    LV_UNUSED(opa);
-    LV_UNUSED(mask);
-    LV_UNUSED(mask_stride);
-    LV_UNUSED(dest_stride);
 
     /*Simple fill*/
     if(mask == NULL && opa >= LV_OPA_MAX) {
@@ -251,6 +241,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_l8(lv_draw_sw_blend_fill_ds
     }
     /*Masked with full opacity*/
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_L8_WITH_MASK(dsc)) {
             uint8_t color8 = lv_color_luminance(dsc->color);
             uint8_t * dest_buf = dsc->dest_buf;
@@ -266,6 +257,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_l8(lv_draw_sw_blend_fill_ds
     }
     /*Masked with opacity*/
     else {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_L8_MIX_MASK_OPA(dsc)) {
             uint8_t color8 = lv_color_luminance(dsc->color);
             uint8_t * dest_buf = dsc->dest_buf;
@@ -337,7 +329,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -369,6 +360,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_L8_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -382,6 +374,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -406,7 +399,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_l8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_l8 = drawbuf_next_row(dest_buf_l8, dest_stride);
             src_buf_i1 = drawbuf_next_row(src_buf_i1, src_stride);
         }
@@ -424,7 +417,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -452,6 +444,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_L8_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -464,6 +457,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -487,7 +481,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_l8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_l8 = drawbuf_next_row(dest_buf_l8, dest_stride);
             src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
         }
@@ -506,7 +500,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -536,6 +529,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_L8_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -549,6 +543,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x++, src_x++) {
@@ -573,7 +568,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_l8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_l8 = drawbuf_next_row(dest_buf_l8, dest_stride);
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
         }
@@ -594,7 +589,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const lv_color16_t * src_buf_c16 = (const lv_color16_t *)dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t src_x;
     int32_t dest_x;
@@ -624,6 +618,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_L8_WITH_MASK(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(src_x = 0, dest_x = 0; src_x < w; dest_x++, src_x++) {
@@ -636,6 +631,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(src_x = 0, dest_x = 0; src_x < w; dest_x++, src_x++) {
@@ -659,7 +655,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[src_x], opa);
                 blend_non_normal_pixel(&dest_buf_u8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 += dest_stride;
             src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
         }
@@ -681,7 +677,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -712,6 +707,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_L8_WITH_MASK(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -725,6 +721,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -750,7 +747,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
                 blend_non_normal_pixel(&dest_buf_l8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_l8 += dest_stride;
             src_buf_u8 += src_stride;
         }
@@ -771,7 +768,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const lv_color32_t * src_buf_c32 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t x;
     int32_t y;
@@ -800,6 +796,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_L8_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -812,6 +809,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_L8_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -833,7 +831,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 else color_argb.alpha = LV_OPA_MIX3(color_argb.alpha, mask_buf[x], opa);
                 blend_non_normal_pixel(&dest_buf_l8[x], color_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_l8 = drawbuf_next_row(dest_buf_l8, dest_stride);
             src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
         }

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -215,23 +215,11 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565(lv_draw_sw_blend_fil
     uint16_t color16 = lv_color_to_u16(dsc->color);
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
     int32_t dest_stride = dsc->dest_stride;
 
     int32_t x;
     int32_t y;
-
-    LV_UNUSED(w);
-    LV_UNUSED(h);
-    LV_UNUSED(x);
-    LV_UNUSED(y);
-    LV_UNUSED(opa);
-    LV_UNUSED(mask);
-    LV_UNUSED(color16);
-    LV_UNUSED(mask_stride);
-    LV_UNUSED(dest_stride);
-    LV_UNUSED(dest_buf_u16);
 
     /*Simple fill*/
     if(mask == NULL && opa >= LV_OPA_MAX)  {
@@ -316,6 +304,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565(lv_draw_sw_blend_fil
 
     /*Masked with full opacity*/
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_RGB565_WITH_MASK(dsc)) {
             for(y = 0; y < h; y++) {
                 x = 0;
@@ -347,6 +336,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565(lv_draw_sw_blend_fil
     }
     /*Masked with opacity*/
     else if(mask && opa < LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_RGB565_MIX_MASK_OPA(dsc)) {
             for(y = 0; y < h; y++) {
                 for(x = 0; x < w; x++) {
@@ -416,7 +406,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -448,6 +437,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc)) {
 
                 for(y = 0; y < h; y++) {
@@ -462,6 +452,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x++) {
@@ -516,7 +507,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
 
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_i1 = drawbuf_next_row(src_buf_i1, src_stride);
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
     }
 }
@@ -533,7 +524,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -564,6 +554,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x++) {
@@ -577,6 +568,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_AL88_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x++) {
@@ -632,7 +624,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
 
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
     }
 }
@@ -651,7 +643,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -681,6 +672,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x++) {
@@ -693,6 +685,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x++) {
@@ -747,7 +740,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
 
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_l8 += src_stride;
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
     }
 }
@@ -764,7 +757,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const uint16_t * src_buf_u16 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t x;
     int32_t y;
@@ -792,6 +784,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -804,6 +797,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(x = 0; x < w; x++) {
@@ -857,7 +851,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
 
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
     }
 }
@@ -874,7 +868,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -906,6 +899,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc, src_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
@@ -918,6 +912,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc, src_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
@@ -966,7 +961,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_u8 += src_stride;
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
 
     }
@@ -986,7 +981,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const uint8_t * src_buf_u8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -1017,6 +1011,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_RGB565_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += 4) {
@@ -1030,6 +1025,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_RGB565_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += 4) {
@@ -1084,7 +1080,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
 
             dest_buf_u16 = drawbuf_next_row(dest_buf_u16, dest_stride);
             src_buf_u8 += src_stride;
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
         }
     }
 }

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c
@@ -187,20 +187,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb888(lv_draw_sw_blend_fil
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     const lv_opa_t * mask = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
     int32_t dest_stride = dsc->dest_stride;
 
     int32_t x;
     int32_t y;
-
-    LV_UNUSED(w);
-    LV_UNUSED(h);
-    LV_UNUSED(x);
-    LV_UNUSED(y);
-    LV_UNUSED(opa);
-    LV_UNUSED(mask);
-    LV_UNUSED(mask_stride);
-    LV_UNUSED(dest_stride);
 
     /*Simple fill*/
     if(mask == NULL && opa >= LV_OPA_MAX) {
@@ -274,6 +264,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb888(lv_draw_sw_blend_fil
     }
     /*Masked with full opacity*/
     else if(mask && opa >= LV_OPA_MAX) {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_RGB888_WITH_MASK(dsc, dest_px_size)) {
             uint32_t color32 = lv_color_to_u32(dsc->color);
             uint8_t * dest_buf = dsc->dest_buf;
@@ -291,6 +282,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb888(lv_draw_sw_blend_fil
     }
     /*Masked with opacity*/
     else {
+        int32_t mask_stride = dsc->mask_stride;
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size)) {
             uint32_t color32 = lv_color_to_u32(dsc->color);
             uint8_t * dest_buf = dsc->dest_buf;
@@ -366,7 +358,6 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_i1 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -400,6 +391,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_888_WITH_MASK(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -413,6 +405,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_I1_BLEND_NORMAL_TO_888_MIX_MASK_OPA(dsc)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -437,7 +430,7 @@ static void LV_ATTRIBUTE_FAST_MEM i1_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[src_x], opa);
                 blend_non_normal_pixel(&dest_buf_u8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 = drawbuf_next_row(dest_buf_u8, dest_stride);
             src_buf_i1 = drawbuf_next_row(src_buf_i1, src_stride);
         }
@@ -456,7 +449,6 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
     const lv_color16a_t * src_buf_al88 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -486,6 +478,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888_WITH_MASK(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -499,6 +492,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -521,7 +515,7 @@ static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t 
                 else src_argb.alpha = LV_OPA_MIX3(src_buf_al88[src_x].alpha, mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_u8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 += dest_stride;
             src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
         }
@@ -542,7 +536,6 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
     const uint8_t * src_buf_l8 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -574,6 +567,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888_WITH_MASK(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -586,6 +580,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -609,7 +604,7 @@ static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * 
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
                 blend_non_normal_pixel(&dest_buf_u8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 += dest_stride;
             src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
         }
@@ -630,7 +625,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     const lv_color16_t * src_buf_c16 = (const lv_color16_t *) dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t src_x;
     int32_t dest_x;
@@ -666,6 +660,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_RGB888_WITH_MASK(dsc, dest_px_size)) {
                 uint8_t res[3];
                 for(y = 0; y < h; y++) {
@@ -682,6 +677,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         else {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size)) {
                 uint8_t res[3];
                 for(y = 0; y < h; y++) {
@@ -709,7 +705,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
                 else src_argb.alpha = LV_OPA_MIX2(mask_buf[src_x], opa);
                 blend_non_normal_pixel(&dest_buf_u8[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf_u8 += dest_stride;
             src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
         }
@@ -729,7 +725,6 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
     const uint8_t * src_buf = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -771,6 +766,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_RGB888_WITH_MASK(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -784,6 +780,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
             }
         }
         if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_RGB888_BLEND_NORMAL_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size, src_px_size)) {
                 uint32_t mask_x;
                 for(y = 0; y < h; y++) {
@@ -809,7 +806,7 @@ static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_
 
                 blend_non_normal_pixel(&dest_buf[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf += dest_stride;
             src_buf += src_stride;
         }
@@ -828,7 +825,6 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     const lv_color32_t * src_buf_c32 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
-    int32_t mask_stride = dsc->mask_stride;
 
     int32_t dest_x;
     int32_t src_x;
@@ -858,6 +854,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa >= LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_RGB888_WITH_MASK(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -871,6 +868,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
             }
         }
         else if(mask_buf && opa < LV_OPA_MAX) {
+            int32_t mask_stride = dsc->mask_stride;
             if(LV_RESULT_INVALID == LV_DRAW_SW_ARGB8888_BLEND_NORMAL_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size)) {
                 for(y = 0; y < h; y++) {
                     for(dest_x = 0, src_x = 0; src_x < w; dest_x += dest_px_size, src_x++) {
@@ -894,7 +892,7 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
 
                 blend_non_normal_pixel(&dest_buf[dest_x], src_argb, dsc->blend_mode);
             }
-            if(mask_buf) mask_buf += mask_stride;
+            if(mask_buf) mask_buf += dsc->mask_stride;
             dest_buf += dest_stride;
             src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
         }


### PR DESCRIPTION
In the various lv_draw_sw_blend_to_*.c files, an assignment is made to the mask_stride variable but for some calls to these functions, the variable has not been initialized.  Change the code to defer the assignment to the paths where the mask_stride has been initialized.

This issue was detected by a static code analysis tool, but it is sort of a "false positive".  The paths that do not initialize mask_stride do not use it either, so the "garbage" value of mask_stride did not affect the operation of the code. 

An alternative simpler fix would be to always initialize "mask_stride" in the lv_draw_sw_blend() routine, so that it has a non-garbage value for all paths for the code.