### PR TITLE
feat(draw/sw): allow custom handlers

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -215,6 +215,7 @@
 
     /** Enable drawing complex gradients in software: linear at an angle, radial or conical */
     #define LV_USE_DRAW_SW_COMPLEX_GRADIENTS    0
+
 #endif
 
 /*Use TSi's aka (Think Silicon) NemaGFX */

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -126,6 +126,7 @@ typedef struct _lv_global_t {
     lv_cache_t * img_header_cache;
 
     lv_draw_global_info_t draw_info;
+    lv_ll_t draw_sw_blend_handler_ll;
 #if defined(LV_DRAW_SW_SHADOW_CACHE_SIZE) && LV_DRAW_SW_SHADOW_CACHE_SIZE > 0
     lv_draw_sw_shadow_cache_t sw_shadow_cache;
 #endif

--- a/src/draw/sw/blend/lv_draw_sw_blend.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend.h
@@ -33,6 +33,18 @@ extern "C" {
  **********************/
 
 /**
+ * Custom draw function for SW rendering.
+ * @param t             pointer to a draw task
+ * @param dsc           pointer to an initialized blend descriptor
+ */
+typedef void (*lv_draw_sw_blend_handler_t)(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * dsc);
+
+typedef struct {
+    lv_color_format_t dest_cf;
+    lv_draw_sw_blend_handler_t handler;
+} lv_draw_sw_custom_blend_handler_t;
+
+/**
  * Call the blend function of the `layer`.
  * @param draw_unit     pointer to a draw unit
  * @param dsc           pointer to an initialized blend descriptor

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -28,6 +28,7 @@ extern "C" {
 #include "../lv_draw_line.h"
 #include "../lv_draw_arc.h"
 #include "lv_draw_sw_utils.h"
+#include "blend/lv_draw_sw_blend.h"
 
 /*********************
  *      DEFINES
@@ -154,6 +155,32 @@ void lv_draw_sw_transform(const lv_area_t * dest_area, const void * src_buf,
 void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc);
 #endif
 
+/**
+ * Register a custom blend handler for a color format.
+ * Handler will be called when blending a color or an
+ * image to a buffer with the given color format.
+ * At most one handler can be registered for a color format.
+ * Subsequent registrations will overwrite the previous handler.
+ *
+ * @param handler pointer to a blend handler
+ * @return true if the handler was registered, false if the handler could not be registered
+ */
+bool lv_draw_sw_register_blend_handler(lv_draw_sw_custom_blend_handler_t * handler);
+
+/**
+ * Unregister a custom blend handler for a color format.
+ * @param dest_cf color format
+ * @return true if a handler was unregistered, false if no handler was registered
+ */
+bool lv_draw_sw_unregister_blend_handler(lv_color_format_t dest_cf);
+
+/**
+ * Get the blend handler for a color format.
+ * @param dest_cf color format
+ * @return pointer to the blend handler or NULL if no handler is registered
+ */
+lv_draw_sw_blend_handler_t lv_draw_sw_get_blend_handler(lv_color_format_t dest_cf);
+
 /***********************
  * GLOBAL VARIABLES
  ***********************/
@@ -161,8 +188,6 @@ void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc
 /**********************
  *      MACROS
  **********************/
-
-#include "blend/lv_draw_sw_blend.h"
 
 #endif /*LV_USE_DRAW_SW*/
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -604,6 +604,7 @@
             #define LV_USE_DRAW_SW_COMPLEX_GRADIENTS    0
         #endif
     #endif
+
 #endif
 
 /*Use TSi's aka (Think Silicon) NemaGFX */

--- a/tests/src/test_cases/draw/test_draw_custom_handlers.c
+++ b/tests/src/test_cases/draw/test_draw_custom_handlers.c
@@ -1,0 +1,61 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_register_custom_handlers(void)
+{
+    lv_draw_sw_custom_blend_handler_t handler = {
+        .dest_cf = LV_COLOR_FORMAT_I2,
+        .handler = NULL,
+    };
+
+    TEST_ASSERT_TRUE(lv_draw_sw_register_blend_handler(&handler));
+}
+
+void test_overwrite_custom_handler(void)
+{
+    lv_draw_sw_custom_blend_handler_t handler = {
+        .dest_cf = LV_COLOR_FORMAT_I2,
+        .handler = (lv_draw_sw_blend_handler_t)0xDEADBEEF,
+    };
+
+    TEST_ASSERT_TRUE(lv_draw_sw_register_blend_handler(&handler));
+
+    lv_draw_sw_custom_blend_handler_t handler2 = {
+        .dest_cf = LV_COLOR_FORMAT_I2,
+        .handler = (lv_draw_sw_blend_handler_t)0xCAFEBABE,
+    };
+
+    TEST_ASSERT_TRUE(lv_draw_sw_register_blend_handler(&handler2));
+
+    lv_draw_sw_blend_handler_t handler3 = lv_draw_sw_get_blend_handler(LV_COLOR_FORMAT_I2);
+    TEST_ASSERT_NOT_NULL(handler3);
+    TEST_ASSERT_EQUAL_PTR(handler3, (lv_draw_sw_blend_handler_t)0xCAFEBABE);
+}
+
+void test_unregister_custom_handler(void)
+{
+    lv_draw_sw_custom_blend_handler_t handler = {
+        .dest_cf = LV_COLOR_FORMAT_I2,
+        .handler = NULL,
+    };
+
+    TEST_ASSERT_TRUE(lv_draw_sw_register_blend_handler(&handler));
+
+    TEST_ASSERT_TRUE(lv_draw_sw_unregister_blend_handler(LV_COLOR_FORMAT_I2));
+
+    lv_draw_sw_blend_handler_t handler2 = lv_draw_sw_get_blend_handler(LV_COLOR_FORMAT_I2);
+    TEST_ASSERT_NULL(handler2);
+}
+
+#endif


### PR DESCRIPTION
This allows LVGL users to register custom software draw handlers. It is beneficial to be able to add blending support for more unusual color formats that are unlikely to be included in the upstream repository (e.g., e-Ink displays with 7-indexed color formats).
It also allows users to register custom handlers if the behavior of the existing ones regarding performance or rules (e.g., for I1, when is a pixel considered to be on?) does not meet their needs.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
