### PR TITLE
feat(vg_lite): enhanced the automatic diagnosis function of GPU errors

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -157,7 +157,6 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
     }
 
     lv_vg_lite_path_end(path);
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
 
     vg_lite_matrix_t matrix = u->global_matrix;
 
@@ -182,7 +181,7 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
 
             lv_vg_lite_draw_pattern(
                 &u->target_buffer,
-                vg_lite_path,
+                lv_vg_lite_path_get_path(path),
                 fill,
                 &path_matrix,
                 &src_buf,
@@ -200,7 +199,7 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
         /* normal color fill */
         lv_vg_lite_draw(
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             fill,
             &matrix,
             VG_LITE_BLEND_SRC_OVER,

--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -161,10 +161,6 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
 
     vg_lite_matrix_t matrix = u->global_matrix;
 
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
     if(dsc->img_src) {
         vg_lite_buffer_t src_buf;
         lv_image_decoder_dsc_t decoder_dsc;
@@ -184,38 +180,31 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
             float img_half_h = decoder_dsc.decoded->header.h / 2.0f;
             vg_lite_translate(cx - img_half_w, cy - img_half_h, &matrix);
 
-            LV_VG_LITE_ASSERT_MATRIX(&matrix);
-            LV_VG_LITE_ASSERT_MATRIX(&path_matrix);
-            LV_VG_LITE_ASSERT_SRC_BUFFER(&src_buf);
+            lv_vg_lite_draw_pattern(
+                &u->target_buffer,
+                vg_lite_path,
+                fill,
+                &path_matrix,
+                &src_buf,
+                &matrix,
+                VG_LITE_BLEND_SRC_OVER,
+                VG_LITE_PATTERN_COLOR,
+                0,
+                img_color,
+                VG_LITE_FILTER_BI_LINEAR);
 
-            LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw_pattern");
-            LV_VG_LITE_CHECK_ERROR(vg_lite_draw_pattern(
-                                       &u->target_buffer,
-                                       vg_lite_path,
-                                       fill,
-                                       &path_matrix,
-                                       &src_buf,
-                                       &matrix,
-                                       VG_LITE_BLEND_SRC_OVER,
-                                       VG_LITE_PATTERN_COLOR,
-                                       0,
-                                       img_color,
-                                       VG_LITE_FILTER_BI_LINEAR));
-            LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
             lv_vg_lite_pending_add(u->image_dsc_pending, &decoder_dsc);
         }
     }
     else {
         /* normal color fill */
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                                   &u->target_buffer,
-                                   vg_lite_path,
-                                   fill,
-                                   &matrix,
-                                   VG_LITE_BLEND_SRC_OVER,
-                                   lv_vg_lite_color(dsc->color, dsc->opa, true)));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+        lv_vg_lite_draw(
+            &u->target_buffer,
+            vg_lite_path,
+            fill,
+            &matrix,
+            VG_LITE_BLEND_SRC_OVER,
+            lv_vg_lite_color(dsc->color, dsc->opa, true));
     }
 
     lv_vg_lite_path_drop(u, path);

--- a/src/draw/vg_lite/lv_draw_vg_lite_border.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_border.c
@@ -86,23 +86,13 @@ void lv_draw_vg_lite_border(lv_draw_task_t * t, const lv_draw_border_dsc_t * dsc
 
     vg_lite_matrix_t matrix = u->global_matrix;
 
-    vg_lite_color_t color = lv_vg_lite_color(dsc->color, dsc->opa, true);
-
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
-    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                               &u->target_buffer,
-                               vg_lite_path,
-                               fill_rule,
-                               &matrix,
-                               VG_LITE_BLEND_SRC_OVER,
-                               color));
-    LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+    lv_vg_lite_draw(
+        &u->target_buffer,
+        lv_vg_lite_path_get_path(path),
+        fill_rule,
+        &matrix,
+        VG_LITE_BLEND_SRC_OVER,
+        lv_vg_lite_color(dsc->color, dsc->opa, true));
 
     lv_vg_lite_path_drop(u, path);
     LV_PROFILER_DRAW_END;

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -69,10 +69,6 @@ void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, co
 
     vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
 
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
     if(dsc->grad.dir != LV_GRAD_DIR_NONE) {
 #if LV_USE_VECTOR_GRAPHIC
         lv_vg_lite_draw_grad_helper(
@@ -88,17 +84,15 @@ void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, co
         LV_LOG_WARN("Gradient fill is not supported without VECTOR_GRAPHIC");
 #endif
     }
-    else { /* normal fill */
-        vg_lite_color_t color = lv_vg_lite_color(dsc->color, dsc->opa, true);
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                                   &u->target_buffer,
-                                   vg_lite_path,
-                                   VG_LITE_FILL_EVEN_ODD,
-                                   &matrix,
-                                   VG_LITE_BLEND_SRC_OVER,
-                                   color));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+    else {
+        /* normal fill */
+        lv_vg_lite_draw(
+            &u->target_buffer,
+            vg_lite_path,
+            VG_LITE_FILL_EVEN_ODD,
+            &matrix,
+            VG_LITE_BLEND_SRC_OVER,
+            lv_vg_lite_color(dsc->color, dsc->opa, true));
     }
 
     lv_vg_lite_path_drop(u, path);

--- a/src/draw/vg_lite/lv_draw_vg_lite_fill.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_fill.c
@@ -67,14 +67,12 @@ void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, co
                                 dsc->radius);
     lv_vg_lite_path_end(path);
 
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
     if(dsc->grad.dir != LV_GRAD_DIR_NONE) {
 #if LV_USE_VECTOR_GRAPHIC
         lv_vg_lite_draw_grad_helper(
             u,
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             coords,
             &dsc->grad,
             &matrix,
@@ -88,7 +86,7 @@ void lv_draw_vg_lite_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, co
         /* normal fill */
         lv_vg_lite_draw(
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             VG_LITE_FILL_EVEN_ODD,
             &matrix,
             VG_LITE_BLEND_SRC_OVER,

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -147,12 +147,11 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
         lv_vg_lite_path_set_bounding_box_area(path, &clip_area);
         lv_vg_lite_path_end(path);
 
-        vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
         vg_lite_matrix_t path_matrix = u->global_matrix;
 
         lv_vg_lite_draw_pattern(
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             VG_LITE_FILL_EVEN_ODD,
             &path_matrix,
             &src_buf,

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -96,10 +96,6 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     vg_lite_matrix_t matrix = u->global_matrix;
     lv_vg_lite_matrix_multiply(&matrix, &image_matrix);
 
-    LV_VG_LITE_ASSERT_SRC_BUFFER(&src_buf);
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
     bool no_transform = lv_matrix_is_identity_or_translation((const lv_matrix_t *)&matrix);
     vg_lite_filter_t filter = no_transform ? VG_LITE_FILTER_POINT : VG_LITE_FILTER_BI_LINEAR;
 
@@ -113,16 +109,14 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
             .height = lv_area_get_height(coords),
         };
 
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_blit_rect");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_blit_rect(
-                                   &u->target_buffer,
-                                   &src_buf,
-                                   &rect,
-                                   &matrix,
-                                   blend,
-                                   color,
-                                   filter));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_blit_rect");
+        lv_vg_lite_blit_rect(
+            &u->target_buffer,
+            &src_buf,
+            &rect,
+            &matrix,
+            blend,
+            color,
+            filter);
     }
     else {
         lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_FP32);
