### PR TITLE
fix(indev): skip press event on new object release

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1259,8 +1259,8 @@ static void indev_proc_press(lv_indev_t * indev)
             indev->pointer.vect.x         = 0;
             indev->pointer.vect.y         = 0;
 
-            
-            /* If the indev was already in a pressed state it means that we got dragged here 
+
+            /* If the indev was already in a pressed state it means that we got dragged here
              * so we shouldn't send any hover nor pressed events for a new object since the
              * originally pressed object didn't get released
              */

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1159,7 +1159,7 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
     i->pointer.act_point.x = x;
     i->pointer.act_point.y = y;
 
-    if(data->state == LV_INDEV_STATE_PRESSED){
+    if(data->state == LV_INDEV_STATE_PRESSED) {
         indev_proc_press(i);
     }
     else {

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1259,12 +1259,19 @@ static void indev_proc_press(lv_indev_t * indev)
             indev->pointer.vect.x         = 0;
             indev->pointer.vect.y         = 0;
 
-            const bool is_enabled = !lv_obj_has_state(indev_obj_act, LV_STATE_DISABLED);
-            if(is_enabled) {
-                if(indev->pointer.last_hovered != indev_obj_act) {
-                    if(send_event(LV_EVENT_HOVER_OVER, indev_act) == LV_RESULT_INVALID) return;
+            
+            /* If the indev was already in a pressed state it means that we got dragged here 
+             * so we shouldn't send any hover nor pressed events for a new object since the
+             * originally pressed object didn't get released
+             */
+            if(indev->prev_state != LV_INDEV_STATE_PRESSED) {
+                const bool is_enabled = !lv_obj_has_state(indev_obj_act, LV_STATE_DISABLED);
+                if(is_enabled) {
+                    if(indev->pointer.last_hovered != indev_obj_act) {
+                        if(send_event(LV_EVENT_HOVER_OVER, indev_act) == LV_RESULT_INVALID) return;
+                    }
+                    if(send_event(LV_EVENT_PRESSED, indev_act) == LV_RESULT_INVALID) return;
                 }
-                if(send_event(LV_EVENT_PRESSED, indev_act) == LV_RESULT_INVALID) return;
             }
 
             if(indev_act->wait_until_release) return;

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -33,6 +33,7 @@ struct _lv_indev_t {
     lv_indev_read_cb_t read_cb;
 
     lv_indev_state_t state; /**< Current state of the input device.*/
+    lv_indev_state_t prev_state; /**< Previous state of the input device.*/
     lv_indev_mode_t mode;
 
     /*Flags*/
@@ -101,6 +102,7 @@ struct _lv_indev_t {
         uint8_t gesture_dir : 4;
         uint8_t gesture_sent : 1;
         uint8_t press_moved : 1;
+        uint8_t pressed : 1;
     } pointer;
     struct {
         /*Keypad data*/


### PR DESCRIPTION
Fixes #6229 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

This PR prevents triggering a press event when the device moves from the originally pressed object to a different object and is then released on that new object.

Testing C code:
```c
static void cl_cb(lv_event_t *e)
{
	LV_LOG_USER("clicked");
}
static void click_scroll(void)
{
	lv_obj_t *btn = lv_button_create(lv_screen_active());
	lv_obj_align(btn, LV_ALIGN_CENTER, 0, 0);
	lv_obj_add_event_cb(btn, cl_cb, LV_EVENT_CLICKED, NULL);
	lv_label_set_text(lv_label_create(btn), "Press This One");
	lv_obj_remove_flag(btn, LV_OBJ_FLAG_PRESS_LOCK);

	lv_obj_t *other_btn = lv_button_create(lv_screen_active());
	lv_obj_align(other_btn, LV_ALIGN_BOTTOM_MID, 0, 0);
	lv_obj_add_event_cb(other_btn, cl_cb, LV_EVENT_CLICKED, NULL);
	lv_label_set_text(lv_label_create(other_btn), "And Release On This");
	lv_obj_remove_flag(other_btn, LV_OBJ_FLAG_PRESS_LOCK);
}
```
Current Master:

https://github.com/user-attachments/assets/b4a8faa0-df8a-44d3-a9d0-c14d85ef7628

With this PR:

https://github.com/user-attachments/assets/d03dc9cd-ea93-4958-875e-5ba28a41754e

The way this is solved is by keeping track if the current device was pressed or not and then blocking the event when the release event happens if the object wasn't pressed.

Please let me know if i'm missing something