### PR TITLE
ci: cancel previous workflow run on new commit

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -4,6 +4,13 @@ on:
     branches: [ master, release/v8.* ]
   pull_request:
     branches: [ master, release/v8.* ]
+
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   lint:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master, release/v8.* ]
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/check_bom.yml
+++ b/.github/workflows/check_bom.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   bom-check:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/check_conf.yml
+++ b/.github/workflows/check_conf.yml
@@ -3,6 +3,12 @@ on:
   push:
   pull_request:
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   verify-conf-internal:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/check_properties.yml
+++ b/.github/workflows/check_properties.yml
@@ -2,6 +2,12 @@ name: Verify the widget property name
 on:
   push:
   pull_request:
+  
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
 
 jobs:
   verify-property-name:

--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -2,6 +2,12 @@ name: Verify code formatting
 on:
   push:
   pull_request:
+  
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
 
 jobs:
   verify-formatting:

--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -4,6 +4,13 @@ on:
     branches:
     - master
     - 'release/*'
+
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 env:
   EM_VERSION: 2.0.4
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/.github/workflows/gen_json.yml
+++ b/.github/workflows/gen_json.yml
@@ -3,6 +3,12 @@ on:
   push:
   pull_request:
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   test_api_json:
     if: github.repository == 'lvgl/lvgl'

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master, release/v8.* ]
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each push
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/makefile_uefi.yml
+++ b/.github/workflows/makefile_uefi.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master ]
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each push
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -6,6 +6,12 @@ on:
       - 'release/v*' # on release branches
   workflow_dispatch: # allow manual triggering
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each push
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   run-release-branch-updater:
     if: github.repository == 'lvgl/lvgl'

--- a/.github/workflows/verify_kconfig.yml
+++ b/.github/workflows/verify_kconfig.yml
@@ -3,6 +3,12 @@ on:
   push:
   pull_request:
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each push
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }} 
+  cancel-in-progress: true
+
 jobs:
   verify-kconfig:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Currently, when a new commit gets pushed for a specific PR, multiple workflows will run at the same time for different commits in the same PR

Since we most likely only care about the latest commit made to the PR, this concurrency rule cancels the previous workflow run when a new commit is made to the same `github.ref` which will, in the case of a push be the branch name

I've also added the same rule to some checks that only happen in master for the same reason, when merging multiple PR's one after the other the same reasoning is probably justified

I didn't create an issue before so I apologize if you feel like this is not a good idea

@liamHowatt 