### PR TITLE
fix(tiny_ttf): fix GPOS lookup list table address

### DIFF
--- a/src/libs/tiny_ttf/stb_truetype_htcw.h
+++ b/src/libs/tiny_ttf/stb_truetype_htcw.h
@@ -2758,7 +2758,7 @@ static stbtt_int32 stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo * info, i
     if(ttUSHORT(data, 2 + info->gpos) != 0) return 0;  // Minor version 0
 
     lookupListOffset = ttUSHORT(data, 8 + info->gpos);
-    lookupList = lookupListOffset;
+    lookupList = info->gpos + lookupListOffset;
     lookupCount = ttUSHORT(data, lookupList);
 
     for(i = 0; i < lookupCount; ++i) {
@@ -2876,7 +2876,7 @@ STBTT_DEF int stbtt_KernTableCheck(const stbtt_fontinfo * info)
         if(ttUSHORT(data, 2 + info->gpos) != 0) return 0;  // Minor version 0
 
         lookupListOffset = ttUSHORT(data, 8 + info->gpos);
-        lookupList = lookupListOffset;
+        lookupList = info->gpos + lookupListOffset;
         lookupCount = ttUSHORT(data, lookupList);
 
         for(i = 0; i < lookupCount; ++i) {


### PR DESCRIPTION
Lookup list offset is specified from start of GPOS table, not from start of file: [specs](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#:~:text=lookupListOffset-,Offset%20to%20LookupList%20table%2C%20from%20beginning%20of%20GPOS%20table.,-GPOS%20Header%2C%20version)