### PR TITLE
example(checkbox): Correct checkbox enable comment

### DIFF
--- a/examples/widgets/checkbox/lv_example_checkbox_2.c
+++ b/examples/widgets/checkbox/lv_example_checkbox_2.c
@@ -17,7 +17,7 @@ static void radio_event_handler(lv_event_t * e)
     if(act_cb == cont) return;
 
     lv_obj_remove_state(old_cb, LV_STATE_CHECKED);   /*Uncheck the previous radio button*/
-    lv_obj_add_state(act_cb, LV_STATE_CHECKED);     /*Uncheck the current radio button*/
+    lv_obj_add_state(act_cb, LV_STATE_CHECKED);     /*Check the current radio button*/
 
     *active_id = lv_obj_get_index(act_cb);
 


### PR DESCRIPTION
Comment says both old and active checkbox are unchecked, this PR corrects it.