### PR TITLE
fix(docs):  clarify obj hierarchy after `lv_menu_page_create()`

### DIFF
--- a/docs/details/widgets/menu.rst
+++ b/docs/details/widgets/menu.rst
@@ -20,24 +20,17 @@ Parts and Styles
 
 The Menu Widget is built from the following Widgets:
 
-    - Menu: :cpp:type:`lv_menu_t`
-        - Main container: :cpp:var:`lv_menu_main_cont_class`
-            - Main header: :cpp:var:`lv_menu_main_header_cont_class`
-                - Back button: :ref:`lv_button`
-                    - Back button icon: :ref:`lv_image`
-            - Main Page: :cpp:type:`lv_menu_page_t`
-        - Sidebar container: :cpp:var:`lv_menu_sidebar_cont_class`   (only when a sidebar is created)
-            - Sidebar header: :cpp:var:`lv_menu_sidebar_header_cont_class`
-                - Back button: :ref:`lv_button`
-                    - Back button icon: :ref:`lv_image`
-            - Sidebar Page: :cpp:type:`lv_menu_page_t`
+- Main container: :cpp:type:`lv_menu_main_cont`
+- Main header: :cpp:type:`lv_menu_main_header_cont`
+- Back button: :ref:`lv_button`
+- Back button icon: :ref:`lv_image`
+- Main Page: :cpp:type:`lv_menu_page`
+- Sidebar container: :cpp:type:`lv_menu_sidebar_cont`
+- Sidebar header: :cpp:type:`lv_menu_sidebar_header_cont`
+- Back button: :ref:`lv_button`
+- Back button icon: :ref:`lv_image`
+- Sidebar Page: :cpp:type:`lv_menu_page`
 
-.. note::
-
-    ``lv_menu_main_cont_class``, ``lv_menu_main_header_cont_class``,
-    ``lv_menu_sidebar_cont_class``, and ``lv_menu_sidebar_header_cont_class``
-    are data types internal to the Menu Widget based on :ref:`base_widget`
-    and are not themselves separate Widgets.
 
 
 .. _lv_menu_usage:
@@ -53,11 +46,12 @@ Create a Menu
 This creates a Menu Widget with this object hierarchy:
 
     - Menu: :cpp:type:`lv_menu_t`
+        - Hidden Sub-Page Storage: :cpp:type:`lv_obj_t`
         - Main container: :cpp:var:`lv_menu_main_cont_class`
             - Main header: :cpp:var:`lv_menu_main_header_cont_class`
                 - Back button: :ref:`lv_button`
                     - Back button icon: :ref:`lv_image`
-            - Main Page: :cpp:type:`lv_menu_page_t`
+                - Main header title: :ref:`lv_label` (default hidden)
 
 Note that no sidebar is created.  You can create one later if you wish.
 

--- a/docs/details/widgets/menu.rst
+++ b/docs/details/widgets/menu.rst
@@ -8,8 +8,9 @@ Menu (lv_menu)
 Overview
 ********
 
-The Menu Widget can be used to easily create multi-level menus. It
-handles the traversal between Pages automatically.
+The Menu Widget can be used to create multi-level menus that automatically handle
+navigation among menu levels, and enable its user to capture page navigation and
+click events.
 
 
 .. _lv_menu_parts_and_styles:
@@ -19,16 +20,24 @@ Parts and Styles
 
 The Menu Widget is built from the following Widgets:
 
-- Main container: :cpp:type:`lv_menu_main_cont`
-- Main header: :cpp:type:`lv_menu_main_header_cont`
-- Back button: :ref:`lv_button`
-- Back button icon: :ref:`lv_image`
-- Main Page: :cpp:type:`lv_menu_page`
-- Sidebar container: :cpp:type:`lv_menu_sidebar_cont`
-- Sidebar header: :cpp:type:`lv_menu_sidebar_header_cont`
-- Back button: :ref:`lv_button`
-- Back button icon: :ref:`lv_image`
-- Sidebar Page: :cpp:type:`lv_menu_page`
+    - Menu: :cpp:type:`lv_menu_t`
+        - Main container: :cpp:var:`lv_menu_main_cont_class`
+            - Main header: :cpp:var:`lv_menu_main_header_cont_class`
+                - Back button: :ref:`lv_button`
+                    - Back button icon: :ref:`lv_image`
+            - Main Page: :cpp:type:`lv_menu_page_t`
+        - Sidebar container: :cpp:var:`lv_menu_sidebar_cont_class`   (only when a sidebar is created)
+            - Sidebar header: :cpp:var:`lv_menu_sidebar_header_cont_class`
+                - Back button: :ref:`lv_button`
+                    - Back button icon: :ref:`lv_image`
+            - Sidebar Page: :cpp:type:`lv_menu_page_t`
+
+.. note::
+
+    ``lv_menu_main_cont_class``, ``lv_menu_main_header_cont_class``,
+    ``lv_menu_sidebar_cont_class``, and ``lv_menu_sidebar_header_cont_class``
+    are data types internal to the Menu Widget based on :ref:`base_widget`
+    and are not themselves separate Widgets.
 
 
 .. _lv_menu_usage:
