### PR TITLE
Don't squash: support multiple value in property

### DIFF
--- a/docs/details/other-components/obj_property.rst
+++ b/docs/details/other-components/obj_property.rst
@@ -35,7 +35,7 @@ Set :c:macro:`LV_USE_OBJ_PROPERTY_NAME` to `1` in order to use property name ins
     } lv_property_t;
 
     lv_result_t lv_obj_set_property(lv_obj_t * widget, const lv_property_t * value);
-    lv_property_t lv_obj_get_property(lv_obj_t * widget, lv_prop_id_t id);
+    lv_result_t lv_obj_get_property(lv_obj_t * obj, lv_property_t *prop);
 
     lv_prop_id_t lv_obj_property_get_id(const lv_obj_class_t * clz, const char * name);
 

--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -29,6 +29,8 @@ typedef void (*lv_property_set_precise_t)(lv_obj_t *, lv_value_precise_t);
 typedef void (*lv_property_set_color_t)(lv_obj_t *, lv_color_t);
 typedef void (*lv_property_set_point_t)(lv_obj_t *, lv_point_t *);
 typedef void (*lv_property_set_pointer_t)(lv_obj_t *, const void *);
+typedef void (*lv_property_set_prop_t)(lv_obj_t *, const lv_property_t *);
+
 typedef lv_result_t (*lv_property_setter_t)(lv_obj_t *, lv_prop_id_t, const lv_property_t *);
 
 typedef int32_t (*lv_property_get_int_t)(const lv_obj_t *);
@@ -37,6 +39,7 @@ typedef lv_value_precise_t (*lv_property_get_precise_t)(const lv_obj_t *);
 typedef lv_color_t (*lv_property_get_color_t)(const lv_obj_t *);
 typedef lv_point_t (*lv_property_get_point_t)(lv_obj_t *);
 typedef void * (*lv_property_get_pointer_t)(const lv_obj_t *);