@@ -154,25 +148,20 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
         lv_vg_lite_path_end(path);
 
         vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-        LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-
         vg_lite_matrix_t path_matrix = u->global_matrix;
-        LV_VG_LITE_ASSERT_MATRIX(&path_matrix);
 
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw_pattern");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_draw_pattern(
-                                   &u->target_buffer,
-                                   vg_lite_path,
-                                   VG_LITE_FILL_EVEN_ODD,
-                                   &path_matrix,
-                                   &src_buf,
-                                   &matrix,
-                                   blend,
-                                   VG_LITE_PATTERN_COLOR,
-                                   0,
-                                   color,
-                                   filter));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
+        lv_vg_lite_draw_pattern(
+            &u->target_buffer,
+            vg_lite_path,
+            VG_LITE_FILL_EVEN_ODD,
+            &path_matrix,
+            &src_buf,
+            &matrix,
+            blend,
+            VG_LITE_PATTERN_COLOR,
+            0,
+            color,
+            filter);
 
         lv_vg_lite_path_drop(u, path);
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -221,9 +221,6 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
 
     const vg_lite_color_t color = lv_vg_lite_color(dsc->color, dsc->opa, true);
 
-    LV_VG_LITE_ASSERT_SRC_BUFFER(&src_buf);
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-
     /* If clipping is not required, blit directly */
     if(lv_area_is_in(&image_area, &t->clip_area, false)) {
         /* rect is used to crop the pixel-aligned padding area */
@@ -234,16 +231,14 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
             .height = lv_area_get_height(&image_area)
         };
 
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_blit_rect");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_blit_rect(
-                                   &u->target_buffer,
-                                   &src_buf,
-                                   &rect,
-                                   &matrix,
-                                   VG_LITE_BLEND_SRC_OVER,
-                                   color,
-                                   VG_LITE_FILTER_LINEAR));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_blit_rect");
+        lv_vg_lite_blit_rect(
+            &u->target_buffer,
+            &src_buf,
+            &rect,
+            &matrix,
+            VG_LITE_BLEND_SRC_OVER,
+            color,
+            VG_LITE_FILTER_LINEAR);
     }
     else {
         lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_S16);
@@ -256,26 +251,22 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
         lv_vg_lite_path_end(path);
 
         vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-        LV_VG_LITE_ASSERT_PATH(vg_lite_path);
 
         vg_lite_matrix_t path_matrix = u->global_matrix;
         if(is_rotated) vg_lite_rotate(dsc->rotation / 10.0f, &path_matrix);
-        LV_VG_LITE_ASSERT_MATRIX(&path_matrix);
 
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw_pattern");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_draw_pattern(
-                                   &u->target_buffer,
-                                   vg_lite_path,
-                                   VG_LITE_FILL_EVEN_ODD,
-                                   &path_matrix,
-                                   &src_buf,
-                                   &matrix,
-                                   VG_LITE_BLEND_SRC_OVER,
-                                   VG_LITE_PATTERN_COLOR,
-                                   0,
-                                   color,
-                                   VG_LITE_FILTER_LINEAR));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
+        lv_vg_lite_draw_pattern(
+            &u->target_buffer,
+            vg_lite_path,
+            VG_LITE_FILL_EVEN_ODD,
+            &path_matrix,
+            &src_buf,
+            &matrix,
+            VG_LITE_BLEND_SRC_OVER,
+            VG_LITE_PATTERN_COLOR,
+            0,
+            color,
+            VG_LITE_FILTER_LINEAR);
 
         lv_vg_lite_path_drop(u, path);
     }
@@ -368,15 +359,13 @@ static void draw_letter_outline(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * 
 
     vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(outline);
 
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&draw_matrix);
-
-    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                               &u->target_buffer, vg_lite_path, VG_LITE_FILL_NON_ZERO,
-                               &draw_matrix, VG_LITE_BLEND_SRC_OVER, lv_vg_lite_color(dsc->color, dsc->opa, true)));
-    LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+    lv_vg_lite_draw(
+        &u->target_buffer,
+        vg_lite_path,
+        VG_LITE_FILL_NON_ZERO,
+        &draw_matrix,
+        VG_LITE_BLEND_SRC_OVER,
+        lv_vg_lite_color(dsc->color, dsc->opa, true));
 
     LV_PROFILER_DRAW_END;
 }

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -250,14 +250,12 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
         lv_vg_lite_path_set_bounding_box_area(path, &clip_area);
         lv_vg_lite_path_end(path);
 
-        vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
         vg_lite_matrix_t path_matrix = u->global_matrix;
         if(is_rotated) vg_lite_rotate(dsc->rotation / 10.0f, &path_matrix);
 
         lv_vg_lite_draw_pattern(
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             VG_LITE_FILL_EVEN_ODD,
             &path_matrix,
             &src_buf,
@@ -357,11 +355,9 @@ static void draw_letter_outline(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * 
     vg_lite_matrix_t draw_matrix = u->global_matrix;
     lv_vg_lite_matrix_multiply(&draw_matrix, &matrix);
 
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(outline);
-
     lv_vg_lite_draw(
         &u->target_buffer,
-        vg_lite_path,
+        lv_vg_lite_path_get_path(outline),
         VG_LITE_FILL_NON_ZERO,
         &draw_matrix,
         VG_LITE_BLEND_SRC_OVER,

--- a/src/draw/vg_lite/lv_draw_vg_lite_line.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_line.c
@@ -180,23 +180,13 @@ void lv_draw_vg_lite_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 
     vg_lite_matrix_t matrix = u->global_matrix;
 
-    vg_lite_color_t color = lv_vg_lite_color(dsc->color, dsc->opa, true);
-
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
-    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                               &u->target_buffer,
-                               vg_lite_path,
-                               VG_LITE_FILL_EVEN_ODD,
-                               &matrix,
-                               VG_LITE_BLEND_SRC_OVER,
-                               color));
-    LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+    lv_vg_lite_draw(
+        &u->target_buffer,
+        lv_vg_lite_path_get_path(path),
+        VG_LITE_FILL_EVEN_ODD,
+        &matrix,
+        VG_LITE_BLEND_SRC_OVER,
+        lv_vg_lite_color(dsc->color, dsc->opa, true));
 
     lv_vg_lite_path_drop(u, path);
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
@@ -141,24 +141,16 @@ void lv_draw_vg_lite_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t
         0);
     lv_vg_lite_path_end(path);
 
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
     vg_lite_matrix_t matrix = u->global_matrix;
 
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
-
     /* Use VG_LITE_BLEND_DST_IN (Sa * D) blending mode to make the corners transparent */
