### PR TITLE
fix(docs):  clarify how to pass color index...

### DIFF
--- a/docs/details/widgets/canvas.rst
+++ b/docs/details/widgets/canvas.rst
@@ -61,7 +61,8 @@ Drawing
 
 To set an individual pixel's color on the Canvas, use
 :cpp:expr:`lv_canvas_set_px(canvas, x, y, color, opa)`.  With indexed color formats
-(``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument.
+(``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument by using
+the *blue* channel in the ``color`` value, e.g. :cpp:expr:``lv_color_make(0,0,index)``.
 
 :cpp:expr:`lv_canvas_fill_bg(canvas, lv_color_hex(0x00ff00), LV_OPA_50)` fills the whole
 Canvas to blue with 50% opacity. Note that if the current color format

--- a/docs/details/widgets/canvas.rst
+++ b/docs/details/widgets/canvas.rst
@@ -62,7 +62,7 @@ Drawing
 To set an individual pixel's color on the Canvas, use
 :cpp:expr:`lv_canvas_set_px(canvas, x, y, color, opa)`.  With indexed color formats
 (``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument by using
-the *blue* channel in the ``color`` value, e.g. :cpp:expr:``lv_color_make(0,0,index)``.
+the *blue* channel in the ``color`` value, e.g. :cpp:expr:``lv_color_make(0, 0, index)``.
 
 :cpp:expr:`lv_canvas_fill_bg(canvas, lv_color_hex(0x00ff00), LV_OPA_50)` fills the whole
 Canvas to blue with 50% opacity. Note that if the current color format

--- a/docs/details/widgets/canvas.rst
+++ b/docs/details/widgets/canvas.rst
@@ -62,7 +62,7 @@ Drawing
 To set an individual pixel's color on the Canvas, use
 :cpp:expr:`lv_canvas_set_px(canvas, x, y, color, opa)`.  With indexed color formats
 (``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument by using
-the *blue* channel in the ``color`` value, e.g. :cpp:expr:``lv_color_make(0, 0, index)``.
+the *blue* channel in the ``color`` value, e.g. :cpp:expr:`lv_color_make(0, 0, index)`.
 
 :cpp:expr:`lv_canvas_fill_bg(canvas, lv_color_hex(0x00ff00), LV_OPA_50)` fills the whole
 Canvas to blue with 50% opacity. Note that if the current color format


### PR DESCRIPTION
...to the `lv_canvas_set_px()` function when color format is indexed.

In PR #6226 @kchudoba correctly pointed out an important omission in the `canvas.rst` documentation when the color format is indexed:  how to pass the color index to `lv_canvas_set_px()` using the `lv_color_t` argument.  This is remedied herein.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
