### PR TITLE
feat(code-format):  2 enhancements

### DIFF
--- a/scripts/code-format.cfg
+++ b/scripts/code-format.cfg
@@ -23,7 +23,7 @@
 # working directory, but uses only LF line endings in the repository.
 # `astyle` also natively uses line the endings it finds in the files,
 # so this will be LF-only on Linux and CR/LF on Windows, in alignment
-* with Git's default behavior. This prevents `astyle` from modifying
+# with Git's default behavior. This prevents `astyle` from modifying
 # every source file, which Git perceives as a change on Windows platforms.
 #--lineend=linux
 --suffix=none

--- a/scripts/code-format.cfg
+++ b/scripts/code-format.cfg
@@ -18,11 +18,13 @@
 --min-conditional-indent=0
 --max-continuation-indent=120
 --mode=c
-# Allows each platform to use its own line endings.  This then
-# does what Git does out of the box:  uses platform line endings
-# in the working directory, but uses only LF line endings in the
-# repository.  This prevents `astyle` from modifying every source
-# file, which Git perceives as a change on Windows platforms.
+# Allows each platform to use its own line endings.  This then does
+# what Git does out of the box:  uses platform line endings in the
+# working directory, but uses only LF line endings in the repository.
+# `astyle` also natively uses line the endings it finds in the files,
+# so this will be LF-only on Linux and CR/LF on Windows, in alignment
+* with Git's default behavior. This prevents `astyle` from modifying
+# every source file, which Git perceives as a change on Windows platforms.
 #--lineend=linux
 --suffix=none
 --preserve-date

--- a/scripts/code-format.cfg
+++ b/scripts/code-format.cfg
@@ -18,7 +18,12 @@
 --min-conditional-indent=0
 --max-continuation-indent=120
 --mode=c
---lineend=linux
+# Allows each platform to use its own line endings.  This then
+# does what Git does out of the box:  uses platform line endings
+# in the working directory, but uses only LF line endings in the
+# repository.  This prevents `astyle` from modifying every source
+# file, which Git perceives as a change on Windows platforms.
+#--lineend=linux
 --suffix=none
 --preserve-date
 --formatted

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -1,19 +1,58 @@
 #!/usr/bin/env python3
 
 import os
+import sys
+
+# Argument enhancement:  to only run `astyle` on a specified directory, to
+# only include changed source code, these arguments have been added.  If
+# run with no arguments, all the normal directories are examined as before:
+# - /demos/
+# - /examples/
+# - /src/
+# - /tests/
+#
+# Args:
+# If ANY args are specified, ONLY run `astyle` on the specified directories.
+# Any combination can be specified.
+include_demos = True
+include_examples = True
+include_src = True
+include_tests = True
+
+args = sys.argv[1:]
+
+# Have any args been specified?
+if args:
+    include_demos = False
+    include_examples = False
+    include_src = False
+    include_tests = False
+
+    if "demos" in args:
+        include_demos = True
+    if "examples" in args:
+        include_examples = True
+    if "src" in args:
+        include_src = True
+    if "tests" in args:
+        include_tests = True
 
 script_dir = os.path.realpath(__file__)
 script_dir = os.path.dirname(script_dir)
 cfg_file = os.path.join(script_dir, 'code-format.cfg')
 
