### PR TITLE
fix(obj): remove all events from the object

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -136,7 +136,20 @@ bool lv_obj_remove_event_dsc(lv_obj_t * obj, lv_event_dsc_t * dsc)
 
 uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
 {
-    return lv_obj_remove_event_cb_with_user_data(obj, event_cb, NULL);
+    LV_ASSERT_NULL(obj);
+
+    uint32_t event_cnt = lv_obj_get_event_count(obj);
+    uint32_t removed_count = 0;
+    uint32_t i;
+    for(i = 0; i < event_cnt; i++) {
+        lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
+        if(dsc && dsc->cb == event_cb) {
+            lv_obj_remove_event(obj, i);
+            removed_count++;
+        }
+    }
+
+    return removed_count;
 }
 
 uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data)
@@ -149,7 +162,7 @@ uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t eve
 
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
-        if(dsc && (event_cb == NULL || dsc->cb == event_cb) && (user_data == NULL || dsc->user_data == user_data)) {
+        if(dsc && (event_cb == NULL || dsc->cb == event_cb) && dsc->user_data == user_data) {
             lv_obj_remove_event(obj, i);
             removed_count ++;
         }

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -126,29 +126,17 @@ bool lv_obj_remove_event(lv_obj_t * obj, uint32_t index)
     return lv_event_remove(&obj->spec_attr->event_list, index);
 }
 
-bool lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
-{
-    LV_ASSERT_NULL(obj);
-
-    uint32_t event_cnt = lv_obj_get_event_count(obj);
-    uint32_t i;
-    for(i = 0; i < event_cnt; i++) {
-        lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
-        if(dsc && dsc->cb == event_cb) {
-            lv_obj_remove_event(obj, i);
-            return true;
-        }
-    }
-
-    return false;
-}
-
 bool lv_obj_remove_event_dsc(lv_obj_t * obj, lv_event_dsc_t * dsc)
 {
     LV_ASSERT_NULL(obj);
     LV_ASSERT_NULL(dsc);
     if(obj->spec_attr == NULL) return false;
     return lv_event_remove_dsc(&obj->spec_attr->event_list, dsc);
+}
+
+uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
+{
+    return lv_obj_remove_event_cb_with_user_data(obj, event_cb, NULL);
 }
 
 uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data)
@@ -161,7 +149,7 @@ uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t eve
 
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
-        if(dsc && (event_cb == NULL || dsc->cb == event_cb) && dsc->user_data == user_data) {
+        if(dsc && (event_cb == NULL || dsc->cb == event_cb) && (user_data == NULL || dsc->user_data == user_data)) {
             lv_obj_remove_event(obj, i);
             removed_count ++;
         }

--- a/src/core/lv_obj_event.h
+++ b/src/core/lv_obj_event.h
@@ -86,9 +86,15 @@ lv_event_dsc_t * lv_obj_get_event_dsc(lv_obj_t * obj, uint32_t index);
 
 bool lv_obj_remove_event(lv_obj_t * obj, uint32_t index);
 
-bool lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb);
-
 bool lv_obj_remove_event_dsc(lv_obj_t * obj, lv_event_dsc_t * dsc);
+
+/**
+ * Remove an event_cb from an object
+ * @param obj           pointer to a obj
+ * @param event_cb      the event_cb of the event to remove
+ * @return              the count of the event removed
+ */
+uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb);
 
 /**
  * Remove an event_cb with user_data


### PR DESCRIPTION
In function lv_obj_remove_event_cb only the first event was removed
respectively marked for deletion.
Changed function prototype to match the prototype
of lv_obj_remove_event_cb_with_user_data.
Simply call this function with user_data = NULL to remove all events.
Expanded if condition in function lv_obj_remove_event_cb_with_user_data
to simply delete all events matching the event_cb without taking
user_data into consideration if user_data is NULL.