### PR TITLE
fix(scripts): initialize reserved fields of lv_image_dsc_t and lv_image_header_t to prevent compiler warnings

### DIFF
--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -355,8 +355,10 @@ const lv_image_dsc_t {varname} = {{
   .header.w = {w},
   .header.h = {h},
   .header.stride = {stride},
+  .header.reserved_2 = 0,
   .data_size = sizeof({varname}_map),
   .data = {varname}_map,
+  .reserved = NULL,
 }};
 
 '''


### PR DESCRIPTION
Previously the LVGLImage.py script did not initialize reserved fields of the lv_image_dsc_t and lv_image_header_t. This led to a flood of compiler warnings about uninitialized variables.

This PR sets these variables to zero and NULL respectively.