### PR TITLE
fix(dave2d): handle LV_COLOR_FORMAT_RGB888 correctly

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -250,7 +250,7 @@ static int32_t _dave2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
 
         case LV_DRAW_TASK_TYPE_IMAGE: {
                 lv_draw_image_dsc_t * dsc = t->draw_dsc;
-                if(dsc->header.cf >= LV_COLOR_FORMAT_PROPRIETARY_START) {
+                if((dsc->header.cf >= LV_COLOR_FORMAT_PROPRIETARY_START) || (dsc->header.cf == LV_COLOR_FORMAT_RGB888)) {
                     ret = 0;
                     break;
                 }

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c
@@ -117,9 +117,6 @@ d2_u32 lv_draw_dave2d_lv_colour_fmt_to_d2_fmt(lv_color_format_t colour_format)
         case(LV_COLOR_FORMAT_RGB565):
             d2_lvgl_mode = d2_mode_rgb565;
             break;
-        case(LV_COLOR_FORMAT_RGB888):
-            d2_lvgl_mode = d2_mode_rgb888;
-            break;
         case(LV_COLOR_FORMAT_ARGB1555):
             d2_lvgl_mode = d2_mode_argb1555;
             break;
@@ -133,6 +130,7 @@ d2_u32 lv_draw_dave2d_lv_colour_fmt_to_d2_fmt(lv_color_format_t colour_format)
             d2_lvgl_mode = d2_mode_argb8888;
             break;
 
+        case(LV_COLOR_FORMAT_RGB888): //LV_COLOR_FORMAT_RGB888 is a 3 byte format, d2_mode_rgb888 is a 4 byte format, not supported
         default:
             LV_ASSERT(0);
             break;


### PR DESCRIPTION
LV_COLOR_FORMAT_RGB888 is a 3 byte format, d2_mode_rgb888 is a 4 byte format, LV_COLOR_FORMAT_RG888 is not supported by Dave2D

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
