### PR TITLE
fix(indev): decouple scroll momentum decay from indev read loop (#6832)

### DIFF
--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -660,6 +660,10 @@ data instead of directly reading the input device. Setting the
 ``data->continue_reading`` flag will tell LVGL there is more data to
 read and it should call ``read_cb`` again.
 
+If the driver can provide precise timestamps for buffered events, it can
+overwrite ``data->timestamp``. By default, this is initialized to
+:cpp:func:`lv_tick_get()` just before invoking ``read_cb``.
+
 Switching the Input Device to Event-Driven Mode
 -----------------------------------------------
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -192,6 +192,8 @@ void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data)
         data->key = LV_KEY_ENTER;
     }
 
+    data->timestamp = lv_tick_get();
+
     if(indev->read_cb) {
         LV_TRACE_INDEV("calling indev_read_cb");
         indev->read_cb(indev, data);
@@ -245,11 +247,12 @@ void lv_indev_read(lv_indev_t * indev)
         indev->state = data.state;
 
         /*Save the last activity time*/
+        indev->timestamp = data.timestamp;
         if(indev->state == LV_INDEV_STATE_PRESSED) {
-            indev->disp->last_activity_time = lv_tick_get();
+            indev->disp->last_activity_time = data.timestamp;
         }
         else if(indev->type == LV_INDEV_TYPE_ENCODER && data.enc_diff) {
-            indev->disp->last_activity_time = lv_tick_get();
+            indev->disp->last_activity_time = data.timestamp;
         }
 
         if(indev->type == LV_INDEV_TYPE_POINTER) {
@@ -438,9 +441,8 @@ void lv_indev_stop_processing(lv_indev_t * indev)
 
 void lv_indev_reset_long_press(lv_indev_t * indev)
 {
-    indev->long_pr_sent         = 0;
-    indev->longpr_rep_timestamp = lv_tick_get();
-    indev->pr_timestamp         = lv_tick_get();
+    indev->long_pr_sent = 0;
+    indev->longpr_rep_timestamp = indev->pr_timestamp = lv_tick_get();
 }
 
 void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj)
@@ -792,7 +794,7 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
     /*Key press happened*/
     if(data->state == LV_INDEV_STATE_PRESSED && prev_state == LV_INDEV_STATE_RELEASED) {
         LV_LOG_INFO("%" LV_PRIu32 " key is pressed", data->key);
-        i->pr_timestamp = lv_tick_get();
+        i->pr_timestamp = i->timestamp;
 
         /*Move the focus on NEXT*/
         if(data->key == LV_KEY_NEXT) {
@@ -838,19 +840,19 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
         }
 
         /*Long press time has elapsed?*/
-        if(i->long_pr_sent == 0 && lv_tick_elaps(i->pr_timestamp) > i->long_press_time) {
+        if(i->long_pr_sent == 0 && lv_tick_diff(i->timestamp, i->pr_timestamp) > i->long_press_time) {
             i->long_pr_sent = 1;
             if(data->key == LV_KEY_ENTER) {
-                i->longpr_rep_timestamp = lv_tick_get();
+                i->longpr_rep_timestamp = i->timestamp;
 
                 if(send_event(LV_EVENT_LONG_PRESSED, indev_act) == LV_RESULT_INVALID) return;
             }
         }
         /*Long press repeated time has elapsed?*/
         else if(i->long_pr_sent != 0 &&
-                lv_tick_elaps(i->longpr_rep_timestamp) > i->long_press_repeat_time) {
+                lv_tick_diff(i->timestamp, i->longpr_rep_timestamp) > i->long_press_repeat_time) {
 
-            i->longpr_rep_timestamp = lv_tick_get();
+            i->longpr_rep_timestamp = i->timestamp;
 
             /*Send LONG_PRESS_REP on ENTER*/
             if(data->key == LV_KEY_ENTER) {
@@ -938,7 +940,7 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
     if(data->state == LV_INDEV_STATE_PRESSED && last_state == LV_INDEV_STATE_RELEASED) {
         LV_LOG_INFO("pressed");
 
-        i->pr_timestamp = lv_tick_get();
+        i->pr_timestamp = i->timestamp;
 
         if(data->key == LV_KEY_ENTER) {
             bool editable_or_scrollable = lv_obj_is_editable(indev_obj_act) ||
@@ -976,10 +978,10 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
     /*Pressing*/
     else if(data->state == LV_INDEV_STATE_PRESSED && last_state == LV_INDEV_STATE_PRESSED) {
         /*Long press*/
-        if(i->long_pr_sent == 0 && lv_tick_elaps(i->pr_timestamp) > i->long_press_time) {
+        if(i->long_pr_sent == 0 && lv_tick_diff(i->timestamp, i->pr_timestamp) > i->long_press_time) {
 
             i->long_pr_sent = 1;
-            i->longpr_rep_timestamp = lv_tick_get();
+            i->longpr_rep_timestamp = i->timestamp;
 
             if(data->key == LV_KEY_ENTER) {
                 /* Always send event to indev callbacks*/
@@ -1010,9 +1012,9 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
             i->long_pr_sent = 1;
         }
         /*Long press repeated time has elapsed?*/
-        else if(i->long_pr_sent != 0 && lv_tick_elaps(i->longpr_rep_timestamp) > i->long_press_repeat_time) {
+        else if(i->long_pr_sent != 0 && lv_tick_diff(i->timestamp, i->longpr_rep_timestamp) > i->long_press_repeat_time) {
 
-            i->longpr_rep_timestamp = lv_tick_get();
+            i->longpr_rep_timestamp = i->timestamp;
 
             if(data->key == LV_KEY_ENTER) {
                 if(is_enabled) {
@@ -1267,7 +1269,7 @@ static void indev_proc_press(lv_indev_t * indev)
         if(indev_obj_act != NULL) {
 
             /*Save the time when the obj pressed to count long press time.*/
-            indev->pr_timestamp                 = lv_tick_get();
+            indev->pr_timestamp                 = indev->timestamp;
             indev->long_pr_sent                 = 0;
             indev->pointer.scroll_sum.x     = 0;
             indev->pointer.scroll_sum.y     = 0;
@@ -1310,13 +1312,13 @@ static void indev_proc_press(lv_indev_t * indev)
     indev->pointer.vect.y = indev->pointer.act_point.y - indev->pointer.last_point.y;
 
     indev->pointer.vect_hist[indev->pointer.vect_hist_index] = indev->pointer.vect;
-    indev->pointer.vect_hist_timestamp[indev->pointer.vect_hist_index] = lv_tick_get();
+    indev->pointer.vect_hist_timestamp[indev->pointer.vect_hist_index] = indev->timestamp;
     indev->pointer.vect_hist_index = (indev->pointer.vect_hist_index + 1) % LV_INDEV_VECT_HIST_SIZE;
 
     indev->pointer.scroll_throw_vect.x = 0;
     indev->pointer.scroll_throw_vect.y = 0;
     for(int i = 0; i < LV_INDEV_VECT_HIST_SIZE; i++) {
-        int32_t t = lv_tick_elaps(indev->pointer.vect_hist_timestamp[i]);
+        int32_t t = lv_tick_diff(indev->timestamp, indev->pointer.vect_hist_timestamp[i]);
         indev->pointer.scroll_throw_vect.x += indev_scroll_throw_decay(indev->pointer.vect_hist[i].x, t);
         indev->pointer.scroll_throw_vect.y += indev_scroll_throw_decay(indev->pointer.vect_hist[i].y, t);
     }
@@ -1374,7 +1376,7 @@ static void indev_proc_press(lv_indev_t * indev)
         /*If there is no scrolling then check for long press time*/
         if(indev->pointer.scroll_obj == NULL && indev->long_pr_sent == 0) {
             /*Send a long press event if enough time elapsed*/
-            if(lv_tick_elaps(indev->pr_timestamp) > indev_act->long_press_time) {
+            if(lv_tick_diff(indev->timestamp, indev->pr_timestamp) > indev_act->long_press_time) {
                 if(is_enabled) {
                     if(send_event(LV_EVENT_LONG_PRESSED, indev_act) == LV_RESULT_INVALID) return;
                 }
@@ -1382,16 +1384,16 @@ static void indev_proc_press(lv_indev_t * indev)
                 indev->long_pr_sent = 1;
 
                 /*Save the long press time stamp for the long press repeat handler*/
-                indev->longpr_rep_timestamp = lv_tick_get();
+                indev->longpr_rep_timestamp = indev->timestamp;
             }
         }
 
         if(indev->pointer.scroll_obj == NULL && indev->long_pr_sent == 1) {
-            if(lv_tick_elaps(indev->longpr_rep_timestamp) > indev_act->long_press_repeat_time) {
+            if(lv_tick_diff(indev->timestamp, indev->longpr_rep_timestamp) > indev_act->long_press_repeat_time) {
                 if(is_enabled) {
                     if(send_event(LV_EVENT_LONG_PRESSED_REPEAT, indev_act) == LV_RESULT_INVALID) return;
                 }
-                indev->longpr_rep_timestamp = lv_tick_get();
+                indev->longpr_rep_timestamp = indev->timestamp;
             }
         }
     }
@@ -1537,7 +1539,7 @@ static lv_result_t indev_proc_short_click(lv_indev_t * indev)
 {
     /*Update streak for clicks within small distance and short time*/
     indev->pointer.short_click_streak++;
-    if(lv_tick_elaps(indev->pointer.last_short_click_timestamp) > indev->long_press_time) {
+    if(lv_tick_diff(indev->timestamp, indev->pointer.last_short_click_timestamp) > indev->long_press_time) {
         indev->pointer.short_click_streak = 1;
     }
     else if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_BUTTON) {
@@ -1546,7 +1548,7 @@ static lv_result_t indev_proc_short_click(lv_indev_t * indev)
         if(dx * dx + dy * dy > indev->scroll_limit * indev->scroll_limit) indev->pointer.short_click_streak = 1;
     }
 
-    indev->pointer.last_short_click_timestamp = lv_tick_get();
+    indev->pointer.last_short_click_timestamp = indev->timestamp;
     lv_indev_get_point(indev, &indev->pointer.last_short_click_point);
 
     /*Simple short click*/
@@ -1631,6 +1633,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
         indev->pointer.last_obj          = NULL;
         indev->pointer.scroll_obj        = NULL;
         indev->pointer.last_hovered      = NULL;
+        indev->timestamp = lv_tick_get();
         indev->long_pr_sent                    = 0;
         indev->pr_timestamp                    = 0;
         indev->longpr_rep_timestamp            = 0;

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -71,6 +71,7 @@ typedef struct {
     uint32_t btn_id;  /**< For LV_INDEV_TYPE_BUTTON the currently pressed button*/
     int16_t enc_diff; /**< For LV_INDEV_TYPE_ENCODER number of steps since the previous read*/
 
+    uint32_t timestamp; /**< Initialized to lv_tick_get(). Driver may provide more accurate timestamp for buffered events*/
     bool continue_reading;  /**< If set to true, the read callback is invoked again, unless the device is in event-driven mode*/
 } lv_indev_data_t;
 

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -45,6 +45,7 @@ struct _lv_indev_t {
     uint8_t wait_until_release : 1;
     uint8_t stop_processing_query : 1;
 
+    uint32_t timestamp;            /**< Timestamp of last event */
     uint32_t pr_timestamp;         /**< Pressed time stamp*/
     uint32_t longpr_rep_timestamp; /**< Long press repeat time stamp*/
 

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -21,6 +21,7 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
+#define LV_INDEV_VECT_HIST_SIZE 8
 
 /**********************
  *      TYPEDEFS
@@ -83,6 +84,9 @@ struct _lv_indev_t {
         lv_point_t last_point; /**< Last point of input device.*/
         lv_point_t last_raw_point; /**< Last point read from read_cb. */
         lv_point_t vect; /**< Difference between `act_point` and `last_point`.*/
+        lv_point_t vect_hist[LV_INDEV_VECT_HIST_SIZE];
+        uint32_t   vect_hist_timestamp[LV_INDEV_VECT_HIST_SIZE];
+        uint8_t    vect_hist_index;
         lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
         lv_point_t scroll_throw_vect;
         lv_point_t scroll_throw_vect_ori;

--- a/src/tick/lv_tick.c
+++ b/src/tick/lv_tick.c
@@ -66,18 +66,13 @@ uint32_t lv_tick_get(void)
 
 uint32_t lv_tick_elaps(uint32_t prev_tick)
 {
-    uint32_t act_time = lv_tick_get();
+    return lv_tick_diff(lv_tick_get(), prev_tick);
+}
 
-    /*If there is no overflow in sys_time simple subtract*/
-    if(act_time >= prev_tick) {
-        prev_tick = act_time - prev_tick;
-    }
-    else {
-        prev_tick = UINT32_MAX - prev_tick + 1;
-        prev_tick += act_time;
-    }
-
-    return prev_tick;
+uint32_t lv_tick_diff(uint32_t tick, uint32_t prev_tick)
+{
+    /*Unsigned overflow is well-defined and works for a single wrap around*/
+    return tick - prev_tick;
 }
 
 void lv_delay_ms(uint32_t ms)

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -55,6 +55,14 @@ uint32_t lv_tick_get(void);
 uint32_t lv_tick_elaps(uint32_t prev_tick);
 
 /**
+ * Get the elapsed milliseconds between two time stamps
+ * @param tick          a time stamp
+ * @param prev_tick     a time stamp before `tick`
+ * @return              the elapsed milliseconds between `prev_tick` and `tick`
+ */
+uint32_t lv_tick_diff(uint32_t tick, uint32_t prev_tick);
+
+/**
  * Delay for the given milliseconds.
  * By default it's a blocking delay, but with `lv_delay_set_cb()`
  * a custom delay function can be set too


### PR DESCRIPTION
Fixes #6832.

As suggested in the issue, this computes the scroll throw vector based on a short history.

Initially I computed the speed over the entire history up to a maximum time, but then it depends a lot on individual history entries making the cut or not and can feel a bit inconsistent.

Next, I applied exponential decay to history entries, `x * exp(-t / 33.0)`, which felt much smoother.

To avoid floating point arithmetic, I tried some series expansions, but ultimately simple linear interpolation seems good enough.

Tested with SDL (where the full history is often relevant) and evdev with default refresh rate (where usually ~2 entries make the cut).