### PR TITLE
docs(profiler): remove tick unit

### DIFF
--- a/docs/details/debugging/profiler.rst
+++ b/docs/details/debugging/profiler.rst
@@ -47,7 +47,7 @@ To enable the profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and conf
         #include <time.h>
         #include <unistd.h>
 
-        static uint64_t my_get_tick_us_cb(void)
+        static uint64_t my_get_tick_cb(void)
         {
             struct timespec ts;
             clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -71,7 +71,7 @@ To enable the profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and conf
             lv_profiler_builtin_config_t config;
             lv_profiler_builtin_config_init(&config);
             config.tick_per_sec = 1000000000; /* One second is equal to 1000000000 nanoseconds */
-            config.tick_get_cb = my_get_tick_us_cb;
+            config.tick_get_cb = my_get_tick_cb;
             config.tid_get_cb = my_get_tid_cb;
             config.cpu_get_cb = my_get_cpu_cb;
             lv_profiler_builtin_init(&config);
@@ -81,7 +81,7 @@ To enable the profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and conf
 
     .. code-block:: c
 
-        static uint64_t my_get_tick_us_cb(void)
+        static uint64_t my_get_tick_cb(void)
         {
             /* Use the microsecond time stamp provided by Arduino */
             return micros();
@@ -92,7 +92,7 @@ To enable the profiler, set :c:macro:`LV_USE_PROFILER` in ``lv_conf.h`` and conf
             lv_profiler_builtin_config_t config;
             lv_profiler_builtin_config_init(&config);
             config.tick_per_sec = 1000000; /* One second is equal to 1000000 microseconds */
-            config.tick_get_cb = my_get_tick_us_cb;
+            config.tick_get_cb = my_get_tick_cb;
             lv_profiler_builtin_init(&config);
         }
 


### PR DESCRIPTION
UNIX systems use nanosecond timestamps

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
