### PR TITLE
fix(lv_conf): get rid of the LV_CONF path building macros

### DIFF
--- a/docs/intro/add-lvgl-to-your-project/configuration.rst
+++ b/docs/intro/add-lvgl-to-your-project/configuration.rst
@@ -36,7 +36,9 @@ will attempt to include ``lv_conf.h`` simply with ``#include "lv_conf.h"``.
 You can even use a different name for ``lv_conf.h``. The custom path can
 be set via the :c:macro:`LV_CONF_PATH` define. For example
 ``-DLV_CONF_PATH="/home/joe/my_project/my_custom_conf.h"``. If this define
-is set :c:macro:`LV_CONF_SKIP` is assumed to be ``0``.
+is set :c:macro:`LV_CONF_SKIP` is assumed to be ``0``. Please notice,
+when defining the :c:macro:`LV_CONF_PATH`, you need to make sure it is
+defined as a string, otherwise a build error will be raised.
 
 If :c:macro:`LV_CONF_SKIP` is defined, LVGL will not try to include
 ``lv_conf.h``. Instead you can pass the config defines using build

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -74,11 +74,7 @@ fout.write(
 /* If lv_conf.h is not skipped, include it. */
 #if !defined(LV_CONF_SKIP) || defined(LV_CONF_PATH)
     #ifdef LV_CONF_PATH                           /* If there is a path defined for lv_conf.h, use it */
-        #define __LV_TO_STR_AUX(x) #x
-        #define __LV_TO_STR(x) __LV_TO_STR_AUX(x)
-        #include __LV_TO_STR(LV_CONF_PATH)
-        #undef __LV_TO_STR_AUX
-        #undef __LV_TO_STR
+        #include LV_CONF_PATH                     /* Note: Make sure to define custom CONF_PATH as a string */
     #elif defined(LV_CONF_INCLUDE_SIMPLE)         /* Or simply include lv_conf.h is enabled. */
         #include "lv_conf.h"
     #else

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -52,11 +52,7 @@
 /* If lv_conf.h is not skipped, include it. */
 #if !defined(LV_CONF_SKIP) || defined(LV_CONF_PATH)
     #ifdef LV_CONF_PATH                           /* If there is a path defined for lv_conf.h, use it */
-        #define __LV_TO_STR_AUX(x) #x
-        #define __LV_TO_STR(x) __LV_TO_STR_AUX(x)
-        #include __LV_TO_STR(LV_CONF_PATH)
-        #undef __LV_TO_STR_AUX
-        #undef __LV_TO_STR
+        #include LV_CONF_PATH                     /* Note: Make sure to define custom CONF_PATH as a string */
     #elif defined(LV_CONF_INCLUDE_SIMPLE)         /* Or simply include lv_conf.h is enabled. */
         #include "lv_conf.h"
     #else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,7 +169,7 @@ endif()
 
 # Options lvgl and examples are compiled with.
 set(COMPILE_OPTIONS
-    -DLV_CONF_PATH=${LVGL_TEST_DIR}/src/lv_test_conf.h
+    -DLV_CONF_PATH="${LVGL_TEST_DIR}/src/lv_test_conf.h"
     -DLV_BUILD_TEST
     ${BUILD_OPTIONS}
     ${BUILD_TARGET_DEF}


### PR DESCRIPTION
A clear and concise description of what the bug or new feature is.

The macros for building LV_CONF_PATH symbol causes problems on platforms like Linux, which does not generate it correctly, so get rid of them, and instruct the user to define the symbol as a string when configuring LVGL.

Fixes: #6815 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