-print("\nFormatting demos")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../demos/*.c,*.cpp,*.h"')
+if include_demos:
+    print("\nFormatting demos")
+    os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../demos/*.c,*.cpp,*.h"')
 
-print("\nFormatting examples")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../examples/*.c,*.cpp,*.h"')
+if include_examples:
+    print("\nFormatting examples")
+    os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../examples/*.c,*.cpp,*.h"')
 
-print("Formatting src")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../src/*.c,*.cpp,*.h"')
+if include_src:
+    print("Formatting src")
+    os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../src/*.c,*.cpp,*.h"')
 
-print("\nFormatting tests")
-os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../tests/*.c,*.cpp,*.h"')
+if include_tests:
+    print("\nFormatting tests")
+    os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../tests/*.c,*.cpp,*.h"')

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -36,7 +36,7 @@ if args:
         elif arg == "src":
             include_src = True
         elif arg == "tests":
-            include_tests = False
+            include_tests = True
         else:
             print(f'Argument [{arg}] not recognized.')
             print('Usage:')

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -59,7 +59,7 @@ if include_examples:
     os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../examples/*.c,*.cpp,*.h"')
 
 if include_src:
-    print("Formatting src")
+    print("\nFormatting src")
     os.system(f'astyle --options={cfg_file} --recursive "{script_dir}/../src/*.c,*.cpp,*.h"')
 
 if include_tests:

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -38,7 +38,6 @@ if args:
         elif arg == "tests":
             include_tests = False
         else:
-            arg_abort = True
             print(f'Argument [{arg}] not recognized.')
             print('Usage:')
             print('  python code-format.py [dir [dir ...]]')

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -29,22 +29,21 @@ if args:
     include_tests = False
 
     for arg in args:
-        match arg:
-            case "demos":
-                include_demos = True
-            case "examples":
-                include_examples = True
-            case 'src':
-                include_src = True
-            case 'tests':
-                include_tests = False
-            case _:
-                arg_abort = True
-                print(f'Argument [{arg}] not recognized.')
-                print('Usage:')
-                print('  python code-format.py [dir [dir ...]]')
-                print('  where: dir can be demos, examples, src or tests.')
-                exit(1)
+        if arg == "demos":
+            include_demos = True
+        elif arg == "examples":
+            include_examples = True
+        elif arg == "src":
+            include_src = True
+        elif arg == "tests":
+            include_tests = False
+        else:
+            arg_abort = True
+            print(f'Argument [{arg}] not recognized.')
+            print('Usage:')
+            print('  python code-format.py [dir [dir ...]]')
+            print('  where: dir can be demos, examples, src or tests.')
+            exit(1)
 
 script_dir = os.path.realpath(__file__)
 script_dir = os.path.dirname(script_dir)

--- a/scripts/code-format.py
+++ b/scripts/code-format.py
@@ -28,14 +28,23 @@ if args:
     include_src = False
     include_tests = False
 
-    if "demos" in args:
-        include_demos = True
-    if "examples" in args:
-        include_examples = True
-    if "src" in args:
-        include_src = True
-    if "tests" in args:
-        include_tests = True
+    for arg in args:
+        match arg:
+            case "demos":
+                include_demos = True
+            case "examples":
+                include_examples = True
+            case 'src':
+                include_src = True
+            case 'tests':
+                include_tests = False
+            case _:
+                arg_abort = True
+                print(f'Argument [{arg}] not recognized.')
+                print('Usage:')
+                print('  python code-format.py [dir [dir ...]]')
+                print('  where: dir can be demos, examples, src or tests.')
+                exit(1)
 
 script_dir = os.path.realpath(__file__)
 script_dir = os.path.dirname(script_dir)


### PR DESCRIPTION
- code-format.cfg doesn't work on Windows because it makes `astyle` edit every single source file and changes the line endings.  Git, perceives this as a change, and makes Windows users have to RESET 672 files just in the ./src/ directory and I didn't count the number in the other directories.  Resetting files can be dangerous to work in progress.  Especially when it involves that many files.

  Rationale:  Git -- out of the box, with default configuration -- automatically stores source files in its repository with LF-only (Linux) line endings. On Windows, each time a file content moves from repository to working directory, its line endings are converted to the line endings native to the platform it is running on.  And each time file content is moved from working directory to repository, the line endings are converted back into LF-only (Linux).  This is a desirable trait and works seamlessly (no one knows its even happening) when Windows and Linux users share source files. This change follows in that spirit and makes it so `AStyle` does NOT try to edit all source files -- only the files that need formatting. I believe this follows the spirit of how it was meant to work.

- code-format.py -- added some command-line argument options that allow `AStyle` to be limited to only certain directories if one already knows that's where it should look.  This saves time -- important when time is precious.  Simultaneously, giving it no arguments makes it run on all 4 directories as it did before.  Normal users, or anyone running this from a script will see no change.

This enhancement was not discussed or asked for, but because it works so nicely on Windows when configured this way, it is submitted in hopes that those in charge will like it too, as it helps accommodate Windows users contribution to LVGL.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Changes documented inside `.py` and `.cfg` files.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  n/a
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