+typedef void (*lv_property_get_prop_t)(lv_obj_t *, lv_property_t *);
 typedef lv_result_t (*lv_property_getter_t)(const lv_obj_t *, lv_prop_id_t, lv_property_t *);
 
 /**********************
@@ -275,6 +278,11 @@ static lv_result_t obj_property(lv_obj_t * obj, lv_prop_id_t id, lv_property_t *
                 case LV_PROPERTY_TYPE_FONT: {
                         if(set)((lv_property_set_pointer_t)(prop->setter))(obj, value->ptr);
                         else value->ptr = ((lv_property_get_pointer_t)(prop->getter))(obj);
+                        break;
+                    }
+                case LV_PROPERTY_TYPE_MIXED: {
+                        if(set)((lv_property_set_prop_t)(prop->setter))(obj, value);
+                        else((lv_property_get_prop_t)(prop->getter))(obj, value);
                         break;
                     }
                 default: {

--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -88,31 +88,31 @@ lv_result_t lv_obj_set_properties(lv_obj_t * obj, const lv_property_t * value, u
     return LV_RESULT_OK;
 }
 
-lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id)
+lv_result_t lv_obj_get_property(lv_obj_t * obj, lv_property_t * prop)
 {
     lv_result_t result;
-    lv_property_t value = { 0 };
+    lv_prop_id_t id = prop->id;
 
     uint32_t index = LV_PROPERTY_ID_INDEX(id);
     if(id == LV_PROPERTY_ID_INVALID || index > LV_PROPERTY_ID_ANY) {
         LV_LOG_WARN("Invalid property id to get from %p", obj);
-        value.id = LV_PROPERTY_ID_INVALID;
-        value.num = 0;
-        return value;
+        prop->id = LV_PROPERTY_ID_INVALID;
+        prop->num = 0;
+        return LV_RESULT_INVALID;
     }
 
     if(index < LV_PROPERTY_ID_START) {
-        lv_obj_get_local_style_prop(obj, index, &value.style, 0);
-        value.id = id;
-        value.selector = 0;
-        return value;
+        lv_obj_get_local_style_prop(obj, index, &prop->style, 0);
+        prop->id = id;
+        prop->selector = 0;
+        return LV_RESULT_OK;
     }
 
-    result = obj_property(obj, id, &value, false);
+    result = obj_property(obj, id, prop, false);
     if(result != LV_RESULT_OK)
-        value.id = LV_PROPERTY_ID_INVALID;
+        prop->id = LV_PROPERTY_ID_INVALID;
 
-    return value;
+    return result;
 }
 
 lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, uint32_t selector)
@@ -221,7 +221,7 @@ static lv_result_t obj_property(lv_obj_t * obj, lv_prop_id_t id, lv_property_t *
 
             /*pass id and value directly to widget's property method*/
             if(prop->id == LV_PROPERTY_ID_ANY) {
-                value->id = prop->id;
+                value->id = id;
                 if(set) return ((lv_property_setter_t)prop->setter)(obj, id, value);
                 else return ((lv_property_getter_t)prop->getter)(obj, id, value);
             }

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -35,6 +35,7 @@ extern "C" {
 #define LV_PROPERTY_TYPE_DISPLAY        9   /*Special pointer of lv_display_t* */
 #define LV_PROPERTY_TYPE_FONT           10  /*Special pointer of lv_font_t* */
 #define LV_PROPERTY_TYPE_BOOL           11  /*int32_t type*/
+#define LV_PROPERTY_TYPE_MIXED          12  /*Multiple property value*/
 
 #define LV_PROPERTY_TYPE_SHIFT          28
 #define LV_PROPERTY_ID(clz, name, type, index)    LV_PROPERTY_## clz ##_##name = (LV_PROPERTY_## clz ##_START + (index)) | ((type) << LV_PROPERTY_TYPE_SHIFT)
@@ -68,6 +69,7 @@ enum {
     LV_PROPERTY_TEXTAREA_START  = 0x0500, /* lv_textarea.c */
     LV_PROPERTY_ROLLER_START    = 0x0600, /* lv_roller.c */
     LV_PROPERTY_DROPDOWN_START  = 0x0700, /* lv_dropdown.c */
+    LV_PROPERTY_SLIDER_START    = 0x0800, /* lv_slider.c */
 
     /*Special ID, use it to extend ID and make sure it's unique and compile time determinant*/
     LV_PROPERTY_ID_BUILTIN_LAST = 0xffff, /*ID of 0x10000 ~ 0xfffffff is reserved for user*/
@@ -80,7 +82,9 @@ struct _lv_property_name_t {
     lv_prop_id_t id;
 };
 
-typedef struct {
+struct _lv_property_t;
+
+struct _lv_property_t {
     lv_prop_id_t id;
     union {
         int32_t num;                /**< Number integer number (opacity, enums, booleans or "normal" numbers)*/
@@ -113,8 +117,13 @@ typedef struct {
             lv_style_value_t style; /**< Make sure it's the first element in struct. */
             uint32_t selector;      /**< Style selector, lv_part_t | lv_state_t */
         };
+
+        struct {
+            uint32_t count;             /**< Count of properties */
+            lv_property_t * properties; /**< Array of properties */
+        };
     };
-} lv_property_t;
+};
 
 typedef struct {
     lv_prop_id_t id;

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -156,10 +156,10 @@ lv_result_t lv_obj_set_properties(lv_obj_t * obj, const lv_property_t * value, u
  * Read property value from object.
  * If id is a style property, the style selector is default to 0.
  * @param obj       pointer to an object
- * @param id        ID of which property to read
+ * @param prop      prop->id is initalized with the property to get
  * @return          return the property value read. The returned property ID is set to `LV_PROPERTY_ID_INVALID` if failed.
  */
-lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id);
+lv_result_t lv_obj_get_property(lv_obj_t * obj, lv_property_t * prop);
 
 /**
  * Read a style property value from object

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -324,8 +324,6 @@ typedef struct _lv_ffmpeg_player_t lv_ffmpeg_player_t;
 typedef struct _lv_glfw_window_t lv_glfw_window_t;
 typedef struct _lv_glfw_texture_t lv_glfw_texture_t;
 
-typedef uint32_t lv_prop_id_t;
-
 typedef struct _lv_array_t lv_array_t;
 
 typedef struct _lv_iter_t lv_iter_t;
@@ -334,9 +332,9 @@ typedef struct _lv_circle_buf_t lv_circle_buf_t;
 
 typedef struct _lv_draw_buf_t lv_draw_buf_t;
 
-#if LV_USE_OBJ_PROPERTY
+typedef uint32_t lv_prop_id_t;
+typedef struct _lv_property_t lv_property_t;
 typedef struct _lv_property_name_t lv_property_name_t;
-#endif
 
 #if LV_USE_SYSMON
 

--- a/src/widgets/property/lv_obj_property_names.h
+++ b/src/widgets/property/lv_obj_property_names.h
@@ -16,6 +16,7 @@
     extern const lv_property_name_t lv_label_property_names[4];
     extern const lv_property_name_t lv_obj_property_names[73];
     extern const lv_property_name_t lv_roller_property_names[3];
+    extern const lv_property_name_t lv_slider_property_names[6];
     extern const lv_property_name_t lv_style_property_names[115];
     extern const lv_property_name_t lv_textarea_property_names[15];
 #endif

--- a/src/widgets/property/lv_slider_properties.c
+++ b/src/widgets/property/lv_slider_properties.c
@@ -1,0 +1,28 @@
+
+/**
+ * GENERATED FILE, DO NOT EDIT IT!
+ * @file lv_slider_properties.c
+ */
+
+#include "../slider/lv_slider.h"
+
+#if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
+
+#if LV_USE_SLIDER
+/**
+ * Slider widget property names, name must be in order.
+ * Generated code from properties.py
+ */
+/* *INDENT-OFF* */
+const lv_property_name_t lv_slider_property_names[6] = {
+    {"is_dragged",             LV_PROPERTY_SLIDER_IS_DRAGGED,},
+    {"is_symmetrical",         LV_PROPERTY_SLIDER_IS_SYMMETRICAL,},
+    {"left_value",             LV_PROPERTY_SLIDER_LEFT_VALUE,},
+    {"mode",                   LV_PROPERTY_SLIDER_MODE,},
+    {"range",                  LV_PROPERTY_SLIDER_RANGE,},
+    {"value",                  LV_PROPERTY_SLIDER_VALUE,},
+};
+#endif /*LV_USE_SLIDER*/
+
+/* *INDENT-ON* */
+#endif

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -46,9 +46,54 @@ static bool is_slider_horizontal(lv_obj_t * obj);
 static void drag_start(lv_obj_t * obj);
 static void update_knob_pos(lv_obj_t * obj, bool check_drag);
 
+#if LV_USE_OBJ_PROPERTY
+    static void property_set_value(lv_obj_t * obj, const lv_property_t * prop);
+    static void property_get_value(lv_obj_t * obj, lv_property_t * prop);
+    static void property_set_left_value(lv_obj_t * obj, const lv_property_t * prop);
+    static void property_get_left_value(lv_obj_t * obj, lv_property_t * prop);
+    static void property_set_range(lv_obj_t * obj, const lv_property_t * prop);
+    static void property_get_range(lv_obj_t * obj, lv_property_t * prop);
+#endif
+
 /**********************
  *  STATIC VARIABLES
  **********************/
+
+#if LV_USE_OBJ_PROPERTY
+static const lv_property_ops_t properties[] = {
+    {
+        .id = LV_PROPERTY_SLIDER_VALUE,
+        .setter = property_set_value,
+        .getter = property_get_value,
+    },
+    {
+        .id = LV_PROPERTY_SLIDER_LEFT_VALUE,
+        .setter = property_set_left_value,
+        .getter = property_get_left_value,
+    },
+    {
+        .id = LV_PROPERTY_SLIDER_RANGE,
+        .setter = property_set_range,
+        .getter = property_get_range,
+    },
+    {
+        .id = LV_PROPERTY_SLIDER_MODE,
+        .setter = lv_slider_set_mode,
+        .getter = lv_slider_get_mode,
+    },
+    {
+        .id = LV_PROPERTY_SLIDER_IS_DRAGGED,
+        .setter = NULL,
+        .getter = lv_slider_is_dragged,
+    },
+    {
+        .id = LV_PROPERTY_SLIDER_IS_SYMMETRICAL,
+        .setter = NULL,
+        .getter = lv_slider_is_symmetrical,
+    },
+};
+#endif
+
 const lv_obj_class_t lv_slider_class = {
     .constructor_cb = lv_slider_constructor,
     .event_cb = lv_slider_event,
@@ -57,6 +102,17 @@ const lv_obj_class_t lv_slider_class = {
     .instance_size = sizeof(lv_slider_t),
     .base_class = &lv_bar_class,
     .name = "slider",
+#if LV_USE_OBJ_PROPERTY
+    .prop_index_start = LV_PROPERTY_SLIDER_START,
+    .prop_index_end = LV_PROPERTY_SLIDER_END,
+    .properties = properties,
+    .properties_count = sizeof(properties) / sizeof(properties[0]),
+
+#if LV_USE_OBJ_PROPERTY_NAME
+    .property_names = lv_slider_property_names,
+    .names_count = sizeof(lv_slider_property_names) / sizeof(lv_property_name_t),
+#endif
+#endif
 };
 
 /**********************
@@ -552,5 +608,59 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
             return;
     }
 }
+
+#if LV_USE_OBJ_PROPERTY
+static void property_set_value(lv_obj_t * obj, const lv_property_t * prop)
+{
+    uint32_t count = prop->count;
+    if(count == 0) {
+        lv_slider_set_value(obj, prop->num, LV_ANIM_OFF);
+    }
+    else {
+        LV_ASSERT(count == 2 && prop->properties);
+        lv_slider_set_value(obj, prop->properties[0].num, prop->properties[1].enable ? LV_ANIM_ON : LV_ANIM_OFF);
+    }
+}
+
+static void property_get_value(lv_obj_t * obj, lv_property_t * prop)
+{
+    LV_ASSERT((int32_t)(prop->id) == LV_PROPERTY_SLIDER_VALUE && prop->count == 2);
+    prop->properties[0].num = lv_slider_get_value(obj);
+}
+
+static void property_set_left_value(lv_obj_t * obj, const lv_property_t * prop)
+{
+    uint32_t count = prop->count;
+
+    if(count == 0) {
+        lv_slider_set_left_value(obj, prop->num, LV_ANIM_OFF);
+    }
+    else {
+        LV_ASSERT(count == 2 && prop->properties);
+        lv_slider_set_left_value(obj, prop->properties[0].num, prop->properties[1].enable ? LV_ANIM_ON : LV_ANIM_OFF);
+    }
+}
+
+static void property_get_left_value(lv_obj_t * obj, lv_property_t * prop)
+{
+    LV_ASSERT((int32_t)(prop->id) == LV_PROPERTY_SLIDER_LEFT_VALUE && prop->count == 2);
+    prop->properties[0].num = lv_slider_get_left_value(obj);
+}
+
+static void property_set_range(lv_obj_t * obj, const lv_property_t * prop)
+{
+    uint32_t count = prop->count;
+    LV_ASSERT(count == 2 && prop->properties);
+    lv_slider_set_range(obj, prop->properties[0].num, prop->properties[1].num);
+}
+
+static void property_get_range(lv_obj_t * obj, lv_property_t * prop)
+{
+    LV_ASSERT((int32_t)(prop->id) == LV_PROPERTY_SLIDER_RANGE && prop->count == 2);
+    prop->properties[0].num = lv_slider_get_min_value(obj);
+    prop->properties[1].num = lv_slider_get_max_value(obj);
+}
+
+#endif
 
 #endif

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -37,6 +37,17 @@ typedef enum {
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_slider_class;
 
+#if LV_USE_OBJ_PROPERTY
+enum {
+    LV_PROPERTY_ID(SLIDER, VALUE,           LV_PROPERTY_TYPE_MIXED,     0),
+    LV_PROPERTY_ID(SLIDER, LEFT_VALUE,      LV_PROPERTY_TYPE_MIXED,     1),
+    LV_PROPERTY_ID(SLIDER, RANGE,           LV_PROPERTY_TYPE_MIXED,     2),
+    LV_PROPERTY_ID(SLIDER, MODE,            LV_PROPERTY_TYPE_INT,       3),
+    LV_PROPERTY_ID(SLIDER, IS_DRAGGED,      LV_PROPERTY_TYPE_BOOL,      4),
+    LV_PROPERTY_ID(SLIDER, IS_SYMMETRICAL,  LV_PROPERTY_TYPE_BOOL,      5),
+    LV_PROPERTY_SLIDER_END,
+};
+#endif
 /**********************
  * GLOBAL PROTOTYPES
  **********************/

--- a/tests/src/test_cases/widgets/test_dropdown.c
+++ b/tests/src/test_cases/widgets/test_dropdown.c
@@ -463,47 +463,60 @@ void test_dropdown_properties(void)
     prop.ptr = "Hello";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_STRING("Hello", lv_dropdown_get_text(obj));
-    TEST_ASSERT_EQUAL_STRING("Hello", lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_TEXT).ptr);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_STRING("Hello", prop.ptr);
 
     prop.id = LV_PROPERTY_DROPDOWN_OPTIONS;
     prop.ptr = "Option 1\nOption 2";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_STRING("Option 1\nOption 2", lv_dropdown_get_options(obj));
-    TEST_ASSERT_EQUAL_STRING("Option 1\nOption 2", lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_OPTIONS).ptr);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_STRING("Option 1\nOption 2", prop.ptr);
 
+    prop.id = LV_PROPERTY_DROPDOWN_OPTION_COUNT;
     TEST_ASSERT_EQUAL(2, lv_dropdown_get_option_count(obj));
-    TEST_ASSERT_EQUAL(2, lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_OPTION_COUNT).num);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL(2, prop.num);
 
     prop.id = LV_PROPERTY_DROPDOWN_SELECTED;
     prop.num = 1;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(1, lv_dropdown_get_selected(obj));
-    TEST_ASSERT_EQUAL_INT(1, lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_SELECTED).num);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(1, prop.num);
 
     prop.id = LV_PROPERTY_DROPDOWN_DIR;
     prop.num = LV_DIR_LEFT;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(LV_DIR_LEFT, lv_dropdown_get_dir(obj));
