### PR TITLE
ci: Port release updater update master as well

### DIFF
--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -3,13 +3,14 @@ name: Port repo release update
 on:
   push:
     branches:
+      - master
       - 'release/v*' # on release branches
   workflow_dispatch: # allow manual triggering
 
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
 # Ensure that only one commit will be running tests at a time on each push
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }} 
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Update the `master`/`main` branch of port repos based on the `master` branch of LVGL after a discussion with @kisvegabor

@AndreCostaaa I was planning to use a concurrency guard in this workflow before you added one in #7619 :smile:, it's important to have. The only difference is I want to cancel _all_ other workflows even if they're for different branches, since this workflow operates globally on all branches.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
