### PR TITLE
perf(draw): optimize lv_draw_label() with text_length for text_local

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -118,7 +118,8 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_layer_t * layer, const lv_draw_label
     /*The text is stored in a local variable so malloc memory for it*/
     if(dsc->text_local) {
         lv_draw_label_dsc_t * new_dsc = t->draw_dsc;
-        new_dsc->text = lv_strdup(dsc->text);
+        new_dsc->text = lv_strndup(dsc->text, dsc->text_length);
+        LV_ASSERT_MALLOC(new_dsc->text);
     }
 
     lv_draw_finalize_task_creation(layer, t);

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -116,10 +116,9 @@ lv_display_t * lv_linux_fbdev_create(void)
 
 void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 {
-    char * devname = lv_malloc(lv_strlen(file) + 1);
+    char * devname = lv_strdup(file);
     LV_ASSERT_MALLOC(devname);
     if(devname == NULL) return;
-    lv_strcpy(devname, file);
 
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->devname = devname;

--- a/src/others/font_manager/lv_font_manager.c
+++ b/src/others/font_manager/lv_font_manager.c
@@ -390,15 +390,11 @@ static void lv_font_manager_add_path_core(lv_font_manager_t * manager, const cha
         font_path->path = (char *)path;
     }
     else {
-        uint32_t name_len = lv_strlen(name) + 1;
-        font_path->name = lv_malloc(name_len);
+        font_path->name = lv_strdup(name);
         LV_ASSERT_MALLOC(font_path->name);
-        lv_memcpy(font_path->name, name, name_len);
 
-        uint32_t path_len = lv_strlen(path) + 1;
-        font_path->path = lv_malloc(path_len);
+        font_path->path = lv_strdup(path);
         LV_ASSERT_MALLOC(font_path->path);
-        lv_memcpy(font_path->path, path, path_len);
     }
 
     LV_LOG_INFO("name: %s, path: %s add success", name, path);

--- a/src/stdlib/builtin/lv_sprintf_builtin.c
+++ b/src/stdlib/builtin/lv_sprintf_builtin.c
@@ -36,6 +36,7 @@
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_BUILTIN
 
 #include "../lv_sprintf.h"
+#include "../lv_string.h"
 #include "../../misc/lv_types.h"
 
 #define PRINTF_DISABLE_SUPPORT_FLOAT    (!LV_USE_FLOAT)
@@ -141,15 +142,6 @@ static inline void _out_null(char character, void * buffer, size_t idx, size_t m
     LV_UNUSED(buffer);
     LV_UNUSED(idx);
     LV_UNUSED(maxlen);
-}
-
-// internal secure strlen
-// \return The length of the string (excluding the terminating 0) limited by 'maxsize'
-static inline unsigned int _strnlen_s(const char * str, size_t maxsize)
-{
-    const char * s;
-    for(s = str; *s && maxsize--; ++s);
-    return (unsigned int)(s - str);
 }
 
 // internal test if char is a digit (0-9)
@@ -822,7 +814,7 @@ static int lv_vsnprintf_inner(out_fct_type out, char * buffer, const size_t maxl
 
             case 's' : {
                     const char * p = va_arg(va, char *);
-                    unsigned int l = _strnlen_s(p, precision ? precision : (size_t) -1);
+                    unsigned int l = lv_strnlen(p, precision ? precision : (size_t) -1);
                     // pre padding
                     if(flags & FLAGS_PRECISION) {
                         l = (l < precision ? l : precision);

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -191,6 +191,14 @@ size_t lv_strlen(const char * str)
     return i;
 }
 
+size_t lv_strnlen(const char * str, size_t max_len)
+{
+    size_t i = 0;
+    while(i < max_len && str[i]) i++;
+
+    return i;
+}
+
 size_t lv_strlcpy(char * dst, const char * src, size_t dst_size)
 {
     size_t i = 0;
@@ -255,6 +263,17 @@ char * lv_strdup(const char * src)
     if(dst == NULL) return NULL;
 
     lv_memcpy(dst, src, len); /*memcpy is faster than strncpy when length is known*/
+    return dst;
+}
+
+char * lv_strndup(const char * src, size_t max_len)
+{
+    size_t len = lv_strnlen(src, max_len);
+    char * dst = lv_malloc(len + 1);
+    if(dst == NULL) return NULL;
+
+    lv_memcpy(dst, src, len);
+    dst[len] = '\0';
     return dst;
 }
 

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -60,6 +60,11 @@ size_t lv_strlen(const char * str)
     return strlen(str);
 }
 
+size_t lv_strnlen(const char * str, size_t max_len)
+{
+    return strnlen(str, max_len);
+}
+
 size_t lv_strlcpy(char * dst, const char * src, size_t dst_size)
 {
     size_t src_len = strlen(src);
@@ -99,6 +104,17 @@ char * lv_strdup(const char * src)
     if(dst == NULL) return NULL;
 
     lv_memcpy(dst, src, len); /*do memcpy is faster than strncpy when length is known*/
+    return dst;
+}
+
+char * lv_strndup(const char * src, size_t max_len)
+{
+    size_t len = lv_strnlen(src, max_len);
+    char * dst = lv_malloc(len + 1);
+    if(dst == NULL) return NULL;
+
+    lv_memcpy(dst, src, len);
+    dst[len] = '\0';
     return dst;
 }
 

--- a/src/stdlib/lv_string.h
+++ b/src/stdlib/lv_string.h
@@ -76,11 +76,20 @@ static inline void lv_memzero(void * dst, size_t len)
 }
 
 /**
- * @brief Computes the length of the string str up to, but not including the terminating null character.
+ * @brief Computes the length of the string str up to (but not including) the terminating null character.
  * @param str Pointer to the null-terminated byte string to be examined.
  * @return The length of the string in bytes.
  */
 size_t lv_strlen(const char * str);
+
+/**
+ * @brief Computes the length of the string str up to (but not including) the terminating null character,
+ *        or the given maximum length.
+ * @param str Pointer to byte string that is null-terminated or at least max_len bytes long.
+ * @param max_len Maximum number of characters to examine.
+ * @return The length of the string in bytes.
+ */
+size_t lv_strnlen(const char * str, size_t max_len);
 
 /**
  * @brief Copies up to dst_size-1 (non-null) characters from src to dst. A null terminator is always added.
@@ -145,6 +154,15 @@ static inline bool lv_streq(const char * s1, const char * s2)
  * @return A pointer to the new allocated string. NULL if failed.
  */
 char * lv_strdup(const char * src);
+
+/**
+ * @brief Duplicate a string by allocating a new one and copying the content
+ *        up to the end or the specified maximum length, whichever comes first.
+ * @param src Pointer to the source of data to be copied.
+ * @param max_len Maximum number of characters to be copied.
+ * @return Pointer to a newly allocated null-terminated string. NULL if failed.
+ */
+char * lv_strndup(const char * src, size_t max_len);
 
 /**
  * @brief Copies the string pointed to by src, including the terminating null character,

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -55,6 +55,14 @@ size_t lv_strlen(const char * str)
     return rt_strlen(str);
 }
 
+size_t lv_strnlen(const char * str, size_t max_len)
+{
+    size_t i = 0;
+    while(i < max_len && str[i]) i++;
+
+    return i;
+}
+
 int lv_memcmp(const void * p1, const void * p2, size_t len)
 {
     return rt_memcmp(p1, p2, len);
@@ -98,6 +106,17 @@ char * lv_strdup(const char * src)
     if(dst == NULL) return NULL;
 
     lv_memcpy(dst, src, len); /*memcpy is faster than strncpy when length is known*/
+    return dst;
+}
+
+char * lv_strndup(const char * src, size_t max_len)
+{
+    size_t len = lv_strnlen(src, max_len);
+    char * dst = lv_malloc(len + 1);
+    if(dst == NULL) return NULL;
+
+    lv_memcpy(dst, src, len);
+    dst[len] = '\0';
     return dst;
 }
 


### PR DESCRIPTION
Introduce `lv_strnlen()` and `lv_strndup()`, mirroring the standard C library.

When using `lv_draw_label()` with `text_length` and `text_local` to draw a slice of a larger string, copy only the required part.

Depending on the size of the larger string, this can be anywhere from insignificant to a major improvement.

I think the additional standard library functions are useful, but it would also be possible to manually malloc and copy diretcly in the draw function.