-    TEST_ASSERT_EQUAL_INT(LV_DIR_LEFT, lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_DIR).num);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(LV_DIR_LEFT, prop.num);
 
     prop.id = LV_PROPERTY_DROPDOWN_SYMBOL;
     prop.ptr = LV_SYMBOL_DOWN;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_STRING(LV_SYMBOL_DOWN, lv_dropdown_get_symbol(obj));
-    TEST_ASSERT_EQUAL_STRING(LV_SYMBOL_DOWN, lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_SYMBOL).ptr);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_STRING(LV_SYMBOL_DOWN, prop.ptr);
 
     prop.id = LV_PROPERTY_DROPDOWN_SELECTED_HIGHLIGHT;
     prop.num = true;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_TRUE(lv_dropdown_get_selected_highlight(obj));
-    TEST_ASSERT_TRUE(lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_SELECTED_HIGHLIGHT).num);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(prop.num);
 
     lv_dropdown_open(obj);
+    prop.id = LV_PROPERTY_DROPDOWN_IS_OPEN;
     TEST_ASSERT_TRUE(lv_dropdown_is_open(obj));
-    TEST_ASSERT_TRUE(lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_IS_OPEN).enable);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(prop.enable);
+
     lv_dropdown_close(obj);
+    prop.id = LV_PROPERTY_DROPDOWN_IS_OPEN;
     TEST_ASSERT_FALSE(lv_dropdown_is_open(obj));
