### PR TITLE
feat(wayland) add double buffer support

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -195,7 +195,8 @@ struct application {
 
 struct window {
     lv_display_t * lv_disp;
-    lv_draw_buf_t * lv_disp_draw_buf;
+    lv_draw_buf_t * lv_disp_draw_buf1;
+    lv_draw_buf_t * lv_disp_draw_buf2;
 
     lv_indev_t * lv_indev_pointer;
     lv_indev_t * lv_indev_pointeraxis;
@@ -2007,10 +2008,15 @@ static bool resize_window(struct window * window, int width, int height)
         stride = lv_draw_buf_width_to_stride(width,
                                              lv_display_get_color_format(window->lv_disp));
 
-        window->lv_disp_draw_buf = lv_draw_buf_reshape(
-                                       window->lv_disp_draw_buf,
-                                       lv_display_get_color_format(window->lv_disp),
-                                       width, height / LVGL_DRAW_BUFFER_DIV, stride);
+        window->lv_disp_draw_buf1 = lv_draw_buf_reshape(
+                                        window->lv_disp_draw_buf1,
+                                        lv_display_get_color_format(window->lv_disp),
+                                        width, height, stride);
+
+        window->lv_disp_draw_buf2 = lv_draw_buf_reshape(
+                                        window->lv_disp_draw_buf2,
+                                        lv_display_get_color_format(window->lv_disp),
+                                        width, height, stride);
 
         lv_display_set_resolution(window->lv_disp, width, height);
 
@@ -2603,15 +2609,20 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
     stride = lv_draw_buf_width_to_stride(hor_res,
                                          lv_display_get_color_format(window->lv_disp));
 
-    window->lv_disp_draw_buf = lv_draw_buf_create(
-                                   hor_res,
-                                   ver_res / LVGL_DRAW_BUFFER_DIV,
-                                   lv_display_get_color_format(window->lv_disp),
-                                   stride);
+    window->lv_disp_draw_buf1 = lv_draw_buf_create(
+                                    hor_res,
+                                    ver_res,
+                                    lv_display_get_color_format(window->lv_disp),
+                                    stride);
+    window->lv_disp_draw_buf2 = lv_draw_buf_create(
+                                    hor_res,
+                                    ver_res,
+                                    lv_display_get_color_format(window->lv_disp),
+                                    stride);
 
 
-    lv_display_set_draw_buffers(window->lv_disp, window->lv_disp_draw_buf, NULL);
-    lv_display_set_render_mode(window->lv_disp, LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_draw_buffers(window->lv_disp, window->lv_disp_draw_buf1, window->lv_disp_draw_buf2);
+    lv_display_set_render_mode(window->lv_disp, LV_DISPLAY_RENDER_MODE_FULL);
     lv_display_set_flush_cb(window->lv_disp, _lv_wayland_flush);
     lv_display_set_user_data(window->lv_disp, window);
 


### PR DESCRIPTION
Change wayland support to double buffering full refresh instead of single buffer with partial refresh.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
