### PR TITLE
fix(example_grad): return value from lv_style_get_prop not checked

### DIFF
--- a/examples/grad/lv_example_grad_1.c
+++ b/examples/grad/lv_example_grad_1.c
@@ -21,34 +21,42 @@ static void frac_1_event_cb(lv_event_t * e)
 {
     lv_style_t * style = lv_event_get_user_data(e);
     lv_style_value_t v;
-    lv_style_get_prop(style, LV_STYLE_BG_GRAD, &v);
-    lv_grad_dsc_t * dsc = (lv_grad_dsc_t *)v.ptr;
+    if(lv_style_get_prop(style, LV_STYLE_BG_GRAD, &v) != LV_STYLE_RES_FOUND) {
+        LV_LOG_WARN("style prop not found");
+    }
+    else {
+        lv_grad_dsc_t * dsc = (lv_grad_dsc_t *)v.ptr;
 
-    lv_point_t p;
-    position_bullet(e, &p);
+        lv_point_t p;
+        position_bullet(e, &p);
 
-    lv_obj_t * bullet = lv_event_get_target(e);
-    lv_obj_t * parent = lv_obj_get_parent(bullet);
-    dsc->stops[0].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
+        lv_obj_t * bullet = lv_event_get_target(e);
+        lv_obj_t * parent = lv_obj_get_parent(bullet);
+        dsc->stops[0].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
 
-    lv_obj_invalidate(parent);
+        lv_obj_invalidate(parent);
+    }
 }
 
 static void frac_2_event_cb(lv_event_t * e)
 {
     lv_style_t * style = lv_event_get_user_data(e);
     lv_style_value_t v;
-    lv_style_get_prop(style, LV_STYLE_BG_GRAD, &v);
-    lv_grad_dsc_t * dsc = (lv_grad_dsc_t *)v.ptr;
+    if(lv_style_get_prop(style, LV_STYLE_BG_GRAD, &v) != LV_STYLE_RES_FOUND) {
+        LV_LOG_WARN("style prop not found");
+    }
+    else {
+        lv_grad_dsc_t * dsc = (lv_grad_dsc_t *)v.ptr;
 
-    lv_point_t p;
-    position_bullet(e, &p);
+        lv_point_t p;
+        position_bullet(e, &p);
 
-    lv_obj_t * bullet = lv_event_get_target(e);
-    lv_obj_t * parent = lv_obj_get_parent(bullet);
+        lv_obj_t * bullet = lv_event_get_target(e);
+        lv_obj_t * parent = lv_obj_get_parent(bullet);
 
-    dsc->stops[1].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
-    lv_obj_invalidate(parent);
+        dsc->stops[1].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
+        lv_obj_invalidate(parent);
+    }
 }
 
 /**


### PR DESCRIPTION
In the frac_1_event_cb and frac_2_event_cb routines, a call is made to lv_style_get_prop() but the return value is not checked.  The returned lv_style_value_t structure is used even if the lv_style_get_prop failed, so uninitialized data would be used.  Add the check for the return value and log a warning if the routine does not return FOUND.

