### PR TITLE
fix(init): remove double call to lv_draw_sw_deinit

### DIFF
--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -384,10 +384,6 @@ void lv_deinit(void)
     lv_span_stack_deinit();
 #endif
 
-#if LV_USE_DRAW_SW
-    lv_draw_sw_deinit();
-#endif
-
 #if LV_USE_FREETYPE
     lv_freetype_uninit();
 #endif

--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -176,6 +176,8 @@ lv_result_t lv_mutex_unlock(lv_mutex_t * pxMutex)
 
 lv_result_t lv_mutex_delete(lv_mutex_t * pxMutex)
 {
+    if(pxMutex->xIsInitialized == pdFALSE)
+        return LV_RESULT_INVALID;
     vSemaphoreDelete(pxMutex->xMutex);
     pxMutex->xIsInitialized = pdFALSE;
 


### PR DESCRIPTION

Calling lv_deinit() with LV_USE_DRAW_SW= 1, LV_DRAW_SW_COMPLEX = 1 and LV_USE_OS = LV_OS_FREERTOS will end up calling lw_draw_sw_deinit() twice (cfr. lv_init.c, lines367 and lines 407); this makes the mutex deinit fail, because the lv_mutex_delete() is not checking for pxMutex->xIsInitialized being already pdFALSE.
