### PR TITLE
feat(vg_lite): reduce unnecessary path quality settings

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -83,7 +83,6 @@ void lv_draw_vg_lite_arc(lv_draw_unit_t * draw_unit, const lv_draw_arc_dsc_t * d
     LV_PROFILER_DRAW_BEGIN;
 
     lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
-    lv_vg_lite_path_set_quality(path, VG_LITE_HIGH);
     lv_vg_lite_path_set_bounding_box_area(path, &clip_area);
 
     float radius_out = dsc->radius;

--- a/src/draw/vg_lite/lv_draw_vg_lite_border.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_border.c
@@ -177,7 +177,6 @@ static vg_lite_fill_t path_append_inner_rect(lv_vg_lite_path_t * path,
 
     /* reset outter rect path */
     lv_vg_lite_path_reset(path, VG_LITE_FP32);
-    lv_vg_lite_path_set_quality(path, VG_LITE_HIGH);
 
     /* coordinate reference map: https://github.com/lvgl/lvgl/pull/6796 */
     const float c1_x = x + r;

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -24,7 +24,6 @@
  *      DEFINES
  *********************/
 
-#define PATH_QUALITY VG_LITE_HIGH
 #define PATH_DATA_COORD_FORMAT VG_LITE_S16
 
 #if LV_VG_LITE_FLUSH_MAX_COUNT > 0
@@ -357,7 +356,6 @@ static void freetype_outline_event_cb(lv_event_t * e)
     switch(code) {
         case LV_EVENT_CREATE:
             param->outline = lv_vg_lite_path_create(PATH_DATA_COORD_FORMAT);
-            lv_vg_lite_path_set_quality(param->outline, PATH_QUALITY);
             break;
         case LV_EVENT_DELETE:
             lv_vg_lite_path_destroy(param->outline);

--- a/src/draw/vg_lite/lv_draw_vg_lite_line.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_line.c
@@ -87,7 +87,6 @@ void lv_draw_vg_lite_line(lv_draw_unit_t * draw_unit, const lv_draw_line_dsc_t *
     }
 
     lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
-    lv_vg_lite_path_set_quality(path, VG_LITE_MEDIUM);
     lv_vg_lite_path_set_bounding_box_area(path, &rel_clip_area);
 
     /* head point */

--- a/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
@@ -104,7 +104,6 @@ void lv_draw_vg_lite_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_re
     int32_t h = lv_area_get_height(&dsc->area);
 
     lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
-    lv_vg_lite_path_set_quality(path, VG_LITE_HIGH);
     lv_vg_lite_path_set_bounding_box_area(path, &draw_area);
 
     /* Use rounded rectangles and normal rectangles of the same size to nest the cropped area */

--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -91,7 +91,7 @@ lv_vg_lite_path_t * lv_vg_lite_path_create(vg_lite_format_t data_format)
     LV_ASSERT(vg_lite_init_path(
                   &path->base,
                   data_format,
-                  VG_LITE_MEDIUM,
+                  VG_LITE_HIGH,
                   0,
                   NULL,
                   0, 0, 0, 0)
@@ -139,7 +139,7 @@ void lv_vg_lite_path_reset(lv_vg_lite_path_t * path, vg_lite_format_t data_forma
     LV_ASSERT_NULL(path);
     path->base.path_length = 0;
     path->base.format = data_format;
-    path->base.quality = VG_LITE_MEDIUM;
+    path->base.quality = VG_LITE_HIGH;
     path->base.path_type = VG_LITE_DRAW_ZERO;
     path->format_len = lv_vg_lite_path_format_len(data_format);
     path->has_transform = false;


### PR DESCRIPTION
Set the default path quality to HIGH to avoid aliasing. The current rendering speed bottleneck is no longer GPU.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
