### PR TITLE
fix(indev): fix scroll_obj not send LV_EVENT_INDEV_RESET

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1756,29 +1756,29 @@ static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj)
         if(obj == NULL || indev->pointer.last_pressed == obj) {
             indev->pointer.last_pressed = NULL;
         }
-        if(obj == NULL || indev->pointer.act_obj == obj) {
-            if(indev->pointer.act_obj) {
-                /* Avoid recursive calls */
-                act_obj = indev->pointer.act_obj;
-                indev->pointer.act_obj = NULL;
-                lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
-                lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, act_obj);
-                act_obj = NULL;
-            }
+
+        if(indev->pointer.act_obj) {
+            /* Avoid recursive calls */
+            act_obj = indev->pointer.act_obj;
+            indev->pointer.act_obj = NULL;
+            lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
+            lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, act_obj);
+            act_obj = NULL;
         }
+
         if(obj == NULL || indev->pointer.last_obj == obj) {
             indev->pointer.last_obj = NULL;
         }
-        if(obj == NULL || indev->pointer.scroll_obj == obj) {
-            if(indev->pointer.scroll_obj) {
-                /* Avoid recursive calls */
-                scroll_obj = indev->pointer.scroll_obj;
-                indev->pointer.scroll_obj = NULL;
-                lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
-                lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, act_obj);
-                scroll_obj = NULL;
-            }
+
+        if(indev->pointer.scroll_obj) {
+            /* Avoid recursive calls */
+            scroll_obj = indev->pointer.scroll_obj;
+            indev->pointer.scroll_obj = NULL;
+            lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
+            lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, scroll_obj);
+            scroll_obj = NULL;
         }
+
         if(obj == NULL || indev->pointer.last_hovered == obj) {
             indev->pointer.last_hovered = NULL;
         }

--- a/tests/src/test_cases/test_indev_reset.c
+++ b/tests/src/test_cases/test_indev_reset.c
@@ -1,0 +1,61 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../lv_test_indev.h"
+#include "unity/unity.h"
+
+static uint32_t indev_reset_count = 0;
+
+void setUp(void)
+{
+    /* Function run before every test */
+    indev_reset_count = 0;
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+static void event_cb(lv_event_t * e)
+{
+    lv_obj_t * scroll_obj = lv_event_get_target(e);
+    lv_obj_t * act_obj = lv_obj_get_child(scroll_obj, 0);
+    lv_event_code_t code = lv_event_get_code(e);
+    if(code == LV_EVENT_SCROLL && act_obj) {
+        lv_obj_delete(act_obj);
+    }
+    else if(code == LV_EVENT_INDEV_RESET) {
+        indev_reset_count += 1;
+    }
+}
+
+void test_indev_wait_release(void)
+{
+    lv_obj_t * scroll_obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(scroll_obj, 300, 300);
+    lv_obj_align(scroll_obj, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_add_event_cb(scroll_obj, event_cb, LV_EVENT_ALL, NULL);
+
+    lv_obj_t * act_obj = lv_obj_create(scroll_obj);
+    lv_obj_set_size(act_obj, 400, 200);
+    lv_obj_align(act_obj, LV_ALIGN_LEFT_MID, 0, 0);
+
+    lv_test_mouse_move_to(200, 200);
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+
+    lv_test_mouse_move_by(-20, 0);
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+
+    lv_test_mouse_move_by(-20, 0);
+    lv_test_mouse_press();
+    lv_test_indev_wait(50);
+
+    lv_test_mouse_release();
+
+    TEST_ASSERT_EQUAL_UINT32(1, indev_reset_count);
+}
+
+#endif


### PR DESCRIPTION
If the `act_obj` is deleted during the scrolling process, it will trigger an `indev_reset`. However, the `scroll_obj`  does not receive the `LV_EVENT_INDEV_RESET` event.

<!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->
```
static void scroll_cb(lv_event_t* e)
{
    lv_obj_t* scroll_obj = lv_event_get_target(e);
    lv_obj_t* act_obj = lv_obj_get_child(scroll_obj, 0);
    lv_event_code_t code = lv_event_get_code(e);
    if (code == LV_EVENT_SCROLL && act_obj) {
        lv_obj_delete(act_obj);
    } else if (code == LV_EVENT_INDEV_RESET) {
        LV_LOG_USER("aaaaaa");
    }
}

static void test(void)
{
    lv_obj_t* scroll_obj = lv_obj_create(lv_screen_active());
    lv_obj_set_size(scroll_obj, 300, 300);
    lv_obj_align(scroll_obj, LV_ALIGN_LEFT_MID, 0, 0);
    lv_obj_add_event_cb(scroll_obj, scroll_cb, LV_EVENT_ALL, NULL);

    lv_obj_t* act_obj = lv_obj_create(scroll_obj);
    lv_obj_set_size(act_obj, 400, 200);
    lv_obj_align(act_obj, LV_ALIGN_LEFT_MID, 0, 0);
}
```

After modification, the log can be triggered
```
[User]  (1.585, +1585)   scroll_cb: aaaaaa main.c:64
```

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
