### PR TITLE
fix(wayland): delete the allocated display and buffers

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -2489,6 +2489,9 @@ static void wayland_deinit(void)
         if(!window->closed) {
             destroy_window(window);
         }
+
+        lv_draw_buf_destroy(window->lv_disp_draw_buf);
+        lv_display_delete(window->lv_disp);
     }
 
     smm_deinit();


### PR DESCRIPTION
The `lv_wayland_window_create` calls `lv_{display,draw_buf}_create`, so `lv_wayland_window_close` should call at some point `lv_{draw_buf_destroy,display_delete}`.
