### PR TITLE
fix(obj_style): transform_scale_(xy)_safe return LV_SCALE_NONE instea…

### DIFF
--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -290,13 +290,13 @@ lv_text_align_t lv_obj_calculate_style_text_align(const lv_obj_t * obj, lv_part_
 static inline int32_t lv_obj_get_style_transform_scale_x_safe(const lv_obj_t * obj, lv_part_t part)
 {
     int32_t scale = lv_obj_get_style_transform_scale_x(obj, part);
-    return scale > 0 ? scale : 1;
+    return scale > 0 ? scale : LV_SCALE_NONE;
 }
 
 static inline int32_t lv_obj_get_style_transform_scale_y_safe(const lv_obj_t * obj, lv_part_t part)
 {
     int32_t scale = lv_obj_get_style_transform_scale_y(obj, part);
-    return scale > 0 ? scale : 1;
+    return scale > 0 ? scale : LV_SCALE_NONE;
 }
 
 /**


### PR DESCRIPTION
If  lv_obj_get_style_transform_scale_x() returns an invalid scale value, the _safe version returns 1,  Where the _safe routine is used, the return value is used to multiply the current scale value, then the resulting scale value is shifted down by 8 bits to produce the final scale value.  If a value of 1 is returned by the _safe function, the resulting scale factor can become 0 after the shift.  The scale value is then used as the denominator of a division, possibly resulting in a divide by zero.
Change the return value for an invalid scale from 1 to LV_SCALE_NONE (defined to be 256).

