### PR TITLE
fix(canvas): initialize layer before return

### DIFF
--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -372,12 +372,12 @@ void lv_canvas_init_layer(lv_obj_t * obj, lv_layer_t * layer)
 {
     LV_ASSERT_NULL(obj);
     LV_ASSERT_NULL(layer);
+    lv_layer_init(layer);
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     if(canvas->draw_buf == NULL) return;
 
     lv_image_header_t * header = &canvas->draw_buf->header;
     lv_area_t canvas_area = {0, 0, header->w - 1,  header->h - 1};
-    lv_layer_init(layer);
 
     layer->draw_buf = canvas->draw_buf;
     layer->color_format = header->cf;


### PR DESCRIPTION
If the canvas->draw_buf is NULL, the lv_canvas_init_layer() routine returns before the layer is initialized.  Later uses of the contents of the layer structure will reference uninitialized values.  Move the lv_layer_init() call to before the return statement to prevent this.