### PR TITLE
fix(nxp): allow vglite build when LV_USE_DRAW_SW is disabled

### DIFF
--- a/demos/widgets/lv_demo_widgets.h
+++ b/demos/widgets/lv_demo_widgets.h
@@ -14,6 +14,8 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_demos.h"
+#include "../../src/draw/lv_draw.h"
+#include "../../src/draw/lv_draw_triangle.h"
 
 #if LV_USE_DEMO_WIDGETS
 

--- a/src/draw/nxp/pxp/lv_draw_pxp.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp.h
@@ -24,7 +24,8 @@ extern "C" {
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP
-#include "../../sw/lv_draw_sw_private.h"
+#include "../../lv_draw_private.h"
+#include "../../../display/lv_display_private.h"
 #include "../../../misc/lv_area_private.h"
 
 /*********************

--- a/src/draw/nxp/vglite/lv_draw_vglite.h
+++ b/src/draw/nxp/vglite/lv_draw_vglite.h
@@ -24,8 +24,14 @@ extern "C" {
 
 #if LV_USE_DRAW_VGLITE
 #include "../../lv_draw_private.h"
-#include "../../sw/lv_draw_sw_private.h"
+#include "../../../display/lv_display_private.h"
 #include "../../../misc/lv_area_private.h"
+
+#include "../../lv_draw_triangle.h"
+#include "../../lv_draw_label.h"
+#include "../../lv_draw_image.h"
+#include "../../lv_draw_line.h"
+#include "../../lv_draw_arc.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/nxp/vglite/lv_vglite_buf.h
+++ b/src/draw/nxp/vglite/lv_vglite_buf.h
@@ -22,7 +22,7 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_DRAW_VGLITE
-#include "../../sw/lv_draw_sw.h"
+#include "../../lv_draw.h"
 
 #include "vg_lite.h"
 

--- a/src/draw/nxp/vglite/lv_vglite_matrix.h
+++ b/src/draw/nxp/vglite/lv_vglite_matrix.h
@@ -22,7 +22,9 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_DRAW_VGLITE
-#include "../../sw/lv_draw_sw.h"
+
+#include "../../lv_draw_image.h"
+#include "../../lv_draw.h"
 
 #include "vg_lite.h"
 

--- a/src/draw/nxp/vglite/lv_vglite_path.h
+++ b/src/draw/nxp/vglite/lv_vglite_path.h
@@ -22,7 +22,8 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_DRAW_VGLITE
-#include "../../sw/lv_draw_sw.h"
+#include "../../lv_draw.h"
+#include "../../lv_draw_triangle.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/nxp/vglite/lv_vglite_utils.h
+++ b/src/draw/nxp/vglite/lv_vglite_utils.h
@@ -22,7 +22,7 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_DRAW_VGLITE
-#include "../../sw/lv_draw_sw.h"
+#include "../../lv_draw.h"
 
 #include "vg_lite.h"
 #include "vg_lite_options.h"


### PR DESCRIPTION
This patch detaches VGLITE code from SW allowing compilation and execution with VGLITE being the only enabled draw unit

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
