### PR TITLE
feat(scroll): adjust scroll behavior for non-elastic objects

### DIFF
--- a/src/indev/lv_indev_scroll.c
+++ b/src/indev/lv_indev_scroll.c
@@ -639,10 +639,19 @@ static void scroll_limit_diff(lv_indev_t * indev, int32_t * diff_x, int32_t * di
 static int32_t elastic_diff(lv_obj_t * scroll_obj, int32_t diff, int32_t scroll_start, int32_t scroll_end,
                             lv_dir_t dir)
 {
+    if(diff == 0) return 0;
+
     /*Scroll back to the edge if required*/
     if(!lv_obj_has_flag(scroll_obj, LV_OBJ_FLAG_SCROLL_ELASTIC)) {
-        if(scroll_end + diff < 0) diff = - scroll_end;
-        if(scroll_start - diff < 0) diff = scroll_start;
+        /*
+         * If the scrolling object does not set the `LV_OBJ_FLAG_SCROLL_ELASTIC` flag,
+         * make sure that `diff` will not cause the scroll to exceed the `start` or `end` boundary of the content.
+         * If the content has exceeded the boundary due to external factors like `LV_SCROLL_SNAP_CENTER`,
+         * then respect the current position instead of going straight back to 0.
+         */
+        const int32_t scroll_ended = diff > 0 ? scroll_start : scroll_end;
+        if(scroll_ended < 0) diff = 0;
+        else if(scroll_ended - diff < 0) diff = scroll_ended;
     }
     /*Handle elastic scrolling*/
     else {


### PR DESCRIPTION
Ensure that the scroll does not exceed content boundaries for objects without the `LV_OBJ_FLAG_SCROLL_ELASTIC` flag, and respect the current position if the content has exceeded due to external factors like `LV_SCROLL_SNAP_CENTER`.

In this way, you can get a better experience.

before:

![iShot_2024-11-20_22 42 50](https://github.com/user-attachments/assets/1c3eebdf-f954-4a15-b2b7-2df8c7590ba6)


after:

![iShot_2024-11-20_22 41 12](https://github.com/user-attachments/assets/9bf2da74-9f4f-4807-8dc1-67675abf5dc8)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
