### PR TITLE
fix(scroll): scrolling animation and finger dragging conflict during continuous sliding, causing flickering

### DIFF
--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -442,6 +442,12 @@ bool lv_obj_is_scrolling(const lv_obj_t * obj)
     return false;
 }
 
+void lv_obj_stop_scroll_anim(const lv_obj_t * obj)
+{
+    lv_anim_delete((lv_obj_t *)obj, scroll_y_anim);
+    lv_anim_delete((lv_obj_t *)obj, scroll_x_anim);
+}
+
 void lv_obj_update_snap(lv_obj_t * obj, lv_anim_enable_t anim_en)
 {
     lv_obj_update_layout(obj);

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -256,6 +256,13 @@ void lv_obj_scroll_to_view_recursive(lv_obj_t * obj, lv_anim_enable_t anim_en);
 bool lv_obj_is_scrolling(const lv_obj_t * obj);
 
 /**
+ * Stop scrolling the current object
+ *
+ * @param obj The object being scrolled
+ */
+void lv_obj_stop_scroll_anim(const lv_obj_t * obj);
+
+/**
  * Check children of `obj` and scroll `obj` to fulfill scroll_snap settings.
  * @param obj       Widget whose children need to be checked and snapped
  * @param anim_en   LV_ANIM_ON/OFF

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1301,6 +1301,10 @@ static void indev_proc_press(lv_indev_t * indev)
 
         if(indev_act->wait_until_release) return;
 
+        if(indev->pointer.scroll_obj) {
+            lv_obj_stop_scroll_anim(indev->pointer.scroll_obj);
+        }
+
         lv_indev_scroll_handler(indev);
         if(indev_reset_check(indev)) return;
         indev_gesture(indev);


### PR DESCRIPTION
Continuous and rapid sliding will conflict with the scrolling animation, causing scrolling to flicker，the scrolling animation needs to be stopped before dragging the finger


![image](https://github.com/user-attachments/assets/4ba9ae9a-3f2f-4412-af6e-6e5be2443100)


Modify as follows: Increase animation duration to increase recurrence probability
`/src/core/lv_obj_scroll.c
+#define SCROLL_ANIM_TIME_MIN    1000    /*ms*/
+#define SCROLL_ANIM_TIME_MAX    1500    /*ms*/`


Example Code：
`void lv_example_flex_4(void)
{

    lv_obj_t * cont = lv_obj_create(lv_screen_active());
    lv_obj_set_size(cont, 300, 220);
    lv_obj_center(cont);
    lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN_REVERSE);
    // lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLL_ELASTIC);
    lv_obj_add_flag(cont, LV_OBJ_FLAG_SNAPPABLE);
    lv_obj_set_scroll_snap_y(cont, LV_SCROLL_SNAP_END);
    lv_obj_set_style_bg_color(cont, lv_color_hex(0x9F79EE), 0);


    uint32_t i;
    for(i = 0; i < 6; i++) {
        lv_obj_t * obj = lv_obj_create(cont);
        lv_obj_set_size(obj, 100, 50);
        lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
        lv_obj_set_style_bg_color(obj, lv_color_hex(0x90EE90), 0);

        lv_obj_t * label = lv_label_create(obj);
        lv_label_set_text_fmt(label, "Item: %"LV_PRIu32, i);
        lv_obj_center(label);
    }
}`

https://github.com/user-attachments/assets/edbb6a48-3476-423a-9802-60096ea27894

