### PR TITLE
perf(obj): use layer to cache the current opa stack

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -609,6 +609,7 @@ static void lv_obj_draw(lv_event_t * e)
         lv_layer_t * layer = lv_event_get_layer(e);
         lv_draw_rect_dsc_t draw_dsc;
         lv_draw_rect_dsc_init(&draw_dsc);
+        draw_dsc.base.layer = layer;
 
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &draw_dsc);
         /*If the border is drawn later disable loading its properties*/
@@ -637,6 +638,7 @@ static void lv_obj_draw(lv_event_t * e)
             draw_dsc.bg_image_opa = LV_OPA_TRANSP;
             draw_dsc.outline_opa = LV_OPA_TRANSP;
             draw_dsc.shadow_opa = LV_OPA_TRANSP;
+            draw_dsc.base.layer = layer;
             lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &draw_dsc);
 
             int32_t w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);

--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -27,6 +27,8 @@
  *  STATIC PROTOTYPES
  **********************/
 
+static inline lv_opa_t try_get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -45,7 +47,7 @@ void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_rect_dsc_
     draw_dsc->base.obj = obj;
     draw_dsc->base.part = part;
 
-    lv_opa_t opa = lv_obj_get_style_opa_recursive(obj, part);
+    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
     if(part != LV_PART_MAIN) {
         if(opa <= LV_OPA_MIN) {
             draw_dsc->bg_opa = LV_OPA_TRANSP;
@@ -160,7 +162,7 @@ void lv_obj_init_draw_label_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_label_ds
         return;
     }
 
-    lv_opa_t opa = lv_obj_get_style_opa_recursive(obj, part);
+    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -198,7 +200,7 @@ void lv_obj_init_draw_image_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_image_ds
         return;
     }
 
-    lv_opa_t opa = lv_obj_get_style_opa_recursive(obj, part);
+    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -233,7 +235,7 @@ void lv_obj_init_draw_line_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_line_dsc_
         return;
     }
 
-    lv_opa_t opa = lv_obj_get_style_opa_recursive(obj, part);
+    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -280,7 +282,7 @@ void lv_obj_init_draw_arc_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_arc_dsc_t 
         return;
     }
 
-    lv_opa_t opa = lv_obj_get_style_opa_recursive(obj, part);
+    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -372,3 +374,14 @@ lv_layer_type_t lv_obj_get_layer_type(const lv_obj_t * obj)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+static inline lv_opa_t try_get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc)
+{
+    if(base_dsc->layer) {
+        /* Accessing the layer opa directly is faster than using get style opa recursive */
+        return base_dsc->layer->opa;
+    }
+
+    /* fallback to old recursive style opa */
+    return lv_obj_get_style_opa_recursive(obj, part);
+}

--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -27,7 +27,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static inline lv_opa_t try_get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc);
+static inline lv_opa_t get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc);
 
 /**********************
  *  STATIC VARIABLES
@@ -47,7 +47,7 @@ void lv_obj_init_draw_rect_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_rect_dsc_
     draw_dsc->base.obj = obj;
     draw_dsc->base.part = part;
 
-    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
+    lv_opa_t opa = get_layer_opa(obj, part, &draw_dsc->base);
     if(part != LV_PART_MAIN) {
         if(opa <= LV_OPA_MIN) {
             draw_dsc->bg_opa = LV_OPA_TRANSP;
@@ -162,7 +162,7 @@ void lv_obj_init_draw_label_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_label_ds
         return;
     }
 
-    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
+    lv_opa_t opa = get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -200,7 +200,7 @@ void lv_obj_init_draw_image_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_image_ds
         return;
     }
 
-    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
+    lv_opa_t opa = get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -235,7 +235,7 @@ void lv_obj_init_draw_line_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_line_dsc_
         return;
     }
 
-    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
+    lv_opa_t opa = get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -282,7 +282,7 @@ void lv_obj_init_draw_arc_dsc(lv_obj_t * obj, lv_part_t part, lv_draw_arc_dsc_t 
         return;
     }
 
-    lv_opa_t opa = try_get_layer_opa(obj, part, &draw_dsc->base);
+    lv_opa_t opa = get_layer_opa(obj, part, &draw_dsc->base);
     if(opa < LV_OPA_MAX) {
         draw_dsc->opa = LV_OPA_MIX2(draw_dsc->opa, opa);
     }
@@ -375,7 +375,7 @@ lv_layer_type_t lv_obj_get_layer_type(const lv_obj_t * obj)
  *   STATIC FUNCTIONS
  **********************/
 
