### PR TITLE
fix(obj): use LV_ASSERT_NULL if LV_ASSERT_OBJ not enabled

### DIFF
--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -470,7 +470,7 @@ void lv_objid_builtin_destroy(void);
         LV_ASSERT_MSG(lv_obj_is_valid(obj_p)  == true, "The object is invalid, deleted or corrupted?"); \
     } while(0)
 # else
-#  define LV_ASSERT_OBJ(obj_p, obj_class) do{}while(0)
+#  define LV_ASSERT_OBJ(obj_p, obj_class) LV_ASSERT_NULL(obj_p)
 #endif
 
 #if LV_USE_LOG && LV_LOG_TRACE_OBJ_CREATE


### PR DESCRIPTION
(Previous pull request for this got deleted)

When the LV_USE_ASSERT_OBJ configuration is not enabled, no checking is done on the object.  Change the macro to call LV_ASSERT_NULL on on the object instead.