-    TEST_ASSERT_FALSE(lv_obj_get_property(obj, LV_PROPERTY_DROPDOWN_IS_OPEN).enable);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_FALSE(prop.enable);
 #endif
 }
 

--- a/tests/src/test_cases/widgets/test_image.c
+++ b/tests/src/test_cases/widgets/test_image.c
@@ -458,33 +458,38 @@ void test_image_properties(void)
     prop.id = LV_PROPERTY_IMAGE_SRC;
     prop.ptr = &test_arc_bg;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_PTR(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_SRC).ptr, &test_arc_bg);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_PTR(prop.ptr, &test_arc_bg);
     TEST_ASSERT_EQUAL_PTR(lv_image_get_src(obj), &test_arc_bg);
 
     prop.id = LV_PROPERTY_IMAGE_OFFSET_X;
     prop.num = 10;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_OFFSET_X).num, 10);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 10);
     TEST_ASSERT_EQUAL_INT(lv_image_get_offset_x(obj), 10);
 
     prop.id = LV_PROPERTY_IMAGE_OFFSET_Y;
     prop.num = 20;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_OFFSET_Y).num, 20);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 20);
     TEST_ASSERT_EQUAL_INT(lv_image_get_offset_y(obj), 20);
 
     prop.id = LV_PROPERTY_IMAGE_ROTATION;
     prop.num = 30;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_ROTATION).num, 30);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 30);
     TEST_ASSERT_EQUAL_INT(lv_image_get_rotation(obj), 30);
 
     prop.id = LV_PROPERTY_IMAGE_PIVOT;
     prop.point.x = 40;
     prop.point.y = 50;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_PIVOT).point.x, 40);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_PIVOT).point.y, 50);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.point.x, 40);
+    TEST_ASSERT_EQUAL_INT(prop.point.y, 50);
     lv_point_t pivot;
     lv_image_get_pivot(obj, &pivot);
     TEST_ASSERT_EQUAL_INT(pivot.x, 40);