-static inline lv_opa_t try_get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc)
+static inline lv_opa_t get_layer_opa(const lv_obj_t * obj, lv_part_t part, const lv_draw_dsc_base_t * base_dsc)
 {
     if(base_dsc->layer) {
         /* Accessing the layer opa directly is faster than using get style opa recursive */

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -1098,10 +1098,13 @@ static void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
 {
     if(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN)) return;
 
+    /*If `opa_layered != LV_OPA_COVER` draw the widget on a new layer and blend that layer with the given opacity.*/
     const lv_opa_t opa_layered = lv_obj_get_style_opa_layered(obj, LV_PART_MAIN);
     if(opa_layered < LV_OPA_MIN) return;
 
     const lv_opa_t layer_opa_ori = layer->opa;
+
+    /*Normal `opa` (not layered) will just scale down `bg_opa`, `text_opa`, etc, in the upcoming drawings.*/
     const lv_opa_t opa_main = lv_obj_get_style_opa(obj, LV_PART_MAIN);
     if(opa_main < LV_OPA_MAX) {
         layer->opa = LV_OPA_MIX2(layer_opa_ori, opa_main);

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -761,9 +761,7 @@ static void refr_configured_layer(lv_layer_t * layer)
 {
     LV_PROFILER_REFR_BEGIN;
 
-#if LV_DRAW_TRANSFORM_USE_MATRIX
-    lv_matrix_identity(&layer->matrix);
-#endif
+    lv_layer_reset(layer);
 
     /* In single buffered mode wait here until the buffer is freed.
      * Else we would draw into the buffer while it's still being transferred to the display*/
@@ -1100,8 +1098,14 @@ static void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
 {
     if(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN)) return;
 
-    lv_opa_t opa = lv_obj_get_style_opa_layered(obj, 0);
-    if(opa < LV_OPA_MIN) return;
+    const lv_opa_t opa_layered = lv_obj_get_style_opa_layered(obj, LV_PART_MAIN);
+    if(opa_layered < LV_OPA_MIN) return;
+
+    const lv_opa_t layer_opa_ori = layer->opa;
+    const lv_opa_t opa_main = lv_obj_get_style_opa(obj, LV_PART_MAIN);
+    if(opa_main < LV_OPA_MAX) {
+        layer->opa = LV_OPA_MIX2(layer_opa_ori, opa_main);
+    }
 
     lv_layer_type_t layer_type = lv_obj_get_layer_type(obj);
     if(layer_type == LV_LAYER_TYPE_NONE) {
@@ -1109,7 +1113,7 @@ static void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
     }
 #if LV_DRAW_TRANSFORM_USE_MATRIX
     /*If the layer opa is full then use the matrix transform*/
-    else if(opa >= LV_OPA_MAX && !refr_check_obj_clip_overflow(layer, obj)) {
+    else if(opa_layered >= LV_OPA_MAX && !refr_check_obj_clip_overflow(layer, obj)) {
         refr_obj_matrix(layer, obj);
     }
 #endif /* LV_DRAW_TRANSFORM_USE_MATRIX */
@@ -1170,7 +1174,7 @@ static void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
             layer_draw_dsc.pivot.x = obj->coords.x1 + pivot.x - new_layer->buf_area.x1;
             layer_draw_dsc.pivot.y = obj->coords.y1 + pivot.y - new_layer->buf_area.y1;
 
-            layer_draw_dsc.opa = opa;
+            layer_draw_dsc.opa = opa_layered;
             layer_draw_dsc.rotation = lv_obj_get_style_transform_rotation(obj, 0);
             while(layer_draw_dsc.rotation > 3600) layer_draw_dsc.rotation -= 3600;
             while(layer_draw_dsc.rotation < 0) layer_draw_dsc.rotation += 3600;
@@ -1189,6 +1193,9 @@ static void refr_obj(lv_layer_t * layer, lv_obj_t * obj)
             layer_area_act.y1 = layer_area_act.y2 + 1;
         }
     }
+
+    /* Restore the original layer opa */
+    layer->opa = layer_opa_ori;
 }
 
 static uint32_t get_max_row(lv_display_t * disp, int32_t area_w, int32_t area_h)

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -84,9 +84,10 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
     disp->tile_cnt = 1;
 #endif
 
-    disp->layer_head = lv_malloc_zeroed(sizeof(lv_layer_t));
+    disp->layer_head = lv_malloc(sizeof(lv_layer_t));
     LV_ASSERT_MALLOC(disp->layer_head);
     if(disp->layer_head == NULL) return NULL;
+    lv_layer_init(disp->layer_head);
 
     if(disp->layer_init) disp->layer_init(disp, disp->layer_head);
     disp->layer_head->buf_area.x1 = 0;

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -385,6 +385,22 @@ uint32_t lv_draw_get_dependent_count(lv_draw_task_t * t_check)
     return cnt;
 }
 
+void lv_layer_init(lv_layer_t * layer)
+{
+    LV_ASSERT_NULL(layer);
+    lv_memzero(layer, sizeof(lv_layer_t));
+    lv_layer_reset(layer);
+}
+
+void lv_layer_reset(lv_layer_t * layer)
+{
+    LV_ASSERT_NULL(layer);
+#if LV_DRAW_TRANSFORM_USE_MATRIX
+    lv_matrix_identity(&layer->matrix);
+#endif
+    layer->opa = LV_OPA_COVER;
+}
+
 lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t color_format, const lv_area_t * area)
 {
     LV_PROFILER_DRAW_BEGIN;
@@ -405,8 +421,7 @@ void lv_draw_layer_init(lv_layer_t * layer, lv_layer_t * parent_layer, lv_color_
                         const lv_area_t * area)
 {
     LV_PROFILER_DRAW_BEGIN;
-    LV_ASSERT_NULL(layer);
-    lv_memzero(layer, sizeof(lv_layer_t));
+    lv_layer_init(layer);
     lv_display_t * disp = lv_refr_get_disp_refreshing();
 
     layer->parent = parent_layer;
@@ -414,10 +429,6 @@ void lv_draw_layer_init(lv_layer_t * layer, lv_layer_t * parent_layer, lv_color_
     layer->buf_area = *area;
     layer->phy_clip_area = *area;
     layer->color_format = color_format;
-
-#if LV_DRAW_TRANSFORM_USE_MATRIX
-    lv_matrix_identity(&layer->matrix);
-#endif
 
     if(disp->layer_init) disp->layer_init(disp, layer);
 

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -413,6 +413,11 @@ lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t c
 
     lv_draw_layer_init(new_layer, parent_layer, color_format, area);
 
+    /*Inherits transparency from parent*/
+    if(parent_layer) {
+        new_layer->opa = parent_layer->opa;
+    }
+
     LV_PROFILER_DRAW_END;
     return new_layer;
 }

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -97,6 +97,9 @@ struct _lv_layer_t  {
     lv_matrix_t matrix;
 #endif
 
+    /** Opacity of the layer */
+    lv_opa_t opa;
+
     /** Linked list of draw tasks */
     lv_draw_task_t * draw_task_head;
 
@@ -209,6 +212,18 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
  * @return          number of tasks depending on `t_check`
  */
 uint32_t lv_draw_get_dependent_count(lv_draw_task_t * t_check);
+
+/**
+ * Initialize a layer
+ * @param layer pointer to a layer to initialize
+ */
+void lv_layer_init(lv_layer_t * layer);
+
+/**
+ * Reset the layer to a drawable state
+ * @param layer pointer to a layer to reset
+ */
+void lv_layer_reset(lv_layer_t * layer);
 
 /**
  * Create (allocate) a new layer on a parent layer

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -240,7 +240,7 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
     lv_draw_task_t * task = u->task_act;
 
     lv_layer_t dest_layer;
-    lv_memzero(&dest_layer, sizeof(dest_layer));
+    lv_layer_init(&dest_layer);
 
     int32_t texture_w = lv_area_get_width(&task->_real_area);
     int32_t texture_h = lv_area_get_height(&task->_real_area);

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -198,7 +198,7 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * cache_data)
     lv_draw_task_t * task = u->task_act;
 
     lv_layer_t dest_layer;
-    lv_memzero(&dest_layer, sizeof(dest_layer));
+    lv_layer_init(&dest_layer);
 
     int32_t texture_w = lv_area_get_width(&task->_real_area);
     int32_t texture_h = lv_area_get_height(&task->_real_area);

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -109,7 +109,7 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
     lv_area_increase(&snapshot_area, ext_size, ext_size);
 
     lv_layer_t layer;
-    lv_memzero(&layer, sizeof(layer));
+    lv_layer_init(&layer);
 
     layer.draw_buf = draw_buf;
     layer.buf_area.x1 = snapshot_area.x1;
@@ -119,9 +119,6 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
     layer.color_format = cf;
     layer._clip_area = snapshot_area;
     layer.phy_clip_area = snapshot_area;
-#if LV_DRAW_TRANSFORM_USE_MATRIX
-    lv_matrix_identity(&layer.matrix);
-#endif
 
     lv_display_t * disp_old = lv_refr_get_disp_refreshing();
     lv_display_t * disp_new = lv_obj_get_display(obj);

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -721,6 +721,7 @@ static void lv_arc_draw(lv_event_t * e)
     lv_draw_arc_dsc_t arc_dsc;
     if(arc_r > 0) {
         lv_draw_arc_dsc_init(&arc_dsc);
+        arc_dsc.base.layer = layer;
         lv_obj_init_draw_arc_dsc(obj, LV_PART_MAIN, &arc_dsc);
         arc_dsc.center = center;
         arc_dsc.start_angle = arc->bg_angle_start + arc->rotation;
@@ -738,6 +739,7 @@ static void lv_arc_draw(lv_event_t * e)
 
     if(indic_r > 0) {
         lv_draw_arc_dsc_init(&arc_dsc);
+        arc_dsc.base.layer = layer;
         lv_obj_init_draw_arc_dsc(obj, LV_PART_INDICATOR, &arc_dsc);
         arc_dsc.center = center;
         arc_dsc.start_angle = arc->indic_angle_start + arc->rotation;
@@ -753,6 +755,7 @@ static void lv_arc_draw(lv_event_t * e)
 
     lv_draw_rect_dsc_t knob_rect_dsc;
     lv_draw_rect_dsc_init(&knob_rect_dsc);
+    knob_rect_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_KNOB, &knob_rect_dsc);
     lv_draw_rect(layer, &knob_rect_dsc, &knob_area);
 }

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -469,6 +469,7 @@ static void draw_indic(lv_event_t * e)
 
     lv_draw_rect_dsc_t draw_rect_dsc;
     lv_draw_rect_dsc_init(&draw_rect_dsc);
+    draw_rect_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &draw_rect_dsc);
 
     int32_t bg_radius = lv_obj_get_style_radius(obj, LV_PART_MAIN);

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -693,7 +693,9 @@ static void draw_main(lv_event_t * e)
     obj->state = LV_STATE_DEFAULT;
     obj->skip_trans = 1;
     lv_draw_rect_dsc_init(&draw_rect_dsc_def);
+    draw_rect_dsc_def.base.layer = layer;
     lv_draw_label_dsc_init(&draw_label_dsc_def);
+    draw_label_dsc_def.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_ITEMS, &draw_rect_dsc_def);
     lv_obj_init_draw_label_dsc(obj, LV_PART_ITEMS, &draw_label_dsc_def);
     obj->skip_trans = 0;
@@ -746,7 +748,9 @@ static void draw_main(lv_event_t * e)
             obj->state = btn_state;
             obj->skip_trans = 1;
             lv_draw_rect_dsc_init(&draw_rect_dsc_act);
+            draw_rect_dsc_act.base.layer = layer;
             lv_draw_label_dsc_init(&draw_label_dsc_act);
+            draw_label_dsc_act.base.layer = layer;
             lv_obj_init_draw_rect_dsc(obj, LV_PART_ITEMS, &draw_rect_dsc_act);
             lv_obj_init_draw_label_dsc(obj, LV_PART_ITEMS, &draw_label_dsc_act);
             obj->state = state_ori;

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -377,16 +377,13 @@ void lv_canvas_init_layer(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_image_header_t * header = &canvas->draw_buf->header;
     lv_area_t canvas_area = {0, 0, header->w - 1,  header->h - 1};
-    lv_memzero(layer, sizeof(*layer));
+    lv_layer_init(layer);
 
     layer->draw_buf = canvas->draw_buf;
     layer->color_format = header->cf;
     layer->buf_area = canvas_area;
     layer->_clip_area = canvas_area;
     layer->phy_clip_area = canvas_area;
-#if LV_DRAW_TRANSFORM_USE_MATRIX
-    lv_matrix_identity(&layer->matrix);
-#endif
 }
 
 void lv_canvas_finish_layer(lv_obj_t * canvas, lv_layer_t * layer)

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -740,6 +740,7 @@ static void draw_div_lines(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_draw_line_dsc_t line_dsc;
     lv_draw_line_dsc_init(&line_dsc);
+    line_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &line_dsc);
 
     lv_opa_t border_opa = lv_obj_get_style_border_opa(obj, LV_PART_MAIN);
@@ -821,10 +822,12 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_draw_line_dsc_t line_dsc;
     lv_draw_line_dsc_init(&line_dsc);
+    line_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_ITEMS, &line_dsc);
 
     lv_draw_rect_dsc_t point_dsc_default;
     lv_draw_rect_dsc_init(&point_dsc_default);
+    point_dsc_default.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &point_dsc_default);
 
     int32_t point_w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
@@ -970,10 +973,12 @@ static void draw_series_scatter(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_draw_line_dsc_t line_dsc;
     lv_draw_line_dsc_init(&line_dsc);
+    line_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_ITEMS, &line_dsc);
 
     lv_draw_rect_dsc_t point_dsc_default;
     lv_draw_rect_dsc_init(&point_dsc_default);
+    point_dsc_default.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &point_dsc_default);
 
     int32_t point_w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
@@ -1102,6 +1107,7 @@ static void draw_series_bar(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_draw_rect_dsc_t col_dsc;
     lv_draw_rect_dsc_init(&col_dsc);
+    col_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_ITEMS, &col_dsc);
     col_dsc.bg_grad.dir = LV_GRAD_DIR_NONE;
     col_dsc.bg_opa = LV_OPA_COVER;
@@ -1171,10 +1177,12 @@ static void draw_cursors(lv_obj_t * obj, lv_layer_t * layer)
 
     lv_draw_line_dsc_t line_dsc_ori;
     lv_draw_line_dsc_init(&line_dsc_ori);
+    line_dsc_ori.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_CURSOR, &line_dsc_ori);
 
     lv_draw_rect_dsc_t point_dsc_ori;
     lv_draw_rect_dsc_init(&point_dsc_ori);
+    point_dsc_ori.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_CURSOR, &point_dsc_ori);
 
     lv_draw_line_dsc_t line_dsc;

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -237,6 +237,7 @@ static void lv_checkbox_draw(lv_event_t * e)
 
     lv_draw_rect_dsc_t indic_dsc;
     lv_draw_rect_dsc_init(&indic_dsc);
+    indic_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &indic_dsc);
     lv_area_t marker_area;
     if(is_rtl) {
@@ -264,6 +265,7 @@ static void lv_checkbox_draw(lv_event_t * e)
 
     lv_draw_label_dsc_t txt_dsc;
     lv_draw_label_dsc_init(&txt_dsc);
+    txt_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &txt_dsc);
     txt_dsc.text = cb->txt;
 

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -865,6 +865,7 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_label_dsc_t symbol_dsc;
     lv_draw_label_dsc_init(&symbol_dsc);
+    symbol_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_INDICATOR, &symbol_dsc);
 
     /*If no text specified use the selected option*/
@@ -923,6 +924,7 @@ static void draw_main(lv_event_t * e)
         else {
             lv_draw_image_dsc_t img_dsc;
             lv_draw_image_dsc_init(&img_dsc);
+            img_dsc.base.layer = layer;
             lv_obj_init_draw_image_dsc(obj, LV_PART_INDICATOR, &img_dsc);
             lv_point_set(&img_dsc.pivot, symbol_w / 2, symbol_h / 2);
             img_dsc.rotation = lv_obj_get_style_transform_rotation(obj, LV_PART_INDICATOR);
@@ -933,6 +935,7 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
+    label_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &label_dsc);
 
     lv_point_t size;
@@ -1033,6 +1036,7 @@ static void draw_box(lv_obj_t * dropdown_obj, lv_layer_t * layer, uint32_t id, l
 
     lv_draw_rect_dsc_t sel_rect;
     lv_draw_rect_dsc_init(&sel_rect);
+    sel_rect.base.layer = layer;
     lv_obj_init_draw_rect_dsc(list_obj,  LV_PART_SELECTED, &sel_rect);
     lv_draw_rect(layer, &sel_rect, &rect_area);
 
@@ -1055,6 +1059,7 @@ static void draw_box_label(lv_obj_t * dropdown_obj, lv_layer_t * layer, uint32_t
 
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
+    label_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(list_obj, LV_PART_SELECTED, &label_dsc);
 
     label_dsc.line_space = lv_obj_get_style_text_line_space(list_obj,

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -752,6 +752,7 @@ static void draw_image(lv_event_t * e)
         if(img->src_type == LV_IMAGE_SRC_FILE || img->src_type == LV_IMAGE_SRC_VARIABLE) {
             lv_draw_image_dsc_t draw_dsc;
             lv_draw_image_dsc_init(&draw_dsc);
+            draw_dsc.base.layer = layer;
             lv_obj_init_draw_image_dsc(obj, LV_PART_MAIN, &draw_dsc);
 
             lv_area_t clip_area_ori = layer->_clip_area;
@@ -798,6 +799,7 @@ static void draw_image(lv_event_t * e)
         else if(img->src_type == LV_IMAGE_SRC_SYMBOL) {
             lv_draw_label_dsc_t label_dsc;
             lv_draw_label_dsc_init(&label_dsc);
+            label_dsc.base.layer = layer;
             lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &label_dsc);
             label_dsc.text = img->src;
             lv_draw_label(layer, &label_dsc, &obj->coords);

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -205,6 +205,7 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_image_dsc_t img_dsc;
     lv_draw_image_dsc_init(&img_dsc);
+    img_dsc.base.layer = layer;
     lv_obj_init_draw_image_dsc(obj, LV_PART_MAIN, &img_dsc);
 
     lv_area_t coords_part;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -828,6 +828,7 @@ static void draw_main(lv_event_t * e)
 #endif
 
     label_draw_dsc.flag = flag;
+    label_draw_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_MAIN, &label_draw_dsc);
     lv_bidi_calculate_align(&label_draw_dsc.align, &label_draw_dsc.bidi_dir, label->text);
 

--- a/src/widgets/led/lv_led.c
+++ b/src/widgets/led/lv_led.c
@@ -147,9 +147,11 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
     if(code == LV_EVENT_DRAW_MAIN) {
         /*Make darker colors in a temporary style according to the brightness*/
         lv_led_t * led = (lv_led_t *)obj;
+        lv_layer_t * layer = lv_event_get_layer(e);
 
         lv_draw_rect_dsc_t rect_dsc;
         lv_draw_rect_dsc_init(&rect_dsc);
+        rect_dsc.base.layer = layer;
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &rect_dsc);
 
         /*Use the original colors brightness to modify color->led*/
@@ -176,8 +178,6 @@ static void lv_led_event(const lv_obj_class_t * class_p, lv_event_t * e)
                                 (LV_LED_BRIGHT_MAX - LV_LED_BRIGHT_MIN);
         rect_dsc.shadow_spread = ((led->bright - LV_LED_BRIGHT_MIN) * rect_dsc.shadow_spread) /
                                  (LV_LED_BRIGHT_MAX - LV_LED_BRIGHT_MIN);
-
-        lv_layer_t * layer = lv_event_get_layer(e);
 
         lv_draw_rect(layer, &rect_dsc, &obj->coords);
     }

--- a/src/widgets/line/lv_line.c
+++ b/src/widgets/line/lv_line.c
@@ -236,6 +236,7 @@ static void lv_line_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         lv_draw_line_dsc_t line_dsc;
         lv_draw_line_dsc_init(&line_dsc);
+        line_dsc.base.layer = layer;
         lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &line_dsc);
 
         /*Read all points and draw the lines*/

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -519,6 +519,7 @@ static void draw_main(lv_event_t * e)
         get_sel_area(obj, &sel_area);
         lv_draw_rect_dsc_t sel_dsc;
         lv_draw_rect_dsc_init(&sel_dsc);
+        sel_dsc.base.layer = layer;
         lv_obj_init_draw_rect_dsc(obj, LV_PART_SELECTED, &sel_dsc);
         lv_draw_rect(layer, &sel_dsc, &sel_area);
     }
@@ -528,6 +529,7 @@ static void draw_main(lv_event_t * e)
 
         lv_draw_label_dsc_t label_dsc;
         lv_draw_label_dsc_init(&label_dsc);
+        label_dsc.base.layer = layer;
         lv_obj_init_draw_label_dsc(obj, LV_PART_SELECTED, &label_dsc);
 
         /*Redraw the text on the selected area*/
@@ -594,12 +596,12 @@ static void draw_label(lv_event_t * e)
      * and a lower (below the selected area)*/
     lv_obj_t * label_obj = lv_event_get_current_target(e);
     lv_obj_t * roller = lv_obj_get_parent(label_obj);
+    lv_layer_t * layer = lv_event_get_layer(e);
     lv_draw_label_dsc_t label_draw_dsc;
     lv_draw_label_dsc_init(&label_draw_dsc);
+    label_draw_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(roller, LV_PART_MAIN, &label_draw_dsc);
     if(lv_label_get_recolor(label_obj)) label_draw_dsc.flag |= LV_TEXT_FLAG_RECOLOR;
-
-    lv_layer_t * layer = lv_event_get_layer(e);
 
     /*If the roller has shadow or outline it has some ext. draw size
      *therefore the label can overflow the roller's boundaries.

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -545,12 +545,14 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
 
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
+    label_dsc.base.layer = layer;
     /* Formatting the labels with the configured style for LV_PART_INDICATOR */
     lv_obj_init_draw_label_dsc(obj, LV_PART_INDICATOR, &label_dsc);
 
     /* Major tick style */
     lv_draw_line_dsc_t major_tick_dsc;
     lv_draw_line_dsc_init(&major_tick_dsc);
+    major_tick_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_INDICATOR, &major_tick_dsc);
     if(LV_SCALE_MODE_ROUND_OUTER == scale->mode || LV_SCALE_MODE_ROUND_INNER == scale->mode) {
         major_tick_dsc.raw_end = 0;
@@ -559,11 +561,13 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
     /* Configure line draw descriptor for the minor tick drawing */
     lv_draw_line_dsc_t minor_tick_dsc;
     lv_draw_line_dsc_init(&minor_tick_dsc);
+    minor_tick_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_ITEMS, &minor_tick_dsc);
 
     /* Main line style */
     lv_draw_line_dsc_t main_line_dsc;
     lv_draw_line_dsc_init(&main_line_dsc);
+    main_line_dsc.base.layer = layer;
     lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &main_line_dsc);
 
     /* These 2 values need to be signed since they are being passed
@@ -581,6 +585,7 @@ static void scale_draw_indicator(lv_obj_t * obj, lv_event_t * event)
 
         label_dsc.base.id1 = tick_idx;
         label_dsc.base.id2 = tick_value;
+        label_dsc.base.layer = layer;
 
         /* Overwrite label and tick properties if tick value is within section range */
         lv_scale_section_t * section;
@@ -814,6 +819,7 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
         /* Configure both line and label draw descriptors for the tick and label drawings */
         lv_draw_line_dsc_t line_dsc;
         lv_draw_line_dsc_init(&line_dsc);
+        line_dsc.base.layer = layer;
         lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &line_dsc);
 
         /* Get style properties so they can be used in the main line drawing */
