### PR TITLE
chore(draw): fix unused function warning

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -34,10 +34,12 @@
 static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check);
 static void lv_cleanup_task(lv_draw_task_t * t, lv_display_t * disp);
 
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
 static inline uint32_t get_layer_size_kb(uint32_t size_byte)
 {
     return (size_byte + 1023) >> 10;
 }
+#endif
 
 /**********************
  *  STATIC VARIABLES


### PR DESCRIPTION
Building with clang and `-Wunused-function` gives the following warning:

```
src/draw/lv_draw.c:37:24: error: unused function
'get_layer_size_kb' [-Werror,-Wunused-function]
static inline uint32_t get_layer_size_kb(uint32_t size_byte)
                       ^
```

`get_layer_size_kb` is only used from the `LV_LOG_LEVEL_INFO` macro, so only include it if the log level is set to INFO or lower.