@@ -493,37 +498,43 @@ void test_image_properties(void)
     prop.id = LV_PROPERTY_IMAGE_SCALE;
     prop.num = 60;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_SCALE).num, 60);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 60);
     TEST_ASSERT_EQUAL_INT(lv_image_get_scale(obj), 60);
 
     prop.id = LV_PROPERTY_IMAGE_SCALE_X;
     prop.num = 70;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_SCALE_X).num, 70);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 70);
     TEST_ASSERT_EQUAL_INT(lv_image_get_scale_x(obj), 70);
 
     prop.id = LV_PROPERTY_IMAGE_SCALE_Y;
     prop.num = 80;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_SCALE_Y).num, 80);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 80);
     TEST_ASSERT_EQUAL_INT(lv_image_get_scale_y(obj), 80);
 
     prop.id = LV_PROPERTY_IMAGE_BLEND_MODE;
     prop.num = LV_BLEND_MODE_ADDITIVE;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_BLEND_MODE).num, LV_BLEND_MODE_ADDITIVE);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, LV_BLEND_MODE_ADDITIVE);
     TEST_ASSERT_EQUAL_INT(lv_image_get_blend_mode(obj), LV_BLEND_MODE_ADDITIVE);
 
     prop.id = LV_PROPERTY_IMAGE_ANTIALIAS;
     prop.num = 0;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_ANTIALIAS).num, 0);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, 0);
     TEST_ASSERT_EQUAL_INT(lv_image_get_antialias(obj), 0);
 
     prop.id = LV_PROPERTY_IMAGE_INNER_ALIGN;
     prop.num = LV_IMAGE_ALIGN_TOP_MID;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_INT(lv_obj_get_property(obj, LV_PROPERTY_IMAGE_INNER_ALIGN).num, LV_IMAGE_ALIGN_TOP_MID);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, LV_IMAGE_ALIGN_TOP_MID);
     TEST_ASSERT_EQUAL_INT(lv_image_get_inner_align(obj), LV_IMAGE_ALIGN_TOP_MID);
 #endif
 }

--- a/tests/src/test_cases/widgets/test_keyboard.c
+++ b/tests/src/test_cases/widgets/test_keyboard.c
@@ -50,26 +50,30 @@ void test_keyboard_properties(void)
     prop.id = LV_PROPERTY_KEYBOARD_TEXTAREA;
     prop.ptr = test_area;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_PTR(test_area, lv_keyboard_get_textarea(obj));
-    TEST_ASSERT_EQUAL_PTR(test_area, lv_obj_get_property(obj, LV_PROPERTY_KEYBOARD_TEXTAREA).ptr);
+    TEST_ASSERT_EQUAL_PTR(test_area, prop.ptr);
 
     prop.id = LV_PROPERTY_KEYBOARD_MODE;
     prop.num = LV_KEYBOARD_MODE_TEXT_UPPER;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(LV_KEYBOARD_MODE_TEXT_UPPER, lv_keyboard_get_mode(obj));
-    TEST_ASSERT_EQUAL_INT(LV_KEYBOARD_MODE_TEXT_UPPER, lv_obj_get_property(obj, LV_PROPERTY_KEYBOARD_MODE).num);
+    TEST_ASSERT_EQUAL_INT(LV_KEYBOARD_MODE_TEXT_UPPER, prop.num);
 
     prop.id = LV_PROPERTY_KEYBOARD_POPOVERS;
     prop.num = 1;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(1, lv_keyboard_get_popovers(obj));
-    TEST_ASSERT_EQUAL_INT(1, lv_obj_get_property(obj, LV_PROPERTY_KEYBOARD_POPOVERS).num);
+    TEST_ASSERT_EQUAL_INT(1, prop.num);
 
     prop.id = LV_PROPERTY_KEYBOARD_SELECTED_BUTTON;
     prop.num = 1;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(1, lv_keyboard_get_selected_button(obj));
-    TEST_ASSERT_EQUAL_INT(1, lv_obj_get_property(obj, LV_PROPERTY_KEYBOARD_SELECTED_BUTTON).num);
+    TEST_ASSERT_EQUAL_INT(1, prop.num);
 #endif
 }
 

--- a/tests/src/test_cases/widgets/test_obj_property.c
+++ b/tests/src/test_cases/widgets/test_obj_property.c
@@ -41,57 +41,65 @@ void test_obj_property_set_get_should_match(void)
     prop.id = LV_PROPERTY_STYLE_X;
     prop.num = 0xaabb;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_style_x(obj, 0));
-    TEST_ASSERT_EQUAL_UINT32(0xaabb, lv_obj_get_property(obj, LV_PROPERTY_STYLE_X).num);
+    TEST_ASSERT_EQUAL_UINT32(0xaabb, prop.num);
 
     /* color type */
     prop.id = LV_PROPERTY_STYLE_BG_COLOR;
     prop.color = color;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_COLOR(color, lv_obj_get_style_bg_color(obj, LV_PART_MAIN));
-    TEST_ASSERT_EQUAL_COLOR(color, lv_obj_get_property(obj, LV_PROPERTY_STYLE_BG_COLOR).color);
+    TEST_ASSERT_EQUAL_COLOR(color, prop.color);
 
     /* pointer type */
     prop.id = LV_PROPERTY_STYLE_TEXT_FONT;
     prop.ptr = &lv_font_montserrat_26;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, lv_obj_get_style_text_font(obj, LV_PART_MAIN));
-    TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, lv_obj_get_property(obj, LV_PROPERTY_STYLE_TEXT_FONT).ptr);
+    TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_26, prop.ptr);
 
     /* Object flags */
-    prop.id = LV_PROPERTY_OBJ_FLAG_HIDDEN ;
+    prop.id = LV_PROPERTY_OBJ_FLAG_HIDDEN;
     prop.num = 1;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_TRUE(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN));
-    TEST_ASSERT_TRUE(lv_obj_get_property(obj, LV_PROPERTY_OBJ_FLAG_HIDDEN).num);
+    TEST_ASSERT_TRUE(prop.num);
 
     prop.id = LV_PROPERTY_OBJ_FLAG_CLICKABLE;
     prop.num = 0;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_FALSE(lv_obj_has_flag(obj, LV_OBJ_FLAG_CLICKABLE));