@@ -878,6 +884,7 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
         LV_LL_READ_BACK(&scale->section_ll, section) {
             lv_draw_line_dsc_t section_line_dsc;
             lv_draw_line_dsc_init(&section_line_dsc);
+            section_line_dsc.base.layer = layer;
             lv_obj_init_draw_line_dsc(obj, LV_PART_MAIN, &section_line_dsc);
 
             /* Calculate the points of the section line */
@@ -920,6 +927,7 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
         /* Configure arc draw descriptors for the main part */
         lv_draw_arc_dsc_t arc_dsc;
         lv_draw_arc_dsc_init(&arc_dsc);
+        arc_dsc.base.layer = layer;
         lv_obj_init_draw_arc_dsc(obj, LV_PART_MAIN, &arc_dsc);
 
         lv_point_t arc_center;
@@ -943,6 +951,7 @@ static void scale_draw_main(lv_obj_t * obj, lv_event_t * event)
         LV_LL_READ_BACK(&scale->section_ll, section) {
             lv_draw_arc_dsc_t main_arc_section_dsc;
             lv_draw_arc_dsc_init(&main_arc_section_dsc);
+            main_arc_section_dsc.base.layer = layer;
             lv_obj_init_draw_arc_dsc(obj, LV_PART_MAIN, &main_arc_section_dsc);
 
             lv_point_t section_arc_center;

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -393,6 +393,7 @@ static void draw_knob(lv_event_t * e)
     }
     lv_draw_rect_dsc_t knob_rect_dsc;
     lv_draw_rect_dsc_init(&knob_rect_dsc);
+    knob_rect_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_KNOB, &knob_rect_dsc);
     /* Update knob area with knob style */
     position_knob(obj, &knob_area, knob_size, is_horizontal);

