### PR TITLE
fix(bin_decoder): check divisor is zero

### DIFF
--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -838,6 +838,12 @@ static lv_result_t decode_alpha_only(lv_image_decoder_t * decoder, lv_image_deco
     uint32_t rn;
     decoder_data_t * decoder_data = dsc->user_data;
     uint8_t bpp = lv_color_format_get_bpp(dsc->header.cf);
+
+    if(bpp == 0) {
+        LV_LOG_ERROR("Error color format: %d", dsc->header.cf);
+        return LV_RESULT_INVALID;
+    }
+
     uint32_t w = (dsc->header.stride * 8) / bpp;
     uint32_t buf_stride = (w * 8 + 7) >> 3; /*stride for img_data*/
     uint32_t buf_len = w * dsc->header.h; /*always decode to A8 format*/


### PR DESCRIPTION
If the color format is unknown, the bits per pixel variable is set to zero.  This value is then used as a divisor.  Add assertion prior to division to check that the "bpp" value is not zero
