### PR TITLE
fix(style): fix conditional jump or move depends on uninitialised value

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -674,7 +674,7 @@ static lv_style_t * get_local_style(lv_obj_t * obj, lv_style_selector_t selector
     }
 
     lv_memzero(&obj->styles[i], sizeof(lv_obj_style_t));
-    obj->styles[i].style = lv_malloc(sizeof(lv_style_t));
+    obj->styles[i].style = lv_malloc_zeroed(sizeof(lv_style_t));
     lv_style_init((lv_style_t *)obj->styles[i].style);
 
     obj->styles[i].is_local = 1;


### PR DESCRIPTION
```
==2459104== Conditional jump or move depends on uninitialised value(s)
==2459104==    at 0x295839: lv_style_init (lv_style.c:179)
==2459104==    by 0x265444: get_local_style (lv_obj_style.c:657)
==2459104==    by 0x263FF1: lv_obj_set_local_style_prop (lv_obj_style.c:359)
==2459104==    by 0x267FA7: lv_obj_set_style_flex_flow (lv_obj_style_gen.c:779)
==2459104==    by 0x289D34: lv_obj_set_flex_flow (lv_flex.c:103)
```
Seen by using valgrind.
