### PR TITLE
fix(vg_lite): fix stroke crash when update failed

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_stroke.c
+++ b/src/draw/vg_lite/lv_vg_lite_stroke.c
@@ -24,16 +24,41 @@
  *      TYPEDEFS
  **********************/
 
-typedef struct {
-    /* stroke path */
-    lv_vg_lite_path_t * path;
 
-    /* stroke parameters */
-    float width;
-    lv_vector_stroke_cap_t cap;
-    lv_vector_stroke_join_t join;
-    uint16_t miter_limit;
-    lv_array_t dash_pattern;
+/**
+ * Since the key-value data structure of lv_cache is integrated, the kv data structure
+ * will be saved at the same time when the cache is successfully created.
+ * In order to pursue efficiency during the matching process, the primary key (lv) used for matching
+ * will not dup the dash_pattern secondary pointer, so when the creation is successful, dash_pattern needs
+ * to be dup to the child key (vg), so type is added here to distinguish where the real data of dash_pattern exists.
+ */
+typedef enum {
+    DASH_PATTERN_TYPE_LV,
+    DASH_PATTERN_TYPE_VG
+} dash_pattern_type_t;
+
+typedef struct {
+    dash_pattern_type_t dash_pattern_type;
+
+    struct {
+        /* path data */
+        lv_vg_lite_path_t * path;
+
+        /* stroke parameters */
+        float width;
+        lv_vector_stroke_cap_t cap;
+        lv_vector_stroke_join_t join;
+        uint16_t miter_limit;
+        lv_array_t dash_pattern;
+    } lv;
+
+    struct {
+        /* stroke path */
+        lv_vg_lite_path_t * path;
+
+        /* dash pattern, for comparison only */
+        lv_array_t dash_pattern;
+    } vg;
 } stroke_item_t;
 
 /**********************
@@ -124,21 +149,21 @@ lv_cache_entry_t * lv_vg_lite_stroke_get(struct _lv_draw_vg_lite_unit_t * unit,
     /* prepare search key */
     stroke_item_t search_key;
     lv_memzero(&search_key, sizeof(search_key));
-    search_key.cap = dsc->cap;
-    search_key.join = dsc->join;
-    search_key.width = dsc->width;
-    search_key.miter_limit = dsc->miter_limit;
+    search_key.lv.cap = dsc->cap;
+    search_key.lv.join = dsc->join;
+    search_key.lv.width = dsc->width;
+    search_key.lv.miter_limit = dsc->miter_limit;
 
     /* A one-time read-only array that only copies the pointer but not the content */
-    search_key.dash_pattern = dsc->dash_pattern;
-    search_key.path = path;
+    search_key.lv.dash_pattern = dsc->dash_pattern;
+    search_key.lv.path = path;
 
-    lv_cache_entry_t * cache_node_entry = lv_cache_acquire(unit->stroke_cache, &search_key, &search_key);
+    lv_cache_entry_t * cache_node_entry = lv_cache_acquire(unit->stroke_cache, &search_key, NULL);
     if(cache_node_entry) {
         return cache_node_entry;
     }
 
-    cache_node_entry = lv_cache_acquire_or_create(unit->stroke_cache, &search_key, &search_key);
+    cache_node_entry = lv_cache_acquire_or_create(unit->stroke_cache, &search_key, NULL);
     if(cache_node_entry == NULL) {
         LV_LOG_ERROR("stroke cache creating failed");
         return NULL;
@@ -153,7 +178,13 @@ struct _lv_vg_lite_path_t * lv_vg_lite_stroke_get_path(lv_cache_entry_t * cache_
 
     stroke_item_t * stroke_item = lv_cache_entry_get_data(cache_entry);
     LV_ASSERT_NULL(stroke_item);
-    return stroke_item->path;
+
+    if(lv_array_size(&stroke_item->vg.dash_pattern)) {
+        /* check if dash pattern must be duped */
+        LV_ASSERT(stroke_item->dash_pattern_type == DASH_PATTERN_TYPE_VG);
+    }
+
+    return stroke_item->vg.path;
 }
 
 void lv_vg_lite_stroke_drop(struct _lv_draw_vg_lite_unit_t * unit,
@@ -170,43 +201,49 @@ void lv_vg_lite_stroke_drop(struct _lv_draw_vg_lite_unit_t * unit,
 
 static bool stroke_create_cb(stroke_item_t * item, void * user_data)
 {
+    LV_UNUSED(user_data);
     LV_ASSERT_NULL(item);
 
-    stroke_item_t * src = user_data;
-    LV_ASSERT_NULL(src);
+    /* Check if stroke width is valid */
+    if(item->lv.width <= 0) {
+        LV_LOG_WARN("stroke width error: %f", item->lv.width);
+        return false;
+    }
 
-    lv_memzero(item, sizeof(stroke_item_t));
+    /* Reset the dash pattern type */
+    item->dash_pattern_type = DASH_PATTERN_TYPE_LV;
 
-    /* copy path */
-    item->path = lv_vg_lite_path_create(VG_LITE_FP32);
-    lv_vg_lite_path_append_path(item->path, src->path);
+    /* dup the path */
+    item->vg.path = lv_vg_lite_path_create(VG_LITE_FP32);
+    lv_vg_lite_path_append_path(item->vg.path, item->lv.path);
 
-    /* copy parameters */
-    item->cap = src->cap;
-    item->join = src->join;
-    item->width = src->width;
-    item->miter_limit = src->miter_limit;
-
-    /* copy dash pattern */
-    uint32_t size = lv_array_size(&src->dash_pattern);
+    /* dup the dash pattern */
+    vg_lite_float_t * vg_dash_pattern = NULL;
+    const uint32_t size = lv_array_size(&item->lv.dash_pattern);
     if(size) {
-        lv_array_init(&item->dash_pattern, size, sizeof(float));
-        lv_array_copy(&item->dash_pattern, &src->dash_pattern);
+        /* Only support float dash pattern */
+        LV_ASSERT(item->lv.dash_pattern.element_size == sizeof(float));
+        lv_array_init(&item->vg.dash_pattern, size, sizeof(float));
+        lv_array_copy(&item->vg.dash_pattern, &item->lv.dash_pattern);
+
+        /* mark dash pattern has been duped */
+        item->dash_pattern_type = DASH_PATTERN_TYPE_VG;
+        vg_dash_pattern = lv_array_front(&item->vg.dash_pattern);
     }
 
     /* update parameters */
-    vg_lite_path_t * vg_path = lv_vg_lite_path_get_path(item->path);
+    vg_lite_path_t * vg_path = lv_vg_lite_path_get_path(item->vg.path);
     LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, VG_LITE_DRAW_STROKE_PATH));
 
     vg_lite_error_t error = vg_lite_set_stroke(
                                 vg_path,
-                                lv_stroke_cap_to_vg(item->cap),
-                                lv_stroke_join_to_vg(item->join),
-                                item->width,
-                                item->miter_limit,
-                                lv_array_front(&item->dash_pattern),
+                                lv_stroke_cap_to_vg(item->lv.cap),
+                                lv_stroke_join_to_vg(item->lv.join),
+                                item->lv.width,
+                                item->lv.miter_limit,
+                                vg_dash_pattern,
                                 size,
-                                item->width / 2,
+                                item->lv.width / 2,
                                 0);
 
     if(error != VG_LITE_SUCCESS) {
@@ -242,21 +279,73 @@ static void stroke_free_cb(stroke_item_t * item, void * user_data)
     LV_UNUSED(user_data);
     LV_ASSERT_NULL(item);
 
-    lv_array_deinit(&item->dash_pattern);
-    lv_vg_lite_path_destroy(item->path);
-    lv_memzero(item, sizeof(stroke_item_t));
-}
-
-static lv_cache_compare_res_t path_compare(const vg_lite_path_t * lhs, const vg_lite_path_t * rhs)
-{
-    LV_ASSERT(lhs->format == VG_LITE_FP32);
-    LV_ASSERT(rhs->format == VG_LITE_FP32);
-
-    if(lhs->path_length != rhs->path_length) {
-        return lhs->path_length > rhs->path_length ? 1 : -1;
+    if(item->vg.path) {
+        lv_vg_lite_path_destroy(item->vg.path);
+        item->vg.path = NULL;
     }
 
-    int cmp_res = lv_memcmp(lhs->path, rhs->path, lhs->path_length);
+    if(item->dash_pattern_type == DASH_PATTERN_TYPE_VG) {
+        lv_array_deinit(&item->vg.dash_pattern);
+        item->dash_pattern_type = DASH_PATTERN_TYPE_LV;
+    }
+}
+
+static lv_cache_compare_res_t dash_pattern_compare(const stroke_item_t * lhs, const stroke_item_t * rhs)
+{
+    /* Select the dash pattern to compare */
+    const lv_array_t * lhs_dash_pattern = lhs->dash_pattern_type == DASH_PATTERN_TYPE_LV ?
+                                          &lhs->lv.dash_pattern :
+                                          &lhs->vg.dash_pattern;
+    const lv_array_t * rhs_dash_pattern = rhs->dash_pattern_type == DASH_PATTERN_TYPE_LV ?
+                                          &rhs->lv.dash_pattern :
+                                          &rhs->vg.dash_pattern;
+
+    const uint32_t lhs_dash_pattern_size = lv_array_size(lhs_dash_pattern);
+    const uint32_t rhs_dash_pattern_size = lv_array_size(rhs_dash_pattern);
+
+    if(lhs_dash_pattern_size != rhs_dash_pattern_size) {
+        return lhs_dash_pattern_size > rhs_dash_pattern_size ? 1 : -1;
+    }
+
+    if(lhs_dash_pattern_size == 0 && rhs_dash_pattern_size == 0) {
+        return 0;
+    }
+
+    /* Both dash pattern has the same size, compare them */
+    LV_ASSERT(lhs_dash_pattern->element_size == sizeof(float));
+    LV_ASSERT(rhs_dash_pattern->element_size == sizeof(float));
+
+    /* compare dash pattern data */
+    int cmp_res = lv_memcmp(
+                      lv_array_front(lhs_dash_pattern),
+                      lv_array_front(rhs_dash_pattern),
+                      lhs_dash_pattern_size * sizeof(float));
+
+    if(cmp_res != 0) {
+        return cmp_res > 0 ? 1 : -1;
+    }
+
+    return 0;
+}
+
+static lv_cache_compare_res_t path_compare(const stroke_item_t * lhs, const stroke_item_t * rhs)
+{
+    /* Give priority to using dup vg.path */
+    const vg_lite_path_t * lhs_path = lhs->vg.path ?
+                                      lv_vg_lite_path_get_path(lhs->vg.path) :
+                                      lv_vg_lite_path_get_path(lhs->lv.path);
+    const vg_lite_path_t * rhs_path = rhs->vg.path ?
+                                      lv_vg_lite_path_get_path(rhs->vg.path) :
+                                      lv_vg_lite_path_get_path(rhs->lv.path);
+
+    LV_ASSERT(lhs_path->format == VG_LITE_FP32);
+    LV_ASSERT(rhs_path->format == VG_LITE_FP32);
+
+    if(lhs_path->path_length != rhs_path->path_length) {
+        return lhs_path->path_length > rhs_path->path_length ? 1 : -1;
+    }
+
+    int cmp_res = lv_memcmp(lhs_path->path, rhs_path->path, lhs_path->path_length);
     if(cmp_res != 0) {
         return cmp_res > 0 ? 1 : -1;
     }
@@ -266,44 +355,28 @@ static lv_cache_compare_res_t path_compare(const vg_lite_path_t * lhs, const vg_
 
 static lv_cache_compare_res_t stroke_compare_cb(const stroke_item_t * lhs, const stroke_item_t * rhs)
 {
-    if(lhs->width != lhs->width) {
-        return lhs->width > lhs->width ? 1 : -1;
+    if(lhs->lv.width != rhs->lv.width) {
+        return lhs->lv.width > rhs->lv.width ? 1 : -1;
     }
 
-    if(lhs->cap != rhs->cap) {
-        return lhs->cap > rhs->cap ? 1 : -1;
+    if(lhs->lv.cap != rhs->lv.cap) {
+        return lhs->lv.cap > rhs->lv.cap ? 1 : -1;
     }
 
-    if(lhs->join != rhs->join) {
-        return lhs->join > rhs->join ? 1 : -1;
+    if(lhs->lv.join != rhs->lv.join) {
+        return lhs->lv.join > rhs->lv.join ? 1 : -1;
     }
 
-    if(lhs->miter_limit != rhs->miter_limit) {
-        return lhs->miter_limit > rhs->miter_limit ? 1 : -1;
+    if(lhs->lv.miter_limit != rhs->lv.miter_limit) {
+        return lhs->lv.miter_limit > rhs->lv.miter_limit ? 1 : -1;
     }
 
-    uint32_t lhs_dash_pattern_size = lv_array_size(&lhs->dash_pattern);
-    uint32_t rhs_dash_pattern_size = lv_array_size(&rhs->dash_pattern);
-
-    if(lhs_dash_pattern_size != rhs_dash_pattern_size) {
-        return lhs_dash_pattern_size > rhs_dash_pattern_size ? 1 : -1;
+    lv_cache_compare_res_t dash_pattern_res = dash_pattern_compare(lhs, rhs);
+    if(dash_pattern_res != 0) {
+        return dash_pattern_res;
     }
 
-    if(lhs_dash_pattern_size > 0 && rhs_dash_pattern_size > 0) {
-        LV_ASSERT(lhs->dash_pattern.element_size == sizeof(float));
-        LV_ASSERT(rhs->dash_pattern.element_size == sizeof(float));
-
-        const float * lhs_dash_pattern = lv_array_front(&lhs->dash_pattern);
-        const float * rhs_dash_pattern = lv_array_front(&rhs->dash_pattern);
-
-        /* compare dash pattern */
-        int cmp_res = lv_memcmp(lhs_dash_pattern, rhs_dash_pattern, lhs_dash_pattern_size * sizeof(float));
-        if(cmp_res != 0) {
-            return cmp_res > 0 ? 1 : -1;
-        }
-    }
-
-    return path_compare(lv_vg_lite_path_get_path(lhs->path), lv_vg_lite_path_get_path(rhs->path));
+    return path_compare(lhs, rhs);
 }
 
 #endif /*LV_USE_DRAW_VG_LITE && LV_USE_VECTOR_GRAPHIC*/


### PR DESCRIPTION
Since the key-value data structure of lv_cache is integrated, the kv data structure will be saved at the same time when the cache is successfully created.
In order to pursue efficiency during the matching process, the primary key (lv) used for matching will not dup the dash_pattern secondary pointer, so when the creation is successful, dash_pattern needs to be dup to the child key (vg), so type is added here to distinguish where the real data of dash_pattern exists.

stroke stress test code:
```c
static float lv_rand_float(float min, float max)
{
    return (float)lv_rand(min, max);
}

static void draw_lines(lv_vector_dsc_t* ctx, lv_vector_path_t* path)
{
    lv_vector_dsc_set_stroke_opa(ctx, LV_OPA_COVER);
    lv_vector_dsc_set_fill_opa(ctx, LV_OPA_0);

    lv_fpoint_t pts1[] = {{50, 50}, {400, 50}};
    lv_vector_path_clear(path);
    lv_vector_path_move_to(path, &pts1[0]);
    lv_vector_path_line_to(path, &pts1[1]);
    lv_vector_dsc_add_path(ctx, path);

    lv_fpoint_t pts2[] = {{50, 80}, {400, 80}};
    lv_vector_path_clear(path);
    lv_vector_path_move_to(path, &pts2[0]);
    lv_vector_path_line_to(path, &pts2[1]);
    lv_vector_dsc_set_stroke_color(ctx, lv_color_make(0xff, 0x00, 0x00));
    lv_vector_dsc_set_stroke_width(ctx, 3.0f);
    lv_vector_dsc_add_path(ctx, path);

    lv_fpoint_t pts3[] = {{50, 120}, {400, 120}};
    lv_vector_path_clear(path);
    lv_vector_path_move_to(path, &pts3[0]);
    lv_vector_path_line_to(path, &pts3[1]);
    lv_vector_dsc_set_stroke_color(ctx, lv_color_make(0x00, 0xff, 0x00));
    lv_vector_dsc_set_stroke_width(ctx, 5.0f);
    float dashes[] = {10, 15, 20, 12};
    lv_vector_dsc_set_stroke_dash(ctx, dashes, 4);
    lv_vector_dsc_add_path(ctx, path);

    lv_fpoint_t pts4[] = {{100, 150}, {50, 250}, {150, 250}};
    lv_vector_path_clear(path);
    lv_vector_path_move_to(path, &pts4[0]);
    lv_vector_path_line_to(path, &pts4[1]);
    lv_vector_path_line_to(path, &pts4[2]);
    lv_vector_dsc_set_stroke_color(ctx, lv_color_make(0x00, 0x00, 0x00));
    lv_vector_dsc_set_stroke_width(ctx, 10.0f);
    lv_vector_dsc_set_stroke_dash(ctx, NULL, 0);
    lv_vector_dsc_set_stroke_join(ctx, LV_VECTOR_STROKE_JOIN_MITER);
    lv_vector_dsc_add_path(ctx, path);

    lv_vector_dsc_translate(ctx, 150, 0);
    lv_vector_dsc_set_stroke_join(ctx, LV_VECTOR_STROKE_JOIN_BEVEL);
    lv_vector_dsc_add_path(ctx, path);

    lv_vector_dsc_translate(ctx, 150, 0);
    lv_vector_dsc_set_stroke_join(ctx, LV_VECTOR_STROKE_JOIN_ROUND);
    lv_vector_dsc_add_path(ctx, path);

    lv_fpoint_t pts5[] = {{50, 300}, {150, 300}};
    lv_vector_dsc_identity(ctx);
    lv_vector_path_clear(path);
    lv_vector_path_move_to(path, &pts5[0]);
    lv_vector_path_line_to(path, &pts5[1]);
    lv_vector_dsc_set_stroke_cap(ctx, LV_VECTOR_STROKE_CAP_BUTT);
    lv_vector_dsc_add_path(ctx, path);

    lv_vector_dsc_translate(ctx, 0, 40);
    lv_vector_dsc_set_stroke_cap(ctx, LV_VECTOR_STROKE_CAP_SQUARE);
    lv_vector_dsc_add_path(ctx, path);

    lv_vector_dsc_translate(ctx, 0, 40);
    lv_vector_dsc_set_stroke_cap(ctx, LV_VECTOR_STROKE_CAP_ROUND);
    lv_vector_dsc_add_path(ctx, path);

    lv_area_t rect1 = {250, 300, 350, 400};
    lv_vector_dsc_identity(ctx);
    lv_vector_path_clear(path);
    lv_vector_path_append_rect(path, &rect1, 0, 0);

    lv_gradient_stop_t stops[2];
    lv_memzero(stops, sizeof(stops));
    stops[0].color = lv_color_hex(0xff0000);
    stops[0].opa = LV_OPA_COVER;
    stops[0].frac = 0;
    stops[1].color = lv_color_hex(0x00ff00);
    stops[1].opa = LV_OPA_COVER;
    stops[1].frac = 255;

    lv_matrix_t mt;
    lv_matrix_identity(&mt);
    lv_matrix_rotate(&mt, 5);
    lv_matrix_translate(&mt, 20, 20);
    lv_vector_dsc_set_stroke_transform(ctx, &mt);
    lv_vector_dsc_set_stroke_join(ctx, LV_VECTOR_STROKE_JOIN_MITER);
    lv_vector_dsc_set_stroke_linear_gradient(ctx, 250, 300, 350, 300);
    lv_vector_dsc_set_stroke_gradient_color_stops(ctx, stops, 2);
    lv_vector_dsc_set_stroke_gradient_spread(ctx, LV_VECTOR_GRADIENT_SPREAD_REFLECT);
    lv_vector_dsc_add_path(ctx, path); // draw a path
}

static void draw_lines_random(lv_vector_dsc_t* ctx, lv_vector_path_t* path)
{
    if(lv_rand(0, 1)) {
        draw_lines(ctx, path);
        return;
    }

    lv_vector_path_clear(path);
    lv_vector_dsc_identity(ctx);

    lv_fpoint_t start_point = { lv_rand_float(0, 480), lv_rand_float(0, 480) };
    lv_vector_path_move_to(path, &start_point);

    int len = lv_rand(2, 30);

    while (len--) {
        lv_fpoint_t pts[] = {
            { lv_rand_float(0, 480), lv_rand_float(0, 480) },
            { lv_rand_float(0, 480), lv_rand_float(0, 480) },
            { lv_rand_float(0, 480), lv_rand_float(0, 480) },
        };

        switch (lv_rand(0, 2)) {
        case 0:
            lv_vector_path_line_to(path, &pts[0]);
            break;
        case 1:
            lv_vector_path_quad_to(path, &pts[0], &pts[1]);
            break;
        case 2:
            lv_vector_path_cubic_to(path, &pts[0], &pts[1], &pts[2]);
            break;
        default:
            break;
        }
    }

    if (lv_rand(0, 1)) {
        lv_vector_path_close(path);
    }

    static const lv_vector_stroke_cap_t cap_list[] = {
        LV_VECTOR_STROKE_CAP_BUTT,
        LV_VECTOR_STROKE_CAP_SQUARE,
        LV_VECTOR_STROKE_CAP_ROUND,
    };

    static const lv_vector_stroke_join_t join_list[] = {
        LV_VECTOR_STROKE_JOIN_MITER,
        LV_VECTOR_STROKE_JOIN_ROUND,
        LV_VECTOR_STROKE_JOIN_BEVEL,
    };

    lv_vector_dsc_set_stroke_cap(ctx, cap_list[lv_rand(0, 2)]);
    lv_vector_dsc_set_stroke_join(ctx, join_list[lv_rand(0, 2)]);
    lv_vector_dsc_set_stroke_color(ctx, lv_color_make(lv_rand(0, 255), lv_rand(0, 255), lv_rand(0, 255)));
    lv_vector_dsc_set_stroke_opa(ctx, lv_rand(LV_OPA_TRANSP, LV_OPA_COVER));

    lv_vector_dsc_set_fill_color(ctx, lv_color_make(lv_rand(0, 255), lv_rand(0, 255), lv_rand(0, 255)));
    lv_vector_dsc_set_fill_opa(ctx, lv_rand(LV_OPA_TRANSP, LV_OPA_COVER));

    lv_vector_dsc_set_stroke_width(ctx, lv_rand(1, 10));

    float dashes[] = { lv_rand_float(10, 50), lv_rand_float(10, 50), lv_rand_float(10, 50), lv_rand_float(10, 50) };
    lv_vector_dsc_set_stroke_dash(ctx, dashes, 4);

    lv_vector_dsc_add_path(ctx, path);
}

static void draw_timer_cb(lv_timer_t* timer)
{
    lv_obj_t* canvas = (lv_obj_t*)lv_timer_get_user_data(timer);

    lv_layer_t layer;
    lv_canvas_init_layer(canvas, &layer);

    lv_vector_dsc_t* ctx = lv_vector_dsc_create(&layer);
    lv_vector_path_t* path = lv_vector_path_create(LV_VECTOR_PATH_QUALITY_MEDIUM);

    draw_lines_random(ctx, path);

    lv_draw_vector(ctx);
    lv_canvas_finish_layer(canvas, &layer);
    lv_vector_path_delete(path);
    lv_vector_dsc_delete(ctx);
}

static void stroke_stress()
{
    lv_draw_buf_t* draw_buf = lv_draw_buf_create(480, 480, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
    lv_draw_buf_clear(draw_buf, NULL);

    lv_obj_t* canvas = lv_canvas_create(lv_screen_active());
    lv_canvas_set_draw_buf(canvas, draw_buf);

    lv_timer_create(draw_timer_cb, 10, canvas);
}
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
