### PR TITLE
fix(draw):  fix bug introduced by PR #6638

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -880,7 +880,7 @@ bool lv_obj_area_is_visible(const lv_obj_t * obj, lv_area_t * area)
     if(!lv_area_intersect(area, area, &obj_coords)) return false;
 
     if(!is_transformed(obj)) {
-        *area = obj->coords;
+        *area = obj_coords;
     }
     else {
         lv_obj_get_transformed_area(obj, area, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);


### PR DESCRIPTION
PR #6638 introduced a bug that caused issue #7230.  This bug was found by @kisvegabor and is tested by myself under `lvgl/lv_port_pc_visual_studio` and it resolves both the issue seen with the Knob as well as with the Roller Widget display updates after the Widget's value has been changed.  (It is probable that there were other Widgets impacted, but these were the only ones I was aware of.)  This PR was not requested, but since I already had it on my screen, and since I did not see a fix already submitted for it, I am submitting it here.

Resolves #7230

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  n/a
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).  Unable.
