### PR TITLE
fix(sysmon): fix heap memory overflow

### DIFF
--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -149,14 +149,16 @@ void lv_sysmon_show_memory(lv_display_t * disp)
         return;
     }
 
-    disp->mem_label = lv_sysmon_create(disp);
     if(disp->mem_label == NULL) {
-        LV_LOG_WARN("Couldn't create sysmon");
-        return;
-    }
+        disp->mem_label = lv_sysmon_create(disp);
+        if(disp->mem_label == NULL) {
+            LV_LOG_WARN("Couldn't create sysmon");
+            return;
+        }
 
-    lv_obj_align(disp->mem_label, LV_USE_MEM_MONITOR_POS, 0, 0);
-    lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, disp->mem_label, NULL);
+        lv_obj_align(disp->mem_label, LV_USE_MEM_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&sysmon_mem.subject, mem_observer_cb, disp->mem_label, NULL);
+    }
 
     lv_obj_remove_flag(disp->mem_label, LV_OBJ_FLAG_HIDDEN);
 }

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -105,17 +105,19 @@ void lv_sysmon_show_performance(lv_display_t * disp)
         return;
     }
 
-    disp->perf_label = lv_sysmon_create(disp);
     if(disp->perf_label == NULL) {
-        LV_LOG_WARN("Couldn't create sysmon");
-        return;
-    }
+        disp->perf_label = lv_sysmon_create(disp);
+        if(disp->perf_label == NULL) {
+            LV_LOG_WARN("Couldn't create sysmon");
+            return;
+        }
 
-    lv_subject_init_pointer(&disp->perf_sysmon_backend.subject, &disp->perf_sysmon_info);
-    lv_obj_align(disp->perf_label, LV_USE_PERF_MONITOR_POS, 0, 0);
-    lv_subject_add_observer_obj(&disp->perf_sysmon_backend.subject, perf_observer_cb, disp->perf_label, NULL);
-    disp->perf_sysmon_backend.timer = lv_timer_create(perf_update_timer_cb, LV_SYSMON_REFR_PERIOD_DEF, disp);
-    lv_display_add_event_cb(disp, perf_monitor_disp_event_cb, LV_EVENT_ALL, NULL);
+        lv_subject_init_pointer(&disp->perf_sysmon_backend.subject, &disp->perf_sysmon_info);
+        lv_obj_align(disp->perf_label, LV_USE_PERF_MONITOR_POS, 0, 0);
+        lv_subject_add_observer_obj(&disp->perf_sysmon_backend.subject, perf_observer_cb, disp->perf_label, NULL);
+        disp->perf_sysmon_backend.timer = lv_timer_create(perf_update_timer_cb, LV_SYSMON_REFR_PERIOD_DEF, disp);
+        lv_display_add_event_cb(disp, perf_monitor_disp_event_cb, LV_EVENT_ALL, NULL);
+    }
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     lv_obj_add_flag(disp->perf_label, LV_OBJ_FLAG_HIDDEN);


### PR DESCRIPTION
fix(sysmon): fix heap memory overflow

- fix(sysmon): fix heap memory overflow caused by calling `lv_sysmon_show_memory` and `lv_sysmon_hide_memory` multiple times
- fix(sysmon): fix heap memory overflow caused by calling `lv_sysmon_show_performance` and `lv_sysmon_hide_performance` multiple times

### Issues
Calling 'lv_sysmon_show_memory' and 'lv_sysmon_show_performance' multiple times will cause less and less heap memory to be available and eventually overflow the heap memory.

### Reasons
Because each call to 'lv_sysmon_show_memory' and 'lv_sysmon_show_performance' creates a 'lv_sysmon_create(disp)', However, 'lv_sysmon_hide_performance' and 'lv_sysmon_hide_memory' only add the 'LV_OBJ_FLAG_HIDDEN' tag and do not remove 'lv_obj_t', which results in the heap memory overflow.

### Fix
In 'lv_sysmon_show_memory' and 'lv_sysmon_show_performance' The function lv_sysmon_create first checks whether 'disp->mem_label' or 'disp->perf_label' is NULL.
If 'disp->mem_label == NULL' or 'disp->perf_label == NULL' then 'lv_sysmon_create' is called to create the object. Otherwise, modify the 'LV_OBJ_FLAG_HIDDEN' flag directly

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
