### PR TITLE
Add missing Kconfig symbols

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2054,6 +2054,10 @@ menu "LVGL configuration"
 			depends on LV_USE_VECTOR_GRAPHIC
 		config LV_USE_DEMO_SMARTWATCH
 			bool "Smartwatch demo"
+		config LV_USE_DEMO_EBIKE
+			bool "Ebike demo"
+		config LV_USE_DEMO_HIGH_RES
+			bool "High resolution demo"
 	endmenu
 
 endmenu

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,6 +206,7 @@ if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
         -Wno-double-promotion
         -Wno-unreachable-code
         -Wno-gnu-zero-variadic-macro-arguments
+        -Wunused-function
 	-Wno-overlength-strings
     )
 else()


### PR DESCRIPTION
First commit arguably could go into another PR, but I wanted to add the warning flag because of https://github.com/lvgl/lvgl/pull/7611.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