--- a/src/widgets/switch/lv_switch.c
+++ b/src/widgets/switch/lv_switch.c
@@ -186,6 +186,7 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_rect_dsc_t draw_indic_dsc;
     lv_draw_rect_dsc_init(&draw_indic_dsc);
+    draw_indic_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_INDICATOR, &draw_indic_dsc);
     lv_draw_rect(layer, &draw_indic_dsc, &indic_area);
 
@@ -265,6 +266,7 @@ static void draw_main(lv_event_t * e)
 
     lv_draw_rect_dsc_t knob_rect_dsc;
     lv_draw_rect_dsc_init(&knob_rect_dsc);
+    knob_rect_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_KNOB, &knob_rect_dsc);
 
     lv_draw_rect(layer, &knob_rect_dsc, &knob_area);

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -696,11 +696,13 @@ static void draw_main(lv_event_t * e)
     lv_draw_rect_dsc_t rect_dsc_def;
     lv_draw_rect_dsc_t rect_dsc_act; /*Passed to the event to modify it*/
     lv_draw_rect_dsc_init(&rect_dsc_def);
+    rect_dsc_def.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_ITEMS, &rect_dsc_def);
 
     lv_draw_label_dsc_t label_dsc_def;
     lv_draw_label_dsc_t label_dsc_act;  /*Passed to the event to modify it*/
     lv_draw_label_dsc_init(&label_dsc_def);
