### PR TITLE
feat(display): add draw buffer size getter

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1031,6 +1031,37 @@ void lv_display_rotate_area(lv_display_t * disp, lv_area_t * area)
     }
 }
 
+uint32_t lv_display_get_draw_buf_size(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) return 0;
+
+    if(disp->buf_1) {
+        return disp->buf_1->data_size;
+    }
+    return 0;
+}
+
+uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t width, uint32_t height)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) return 0;
+
+    if(disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL) {
+        width = lv_display_get_horizontal_resolution(disp);
+        height = lv_display_get_vertical_resolution(disp);
+    }
+
+    lv_color_format_t cf = lv_display_get_color_format(disp);
+    uint32_t stride = lv_draw_buf_width_to_stride(width, cf);
+    uint32_t buf_size = stride * height;
+
+    LV_ASSERT(disp->buf_1 && disp->buf_1->data_size >= buf_size);
+    if(disp->buf_2) LV_ASSERT(disp->buf_2->data_size >= buf_size);
+
+    return buf_size;
+}
+
 lv_obj_t * lv_screen_active(void)
 {
     return lv_display_get_screen_active(lv_display_get_default());

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -569,6 +569,24 @@ lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp);
  */
 void lv_display_rotate_area(lv_display_t * disp, lv_area_t * area);
 
