### PR TITLE
fix(vg_lite_math): initialize all variables to avoid error of uninitialized variables on some compilers.

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_math.c
+++ b/src/draw/vg_lite/lv_vg_lite_math.c
@@ -39,13 +39,12 @@
 
 float math_fast_inv_sqrtf(float number)
 {
-    int32_t i;
-    float x2, y;
     const float threehalfs = 1.5f;
 
-    x2 = number * 0.5f;
-    y = number;
-    i = *(int32_t *)&y; /* evil floating point bit level hacking */
+    float x2 = number * 0.5f;
+    float y = number;
+    int32_t i = *(int32_t *)&y; /* evil floating point bit level hacking */
+
     i = 0x5f3759df /* floating-point representation of an approximation of {\sqrt {2^{127}}}} see https://en.wikipedia.org/wiki/Fast_inverse_square_root. */
         - (i >>
            1);


### PR DESCRIPTION
On some environments, the inverse squareroot present on the vg_lite Math module may point to an uninitialized variable warning, which may lead to a compiler error.

This PR just initializes the x2 and y variables to blow off the warning and the possible compiler error. 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