+    label_dsc_def.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_ITEMS, &label_dsc_def);
     obj->state = state_ori;
     obj->skip_trans = 0;
@@ -799,7 +801,9 @@ static void draw_main(lv_event_t * e)
                 obj->state = cell_state;
                 obj->skip_trans = 1;
                 lv_draw_rect_dsc_init(&rect_dsc_act);
+                rect_dsc_act.base.layer = layer;
                 lv_draw_label_dsc_init(&label_dsc_act);
+                label_dsc_act.base.layer = layer;
                 lv_obj_init_draw_rect_dsc(obj, LV_PART_ITEMS, &rect_dsc_act);
                 lv_obj_init_draw_label_dsc(obj, LV_PART_ITEMS, &label_dsc_act);
                 obj->state = state_ori;

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -1398,6 +1398,7 @@ static void draw_placeholder(lv_event_t * e)
     if(txt[0] == '\0' && ta->placeholder_txt && ta->placeholder_txt[0] != 0) {
         lv_draw_label_dsc_t ph_dsc;
         lv_draw_label_dsc_init(&ph_dsc);
+        ph_dsc.base.layer = layer;
         lv_obj_init_draw_label_dsc(obj, LV_PART_TEXTAREA_PLACEHOLDER, &ph_dsc);
 
         if(ta->one_line) ph_dsc.flag |= LV_TEXT_FLAG_EXPAND;
@@ -1429,6 +1430,7 @@ static void draw_cursor(lv_event_t * e)
 
     lv_draw_rect_dsc_t cur_dsc;
     lv_draw_rect_dsc_init(&cur_dsc);
+    cur_dsc.base.layer = layer;
     lv_obj_init_draw_rect_dsc(obj, LV_PART_CURSOR, &cur_dsc);
 
     /*Draw he cursor according to the type*/
@@ -1457,6 +1459,7 @@ static void draw_cursor(lv_event_t * e)
     lv_color_t label_color = lv_obj_get_style_text_color(ta->label, 0);
     lv_draw_label_dsc_t cur_label_dsc;
     lv_draw_label_dsc_init(&cur_label_dsc);
+    cur_label_dsc.base.layer = layer;
     lv_obj_init_draw_label_dsc(obj, LV_PART_CURSOR, &cur_label_dsc);
     if(cur_dsc.bg_opa > LV_OPA_MIN || !lv_color_eq(cur_label_dsc.color, label_color)) {
         cur_label_dsc.text = letter_buf;


### PR DESCRIPTION
The low efficiency of `lv_obj_get_style_opa_recursive` found in this PR: https://github.com/lvgl/lvgl/pull/7430 has been optimized by caching the current global opa in the stack to reduce the recursive access to the parent opa calculation.

![image](https://github.com/user-attachments/assets/3180d910-0821-4629-8018-4da5f4df06b9)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
