### PR TITLE
feat(draw_vector): add partial rendering support

### DIFF
--- a/demos/vector_graphic/lv_demo_vector_graphic.h
+++ b/demos/vector_graphic/lv_demo_vector_graphic.h
@@ -40,6 +40,14 @@ void lv_demo_vector_graphic_buffered(void);
  */
 void lv_demo_vector_graphic_not_buffered(void);
 
+/**
+ * Draw many vector based shapes and paths to a partial draw buffer.
+ * The buffer is then blended in
+ * it is used on devices that don't have much RAM or
+ * if color format of the display is not XRGB8888/ARGB8888
+ */
+void lv_demo_vector_graphic_partially_buffered(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/lv_draw_vector.h
+++ b/src/draw/lv_draw_vector.h
@@ -16,6 +16,7 @@ extern "C" {
 #include "../misc/lv_array.h"
 #include "../misc/lv_matrix.h"
 #include "lv_draw_image.h"
+#include "../core/lv_obj_private.h"
 
 #if LV_USE_VECTOR_GRAPHIC
 
@@ -458,6 +459,13 @@ void lv_vector_dsc_translate(lv_vector_dsc_t * dsc, float tx, float ty);
 void lv_vector_dsc_skew(lv_vector_dsc_t * dsc, float skew_x, float skew_y);
 
 /**
+ * Set the draw buffer that is used for partial rendering
+ * @param dsc           pointer to a vector graphic descriptor
+ * @param path          pointer to a path
+ */
+void lv_vector_dsc_set_draw_buf(lv_vector_dsc_t * dsc, lv_draw_buf_t * buf);
+
+/**
  * Add a graphic path to the draw list
  * @param dsc           pointer to a vector graphic descriptor
  * @param path          pointer to a path
@@ -472,10 +480,25 @@ void lv_vector_dsc_add_path(lv_vector_dsc_t * dsc, const lv_vector_path_t * path
 void lv_vector_clear_area(lv_vector_dsc_t * dsc, const lv_area_t * rect);
 
 /**
+ * sets the color of shape before blending it in
+ * @param dsc           pointer to the vector graphic descriptor
+ * @param blend_color   the color to apply on the shape
+ */
+void lv_vector_dsc_set_blend_color(lv_vector_dsc_t * dsc, lv_color_t blend_color);
+
+/**
  * Draw all the vector graphic paths
  * @param dsc           pointer to a vector graphic descriptor
  */
 void lv_draw_vector(lv_vector_dsc_t * dsc);
+
+/**
+ * Parial rendering of the vector graphic paths within the bounds of an object
+ * before calling, be sure to set a draw buffer on the vector graphic descriptor
+ * @param dsc           pointer to a vector graphic descriptor
+ * @param obj           pointer to the object containing the layer on which the paths will be drawn
+ */
+void lv_draw_vector_partial(lv_vector_dsc_t * dsc, lv_obj_t * obj);
 
 /* Traverser for task list */
 typedef void (*vector_draw_task_cb)(void * ctx, const lv_vector_path_t * path, const lv_vector_draw_dsc_t * dsc);

--- a/src/draw/lv_draw_vector_private.h
+++ b/src/draw/lv_draw_vector_private.h
@@ -79,14 +79,30 @@ struct _lv_vector_draw_dsc_t {
 
 struct _lv_draw_vector_task_dsc_t {
     lv_draw_dsc_base_t base;
-    lv_ll_t * task_list; /*draw task list.*/
+    lv_ll_t * task_list;            /*draw task list.*/
+    lv_draw_buf_t * draw_buf;       /*draw buffer that used for partial rendering*/
+    lv_color_t * blend_color;       /*when A8 is used all paths are blended to one color*/
+
+    /*used for partial rendering - it is a delta
+     *between y1 of the lv_obj_t containing the paths and y1 of the clip area*/
+    int32_t obj_offset_y;
+
+    /*used for partial rendering - it is a delta
+     *between x1 of the lv_obj_t containing the paths and x1 of the clip area*/
+    int32_t obj_offset_x;
+
+    /* partial rendering - width of the object containing the path the stride
+     * calculated based on the object width not the clip area */
+    int32_t obj_width;
 };
 
 struct _lv_vector_dsc_t {
     lv_layer_t * layer;
     lv_vector_draw_dsc_t current_dsc;
+    lv_color_t blend_color;
     /* private data */
     lv_draw_vector_task_dsc_t tasks;
+    lv_draw_buf_t * draw_buf;
 };
 
 
@@ -94,7 +110,10 @@ struct _lv_vector_dsc_t {
  * GLOBAL PROTOTYPES
  **********************/
 
-void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb cb, void * data);
+/* Execute a callback for each task/path */
+void lv_vector_for_each_task_ex(lv_ll_t * task_list, vector_draw_task_cb cb, void * data);
+
+void lv_vector_destroy_tasks(lv_ll_t * task_list);
 
 /**********************
  *      MACROS

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -65,7 +65,8 @@ void lv_draw_vg_lite_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t 
     lv_draw_vg_lite_unit_t * u = (lv_draw_vg_lite_unit_t *)t->draw_unit;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_vector_for_each_destroy_tasks(dsc->task_list, task_draw_cb, u);
+    lv_vector_for_each_task_ex(dsc->task_list, task_draw_cb, u);
+    lv_vector_destroy_tasks(dsc->task_list);
     LV_PROFILER_DRAW_END;
 }
 

--- a/src/libs/thorvg/thorvg_capi.h
+++ b/src/libs/thorvg/thorvg_capi.h
@@ -445,7 +445,8 @@ typedef enum {
     TVG_COLORSPACE_ABGR8888 = 0, ///< The channels are joined in the order: alpha, blue, green, red. Colors are alpha-premultiplied. (a << 24 | b << 16 | g << 8 | r)
     TVG_COLORSPACE_ARGB8888,     ///< The channels are joined in the order: alpha, red, green, blue. Colors are alpha-premultiplied. (a << 24 | r << 16 | g << 8 | b)
     TVG_COLORSPACE_ABGR8888S,    ///< The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied. @since 0.13
-    TVG_COLORSPACE_ARGB8888S     ///< The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied. @since 0.13
+    TVG_COLORSPACE_ARGB8888S,    ///< The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied. @since 0.13
+    TVG_COLORSPACE_GRAYSCALE
 } Tvg_Colorspace;
 
 


### PR DESCRIPTION
Feature that adds partial rendering to the ThorVG integration - this was needed to render custom shapes
in a memory constrained environment that could not accommodate a large draw buffer using the canvas.

This solution runs the existing example located in the `demos/vector_graphics` directory, but there is an issue with the pattern fill. 
To perform rendering over multiple passes a transform with a y_offset is applied on each pass.


<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
   Waiting on #7241 to get merged before adding a section on vector graphics.

- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples)
  The example is located in the `demos/vector_graphics` directory
