### PR TITLE
feat(draw): add alpha for RGB565A8 dest buffers

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -84,6 +84,8 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         lv_area_move(&fill_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
         fill_dsc.dest_buf = lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1,
                                                    blend_area.y1 - layer->buf_area.y1);
+        fill_dsc.dest_alpha_buf = layer->draw_buf->data + (((uint8_t*)fill_dsc.dest_buf - (uint8_t*)layer->draw_buf->data) / 2 + (layer->draw_buf->header.stride * layer->draw_buf->header.h));
+        fill_dsc.dest_alpha_stride = layer->draw_buf->header.stride / 2;
         if(fill_dsc.mask_buf) {
             fill_dsc.mask_stride = blend_dsc->mask_stride == 0  ? lv_area_get_width(blend_dsc->mask_area) : blend_dsc->mask_stride;
             fill_dsc.mask_buf += fill_dsc.mask_stride * (blend_area.y1 - blend_dsc->mask_area->y1) +
@@ -93,6 +95,7 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
         switch(layer->color_format) {
 #if LV_DRAW_SW_SUPPORT_RGB565
             case LV_COLOR_FORMAT_RGB565:
+            case LV_COLOR_FORMAT_RGB565A8:
                 lv_draw_sw_blend_color_to_rgb565(&fill_dsc);
                 break;
 #endif
@@ -178,6 +181,8 @@ void lv_draw_sw_blend(lv_draw_unit_t * draw_unit, const lv_draw_sw_blend_dsc_t *
 
         image_dsc.dest_buf = lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1,
                                                     blend_area.y1 - layer->buf_area.y1);
+        image_dsc.dest_alpha_buf = layer->draw_buf->data + (((uint8_t*)image_dsc.dest_buf - (uint8_t*)layer->draw_buf->data) / 2 + (layer->draw_buf->header.stride * layer->draw_buf->header.h));
+        image_dsc.dest_alpha_stride = layer->draw_buf->header.stride / 2;
 
         switch(layer->color_format) {
 #if LV_DRAW_SW_SUPPORT_RGB565

--- a/src/draw/sw/blend/lv_draw_sw_blend_private.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend_private.h
@@ -48,9 +48,11 @@ struct _lv_draw_sw_blend_dsc_t {
 
 struct _lv_draw_sw_blend_fill_dsc_t {
     void * dest_buf;
+    void * dest_alpha_buf;
     int32_t dest_w;
     int32_t dest_h;
     int32_t dest_stride;
+    int32_t dest_alpha_stride;
     const lv_opa_t * mask_buf;
     int32_t mask_stride;
     lv_color_t color;
@@ -60,9 +62,11 @@ struct _lv_draw_sw_blend_fill_dsc_t {
 
 struct _lv_draw_sw_blend_image_dsc_t {
     void * dest_buf;
+    void * dest_alpha_buf;
     int32_t dest_w;
     int32_t dest_h;
     int32_t dest_stride;
+    int32_t dest_alpha_stride;
     const lv_opa_t * mask_buf;
     int32_t mask_stride;
     const void * src_buf;

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -217,10 +217,36 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565(lv_draw_sw_blend_fil
     const lv_opa_t * mask = dsc->mask_buf;
     int32_t mask_stride = dsc->mask_stride;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
+    uint8_t * alpha_buf_u8 = dsc->dest_alpha_buf;
     int32_t dest_stride = dsc->dest_stride;
+    int32_t dest_alpha_stride = dsc->dest_alpha_stride;
 
     int32_t x;
     int32_t y;
+
+    for (y = 0; y < h; y++)
+    {
+        if(mask == NULL) 
+        {
+            lv_memset(alpha_buf_u8, opa, w);
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+        else if(opa > LV_OPA_MIN)
+        {
+            for(x = 0; x < w; x++)
+            {
+               alpha_buf_u8[x] = alpha_buf_u8[x] | LV_OPA_MIX2(mask[x], opa);
+            }
+            mask += mask_stride;
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+        else
+        {
+            lv_memset(alpha_buf_u8, opa, w);
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+    }
+    mask = dsc->mask_buf;
 
     LV_UNUSED(w);
     LV_UNUSED(h);
@@ -760,7 +786,9 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
     int32_t h = dsc->dest_h;
     lv_opa_t opa = dsc->opa;
     uint16_t * dest_buf_u16 = dsc->dest_buf;
+    uint8_t * alpha_buf_u8 = dsc->dest_alpha_buf;
     int32_t dest_stride = dsc->dest_stride;
+    int32_t dest_alpha_stride = dsc->dest_alpha_stride;
     const uint16_t * src_buf_u16 = dsc->src_buf;
     int32_t src_stride = dsc->src_stride;
     const lv_opa_t * mask_buf = dsc->mask_buf;
@@ -768,6 +796,31 @@ static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_
 
     int32_t x;
     int32_t y;
+
+    for (y = 0; y < h; y++)
+    {
+        if(mask_buf == NULL) 
+        {
+            lv_memset(alpha_buf_u8, opa, w);
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+        else if(opa > LV_OPA_MIN)
+        {
+            for(x = 0; x < w; x++)
+            {
+               alpha_buf_u8[x] = alpha_buf_u8[x] | LV_OPA_MIX2(mask_buf[x], opa);
+            }
+            mask_buf += mask_stride;
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+        else
+        {
+            lv_memset(alpha_buf_u8, opa, w);
+            alpha_buf_u8 += dest_alpha_stride;
+        }
+    }
+
+    mask_buf = dsc->mask_buf;
 
     if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
         if(mask_buf == NULL && opa >= LV_OPA_MAX) {


### PR DESCRIPTION
reference issue #7312

added writes to the alpha buffer location when using RGB565A8 as the display color format
modified copy, clear, and blend functions to accomplish this
this solution is incomplete but works for my use case

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
