### PR TITLE
fix(examples): fix infinite scroll crash

### DIFF
--- a/examples/scroll/lv_example_scroll_7.c
+++ b/examples/scroll/lv_example_scroll_7.c
@@ -17,6 +17,10 @@ static lv_obj_t * load_item(lv_obj_t * parent, int32_t num)
 
 static void update_scroll(lv_obj_t * obj)
 {
+    bool is_already_in = (bool)(uintptr_t)lv_obj_get_user_data(obj);
+    if(is_already_in) return;
+    lv_obj_set_user_data(obj, (void *)(uintptr_t)true);
+
     int32_t top_num_original = top_num;
     int32_t bottom_num_original = bottom_num;
 
@@ -63,6 +67,8 @@ static void update_scroll(lv_obj_t * obj)
     if(bottom_num != bottom_num_original) {
         lv_label_set_text_fmt(low_label, "current smallest\nloaded value:\n%"PRId32, bottom_num);
     }
+
+    lv_obj_set_user_data(obj, (void *)(uintptr_t)false);
 }
 
 static void scroll_cb(lv_event_t * e)

--- a/examples/scroll/lv_example_scroll_7.c
+++ b/examples/scroll/lv_example_scroll_7.c
@@ -110,16 +110,10 @@ void lv_example_scroll_7(void)
     lv_label_set_text_static(low_label, "current smallest\nloaded value:");
     lv_obj_align(low_label, LV_ALIGN_BOTTOM_LEFT, 10, -10);
 
-    /* These counters hold the the highest/lowest number currently shown.
-     * Since no numbers are show yet, set them such that they will be
-     * correct after the first value is added.
-     * I.e., if a value is added at the top, `top_num` will be incremented
-     * and its new value (4) will be added to the top (`top_num`=4, `bottom_num`=4).
-     * If a value is added to the bottom, `bottom_num` will be decremented
-     * and its new value (3) will be added to the bottom (`top_num`=3, `bottom_num`=3).
-     */
+    load_item(obj, 3);
+    /* These counters hold the the highest/lowest number currently loaded. */
     top_num = 3;
-    bottom_num = 4;
+    bottom_num = 3;
 
     lv_obj_update_layout(obj);
     update_scroll(obj);

--- a/examples/scroll/lv_example_scroll_7.c
+++ b/examples/scroll/lv_example_scroll_7.c
@@ -5,6 +5,7 @@ static lv_obj_t * high_label;
 static lv_obj_t * low_label;
 static int32_t top_num;
 static int32_t bottom_num;
+static bool update_scroll_running = false;
 
 static lv_obj_t * load_item(lv_obj_t * parent, int32_t num)
 {
@@ -17,9 +18,11 @@ static lv_obj_t * load_item(lv_obj_t * parent, int32_t num)
 
 static void update_scroll(lv_obj_t * obj)
 {
-    bool is_already_in = (bool)(uintptr_t)lv_obj_get_user_data(obj);
-    if(is_already_in) return;
-    lv_obj_set_user_data(obj, (void *)(uintptr_t)true);
+    /* do not re-enter this function when `lv_obj_scroll_by`
+     * triggers this callback again.
+     */
+    if(update_scroll_running) return;
+    update_scroll_running = true;
 
     int32_t top_num_original = top_num;
     int32_t bottom_num_original = bottom_num;
@@ -68,7 +71,7 @@ static void update_scroll(lv_obj_t * obj)
         lv_label_set_text_fmt(low_label, "current smallest\nloaded value:\n%"PRId32, bottom_num);
     }
 
-    lv_obj_set_user_data(obj, (void *)(uintptr_t)false);
+    update_scroll_running = false;
 }
 
 static void scroll_cb(lv_event_t * e)


### PR DESCRIPTION
Infinite (or near enough) recursion can occur in some cases. The `lv_obj_scroll_by` calls cause the event callback to recur. Make the function return if it is reentered with the same object.

Reproducable on Emscripten (i.e. the docs) by scrolling to the bottom (-30) https://docs.lvgl.io/master/examples.html#infinite-scrolling
I tested the fix with Emscripten locally.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
