### PR TITLE
fix(text): fix oob read for utf8-next

### DIFF
--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -649,6 +649,12 @@ static uint32_t lv_text_utf8_next(const char * txt, uint32_t * i)
     uint32_t i_tmp = 0;
     if(i == NULL) i = &i_tmp;
 
+    /* Ensure the string is not null */
+    if(txt == NULL || *i >= lv_strlen(txt)) {
+        (*i)++;
+        return result;
+    }
+
     /*Normal ASCII*/
     if(LV_IS_ASCII(txt[*i])) {
         result = txt[*i];

--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -429,7 +429,7 @@ int32_t lv_text_get_width_with_flags(const char * txt, uint32_t length, const lv
     lv_text_cmd_state_t cmd_state = LV_TEXT_CMD_STATE_WAIT;
 
     if(length != 0) {
-        while(i < length) {
+        while(txt[i] != '\0' && i < length) {
             uint32_t letter;
             uint32_t letter_next;
             lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &i);
@@ -650,8 +650,7 @@ static uint32_t lv_text_utf8_next(const char * txt, uint32_t * i)
     if(i == NULL) i = &i_tmp;
 
     /* Ensure the string is not null */
-    if(txt == NULL || *i >= lv_strlen(txt)) {
-        (*i)++;
+    if(txt == NULL || txt[*i] == '\0') {
         return result;
     }
 

--- a/tests/src/test_cases/test_txt.c
+++ b/tests/src/test_cases/test_txt.c
@@ -142,27 +142,27 @@ void test_txt_next_line_should_handle_empty_string(void)
 void test_lv_text_encoded_letter_next_2_should_handle_null_pointer(void)
 {
     const char * txt = NULL;
-    uint32_t letter = 0, letter_next = 0, ofs = 0;
+    uint32_t letter = 100, letter_next = 101, ofs = 0;
 
     lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
 
     /* Expect both letter and letter_next to be 0 because the input string is NULL */
     TEST_ASSERT_EQUAL_UINT32(0, letter);
     TEST_ASSERT_EQUAL_UINT32(0, letter_next);
-    TEST_ASSERT_EQUAL_UINT32(1, ofs);
+    TEST_ASSERT_EQUAL_UINT32(0, ofs);
 }
 
 void test_lv_text_encoded_letter_next_2_should_handle_empty_string(void)
 {
     const char * txt = "";
-    uint32_t letter = 0, letter_next = 0, ofs = 0;
+    uint32_t letter = 100, letter_next = 101, ofs = 0;
 
     lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
 
     /* Expect both letter and letter_next to be 0 because the input string is empty */
     TEST_ASSERT_EQUAL_UINT32(0, letter);
     TEST_ASSERT_EQUAL_UINT32(0, letter_next);
-    TEST_ASSERT_EQUAL_UINT32(1, ofs);
+    TEST_ASSERT_EQUAL_UINT32(0, ofs);
 }
 
 void test_lv_text_encoded_letter_next_2_should_handle_single_ascii_character(void)

--- a/tests/src/test_cases/test_txt.c
+++ b/tests/src/test_cases/test_txt.c
@@ -139,4 +139,69 @@ void test_txt_next_line_should_handle_empty_string(void)
     TEST_ASSERT_EQUAL_UINT32(0, next_line);
 }
 
+void test_lv_text_encoded_letter_next_2_should_handle_null_pointer(void)
+{
+    const char * txt = NULL;
+    uint32_t letter = 0, letter_next = 0, ofs = 0;
+
+    lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
+
+    /* Expect both letter and letter_next to be 0 because the input string is NULL */
+    TEST_ASSERT_EQUAL_UINT32(0, letter);
+    TEST_ASSERT_EQUAL_UINT32(0, letter_next);
+    TEST_ASSERT_EQUAL_UINT32(1, ofs);
+}
+
+void test_lv_text_encoded_letter_next_2_should_handle_empty_string(void)
+{
+    const char * txt = "";
+    uint32_t letter = 0, letter_next = 0, ofs = 0;
+
+    lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
+
+    /* Expect both letter and letter_next to be 0 because the input string is empty */
+    TEST_ASSERT_EQUAL_UINT32(0, letter);
+    TEST_ASSERT_EQUAL_UINT32(0, letter_next);
+    TEST_ASSERT_EQUAL_UINT32(1, ofs);
+}
+
+void test_lv_text_encoded_letter_next_2_should_handle_single_ascii_character(void)
+{
+    const char * txt = "A";
+    uint32_t letter = 0, letter_next = 0, ofs = 0;
+
+    lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
+
+    /* Expect letter to be 'A' (ASCII 65), letter_next to be 0 (no next character), and ofs to point to end of string */
+    TEST_ASSERT_EQUAL_UINT32('A', letter);
+    TEST_ASSERT_EQUAL_UINT32(0, letter_next);
+    TEST_ASSERT_EQUAL_UINT32(1, ofs);
+}
+
+void test_lv_text_encoded_letter_next_2_should_handle_utf8_multibyte_character(void)
+{
+    const char * txt = "é"; /* UTF-8 encoding: 0xC3 0xA9 */
+    uint32_t letter = 0, letter_next = 0, ofs = 0;
+
+    lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
+
+    /* Expect letter to decode 'é', letter_next to be 0 (no next character), and ofs to point to end of string */
+    TEST_ASSERT_EQUAL_UINT32(0xE9, letter); /* Unicode code point for 'é' */
+    TEST_ASSERT_EQUAL_UINT32(0, letter_next);
+    TEST_ASSERT_EQUAL_UINT32(2, ofs); /* 'é' is 2 bytes long in UTF-8 */
+}
+
+void test_lv_text_encoded_letter_next_2_should_handle_two_utf8_characters(void)
+{
+    const char * txt = "éA"; /* UTF-8 encoding: 0xC3 0xA9 0x41 */
+    uint32_t letter = 0, letter_next = 0, ofs = 0;
+
+    lv_text_encoded_letter_next_2(txt, &letter, &letter_next, &ofs);
+
+    /* Expect letter to decode 'é', letter_next to be 'A', and ofs to point after 'é' */
+    TEST_ASSERT_EQUAL_UINT32(0xE9, letter);      /* Unicode code point for 'é' */
+    TEST_ASSERT_EQUAL_UINT32('A', letter_next); /* ASCII value for 'A' */
+    TEST_ASSERT_EQUAL_UINT32(2, ofs);           /* Offset after 'é' */
+}
+
 #endif

--- a/tests/src/test_cases/widgets/test_label.c
+++ b/tests/src/test_cases/widgets/test_label.c
@@ -56,7 +56,7 @@ void test_label_set_text(void)
 
 void test_label_get_letter_pos_align_left(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -84,7 +84,7 @@ void test_label_get_letter_pos_align_left(void)
 
 void test_label_get_letter_pos_align_left_on_empty_text(void)
 {
-    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_LEFT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -112,7 +112,7 @@ void test_label_get_letter_pos_align_left_on_empty_text(void)
 
 void test_label_long_text_multiline_get_letter_pos_align_left(void)
 {
-    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_LEFT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     lv_point_t last_letter_after_new_line_point;
@@ -154,7 +154,7 @@ void test_label_long_text_get_letter_pos_align_left(void)
     lv_label_set_long_mode(long_label, LV_LABEL_LONG_MODE_WRAP);
     lv_obj_set_width(long_label, 150);
     lv_obj_set_height(long_label, 500);
-    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_LEFT, 0);
 
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
@@ -183,7 +183,7 @@ void test_label_long_text_get_letter_pos_align_left(void)
 
 void test_label_get_letter_pos_align_right(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -211,7 +211,7 @@ void test_label_get_letter_pos_align_right(void)
 
 void test_label_get_letter_pos_align_right_on_empty_text(void)
 {
-    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_RIGHT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -239,7 +239,7 @@ void test_label_get_letter_pos_align_right_on_empty_text(void)
 
 void test_label_long_text_multiline_get_letter_pos_align_right(void)
 {
-    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_RIGHT, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     lv_point_t last_letter_after_new_line_point;
@@ -281,7 +281,7 @@ void test_label_long_text_get_letter_pos_align_right(void)
     lv_label_set_long_mode(long_label, LV_LABEL_LONG_MODE_WRAP);
     lv_obj_set_width(long_label, 150);
     lv_obj_set_height(long_label, 500);
-    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_RIGHT, 0);
 
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
@@ -310,7 +310,7 @@ void test_label_long_text_get_letter_pos_align_right(void)
 
 void test_label_get_letter_pos_align_center(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -338,7 +338,7 @@ void test_label_get_letter_pos_align_center(void)
 
 void test_label_get_letter_pos_align_center_on_empty_text(void)
 {
-    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(empty_label, LV_TEXT_ALIGN_CENTER, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     const lv_point_t expected_first_letter_point = {
@@ -366,7 +366,7 @@ void test_label_get_letter_pos_align_center_on_empty_text(void)
 
 void test_label_long_text_multiline_get_letter_pos_align_center(void)
 {
-    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label_multiline, LV_TEXT_ALIGN_CENTER, 0);
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
     lv_point_t last_letter_after_new_line_point;
@@ -408,7 +408,7 @@ void test_label_long_text_get_letter_pos_align_center(void)
     lv_label_set_long_mode(long_label, LV_LABEL_LONG_MODE_WRAP);
     lv_obj_set_width(long_label, 150);
     lv_obj_set_height(long_label, 500);
-    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(long_label, LV_TEXT_ALIGN_CENTER, 0);
 
     lv_point_t first_letter_point;
     lv_point_t last_letter_point;
@@ -437,7 +437,7 @@ void test_label_long_text_get_letter_pos_align_center(void)
 
 void test_label_is_char_under_pos_align_left(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
     bool expected_result = true;
     bool result = false;
     lv_point_t last_letter_point;
@@ -460,7 +460,7 @@ void test_label_is_char_under_pos_align_left(void)
 
 void test_label_is_char_under_pos_align_right(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, 0);
     bool expected_result = true;
     bool result = false;
     lv_point_t last_letter_point;
@@ -483,7 +483,7 @@ void test_label_is_char_under_pos_align_right(void)
 
 void test_label_is_char_under_pos_align_center(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
     bool expected_result = true;
     bool result = false;
     lv_point_t last_letter_point;
@@ -515,7 +515,7 @@ void test_label_cut_text(void)
 
 void test_label_get_letter_on_left(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
     lv_point_t last_letter_point;
 
     const uint32_t last_letter_idx = strlen(lv_label_get_text(label)) - 1;
@@ -528,7 +528,7 @@ void test_label_get_letter_on_left(void)
 
 void test_label_get_letter_on_center(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
     lv_point_t last_letter_point;
 
     const uint32_t last_letter_idx = strlen(lv_label_get_text(label)) - 1;
@@ -541,7 +541,7 @@ void test_label_get_letter_on_center(void)
 
 void test_label_get_letter_on_right(void)
 {
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, LV_STYLE_STATE_CMP_SAME);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, 0);
     lv_point_t last_letter_point;
 
     const uint32_t last_letter_idx = strlen(lv_label_get_text(label)) - 1;
@@ -660,7 +660,6 @@ void test_label_scroll_mid_update(void)
     for(i = 0; i < 15; i++) {
         scroll_next_step(label1, label2, text1, text2, i);
     }
-
 }
 
 #endif


### PR DESCRIPTION
Originally raised in zephyr clone https://github.com/zephyrproject-rtos/lvgl/pull/55 

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
