### PR TITLE
fix(cmake): fix msvc building error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,11 @@ cmake_minimum_required(VERSION 3.12.4)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(NOT ESP_PLATFORM)
+  project(lvgl LANGUAGES C HOMEPAGE_URL https://github.com/lvgl/lvgl)
   if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
-    project(lvgl LANGUAGES C CXX ASM HOMEPAGE_URL https://github.com/lvgl/lvgl)
+    enable_language(CXX ASM)
   else()
-    project(lvgl LANGUAGES C CXX HOMEPAGE_URL https://github.com/lvgl/lvgl)
+    enable_language(CXX)
   endif()
 endif()
 


### PR DESCRIPTION
fix #6931 #7371 
(similar issue exists when using msvc as compiler, and ninja or nmake as generator, they are also being fixed. )

further investigation of the issue:

CMake generates a PreLinkEvent in the "lvgl.vcxproj" when using visual studio as the generator. 

```
    <PreLinkEvent>
      <UseUtf8Encoding>Always</UseUtf8Encoding>
      <Message>Auto build dll exports</Message>
      <Command>setlocal
cd D:\lvgl_windows_9.3\build
if %errorlevel% neq 0 goto :cmEnd
D:
if %errorlevel% neq 0 goto :cmEnd
"C:\Program Files\CMake\bin\cmake.exe" -E __create_def D:/lvgl_windows_9.3/build/lvgl.dir/Debug/exports.def D:/lvgl_windows_9.3/build/lvgl.dir/Debug//objects.txt
if %errorlevel% neq 0 goto :cmEnd
:cmEnd
endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
:cmErrorLevel
exit /b %1
:cmDone
if %errorlevel% neq 0 goto :VCEnd</Command>
    </PreLinkEvent>
```

this line
`"C:\Program Files\CMake\bin\cmake.exe" -E __create_def D:/lvgl_windows_9.3/build/lvgl.dir/Debug/exports.def D:/lvgl_windows_9.3/build/lvgl.dir/Debug//objects.txt`
tries to generate the "export.def" file from all the object files listed in "objects.txt", including "lv_blend_helium.obj" and "lv_blend_neon.obj". but those two files do not exist so it fails, causing the error.


so here is the question: (0) should those two object files be included in the prerequisites of the dll library? (in fact they are useless on non-ARM platforms)

if the answer is no, (1) why are those files being included by CMake?
if the answer is yes, (2) why are those files not being generated by msvc?

after some research i found the answer of (1) is this part of code in "lvgl/CMakeLists.txt" doesn't work as expected:

```
if(NOT ESP_PLATFORM)
  if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
    project(lvgl LANGUAGES C CXX ASM HOMEPAGE_URL https://github.com/lvgl/lvgl)
  else()
    project(lvgl LANGUAGES C CXX HOMEPAGE_URL https://github.com/lvgl/lvgl)
  endif()
endif()
```

the CMAKE_C_COMPILER_ID is empty before the C language being specified using project() or enable_language(), so the first branch with ASM is always taken, regardless of the compiler is msvc or not.
this PR fixes the bug. asm files will be excluded from "objects.txt" and the project should be able to build without error now. 

for (2), the reason is that the msvc itself (cl.exe) supports only inline assembly (__asm blocks) but not individual assembly files. for individual assembly files masm (ml64.exe) is required. 

masm support can be enabled this way:

in lvgl/CMakeLists.txt:
```
if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
  enable_language(ASM_MASM)
endif()
```

in lvgl/env_support/cmake/custom.cmake:
```
if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
  file(GLOB_RECURSE ASM_SOURCES "${LVGL_ROOT_DIR}/src/*.S")
  set_source_files_properties(${ASM_SOURCES} PROPERTIES LANGUAGE ASM_MASM)
endif()
```

by this modification masm will try to assemble those .S files. but unfortunately masm itself (ml64.exe) doesn't support C-style comments and preprocessing directives, also it won't call the cl.exe to do the preprocessing job, so it fails on the first line (/**):
```
  1>Checking Build System
  Building Custom Rule D:/lvgl_windows_9.3/lvgl/CMakeLists.txt
  Assembling D:\lvgl_windows_9.3\lvgl\src\draw\sw\blend\helium\lv_blend_helium.S...
D:\lvgl_windows_9.3\lvgl\src\draw\sw\blend\helium\lv_blend_helium.S(1): error A2008: syntax error : / [D:\lvgl_windows_9.3\build\lvgl.vcxproj]
...
```

to make things right we need to use customized build process on those files: call the preprocessor first (cl.exe /P) and then feed the output to the masm. there should be a way to do that in CMake but i haven't figured out by now. 

another option is to change those .S files to .c files with inline assembly that cl.exe supports. C-style comments and preprocessing directives in inline assembly are supported too. but i don't think it's worth taking the risk of making such big change. 

the simplest way may be better: just exclude those files from msvc build since they are very unlikely to be enabled on windows PCs. (microsoft said they have added support for ARM arch, but i've never tried to compile for ARM arch using msvc and masm on windows so far, don't know if it's possible)
