### PR TITLE
feat(vg_lite): optimize resource reference count management

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_pending.h
+++ b/src/draw/vg_lite/lv_vg_lite_pending.h
@@ -65,10 +65,16 @@ void lv_vg_lite_pending_set_free_cb(lv_vg_lite_pending_t * pending, lv_vg_lite_p
 void lv_vg_lite_pending_add(lv_vg_lite_pending_t * pending, void * obj);
 
 /**
- * Remove all objects from the pending list
+ * Remove all objects from the active pending list
  * @param pending pointer to the pending list
  */
 void lv_vg_lite_pending_remove_all(lv_vg_lite_pending_t * pending);
+
+/**
+ * Rremove all old objects reference and swap new objects reference
+ * @param pending pointer to the pending list
+ */
+void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending);
 
 /**********************
  *      MACROS

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -1315,6 +1315,14 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u)
 #endif
 
     LV_VG_LITE_CHECK_ERROR(vg_lite_flush(), {});
+
+    /* Rremove all old caches reference and swap new caches reference */
+    if(u->grad_pending) {
+        lv_vg_lite_pending_swap(u->grad_pending);
+    }
+
+    lv_vg_lite_pending_swap(u->image_dsc_pending);
+
     u->flush_count = 0;
     LV_PROFILER_DRAW_END;
 }


### PR DESCRIPTION
After calling `vg_lite_flush`, the driver will swap the drawing command buffer and the old resource reference count can be released. Add swap function to `vg_lite_pending` to reduce the cache lock time and number.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
