### PR TITLE
feat(docs):  document LV_DPX(n)

### DIFF
--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -22,14 +22,16 @@ In short this means:
 - width/height means the full size, the "content area" is smaller with padding and border width
 - a subset of flexbox and grid layouts are supported
 
+
+
 .. _coord_units:
 
-Units
-*****
+Length Units
+************
 
-When passing "distance units" as arguments to functions that modify position, size,
-etc., in many cases, to make layout of your UI maximally convenient, you have a
-choice of several different types of units you can use.
+When passing "length units" (a.k.a. "distance units") as arguments to functions that
+modify position, size, etc., in many cases, to make layout of your UI maximally
+convenient, you have a choice of several different types of units you can use.
 
 :pixels:             Specify size as pixels:  an integer value always means pixels.
                      E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`.
@@ -91,6 +93,8 @@ keeps a "padding margin" when placing a Widget's children.
 
 The outline is drawn outside the bounding box.
 
+
+
 .. _coord_notes:
 
 Important Notes
@@ -116,6 +120,8 @@ the coordinates. To do this call :cpp:func:`lv_obj_update_layout`.
 The size and position might depend on the parent or layout. Therefore
 :cpp:func:`lv_obj_update_layout` recalculates the coordinates of all Widgets on
 the screen of ``obj``.
+
+
 
 .. _coord_removing styles:
 

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -30,8 +30,8 @@ Length Units
 ************
 
 When passing "length units" (a.k.a. "distance units" or "size units") as arguments to
-functions that modify position, size, etc., in many cases, to make layout of your UI
-convenient, you have a choice of several different types of units you can use.
+functions that modify position, size, etc., to make layout of your UI convenient, you
+have a choice of several different types of units you can use.
 
 :pixels:             Specify size as pixels:  an integer value always means pixels.
                      E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`.

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -29,8 +29,8 @@ In short this means:
 Length Units
 ************
 
-When passing "length units" (a.k.a. "distance units") as arguments to functions that
-modify position, size, etc., in many cases, to make layout of your UI maximally
+When passing "length units" (a.k.a. "distance units" or "size units") as arguments to
+functions that modify position, size, etc., in many cases, to make layout of your UI
 convenient, you have a choice of several different types of units you can use.
 
 :pixels:             Specify size as pixels:  an integer value always means pixels.

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -33,8 +33,9 @@ When passing "length units" (a.k.a. "distance units" or "size units") as argumen
 functions that modify position, size, etc., to make layout of your UI convenient, you
 have a choice of several different types of units you can use.
 
-:pixels:             Specify size as pixels:  an integer value always means pixels.
-                     E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`.
+:pixels:             Specify size as pixels:  an integer value <
+                     :c:macro:`LV_COORD_MAX` always means pixels.  E.g.
+                     :cpp:expr:`lv_obj_set_x(btn, 10)`.
 
 :percentage:         Specify size as a percentage of the size of the Widget's
                      parent or of itself, depending on the property.

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -35,7 +35,7 @@ choice of several different types of units you can use.
                      E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`.
 
 :percentage:         Specify size as a percentage of the size of the Widget's
-                     parent or of itself, depending on the property).
+                     parent or of itself, depending on the property.
                      :cpp:expr:`lv_pct(value)` converts ``value`` to a percentage.
                      E.g. :cpp:expr:`lv_obj_set_width(btn, lv_pct(50))`.  If you want
                      to avoid the overhead of the call to :cpp:func:`lv_pct`, you can

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -43,6 +43,10 @@ have a choice of several different types of units you can use.
                      E.g. :cpp:expr:`lv_obj_set_width(btn, lv_pct(50))`.  If you want
                      to avoid the overhead of the call to :cpp:func:`lv_pct`, you can
                      also use the macro :c:macro:`LV_PCT(x)` to mean the same thing.
+                     Note that when you use this feature, your value is *stored as a
+                     percent* so that if/when the size of the parent container (or
+                     other positioning factor) changes, this style value dynamically
+                     retains its meaning.
 
 :contained content:  Specify size as a function of the Widget's children.  The macro
                      :c:macro:`LV_SIZE_CONTENT`: passed as a size value has special

