### PR TITLE
fix(widgets): fix an incorrect text replacement

### DIFF
--- a/src/widgets/objx_templ/lv_objx_templ.c
+++ b/src/widgets/objx_templ/lv_objx_templ.c
@@ -128,7 +128,7 @@ static void lv_templ_event(const lv_obj_class_t * class_p, lv_event_t * e)
     lv_result_t res;
 
     /*Call the ancestor's event handler*/
-    res = LV_EVENT_base(MY_CLASS, e);
+    res = lv_obj_event_base(MY_CLASS, e);
     if(res != LV_RESULT_OK) return;
 
     /*Add the widget specific event handling here*/


### PR DESCRIPTION
There is an incorrect text replacing that replaces "lv_obj_event_base" with "LV_EVENT_base" in widget template, this commit will reverse this replacement.
