### PR TITLE
feat(docs):  update threading details in answer to #7313

### DIFF
--- a/docs/intro/add-lvgl-to-your-project/connecting_lvgl.rst
+++ b/docs/intro/add-lvgl-to-your-project/connecting_lvgl.rst
@@ -78,22 +78,11 @@ There are two ways to provide this information to LVGL:
         called from an interrupt if writing to a ``uint32_t`` value is atomic on your
         platform.  See below and the :ref:`threading` section to learn more.
 
-Either way, it is up to the system designer to ensure that the tick value can never
-be read when it is in a partially-written state.  Whether this is because ``uint32_t``
-values are :ref:`atomic <atomic>` on your platform, or because the value is protected
-from being seen in a partially-written state with a MUTEX or other mechanism, it is
-vital that this value can never be used by LVGL in a corrupted state.
-
-If writing a ``uint32_t`` value is not :ref:`atomic <atomic>` on your system (e.g. if
-it is on a 16-bit platform and writing a ``uint32_t`` requires two [2] machine
-intructions to write), then it is up to you to protect that value from being seen in
-a partially-written state.
-
-Assuming your elapsed-milliseconds value is updated in an interrupt service routine
-(ISR), an example of one way of doing this on a microcontroller that uses the Harvard
-instruction set (as do most 16-bit PIC microcontrollers), is using the ``disi``
-assembly instruction that disables interrupts for a specified number of clock cycles.
-Example:
+Either way, the writing of the ``uint32_t`` Tick value must be :ref:`atomic <atomic>`,
+which is usually the case with a 32- or 64-bit platform.  If you are using a 16-bit
+system (causing the update of the Tick value to not be atomic) and your platform uses
+the Harvard instruction set, you can set a function like this as the callback passed
+to :cpp:expr:`lv_tick_set_cb(my_get_milliseconds)`:
 
 .. code-block:: c
 

--- a/docs/intro/add-lvgl-to-your-project/threading.rst
+++ b/docs/intro/add-lvgl-to-your-project/threading.rst
@@ -93,8 +93,9 @@ before any other LVGL function is started.
 
     These two LVGL functions may be called from any thread:
 
-    - :cpp:func:`lv_tick_inc` (see :ref:`tick_interface` for more information) and
-    - :cpp:func:`lv_display_flush_ready` (see :ref:`flush_callback` for more information)
+    - :cpp:func:`lv_tick_inc` (if writing to a ``uint32_t`` is atomic on your
+      platform; see :ref:`tick_interface` for more information) and
+    - :cpp:func:`lv_display_flush_ready` (:ref:`flush_callback` for more information)
 
     The reason this is okay is that the LVGL data changed by them is :ref:`atomic <atomic>`.
 
@@ -103,6 +104,12 @@ before any other LVGL function is started.
     (or an :ref:`LVGL Timer <timer>` you create) can read from and take action.
 
     If you are using an OS, there are a few other options.  See below.
+
+
+Ensuring Time Updates are Atomic
+--------------------------------
+See
+
 
 
 .. _tasks:

--- a/docs/intro/add-lvgl-to-your-project/threading.rst
+++ b/docs/intro/add-lvgl-to-your-project/threading.rst
@@ -16,12 +16,12 @@ Thread
     In "bare-metal" implementations (i.e. no OS), threads include:
 
     - the main thread executing a while(1) loop that runs the system, and
-    - interrupts.
+    - interrupt service routines (ISRs).
 
     When running under an OS, threads include:
 
     - each task (or process),
-    - interrupts, and
+    - ISRs, and
     - advanced OSes can have multiple "execution threads" within a processes.
 
 .. _atomic operation:

--- a/docs/intro/add-lvgl-to-your-project/threading.rst
+++ b/docs/intro/add-lvgl-to-your-project/threading.rst
@@ -108,7 +108,9 @@ before any other LVGL function is started.
 
 Ensuring Time Updates are Atomic
 --------------------------------
-See
+For LVGL's time-related tasks to be reliable, the time updates via the Tick Interface
+must be reliable and the Tick Value must appear :ref:`atomic <atomic>` to LVGL.  See
+:ref:`tick_interface` for details.
 
 
 


### PR DESCRIPTION
In Issue #7313, @JohanChane made a valid point about a threading consideration regarding `lv_tick_inc()`.  This PR makes the needed clarifications about it in the documentation.

This PR partially addresses #7313.

The "demo" versions of these documents are updated with the changes herein:

- connecting_lvgl.rst  [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/intro/add-lvgl-to-your-project/connecting_lvgl.html)]
- threading.rst  [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/intro/add-lvgl-to-your-project/threading.html)]

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
