### PR TITLE
fix(indev.rst):  handle lv_obj_is_focused no longer exists.

### DIFF
--- a/docs/details/main-components/indev.rst
+++ b/docs/details/main-components/indev.rst
@@ -217,7 +217,7 @@ Handling touch events
 Touch events are handled like any other event. First, setup a listener for the ``LV_EVENT_GESTURE`` event type by defining and setting the callback function.
 
 The state or scale of the pinch gesture can be retrieved by
-calling the ``lv_event_get_pinch_scale`` and ``lv_indev_get_gesture_state`` from within the 
+calling the ``lv_event_get_pinch_scale`` and ``lv_indev_get_gesture_state`` from within the
 callback.
 
 An example of such an application is available in
@@ -319,8 +319,9 @@ a Widget to the group use :cpp:expr:`lv_group_add_obj(g, widget)`.
 Once a Widget has been added to a group, you can find out what group it is in
 using :cpp:expr:`lv_obj_get_group(widget)`.
 
-To find out if a Widget in a group has focus, call :cpp:expr:`lv_obj_is_focused(widget)`.
-If the Widget is not part of a group, this function will return ``false``.
+To find out what Widget in a group has focus, if any, call
+:cpp:expr:`lv_group_get_focused(group)`.  If a Widget in that group has focus, it
+will return a pointer to it, otherwise it will return NULL.
 
 To associate a group with an input device use :cpp:expr:`lv_indev_set_group(indev, g)`.
 


### PR DESCRIPTION
The `lv_obj_is_focused()` functionality got moved to lv_group. This updates the documentation that goes with that change.

Resolves #7689

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
