### PR TITLE
fix(test_anim): fix stack-use-after-return

### DIFF
--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -145,6 +145,9 @@ void test_anim_pause_for(void)
     lv_test_wait(40);
 
     TEST_ASSERT_EQUAL(79, var);
+
+    /*Delete the animation to avoid accessing it after return*/
+    lv_anim_delete(&var, exec_cb);
 }
 
 void test_anim_pause_for_resume(void)


### PR DESCRIPTION
Fix possible issues with https://github.com/lvgl/lvgl/pull/7583

This problem was discovered by ASAN when I was running the test case locally:

```bash
lvgl/tests/src/test_cases/test_anim.c:30:test_anim_delete:PASS
lvgl/tests/src/test_cases/test_anim.c:62:test_anim_delete_custom:PASS
lvgl/tests/src/test_cases/test_anim.c:93:test_anim_pause:PASS
lvgl/tests/src/test_cases/test_anim.c:123:test_anim_pause_for:PASS
=================================================================
==865578==ERROR: AddressSanitizer: stack-use-after-return on address 0x7ffff4d01620 at pc 0x5555564a1aa1 bp 0x7fffffffd560 sp 0x7fffffffd550
WRITE of size 4 at 0x7ffff4d01620 thread T0
    #0 0x5555564a1aa0 in exec_cb lvgl/tests/src/test_cases/test_anim.c:21
    #1 0x55555656ad42 in anim_timer lvgl/src/misc/lv_anim.c:603
    #2 0x555556565ce0 in lv_anim_refr_now lvgl/src/misc/lv_anim.c:251
    #3 0x5555564b0e87 in lv_refr_now lvgl/src/core/lv_refr.c:85
    #4 0x5555564a414e in lv_test_wait lvgl/tests/src/lv_test_helpers.c:9
    #5 0x5555564a3015 in test_anim_pause_for_resume lvgl/tests/src/test_cases/test_anim.c:165
    #6 0x5555564a36a3 in run_test lvgl/tests/build_test_sysheap/test_anim_Runner.c:75
    #7 0x5555564a38d1 in main lvgl/tests/build_test_sysheap/test_anim_Runner.c:96
    #8 0x7ffff6b73d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7ffff6b73e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #10 0x5555564a1904 in _start (lvgl/tests/build_test_sysheap/test_anim+0xf4d904) (BuildId: f34cbfda264b05c45399af4c73725fbdad6e2ffb)

Address 0x7ffff4d01620 is located in stack of thread T0 at offset 32 in frame
    #0 0x5555564a2a34 in test_anim_pause_for lvgl/tests/src/test_cases/test_anim.c:124

  This frame has 2 object(s):
    [32, 36) 'var' (line 125) <== Memory access at offset 32 is inside this variable
    [48, 184) 'a' (line 128)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-return lvgl/tests/src/test_cases/test_anim.c:21 in exec_cb
Shadow bytes around the buggy address:
  0x7ffff4d01380: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ffff4d01400: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01480: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ffff4d01500: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01580: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7ffff4d01600: f5 f5 f5 f5[f5]f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01680: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01700: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01780: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ffff4d01800: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ffff4d01880: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==865578==ABORTING
[1] + Done                       "/usr/bin/gdb" --interpreter=mi --tty=${DbgTerm} 0<"/tmp/Microsoft-MIEngine-In-pyofsyce.kpr" 1>"/tmp/Microsoft-MIEngine-Out-tdi2pdup.j2x"
```

After the test case `test_anim_pause_for` exits, there are still temporary variables of anim on the reference stack, which leads to the stack-use-after-return problem.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
