### PR TITLE
fix(label): add assignment to uninitialized variable

### DIFF
--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -320,6 +320,7 @@ void lv_label_get_letter_pos(const lv_obj_t * obj, uint32_t char_id, lv_point_t 
                 pos->x = lv_obj_get_content_width(obj) / 2;
                 break;
             default:
+                pos->x = 0;
                 break;
         }
         return;


### PR DESCRIPTION
If the alignment value is not LEFT, RIGHT or CENTER, the x is not assigned.  Add assignment to set x to zero if the alignment value is not LEFT, RIGHT or CENTER