### PR TITLE
fix(nema_gfx): use draw task instead of draw unit

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -263,8 +263,8 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_nema_gfx_unit->base_unit.target_layer = layer;
-    draw_nema_gfx_unit->base_unit.clip_area = &t->clip_area;
+    t->target_layer = layer;
+    lv_area_copy(&t->clip_area, &layer->_clip_area);
     draw_nema_gfx_unit->task_act = t;
 
 #if LV_USE_OS

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -95,7 +95,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
                 nema_fill_rounded_rect_aa(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, radius, bg_color);
             }
         }
-        
+
         else
             nema_fill_rect(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, bg_color);
     }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -51,7 +51,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
     lv_area_move(&rel_coords, -layer->buf_area.x1, -layer->buf_area.y1);
 
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, draw_unit->clip_area);
+    lv_area_copy(&rel_clip_area, &t->clip_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     nema_set_clip(rel_clip_area.x1, rel_clip_area.y1, lv_area_get_width(&rel_clip_area),

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -70,7 +70,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
 
     int32_t coords_bg_w = lv_area_get_width(&rel_coords);
     int32_t coords_bg_h = lv_area_get_height(&rel_coords);
-    bool isCircle = ((dsc->radius == LV_RADIUS_CIRCLE) && (coords_bg_h == coords_bg_w)); 
+    bool is_circle = ((dsc->radius == LV_RADIUS_CIRCLE) && (coords_bg_h == coords_bg_w));
     int32_t short_side = LV_MIN(coords_bg_w, coords_bg_h);
     int32_t radius = LV_MIN(dsc->radius, short_side >> 1);
 
@@ -88,7 +88,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
         }
 
         if(radius > 0.f) {
-            if(isCircle) {
+            if(is_circle) {
                 nema_fill_circle_aa(rel_coords.x1 + coords_bg_w / 2, rel_coords.y1 + coords_bg_h / 2, radius, bg_color);
             }
             else {

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -87,11 +87,11 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
             nema_set_blend_fill(NEMA_BL_SRC);
         }
 
-        if(radius > 0.f){
-            if(isCircle){
+        if(radius > 0.f) {
+            if(isCircle) {
                 nema_fill_circle_aa(rel_coords.x1 + coords_bg_w / 2, rel_coords.y1 + coords_bg_h / 2, radius, bg_color);
             }
-            else{
+            else {
                 nema_fill_rounded_rect_aa(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, radius, bg_color);
             }
         }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -95,7 +95,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
                 nema_fill_rounded_rect_aa(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, radius, bg_color);
             }
         }
-            
+        
         else
             nema_fill_rect(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, bg_color);
     }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -70,6 +70,7 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
 
     int32_t coords_bg_w = lv_area_get_width(&rel_coords);
     int32_t coords_bg_h = lv_area_get_height(&rel_coords);
+    bool isCircle = ((dsc->radius == LV_RADIUS_CIRCLE) && (coords_bg_h == coords_bg_w)); 
     int32_t short_side = LV_MIN(coords_bg_w, coords_bg_h);
     int32_t radius = LV_MIN(dsc->radius, short_side >> 1);
 
@@ -86,8 +87,15 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
             nema_set_blend_fill(NEMA_BL_SRC);
         }
 
-        if(radius > 0.f)
-            nema_fill_rounded_rect_aa(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, radius, bg_color);
+        if(radius > 0.f){
+            if(isCircle){
+                nema_fill_circle_aa(rel_coords.x1 + coords_bg_w / 2, rel_coords.y1 + coords_bg_h / 2, radius, bg_color);
+            }
+            else{
+                nema_fill_rounded_rect_aa(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, radius, bg_color);
+            }
+        }
+            
         else
             nema_fill_rect(rel_coords.x1, rel_coords.y1, coords_bg_w, coords_bg_h, bg_color);
     }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
@@ -76,8 +76,8 @@ static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * 
 
     int32_t tile_x_start = tile_area.x1;
 
-    while(tile_area.y1 <= t->clip_area->y2) {
-        while(tile_area.x1 <= t->clip_area->x2) {
+    while(tile_area.y1 <= t->clip_area.y2) {
+        while(tile_area.x1 <= t->clip_area.x2) {
 
             lv_area_t clipped_img_area;
             if(lv_area_intersect(&clipped_img_area, &tile_area, &t->clip_area)) {

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
@@ -81,7 +81,7 @@ static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * 
 
             lv_area_t clipped_img_area;
             if(lv_area_intersect(&clipped_img_area, &tile_area, &t->clip_area)) {
-                _draw_nema_gfx_img(draw_unit, dsc, &tile_area);
+                _draw_nema_gfx_img(t, dsc, &tile_area);
             }
 
             tile_area.x1 += img_w;

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -457,7 +457,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
                                                            w, NULL, dsc->flag);
 
     /*Go the first visible line*/
-    while(pos.y + line_height_font < t->clip_area->y1) {
+    while(pos.y + line_height_font < t->clip_area.y1) {
         /*Go to next line*/
         line_start = line_end;
         line_end += lv_text_get_next_line(&dsc->text[line_start], remaining_len, font, dsc->letter_space, w, NULL, dsc->flag);
@@ -733,7 +733,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
         /*Go the next line position*/
         pos.y += line_height;
 
-        if(pos.y > t->clip_area->y2) break;
+        if(pos.y > t->clip_area.y2) break;
     }
 
     if(draw_letter_dsc._draw_buf) lv_draw_buf_destroy(draw_letter_dsc._draw_buf);

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -133,7 +133,7 @@ void lv_draw_nema_gfx_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
 
     nema_set_clip(clip_area.x1, clip_area.y1, lv_area_get_width(&clip_area), lv_area_get_height(&clip_area));
 
-    _draw_label_iterate_characters(draw_unit, dsc, coords);
+    _draw_label_iterate_characters(t, dsc, coords);
 
     lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
     nema_cl_submit(&(draw_nema_gfx_unit->cl));
@@ -302,7 +302,7 @@ static void _draw_nema_gfx_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyp
             border_draw_dsc.opa = glyph_draw_dsc->opa;
             border_draw_dsc.color = glyph_draw_dsc->color;
             border_draw_dsc.width = 1;
-            lv_draw_nema_gfx_border(draw_unit, &border_draw_dsc, glyph_draw_dsc->bg_coords);
+            lv_draw_nema_gfx_border(t, &border_draw_dsc, glyph_draw_dsc->bg_coords);
 #endif
         }
         else if(glyph_draw_dsc->format >= LV_FONT_GLYPH_FORMAT_A1 &&
@@ -374,7 +374,7 @@ static void _draw_nema_gfx_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyp
     }
 
     if(fill_draw_dsc && fill_area) {
-        lv_draw_nema_gfx_fill(draw_unit, fill_draw_dsc, fill_area);
+        lv_draw_nema_gfx_fill(t, fill_draw_dsc, fill_area);
     }
 
 }
@@ -653,7 +653,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
                     fill_area.y2 = fill_area.y1 + underline_width - 1;
 
                     fill_dsc.color = dsc->color;
-                    lv_draw_nema_gfx_fill(draw_unit, &fill_dsc, &fill_area);
+                    lv_draw_nema_gfx_fill(t, &fill_dsc, &fill_area);
                 }
                 if(dsc->decor & LV_TEXT_DECOR_STRIKETHROUGH) {
                     lv_area_t fill_area;
@@ -663,7 +663,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
                     fill_area.y2 = fill_area.y1 + underline_width - 1;
 
                     fill_dsc.color = dsc->color;
-                    lv_draw_nema_gfx_fill(draw_unit, &fill_dsc, &fill_area);
+                    lv_draw_nema_gfx_fill(t, &fill_dsc, &fill_area);
                 }
             }
 
@@ -672,7 +672,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
                && logical_char_pos >= sel_start && logical_char_pos < sel_end) {
                 draw_letter_dsc.color = dsc->sel_color;
                 fill_dsc.color = dsc->sel_bg_color;
-                lv_draw_nema_gfx_fill(draw_unit, &fill_dsc, &bg_coords);
+                lv_draw_nema_gfx_fill(t, &fill_dsc, &bg_coords);
                 cur_state = 0 ;
                 blend_alpha = dsc_sel_col32.alpha;
                 blend_color = nema_dsc_sel_color;
@@ -697,7 +697,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
                 prev_state = cur_state;
             }
 
-            _draw_letter(draw_unit, &draw_letter_dsc, &pos, font, letter);
+            _draw_letter(t, &draw_letter_dsc, &pos, font, letter);
 
             if(letter_w > 0) {
                 pos.x += letter_w + dsc->letter_space;
@@ -812,7 +812,7 @@ static void _draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  const l
 
     dsc->letter_coords = &letter_coords;
     dsc->g = &g;
-    _draw_nema_gfx_letter(draw_unit, dsc, NULL, NULL);
+    _draw_nema_gfx_letter(t, dsc, NULL, NULL);
 
     lv_font_glyph_release_draw_data(&g);
 

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -118,7 +118,7 @@ void lv_draw_nema_gfx_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc,
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
-    lv_layer_t * layer = draw_unit->target_layer;
+    lv_layer_t * layer = t->target_layer;
 
     lv_area_t clip_area;
     lv_area_copy(&clip_area, &t->clip_area);
@@ -311,7 +311,7 @@ static void _draw_nema_gfx_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyp
             if(glyph_draw_dsc->opa <= LV_OPA_MIN)
                 return;
 
-            lv_layer_t * layer = draw_unit->target_layer;
+            lv_layer_t * layer = t->target_layer;
 
             lv_area_t blend_area;
             if(!lv_area_intersect(&blend_area, glyph_draw_dsc->letter_coords, &t->clip_area))

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c
@@ -65,9 +65,9 @@ uint32_t lv_nemagfx_cf_to_nema(lv_color_format_t cf)
         case LV_COLOR_FORMAT_RGB888:
             return NEMA_BGR24;
         case LV_COLOR_FORMAT_ARGB8888:
-            return NEMA_BGRA8888;
+            return NEMA_RGBA8888;
         case LV_COLOR_FORMAT_XRGB8888:
-            return NEMA_BGRX8888;
+            return NEMA_RGBX8888;
         case LV_COLOR_FORMAT_NEMA_TSC4:
             return NEMA_TSC4;
         case LV_COLOR_FORMAT_NEMA_TSC6:


### PR DESCRIPTION
Replace references to draw_unit with draw_task in drawing functions. Access area fields with . instead of ->as it's not a pointer in lv_draw_task_t