-    TEST_ASSERT_FALSE(lv_obj_get_property(obj, LV_PROPERTY_OBJ_FLAG_CLICKABLE).num);
+    TEST_ASSERT_FALSE(prop.num);
 
     /* Obj property */
     prop.id = LV_PROPERTY_OBJ_PARENT;
     prop.ptr = root;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_PTR(root, lv_obj_get_parent(obj));
-    TEST_ASSERT_EQUAL_PTR(root, lv_obj_get_property(obj, LV_PROPERTY_OBJ_PARENT).ptr);
+    TEST_ASSERT_EQUAL_PTR(root, prop.ptr);
 
     /* Derived widget could use same property */
     lv_obj_t * img = lv_image_create(obj);
     prop.id = LV_PROPERTY_OBJ_PARENT;
     prop.ptr = root;
     TEST_ASSERT_TRUE(lv_obj_set_property(img, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_PTR(root, lv_obj_get_parent(img));
-    TEST_ASSERT_EQUAL_PTR(root, lv_obj_get_property(img, LV_PROPERTY_OBJ_PARENT).ptr);
+    TEST_ASSERT_EQUAL_PTR(root, prop.ptr);
 
     /* Image properties */
     prop.id = LV_PROPERTY_IMAGE_OFFSET_X;
     prop.num = 0x1234;
     TEST_ASSERT_TRUE(lv_obj_set_property(img, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(img, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT16(0x1234, lv_image_get_offset_x(img));
-    TEST_ASSERT_EQUAL_UINT16(0x1234, lv_obj_get_property(img, LV_PROPERTY_IMAGE_OFFSET_X).num);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, prop.num);
 #endif
 }
 
@@ -114,7 +122,7 @@ void test_obj_property_style_selector(void)
     prop.num = 0x1122;
     prop.selector = selector;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    TEST_ASSERT_EQUAL_UINT32(0x1122, lv_obj_get_style_x(obj, selector));
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_UINT32(0x1122, lv_obj_get_style_property(obj, LV_PROPERTY_STYLE_X, selector).num);
 #endif
 }
@@ -161,25 +169,30 @@ void test_obj_property_flag(void)
     lv_obj_t * obj = lv_obj_create(lv_screen_active());
     obj->flags = 0;
     for(unsigned long i = 0; i < sizeof(properties) / sizeof(properties[0]); i++) {
-
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, properties[i].id).num);
-        lv_obj_add_flag(obj, properties[i].flag);
-        TEST_ASSERT_TRUE(lv_obj_get_property(obj, properties[i].id).num);
-
-        lv_obj_remove_flag(obj, properties[i].flag);
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, properties[i].id).num);
-
         lv_property_t prop = { };
         prop.id = properties[i].id;
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
+
+        lv_obj_add_flag(obj, properties[i].flag);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_TRUE(prop.num);
+
+        lv_obj_remove_flag(obj, properties[i].flag);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
+
         prop.num = 1;
         TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-        TEST_ASSERT_TRUE(lv_obj_get_property(obj, properties[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_TRUE(prop.num);
         TEST_ASSERT_TRUE(lv_obj_has_flag(obj, properties[i].flag));
 
         prop.id = properties[i].id;
         prop.num = 0;
         TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, properties[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
         TEST_ASSERT_FALSE(lv_obj_has_flag(obj, properties[i].flag));
     }
 #endif
@@ -209,25 +222,31 @@ void test_obj_property_state(void)
     lv_obj_t * obj = lv_obj_create(lv_screen_active());
     obj->state = 0;
     for(unsigned long i = 0; i < sizeof(states) / sizeof(states[0]); i++) {
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+        lv_property_t prop = { };
+        prop.id = states[i].id;
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
         lv_obj_add_state(obj, states[i].state);
-        printf("state: %d, value: %d\n", states[i].state, lv_obj_get_property(obj, states[i].id).num);
-        TEST_ASSERT_TRUE(lv_obj_get_property(obj, states[i].id).num);
+        printf("state: %d, value: %d\n", states[i].state, prop.num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_TRUE(prop.num);
 
         lv_obj_remove_state(obj, states[i].state);
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
 
-        lv_property_t prop = { };
         prop.id = states[i].id;
         prop.num = 1;
         TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-        TEST_ASSERT_TRUE(lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_TRUE(prop.num);
         TEST_ASSERT_TRUE(lv_obj_get_state(obj) & states[i].state);
 
         prop.id = states[i].id;
         prop.num = 0;
         TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-        TEST_ASSERT_FALSE(lv_obj_get_property(obj, states[i].id).num);
+        TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+        TEST_ASSERT_FALSE(prop.num);
         TEST_ASSERT_FALSE(lv_obj_get_state(obj) & states[i].state);
     }
 #endif
@@ -244,9 +263,9 @@ void test_obj_property_type_point(void)
     prop.point.y = 0x5678;
 
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
-    lv_property_t prop_get = lv_obj_get_property(obj, LV_PROPERTY_IMAGE_PIVOT);
-    TEST_ASSERT_EQUAL_UINT16(0x1234, prop_get.point.x);
-    TEST_ASSERT_EQUAL_UINT16(0x5678, prop_get.point.y);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, prop.point.x);
+    TEST_ASSERT_EQUAL_UINT16(0x5678, prop.point.y);
 #endif
 }
 
@@ -298,27 +317,31 @@ void test_label_properties(void)
     prop.id = LV_PROPERTY_LABEL_TEXT;
     prop.ptr = "Hello world";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_STRING("Hello world", lv_label_get_text(obj));
-    TEST_ASSERT_EQUAL_STRING("Hello world", lv_obj_get_property(obj, LV_PROPERTY_LABEL_TEXT).ptr);
+    TEST_ASSERT_EQUAL_STRING("Hello world", prop.ptr);
 
     prop.id = LV_PROPERTY_LABEL_LONG_MODE;
     prop.num = LV_LABEL_LONG_SCROLL;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(LV_LABEL_LONG_SCROLL, lv_label_get_long_mode(obj));
-    TEST_ASSERT_EQUAL_INT(LV_LABEL_LONG_SCROLL, lv_obj_get_property(obj, LV_PROPERTY_LABEL_LONG_MODE).num);
+    TEST_ASSERT_EQUAL_INT(LV_LABEL_LONG_SCROLL, prop.num);
 
 #if LV_LABEL_TEXT_SELECTION
     prop.id = LV_PROPERTY_LABEL_TEXT_SELECTION_START;
     prop.num = 2;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(2, lv_label_get_text_selection_start(obj));
-    TEST_ASSERT_EQUAL_INT(2, lv_obj_get_property(obj, LV_PROPERTY_LABEL_TEXT_SELECTION_START).num);
+    TEST_ASSERT_EQUAL_INT(2, prop.num);
 
     prop.id = LV_PROPERTY_LABEL_TEXT_SELECTION_END;
     prop.num = 5;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(5, lv_label_get_text_selection_end(obj));
-    TEST_ASSERT_EQUAL_INT(5, lv_obj_get_property(obj, LV_PROPERTY_LABEL_TEXT_SELECTION_END).num);
+    TEST_ASSERT_EQUAL_INT(5, prop.num);
 #endif
 #endif
 }

--- a/tests/src/test_cases/widgets/test_roller.c
+++ b/tests/src/test_cases/widgets/test_roller.c
@@ -358,14 +358,16 @@ void test_roller_properties(void)
     prop.id = LV_PROPERTY_ROLLER_OPTIONS;
     prop.ptr = "One\nTwo\nThree";
     lv_roller_set_options(obj, prop.ptr, LV_ROLLER_MODE_NORMAL);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_STRING("One\nTwo\nThree", lv_roller_get_options(obj));
-    TEST_ASSERT_EQUAL_STRING("One\nTwo\nThree", lv_obj_get_property(obj, LV_PROPERTY_ROLLER_OPTIONS).ptr);
+    TEST_ASSERT_EQUAL_STRING("One\nTwo\nThree", prop.ptr);
 
     prop.id = LV_PROPERTY_ROLLER_SELECTED;
     prop.num = 1;
     lv_roller_set_selected(obj, 1, LV_ANIM_OFF);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
     TEST_ASSERT_EQUAL_INT(1, lv_roller_get_selected(obj));
-    TEST_ASSERT_EQUAL_INT(1, lv_obj_get_property(obj, LV_PROPERTY_ROLLER_SELECTED).num);
+    TEST_ASSERT_EQUAL_INT(1, prop.num);
 #endif
 }
 

--- a/tests/src/test_cases/widgets/test_slider.c
+++ b/tests/src/test_cases/widgets/test_slider.c
@@ -212,4 +212,65 @@ void test_slider_range_event_hit_test(void)
     TEST_ASSERT(info.res);
 }
 