+/**
+ * Get the size of the draw buffers
+ * @param disp      pointer to a display
+ * @return          the size of the draw buffer in bytes for valid display, 0 otherwise
+ */
+uint32_t lv_display_get_draw_buf_size(lv_display_t * disp);
+
+/**
+ * Get the size of the invalidated draw buffer. Can be used in the flush callback
+ * to get the number of bytes used in the current render buffer.
+ * @param disp      pointer to a display
+ * @param width     the width of the invalidated area
+ * @param height    the height of the invalidated area
+ * @return          the size of the invalidated draw buffer in bytes, not accounting for
+ *                  any preceeding palette information for a valid display, 0 otherwise
+ */
+uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t width, uint32_t height);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/sw/lv_draw_sw_utils.c
+++ b/src/draw/sw/lv_draw_sw_utils.c
@@ -197,7 +197,7 @@ void lv_draw_sw_i1_convert_to_vtiled(const void * buf, uint32_t buf_size, uint32
 {
     LV_ASSERT(buf && out_buf);
     LV_ASSERT(width % 8 == 0 && height % 8 == 0);
-    LV_ASSERT(buf_size == (width / 8) * height);
+    LV_ASSERT(buf_size >= (width / 8) * height);
     LV_ASSERT(out_buf_size >= buf_size);
 
     lv_memset(out_buf, 0, out_buf_size);

--- a/tests/src/test_cases/test_display.c
+++ b/tests/src/test_cases/test_display.c
@@ -1,0 +1,130 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+}
+
+struct display_area_test_set {
+    /* Parameters for setting up the display */
+    uint32_t width;
+    uint32_t height;
+    lv_color_format_t color_format;
+    lv_display_render_mode_t render_mode;
+    /* Parameters for testing */
+    uint32_t invalidated_width;
+    uint32_t invalidated_height;
+    uint32_t expected_buf0_size;
+};
+
+void test_get_drawbuf_size_double_buffered(void)
+{
+    static  LV_ATTRIBUTE_MEM_ALIGN uint8_t buf0[200 + LV_DRAW_BUF_ALIGN];
+    static  LV_ATTRIBUTE_MEM_ALIGN uint8_t buf1[200 + LV_DRAW_BUF_ALIGN];
+
+    lv_display_t * disp = lv_display_create(10, 20);
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB888);
+
+    lv_display_set_buffers(disp, lv_draw_buf_align(buf0, LV_COLOR_FORMAT_RGB888), lv_draw_buf_align(buf1,
+                                                                                                    LV_COLOR_FORMAT_RGB888), 200, LV_DISPLAY_RENDER_MODE_PARTIAL);
+
+    TEST_ASSERT_EQUAL(200, lv_display_get_draw_buf_size(disp));
+}
+
+void test_get_drawbuf_size_single_buffered(void)
+{
+    static  LV_ATTRIBUTE_MEM_ALIGN uint8_t buf0[200 + LV_DRAW_BUF_ALIGN];
+
+    lv_display_t * disp = lv_display_create(10, 20);
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB888);
+
+    lv_display_set_buffers(disp, lv_draw_buf_align(buf0, LV_COLOR_FORMAT_RGB888), NULL, 200,
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+
+    TEST_ASSERT_EQUAL(200,  lv_display_get_draw_buf_size(disp));
+}
+
+static void exec_invalidated_drawbuf_size_test(const struct display_area_test_set * test_set)
+{
+    uint32_t buffer_size = lv_draw_buf_width_to_stride(test_set->width, test_set->color_format) * test_set->height;
+
+    uint8_t * buf0 = lv_malloc(buffer_size + LV_DRAW_BUF_ALIGN);
+
+    lv_display_t * disp = lv_display_create(test_set->width, test_set->height);
+    lv_display_set_color_format(disp, test_set->color_format);
+
+    lv_display_set_buffers(disp, lv_draw_buf_align(buf0, test_set->color_format), NULL, buffer_size,
+                           test_set->render_mode);
+    uint32_t invalidated_size = lv_display_get_invalidated_draw_buf_size(disp, test_set->invalidated_width,
+                                                                         test_set->invalidated_height);
+
+    TEST_ASSERT_EQUAL(test_set->expected_buf0_size, invalidated_size);
+    lv_free(buf0);
+    lv_display_delete(disp);
+}
+
+void test_get_invalidated_drawbuf_size_rgb888_partial()
+{
+    struct display_area_test_set test_set = {
+        .width = 10,
+        .height = 20,
+        .color_format = LV_COLOR_FORMAT_RGB888,
+        .render_mode = LV_DISPLAY_RENDER_MODE_PARTIAL,
+        .invalidated_width = 5,
+        .invalidated_height = 5,
+        .expected_buf0_size = lv_draw_buf_width_to_stride(5, LV_COLOR_FORMAT_RGB888) * 5,
+    };
+    exec_invalidated_drawbuf_size_test(&test_set);
+}
+
+void test_get_invalidated_drawbuf_size_rgb888_full()
+{
+    struct display_area_test_set test_set = {
+        .width = 10,
+        .height = 20,
+        .color_format = LV_COLOR_FORMAT_RGB888,
+        .render_mode = LV_DISPLAY_RENDER_MODE_FULL,
+        .invalidated_width = 10,
+        .invalidated_height = 20,
+        .expected_buf0_size = lv_draw_buf_width_to_stride(10, LV_COLOR_FORMAT_RGB888) * 20,
+    };
+    exec_invalidated_drawbuf_size_test(&test_set);
+}
+
+void test_get_invalidated_drawbuf_size_i1_full()
+{
+    struct display_area_test_set test_set =  {
+        .width = 180,
+        .height = 90,
+        .color_format = LV_COLOR_FORMAT_I1,
+        .render_mode = LV_DISPLAY_RENDER_MODE_FULL,
+        .invalidated_width = 180,
+        .invalidated_height = 90,
+        .expected_buf0_size = lv_draw_buf_width_to_stride(180, LV_COLOR_FORMAT_I1) * 90,
+    };
+    exec_invalidated_drawbuf_size_test(&test_set);
+}
+
+void test_get_invalidated_drawbuf_size_i1_partial()
+{
+    struct display_area_test_set test_set = {
+        .width = 180,
+        .height = 90,
+        .color_format = LV_COLOR_FORMAT_I1,
+        .render_mode = LV_DISPLAY_RENDER_MODE_PARTIAL,
+        .invalidated_width = 180,
+        .invalidated_height = 10,
+        .expected_buf0_size = lv_draw_buf_width_to_stride(180, LV_COLOR_FORMAT_I1) * 10,
+    };
+    exec_invalidated_drawbuf_size_test(&test_set);
+}
+
+
+#endif


### PR DESCRIPTION
A clear and concise description of what the bug or new feature is.

- Relax constraint in the vtile method && add a parameter for the buffer size to the flush callback.
I am sure I missed to adjust some documentation somewhere.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
