### PR TITLE
fix(sw_blend): make sure mask_stride is initialized

### DIFF
--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -470,7 +470,7 @@ void lv_objid_builtin_destroy(void);
         LV_ASSERT_MSG(lv_obj_is_valid(obj_p)  == true, "The object is invalid, deleted or corrupted?"); \
     } while(0)
 # else
-#  define LV_ASSERT_OBJ(obj_p, obj_class) do{}while(0)
+#  define LV_ASSERT_OBJ(obj_p, obj_class) LV_ASSERT_NULL(obj_p)
 #endif
 
 #if LV_USE_LOG && LV_LOG_TRACE_OBJ_CREATE

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -73,6 +73,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         fill_dsc.dest_stride = layer_stride_byte;
         fill_dsc.opa = blend_dsc->opa;
         fill_dsc.color = blend_dsc->color;
+        fill_dsc.mask_stride = 0;
 
         if(blend_dsc->mask_buf == NULL) fill_dsc.mask_buf = NULL;
         else if(blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) fill_dsc.mask_buf = NULL;
@@ -155,7 +156,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         src_buf += image_dsc.src_stride * (blend_area.y1 - blend_dsc->src_area->y1);
         src_buf += ((blend_area.x1 - blend_dsc->src_area->x1) * src_px_size) >> 3;
         image_dsc.src_buf = src_buf;
-
+        image_dsc.mask_stride = 0;
 
         if(blend_dsc->mask_buf == NULL) image_dsc.mask_buf = NULL;
         else if(blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) image_dsc.mask_buf = NULL;


### PR DESCRIPTION
(Previous pull request for this was deleted).

In some paths through the code, the value of mask_stride did not get initialized (but it was not used in those paths, so no bad behavior resulted from the uninitialized value).  Add initialization to the mask_stride value so that it is initialized for all paths.