### PR TITLE
feat(mem): add lv_reallocf

### DIFF
--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -136,6 +136,15 @@ void lv_free(void * data)
     lv_free_core(data);
 }
 
+void * lv_reallocf(void * data_p, size_t new_size)
+{
+    void * new = lv_realloc(data_p, new_size);
+    if(!new) {
+        lv_free(data_p);
+    }
+    return new;
+}
+
 void * lv_realloc(void * data_p, size_t new_size)
 {
     LV_TRACE_MEM("reallocating %p with %lu size", data_p, (unsigned long)new_size);

--- a/src/stdlib/lv_mem.h
+++ b/src/stdlib/lv_mem.h
@@ -106,6 +106,16 @@ void lv_free(void * data);
 void * lv_realloc(void * data_p, size_t new_size);
 
 /**
+ * Reallocate a memory with a new size. The old content will be kept.
+ * In case of failure, the old pointer is free'd.
+ * @param data_p pointer to an allocated memory.
+ *               Its content will be copied to the new memory block and freed
+ * @param new_size the desired new size in byte
+ * @return pointer to the new memory, NULL on failure
+ */
+void * lv_reallocf(void * data_p, size_t new_size);
+
+/**
  * Used internally to execute a plain `malloc` operation
  * @param size      size in bytes to `malloc`
  */


### PR DESCRIPTION
Related issue is #7489  

https://github.com/lvgl/lvgl/issues/7489#issuecomment-2624809026 @liamHowatt 

Adds lv_reallocf which makes it possible to do 

```c
void * ptr;
....
ptr = lv_reallocf(ptr, NEW_SIZE);
``` 
without causing a memory leak in case realloc fails.

Man page can be found [here](https://linux.die.net/man/3/reallocf)