### PR TITLE
fix(draw): fix incorrect clip area computation when clearing transparent framebuffers

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -770,9 +770,7 @@ static void refr_configured_layer(lv_layer_t * layer)
     }
     /*If the screen is transparent initialize it when the flushing is ready*/
     if(lv_color_format_has_alpha(disp_refr->color_format)) {
-        lv_area_t clear_area;
-        lv_area_set(&clear_area, layer->_clip_area.x1, layer->_clip_area.y1,
-                    layer->_clip_area.x2, layer->_clip_area.y2);
+        lv_area_t clear_area = layer->_clip_area;
         lv_area_move(&clear_area, -layer->buf_area.x1, -layer->buf_area.y1);
         lv_draw_buf_clear(layer->draw_buf, &clear_area);
     }

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -770,7 +770,11 @@ static void refr_configured_layer(lv_layer_t * layer)
     }
     /*If the screen is transparent initialize it when the flushing is ready*/
     if(lv_color_format_has_alpha(disp_refr->color_format)) {
-        lv_draw_buf_clear(layer->draw_buf, &layer->_clip_area);
+        lv_area_t clear_area;
+        lv_area_set(&clear_area, layer->_clip_area.x1, layer->_clip_area.y1,
+                    layer->_clip_area.x2, layer->_clip_area.y2);
+        lv_area_move(&clear_area, -layer->buf_area.x1, -layer->buf_area.y1);
+        lv_draw_buf_clear(layer->draw_buf, &clear_area);
     }
 
     lv_obj_t * top_act_scr = NULL;


### PR DESCRIPTION
Fixes #7268.

Fixes incorrect clip area computation when clearing the framebuffer of transparent screens.

This is especially an issue with partial renders, as the framebuffer duplicates content into the next writes. This can be seen here:

Screenshot without the fix:
![384604453-59c5913e-86c7-4b08-bba1-865e11487207](https://github.com/user-attachments/assets/d85c101c-a8f4-4cca-abf3-f867d3109c13)

Screenshot with the fix:
![image](https://github.com/user-attachments/assets/4cf118ce-5a69-4416-9f8d-aa3bc88cb1f1)
