### PR TITLE
feat(osal): add lv_os_get_idle_percent for linux

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -963,7 +963,7 @@
 #define LV_USE_SYSMON   0
 #if LV_USE_SYSMON
     /** Get the idle percentage. E.g. uint32_t my_get_idle(void); */
-    #define LV_SYSMON_GET_IDLE lv_timer_get_idle
+    #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
 
     /** 1: Show CPU usage and FPS count.
      *  - Requires `LV_USE_SYSMON = 1` */

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -35,6 +35,10 @@ extern "C" {
 #include "../font/lv_font_fmt_txt_private.h"
 #endif
 
+#if LV_USE_OS != LV_OS_NONE && defined(__linux__)
+#include "../osal/lv_linux_private.h"
+#endif
+
 #include "../tick/lv_tick.h"
 #include "../layouts/lv_layout.h"
 
@@ -224,6 +228,9 @@ typedef struct _lv_global_t {
 
 #if LV_USE_OS != LV_OS_NONE
     lv_mutex_t lv_general_mutex;
+#if defined(__linux__)
+    lv_proc_stat_t linux_last_proc_stat;
+#endif
 #endif
 
 #if LV_USE_OS == LV_OS_FREERTOS

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3067,7 +3067,7 @@
         #ifdef CONFIG_LV_SYSMON_GET_IDLE
             #define LV_SYSMON_GET_IDLE CONFIG_LV_SYSMON_GET_IDLE
         #else
-            #define LV_SYSMON_GET_IDLE lv_timer_get_idle
+            #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
         #endif
     #endif
 

--- a/src/osal/lv_cmsis_rtos2.c
+++ b/src/osal/lv_cmsis_rtos2.c
@@ -190,6 +190,11 @@ lv_result_t lv_thread_sync_delete(lv_thread_sync_t * sync)
     return LV_RESULT_OK;
 }
 
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/osal/lv_cmsis_rtos2.c
+++ b/src/osal/lv_cmsis_rtos2.c
@@ -17,6 +17,7 @@
 #if LV_USE_OS == LV_OS_CMSIS_RTOS2
 
 #include "../misc/lv_log.h"
+#include "../misc/lv_timer.h"
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -84,13 +84,6 @@ void lv_freertos_task_switch_in(const char * name);
  */
 void lv_freertos_task_switch_out(void);
 
-/**
- * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
- * as reported based the usage of FreeRTOS's idle task
- * If it's important when a GPU is used.
- * @return the idle percentage since the last call
- */
-uint32_t lv_os_get_idle_percent(void);
 
 /**********************
  *      MACROS

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -97,7 +97,7 @@ uint32_t lv_os_get_idle_percent(void)
 
 static lv_result_t lv_read_proc_stat(lv_proc_stat_t * result)
 {
-    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+    FILE * fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
 
     if(!fp) {
         LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -11,7 +11,9 @@
 
 #if LV_USE_OS != LV_OS_NONE && defined(__linux__)
 
+#include "../core/lv_global.h"
 #include "../misc/lv_log.h"
+#include "lv_linux_private.h"
 #include <stdio.h>
 
 /*********************
@@ -22,23 +24,10 @@
 
 #define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
-#define LV_PROC_STAT_PARAMS_LEN        7
 
 /**********************
  *      TYPEDEFS
  **********************/
-typedef union {
-    struct {
-        /*
-         *  We ignore the iowait column as it's not reliable
-         *  We ignore the guest and guest_nice columns because they're accounted
-         *   for in user and nice respectively
-         */
-        uint32_t user, nice, system, idle, /*iowait,*/ irq, softirq,
-                 steal /*, guest, guest_nice*/;
-    } fields;
-    uint32_t buffer[LV_PROC_STAT_PARAMS_LEN];
-} lv_proc_stat_t;
 
 /**********************
  *  STATIC PROTOTYPES
@@ -51,11 +40,11 @@ static uint32_t lv_proc_stat_get_total(const lv_proc_stat_t * p);
  *  STATIC VARIABLES
  **********************/
 
-static lv_proc_stat_t last_proc_stat;
-
 /**********************
  *      MACROS
  **********************/
+
+#define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
 
 /**********************
  *   GLOBAL FUNCTIONS

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -100,6 +100,7 @@ static int lv_proc_get_uptime(uint32_t * active_s, int * active_ms, uint32_t * i
         LV_LOG_WARN("Failed to parse " LV_UPTIME_MONITOR_FILE);
         return -1;
     }
+    return 0;
 }
 
 #endif

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -36,7 +36,7 @@ uint32_t lv_os_get_idle_percent(void)
     uint32_t delta_uptime_s, delta_idletime_s;
     int delta_uptime_ms, delta_idletime_ms;
 
-    // Calculate the delta first to avoid overflowing
+    /* Calculate the delta first to avoid overflowing */
     lv_proc_get_delta(uptime_s, uptime_ms, last_uptime_s,
                       last_uptime_ms, &delta_uptime_s, &delta_uptime_ms);
 
@@ -44,7 +44,7 @@ uint32_t lv_os_get_idle_percent(void)
                       last_idletime_ms, &delta_idletime_s,
                       &delta_idletime_ms);
 