-    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                               &u->target_buffer,
-                               vg_lite_path,
-                               VG_LITE_FILL_EVEN_ODD,
-                               &matrix,
-                               VG_LITE_BLEND_DST_IN,
-                               0));
-    LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+    lv_vg_lite_draw(
+        &u->target_buffer,
+        lv_vg_lite_path_get_path(path),
+        VG_LITE_FILL_EVEN_ODD,
+        &matrix,
+        VG_LITE_BLEND_DST_IN,
+        0);
 
     lv_vg_lite_path_drop(u, path);
 #endif /*LV_USE_VG_LITE_THORVG*/

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -66,12 +66,7 @@ void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t *
     lv_vg_lite_path_end(path);
 
     vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
-
-    LV_VG_LITE_ASSERT_DEST_BUFFER(&u->target_buffer);
-    LV_VG_LITE_ASSERT_PATH(vg_lite_path);
-
     vg_lite_matrix_t matrix = u->global_matrix;
-    LV_VG_LITE_ASSERT_MATRIX(&matrix);
 
     if(dsc->bg_grad.dir != LV_GRAD_DIR_NONE) {
 #if LV_USE_VECTOR_GRAPHIC
@@ -89,16 +84,13 @@ void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t *
 #endif
     }
     else { /* normal fill */
-        vg_lite_color_t color = lv_vg_lite_color(dsc->bg_color, dsc->bg_opa, true);
-        LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                                   &u->target_buffer,
-                                   vg_lite_path,
-                                   VG_LITE_FILL_EVEN_ODD,
-                                   &matrix,
-                                   VG_LITE_BLEND_SRC_OVER,
-                                   color));
-        LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+        lv_vg_lite_draw(
+            &u->target_buffer,
+            vg_lite_path,
+            VG_LITE_FILL_EVEN_ODD,
+            &matrix,
+            VG_LITE_BLEND_SRC_OVER,
+            lv_vg_lite_color(dsc->bg_color, dsc->bg_opa, true));
     }
 
     lv_vg_lite_path_drop(u, path);

--- a/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
@@ -65,7 +65,6 @@ void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t *
     lv_vg_lite_path_close(path);
     lv_vg_lite_path_end(path);
 
-    vg_lite_path_t * vg_lite_path = lv_vg_lite_path_get_path(path);
     vg_lite_matrix_t matrix = u->global_matrix;
 
     if(dsc->bg_grad.dir != LV_GRAD_DIR_NONE) {
@@ -73,7 +72,7 @@ void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t *
         lv_vg_lite_draw_grad_helper(
             u,
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             &tri_area,
             &dsc->bg_grad,
             &matrix,
@@ -86,7 +85,7 @@ void lv_draw_vg_lite_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t *
     else { /* normal fill */
         lv_vg_lite_draw(
             &u->target_buffer,
-            vg_lite_path,
+            lv_vg_lite_path_get_path(path),
             VG_LITE_FILL_EVEN_ODD,
             &matrix,
             VG_LITE_BLEND_SRC_OVER,

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -98,7 +98,11 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
         vg_lite_rectangle_t rect;
         lv_vg_lite_rect(&rect, &dsc->scissor_area);
         LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_clear");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_clear(&u->target_buffer, &rect, c));
+        LV_VG_LITE_CHECK_ERROR(vg_lite_clear(&u->target_buffer, &rect, c), {
+            lv_vg_lite_buffer_dump_info(&u->target_buffer);
+            LV_LOG_ERROR("rect: X%d Y%d W%d H%d", rect.x, rect.y, rect.width, rect.height);
+            lv_vg_lite_color_dump_info(c);
+        });
         LV_PROFILER_DRAW_END_TAG("vg_lite_clear");
         LV_PROFILER_DRAW_END;
         return;
@@ -159,7 +163,7 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
         vg_lite_path_t * vg_path = lv_vg_lite_path_get_path(stroke_path);
 
         /* set stroke params */
-        LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, path_type));
+        LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, path_type), {});
         vg_path->stroke_color = lv_color32_to_vg(dsc->stroke_dsc.color, dsc->stroke_dsc.opa);
         vg_path->quality = ori_vg_path->quality;
         lv_memcpy(vg_path->bounding_box, ori_vg_path->bounding_box, sizeof(ori_vg_path->bounding_box));
@@ -210,15 +214,13 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
     switch(dsc->fill_dsc.style) {
         case LV_VECTOR_DRAW_STYLE_SOLID: {
                 /* normal draw shape */
-                LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
-                LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
-                                           &u->target_buffer,
-                                           vg_path,
-                                           fill,
-                                           &matrix,
-                                           blend,
-                                           vg_color));
-                LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+                lv_vg_lite_draw(
+                    &u->target_buffer,
+                    vg_path,
+                    fill,
+                    &matrix,
+                    blend,
+                    vg_color);
             }
             break;
         case LV_VECTOR_DRAW_STYLE_PATTERN: {
@@ -236,22 +238,18 @@ static void task_draw_cb(void * ctx, const lv_vector_path_t * path, const lv_vec
 
                     vg_lite_color_t recolor = lv_vg_lite_image_recolor(&image_buffer, &dsc->fill_dsc.img_dsc);
 
-                    LV_VG_LITE_ASSERT_MATRIX(&pattern_matrix);
-
-                    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw_pattern");
-                    LV_VG_LITE_CHECK_ERROR(vg_lite_draw_pattern(
-                                               &u->target_buffer,
-                                               vg_path,
-                                               fill,
-                                               &matrix,
-                                               &image_buffer,
-                                               &pattern_matrix,
-                                               blend,
-                                               VG_LITE_PATTERN_COLOR,
-                                               0,
-                                               recolor,
-                                               VG_LITE_FILTER_BI_LINEAR));
-                    LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
+                    lv_vg_lite_draw_pattern(
+                        &u->target_buffer,
+                        vg_path,
+                        fill,
+                        &matrix,
+                        &image_buffer,
+                        &pattern_matrix,
+                        blend,
+                        VG_LITE_PATTERN_COLOR,
+                        0,
+                        recolor,
+                        VG_LITE_FILTER_BI_LINEAR);
 
                     lv_vg_lite_pending_add(u->image_dsc_pending, &decoder_dsc);
                 }

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -176,6 +176,8 @@ bool lv_vg_lite_draw_grad(
                     lv_vg_lite_path_dump_info(path);
                     LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
                     lv_vg_lite_matrix_dump_info(matrix);
+                    lv_vg_lite_linear_gradient_dump_info(linear_grad);
+                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
                 });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_grad");
             }
