### PR TITLE
fixed After the folder is entered, it cannot be re-entered.

### DIFF
--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -478,7 +478,6 @@ static void browser_file_event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_user_data(e);
-
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
 
     if(code == LV_EVENT_VALUE_CHANGED) {
@@ -502,7 +501,14 @@ static void browser_file_event_handler(lv_event_t * e)
         }
         else {
             if(lv_strcmp(str_fn, "..") != 0) {
+                if(explorer->current_path[lv_strlen(explorer->current_path) - 1] != '/') {
+                    // strip_ext(explorer->current_path);
+                    lv_snprintf((char *)file_name, sizeof(file_name), "%s/%s", explorer->current_path, str_fn);
+                }
+                else {
                 lv_snprintf((char *)file_name, sizeof(file_name), "%s%s", explorer->current_path, str_fn);
+
+                }
             }
         }
 
@@ -603,10 +609,11 @@ static void show_dir(lv_obj_t * obj, const char * path)
     lv_strlcpy(explorer->current_path, path, sizeof(explorer->current_path));
     lv_label_set_text_fmt(explorer->path_label, LV_SYMBOL_EYE_OPEN" %s", path);
 
-    size_t current_path_len = lv_strlen(explorer->current_path);
-    if((*((explorer->current_path) + current_path_len) != '/') && (current_path_len < LV_FILE_EXPLORER_PATH_MAX_LEN)) {
-        *((explorer->current_path) + current_path_len) = '/';
-    }
+    // size_t current_path_len = lv_strlen(explorer->current_path);
+    // if((*((explorer->current_path) + current_path_len) != '/') && (current_path_len < LV_FILE_EXPLORER_PATH_MAX_LEN)) {
+    //     *((explorer->current_path) + current_path_len) = '/';
+    // }
+
 }
 
 /*Remove the specified suffix*/


### PR DESCRIPTION
Fixed After the folder is entered, it cannot be re-entered.
`    line 612 remove
// size_t current_path_len = lv_strlen(explorer->current_path);
    // if((*((explorer->current_path) + current_path_len) != '/') && (current_path_len < LV_FILE_EXPLORER_PATH_MAX_LEN)) {
    //     *((explorer->current_path) + current_path_len) = '/';
    // }`


line 502
`if(lv_strcmp(str_fn, "..") != 0) {
                if(explorer->current_path[lv_strlen(explorer->current_path) - 1] != '/') {
                    // strip_ext(explorer->current_path);
                    lv_snprintf((char *)file_name, sizeof(file_name), "%s/%s", explorer->current_path, str_fn);
                }
                else {
                lv_snprintf((char *)file_name, sizeof(file_name), "%s%s", explorer->current_path, str_fn);

                }
            }`