### PR TITLE
fix(style): remove style reset sentinel assigned

### DIFF
--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -193,9 +193,6 @@ void lv_style_reset(lv_style_t * style)
 
     if(style->prop_cnt != 255) lv_free(style->values_and_props);
     lv_memzero(style, sizeof(lv_style_t));
-#if LV_USE_ASSERT_STYLE
-    style->sentinel = LV_STYLE_SENTINEL_VALUE;
-#endif
 }
 
 lv_style_prop_t lv_style_register_prop(uint8_t flag)


### PR DESCRIPTION
When the style is reset, the style is invalid and `LV_STYLE_SENTINEL_VALUE` should not be assigned. This can detect this situation:

```c
void style_double_reset(void)
{
    static lv_style_t style;
    lv_style_init(&style);
    lv_style_reset(&style);
    lv_style_reset(&style);
}
```

```bash
[Error] (0.875, +875)    lv_style_reset: Asserted at expression: style->sentinel == LV_STYLE_SENTINEL_VALUE (Style is not initialized or corrupted) lv_style.c:192
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