@@ -195,14 +197,23 @@ bool lv_vg_lite_draw_grad(
                                            linear_grad,
                                            0,
                                            blend,
-                                           VG_LITE_FILTER_LINEAR), {});
+                                           VG_LITE_FILTER_LINEAR),
+                                       /*Error handler*/
+                {
+                    lv_vg_lite_buffer_dump_info(buffer);
+                    lv_vg_lite_path_dump_info(path);
+                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    lv_vg_lite_matrix_dump_info(matrix);
+                    lv_vg_lite_ext_linear_gradient_dump_info(linear_grad);
+                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
+                });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_linear_grad");
             }
             break;
 
         case GRAD_TYPE_RADIAL: {
-                vg_lite_radial_gradient_t * radial = &grad_item->vg.radial;
-                vg_lite_matrix_t * grad_mat_p = vg_lite_get_radial_grad_matrix(radial);
+                vg_lite_radial_gradient_t * radial_gradient = &grad_item->vg.radial;
+                vg_lite_matrix_t * grad_mat_p = vg_lite_get_radial_grad_matrix(radial_gradient);
                 LV_ASSERT_NULL(grad_mat_p);
                 *grad_mat_p = *grad_matrix;
 
@@ -213,10 +224,19 @@ bool lv_vg_lite_draw_grad(
                         path,
                         fill,
                         (vg_lite_matrix_t *)matrix,
-                        &grad_item->vg.radial,
+                        radial_gradient,
                         0,
                         blend,
-                        VG_LITE_FILTER_LINEAR), {});
+                        VG_LITE_FILTER_LINEAR),
+                    /*Error handler*/
+                {
+                    lv_vg_lite_buffer_dump_info(buffer);
+                    lv_vg_lite_path_dump_info(path);
+                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    lv_vg_lite_matrix_dump_info(matrix);
+                    lv_vg_lite_radial_gradient_dump_info(radial_gradient);
+                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
+                });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_radial_grad");
             }
             break;
@@ -323,21 +343,6 @@ bool lv_vg_lite_draw_grad_helper(
     return lv_vg_lite_draw_grad(u, buffer, path, &grad, matrix, matrix, fill, blend);
 }
 
-void lv_vg_lite_linear_gradient_dump_info(const vg_lite_linear_gradient_t * grad)
-{
-
-}
-
-void lv_vg_lite_ext_linear_gradient_dump_info(const vg_lite_ext_linear_gradient_t * grad)
-{
-
-}
-
-void lv_vg_lite_radial_gradient_dump_info(const vg_lite_radial_gradient_t * grad)
-{
-
-}
-
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -409,13 +414,14 @@ static bool linear_grad_create(grad_item_t * item)
 {
     LV_PROFILER_DRAW_BEGIN;
 
-    vg_lite_error_t err = vg_lite_init_grad(&item->vg.linear);
-    if(err != VG_LITE_SUCCESS) {
+    LV_VG_LITE_CHECK_ERROR(
+        vg_lite_init_grad(&item->vg.linear),
+        /* Error handler */
+    {
+        lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
         LV_PROFILER_DRAW_END;
-        LV_LOG_ERROR("vg_lite_init_grad error: %d", (int)err);
-        lv_vg_lite_error_dump_info(err);
         return false;
-    }
+    });
 
     vg_lite_uint32_t colors[VLC_MAX_GRADIENT_STOPS];
     vg_lite_uint32_t stops[VLC_MAX_GRADIENT_STOPS];
@@ -436,10 +442,20 @@ static bool linear_grad_create(grad_item_t * item)
         colors[i] = lv_vg_lite_color(grad_color, opa, true);
     }
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops), {});
+    LV_VG_LITE_CHECK_ERROR(
+        vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops),
+        /* Error handler */
+    {
+        lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
+    });
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_grad");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&item->vg.linear), {});
+    LV_VG_LITE_CHECK_ERROR(
+        vg_lite_update_grad(&item->vg.linear),
+        /* Error handler */
+    {
+        lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
+    });
     LV_PROFILER_DRAW_END_TAG("vg_lite_update_grad");
 
     LV_PROFILER_DRAW_END;
@@ -479,7 +495,11 @@ static bool linear_ext_grad_create(grad_item_t * item)
             color_ramp,
             grad_param,
             lv_spread_to_vg(item->lv.spread),
-            1), {});
+            1),
+        /* Error handler */
+    {
+        lv_vg_lite_ext_linear_gradient_dump_info(&linear_grad);
+    });
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_linear_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_linear_grad");
@@ -491,6 +511,7 @@ static bool linear_ext_grad_create(grad_item_t * item)
     else {
         LV_LOG_ERROR("vg_lite_update_linear_grad error: %d", (int)err);
         lv_vg_lite_error_dump_info(err);
+        lv_vg_lite_ext_linear_gradient_dump_info(&linear_grad);
     }
 
     lv_free(color_ramp);
@@ -533,7 +554,11 @@ static bool radial_grad_create(grad_item_t * item)
             color_ramp,
             grad_param,
             lv_spread_to_vg(item->lv.spread),
-            1), {});
+            1),
+        /* Error handler */
+    {
+        lv_vg_lite_radial_gradient_dump_info(&radial_grad);
+    });
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_radial_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_radial_grad");
@@ -545,6 +570,7 @@ static bool radial_grad_create(grad_item_t * item)
     else {
         LV_LOG_ERROR("vg_lite_update_radial_grad error: %d", (int)err);
         lv_vg_lite_error_dump_info(err);
+        lv_vg_lite_radial_gradient_dump_info(&radial_grad);
     }
 
     lv_free(color_ramp);
@@ -705,6 +731,63 @@ static lv_cache_compare_res_t grad_compare_cb(const grad_item_t * lhs, const gra
     }
 
     return 0;