+void test_slider_properties(void)
+{
+#if LV_USE_OBJ_PROPERTY
+    lv_obj_t * obj = lv_slider_create(lv_screen_active());
+    lv_property_t prop = { };
+
+    lv_property_t values[2];
+
+    prop.id = LV_PROPERTY_SLIDER_RANGE;
+    prop.properties = values;
+    prop.count = 2;
+    values[0].num = 10;
+    values[1].num = 100;
+    TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(values[0].num, 10);
+    TEST_ASSERT_EQUAL_INT(values[1].num, 100);
+    TEST_ASSERT_EQUAL_INT(lv_slider_get_min_value(obj), 10);
+    TEST_ASSERT_EQUAL_INT(lv_slider_get_max_value(obj), 100);
+
+    prop.id = LV_PROPERTY_SLIDER_VALUE;
+    prop.properties = values;
+    prop.count = 2;
+    values[0].num = 50;
+    values[1].enable = false;
+    TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(values[0].num, 50);
+    TEST_ASSERT_EQUAL_INT(lv_slider_get_value(obj), 50);
+
+    prop.id = LV_PROPERTY_SLIDER_MODE;
+    prop.num = LV_SLIDER_MODE_RANGE;
+    TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(prop.num, LV_SLIDER_MODE_RANGE);
+    TEST_ASSERT_EQUAL_INT(lv_slider_get_mode(obj), LV_SLIDER_MODE_RANGE);
+
+    prop.id = LV_PROPERTY_SLIDER_LEFT_VALUE;
+    prop.properties = values;
+    prop.count = 2;
+    values[0].num = 40;
+    values[1].enable = false;
+    TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_EQUAL_INT(values[0].num, 40);
+    TEST_ASSERT_EQUAL_INT(lv_slider_get_left_value(obj), 40);
+
+    prop.id = LV_PROPERTY_SLIDER_IS_DRAGGED;
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_FALSE(prop.enable);
+    TEST_ASSERT_FALSE(lv_slider_is_dragged(obj));
+
+    prop.id = LV_PROPERTY_SLIDER_IS_SYMMETRICAL;
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RESULT_OK);
+    TEST_ASSERT_FALSE(prop.enable);
+    TEST_ASSERT_FALSE(lv_slider_is_dragged(obj));
+
+#endif
+}
+
+
 #endif

--- a/tests/src/test_cases/widgets/test_textarea.c
+++ b/tests/src/test_cases/widgets/test_textarea.c
@@ -143,56 +143,65 @@ void test_textarea_properties(void)
     prop.id = LV_PROPERTY_TEXTAREA_TEXT;
     prop.ptr = "Hello World!";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_STRING("Hello World!", lv_textarea_get_text(obj));
