### PR TITLE
fix(indev): fix rotation calculation error

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -698,17 +698,17 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     switch(disp->rotation) {
         case LV_DISPLAY_ROTATION_90:
             data->point.x = data->point.y;
-            data->point.y = disp->hor_res - 1 - i->pointer.last_raw_point.x; 
+            data->point.y = disp->hor_res - 1 - i->pointer.last_raw_point.x;
             break;
 
         case LV_DISPLAY_ROTATION_180:
             data->point.x = disp->hor_res - 1 - data->point.x;
-            data->point.y = disp->ver_res - 1 - data->point.y;        
+            data->point.y = disp->ver_res - 1 - data->point.y;
             break;
 
         case LV_DISPLAY_ROTATION_270:
             data->point.x = disp->ver_res - 1 - data->point.y;
-            data->point.y = i->pointer.last_raw_point.x;        
+            data->point.y = i->pointer.last_raw_point.x;
             break;
     }
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -695,14 +695,21 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     i->pointer.last_raw_point.x = data->point.x;
     i->pointer.last_raw_point.y = data->point.y;
 
-    if(disp->rotation == LV_DISPLAY_ROTATION_180 || disp->rotation == LV_DISPLAY_ROTATION_270) {
-        data->point.x = disp->hor_res - data->point.x - 1;
-        data->point.y = disp->ver_res - data->point.y - 1;
-    }
-    if(disp->rotation == LV_DISPLAY_ROTATION_90 || disp->rotation == LV_DISPLAY_ROTATION_270) {
-        int32_t tmp = data->point.y;
-        data->point.y = data->point.x;
-        data->point.x = disp->ver_res - tmp - 1;
+    switch (disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+            data->point.x = data->point.y;
+            data->point.y = disp->hor_res - 1 - i->pointer.last_raw_point.x; 
+            break;
+
+        case LV_DISPLAY_ROTATION_180:
+            data->point.x = disp->hor_res - 1 - data->point.x;
+            data->point.y = disp->ver_res - 1 - data->point.y;        
+            break;
+
+        case LV_DISPLAY_ROTATION_270:
+            data->point.x = disp->ver_res - 1 - data->point.y;
+            data->point.y = i->pointer.last_raw_point.x;        
+            break;
     }
 
     /*Simple sanity check*/

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -695,7 +695,7 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     i->pointer.last_raw_point.x = data->point.x;
     i->pointer.last_raw_point.y = data->point.y;
 
-    switch (disp->rotation) {
+    switch(disp->rotation) {
         case LV_DISPLAY_ROTATION_90:
             data->point.x = data->point.y;
             data->point.y = disp->hor_res - 1 - i->pointer.last_raw_point.x; 


### PR DESCRIPTION
When the display is rotated the logic to recalculate the mouse pointer (touch coordinates on a touch screen) results in wrong coordinates. This patch fixes this.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
