### PR TITLE
fix(thorvg): fix internal types of rasterXYFlip

### DIFF
--- a/src/libs/thorvg/tvgSwRaster.cpp
+++ b/src/libs/thorvg/tvgSwRaster.cpp
@@ -1824,7 +1824,7 @@ bool rasterConvertCS(RenderSurface* surface, ColorSpace to)
 //TODO: SIMD OPTIMIZATION?
 void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32_t h, const SwBBox& bbox, bool flipped)
 {
-    constexpr int BLOCK = 8;  //experimental decision
+    constexpr int32_t BLOCK = 8;  //experimental decision
 
     if (flipped) {
         src += ((bbox.min.x * stride) + bbox.min.y);
@@ -1834,16 +1834,16 @@ void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32
         dst += ((bbox.min.x * stride) + bbox.min.y);
     }
 
-    for (int x = 0; x < w; x += BLOCK) {
+    for (int32_t x = 0; x < w; x += BLOCK) {
         auto bx = std::min(w, x + BLOCK) - x;
         auto in = &src[x];
         auto out = &dst[x * stride];
-        for (int y = 0; y < h; y += BLOCK) {
+        for (int32_t y = 0; y < h; y += BLOCK) {
             auto p = &in[y * stride];
             auto q = &out[y];
             auto by = std::min(h, y + BLOCK) - y;
-            for (int xx = 0; xx < bx; ++xx) {
-                for (int yy = 0; yy < by; ++yy) {
+            for (int32_t xx = 0; xx < bx; ++xx) {
+                for (int32_t yy = 0; yy < by; ++yy) {
                     *q = *p;
                     p += stride;
                     ++q;


### PR DESCRIPTION
Before the C++ compiler couldn't decide the template of std::min (that happen if `int` type is not an `int32_t`), so explicitly changing all types to int32_t fixes this.