### PR TITLE
fix(scale): assert mode value is valid

### DIFF
--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -1065,6 +1065,14 @@ static void scale_get_tick_points(lv_obj_t * obj, const uint32_t tick_idx, bool 
     int32_t major_len = 0;
     int32_t radial_offset = 0;
 
+    LV_ASSERT_MSG((scale->mode == LV_SCALE_MODE_HORIZONTAL_TOP) ||
+                  (scale->mode == LV_SCALE_MODE_HORIZONTAL_BOTTOM) ||
+                  (scale->mode == LV_SCALE_MODE_VERTICAL_LEFT) ||
+                  (scale->mode == LV_SCALE_MODE_VERTICAL_RIGHT) ||
+                  (scale->mode == LV_SCALE_MODE_ROUND_INNER) ||
+                  (scale->mode == LV_SCALE_MODE_ROUND_OUTER),
+                  "unknown value for scale mode");
+
     if(is_major_tick) {
         major_len = lv_obj_get_style_length(obj, LV_PART_INDICATOR);
         radial_offset = lv_obj_get_style_radial_offset(obj, LV_PART_INDICATOR);


### PR DESCRIPTION
If an invalid scale mode is used, the scale_get_tick_points() does not assign values to the tick points and uninitialized values are used to draw lines.  The following sequence of code causes  the issue when rendered:

```
    lv_obj_t * scale = lv_scale_create(lv_screen_active());

    lv_scale_set_post_draw(scale, true);
    lv_scale_set_draw_ticks_on_top(scale, true);
    lv_scale_set_label_show(scale, false);
    // set an invalid value for the mode
    lv_scale_set_mode(scale, LV_SCALE_MODE_HORIZONTAL_TOP |
                             LV_SCALE_MODE_ROUND_OUTER);
```
Add an assertion message to check that the mode is one of the valid values.