### PR TITLE
feat(gen_json): adds option to gen_json to build without docstrings

### DIFF
--- a/scripts/gen_json/gen_json.py
+++ b/scripts/gen_json/gen_json.py
@@ -330,4 +330,4 @@ if __name__ == '__main__':
 
     DEVELOP = args.develop
 
-    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, args.no_docstrings *extra_args)
+    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, args.no_docstringsm, *extra_args)

--- a/scripts/gen_json/gen_json.py
+++ b/scripts/gen_json/gen_json.py
@@ -330,4 +330,4 @@ if __name__ == '__main__':
 
     DEVELOP = args.develop
 
-    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, args.no_docstringsm, *extra_args)
+    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, args.no_docstrings, *extra_args)

--- a/scripts/gen_json/gen_json.py
+++ b/scripts/gen_json/gen_json.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 import json
 import subprocess
-import threading
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, base_path)
@@ -21,50 +20,12 @@ import pycparser  # NOQA
 DEVELOP = False
 
 
-class STDOut:
-    def __init__(self):
-        self._stdout = sys.stdout
-        sys.__stdout__ = self
-        sys.stdout = self
-
-    def write(self, data):
-        pass
-
-    def __getattr__(self, item):
-        if item in self.__dict__:
-            return self.__dict__[item]
-
-        return getattr(self._stdout, item)
-
-    def reset(self):
-        sys.stdout = self._stdout
-
-
 temp_directory = tempfile.mkdtemp(suffix='.lvgl_json')
 
 
-def run(output_path, lvgl_config_path, output_to_stdout, target_header, filter_private, *compiler_args):
-    # stdout = STDOut()
+def run(output_path, lvgl_config_path, output_to_stdout, target_header, filter_private, no_docstrings, *compiler_args):
 
     pycparser_monkeypatch.FILTER_PRIVATE = filter_private
-
-    # The thread is to provide an indication that things are being processed.
-    # There are long periods where nothing gets output to the screen and this
-    # is to let the user know that it is still working.
-    if not output_to_stdout:
-        event = threading.Event()
-
-        def _do():
-            while not event.is_set():
-                event.wait(1)
-                sys.stdout.write('.')
-                sys.stdout.flush()
-
-            print()
-
-        t = threading.Thread(target=_do)
-        t.daemon = True
-        t.start()
 
     lvgl_path = project_path
     lvgl_src_path = os.path.join(lvgl_path, 'src')
@@ -218,11 +179,9 @@ def run(output_path, lvgl_config_path, output_to_stdout, target_header, filter_p
         cparser = pycparser.CParser()
         ast = cparser.parse(pp_data, target_header)
 
-        ast.setup_docs(temp_directory)
+        ast.setup_docs(no_docstrings, temp_directory)
 
         if not output_to_stdout and output_path is None:
-            # stdout.reset()
-
             if not DEVELOP:
                 shutil.rmtree(temp_directory)
 
@@ -240,17 +199,7 @@ def run(output_path, lvgl_config_path, output_to_stdout, target_header, filter_p
             with open(output_path, 'w') as f:
                 f.write(json.dumps(ast.to_dict(), indent=4))
 
-            # stdout.reset()
-
-        if not output_to_stdout:
-            event.set()  # NOQA
-            t.join()  # NOQA
     except Exception as err:
-        if not output_to_stdout:
-            event.set()  # NOQA
-            t.join()  # NOQA
-
-        print()
         try:
             print(cpp_cmd)  # NOQA
             print()
@@ -370,9 +319,15 @@ if __name__ == '__main__':
         help='Internal Use',
         action='store_true',
     )
+    parser.add_argument(
+        '--no-docstrings',
+        dest='no_docstrings',
+        help='Internal Use',
+        action='store_true',
+    )
 
     args, extra_args = parser.parse_known_args()
 
     DEVELOP = args.develop
 
-    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, *extra_args)
+    run(args.output_path, args.lv_conf, args.output_path is None, args.target_header, args.filter_private, args.no_docstrings *extra_args)

--- a/scripts/gen_json/pycparser_monkeypatch.py
+++ b/scripts/gen_json/pycparser_monkeypatch.py
@@ -16,12 +16,8 @@ except ImportError:
 from pycparser.c_generator import CGenerator
 from collections import OrderedDict
 
-import doc_builder  # NOQA
 
 generator = CGenerator()
-
-doc_builder.EMIT_WARNINGS = False
-# doc_builder.DOXYGEN_OUTPUT = False
 
 
 BASIC_TYPES = [
@@ -575,7 +571,7 @@ class FileAST(c_ast.FileAST):
         super().__init__(*args, **kwargs)
         self._parent = None
 
-    def setup_docs(self, temp_directory):  # NOQA
+    def setup_docs(self, no_docstrings, temp_directory):  # NOQA
         global get_enum_item_docs
         global get_enum_docs
         global get_func_docs
@@ -586,17 +582,41 @@ class FileAST(c_ast.FileAST):
         global get_macro_docs
         global get_macros
 
-        docs = doc_builder.XMLSearch(temp_directory)
+        if no_docstrings:
 
-        get_enum_item_docs = docs.get_enum_item
-        get_enum_docs = docs.get_enum
-        get_func_docs = docs.get_function
-        get_var_docs = docs.get_variable
-        get_union_docs = docs.get_union
-        get_struct_docs = docs.get_structure
-        get_typedef_docs = docs.get_typedef
-        get_macro_docs = docs.get_macro
-        get_macros = docs.get_macros
+            def dummy_list():
+                return []
+
+            def dummy_doc(_):
+                return None
+
+            get_enum_item_docs = dummy_doc
+            get_enum_docs = dummy_doc
+            get_func_docs = dummy_doc
+            get_var_docs = dummy_doc
+            get_union_docs = dummy_doc
+            get_struct_docs = dummy_doc
+            get_typedef_docs = dummy_doc
+            get_macro_docs = dummy_doc
+            get_macros = dummy_list
+
+        else:
+            import doc_builder  # NOQA
+
+            doc_builder.EMIT_WARNINGS = False
+            # doc_builder.DOXYGEN_OUTPUT = False
+
+            docs = doc_builder.XMLSearch(temp_directory)
+
+            get_enum_item_docs = docs.get_enum_item
+            get_enum_docs = docs.get_enum
+            get_func_docs = docs.get_function
+            get_var_docs = docs.get_variable
+            get_union_docs = docs.get_union
+            get_struct_docs = docs.get_structure
+            get_typedef_docs = docs.get_typedef
+            get_macro_docs = docs.get_macro
+            get_macros = docs.get_macros
 
     @property
     def name(self):


### PR DESCRIPTION
Currently, in the MicroPython binding gen_json.py is used to properly map a callbacks userdata that is stored in a nonpublic structure. While doing this works without any issues it takes a bit of additional time for the gen_json.py script to run. This additional time is caused by the parsing of the docstrings from the header files. The docstrings do not need to be parsed in order to provide the information that the MicroPython binding code generator needs in order to work. Having the ability to turn off the docstrings will speed up the compile time, it also removes doxygen as a dependency to compile the binding.

I have also removed the threading from the gen_json.py script that was used to output dots to stdout. Having this causes issues if importing the gen_json.py script instead of running it using a subprocess.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
