### PR TITLE
perf(bin_decoder): improve the decoding performance of a8

### DIFF
--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -275,13 +275,20 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
             }
         }
         else if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf)) {
-            /*Alpha only image will need decoder data to store pointer to decoded image, to free it when decoder closes*/
-            decoder_data_t * decoder_data = get_decoder_data(dsc);
-            if(decoder_data == NULL) {
-                return LV_RESULT_INVALID;
+            if(cf == LV_COLOR_FORMAT_A8) {
+                res = LV_RESULT_OK;
+                use_directly = true;
+                dsc->decoded = (lv_draw_buf_t *)image;
             }
+            else {
+                /*Alpha only image will need decoder data to store pointer to decoded image, to free it when decoder closes*/
+                decoder_data_t * decoder_data = get_decoder_data(dsc);
+                if(decoder_data == NULL) {
+                    return LV_RESULT_INVALID;
+                }
 
-            res = decode_alpha_only(decoder, dsc);
+                res = decode_alpha_only(decoder, dsc);
+            }
         }
         else {
             /*In case of uncompressed formats the image stored in the ROM/RAM.


### PR DESCRIPTION
1. Variable `A8` should not enter cache. Entering cache in the past will cause unexpected errors when the memory address is the same.

2. Reduce decoder_data allocation and release

3. Reduce `decoded draw_buf` allocation and release

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/d4bcf0d8-bbb2-42a1-a59e-29d0423217bd" />

and it will reduce the `get_decoder_data` allocation and this draw buf allocation below

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/3a1e3324-d4b0-412a-87f9-5c7721eef79e" />


cc @XuNeo 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
