### PR TITLE
fix(indev): add the missing wait_until_release flag to clean up

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1367,7 +1367,10 @@ static void indev_proc_release(lv_indev_t * indev)
 
     if(indev->wait_until_release) {
         lv_obj_send_event(indev->pointer.act_obj, LV_EVENT_PRESS_LOST, indev_act);
-        if(indev_reset_check(indev)) return;
+        if(indev_reset_check(indev)) {
+            indev->wait_until_release = 0;
+            return;
+        }
 
         indev->pointer.act_obj  = NULL;
         indev->pointer.last_obj = NULL;

--- a/tests/src/test_cases/test_indev_wait_release.c
+++ b/tests/src/test_cases/test_indev_wait_release.c
@@ -1,0 +1,59 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../lv_test_indev.h"
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+static void event_cb(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target(e);
+    uint32_t * pressed_count = lv_event_get_user_data(e);
+
+    switch(lv_event_get_code(e)) {
+        case LV_EVENT_PRESSED:
+            (*pressed_count)++;
+            lv_indev_wait_release(lv_indev_active());
+            break;
+        case LV_EVENT_PRESS_LOST:
+            lv_indev_reset(lv_indev_active(), obj);
+            break;
+        default:
+            break;
+    }
+}
+
+void test_indev_wait_release(void)
+{
+    uint32_t pressed_count = 0;
+    lv_obj_t * btn = lv_button_create(lv_screen_active());
+    lv_obj_set_size(btn, 100, 100);
+    lv_obj_add_event_cb(btn, event_cb, LV_EVENT_ALL, &pressed_count);
+
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
+    lv_test_mouse_move_to(50, 50);
+
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
+
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+    lv_test_mouse_release();
+    lv_test_indev_wait(50);
+
+    TEST_ASSERT_EQUAL_UINT32(2, pressed_count);
+}
+
+#endif


### PR DESCRIPTION
fix(indev): When releasing, satisfying wait until release and reset indev will cause the next clicked to fail

Example Code：
```
static void event_cb(lv_event_t * e)
{
  lv_event_code_t code = lv_event_get_code(e);
  if(code == LV_EVENT_PRESSED) {
    lv_indev_wait_release(lv_indev_get_act());
  } else if(code == LV_EVENT_PRESS_LOST) {
    LV_LOG_INFO("press lost");
    lv_obj_t* obj = lv_event_get_target(e);
    lv_indev_reset(lv_indev_get_act(), obj);
  }
}

static void demo()
{
  lv_obj_t* btn = lv_button_create(lv_scr_act());
  lv_obj_t* label = lv_label_create(btn);
  lv_label_set_text(label, "Button");
  lv_obj_set_size(btn, 100, 100);
  lv_obj_center(btn);
  lv_obj_remove_flag(btn, LV_OBJ_FLAG_PRESS_LOCK);

  lv_obj_add_event_cb(btn, event_cb, LV_EVENT_ALL, NULL);
}
```