+}
+
+
+static void lv_vg_lite_linear_gradient_dump_info(const vg_lite_linear_gradient_t * grad)
+{
+    LV_LOG_USER("count: %d", (int)grad->count);
+
+    for(vg_lite_uint32_t i = 0; i < grad->count; i++) {
+        LV_LOG_USER("[%d] color: 0x%08X, stop: 0x%08X", (int)i, grad->colors[i], grad->stops[i]);
+    }
+
+    lv_vg_lite_matrix_dump_info(&grad->matrix);
+    lv_vg_lite_buffer_dump_info(&grad->image);
+}
+
+static void lv_vg_lite_color_ramp_dump_info(const vg_lite_color_ramp_t * ramp, const vg_lite_uint32_t length)
+{
+    for(vg_lite_uint32_t i = 0; i < length; i++) {
+        LV_LOG_USER("[%d] stop: %f, red: %f, green: %f, blue: %f, alpha: %f",
+                    (int)i, ramp[i].stop, ramp[i].red, ramp[i].green, ramp[i].blue, ramp[i].alpha);
+    }
+}
+
+static void lv_vg_lite_ext_linear_gradient_dump_info(const vg_lite_ext_linear_gradient_t * grad)
+{
+    LV_LOG_USER("count: %d", (int)grad->count);
+    lv_vg_lite_matrix_dump_info(&grad->matrix);
+    lv_vg_lite_buffer_dump_info(&grad->image);
+    LV_LOG_USER("linear_grad: X0: %f, Y0: %f, X1: %f, Y1: %f",
+                grad->linear_grad.X0, grad->linear_grad.Y0, grad->linear_grad.X1, grad->linear_grad.Y1);
+
+    LV_LOG_USER("ramp_length: %d", (int)grad->ramp_length);
+    lv_vg_lite_color_ramp_dump_info(grad->color_ramp, grad->ramp_length);
+
+    LV_LOG_USER("converted_length: %d", (int)grad->converted_length);
+    lv_vg_lite_color_ramp_dump_info(grad->converted_ramp, grad->converted_length);
+
+    LV_LOG_USER("pre_multiplied: %d", grad->pre_multiplied);
+    LV_LOG_USER("spread_mode: %d", (int)grad->spread_mode);
+}
+
+static void lv_vg_lite_radial_gradient_dump_info(const vg_lite_radial_gradient_t * grad)
+{
+    LV_LOG_USER("count: %d", (int)grad->count);
+    lv_vg_lite_matrix_dump_info(&grad->matrix);
+    lv_vg_lite_buffer_dump_info(&grad->image);
+    LV_LOG_USER("radial_grad: cx: %f, cy: %f, r: %f, fx: %f, fy: %f",
+                grad->radial_grad.cx, grad->radial_grad.cy, grad->radial_grad.r, grad->radial_grad.fx, grad->radial_grad.fy);
+
+    LV_LOG_USER("ramp_length: %d", (int)grad->ramp_length);
+    lv_vg_lite_color_ramp_dump_info(grad->color_ramp, grad->ramp_length);
+
+    LV_LOG_USER("converted_length: %d", (int)grad->converted_length);
+    lv_vg_lite_color_ramp_dump_info(grad->converted_ramp, grad->converted_length);
+
+    LV_LOG_USER("pre_multiplied: %d", grad->pre_multiplied);
+    LV_LOG_USER("spread_mode: %d", (int)grad->spread_mode);
 }
 
 #endif /*LV_USE_DRAW_VG_LITE && LV_USE_VECTOR_GRAPHIC*/

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -63,6 +63,10 @@ static grad_type_t lv_grad_style_to_type(lv_vector_gradient_style_t style);
 static void grad_point_to_matrix(vg_lite_matrix_t * grad_matrix, float x1, float y1, float x2, float y2);
 static vg_lite_gradient_spreadmode_t lv_spread_to_vg(lv_vector_gradient_spread_t spread);
 
+static void lv_vg_lite_linear_gradient_dump_info(const vg_lite_linear_gradient_t * grad);
+static void lv_vg_lite_ext_linear_gradient_dump_info(const vg_lite_ext_linear_gradient_t * grad);
+static void lv_vg_lite_radial_gradient_dump_info(const vg_lite_radial_gradient_t * grad);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -165,7 +169,14 @@ bool lv_vg_lite_draw_grad(
                                            fill,
                                            (vg_lite_matrix_t *)matrix,
                                            linear_grad,
-                                           blend));
+                                           blend),
+                                       /*Error handler*/
+                {
+                    lv_vg_lite_buffer_dump_info(buffer);
+                    lv_vg_lite_path_dump_info(path);
+                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    lv_vg_lite_matrix_dump_info(matrix);
+                });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_grad");
             }
             break;
@@ -184,7 +195,7 @@ bool lv_vg_lite_draw_grad(
                                            linear_grad,
                                            0,
                                            blend,
-                                           VG_LITE_FILTER_LINEAR));
+                                           VG_LITE_FILTER_LINEAR), {});
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_linear_grad");
             }
             break;
@@ -205,7 +216,7 @@ bool lv_vg_lite_draw_grad(
                         &grad_item->vg.radial,
                         0,
                         blend,
-                        VG_LITE_FILTER_LINEAR));
+                        VG_LITE_FILTER_LINEAR), {});
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_radial_grad");
             }
             break;
@@ -312,6 +323,21 @@ bool lv_vg_lite_draw_grad_helper(
     return lv_vg_lite_draw_grad(u, buffer, path, &grad, matrix, matrix, fill, blend);
 }
 
+void lv_vg_lite_linear_gradient_dump_info(const vg_lite_linear_gradient_t * grad)
+{
+
+}
+
+void lv_vg_lite_ext_linear_gradient_dump_info(const vg_lite_ext_linear_gradient_t * grad)
+{
+
+}
+
+void lv_vg_lite_radial_gradient_dump_info(const vg_lite_radial_gradient_t * grad)
+{
+
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -410,10 +436,10 @@ static bool linear_grad_create(grad_item_t * item)
         colors[i] = lv_vg_lite_color(grad_color, opa, true);
     }
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops), {});
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_grad");
-    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&item->vg.linear));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_update_grad(&item->vg.linear), {});
     LV_PROFILER_DRAW_END_TAG("vg_lite_update_grad");
 
     LV_PROFILER_DRAW_END;
@@ -453,7 +479,7 @@ static bool linear_ext_grad_create(grad_item_t * item)
             color_ramp,
             grad_param,
             lv_spread_to_vg(item->lv.spread),
-            1));
+            1), {});
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_linear_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_linear_grad");
@@ -507,7 +533,7 @@ static bool radial_grad_create(grad_item_t * item)
             color_ramp,
             grad_param,
             lv_spread_to_vg(item->lv.spread),
