### PR TITLE
fix(event): remove preprocess flag when get name

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -86,9 +86,9 @@ lv_result_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e)
 
     /*Call the actual event callback*/
     e->user_data = NULL;
-    LV_PROFILER_EVENT_BEGIN_TAG(lv_event_get_code_name(e->code));
+    LV_PROFILER_EVENT_BEGIN_TAG(lv_event_code_get_name(e->code));
     base->event_cb(base, e);
-    LV_PROFILER_EVENT_END_TAG(lv_event_get_code_name(e->code));
+    LV_PROFILER_EVENT_END_TAG(lv_event_code_get_name(e->code));
 
     lv_result_t res = LV_RESULT_OK;
     /*Stop if the object is deleted*/

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -250,16 +250,24 @@ void lv_event_mark_deleted(void * target)
     }
 }
 
-const char * lv_event_get_code_name(lv_event_code_t code)
+const char * lv_event_code_get_name(lv_event_code_t code)
 {
+    /*Remove the preprocess flag*/
+    code &= ~LV_EVENT_PREPROCESS;
+
 #define ENUM_CASE(x) case LV_##x: return #x
 
     switch(code) {
+            ENUM_CASE(EVENT_ALL);
+
             /** Input device events*/
             ENUM_CASE(EVENT_PRESSED);
             ENUM_CASE(EVENT_PRESSING);
             ENUM_CASE(EVENT_PRESS_LOST);
             ENUM_CASE(EVENT_SHORT_CLICKED);
+            ENUM_CASE(EVENT_SINGLE_CLICKED);
+            ENUM_CASE(EVENT_DOUBLE_CLICKED);
+            ENUM_CASE(EVENT_TRIPLE_CLICKED);
             ENUM_CASE(EVENT_LONG_PRESSED);
             ENUM_CASE(EVENT_LONG_PRESSED_REPEAT);
             ENUM_CASE(EVENT_CLICKED);
@@ -276,6 +284,8 @@ const char * lv_event_get_code_name(lv_event_code_t code)
             ENUM_CASE(EVENT_LEAVE);
             ENUM_CASE(EVENT_HIT_TEST);
             ENUM_CASE(EVENT_INDEV_RESET);
+            ENUM_CASE(EVENT_HOVER_OVER);
+            ENUM_CASE(EVENT_HOVER_LEAVE);
 
             /** Drawing events*/
             ENUM_CASE(EVENT_COVER_CHECK);
@@ -326,11 +336,18 @@ const char * lv_event_get_code_name(lv_event_code_t code)
 
             ENUM_CASE(EVENT_VSYNC);
 
-        default:
+        /* Special event flags */
+        case LV_EVENT_LAST:
+        case LV_EVENT_PREPROCESS:
+        case LV_EVENT_MARKED_DELETING:
             break;
+
+            /* Note that default is not added here because when adding new event code,
+             * if forget to add case, the compiler will automatically report a warning.
+             */
     }
 
-#undef EVENT_ENUM_CASE
+#undef ENUM_CASE
 
     return "EVENT_UNKNOWN";
 }

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -218,7 +218,7 @@ uint32_t lv_event_register_id(void);
  * @param code  the event code
  * @return      the name of the event code as a string
  */
-const char * lv_event_get_code_name(lv_event_code_t code);
+const char * lv_event_code_get_name(lv_event_code_t code);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
1. Remove the preprocess flag.
2. fix undef `ENUM_CASE` missmatched.
3. Rename `lv_event_get_code_name` -> `lv_event_code_get_name`, closer to type definition name.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
