### PR TITLE
fix(chart): avoid divide by zero

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -261,10 +261,15 @@ void lv_chart_get_point_pos_by_id(lv_obj_t * obj, lv_chart_series_t * ser, uint3
         }
 
         p_out->x = (int32_t)((int32_t)(w + block_gap) * id) / chart->point_cnt;
-        p_out->x += block_w * ser_idx / ser_cnt;
+        if(ser_cnt > 0) {
+            p_out->x += block_w * ser_idx / ser_cnt;
 
-        int32_t col_w = (block_w - (ser_gap * (ser_cnt - 1))) / ser_cnt;
-        p_out->x += col_w / 2;
+            int32_t col_w = (block_w - (ser_gap * (ser_cnt - 1))) / ser_cnt;
+            p_out->x += col_w / 2;
+        }
+        else {
+            LV_LOG_WARN("bar chart series count is zero");
+        }
     }
     else {
         p_out->x = 0;


### PR DESCRIPTION
For a BAR chart with a series count of zero, the count is being used in a divisor to adjust the x position.  Change to bypass the x adjustment if the series count is zero,