-    TEST_ASSERT_EQUAL_STRING("Hello World!", lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_TEXT).ptr);
+    TEST_ASSERT_EQUAL_STRING("Hello World!", prop.ptr);
 
     prop.id = LV_PROPERTY_TEXTAREA_PLACEHOLDER_TEXT;
     prop.ptr = "Hello!";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_STRING("Hello!", lv_textarea_get_placeholder_text(obj));
-    TEST_ASSERT_EQUAL_STRING("Hello!", lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_PLACEHOLDER_TEXT).ptr);
+    TEST_ASSERT_EQUAL_STRING("Hello!", prop.ptr);
 
     prop.id = LV_PROPERTY_TEXTAREA_CURSOR_POS;
     prop.num = 5;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(5, lv_textarea_get_cursor_pos(obj));
-    TEST_ASSERT_EQUAL_INT(5, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_CURSOR_POS).num);
+    TEST_ASSERT_EQUAL_INT(5, prop.num);
 
     prop.id = LV_PROPERTY_TEXTAREA_CURSOR_CLICK_POS;
     prop.num = 1;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(1, lv_textarea_get_cursor_click_pos(obj));
-    TEST_ASSERT_EQUAL_INT(1, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_CURSOR_CLICK_POS).num);
+    TEST_ASSERT_EQUAL_INT(1, prop.num);
 
     prop.id = LV_PROPERTY_TEXTAREA_PASSWORD_MODE;
     prop.num = true;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_TRUE(lv_textarea_get_password_mode(obj));
-    TEST_ASSERT_TRUE(lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_PASSWORD_MODE).num);
+    TEST_ASSERT_TRUE(prop.num);
 
     prop.id = LV_PROPERTY_TEXTAREA_PASSWORD_BULLET;
     prop.ptr = "password bullet";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_STRING("password bullet", lv_textarea_get_password_bullet(obj));
-    TEST_ASSERT_EQUAL_STRING("password bullet", lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_PASSWORD_BULLET).ptr);
+    TEST_ASSERT_EQUAL_STRING("password bullet", prop.ptr);
 
     prop.id = LV_PROPERTY_TEXTAREA_ONE_LINE;
     prop.enable = true;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(true, lv_textarea_get_one_line(obj));
-    TEST_ASSERT_EQUAL_INT(true, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_ONE_LINE).enable);
+    TEST_ASSERT_EQUAL_INT(true, prop.enable);
 
     prop.id = LV_PROPERTY_TEXTAREA_ACCEPTED_CHARS;
     prop.ptr = "ABCDEF";
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_STRING("ABCDEF", lv_textarea_get_accepted_chars(obj));
-    TEST_ASSERT_EQUAL_STRING("ABCDEF", lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_ACCEPTED_CHARS).ptr);
+    TEST_ASSERT_EQUAL_STRING("ABCDEF", prop.ptr);
 
     prop.id = LV_PROPERTY_TEXTAREA_MAX_LENGTH;
     prop.num = 10;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(10, lv_textarea_get_max_length(obj));
-    TEST_ASSERT_EQUAL_INT(10, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_MAX_LENGTH).num);
+    TEST_ASSERT_EQUAL_INT(10, prop.num);
 
     prop.id = LV_PROPERTY_TEXTAREA_INSERT_REPLACE;
     prop.ptr = "abcdef";
@@ -202,14 +211,16 @@ void test_textarea_properties(void)
     prop.id = LV_PROPERTY_TEXTAREA_TEXT_SELECTION;
     prop.num = true;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(true, lv_textarea_get_text_selection(obj));
-    TEST_ASSERT_EQUAL_INT(true, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_TEXT_SELECTION).enable);
+    TEST_ASSERT_EQUAL_INT(true, prop.enable);
 
     prop.id = LV_PROPERTY_TEXTAREA_PASSWORD_SHOW_TIME;
     prop.num = 10;
     TEST_ASSERT_TRUE(lv_obj_set_property(obj, &prop) == LV_RES_OK);
+    TEST_ASSERT_TRUE(lv_obj_get_property(obj, &prop) == LV_RES_OK);
     TEST_ASSERT_EQUAL_INT(10, lv_textarea_get_password_show_time(obj));
-    TEST_ASSERT_EQUAL_INT(10, lv_obj_get_property(obj, LV_PROPERTY_TEXTAREA_PASSWORD_SHOW_TIME).num);
+    TEST_ASSERT_EQUAL_INT(10, prop.num);
 #endif
 }
 


### PR DESCRIPTION
This PR firstly changes the API signature of `lv_obj_get_property`. Now it support a pointer as input.
Added multiple value in property by introducing property type of `LV_PROPERTY_TYPE_MIXED`. The value of it is defined as:
```c
        struct {
            uint32_t count;             /**< Count of properties */
            lv_property_t * properties; /**< Array of properties */
        };
```

Add slider widget property as demonstration of usage.

```c
static const lv_property_ops_t properties[] = {
    {
        .id = LV_PROPERTY_SLIDER_RANGE,
        .setter = property_set_range,
        .getter = property_get_range,
    },
};

static void property_set_range(lv_obj_t * obj, const lv_property_t * prop)
{
    uint32_t count = prop->count;
    LV_ASSERT(count == 2 && prop->properties);
    lv_slider_set_range(obj, prop->properties[0].num, prop->properties[1].num);
}

static void property_get_range(lv_obj_t * obj, lv_property_t * prop)
{
    LV_ASSERT((int32_t)(prop->id) == LV_PROPERTY_SLIDER_RANGE && prop->count == 2);
    prop->properties[0].num = lv_slider_get_min_value(obj);
    prop->properties[1].num = lv_slider_get_max_value(obj);
}

```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
