### PR TITLE
fix(vg_lite): fix path memory reallocation error

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -260,7 +260,10 @@ static void lv_vg_lite_path_append_data(lv_vg_lite_path_t * path, const void * d
     LV_ASSERT_NULL(path);
     LV_ASSERT_NULL(data);
 
-    if(path->base.path_length + len > path->mem_size) {
+    bool need_reallocated = false;
+
+    /*Calculate new mem size until match the contidion*/
+    while(path->base.path_length + len > path->mem_size) {
         if(path->mem_size == 0) {
             path->mem_size = LV_MAX(len, PATH_MEM_SIZE_MIN);
         }
@@ -268,6 +271,10 @@ static void lv_vg_lite_path_append_data(lv_vg_lite_path_t * path, const void * d
             /* Increase memory size by 1.5 times */
             path->mem_size = path->mem_size * 3 / 2;
         }
+        need_reallocated = true;
+    }
+
+    if(need_reallocated) {
         path->base.path = lv_realloc(path->base.path, path->mem_size);
         LV_ASSERT_MALLOC(path->base.path);
     }


### PR DESCRIPTION
Adjust the condition for calculating the new memory size and introduce a flag to track if reallocation is needed. This ensures that the memory size is increased by 1.5 times until it meets the required length, and only reallocates when necessary.

A clear and concise description of what the bug or new feature is.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
