### PR TITLE
feat(scroll): user-defined scrollbar length using LV_STYLE_LENGTH

### DIFF
--- a/docs/details/base-widget/scroll.rst
+++ b/docs/details/base-widget/scroll.rst
@@ -74,8 +74,23 @@ can be set directly on the :cpp:enumerator:`LV_PART_SCROLLBAR` part of a Widget 
 the Widget's or any parent's main part to make a scrollbar inherit the
 base direction.
 
-``pad_left/right/top/bottom`` sets the spacing around the scrollbars and
-``width`` sets the scrollbar's width.
+``pad_left/right/top/bottom`` sets the spacing around the scrollbars,
+``width`` sets the scrollbar's width and ``length`` sets the scrollbar's length:
+
+.. code-block:: c
+
+   static lv_style_t style_scrollbar;
+   lv_style_init(&style_scrollbar);
+   lv_style_set_pad_left(&style_scrollbar, 2);
+   lv_style_set_pad_right(&style_scrollbar, 2);
+   lv_style_set_pad_top(&style_scrollbar, 2);
+   lv_style_set_pad_bottom(&style_scrollbar, 2);
+   lv_style_set_width(&style_scrollbar, 10);
+   lv_style_set_length(&style_scrollbar, 50);
+
+   ...
+
+   lv_obj_add_style(widget, &style_scrollbar, LV_PART_SCROLLBAR);
 
 
 .. _scroll_events:

--- a/docs/details/base-widget/scroll.rst
+++ b/docs/details/base-widget/scroll.rst
@@ -92,6 +92,9 @@ base direction.
 
    lv_obj_add_style(widget, &style_scrollbar, LV_PART_SCROLLBAR);
 
+The minimum length of the scrollbar is fixed to 10, while its maximum length is limited by the
+Widget's height or width, depending on whether the scrollbar is vertical or horizontal. Any length value
+set outside of these limits will automatically result in a length fixed to either limit.
 
 .. _scroll_events:
 

--- a/docs/details/base-widget/scroll.rst
+++ b/docs/details/base-widget/scroll.rst
@@ -76,7 +76,7 @@ base direction.
 
 ``pad_left/right/top/bottom`` sets the spacing around the scrollbars,
 ``width`` sets the scrollbar's width and ``length`` sets the scrollbar's length:
-
+If `length` is not set or left at `0` the scrollbar's length will be set automatically according to the length of the content.  
 .. code-block:: c
 
    static lv_style_t style_scrollbar;

--- a/examples/scroll/lv_example_scroll_4.c
+++ b/examples/scroll/lv_example_scroll_4.c
@@ -39,6 +39,7 @@ void lv_example_scroll_4(void)
     static lv_style_t style;
     lv_style_init(&style);
     lv_style_set_width(&style, 4);      /*Width of the scrollbar*/
+    lv_style_set_length(&style, 20);    /*Length of the scrollbar*/
     lv_style_set_pad_right(&style, 5);  /*Space from the parallel side*/
     lv_style_set_pad_top(&style, 5);    /*Space from the perpendicular side*/
 

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -504,6 +504,7 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
     int32_t left_space = lv_obj_get_style_pad_left(obj, LV_PART_SCROLLBAR);
     int32_t right_space = lv_obj_get_style_pad_right(obj, LV_PART_SCROLLBAR);
     int32_t thickness = lv_obj_get_style_width(obj, LV_PART_SCROLLBAR);
+    int32_t length = lv_obj_get_style_length(obj, LV_PART_SCROLLBAR);
 
     int32_t obj_h = lv_obj_get_height(obj);
     int32_t obj_w = lv_obj_get_width(obj);
@@ -533,7 +534,8 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
         }
 
         int32_t sb_h = ((obj_h - top_space - bottom_space - hor_req_space) * obj_h) / content_h;
-        sb_h = LV_MAX(sb_h, SCROLLBAR_MIN_SIZE);
+        sb_h = LV_MAX(length > 0 ? length : sb_h, SCROLLBAR_MIN_SIZE); /*Style-defined size, calculated size, or minimum size*/
+        sb_h = LV_MIN(sb_h, obj_h); /*Limit scrollbar length to parent height*/
         rem = (obj_h - top_space - bottom_space - hor_req_space) -
               sb_h;  /*Remaining size from the scrollbar track that is not the scrollbar itself*/
         int32_t scroll_h = content_h - obj_h; /*The size of the content which can be really scrolled*/
@@ -571,7 +573,8 @@ void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t *
         hor_area->x2 = obj->coords.x2;
 
         int32_t sb_w = ((obj_w - left_space - right_space - ver_reg_space) * obj_w) / content_w;
-        sb_w = LV_MAX(sb_w, SCROLLBAR_MIN_SIZE);
+        sb_w = LV_MAX(length > 0 ? length : sb_w, SCROLLBAR_MIN_SIZE); /*Style-defined size, calculated size, or minimum size*/
+        sb_w = LV_MIN(sb_w, obj_w); /*Limit scrollbar length to parent width*/
         rem = (obj_w - left_space - right_space - ver_reg_space) -
               sb_w;  /*Remaining size from the scrollbar track that is not the scrollbar itself*/
         int32_t scroll_w = content_w - obj_w; /*The size of the content which can be really scrolled*/


### PR DESCRIPTION
This PR adds a small feature to the scrollbar element; using the LV_STYLE_LENGTH property applied to LV_PART_SCROLLBAR will set the lenght of the scrollbar element to a user-specified value. 
The minimum scrollbar length is still 10px, so any specified length below 10 is not going to have any effect, while the maximum length of the scrollbar is set to the parent's height/width.