-    /* From here onwards, there's no risk as long as we call this function regularly */
+    /* From here onwards, there's no risk of overflowing as long as we call this function regularly */
 
     /* Update for next call */
     last_uptime_s = uptime_s;

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -18,9 +18,9 @@
  *      DEFINES
  *********************/
 
-#define LV_UPTIME_MONITOR_FILE	       "/proc/stat"
+#define LV_UPTIME_MONITOR_FILE         "/proc/stat"
 
-#define LV_PROC_STAT_VAR_FORMAT	       " %" PRIu32
+#define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
 
 /**********************
@@ -31,7 +31,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static lv_result_t lv_proc_get_uptime(uint32_t *active, uint32_t *idle);
+static lv_result_t lv_proc_get_uptime(uint32_t * active, uint32_t * idle);
 
 /**********************
  *  STATIC VARIABLES
@@ -49,61 +49,61 @@ static uint32_t last_active, last_idle;
 
 uint32_t lv_os_get_idle_percent(void)
 {
-	uint32_t delta_active, delta_idle;
-	{
-		uint32_t active, idle;
+    uint32_t delta_active, delta_idle;
+    {
+        uint32_t active, idle;
 
-		lv_result_t err = lv_proc_get_uptime(&active, &idle);
+        lv_result_t err = lv_proc_get_uptime(&active, &idle);
 
-		if (err == LV_RESULT_INVALID) {
-			return UINT32_MAX;
-		}
+        if(err == LV_RESULT_INVALID) {
+            return UINT32_MAX;
+        }
 
-		delta_active = active - last_active;
-		delta_idle = idle - last_idle;
+        delta_active = active - last_active;
+        delta_idle = idle - last_idle;
 
-		/* Update for next call */
-		last_active = active;
-		last_idle = idle;
-	}
+        /* Update for next call */
+        last_active = active;
+        last_idle = idle;
+    }
 
-	/* From here onwards, there's no risk of overflowing as long as we call this function regularly */
+    /* From here onwards, there's no risk of overflowing as long as we call this function regularly */
 
-	const uint32_t total = delta_active + delta_idle;
+    const uint32_t total = delta_active + delta_idle;
 
-	if (total == 0) {
-		return 0;
-	}
+    if(total == 0) {
+        return 0;
+    }
 
-	return (delta_idle * 100) / total;
+    return (delta_idle * 100) / total;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_result_t lv_proc_get_uptime(uint32_t *active, uint32_t *idle)
+static lv_result_t lv_proc_get_uptime(uint32_t * active, uint32_t * idle)
 {
-	FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
 
-	if (!fp) {
-		LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);
-		return LV_RESULT_INVALID;
-	}
+    if(!fp) {
+        LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);
+        return LV_RESULT_INVALID;
+    }
 
-	int err = fscanf(
-		fp,
-		"cpu " LV_PROC_STAT_VAR_FORMAT LV_PROC_STAT_IGNORE_VAR_FORMAT
-			LV_PROC_STAT_IGNORE_VAR_FORMAT LV_PROC_STAT_VAR_FORMAT,
-		active, idle);
+    int err = fscanf(
+                  fp,
+                  "cpu " LV_PROC_STAT_VAR_FORMAT LV_PROC_STAT_IGNORE_VAR_FORMAT
+                  LV_PROC_STAT_IGNORE_VAR_FORMAT LV_PROC_STAT_VAR_FORMAT,
+                  active, idle);
 
-	fclose(fp);
+    fclose(fp);
 