-            1));
+            1), {});
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_radial_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_radial_grad");
@@ -595,15 +621,15 @@ static void grad_free_cb(grad_item_t * item, void * user_data)
     LV_UNUSED(user_data);
     switch(item->type) {
         case GRAD_TYPE_LINEAR:
-            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&item->vg.linear));
+            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_grad(&item->vg.linear), {});
             break;
 
         case GRAD_TYPE_LINEAR_EXT:
-            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_linear_grad(&item->vg.linear_ext));
+            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_linear_grad(&item->vg.linear_ext), {});
             break;
 
         case GRAD_TYPE_RADIAL:
-            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_radial_grad(&item->vg.radial));
+            LV_VG_LITE_CHECK_ERROR(vg_lite_clear_radial_grad(&item->vg.radial), {});
             break;
 
         default:

--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -112,7 +112,7 @@ void lv_vg_lite_path_destroy(lv_vg_lite_path_t * path)
         path->base.path = NULL;
 
         /* clear remaining path data */
-        LV_VG_LITE_CHECK_ERROR(vg_lite_clear_path(&path->base));
+        LV_VG_LITE_CHECK_ERROR(vg_lite_clear_path(&path->base), {});
     }
     lv_free(path);
     LV_PROFILER_DRAW_END;

--- a/src/draw/vg_lite/lv_vg_lite_stroke.c
+++ b/src/draw/vg_lite/lv_vg_lite_stroke.c
@@ -233,7 +233,7 @@ static bool stroke_create_cb(stroke_item_t * item, void * user_data)
 
     /* update parameters */
     vg_lite_path_t * vg_path = lv_vg_lite_path_get_path(item->vg.path);
-    LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, VG_LITE_DRAW_STROKE_PATH));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, VG_LITE_DRAW_STROKE_PATH), {});
 
     vg_lite_error_t error = vg_lite_set_stroke(
                                 vg_path,

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -324,7 +324,7 @@ static void path_data_print_cb(void * user_data, uint8_t op_code, const float * 
             LV_LOG("%s, %f, %f, %f, %f, %f, %f,\n", op_str, data[0], data[1], data[2], data[3], data[4], data[5]);
             break;
         default: {
-                LV_LOG("%s, ", lv_vg_lite_vlc_op_string(op_code));
+                LV_LOG("%s, ", op_str);
                 for(uint32_t i = 0; i < len; i++) {
                     LV_LOG("%f, ", data[i]);
                 }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -103,6 +103,10 @@ void lv_vg_lite_error_dump_info(vg_lite_error_t error)
             LV_LOG_USER("No error");
             break;
 
+        case VG_LITE_NOT_ALIGNED:
+        case VG_LITE_INVALID_ARGUMENT:
+            break;
+
         case VG_LITE_OUT_OF_MEMORY:
         case VG_LITE_OUT_OF_RESOURCES: {
                 vg_lite_uint32_t mem_size = 0;
@@ -301,12 +305,33 @@ const char * lv_vg_lite_vlc_op_string(uint8_t vlc_op)
 static void path_data_print_cb(void * user_data, uint8_t op_code, const float * data, uint32_t len)
 {
     LV_UNUSED(user_data);
+    const char * op_str = lv_vg_lite_vlc_op_string(op_code);
 
-    LV_LOG("%s, ", lv_vg_lite_vlc_op_string(op_code));
-    for(uint32_t i = 0; i < len; i++) {
-        LV_LOG("%0.2f, ", data[i]);
+    switch(len) {
+        case 0:
+            LV_LOG("%s,\n", op_str);
+            break;
+        case 2:
+            LV_LOG("%s, %f, %f,\n", op_str, data[0], data[1]);
+            break;
+        case 4:
+            LV_LOG("%s, %f, %f, %f, %f,\n", op_str, data[0], data[1], data[2], data[3]);
+            break;
+        case 5:
+            LV_LOG("%s, %f, %f, %f, %f, %f,\n", op_str, data[0], data[1], data[2], data[3], data[4]);
+            break;
+        case 6:
+            LV_LOG("%s, %f, %f, %f, %f, %f, %f,\n", op_str, data[0], data[1], data[2], data[3], data[4], data[5]);
+            break;
+        default: {
+                LV_LOG("%s, ", lv_vg_lite_vlc_op_string(op_code));
+                for(uint32_t i = 0; i < len; i++) {
+                    LV_LOG("%f, ", data[i]);
+                }
+                LV_LOG("\n");
+            }
+            break;
     }
-    LV_LOG("\n");
 }
 
 void lv_vg_lite_path_dump_info(const vg_lite_path_t * path)
@@ -434,6 +459,16 @@ void lv_vg_lite_matrix_dump_info(const vg_lite_matrix_t * matrix)
         LV_LOG_USER("| %f, %f, %f |",
                     (matrix)->m[i][0], (matrix)->m[i][1], (matrix)->m[i][2]);
     }
+}
+
+void lv_vg_lite_color_dump_info(const vg_lite_color_t color)
+{
+    LV_LOG_USER("0x%08X (A%d, B%d, G%d, R%d)",
+                (int)color,
+                (int)((color >> 24) & 0xFF),
+                (int)((color >> 16) & 0xFF),
+                (int)((color >> 8) & 0xFF),
+                (int)((color >> 0) & 0xFF));
 }
 
 bool lv_vg_lite_is_dest_cf_supported(lv_color_format_t cf)
@@ -839,7 +874,7 @@ bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_ds
     if(LV_COLOR_FORMAT_IS_INDEXED(decoded->header.cf)) {
         uint32_t palette_size = LV_COLOR_INDEXED_PALETTE_SIZE(decoded->header.cf);
         LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_set_CLUT");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_set_CLUT(palette_size, (vg_lite_uint32_t *)decoded->data));
+        LV_VG_LITE_CHECK_ERROR(vg_lite_set_CLUT(palette_size, (vg_lite_uint32_t *)decoded->data), {});
         LV_PROFILER_DRAW_END_TAG("vg_lite_set_CLUT");
     }
 
@@ -1224,13 +1259,13 @@ void lv_vg_lite_set_scissor_area(const lv_area_t * area)
      * for the render target. This scissor API is supported by a different hardware mechanism other than the mask layer,
      * and it is not enabled/disabled by vg_lite_enable_scissor and vg_lite_disable_scissor APIs.
      */
-    LV_VG_LITE_CHECK_ERROR(vg_lite_enable_scissor());
+    LV_VG_LITE_CHECK_ERROR(vg_lite_enable_scissor(), {});
 #endif
     LV_VG_LITE_CHECK_ERROR(vg_lite_set_scissor(
                                area->x1,
                                area->y1,
                                area->x2 + 1,
-                               area->y2 + 1));
+                               area->y2 + 1), {});
     LV_PROFILER_DRAW_END;
 }
 