--- a/docs/details/base-widget/coord.rst
+++ b/docs/details/base-widget/coord.rst
@@ -27,14 +27,45 @@ In short this means:
 Units
 *****
 
--  pixel: Simply a position in pixels. An integer always means pixels.
-   E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`
--  percentage: The percentage of the size of the Widget or its parent
-   (depending on the property). :cpp:expr:`lv_pct(value)` converts a value to
-   percentage. E.g. :cpp:expr:`lv_obj_set_width(btn, lv_pct(50))`
--  :c:macro:`LV_SIZE_CONTENT`: Special value to set the width/height of an
-   Widget to involve all the children. It's similar to ``auto`` in CSS.
-   E.g. :cpp:expr:`lv_obj_set_width(btn, LV_SIZE_CONTENT)`.
+When passing "distance units" as arguments to functions that modify position, size,
+etc., in many cases, to make layout of your UI maximally convenient, you have a
+choice of several different types of units you can use.
+
+:pixels:             Specify size as pixels:  an integer value always means pixels.
+                     E.g. :cpp:expr:`lv_obj_set_x(btn, 10)`.
+
+:percentage:         Specify size as a percentage of the size of the Widget's
+                     parent or of itself, depending on the property).
+                     :cpp:expr:`lv_pct(value)` converts ``value`` to a percentage.
+                     E.g. :cpp:expr:`lv_obj_set_width(btn, lv_pct(50))`.  If you want
+                     to avoid the overhead of the call to :cpp:func:`lv_pct`, you can
+                     also use the macro :c:macro:`LV_PCT(x)` to mean the same thing.
+
+:contained content:  Specify size as a function of the Widget's children.  The macro
+                     :c:macro:`LV_SIZE_CONTENT`: passed as a size value has special
+                     meaning:  it means to set the width and/or height of a Widget
+                     just large enough to include all of its children.  This is
+                     similar to ``auto`` in CSS.  E.g.
+                     :cpp:expr:`lv_obj_set_width(btn, LV_SIZE_CONTENT)`.
+
+:inches:             Specify size as 1/160-th portion of an inch as if it were pixels
+                     on a 160-DPI display, even though a display may have a different
+                     DPI.  Use :cpp:expr:`lv_dpx(n)` or :c:macro:`LV_DPX(n)` to do
+                     this.  Examples:
+
+                     +----+-----+----------------------------+
+                     | n  | DPI | Computed Pixels            |
+                     +====+=====+============================+
+                     | 40 | 320 | 80 pixels to make 1/4 inch |
+                     +----+-----+----------------------------+
+                     | 40 | 160 | 40 pixels to make 1/4 inch |
+                     +----+-----+----------------------------+
+                     | 40 | 130 | 33 pixels to make 1/4 inch |
+                     +----+-----+----------------------------+
+                     | 80 | 130 | 66 pixels to make 1/2 inch |
+                     +----+-----+----------------------------+
+
+                     See DPI under :ref:`display_features`.
 
 
 

--- a/docs/details/main-components/display.rst
+++ b/docs/details/main-components/display.rst
@@ -52,6 +52,8 @@ it is representing, as well as other things relevant to its lifetime:
 - Resolution (width and height in pixels)
 - Color Depth (bits per pixel)
 - Color Format (how colors in pixels are laid out)
+- DPI (default is configured :c:macro:`LV_DPI_DEF` in ``lv_conf.h``, but can be
+  modified with :cpp:expr:`lv_display_set_dpi(disp, new_dpi)`).
 - 4 :ref:`screen_layers` automatically created with each display
 - All :ref:`screens` created in association with this display (and not yet deleted---only
   one is dislayed at any given time)

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -593,32 +593,37 @@ void lv_display_rotate_area(lv_display_t * disp, lv_area_t * area);
 #endif
 
 /**
+ * See `lv_dpx()` and `lv_display_dpx()`.
  * Same as Android's DIP. (Different name is chosen to avoid mistype between LV_DPI and LV_DIP)
- * 1 dip is 1 px on a 160 DPI screen
- * 1 dip is 2 px on a 320 DPI screen
- * https://stackoverflow.com/questions/2025282/what-is-the-difference-between-px-dip-dp-and-sp
+ *
+ * - 40 dip is 40 px on a 160 DPI screen (distance = 1/4 inch).
+ * - 40 dip is 80 px on a 320 DPI screen (distance still = 1/4 inch).
+ *
+ * @sa https://stackoverflow.com/questions/2025282/what-is-the-difference-between-px-dip-dp-and-sp
  */
 #define LV_DPX_CALC(dpi, n)   ((n) == 0 ? 0 :LV_MAX((( (dpi) * (n) + 80) / 160), 1)) /*+80 for rounding*/
 #define LV_DPX(n)   LV_DPX_CALC(lv_display_get_dpi(NULL), n)
 
 /**
- * Scale the given number of pixels (a distance or size) relative to a 160 DPI display
- * considering the DPI of the default display.
- * It ensures that e.g. `lv_dpx(100)` will have the same physical size regardless to the
- * DPI of the display.
- * @param n     the number of pixels to scale
- * @return      `n x current_dpi/160`
+ * For default display, computes the number of pixels (a distance or size) as if the
+ * display had 160 DPI.  This allows you to specify 1/160-th fractions of an inch to
+ * get real distance on the display that will be consistent regardless of its current
+ * DPI.  It ensures `lv_dpx(100)`, for example, will have the same physical size
+ * regardless to the DPI of the display.
+ * @param n     number of 1/160-th-inch units to compute with
+ * @return      number of pixels to use to make that distance
  */
 int32_t lv_dpx(int32_t n);
 
 /**
- * Scale the given number of pixels (a distance or size) relative to a 160 DPI display
- * considering the DPI of the given display.
- * It ensures that e.g. `lv_dpx(100)` will have the same physical size regardless to the
- * DPI of the display.
- * @param disp   a display whose dpi should be considered
- * @param n     the number of pixels to scale
- * @return      `n x current_dpi/160`
+ * For specified display, computes the number of pixels (a distance or size) as if the
+ * display had 160 DPI.  This allows you to specify 1/160-th fractions of an inch to
+ * get real distance on the display that will be consistent regardless of its current
+ * DPI.  It ensures `lv_dpx(100)`, for example, will have the same physical size
+ * regardless to the DPI of the display.
+ * @param disp  pointer to display whose dpi should be considered
+ * @param n     number of 1/160-th-inch units to compute with
+ * @return      number of pixels to use to make that distance
  */
 int32_t lv_display_dpx(const lv_display_t * disp, int32_t n);
 


### PR DESCRIPTION
This comes from a conversation about documenting display "units" in PR #7306.  DPX was the unit that had not been documented yet.  It includes some dramatic improvements of the readability and clarity of meaning to the documentation of the other units as well (pixels, percent, and `LV_SIZE_CONTENT`).

Note:  In the discussion of documenting DPX in PR #7306, I realized that the way it was previously documented (in `coord.rst` under section merely called "Units"), that the readers in the discussion were unaware that `percent` and `pixels` as "Distance Units" were already documented in the first major section of this document.  Thinking about this, I realized that the
existing "Units" section does not convey (as well as it could) to the reader that it is a HUGE PART of LVGL Styles and applies across the boards to every part of the drawing domain when a length (distance) between 2 points is calculated, which is ubiquitous across virtually all of the drawing logic.

So I made it a point of calling attention to the actual breadth and depth of the meaning of this section by highlighting its real, deeper meaning, thus better conveying to the reader the import of these tools for designing and programming their UIs with LVGL.

Note for @kisvegabor :  In alignment with the effect of [Document-Driven Development](https://opensource.com/article/17/8/doc-driven-development) for perfecting library APIs (highlighting it that it makes the development team think about the API from the user's viewpoint), I am noticing that reading this new "Length Units" section now begs for a set of `mm` units functions that convert millimeters to LV_DPX(n).  😄 

This update involves updates these documents:

- coord.rst  [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/details/base-widget/coord.html#units)]
- display.rst  [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/details/main-components/display.html#attributes)]
- lv_display.h
    - [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/API/display/lv_display.html#c.LV_DPX_CALC)]
    - [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/API/display/lv_display.html#_CPPv46lv_dpx7int32_t)]
    - [[link](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/API/display/lv_display.html#_CPPv414lv_display_dpxPK12lv_display_t7int32_t)]

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done w/ clarif to API documentation.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  Done.
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
