### PR TITLE
fix(docs):  add warning not to modify Widgets during draw events.

### DIFF
--- a/docs/details/base-widget/event.rst
+++ b/docs/details/base-widget/event.rst
@@ -156,6 +156,16 @@ Drawing Events
 -  :cpp:enumerator:`LV_EVENT_DRAW_POST_END`: Finishing the post draw phase (when all children are drawn)
 -  :cpp:enumerator:`LV_EVENT_DRAW_TASK_ADDED`: Adding a draw task
 
+.. attention::
+
+    In drawing-event callback functions, it is important to note that the rendering
+    sequence has already begun, and during this period, making changes to the Widget
+    that causes any part of it to be invalidated (i.e. causes its appearance to
+    change) is not permitted.  This includes modifying the Widget's flags, states,
+    color, opacity, coordinates, padding, etc..  If you attempt to do so, LVGL will
+    generate an assertion failure with a message indicating that invalidating an
+    ``area`` is not allowed during rendering.
+
 Special Events
 --------------
 

--- a/docs/details/base-widget/event.rst
+++ b/docs/details/base-widget/event.rst
@@ -158,13 +158,11 @@ Drawing Events
 
 .. attention::
 
-    In drawing-event callback functions, it is important to note that the rendering
-    sequence has already begun, and during this period, making changes to the Widget
-    that causes any part of it to be invalidated (i.e. causes its appearance to
-    change) is not permitted.  This includes modifying the Widget's flags, states,
-    color, opacity, coordinates, padding, etc..  If you attempt to do so, LVGL will
-    generate an assertion failure with a message indicating that invalidating an
-    ``area`` is not allowed during rendering.
+    In drawing-event callback functions the rendering
+    sequence has already begun, and during this period, making changes to any
+    Widget's attributes, styles, or creating/deleting  widgets.  If you attempt to do so, 
+    LVGL will generate an assertion failure with a message 
+    indicating that invalidating an area is not allowed during rendering.
 
 Special Events
 --------------

--- a/docs/details/base-widget/event.rst
+++ b/docs/details/base-widget/event.rst
@@ -160,7 +160,7 @@ Drawing Events
 
     In drawing-event callback functions the rendering
     sequence has already begun, and during this period, making changes to any
-    Widget's attributes, styles, or creating/deleting  widgets.  If you attempt to do so, 
+    Widget's attributes, styles, or creating/deleting  widgets is forbidden.  If you attempt to do so, 
     LVGL will generate an assertion failure with a message 
     indicating that invalidating an area is not allowed during rendering.
 


### PR DESCRIPTION
Resolves #5678

See generated result in [Base Widget > Events > Drawing Events section](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/details/base-widget/event.html#drawing-events).

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
