### PR TITLE
fix(menu): add missing LV_ASSERT_OBJ

### DIFF
--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -143,7 +143,7 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title)
 
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
-    LV_ASSERT_OBJ(parent, lv_menu_page_class);
+    LV_ASSERT_OBJ(parent, &lv_menu_page_class);
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_cont_class, parent);
@@ -153,7 +153,7 @@ lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_section_create(lv_obj_t * parent)
 {
-    LV_ASSERT_OBJ(parent, lv_menu_page_class);
+    LV_ASSERT_OBJ(parent, &lv_menu_page_class);
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_section_class, parent);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -126,6 +126,8 @@ lv_obj_t * lv_menu_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title)
 {
+    LV_ASSERT_OBJ(parent, MY_CLASS);
+
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_page_class, parent);
     lv_obj_class_init_obj(obj);
@@ -141,6 +143,8 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title)
 
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
+    LV_ASSERT_OBJ(parent, lv_menu_page_class);
+
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_cont_class, parent);
     lv_obj_class_init_obj(obj);
@@ -149,6 +153,8 @@ lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_section_create(lv_obj_t * parent)
 {
+    LV_ASSERT_OBJ(parent, lv_menu_page_class);
+
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_section_class, parent);
     lv_obj_class_init_obj(obj);
@@ -157,6 +163,8 @@ lv_obj_t * lv_menu_section_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_separator_create(lv_obj_t * parent)
 {
+    LV_ASSERT_OBJ(parent, &lv_menu_page_class);
+
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_separator_class, parent);
     lv_obj_class_init_obj(obj);
@@ -389,6 +397,8 @@ void lv_menu_set_load_page_event(lv_obj_t * menu, lv_obj_t * obj, lv_obj_t * pag
 
 void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
 {
+    LV_ASSERT_OBJ(page_obj, &lv_menu_page_class);
+
     LV_LOG_INFO("begin");
     lv_menu_page_t * page = (lv_menu_page_t *)page_obj;
 
@@ -414,6 +424,8 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
 
 void lv_menu_set_page_title_static(lv_obj_t * page_obj, char const * const title)
 {
+    LV_ASSERT_OBJ(page_obj, &lv_menu_page_class);
+
     LV_LOG_INFO("begin");
     lv_menu_page_t * page = (lv_menu_page_t *)page_obj;
 

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -69,21 +69,21 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * parent, char const * const title);
 
 /**
  * Create a menu cont object
- * @param parent    pointer to an object, it will be the parent of the new menu cont object
+ * @param parent    pointer to a menu page object, it will be the parent of the new menu cont object
  * @return          pointer to the created menu cont
  */
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent);
 
 /**
  * Create a menu section object
- * @param parent    pointer to an object, it will be the parent of the new menu section object
+ * @param parent    pointer to a menu page object, it will be the parent of the new menu section object
  * @return          pointer to the created menu section
  */
 lv_obj_t * lv_menu_section_create(lv_obj_t * parent);
 
 /**
  * Create a menu separator object
- * @param parent    pointer to an object, it will be the parent of the new menu separator object
+ * @param parent    pointer to a menu page object, it will be the parent of the new menu separator object
  * @return          pointer to the created menu separator
  */
 lv_obj_t * lv_menu_separator_create(lv_obj_t * parent);


### PR DESCRIPTION
Partial fix for #7586. Docs could be improved.

cc @phelter @vwheeler63 

Note, `LV_USE_ASSERT_OBJ` needs to be enabled for the asserts to trigger. I would add `if(!lv_obj_has_class(parent, MY_CLASS)) return NULL;` but I don't want to opt unwilling users into the performance cost without a greater discussion.

Also, I'm not 100% certain `lv_menu_cont_create`, `lv_menu_section_create`, and `lv_menu_separator_create` really do only accept `lv_menu_page_class` but it only makes sense to use them that way, I think.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