-	if (err != 2) {
-		LV_LOG_ERROR("Failed to parse " LV_UPTIME_MONITOR_FILE);
-		return LV_RESULT_INVALID;
-	}
-	return LV_RESULT_OK;
+    if(err != 2) {
+        LV_LOG_ERROR("Failed to parse " LV_UPTIME_MONITOR_FILE);
+        return LV_RESULT_INVALID;
+    }
+    return LV_RESULT_OK;
 }
 
 #endif

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -14,7 +14,7 @@ static int last_uptime_ms, last_idletime_ms;
 
 uint32_t lv_os_get_idle_percent(void)
 {
-    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+    FILE * fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
 
     if(!fp) {
         LV_LOG_WARN("Failed to open " LV_UPTIME_MONITOR_FILE);
@@ -30,9 +30,9 @@ uint32_t lv_os_get_idle_percent(void)
                      "%" PRIu32 ".%d"
                      " %" PRIu32 ".%d",
                      &uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
-    
+
     fclose(fp);
-    if(err != 4){
+    if(err != 4) {
         LV_LOG_WARN("Failed to parse " LV_UPTIME_MONITOR_FILE);
         return UINT_MAX;
     }

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -58,8 +58,13 @@ uint32_t lv_os_get_idle_percent(void)
         total_ms -= 100;
     }
 
-    return ((delta_idletime_s * 100 + delta_idletime_ms) * 100) /
-           (total_s * 100 + total_ms);
+    const uint32_t total = total_s * 100 + total_ms;
+
+    if(total == 0) {
+        return 0;
+    }
+
+    return ((delta_idletime_s * 100 + delta_idletime_ms) * 100) / total;
 }
 
 static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -22,9 +22,9 @@ uint32_t lv_os_get_idle_percent(void)
     int delta_active_ms, delta_idle_ms;
     {
 
-        // UINT32_MAX seconds > 136 years
+        /* UINT32_MAX seconds > 136 years */
         uint32_t active_s, idletime_s;
-        // Range is [0: 99[
+        /* Range is [0: 99[ */
         int active_ms, idletime_ms;
 
         int err = lv_proc_get_uptime(&active_s, &active_ms, &idletime_s, &idletime_ms);

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -2,7 +2,6 @@
 #ifdef __linux__
 
 #include "../misc/lv_log.h"
-#include "lv_os.h"
 #include <stdio.h>
 
 #define LV_UPTIME_MONITOR_FILE "/proc/uptime"
@@ -31,7 +30,12 @@ uint32_t lv_os_get_idle_percent(void)
                      "%" PRIu32 ".%d"
                      " %" PRIu32 ".%d",
                      &uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
+    
     fclose(fp);
+    if(err != 4){
+        LV_LOG_WARN("Failed to parse " LV_UPTIME_MONITOR_FILE);
+        return UINT_MAX;
+    }
 
     uint32_t delta_uptime_s, delta_idletime_s;
     int delta_uptime_ms, delta_idletime_ms;

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -84,7 +84,7 @@ uint32_t lv_os_get_idle_percent(void)
 
 static lv_result_t lv_proc_get_uptime(uint32_t * active, uint32_t * idle)
 {
-    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+    FILE * fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
 
     if(!fp) {
         LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -34,7 +34,7 @@ typedef union {
          *  We ignore the guest and guest_nice columns because they're accounted
          *   for in user and nice respectively
          */
-        uint32_t user, nice, system, /*iowait,*/ idle, irq, softirq,
+        uint32_t user, nice, system, idle, /*iowait,*/ irq, softirq,
                  steal /*, guest, guest_nice*/;
     } fields;
     uint32_t buffer[LV_PROC_STAT_PARAMS_LEN];

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -1,0 +1,79 @@
+
+#ifdef __linux__
+
+#include "../misc/lv_log.h"
+#include "lv_os.h"
+#include <stdio.h>
+
+#define LV_UPTIME_MONITOR_FILE "/proc/uptime"
+
+static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
+                              int original_ms, uint32_t * delta_s, int * delta_ms);
+
+static uint32_t last_uptime_s, last_idletime_s;
+static int last_uptime_ms, last_idletime_ms;
+
+uint32_t lv_os_get_idle_percent(void)
+{
+    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+
+    if(!fp) {
+        LV_LOG_WARN("Failed to open " LV_UPTIME_MONITOR_FILE);
+        return UINT_MAX;
+    }
+    // UINT32_MAX seconds > 136 years
+    uint32_t uptime_s, idletime_s;
+
+    // Range is [0:100[
+    int uptime_ms, idletime_ms;
+
+    int err = fscanf(fp,
+                     "%" PRIu32 ".%d"
+                     " %" PRIu32 ".%d",
+                     &uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
+    fclose(fp);
+
+    uint32_t delta_uptime_s, delta_idletime_s;
+    int delta_uptime_ms, delta_idletime_ms;
+
+    // Calculate the delta first to avoid overflowing
+    lv_proc_get_delta(uptime_s, uptime_ms, last_uptime_s,
+                      last_uptime_ms, &delta_uptime_s, &delta_uptime_ms);
+
+    lv_proc_get_delta(idletime_s, idletime_ms, last_idletime_s,
+                      last_idletime_ms, &delta_idletime_s,
+                      &delta_idletime_ms);
+
+    /* From here onwards, there's no risk as long as we call this function regularly */
+
+    /* Update for next call */
+    last_uptime_s = uptime_s;
+    last_uptime_ms = uptime_ms;
+    last_idletime_s = idletime_s;
+    last_idletime_ms = idletime_ms;
+
+    uint32_t total_ms = delta_uptime_ms + delta_idletime_ms;
+    uint32_t total_s = delta_uptime_s + delta_idletime_s;
+
+    if(total_ms >= 100) {
+        total_s += 1;
+        total_ms -= 100;
+    }
+
+    return ((delta_idletime_s * 100 + delta_idletime_ms) * 100) /
+           (total_s * 100 + total_ms);
+}
+
+static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
+                              int original_ms, uint32_t * delta_s, int * delta_ms)
+{
+    *delta_s = now_s - original_s;
+    *delta_ms = now_ms - original_ms;
+
+    if(*delta_ms < 0) {
+        *delta_s -= 1;
+        *delta_ms += 100;
+    }
+}
+
+#endif

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -65,8 +65,6 @@ uint32_t lv_os_get_idle_percent(void)
 {
     lv_proc_stat_t proc_stat;
     {
-        uint32_t active, idle;
-
         lv_result_t err = lv_read_proc_stat(&proc_stat);
 
         if(err == LV_RESULT_INVALID) {

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -123,7 +123,7 @@ static lv_result_t lv_read_proc_stat(lv_proc_stat_t * result)
 }
 static uint32_t lv_proc_stat_get_total(const lv_proc_stat_t * p)
 {
-    size_t sum = 0;
+    uint32_t sum = 0;
     for(size_t i = 0; i < LV_PROC_STAT_PARAMS_LEN; ++i) {
         sum += p->buffer[i];
     }

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -1,3 +1,13 @@
+/**
+ * @file lv_linux.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+
 #include "lv_os.h"
 
 #if LV_USE_OS != LV_OS_NONE && defined(__linux__)
@@ -5,15 +15,42 @@
 #include "../misc/lv_log.h"
 #include <stdio.h>
 
+/*********************
+ *      DEFINES
+ *********************/
+
 #define LV_UPTIME_MONITOR_FILE "/proc/uptime"
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
 
 static void lv_proc_get_delta(uint32_t now_s, int32_t now_ms, uint32_t original_s,
                               int32_t original_ms, uint32_t * delta_s, int32_t * delta_ms);
 
 static lv_result_t lv_proc_get_uptime(uint32_t * now_s, int32_t * now_ms, uint32_t * idle_s, int32_t * idle_ms);
 
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
 static uint32_t last_uptime_s, last_idletime_s;
 static int32_t last_uptime_ms, last_idletime_ms;
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+
 
 uint32_t lv_os_get_idle_percent(void)
 {
@@ -66,6 +103,10 @@ uint32_t lv_os_get_idle_percent(void)
 
     return ((delta_idle_s * 100 + delta_idle_ms) * 100) / total;
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
 
 static void lv_proc_get_delta(uint32_t now_s, int32_t now_ms, uint32_t original_s,
                               int32_t original_ms, uint32_t * delta_s, int * delta_ms)

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -27,7 +27,7 @@ uint32_t lv_os_get_idle_percent(void)
         // Range is [0: 99[
         int uptime_ms, idletime_ms;
 
-        int err = lv_proc_get_duration(&uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
+        int err = lv_proc_get_uptime(&uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
 
         if(err < 0) {
             return UINT_MAX;

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -7,30 +7,30 @@
 
 #define LV_UPTIME_MONITOR_FILE "/proc/uptime"
 
-static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
-                              int original_ms, uint32_t * delta_s, int * delta_ms);
+static void lv_proc_get_delta(uint32_t now_s, int32_t now_ms, uint32_t original_s,
+                              int32_t original_ms, uint32_t * delta_s, int32_t * delta_ms);
 
-static int lv_proc_get_uptime(uint32_t * now_s, int * now_ms, uint32_t * idle_s, int * idle_ms);
+static lv_result_t lv_proc_get_uptime(uint32_t * now_s, int32_t * now_ms, uint32_t * idle_s, int32_t * idle_ms);
 
 static uint32_t last_uptime_s, last_idletime_s;
-static int last_uptime_ms, last_idletime_ms;
+static int32_t last_uptime_ms, last_idletime_ms;
 
 uint32_t lv_os_get_idle_percent(void)
 {
 
     uint32_t delta_active_s, delta_idle_s;
-    int delta_active_ms, delta_idle_ms;
+    int32_t delta_active_ms, delta_idle_ms;
     {
 
         /* UINT32_MAX seconds > 136 years */
         uint32_t active_s, idletime_s;
         /* Range is [0: 99[ */
-        int active_ms, idletime_ms;
+        int32_t active_ms, idletime_ms;
 
         int err = lv_proc_get_uptime(&active_s, &active_ms, &idletime_s, &idletime_ms);
 
         if(err < 0) {
-            return UINT_MAX;
+            return UINT32_MAX;
         }
 
         /* Calculate the delta first to avoid overflowing */
@@ -67,8 +67,8 @@ uint32_t lv_os_get_idle_percent(void)
     return ((delta_idle_s * 100 + delta_idle_ms) * 100) / total;
 }
 
-static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
-                              int original_ms, uint32_t * delta_s, int * delta_ms)
+static void lv_proc_get_delta(uint32_t now_s, int32_t now_ms, uint32_t original_s,
+                              int32_t original_ms, uint32_t * delta_s, int * delta_ms)
 {
     *delta_s = now_s - original_s;
     *delta_ms = now_ms - original_ms;
@@ -79,7 +79,7 @@ static void lv_proc_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
     }
 }
 
-static int lv_proc_get_uptime(uint32_t * active_s, int * active_ms, uint32_t * idle_s, int * idle_ms)
+static lv_result_t lv_proc_get_uptime(uint32_t * active_s, int32_t * active_ms, uint32_t * idle_s, int32_t * idle_ms)
 {
 
     FILE * fp = fopen(LV_UPTIME_MONITOR_FILE, "r");

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -2,6 +2,7 @@
 #ifdef __linux__
 
 #include "../misc/lv_log.h"
+#include "lv_os.h"
 #include <stdio.h>
 
 #define LV_UPTIME_MONITOR_FILE "/proc/uptime"

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -85,7 +85,7 @@ static int lv_proc_get_uptime(uint32_t * active_s, int * active_ms, uint32_t * i
     FILE * fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
 
     if(!fp) {
-        LV_LOG_WARN("Failed to open " LV_UPTIME_MONITOR_FILE);
+        LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);
         return -1;
     }
 
@@ -97,7 +97,7 @@ static int lv_proc_get_uptime(uint32_t * active_s, int * active_ms, uint32_t * i
     fclose(fp);
 
     if(err != 4) {
-        LV_LOG_WARN("Failed to parse " LV_UPTIME_MONITOR_FILE);
+        LV_LOG_ERROR("Failed to parse " LV_UPTIME_MONITOR_FILE);
         return -1;
     }
     return 0;

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -25,6 +25,8 @@
 #define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
 
+#define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -43,8 +45,6 @@ static uint32_t lv_proc_stat_get_total(const lv_proc_stat_t * p);
 /**********************
  *      MACROS
  **********************/
-
-#define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
 
 /**********************
  *   GLOBAL FUNCTIONS

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -27,9 +27,9 @@ uint32_t lv_os_get_idle_percent(void)
         /* Range is [0: 99[ */
         int32_t active_ms, idletime_ms;
 
-        int err = lv_proc_get_uptime(&active_s, &active_ms, &idletime_s, &idletime_ms);
+        lv_result_t err = lv_proc_get_uptime(&active_s, &active_ms, &idletime_s, &idletime_ms);
 
-        if(err < 0) {
+        if(err == LV_RESULT_INVALID) {
             return UINT32_MAX;
         }
 
@@ -86,7 +86,7 @@ static lv_result_t lv_proc_get_uptime(uint32_t * active_s, int32_t * active_ms, 
 
     if(!fp) {
         LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_FILE);
-        return -1;
+        return LV_RESULT_INVALID;
     }
 
     int err = fscanf(fp,
@@ -98,9 +98,9 @@ static lv_result_t lv_proc_get_uptime(uint32_t * active_s, int32_t * active_ms, 
 
     if(err != 4) {
         LV_LOG_ERROR("Failed to parse " LV_UPTIME_MONITOR_FILE);
-        return -1;
+        return LV_RESULT_INVALID;
     }
-    return 0;
+    return LV_RESULT_OK;
 }
 
 #endif

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -1,8 +1,8 @@
+#include "lv_os.h"
 
-#ifdef __linux__
+#if LV_USE_OS != LV_OS_NONE && defined(__linux__)
 
 #include "../misc/lv_log.h"
-#include "lv_os.h"
 #include <stdio.h>
 
 #define LV_UPTIME_MONITOR_FILE "/proc/uptime"

--- a/src/osal/lv_linux_private.h
+++ b/src/osal/lv_linux_private.h
@@ -29,16 +29,16 @@ extern "C" {
 
 
 typedef union {
-	struct {
-            /*
-             *  We ignore the iowait column as it's not reliable
-             *  We ignore the guest and guest_nice columns because they're accounted
-             *   for in user and nice respectively
-             */
-		uint32_t user, nice, system, idle, /*iowait,*/ irq, softirq,
-			steal /*, guest, guest_nice*/;
-	} fields;
-	uint32_t buffer[LV_PROC_STAT_PARAMS_LEN];
+    struct {
+        /*
+         *  We ignore the iowait column as it's not reliable
+         *  We ignore the guest and guest_nice columns because they're accounted
+         *   for in user and nice respectively
+         */
+        uint32_t user, nice, system, idle, /*iowait,*/ irq, softirq,
+                 steal /*, guest, guest_nice*/;
+    } fields;
+    uint32_t buffer[LV_PROC_STAT_PARAMS_LEN];
 } lv_proc_stat_t;
 
 /**********************

--- a/src/osal/lv_linux_private.h
+++ b/src/osal/lv_linux_private.h
@@ -1,0 +1,56 @@
+
+/**
+ * @file lv_linux_private.h
+ *
+ */
+
+#ifndef LV_LINUX_PRIVATE_H
+#define LV_LINUX_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../misc/lv_types.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define LV_PROC_STAT_PARAMS_LEN 7
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+
+typedef union {
+	struct {
+            /*
+             *  We ignore the iowait column as it's not reliable
+             *  We ignore the guest and guest_nice columns because they're accounted
+             *   for in user and nice respectively
+             */
+		uint32_t user, nice, system, idle, /*iowait,*/ irq, softirq,
+			steal /*, guest, guest_nice*/;
+	} fields;
+	uint32_t buffer[LV_PROC_STAT_PARAMS_LEN];
+} lv_proc_stat_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_LINUX_PRIVATE_H*/

--- a/src/osal/lv_mqx.c
+++ b/src/osal/lv_mqx.c
@@ -163,6 +163,11 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/osal/lv_mqx.c
+++ b/src/osal/lv_mqx.c
@@ -11,6 +11,7 @@
 #if LV_USE_OS == LV_OS_MQX
 
 #include "../misc/lv_log.h"
+#include "../misc/lv_timer.h"
 #include "../stdlib/lv_string.h"
 
 /*********************

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -181,15 +181,11 @@ lv_result_t lv_lock_isr(void);
  */
 void lv_unlock(void);
 
-#if LV_USE_OS == LV_OS_FREERTOS || LV_USE_OS == LV_OS_PTHREAD
-
 /**
  * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
  * @return the idle percentage since the last call
  */
 uint32_t lv_os_get_idle_percent(void);
-
-#endif /* LV_USE_OS == LV_OS_FREERTOS || LV_USE_OS == LV_OS_PTHREAD */
 
 #else
 

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -181,6 +181,16 @@ lv_result_t lv_lock_isr(void);
  */
 void lv_unlock(void);
 
+#if LV_USE_OS == LV_OS_FREERTOS || LV_USE_OS == LV_OS_PTHREAD
+
+/**
+ * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
+ * @return the idle percentage since the last call
+ */
+uint32_t lv_os_get_idle_percent(void);
+
+#endif /* LV_USE_OS == LV_OS_FREERTOS || LV_USE_OS == LV_OS_PTHREAD */
+
 #else
 
 /* Since compilation does not necessarily optimize cross-file empty functions well

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -60,6 +60,12 @@ typedef enum {
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
+ * @return the idle percentage since the last call
+ */
+uint32_t lv_os_get_idle_percent(void);
+
 #if LV_USE_OS != LV_OS_NONE
 
 /*----------------------------------------
@@ -180,12 +186,6 @@ lv_result_t lv_lock_isr(void);
  * It is called internally in lv_timer_handler().
  */
 void lv_unlock(void);
-
-/**
- * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
- * @return the idle percentage since the last call
- */
-uint32_t lv_os_get_idle_percent(void);
 
 #else
 

--- a/src/osal/lv_os_none.c
+++ b/src/osal/lv_os_none.c
@@ -1,0 +1,11 @@
+#include "../lv_conf_internal.h"
+#if LV_USE_OS == LV_OS_NONE
+#include "lv_os.h"
+#include "../misc/lv_timer.h"
+
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+
+#endif

--- a/src/osal/lv_os_none.c
+++ b/src/osal/lv_os_none.c
@@ -1,11 +1,50 @@
+/**
+ * @file lv_os_none.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
 #include "../lv_conf_internal.h"
 #if LV_USE_OS == LV_OS_NONE
+
 #include "lv_os.h"
 #include "../misc/lv_timer.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
 
 uint32_t lv_os_get_idle_percent(void)
 {
     return lv_timer_get_idle();
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
 
 #endif

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -15,6 +15,10 @@
 #include <limits.h>
 #include "../misc/lv_log.h"
 
+#ifndef __linux__
+    #include "../misc/lv_timer.h"
+#endif
+
 /*********************
  *      DEFINES
  *********************/

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -10,9 +10,15 @@
 
 #if LV_USE_OS == LV_OS_PTHREAD
 
-#include <errno.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <limits.h>
 #include "../misc/lv_log.h"
 
+#define LV_UPTIME_MONITOR_FILE "/proc/uptime"
+
+static uint32_t original_uptime_s, original_idletime_s;
+static int original_uptime_ms, original_idletime_ms;
 /*********************
  *      DEFINES
  *********************/
@@ -26,6 +32,9 @@
  **********************/
 static void * generic_callback(void * user_data);
 
+static void lv_os_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
+                            int original_ms, uint32_t * delta_s, int * delta_ms);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -38,9 +47,9 @@ static void * generic_callback(void * user_data);
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_result_t lv_thread_init(lv_thread_t * thread, const char * const name, lv_thread_prio_t prio,
-                           void (*callback)(void *), size_t stack_size,
-                           void * user_data)
+lv_result_t lv_thread_init(lv_thread_t * thread, const char * const name,
+                           lv_thread_prio_t prio, void (*callback)(void *),
+                           size_t stack_size, void * user_data)
 {
     LV_UNUSED(name);
     LV_UNUSED(prio);
@@ -167,6 +176,57 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
+uint32_t lv_os_get_idle_percent(void)
+{
+    FILE *fp = fopen(LV_UPTIME_MONITOR_FILE, "r");
+
+    if(!fp) {
+        LV_LOG_WARN("Failed to open " LV_UPTIME_MONITOR_FILE);
+        return UINT_MAX;
+    }
+    // UINT32_MAX seconds > 136 years
+    uint32_t uptime_s, idletime_s;
+
+    // Range is [0:100[
+    int uptime_ms, idletime_ms;
+
+    int err = fscanf(fp,
+                     "%" PRIu32 ".%d"
+                     " %" PRIu32 ".%d",
+                     &uptime_s, &uptime_ms, &idletime_s, &idletime_ms);
+    fclose(fp);
+
+    if(original_uptime_s == 0) {
+        original_uptime_s = uptime_s;
+        original_uptime_ms = uptime_ms;
+        original_idletime_s = idletime_s;
+        original_idletime_ms = idletime_ms;
+        return 0;
+    }
+
+    uint32_t delta_uptime_s, delta_idletime_s;
+    int delta_uptime_ms, delta_idletime_ms;
+
+    // Calculate the delta first to avoid overflowing
+    lv_os_get_delta(uptime_s, uptime_ms, original_uptime_s,
+                    original_uptime_ms, &delta_uptime_s, &delta_uptime_ms);
+
+    lv_os_get_delta(idletime_s, idletime_ms, original_idletime_s,
+                    original_idletime_ms, &delta_idletime_s,
+                    &delta_idletime_ms);
+
+    uint32_t total_ms = delta_uptime_ms + delta_idletime_ms;
+    uint32_t total_s = delta_uptime_s + delta_idletime_s;
+
+    if(total_ms >= 100) {
+        total_s += 1;
+        total_ms -= 100;
+    }
+
+    return ((delta_idletime_s * 100 + delta_idletime_ms) * 100) /
+           (total_s * 100 + total_ms);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -176,6 +236,18 @@ static void * generic_callback(void * user_data)
     lv_thread_t * thread = user_data;
     thread->callback(thread->user_data);
     return NULL;
+}
+
+static void lv_os_get_delta(uint32_t now_s, int now_ms, uint32_t original_s,
+                            int original_ms, uint32_t * delta_s, int * delta_ms)
+{
+    *delta_s = now_s - original_s;
+    *delta_ms = now_ms - original_ms;
+
+    if(*delta_ms < 0) {
+        *delta_s -= 1;
+        *delta_ms += 100;
+    }
 }
 
 #endif /*LV_USE_OS == LV_OS_PTHREAD*/

--- a/src/osal/lv_pthread.c
+++ b/src/osal/lv_pthread.c
@@ -10,9 +10,6 @@
 
 #if LV_USE_OS == LV_OS_PTHREAD
 
-#include <stdio.h>
-#include <inttypes.h>
-#include <limits.h>
 #include "../misc/lv_log.h"
 
 #ifndef __linux__

--- a/src/osal/lv_rtthread.c
+++ b/src/osal/lv_rtthread.c
@@ -11,6 +11,7 @@
 #if LV_USE_OS == LV_OS_RTTHREAD
 
 #include "../misc/lv_log.h"
+#include "../misc/lv_timer.h"
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_rtthread.c
+++ b/src/osal/lv_rtthread.c
@@ -184,6 +184,13 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
+#ifndef __linux__
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+#endif
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/osal/lv_rtthread.c
+++ b/src/osal/lv_rtthread.c
@@ -185,12 +185,10 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
-#ifndef __linux__
 uint32_t lv_os_get_idle_percent(void)
 {
     return lv_timer_get_idle();
 }
-#endif
 
 /**********************
  *   STATIC FUNCTIONS

--- a/src/osal/lv_sdl2.c
+++ b/src/osal/lv_sdl2.c
@@ -13,6 +13,10 @@
 #include <errno.h>
 #include "../misc/lv_log.h"
 
+#ifndef __linux__
+    #include "../misc/lv_timer.h"
+#endif
+
 /*********************
  *      DEFINES
  *********************/

--- a/src/osal/lv_sdl2.c
+++ b/src/osal/lv_sdl2.c
@@ -169,6 +169,13 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
+#ifndef __linux__
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+#endif
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/osal/lv_windows.c
+++ b/src/osal/lv_windows.c
@@ -206,6 +206,11 @@ lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
     return LV_RESULT_INVALID;
 }
 
+uint32_t lv_os_get_idle_percent(void)
+{
+    return lv_timer_get_idle();
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/osal/lv_windows.c
+++ b/src/osal/lv_windows.c
@@ -12,6 +12,7 @@
 #if LV_USE_OS == LV_OS_WINDOWS
 
 #include <process.h>
+#include "../misc/lv_timer.h"
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
Fixes #7592 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

- Implemented lv_os_get_idle_percent for linux by reading the `proc/uptime` file which returns the active and idle times of the system since boot. From `man proc_uptime`:

```
proc_uptime(5)                                                                                   File Formats Manual                                                                                  proc_uptime(5)

NAME
       /proc/uptime - system uptime

DESCRIPTION
       /proc/uptime
              This file contains two numbers (values in seconds): the uptime of the system (including time spent in suspend) and the amount of time spent in the idle process.
``` 

The values are in seconds with two decimal values

```bash
cat /proc/uptime
7673.63 88861.75
```
This implementation doesn't use floating point values

- Created a default `lv_os_get_idle_percent` that calls `lv_timer_get_idle` for other os