@@ -1242,7 +1277,7 @@ void lv_vg_lite_disable_scissor(void)
                                0,
                                0,
                                LV_HOR_RES,
-                               LV_VER_RES));
+                               LV_VER_RES), {});
     LV_PROFILER_DRAW_END;
 }
 
@@ -1262,7 +1297,7 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
     }
 #else
     vg_lite_uint32_t is_gpu_idle = 0;
-    LV_VG_LITE_CHECK_ERROR(vg_lite_get_parameter(VG_LITE_GPU_IDLE_STATE, 1, (vg_lite_pointer)&is_gpu_idle));
+    LV_VG_LITE_CHECK_ERROR(vg_lite_get_parameter(VG_LITE_GPU_IDLE_STATE, 1, (vg_lite_pointer)&is_gpu_idle), {});
     if(!is_gpu_idle) {
         /* Do not flush if GPU is busy */
         LV_PROFILER_DRAW_END;
@@ -1270,7 +1305,7 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
     }
 #endif
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_flush());
+    LV_VG_LITE_CHECK_ERROR(vg_lite_flush(), {});
     u->flush_count = 0;
     LV_PROFILER_DRAW_END;
 }
@@ -1280,7 +1315,7 @@ void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u)
     LV_ASSERT_NULL(u);
     LV_PROFILER_DRAW_BEGIN;
 
-    LV_VG_LITE_CHECK_ERROR(vg_lite_finish());
+    LV_VG_LITE_CHECK_ERROR(vg_lite_finish(), {});
 
     /* Clear all gradient caches reference */
     if(u->grad_pending) {

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1265,7 +1265,12 @@ void lv_vg_lite_set_scissor_area(const lv_area_t * area)
                                area->x1,
                                area->y1,
                                area->x2 + 1,
-                               area->y2 + 1), {});
+                               area->y2 + 1),
+                           /* Error handler */
+    {
+        LV_LOG_ERROR("area: %d, %d, %d, %d",
+                     (int)area->x1, (int)area->y1, (int)area->x2, (int)area->y2);
+    });
     LV_PROFILER_DRAW_END;
 }
 
@@ -1277,7 +1282,11 @@ void lv_vg_lite_disable_scissor(void)
                                0,
                                0,
                                LV_HOR_RES,
-                               LV_VER_RES), {});
+                               LV_VER_RES),
+                           /* Error handler */
+    {
+        LV_LOG_ERROR("hor_res: %d, ver_res: %d", (int)LV_HOR_RES, (int)LV_VER_RES);
+    });
     LV_PROFILER_DRAW_END;
 }
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -31,20 +31,19 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define LV_VG_LITE_IS_ERROR(err) (err > 0)
-
 #if LV_VG_LITE_USE_ASSERT
 #define LV_VG_LITE_ASSERT(expr) LV_ASSERT(expr)
 #else
 #define LV_VG_LITE_ASSERT(expr)
 #endif
 
-#define LV_VG_LITE_CHECK_ERROR(expr)                          \
+#define LV_VG_LITE_CHECK_ERROR(expr, error_handler)           \
     do {                                                      \
         vg_lite_error_t error = expr;                         \
-        if (LV_VG_LITE_IS_ERROR(error)) {                     \
+        if (error != VG_LITE_SUCCESS) {                       \
             LV_LOG_ERROR("Execute '" #expr "' error: %d", (int)error);  \
             lv_vg_lite_error_dump_info(error);                \
+            error_handler;                                    \
             LV_VG_LITE_ASSERT(false);                         \
         }                                                     \
     } while (0)
@@ -96,6 +95,8 @@ void lv_vg_lite_stroke_dump_info(const vg_lite_stroke_t * stroke);
 void lv_vg_lite_buffer_dump_info(const vg_lite_buffer_t * buffer);
 
 void lv_vg_lite_matrix_dump_info(const vg_lite_matrix_t * matrix);
+
+void lv_vg_lite_color_dump_info(const vg_lite_color_t color);
 
 bool lv_vg_lite_is_dest_cf_supported(lv_color_format_t cf);
 
@@ -177,6 +178,119 @@ void lv_vg_lite_disable_scissor(void);
 void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u);
 
 void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u);
