### PR TITLE
fix(lv_freetype):  clean up #includes in lv_freetype.*

### DIFF
--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -6,12 +6,11 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../misc/lv_fs_private.h"
 #include "lv_freetype_private.h"
 
 #if LV_USE_FREETYPE
 
-#include "lv_freetype_private.h"
+#include "../../misc/lv_fs_private.h"
 #include "../../core/lv_global.h"
 
 /*********************

--- a/src/libs/freetype/lv_freetype.h
+++ b/src/libs/freetype/lv_freetype.h
@@ -20,9 +20,9 @@ extern "C" {
 #include "../../misc/lv_event.h"
 #include LV_STDBOOL_INCLUDE
 
- /*********************
- *      DEFINES
- *********************/
+/*********************
+*      DEFINES
+*********************/
 
 #define LV_FREETYPE_F26DOT6_TO_INT(x)   ((x) >> 6)
 #define LV_FREETYPE_F26DOT6_TO_FLOAT(x) ((float)(x) / 64)

--- a/src/libs/freetype/lv_freetype.h
+++ b/src/libs/freetype/lv_freetype.h
@@ -13,13 +13,14 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../../lv_conf_internal.h"
+
+#if LV_USE_FREETYPE
+
 #include "../../misc/lv_types.h"
 #include "../../misc/lv_event.h"
 #include LV_STDBOOL_INCLUDE
 
-#if LV_USE_FREETYPE
-
-/*********************
+ /*********************
  *      DEFINES
  *********************/
 

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -15,12 +15,12 @@ extern "C" {
  *********************/
 
 #include "lv_freetype.h"
-#include "../../misc/cache/lv_cache.h"
-#include "../../misc/lv_ll.h"
-#include "../../font/lv_font.h"
 
 #if LV_USE_FREETYPE
 
+#include "../../misc/cache/lv_cache.h"
+#include "../../misc/lv_ll.h"
+#include "../../font/lv_font.h"
 #include "ft2build.h"
 #include FT_FREETYPE_H
 #include FT_GLYPH_H


### PR DESCRIPTION
A redundant include in `lv_freetype.c` caught my attention and I found the include logic among the main 3 files needing some clean-up. The clean-up moved #includes so that only just the #includes needed to provide the `LV_USE_FREETYPE` macro were kept above that #if directive, and all others were moved below it.  Compilation was tested both with and without `LV_USE_FREETYPE` enabled and I can confirm nothing was broken.  (And the redundant #include was removed.)

Resolves #7452

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  n/a
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  Done.
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
