### PR TITLE
fix(obj): use LV_ASSERT_NULL if LV_ASSERT_OBJ not enabled

### DIFF
--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -470,7 +470,7 @@ void lv_objid_builtin_destroy(void);
         LV_ASSERT_MSG(lv_obj_is_valid(obj_p)  == true, "The object is invalid, deleted or corrupted?"); \
     } while(0)
 # else
-#  define LV_ASSERT_OBJ(obj_p, obj_class) do{}while(0)
+#  define LV_ASSERT_OBJ(obj_p, obj_class) LV_ASSERT_NULL(obj_p)
 #endif
 
 #if LV_USE_LOG && LV_LOG_TRACE_OBJ_CREATE


### PR DESCRIPTION
If LV_USE_ASSERT_OBJ is set to 0, no validation of the object is done.  Add call to LV_ASSERT_NULL on the object in this case to at least validate the object pointer is not NULL.