+
+static inline void lv_vg_lite_draw(vg_lite_buffer_t * target,
+                                   vg_lite_path_t * path,
+                                   vg_lite_fill_t fill_rule,
+                                   vg_lite_matrix_t * matrix,
+                                   vg_lite_blend_t blend,
+                                   vg_lite_color_t color)
+{
+    LV_VG_LITE_ASSERT_DEST_BUFFER(target);
+    LV_VG_LITE_ASSERT_PATH(path);
+    LV_VG_LITE_ASSERT_MATRIX(matrix);
+
+    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw");
+    LV_VG_LITE_CHECK_ERROR(vg_lite_draw(
+                               target,
+                               path,
+                               fill_rule,
+                               matrix,
+                               blend,
+                               color),
+                           /*Error handler*/
+    {
+        lv_vg_lite_buffer_dump_info(target);
+        lv_vg_lite_path_dump_info(path);
+        LV_LOG_ERROR("fill_rule: 0x%X,", (int)fill_rule);
+        lv_vg_lite_matrix_dump_info(matrix);
+        LV_LOG_ERROR("blend: 0x%X,", (int)blend);
+        lv_vg_lite_color_dump_info(color);
+    });
+    LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
+}
+
+static inline void lv_vg_lite_draw_pattern(vg_lite_buffer_t * target,
+                                           vg_lite_path_t * path,
+                                           vg_lite_fill_t fill_rule,
+                                           vg_lite_matrix_t * path_matrix,
+                                           vg_lite_buffer_t * pattern_image,
+                                           vg_lite_matrix_t * pattern_matrix,
+                                           vg_lite_blend_t blend,
+                                           vg_lite_pattern_mode_t pattern_mode,
+                                           vg_lite_color_t pattern_color,
+                                           vg_lite_color_t color,
+                                           vg_lite_filter_t filter)
+{
+    LV_VG_LITE_ASSERT_DEST_BUFFER(target);
+    LV_VG_LITE_ASSERT_PATH(path);
+    LV_VG_LITE_ASSERT_MATRIX(path_matrix);
+    LV_VG_LITE_ASSERT_SRC_BUFFER(pattern_image);
+    LV_VG_LITE_ASSERT_MATRIX(pattern_matrix);
+
+    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_draw_pattern");
+    LV_VG_LITE_CHECK_ERROR(vg_lite_draw_pattern(
+                               target,
+                               path,
+                               fill_rule,
+                               path_matrix,
+                               pattern_image,
+                               pattern_matrix,
+                               blend,
+                               pattern_mode,
+                               pattern_color,
+                               color,
+                               filter),
+                           /*Error handler*/
+    {
+        lv_vg_lite_buffer_dump_info(target);
+        lv_vg_lite_path_dump_info(path);
+        LV_LOG_ERROR("fill_rule: 0x%X,", (int)fill_rule);
+        lv_vg_lite_matrix_dump_info(path_matrix);
+        lv_vg_lite_buffer_dump_info(pattern_image);
+        lv_vg_lite_matrix_dump_info(pattern_matrix);
+        LV_LOG_ERROR("blend: 0x%X,", (int)blend);
+        LV_LOG_ERROR("pattern_mode: 0x%X,", (int)pattern_mode);
+        lv_vg_lite_color_dump_info(pattern_color);
+        lv_vg_lite_color_dump_info(color);
+        LV_LOG_ERROR("filter: 0x%X,", (int)filter);
+    });
+    LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
+}
+
+static inline void lv_vg_lite_blit_rect(vg_lite_buffer_t * target,
+                                        vg_lite_buffer_t * source,
+                                        vg_lite_rectangle_t * rect,
+                                        vg_lite_matrix_t * matrix,
+                                        vg_lite_blend_t blend,
+                                        vg_lite_color_t color,
+                                        vg_lite_filter_t filter)
+{
+    LV_VG_LITE_ASSERT_DEST_BUFFER(target);
+    LV_VG_LITE_ASSERT_SRC_BUFFER(source);
+    LV_VG_LITE_ASSERT_MATRIX(matrix);
+
+    LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_blit_rect");
+    LV_VG_LITE_CHECK_ERROR(vg_lite_blit_rect(
+                               target,
+                               source,
+                               rect,
+                               matrix,
+                               blend,
+                               color,
+                               filter),
+                           /*Error handler*/
+    {
+        lv_vg_lite_buffer_dump_info(target);
+        lv_vg_lite_buffer_dump_info(source);
+        LV_LOG_ERROR("rect: X%d Y%d W%d H%d", rect->x, rect->y, rect->width, rect->height);
+        lv_vg_lite_matrix_dump_info(matrix);
+        LV_LOG_ERROR("blend: 0x%X", (int)blend);
+        lv_vg_lite_color_dump_info(color);
+        LV_LOG_ERROR("filter: 0x%X", (int)filter);
+    });
+    LV_PROFILER_DRAW_END_TAG("vg_lite_blit_rect");
+}
 
 /**********************
  *      MACROS

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -283,7 +283,8 @@ static inline void lv_vg_lite_blit_rect(vg_lite_buffer_t * target,
     {
         lv_vg_lite_buffer_dump_info(target);
         lv_vg_lite_buffer_dump_info(source);
-        LV_LOG_ERROR("rect: X%d Y%d W%d H%d", rect->x, rect->y, rect->width, rect->height);
+        LV_LOG_ERROR("rect: X%d Y%d W%d H%d",
+                     (int)rect->x, (int)rect->y, (int)rect->width, (int)rect->height);
         lv_vg_lite_matrix_dump_info(matrix);
         LV_LOG_ERROR("blend: 0x%X", (int)blend);
         lv_vg_lite_color_dump_info(color);


### PR DESCRIPTION
Enhanced the automatic diagnosis function of GPU errors.

```bash
[Error] (0.380, +380)    lv_vg_lite_draw: Execute 'vg_lite_draw( target, path, fill_rule, matrix, blend, color)' error: 4 lv_vg_lite_utils.h:194
[User]  (0.380, +0)      lv_vg_lite_error_dump_info: Error code: 4(TIMEOUT) lv_vg_lite_utils.c:100
[User]  (0.380, +0)      vg_lite_dump_command_buffer: command: vg_lite_tvg.cpp:2147
[User]  (0.380, +0)      vg_lite_dump_command_buffer: @[commit] vg_lite_tvg.cpp:2148
[User]  (0.380, +0)      lv_vg_lite_error_dump_info: Command buffer finished lv_vg_lite_utils.c:133
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: memory: 0x7fffd6a35800 lv_vg_lite_utils.c:446
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: address: 0xd6a35800 lv_vg_lite_utils.c:447
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: size: W800 x H600 lv_vg_lite_utils.c:448
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: stride: 3200 lv_vg_lite_utils.c:449
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: format: 1027 (BGRX8888) lv_vg_lite_utils.c:450
[User]  (0.380, +0)      lv_vg_lite_buffer_dump_info: tiled: 0 lv_vg_lite_utils.c:453
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: address: 0x60c00000b740 lv_vg_lite_utils.c:346
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: length: 14 lv_vg_lite_utils.c:347
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: bounding box: (0.00, 0.00) - (800.00, 600.00) lv_vg_lite_utils.c:348
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: format: 3 lv_vg_lite_utils.c:351
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: quality: 3 lv_vg_lite_utils.c:352
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: path_changed: 1 lv_vg_lite_utils.c:353
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: pdata_internal: 0 lv_vg_lite_utils.c:354
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: type: 0 lv_vg_lite_utils.c:355
[User]  (0.380, +0)      lv_vg_lite_path_dump_info: add_end: 1 lv_vg_lite_utils.c:356
MOVE, 0.000000, 0.000000,
LINE, 800.000000, 0.000000,
LINE, 800.000000, 600.000000,
LINE, 0.000000, 600.000000,
CLOSE,
END,
[Error] (0.380, +0)      lv_vg_lite_draw: fill_rule: 0x1900, lv_vg_lite_utils.h:205
[User]  (0.380, +0)      lv_vg_lite_matrix_dump_info: | 1.000000, 0.000000, 0.000000 | lv_vg_lite_utils.c:459
[User]  (0.380, +0)      lv_vg_lite_matrix_dump_info: | 0.000000, 1.000000, 0.000000 | lv_vg_lite_utils.c:459
[User]  (0.380, +0)      lv_vg_lite_matrix_dump_info: | 0.000000, 0.000000, 1.000000 | lv_vg_lite_utils.c:459
[Error] (0.380, +0)      lv_vg_lite_draw: blend: 0x1, lv_vg_lite_utils.h:207
[User]  (0.380, +0)      lv_vg_lite_color_dump_info: 0xFFF5F5F5 (A255, B245, G245, R245) lv_vg_lite_utils.c:466
[Error] (0.380, +0)      lv_vg_lite_draw: Asserted at expression: 0 lv_vg_lite_utils.h:194
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
