### PR TITLE
refactor(scripts): initialize lv_image_dsc_t by using C++20 compatible designated initializers

### DIFF
--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -349,13 +349,15 @@ uint8_t {varname}_map[] = {{
 }};
 
 const lv_image_dsc_t {varname} = {{
-  .header.magic = LV_IMAGE_HEADER_MAGIC,
-  .header.cf = LV_COLOR_FORMAT_{cf.name},
-  .header.flags = {flags},
-  .header.w = {w},
-  .header.h = {h},
-  .header.stride = {stride},
-  .header.reserved_2 = 0,
+  .header = {{
+    .magic = LV_IMAGE_HEADER_MAGIC,
+    .cf = LV_COLOR_FORMAT_{cf.name},
+    .flags = {flags},
+    .w = {w},
+    .h = {h},
+    .stride = {stride},
+    .reserved_2 = 0,
+  }},
   .data_size = sizeof({varname}_map),
   .data = {varname}_map,
   .reserved = NULL,

--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -355,8 +355,10 @@ const lv_image_dsc_t {varname} = {{
   .header.w = {w},
   .header.h = {h},
   .header.stride = {stride},
+  .header.reserved_2 = 0,
   .data_size = sizeof({varname}_map),
   .data = {varname}_map,
+  .reserved = NULL,
 }};
 
 '''


### PR DESCRIPTION
In our project we use a single C++ compiler to compile resources like icons and images. Up to now the `LVGLImage.py` generates C code that uses nested designated initializers which is not compatible with C++.  Starting at C++ >=20 it has become possible to use ("unnested") designated initializers.

Therefore, I would like to propose a change of the code to make it use designated initializers but only in a not nested fashion. From my understanding this is compatible to the C standard.


_Remark: do we have a CI job for testing 'compilability' of LVGLImage.py generated code?_

Merge requirements:

- [ ] <https://github.com/lvgl/lvgl/pull/7799>