### PR TITLE
feat(thorvg): use LVGL's malloc/realloc/zalloc/free

### DIFF
--- a/examples/widgets/lottie/lv_example_lottie_1.c
+++ b/examples/widgets/lottie/lv_example_lottie_1.c
@@ -7,17 +7,17 @@
  */
 void lv_example_lottie_1(void)
 {
-    extern const uint8_t lv_example_lottie_approve[];
-    extern const size_t lv_example_lottie_approve_size;
+    extern const uint8_t rain[];
+    extern const size_t rain_size;
 
     lv_obj_t * lottie = lv_lottie_create(lv_screen_active());
-    lv_lottie_set_src_data(lottie, lv_example_lottie_approve, lv_example_lottie_approve_size);
+    lv_lottie_set_src_data(lottie, rain, rain_size);
 
 #if LV_DRAW_BUF_ALIGN == 4 && LV_DRAW_BUF_STRIDE_ALIGN == 1
     /*If there are no special requirements, just declare a buffer
       x4 because the Lottie is rendered in ARGB8888 format*/
-    static uint8_t buf[64 * 64 * 4];
-    lv_lottie_set_buffer(lottie, 64, 64, buf);
+    static uint8_t buf[364 * 364 * 4];
+    lv_lottie_set_buffer(lottie, 364, 364, buf);
 #else
     /*For GPUs and special alignment/strid setting use a draw_buf instead*/
     LV_DRAW_BUF_DEFINE(draw_buf, 64, 64, LV_COLOR_FORMAT_ARGB8888);

--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -428,7 +428,7 @@ void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc
     int32_t height = lv_area_get_height(&layer->buf_area) - 1;
     uint32_t stride = draw_buf->header.stride;
     Tvg_Canvas * canvas = tvg_swcanvas_create();
-    tvg_swcanvas_set_target(canvas, buf, stride / 4, width, height, TVG_COLORSPACE_ARGB8888);
+    tvg_swcanvas_set_target(canvas, buf, stride / 4, width, height, TVG_COLORSPACE_ARGB8888S);
 
     _tvg_rect rc;
     lv_area_to_tvg(&rc, &t->clip_area);

--- a/src/libs/thorvg/rapidjson/allocators.h
+++ b/src/libs/thorvg/rapidjson/allocators.h
@@ -25,6 +25,8 @@
 #include <type_traits>
 #endif
 
+#include "../../../misc/lv_assert.h"
+
 RAPIDJSON_NAMESPACE_BEGIN
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -84,10 +86,13 @@ class CrtAllocator {
 public:
     static const bool kNeedFree = true;
     void* Malloc(size_t size) {
-        if (size) //  behavior of malloc(0) is implementation defined.
-            return RAPIDJSON_MALLOC(size);
-        else
+        if (size) { //  behavior of malloc(0) is implementation defined.
+            void * p = RAPIDJSON_MALLOC(size);
+            LV_ASSERT_MALLOC(p);
+            return p;
+        } else {
             return NULL; // standardize to returning NULL.
+        }
     }
     void* Realloc(void* originalPtr, size_t originalSize, size_t newSize) {
         (void)originalSize;
@@ -95,7 +100,9 @@ public:
             RAPIDJSON_FREE(originalPtr);
             return NULL;
         }
-        return RAPIDJSON_REALLOC(originalPtr, newSize);
+        void * p = RAPIDJSON_REALLOC(originalPtr, newSize);
+        LV_ASSERT_MALLOC(p);
+        return p;
     }
     static void Free(void *ptr) RAPIDJSON_NOEXCEPT { RAPIDJSON_FREE(ptr); }
 

--- a/src/libs/thorvg/rapidjson/rapidjson.h
+++ b/src/libs/thorvg/rapidjson/rapidjson.h
@@ -690,18 +690,18 @@ RAPIDJSON_NAMESPACE_END
 
 ///////////////////////////////////////////////////////////////////////////////
 // malloc/realloc/free
-
+#include "../../../stdlib/lv_mem.h"
 #ifndef RAPIDJSON_MALLOC
 ///! customization point for global \c malloc
-#define RAPIDJSON_MALLOC(size) std::malloc(size)
+#define RAPIDJSON_MALLOC(size) lv_malloc(size)
 #endif
 #ifndef RAPIDJSON_REALLOC
 ///! customization point for global \c realloc
-#define RAPIDJSON_REALLOC(ptr, new_size) std::realloc(ptr, new_size)
+#define RAPIDJSON_REALLOC(ptr, new_size) lv_realloc(ptr, new_size)
 #endif
 #ifndef RAPIDJSON_FREE
 ///! customization point for global \c free
-#define RAPIDJSON_FREE(ptr) std::free(ptr)
+#define RAPIDJSON_FREE(ptr) lv_free(ptr)
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/libs/thorvg/thorvg.h
+++ b/src/libs/thorvg/thorvg.h
@@ -16,6 +16,9 @@
 #include <memory>
 #include <string>
 #include <list>
+#include "../../stdlib/lv_mem.h"
+#include "../../stdlib/lv_string.h"
+#include "../../misc/lv_assert.h"
 
 #ifdef TVG_API
     #undef TVG_API
@@ -1056,7 +1059,7 @@ public:
      * @param[in] miterlimit The miterlimit imposes a limit on the extent of the stroke join, when the @c StrokeJoin::Miter join style is set. The default value is 4.
      *
      * @retval Result::InvalidArgument for @p miterlimit values less than zero.
-     * 
+     *
      * @since 0.11
      */
     Result strokeMiterlimit(float miterlimit) noexcept;
@@ -1605,7 +1608,7 @@ public:
      *
      * @note If the font data is currently in use, it will not be immediately unloaded.
      * @see Text::load(const std::string& path)
-     * 
+     *
      * @since 0.15
      */
     static Result unload(const std::string& path) noexcept;

--- a/src/libs/thorvg/tvgArray.h
+++ b/src/libs/thorvg/tvgArray.h
@@ -57,7 +57,8 @@ struct Array
     {
         if (count + 1 > reserved) {
             reserved = count + (count + 2) / 2;
-            data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
+            data = static_cast<T*>(lv_realloc(data, sizeof(T) * reserved));
+            LV_ASSERT_MALLOC(data);
         }
         data[count++] = element;
     }
@@ -74,7 +75,8 @@ struct Array
     {
         if (size > reserved) {
             reserved = size;
-            data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
+            data = static_cast<T*>(lv_realloc(data, sizeof(T) * reserved));
+            LV_ASSERT_MALLOC(data);
         }
         return true;
     }
@@ -141,7 +143,7 @@ struct Array
 
     void reset()
     {
-        free(data);
+        lv_free(data);
         data = nullptr;
         count = reserved = 0;
     }
@@ -171,7 +173,7 @@ struct Array
 
     ~Array()
     {
-        free(data);
+        lv_free(data);
     }
 
 private:

--- a/src/libs/thorvg/tvgCompressor.cpp
+++ b/src/libs/thorvg/tvgCompressor.cpp
@@ -57,8 +57,7 @@
  * http://marknelson.us/1989/10/01/lzw-data-compression/
  */
 #include "config.h"
-
-
+#include "thorvg.h"
 
 #include <string>
 #include <memory.h>
@@ -112,7 +111,8 @@ struct BitStreamWriter
 
     uint8_t* allocBytes(const int bytesWanted, uint8_t * oldPtr, const int oldSize)
     {
-        auto newMemory = static_cast<uint8_t *>(malloc(bytesWanted));
+        auto newMemory = static_cast<uint8_t *>(lv_malloc(bytesWanted));
+        LV_ASSERT_MALLOC(newMemory);
         memset(newMemory, 0, bytesWanted);
 
         if (oldPtr) {
@@ -349,7 +349,8 @@ uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint
     int firstByte = 0;
     int bytesDecoded = 0;
     int codeBitsWidth = StartBits;
-    auto uncompressed = (uint8_t*) malloc(sizeof(uint8_t) * uncompressedSizeBytes);
+    auto uncompressed = (uint8_t*) lv_malloc(sizeof(uint8_t) * uncompressedSizeBytes);
+    LV_ASSERT_MALLOC(uncompressed);
     auto ptr = uncompressed;
 
     /* We'll reconstruct the dictionary based on the bit stream codes.
@@ -445,7 +446,8 @@ size_t b64Decode(const char* encoded, const size_t len, char** decoded)
     if (!decoded || !encoded || len == 0) return 0;
 
     auto reserved = 3 * (1 + (len >> 2)) + 1;
-    auto output = static_cast<char*>(malloc(reserved * sizeof(char)));
+    auto output = static_cast<char*>(lv_malloc(reserved * sizeof(char)));
+    LV_ASSERT_MALLOC(output);
     if (!output) return 0;
     output[reserved - 1] = '\0';
 

--- a/src/libs/thorvg/tvgFill.cpp
+++ b/src/libs/thorvg/tvgFill.cpp
@@ -103,7 +103,8 @@ Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept
     }
 
     if (pImpl->cnt != cnt) {
-        pImpl->colorStops = static_cast<ColorStop*>(realloc(pImpl->colorStops, cnt * sizeof(ColorStop)));
+        pImpl->colorStops = static_cast<ColorStop*>(lv_realloc(pImpl->colorStops, cnt * sizeof(ColorStop)));
+        LV_ASSERT_MALLOC(pImpl->colorStops);
     }
 
     pImpl->cnt = cnt;
@@ -138,7 +139,8 @@ FillSpread Fill::spread() const noexcept
 Result Fill::transform(const Matrix& m) noexcept
 {
     if (!pImpl->transform) {
-        pImpl->transform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
+        pImpl->transform = static_cast<Matrix*>(lv_malloc(sizeof(Matrix)));
+        LV_ASSERT_MALLOC(pImpl->transform);
     }
     *pImpl->transform = m;
     return Result::Success;

--- a/src/libs/thorvg/tvgFill.h
+++ b/src/libs/thorvg/tvgFill.h
@@ -62,8 +62,8 @@ struct Fill::Impl
     ~Impl()
     {
         delete(dup);
-        free(colorStops);
-        free(transform);
+        lv_free(colorStops);
+        lv_free(transform);
     }
 
     void method(DuplicateMethod<Fill>* dup)
@@ -78,10 +78,12 @@ struct Fill::Impl
 
         ret->pImpl->cnt = cnt;
         ret->pImpl->spread = spread;
-        ret->pImpl->colorStops = static_cast<ColorStop*>(malloc(sizeof(ColorStop) * cnt));
+        ret->pImpl->colorStops = static_cast<ColorStop*>(lv_malloc(sizeof(ColorStop) * cnt));
+        LV_ASSERT_MALLOC(ret->pImpl->colorStops);
         memcpy(ret->pImpl->colorStops, colorStops, sizeof(ColorStop) * cnt);
         if (transform) {
-            ret->pImpl->transform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
+            ret->pImpl->transform = static_cast<Matrix*>(lv_malloc(sizeof(Matrix)));
+			LV_ASSERT_MALLOC(ret->pImpl->transform);
             *ret->pImpl->transform = *transform;
         }
         return ret;

--- a/src/libs/thorvg/tvgLoadModule.h
+++ b/src/libs/thorvg/tvgLoadModule.h
@@ -48,7 +48,7 @@ struct LoadModule
     LoadModule(FileType type) : type(type) {}
     virtual ~LoadModule()
     {
-        if (pathcache) free(hashpath);
+        if (pathcache) lv_free(hashpath);
     }
 
     virtual bool open(const string& path) { return false; }

--- a/src/libs/thorvg/tvgLoader.cpp
+++ b/src/libs/thorvg/tvgLoader.cpp
@@ -309,7 +309,7 @@ LoadModule* LoaderMgr::loader(const string& path, bool* invalid)
     if (auto loader = _findByPath(path)) {
         if (loader->open(path)) {
             if (allowCache) {
-                loader->hashpath = strdup(path.c_str());
+                loader->hashpath = lv_strdup(path.c_str());
                 loader->pathcache = true;
                 {
                     ScopedLock lock(key);
@@ -325,7 +325,7 @@ LoadModule* LoaderMgr::loader(const string& path, bool* invalid)
         if (auto loader = _find(static_cast<FileType>(i))) {
             if (loader->open(path)) {
                 if (allowCache) {
-                    loader->hashpath = strdup(path.c_str());
+                    loader->hashpath = lv_strdup(path.c_str());
                     loader->pathcache = true;
                     {
                         ScopedLock lock(key);
@@ -448,7 +448,7 @@ LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size,
     //function is dedicated for ttf loader (the only supported font loader)
     auto loader = new TtfLoader;
     if (loader->open(data, size, copy)) {
-        loader->hashpath = strdup(name);
+        loader->hashpath = lv_strdup(name);
         loader->pathcache = true;
         ScopedLock lock(key);
         _activeLoaders.back(loader);

--- a/src/libs/thorvg/tvgLottieBuilder.cpp
+++ b/src/libs/thorvg/tvgLottieBuilder.cpp
@@ -181,7 +181,10 @@ void LottieBuilder::updateTransform(LottieGroup* parent, LottieObject** child, f
     uint8_t opacity;
 
     if (parent->mergeable()) {
-        if (!ctx->transform) ctx->transform = (Matrix*)malloc(sizeof(Matrix));
+        if (!ctx->transform) {
+        	ctx->transform = (Matrix*)lv_malloc(sizeof(Matrix));
+            LV_ASSERT_MALLOC(ctx->transform);
+        }
         _updateTransform(transform, frameNo, false, *ctx->transform, opacity, exps);
         return;
     }
@@ -481,7 +484,7 @@ void LottieBuilder::updateRect(LottieGroup* parent, LottieObject** child, float 
     } else {
         r = std::min({r, size.x * 0.5f, size.y * 0.5f});
     }
-    
+
     if (!ctx->repeaters.empty()) {
         auto shape = rect->pooling();
         shape->reset();
@@ -531,7 +534,7 @@ static void _appendCircle(Shape* shape, float cx, float cy, float rx, float ry, 
             points[i] *= *transform;
         }
     }
-    
+
     shape->appendPath(commands, cmdsCnt, points, ptsCnt);
 }
 

--- a/src/libs/thorvg/tvgLottieBuilder.h
+++ b/src/libs/thorvg/tvgLottieBuilder.h
@@ -74,7 +74,7 @@ struct RenderContext
     ~RenderContext()
     {
         PP(propagator)->unref();
-        free(transform);
+        lv_free(transform);
         delete(roundness);
         delete(offsetPath);
     }

--- a/src/libs/thorvg/tvgLottieExpressions.cpp
+++ b/src/libs/thorvg/tvgLottieExpressions.cpp
@@ -63,7 +63,8 @@ static LottieExpressions* exps = nullptr;   //singleton instance engine
 
 static ExpContent* _expcontent(LottieExpression* exp, float frameNo, LottieObject* obj)
 {
-    auto data = (ExpContent*)malloc(sizeof(ExpContent));
+    auto data = (ExpContent*)lv_malloc(sizeof(ExpContent));
+    LV_ASSERT_MALLOC(ndata);
     data->exp = exp;
     data->frameNo = frameNo;
     data->obj = obj;
@@ -73,7 +74,7 @@ static ExpContent* _expcontent(LottieExpression* exp, float frameNo, LottieObjec
 
 static void contentFree(void *native_p, struct jerry_object_native_info_t *info_p)
 {
-    free(native_p);
+    lv_free(native_p);
 }
 
 static jerry_object_native_info_t freeCb {contentFree, 0, 0};
@@ -84,7 +85,8 @@ static char* _name(jerry_value_t args)
 {
     auto arg0 = jerry_value_to_string(args);
     auto len = jerry_string_length(arg0);
-    auto name = (jerry_char_t*)malloc(len * sizeof(jerry_char_t) + 1);
+    auto name = (jerry_char_t*)lv_malloc(len * sizeof(jerry_char_t) + 1);
+    LV_ASSERT_MALLOC(name);
     jerry_string_to_buffer(arg0, JERRY_ENCODING_UTF8, name, len);
     name[len] = '\0';
     jerry_value_free(arg0);
@@ -96,7 +98,7 @@ static unsigned long _idByName(jerry_value_t args)
 {
     auto name = _name(args);
     auto id = djb2Encode(name);
-    free(name);
+    lv_free(name);
     return id;
 }
 
@@ -832,7 +834,7 @@ static bool _loopOutCommon(LottieExpression* exp, const jerry_value_t args[], co
         else if (!strcmp(name, EXP_PINGPONG)) exp->loop.mode = LottieExpression::LoopMode::OutPingPong;
         else if (!strcmp(name, EXP_OFFSET)) exp->loop.mode = LottieExpression::LoopMode::OutOffset;
         else if (!strcmp(name, EXP_CONTINUE)) exp->loop.mode = LottieExpression::LoopMode::OutContinue;
-        free(name);
+        lv_free(name);
     }
 
     if (exp->loop.mode != LottieExpression::LoopMode::OutCycle && exp->loop.mode != LottieExpression::LoopMode::OutPingPong) {
@@ -884,7 +886,7 @@ static bool _loopInCommon(LottieExpression* exp, const jerry_value_t args[], con
         else if (!strcmp(name, EXP_PINGPONG)) exp->loop.mode = LottieExpression::LoopMode::InPingPong;
         else if (!strcmp(name, EXP_OFFSET)) exp->loop.mode = LottieExpression::LoopMode::InOffset;
         else if (!strcmp(name, EXP_CONTINUE)) exp->loop.mode = LottieExpression::LoopMode::InContinue;
-        free(name);
+        lv_free(name);
     }
 
     if (exp->loop.mode != LottieExpression::LoopMode::InCycle && exp->loop.mode != LottieExpression::LoopMode::InPingPong) {

--- a/src/libs/thorvg/tvgLottieInterpolator.cpp
+++ b/src/libs/thorvg/tvgLottieInterpolator.cpp
@@ -130,7 +130,7 @@ float LottieInterpolator::progress(float t)
 
 void LottieInterpolator::set(const char* key, Point& inTangent, Point& outTangent)
 {
-    this->key = strdup(key);
+    this->key = lv_strdup(key);
     this->inTangent = inTangent;
     this->outTangent = outTangent;
 

--- a/src/libs/thorvg/tvgLottieLoader.cpp
+++ b/src/libs/thorvg/tvgLottieLoader.cpp
@@ -57,10 +57,10 @@ void LottieLoader::run(unsigned tid)
 void LottieLoader::release()
 {
     if (copy) {
-        free((char*)content);
+        lv_free((char*)content);
         content = nullptr;
     }
-    free(dirName);
+    lv_free(dirName);
     dirName = nullptr;
 }
 
@@ -201,13 +201,14 @@ bool LottieLoader::header()
 bool LottieLoader::open(const char* data, uint32_t size, bool copy)
 {
     if (copy) {
-        content = (char*)malloc(size + 1);
+        content = (char*)lv_malloc(size + 1);
+        LV_ASSERT_MALLOC(content);
         if (!content) return false;
         memcpy((char*)content, data, size);
         const_cast<char*>(content)[size] = '\0';
     } else content = data;
 
-    this->dirName = strdup(".");
+    this->dirName = lv_strdup(".");
 
     this->size = size;
     this->copy = copy;
@@ -229,7 +230,8 @@ bool LottieLoader::open(const string& path)
         return false;
     }
 
-    auto content = (char*)(malloc(sizeof(char) * size + 1));
+    auto content = (char*)(lv_malloc(sizeof(char) * size + 1));
+    LV_ASSERT_MALLOC(content);
     fseek(f, 0, SEEK_SET);
     auto ret = fread(content, sizeof(char), size, f);
     if (ret < size) {
@@ -298,7 +300,7 @@ bool LottieLoader::override(const char* slot)
     //override slots
     if (slot) {
         //Copy the input data because the JSON parser will encode the data immediately.
-        auto temp = strdup(slot);
+        auto temp = lv_strdup(slot);
 
         //parsing slot json
         LottieParser parser(temp, dirName);
@@ -315,7 +317,7 @@ bool LottieLoader::override(const char* slot)
         }
 
         if (idx < 1) success = false;
-        free(temp);
+        lv_free(temp);
         rebuild = overridden = success;
     //reset slots
     } else if (overridden) {

--- a/src/libs/thorvg/tvgLottieModel.cpp
+++ b/src/libs/thorvg/tvgLottieModel.cpp
@@ -133,8 +133,8 @@ void LottieTextRange::range(float frameNo, float totalLen, float& start, float& 
 
 LottieImage::~LottieImage()
 {
-    free(b64Data);
-    free(mimeType);
+    lv_free(b64Data);
+    lv_free(mimeType);
 }
 
 
@@ -423,7 +423,7 @@ LottieLayer::~LottieLayer()
     }
 
     delete(transform);
-    free(name);
+    lv_free(name);
 }
 
 
@@ -473,13 +473,13 @@ LottieComposition::~LottieComposition()
     if (!initiated && root) delete(root->scene);
 
     delete(root);
-    free(version);
-    free(name);
+    lv_free(version);
+    lv_free(name);
 
     //delete interpolators
     for (auto i = interpolators.begin(); i < interpolators.end(); ++i) {
-        free((*i)->key);
-        free(*i);
+    	lv_free((*i)->key);
+    	lv_free(*i);
     }
 
     //delete assets
@@ -496,7 +496,7 @@ LottieComposition::~LottieComposition()
     for (auto s = slots.begin(); s < slots.end(); ++s) {
         delete(*s);
     }
-    
+
     for (auto m = markers.begin(); m < markers.end(); ++m) {
         delete(*m);
     }

--- a/src/libs/thorvg/tvgLottieModel.h
+++ b/src/libs/thorvg/tvgLottieModel.h
@@ -177,7 +177,7 @@ struct LottieGlyph
     ~LottieGlyph()
     {
         for (auto p = children.begin(); p < children.end(); ++p) delete(*p);
-        free(code);
+        lv_free(code);
     }
 };
 
@@ -229,9 +229,9 @@ struct LottieFont
     ~LottieFont()
     {
         for (auto c = chars.begin(); c < chars.end(); ++c) delete(*c);
-        free(style);
-        free(family);
-        free(name);
+        lv_free(style);
+        lv_free(family);
+        lv_free(name);
     }
 
     Array<LottieGlyph*> chars;
@@ -247,10 +247,10 @@ struct LottieMarker
     char* name = nullptr;
     float time = 0.0f;
     float duration = 0.0f;
-    
+
     ~LottieMarker()
     {
-        free(name);
+    	lv_free(name);
     }
 };
 
@@ -500,7 +500,7 @@ struct LottieTransform : LottieObject
 };
 
 
-struct LottieSolid : LottieObject 
+struct LottieSolid : LottieObject
 {
     LottieColor color = RGB24{255, 255, 255};
     LottieOpacity opacity = 255;
@@ -836,7 +836,7 @@ struct LottieSlot
 
     ~LottieSlot()
     {
-        free(sid);
+    	lv_free(sid);
         if (!overridden) return;
         for (auto pair = pairs.begin(); pair < pairs.end(); ++pair) {
             delete(pair->prop);

--- a/src/libs/thorvg/tvgLottieParser.cpp
+++ b/src/libs/thorvg/tvgLottieParser.cpp
@@ -373,7 +373,7 @@ template<typename T>
 bool LottieParser::parseTangent(const char *key, LottieVectorFrame<T>& value)
 {
     if (KEY_AS("ti") && getValue(value.inTangent)) ;
-    else if (KEY_AS("to") && getValue(value.outTangent)) ;       
+    else if (KEY_AS("to") && getValue(value.outTangent)) ;
     else return false;
 
     value.hasTangent = true;
@@ -406,7 +406,8 @@ LottieInterpolator* LottieParser::getInterpolator(const char* key, Point& in, Po
 
     //new interpolator
     if (!interpolator) {
-        interpolator = static_cast<LottieInterpolator*>(malloc(sizeof(LottieInterpolator)));
+        interpolator = static_cast<LottieInterpolator*>(lv_malloc(sizeof(LottieInterpolator)));
+        LV_ASSERT_MALLOC(interpolator);
         interpolator->set(key, in, out);
         comp->interpolators.push(interpolator);
     }
@@ -944,7 +945,8 @@ LottieImage* LottieParser::parseImage(const char* data, const char* subPath, boo
     //external image resource
     } else {
         auto len = strlen(dirName) + strlen(subPath) + strlen(data) + 1;
-        image->path = static_cast<char*>(malloc(len));
+        image->path = static_cast<char*>(lv_malloc(len));
+        LV_ASSERT_MALLOC(image->path);
         snprintf(image->path, len, "%s%s%s", dirName, subPath, data);
     }
 
@@ -1024,16 +1026,16 @@ void LottieParser::parseAssets()
 LottieMarker* LottieParser::parseMarker()
 {
     enterObject();
-    
+
     auto marker = new LottieMarker;
-    
+
     while (auto key = nextObjectKey()) {
         if (KEY_AS("cm")) marker->name = getStringCopy();
         else if (KEY_AS("tm")) marker->time = getFloat();
         else if (KEY_AS("dr")) marker->duration = getFloat();
         else skip(key);
     }
-    
+
     return marker;
 }
 
@@ -1406,8 +1408,8 @@ void LottieParser::postProcess(Array<LottieGlyph*>& glyphs)
             auto& font = comp->fonts[i];
             if (!strcmp(font->family, glyph->family) && !strcmp(font->style, glyph->style)) {
                 font->chars.push(glyph);
-                free(glyph->family);
-                free(glyph->style);
+                lv_free(glyph->family);
+                lv_free(glyph->style);
                 break;
             }
         }

--- a/src/libs/thorvg/tvgLottieParserHandler.cpp
+++ b/src/libs/thorvg/tvgLottieParserHandler.cpp
@@ -126,7 +126,7 @@ const char* LookaheadParserHandler::getString()
 char* LookaheadParserHandler::getStringCopy()
 {
     auto str = getString();
-    if (str) return strdup(str);
+    if (str) return lv_strdup(str);
     return nullptr;
 }
 

--- a/src/libs/thorvg/tvgLottieProperty.h
+++ b/src/libs/thorvg/tvgLottieProperty.h
@@ -148,7 +148,7 @@ struct LottieExpression
 
     ~LottieExpression()
     {
-        free(code);
+    	lv_free(code);
     }
 };
 
@@ -364,17 +364,17 @@ struct LottiePathSet : LottieProperty
             exp = nullptr;
         }
 
-        free(value.cmds);
-        free(value.pts);
+        lv_free(value.cmds);
+        lv_free(value.pts);
 
         if (!frames) return;
 
         for (auto p = frames->begin(); p < frames->end(); ++p) {
-            free((*p).value.cmds);
-            free((*p).value.pts);
+        	lv_free((*p).value.cmds);
+        	lv_free((*p).value.pts);
         }
-        free(frames->data);
-        free(frames);
+        lv_free(frames->data);
+        lv_free(frames);
     }
 
     uint32_t nearest(float frameNo) override
@@ -395,7 +395,8 @@ struct LottiePathSet : LottieProperty
     LottieScalarFrame<PathSet>& newFrame()
     {
         if (!frames) {
-            frames = static_cast<Array<LottieScalarFrame<PathSet>>*>(calloc(1, sizeof(Array<LottieScalarFrame<PathSet>>)));
+            frames = static_cast<Array<LottieScalarFrame<PathSet>>*>(lv_zalloc(sizeof(Array<LottieScalarFrame<PathSet>>)));
+            LV_ASSERT_MALLOC(frames);
         }
         if (frames->count + 1 >= frames->reserved) {
             auto old = frames->reserved;
@@ -465,7 +466,8 @@ struct LottiePathSet : LottieProperty
             return true;
         }
 
-        auto interpPts = (Point*)malloc(frame->value.ptsCnt * sizeof(Point));
+        auto interpPts = (Point*)lv_malloc(frame->value.ptsCnt * sizeof(Point));
+        LV_ASSERT_MALLOC(interpPts);
         auto p = interpPts;
         for (auto i = 0; i < frame->value.ptsCnt; ++i, ++s, ++e, ++p) {
             *p = lerp(*s, *e, t);
@@ -481,7 +483,7 @@ struct LottiePathSet : LottieProperty
             } else roundness->modifyPath(frame->value.cmds, frame->value.cmdsCnt, interpPts, frame->value.ptsCnt, cmds, pts, nullptr);
         } else if (offsetPath) offsetPath->modifyPath(frame->value.cmds, frame->value.cmdsCnt, interpPts, frame->value.ptsCnt, cmds, pts);
 
-        free(interpPts);
+        lv_free(interpPts);
 
         return true;
     }
@@ -520,17 +522,17 @@ struct LottieColorStop : LottieProperty
         }
 
         if (value.data) {
-            free(value.data);
+        	lv_free(value.data);
             value.data = nullptr;
         }
 
         if (!frames) return;
 
         for (auto p = frames->begin(); p < frames->end(); ++p) {
-            free((*p).value.data);
+        	lv_free((*p).value.data);
         }
-        free(frames->data);
-        free(frames);
+        lv_free(frames->data);
+        lv_free(frames);
         frames = nullptr;
     }
 
@@ -552,7 +554,8 @@ struct LottieColorStop : LottieProperty
     LottieScalarFrame<ColorStop>& newFrame()
     {
         if (!frames) {
-            frames = static_cast<Array<LottieScalarFrame<ColorStop>>*>(calloc(1, sizeof(Array<LottieScalarFrame<ColorStop>>)));
+            frames = static_cast<Array<LottieScalarFrame<ColorStop>>*>(lv_zalloc(sizeof(Array<LottieScalarFrame<ColorStop>>)));
+            LV_ASSERT_MALLOC(frames);
         }
         if (frames->count + 1 >= frames->reserved) {
             auto old = frames->reserved;
@@ -753,19 +756,19 @@ struct LottieTextDoc : LottieProperty
         }
 
         if (value.text) {
-            free(value.text);
+        	lv_free(value.text);
             value.text = nullptr;
         }
         if (value.name) {
-            free(value.name);
+        	lv_free(value.name);
             value.name = nullptr;
         }
 
         if (!frames) return;
 
         for (auto p = frames->begin(); p < frames->end(); ++p) {
-            free((*p).value.text);
-            free((*p).value.name);
+        	lv_free((*p).value.text);
+        	lv_free((*p).value.name);
         }
         delete(frames);
         frames = nullptr;

--- a/src/libs/thorvg/tvgPaint.cpp
+++ b/src/libs/thorvg/tvgPaint.cpp
@@ -366,7 +366,7 @@ void Paint::Impl::reset()
 
     if (compData) {
         if (P(compData->target)->unref() == 0) delete(compData->target);
-        free(compData);
+        lv_free(compData);
         compData = nullptr;
     }
 

--- a/src/libs/thorvg/tvgPaint.h
+++ b/src/libs/thorvg/tvgPaint.h
@@ -90,7 +90,7 @@ namespace tvg
         {
             if (compData) {
                 if (P(compData->target)->unref() == 0) delete(compData->target);
-                free(compData);
+                lv_free(compData);
             }
             if (clipper && P(clipper)->unref() == 0) delete(clipper);
             if (renderer && (renderer->unref() == 0)) delete(renderer);
@@ -151,13 +151,14 @@ namespace tvg
                 }
                 //Reset scenario
                 if (!target && method == CompositeMethod::None) {
-                    free(compData);
+                	lv_free(compData);
                     compData = nullptr;
                     return true;
                 }
             } else {
                 if (!target && method == CompositeMethod::None) return true;
-                compData = static_cast<Composite*>(calloc(1, sizeof(Composite)));
+                compData = static_cast<Composite*>(lv_zalloc(sizeof(Composite)));
+                LV_ASSERT_MALLOC(compData);
             }
             P(target)->ref();
             compData->target = target;

--- a/src/libs/thorvg/tvgRawLoader.cpp
+++ b/src/libs/thorvg/tvgRawLoader.cpp
@@ -44,7 +44,7 @@ RawLoader::RawLoader() : ImageLoader(FileType::Raw)
 
 RawLoader::~RawLoader()
 {
-    if (copy) free(surface.buf32);
+    if (copy) lv_free(surface.buf32);
 }
 
 
@@ -59,7 +59,8 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool copy)
     this->copy = copy;
 
     if (copy) {
-        surface.buf32 = (uint32_t*)malloc(sizeof(uint32_t) * w * h);
+        surface.buf32 = (uint32_t*)lv_malloc(sizeof(uint32_t) * w * h);
+        LV_ASSERT_MALLOC(surface.buf32);
         if (!surface.buf32) return false;
         memcpy((void*)surface.buf32, data, sizeof(uint32_t) * w * h);
     }

--- a/src/libs/thorvg/tvgRender.h
+++ b/src/libs/thorvg/tvgRender.h
@@ -132,9 +132,10 @@ struct RenderStroke
         if (rhs.fill) fill = rhs.fill->duplicate();
         else fill = nullptr;
 
-        free(dashPattern);
+        lv_free(dashPattern);
         if (rhs.dashCnt > 0) {
-            dashPattern = static_cast<float*>(malloc(sizeof(float) * rhs.dashCnt));
+            dashPattern = static_cast<float*>(lv_malloc(sizeof(float) * rhs.dashCnt));
+            LV_ASSERT_MALLOC(dashPattern);
             memcpy(dashPattern, rhs.dashPattern, sizeof(float) * rhs.dashCnt);
         } else {
             dashPattern = nullptr;
@@ -175,7 +176,7 @@ struct RenderStroke
 
     ~RenderStroke()
     {
-        free(dashPattern);
+    	lv_free(dashPattern);
         delete(fill);
     }
 };
@@ -275,7 +276,7 @@ struct RenderEffect
 
     virtual ~RenderEffect()
     {
-        free(rd);
+    	lv_free(rd);
     }
 };
 

--- a/src/libs/thorvg/tvgShape.h
+++ b/src/libs/thorvg/tvgShape.h
@@ -109,7 +109,7 @@ struct Shape::Impl
 
         if ((needComp = needComposition(opacity))) {
             /* Overriding opacity value. If this scene is half-translucent,
-               It must do intermediate composition with that opacity value. */ 
+               It must do intermediate composition with that opacity value. */
             this->opacity = opacity;
             opacity = 255;
         }
@@ -310,16 +310,17 @@ struct Shape::Impl
 
         //Reset dash
         if (!pattern && cnt == 0) {
-            free(rs.stroke->dashPattern);
+        	lv_free(rs.stroke->dashPattern);
             rs.stroke->dashPattern = nullptr;
         } else {
             if (!rs.stroke) rs.stroke = new RenderStroke();
             if (rs.stroke->dashCnt != cnt) {
-                free(rs.stroke->dashPattern);
+            	lv_free(rs.stroke->dashPattern);
                 rs.stroke->dashPattern = nullptr;
             }
             if (!rs.stroke->dashPattern) {
-                rs.stroke->dashPattern = static_cast<float*>(malloc(sizeof(float) * cnt));
+                rs.stroke->dashPattern = static_cast<float*>(lv_malloc(sizeof(float) * cnt));
+                LV_ASSERT_MALLOC(rs.stroke->dashPattern);
                 if (!rs.stroke->dashPattern) return Result::FailedAllocation;
             }
             for (uint32_t i = 0; i < cnt; ++i) {

--- a/src/libs/thorvg/tvgStr.cpp
+++ b/src/libs/thorvg/tvgStr.cpp
@@ -215,7 +215,8 @@ char* strDuplicate(const char *str, size_t n)
     auto len = strlen(str);
     if (len < n) n = len;
 
-    auto ret = (char *) malloc(n + 1);
+    auto ret = (char *) lv_malloc(n + 1);
+    LV_ASSERT_MALLOC(ret);
     if (!ret) return nullptr;
     ret[n] = '\0';
 
@@ -226,7 +227,8 @@ char* strAppend(char* lhs, const char* rhs, size_t n)
 {
     if (!rhs) return lhs;
     if (!lhs) return strDuplicate(rhs, n);
-    lhs = (char*)realloc(lhs, strlen(lhs) + n + 1);
+    lhs = (char*)lv_realloc(lhs, strlen(lhs) + n + 1);
+    LV_ASSERT_MALLOC(lhs);
     return strncat(lhs, rhs, n);
 }
 

--- a/src/libs/thorvg/tvgSvgCssStyle.cpp
+++ b/src/libs/thorvg/tvgSvgCssStyle.cpp
@@ -75,8 +75,8 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from)
         to->fill.paint.none = from->fill.paint.none;
         to->fill.paint.curColor = from->fill.paint.curColor;
         if (from->fill.paint.url) {
-            if (to->fill.paint.url) free(to->fill.paint.url);
-            to->fill.paint.url = strdup(from->fill.paint.url);
+            if (to->fill.paint.url) lv_free(to->fill.paint.url);
+            to->fill.paint.url = lv_strdup(from->fill.paint.url);
         }
         to->fill.flags = (to->fill.flags | SvgFillFlags::Paint);
         to->flags = (to->flags | SvgStyleFlags::Fill);
@@ -109,8 +109,8 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from)
         to->stroke.paint.none = from->stroke.paint.none;
         to->stroke.paint.curColor = from->stroke.paint.curColor;
         if (from->stroke.paint.url) {
-            if (to->stroke.paint.url) free(to->stroke.paint.url);
-            to->stroke.paint.url = strdup(from->stroke.paint.url);
+            if (to->stroke.paint.url) lv_free(to->stroke.paint.url);
+            to->stroke.paint.url = lv_strdup(from->stroke.paint.url);
         }
         to->stroke.flags = (to->stroke.flags | SvgStrokeFlags::Paint);
         to->flags = (to->flags | SvgStyleFlags::Stroke);
@@ -190,7 +190,8 @@ void cssCopyStyleAttr(SvgNode* to, const SvgNode* from)
 {
     //Copy matrix attribute
     if (from->transform && !(to->style->flags & SvgStyleFlags::Transform)) {
-        to->transform = (Matrix*)malloc(sizeof(Matrix));
+        to->transform = (Matrix*)lv_malloc(sizeof(Matrix));
+        LV_ASSERT_MALLOC(to->transform);
         if (to->transform) {
             *to->transform = *from->transform;
             to->style->flags = (to->style->flags | SvgStyleFlags::Transform);
@@ -200,12 +201,12 @@ void cssCopyStyleAttr(SvgNode* to, const SvgNode* from)
     _copyStyle(to->style, from->style);
 
     if (from->style->clipPath.url) {
-        if (to->style->clipPath.url) free(to->style->clipPath.url);
-        to->style->clipPath.url = strdup(from->style->clipPath.url);
+        if (to->style->clipPath.url) lv_free(to->style->clipPath.url);
+        to->style->clipPath.url = lv_strdup(from->style->clipPath.url);
     }
     if (from->style->mask.url) {
-        if (to->style->mask.url) free(to->style->mask.url);
-        to->style->mask.url = strdup(from->style->mask.url);
+        if (to->style->mask.url) lv_free(to->style->mask.url);
+        to->style->mask.url = lv_strdup(from->style->mask.url);
     }
 }
 

--- a/src/libs/thorvg/tvgSvgLoaderCommon.h
+++ b/src/libs/thorvg/tvgSvgLoaderCommon.h
@@ -459,11 +459,11 @@ struct SvgStyleGradient
     void clear()
     {
         stops.reset();
-        free(transform);
-        free(radial);
-        free(linear);
-        free(ref);
-        free(id);
+        lv_free(transform);
+        lv_free(radial);
+        lv_free(linear);
+        lv_free(ref);
+        lv_free(id);
     }
 };
 

--- a/src/libs/thorvg/tvgSvgSceneBuilder.cpp
+++ b/src/libs/thorvg/tvgSvgSceneBuilder.cpp
@@ -122,7 +122,8 @@ static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient*
     //Update the stops
     stopCount = g->stops.count;
     if (stopCount > 0) {
-        stops = (Fill::ColorStop*)calloc(stopCount, sizeof(Fill::ColorStop));
+        stops = (Fill::ColorStop*)lv_zalloc(stopCount * sizeof(Fill::ColorStop));
+        LV_ASSERT_MALLOC(stops);
         if (!stops) return fillGrad;
         auto prevOffset = 0.0f;
         for (uint32_t i = 0; i < g->stops.count; ++i) {
@@ -139,7 +140,7 @@ static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient*
             prevOffset = stops[i].offset;
         }
         fillGrad->colorStops(stops, stopCount);
-        free(stops);
+        lv_free(stops);
     }
     return fillGrad;
 }
@@ -181,7 +182,8 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
     //Update the stops
     stopCount = g->stops.count;
     if (stopCount > 0) {
-        stops = (Fill::ColorStop*)calloc(stopCount, sizeof(Fill::ColorStop));
+        stops = (Fill::ColorStop*)lv_zalloc(stopCount * sizeof(Fill::ColorStop));
+        LV_ASSERT_MALLOC(stops);
         if (!stops) return fillGrad;
         auto prevOffset = 0.0f;
         for (uint32_t i = 0; i < g->stops.count; ++i) {
@@ -198,7 +200,7 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
             prevOffset = stops[i].offset;
         }
         fillGrad->colorStops(stops, stopCount);
-        free(stops);
+        lv_free(stops);
     }
     return fillGrad;
 }
@@ -588,14 +590,14 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
         if (encoding == imageMimeTypeEncoding::base64) {
             auto size = b64Decode(href, strlen(href), &decoded);
             if (picture->load(decoded, size, mimetype, false) != Result::Success) {
-                free(decoded);
+                lv_free(decoded);
                 TaskScheduler::async(true);
                 return nullptr;
             }
         } else {
             auto size = svgUtilURLDecode(href, &decoded);
             if (picture->load(decoded, size, mimetype, false) != Result::Success) {
-                free(decoded);
+                lv_free(decoded);
                 TaskScheduler::async(true);
                 return nullptr;
             }

--- a/src/libs/thorvg/tvgSvgUtil.cpp
+++ b/src/libs/thorvg/tvgSvgUtil.cpp
@@ -49,7 +49,8 @@ size_t svgUtilURLDecode(const char *src, char** dst)
     auto length = strlen(src);
     if (length == 0) return 0;
 
-    char* decoded = (char*)malloc(sizeof(char) * length + 1);
+    char* decoded = (char*)lv_malloc(sizeof(char) * length + 1);
+    LV_ASSERT_MALLOC(decoded);
 
     char a, b;
     int idx =0;

--- a/src/libs/thorvg/tvgSwFill.cpp
+++ b/src/libs/thorvg/tvgSwFill.cpp
@@ -131,7 +131,8 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
     if (fill->solid) return true;
 
     if (!fill->ctable) {
-        fill->ctable = static_cast<uint32_t*>(malloc(GRADIENT_STOP_SIZE * sizeof(uint32_t)));
+        fill->ctable = static_cast<uint32_t*>(lv_malloc(GRADIENT_STOP_SIZE * sizeof(uint32_t)));
+        LV_ASSERT_MALLOC(fill->ctable);
         if (!fill->ctable) return false;
     }
 
@@ -857,7 +858,7 @@ const Fill::ColorStop* fillFetchSolid(const SwFill* fill, const Fill* fdata)
 void fillReset(SwFill* fill)
 {
     if (fill->ctable) {
-        free(fill->ctable);
+        lv_free(fill->ctable);
         fill->ctable = nullptr;
     }
     fill->translucent = false;
@@ -869,9 +870,9 @@ void fillFree(SwFill* fill)
 {
     if (!fill) return;
 
-    if (fill->ctable) free(fill->ctable);
+    if (fill->ctable) lv_free(fill->ctable);
 
-    free(fill);
+    lv_free(fill);
 }
 
 #endif /* LV_USE_THORVG_INTERNAL */

--- a/src/libs/thorvg/tvgSwMemPool.cpp
+++ b/src/libs/thorvg/tvgSwMemPool.cpp
@@ -84,10 +84,14 @@ SwMpool* mpoolInit(uint32_t threads)
 {
     auto allocSize = threads + 1;
 
-    auto mpool = static_cast<SwMpool*>(calloc(1, sizeof(SwMpool)));
-    mpool->outline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
-    mpool->strokeOutline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
-    mpool->dashOutline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
+    auto mpool = static_cast<SwMpool*>(lv_zalloc(sizeof(SwMpool)));
+    LV_ASSERT_MALLOC(mpool);
+    mpool->outline = static_cast<SwOutline*>(lv_zalloc(sizeof(SwOutline) * allocSize));
+    LV_ASSERT_MALLOC(mpool->outline);
+    mpool->strokeOutline = static_cast<SwOutline*>(lv_zalloc(sizeof(SwOutline) * allocSize));
+    LV_ASSERT_MALLOC(mpool->strokeOutline);
+    mpool->dashOutline = static_cast<SwOutline*>(lv_zalloc(sizeof(SwOutline) * allocSize));
+    LV_ASSERT_MALLOC(mpool->dashOutline);
     mpool->allocSize = allocSize;
 
     return mpool;
@@ -123,10 +127,10 @@ bool mpoolTerm(SwMpool* mpool)
 
     mpoolClear(mpool);
 
-    free(mpool->outline);
-    free(mpool->strokeOutline);
-    free(mpool->dashOutline);
-    free(mpool);
+    lv_free(mpool->outline);
+    lv_free(mpool->strokeOutline);
+    lv_free(mpool->dashOutline);
+    lv_free(mpool);
 
     return true;
 }

--- a/src/libs/thorvg/tvgSwPostEffect.cpp
+++ b/src/libs/thorvg/tvgSwPostEffect.cpp
@@ -131,7 +131,8 @@ static int _gaussianInit(int* kernel, float sigma, int level)
 
 bool effectGaussianPrepare(RenderEffectGaussian* params)
 {
-    auto data = (SwGaussianBlur*)malloc(sizeof(SwGaussianBlur));
+    auto data = (SwGaussianBlur*)lv_malloc(sizeof(SwGaussianBlur));
+    LV_ASSERT_MALLOC(data);
 
     //compute box kernel sizes
     data->level = int(SwGaussianBlur::MAX_LEVEL * ((params->quality - 1) * 0.01f)) + 1;
@@ -140,7 +141,7 @@ bool effectGaussianPrepare(RenderEffectGaussian* params)
     //skip, if the parameters are invalid.
     if (extends == 0) {
         params->invalid = true;
-        free(data);
+        lv_free(data);
         return false;
     }
 

--- a/src/libs/thorvg/tvgSwRasterTexmap.h
+++ b/src/libs/thorvg/tvgSwRasterTexmap.h
@@ -831,14 +831,16 @@ static AASpans* _AASpans(float ymin, float ymax, const SwImage* image, const SwB
 
     if (!_arrange(image, region, yStart, yEnd)) return nullptr;
 
-    auto aaSpans = static_cast<AASpans*>(malloc(sizeof(AASpans)));
+    auto aaSpans = static_cast<AASpans*>(lv_malloc(sizeof(AASpans)));
+    LV_ASSERT_MALLOC(aaSpans);
     aaSpans->yStart = yStart;
     aaSpans->yEnd = yEnd;
 
     //Initialize X range
     auto height = yEnd - yStart;
 
-    aaSpans->lines = static_cast<AALine*>(malloc(height * sizeof(AALine)));
+    aaSpans->lines = static_cast<AALine*>(lv_malloc(height * sizeof(AALine)));
+    LV_ASSERT_MALLOC(aaSpans->lines);
 
     for (int32_t i = 0; i < height; i++) {
         aaSpans->lines[i].x[0] = INT32_MAX;
@@ -1094,8 +1096,8 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
         y++;
     }
 
-    free(aaSpans->lines);
-    free(aaSpans);
+    lv_free(aaSpans->lines);
+    lv_free(aaSpans);
 
     return true;
 }

--- a/src/libs/thorvg/tvgSwRenderer.cpp
+++ b/src/libs/thorvg/tvgSwRenderer.cpp
@@ -387,7 +387,7 @@ void SwRenderer::clearCompositors()
 {
     //Free Composite Caches
     for (auto comp = compositors.begin(); comp < compositors.end(); ++comp) {
-        free((*comp)->compositor->image.data);
+        lv_free((*comp)->compositor->image.data);
         delete((*comp)->compositor);
         delete(*comp);
     }
@@ -566,7 +566,8 @@ SwSurface* SwRenderer::request(int channelSize)
         //Inherits attributes from main surface
         cmp = new SwSurface(surface);
         cmp->compositor = new SwCompositor;
-        cmp->compositor->image.data = (pixel_t*)malloc(channelSize * surface->stride * surface->h);
+        cmp->compositor->image.data = (pixel_t*)lv_malloc(channelSize * surface->stride * surface->h);
+        LV_ASSERT_MALLOC(cmp->compositor->image.data);
         cmp->compositor->image.w = surface->w;
         cmp->compositor->image.h = surface->h;
         cmp->compositor->image.stride = surface->stride;
@@ -701,7 +702,7 @@ void* SwRenderer::prepareCommon(SwTask* task, const Matrix& transform, const Arr
 
     task->clips = clips;
     task->transform = transform;
-    
+
     //zero size?
     if (task->transform.e11 == 0.0f && task->transform.e12 == 0.0f) return task; //zero width
     if (task->transform.e21 == 0.0f && task->transform.e22 == 0.0f) return task; //zero height

--- a/src/libs/thorvg/tvgSwShape.cpp
+++ b/src/libs/thorvg/tvgSwShape.cpp
@@ -75,7 +75,7 @@ static void _outlineCubicTo(SwOutline& outline, const Point* ctrl1, const Point*
     outline.types.push(SW_CURVE_TYPE_CUBIC);
 
     outline.pts.push(mathTransform(ctrl2, transform));
-    outline.types.push(SW_CURVE_TYPE_CUBIC);    
+    outline.types.push(SW_CURVE_TYPE_CUBIC);
 
     outline.pts.push(mathTransform(to, transform));
     outline.types.push(SW_CURVE_TYPE_POINT);
@@ -347,7 +347,10 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, const Matrix& trans
     if (trimmed) rshape->stroke->strokeTrim(trimBegin, trimEnd);
 
     if (dash.cnt == 0) {
-        if (trimmed) dash.pattern = (float*)malloc(sizeof(float) * 4);
+        if (trimmed) {
+        	dash.pattern = (float*)lv_malloc(sizeof(float) * 4);
+			LV_ASSERT_MALLOC(dash.pattern);
+        }
         else return nullptr;
     } else {
         //TODO: handle dash + trim - for now trimming ignoring is forced
@@ -414,7 +417,7 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, const Matrix& trans
 
     _outlineEnd(*dash.outline);
 
-    if (trimmed) free(dash.pattern);
+    if (trimmed) lv_free(dash.pattern);
 
     return dash.outline;
 }
@@ -580,7 +583,10 @@ void shapeDelStroke(SwShape* shape)
 
 void shapeResetStroke(SwShape* shape, const RenderShape* rshape, const Matrix& transform)
 {
-    if (!shape->stroke) shape->stroke = static_cast<SwStroke*>(calloc(1, sizeof(SwStroke)));
+    if (!shape->stroke) {
+    	shape->stroke = static_cast<SwStroke*>(lv_zalloc(sizeof(SwStroke)));
+        LV_ASSERT_MALLOC(shape->stroke);
+    }
     auto stroke = shape->stroke;
     if (!stroke) return;
 
@@ -647,7 +653,8 @@ bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix& tr
 void shapeResetFill(SwShape* shape)
 {
     if (!shape->fill) {
-        shape->fill = static_cast<SwFill*>(calloc(1, sizeof(SwFill)));
+        shape->fill = static_cast<SwFill*>(lv_zalloc(sizeof(SwFill)));
+        LV_ASSERT_MALLOC(shape->fill);
         if (!shape->fill) return;
     }
     fillReset(shape->fill);
@@ -657,7 +664,8 @@ void shapeResetFill(SwShape* shape)
 void shapeResetStrokeFill(SwShape* shape)
 {
     if (!shape->stroke->fill) {
-        shape->stroke->fill = static_cast<SwFill*>(calloc(1, sizeof(SwFill)));
+        shape->stroke->fill = static_cast<SwFill*>(lv_zalloc(sizeof(SwFill)));
+        LV_ASSERT_MALLOC(shape->stroke->fill);
         if (!shape->stroke->fill) return;
     }
     fillReset(shape->stroke->fill);

--- a/src/libs/thorvg/tvgSwStroke.cpp
+++ b/src/libs/thorvg/tvgSwStroke.cpp
@@ -61,8 +61,10 @@ static void _growBorder(SwStrokeBorder* border, uint32_t newPts)
     while (maxCur < maxNew)
         maxCur += (maxCur >> 1) + 16;
     //OPTIMIZE: use mempool!
-    border->pts = static_cast<SwPoint*>(realloc(border->pts, maxCur * sizeof(SwPoint)));
-    border->tags = static_cast<uint8_t*>(realloc(border->tags, maxCur * sizeof(uint8_t)));
+    border->pts = static_cast<SwPoint*>(lv_realloc(border->pts, maxCur * sizeof(SwPoint)));
+    LV_ASSERT_MALLOC(border->pts);
+    border->tags = static_cast<uint8_t*>(lv_realloc(border->tags, maxCur * sizeof(uint8_t)));
+    LV_ASSERT_MALLOC(border->tags);
     border->maxPts = maxCur;
 }
 
@@ -806,15 +808,15 @@ void strokeFree(SwStroke* stroke)
     if (!stroke) return;
 
     //free borders
-    if (stroke->borders[0].pts) free(stroke->borders[0].pts);
-    if (stroke->borders[0].tags) free(stroke->borders[0].tags);
-    if (stroke->borders[1].pts) free(stroke->borders[1].pts);
-    if (stroke->borders[1].tags) free(stroke->borders[1].tags);
+    if (stroke->borders[0].pts) lv_free(stroke->borders[0].pts);
+    if (stroke->borders[0].tags) lv_free(stroke->borders[0].tags);
+    if (stroke->borders[1].pts) lv_free(stroke->borders[1].pts);
+    if (stroke->borders[1].tags) lv_free(stroke->borders[1].tags);
 
     fillFree(stroke->fill);
     stroke->fill = nullptr;
 
-    free(stroke);
+    lv_free(stroke);
 }
 
 

--- a/src/libs/thorvg/tvgText.h
+++ b/src/libs/thorvg/tvgText.h
@@ -47,15 +47,15 @@ struct Text::Impl
 
     ~Impl()
     {
-        free(utf8);
+        lv_free(utf8);
         LoaderMgr::retrieve(loader);
         delete(shape);
     }
 
     Result text(const char* utf8)
     {
-        free(this->utf8);
-        if (utf8) this->utf8 = strdup(utf8);
+        lv_free(this->utf8);
+        if (utf8) this->utf8 = lv_strdup(utf8);
         else this->utf8 = nullptr;
         changed = true;
 
@@ -157,7 +157,7 @@ struct Text::Impl
             ++dup->loader->sharing;
         }
 
-        dup->utf8 = strdup(utf8);
+        dup->utf8 = lv_strdup(utf8);
         dup->italic = italic;
         dup->fontSize = fontSize;
 

--- a/src/libs/thorvg/tvgXmlParser.cpp
+++ b/src/libs/thorvg/tvgXmlParser.cpp
@@ -301,7 +301,8 @@ bool isIgnoreUnsupportedLogElements(TVG_UNUSED const char* tagName)
 bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttributeCb func, const void* data)
 {
     const char *itr = buf, *itrEnd = buf + bufLength;
-    char* tmpBuf = (char*)malloc(bufLength + 1);
+    char* tmpBuf = (char*)lv_malloc(bufLength + 1);
+    LV_ASSERT_MALLOC(tmpBuf);
 
     if (!buf || !func || !tmpBuf) goto error;
 
@@ -366,11 +367,11 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
     }
 
 success:
-    free(tmpBuf);
+    lv_free(tmpBuf);
     return true;
 
 error:
-    free(tmpBuf);
+    lv_free(tmpBuf);
     return false;
 }
 
@@ -564,7 +565,7 @@ const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char
         if (*p == '.') break;
     }
 
-    if (p == itr) *tag = strdup("all");
+    if (p == itr) *tag = lv_strdup("all");
     else *tag = strDuplicate(itr, p - itr);
 
     if (p == itrEnd) *name = nullptr;


### PR DESCRIPTION
Now there are lot of hard to debug out of memory issues using ThorVG's Lottie. With this updated 
- we have ASSERTs on out of memory
- we can monitor the memory usage
- we can use a single heap for LVGL and Lottie

These new `lv_*` symbols are also easy to refactor to any `tvg_*` if there from ThorVG.

cc @FASTSHIFT @XuNeo @onecoolx @hermet

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
