### PR TITLE
feat(nuttx_image_cache): add configuration to use image cache heap for default heap

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1826,6 +1826,11 @@ menu "LVGL configuration"
 			depends on LV_USE_NUTTX
 			default n
 
+		config LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+			bool "Use independent image heap for default draw buffer"
+			depends on LV_USE_NUTTX_INDEPENDENT_IMAGE_HEAP
+			default n
+
 		config LV_USE_NUTTX_LIBUV
 			bool "Use uv loop to replace default timer loop and other fb/indev timers"
 			depends on LV_USE_NUTTX

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1149,6 +1149,9 @@
 #if LV_USE_NUTTX
     #define LV_USE_NUTTX_INDEPENDENT_IMAGE_HEAP 0
 
+    /** Use independent image heap for default draw buffer */
+    #define LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP    0
+
     #define LV_USE_NUTTX_LIBUV    0
 
     /** Use Nuttx custom init API to open window and handle touchscreen */

--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -44,6 +44,11 @@ typedef struct {
 
     lv_draw_buf_malloc_cb malloc_cb;
     lv_draw_buf_free_cb free_cb;
+
+#if LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+    lv_draw_buf_malloc_cb malloc_cb_default;
+    lv_draw_buf_free_cb free_cb_default;
+#endif
 } lv_nuttx_ctx_image_cache_t;
 /**********************
  *  STATIC PROTOTYPES
@@ -77,6 +82,15 @@ void lv_nuttx_image_cache_init(bool use_independent_image_heap)
     handlers->buf_malloc_cb = malloc_cb;
     handlers->buf_free_cb = free_cb;
 
+#if LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+    handlers = lv_draw_buf_get_handlers();
+    ctx->malloc_cb_default = handlers->buf_malloc_cb;
+    ctx->free_cb_default = handlers->buf_free_cb;
+
+    handlers->buf_malloc_cb = malloc_cb;
+    handlers->buf_free_cb = free_cb;
+#endif
+
     ctx->initialized = false;
     ctx->independent_image_heap = use_independent_image_heap;
 }
@@ -93,6 +107,13 @@ FREE_CONTEXT:
     lv_draw_buf_handlers_t * handlers = image_cache_draw_buf_handlers;
     handlers->buf_malloc_cb = ctx->malloc_cb;
     handlers->buf_free_cb = ctx->free_cb;
+
+#if LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+    handlers = lv_draw_buf_get_handlers();
+    handlers->buf_malloc_cb = ctx->malloc_cb_default;
+    handlers->buf_free_cb = ctx->free_cb_default;
+#endif
+
     lv_free(ctx);
 
     ctx = NULL;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3723,6 +3723,15 @@
         #endif
     #endif
 
+    /** Use independent image heap for default draw buffer */
+    #ifndef LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+        #ifdef CONFIG_LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+            #define LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP CONFIG_LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+        #else
+            #define LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP    0
+        #endif
+    #endif
+
     #ifndef LV_USE_NUTTX_LIBUV
         #ifdef CONFIG_LV_USE_NUTTX_LIBUV
             #define LV_USE_NUTTX_LIBUV CONFIG_LV_USE_NUTTX_LIBUV


### PR DESCRIPTION
<!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