@@ -41,12 +50,24 @@ Create a Menu
 
 :cpp:expr:`lv_menu_create(parent)` creates a new empty Menu.
 
+This creates a Menu Widget with this object hierarchy:
+
+    - Menu: :cpp:type:`lv_menu_t`
+        - Main container: :cpp:var:`lv_menu_main_cont_class`
+            - Main header: :cpp:var:`lv_menu_main_header_cont_class`
+                - Back button: :ref:`lv_button`
+                    - Back button icon: :ref:`lv_image`
+            - Main Page: :cpp:type:`lv_menu_page_t`
+
+Note that no sidebar is created.  You can create one later if you wish.
+
+
 Header mode
 -----------
 
 The following header modes exist:
 
-- :cpp:enumerator:`LV_MENU_HEADER_TOP_FIXED` Header is positioned at the top.
+- :cpp:enumerator:`LV_MENU_HEADER_TOP_FIXED` Header is positioned at the top.  (default)
 - :cpp:enumerator:`LV_MENU_HEADER_TOP_UNFIXED` Header is positioned at the top and can be scrolled out of view.
 - :cpp:enumerator:`LV_MENU_HEADER_BOTTOM_FIXED` Header is positioned at the bottom.
 
@@ -57,7 +78,7 @@ Root back button mode
 
 The following root back button modes exist:
 
-- :cpp:enumerator:`LV_MENU_ROOT_BACK_BTN_DISABLED`
+- :cpp:enumerator:`LV_MENU_ROOT_BACK_BTN_DISABLED`  (default)
 - :cpp:enumerator:`LV_MENU_ROOT_BACK_BTN_ENABLED`
 
 You can set root back button modes with

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -126,7 +126,7 @@ lv_obj_t * lv_menu_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 {
-    LV_ASSERT_OBJ(parent, MY_CLASS);
+    LV_ASSERT_OBJ(menu, MY_CLASS);
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_page_class, menu);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -124,12 +124,12 @@ lv_obj_t * lv_menu_create(lv_obj_t * parent)
     return obj;
 }
 
-lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title)
+lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 {
     LV_ASSERT_OBJ(parent, MY_CLASS);
 
     LV_LOG_INFO("begin");
-    lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_page_class, parent);
+    lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_page_class, menu);
     lv_obj_class_init_obj(obj);
 
     lv_menu_page_t * page = (lv_menu_page_t *)obj;

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -113,7 +113,6 @@ static void lv_menu_value_changed_event_cb(lv_event_t * e);
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-bool lv_menu_item_back_button_is_root(lv_obj_t * menu, lv_obj_t * obj);
 void lv_menu_clear_history(lv_obj_t * obj);
 
 lv_obj_t * lv_menu_create(lv_obj_t * parent)

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -60,12 +60,16 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_menu_main_header_cont_cl
 lv_obj_t * lv_menu_create(lv_obj_t * parent);
 
 /**
- * Create a menu page object
- * @param parent    pointer to menu object
+ * Create a menu page object.
+ *
+ * This call inserts the new page under menu->storage as its parent, which is itself a
+ * child of the menu, so the resulting object hierarchy is: menu => storage => new_page
+ * where `storage` is a Base Widget.
+ * @param menu      pointer to menu object.
  * @param title     pointer to text for title in header (NULL to not display title)
  * @return          pointer to the created menu page
  */
-lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title);
+lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title);
 
 /**
  * Create a menu cont object


### PR DESCRIPTION
In Issue #7600, @phelter correctly pointed out that the API documentation for `lv_menu_page_create()` (and its 1st argument name) is misleading about the resulting object hierarchy after the call.  This submission both clarifies the result in the API documentation as well as adds some enhancements to `menu.rst`, though it still needs a thorough review.

Resolves #7600

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
