### PR TITLE
fix(profiler_builtin): fix uint32_t storage nanosecond time overflow

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_profiler.c
+++ b/src/drivers/nuttx/lv_nuttx_profiler.c
@@ -72,7 +72,7 @@ static uint64_t tick_get_cb(void)
     static uint32_t prev_tick = 0;
     static uint64_t cur_tick_ns = 0;
     uint32_t act_time = up_perf_gettime();
-    uint32_t elaps;
+    uint64_t elaps;
 
     /*If there is no overflow in sys_time simple subtract*/
     if(act_time >= prev_tick) {

--- a/src/misc/lv_profiler_builtin.c
+++ b/src/misc/lv_profiler_builtin.c
@@ -241,12 +241,12 @@ static void flush_no_lock(void)
     uint32_t tick_per_sec = profiler_ctx->config.tick_per_sec;
     while(cur < profiler_ctx->cur_index) {
         lv_profiler_builtin_item_t * item = &profiler_ctx->item_arr[cur++];
-        uint32_t sec = item->tick / tick_per_sec;
-        uint32_t nsec = (item->tick % tick_per_sec) * (LV_PROFILER_TICK_PER_SEC_MAX / tick_per_sec);
+        uint64_t sec = item->tick / tick_per_sec;
+        uint64_t nsec = (item->tick % tick_per_sec) * (LV_PROFILER_TICK_PER_SEC_MAX / tick_per_sec);
 
 #if LV_USE_OS
         lv_snprintf(buf, sizeof(buf),
-                    "   LVGL-%d [%d] %" LV_PRIu32 ".%09" LV_PRIu32 ": tracing_mark_write: %c|1|%s\n",
+                    "   LVGL-%d [%d] %" LV_PRIu64 ".%09" LV_PRIu64 ": tracing_mark_write: %c|1|%s\n",
                     item->tid,
                     item->cpu,
                     sec,
@@ -255,7 +255,7 @@ static void flush_no_lock(void)
                     item->func);
 #else
         lv_snprintf(buf, sizeof(buf),
-                    "   LVGL-1 [0] %" LV_PRIu32 ".%09" LV_PRIu32 ": tracing_mark_write: %c|1|%s\n",
+                    "   LVGL-1 [0] %" LV_PRIu64 ".%09" LV_PRIu64 ": tracing_mark_write: %c|1|%s\n",
                     sec,
                     nsec,
                     item->tag,

--- a/src/stdlib/lv_sprintf.h
+++ b/src/stdlib/lv_sprintf.h
@@ -14,11 +14,21 @@
         #define LV_PRIu32 PRIu32
         #define LV_PRIx32 PRIx32
         #define LV_PRIX32 PRIX32
+
+        #define LV_PRId64 PRId64
+        #define LV_PRIu64 PRIu64
+        #define LV_PRIx64 PRIx64
+        #define LV_PRIX64 PRIX64
     #else
         #define LV_PRId32 "d"
         #define LV_PRIu32 "u"
         #define LV_PRIx32 "x"
         #define LV_PRIX32 "X"
+
+        #define LV_PRId64 "lld"
+        #define LV_PRIu64 "llu"
+        #define LV_PRIx64 "llx"
+        #define LV_PRIX64 "llX"
     #endif
 #else
     /* hope this is correct for ports without __has_include or without inttypes.h */
@@ -26,6 +36,11 @@
     #define LV_PRIu32 "u"
     #define LV_PRIx32 "x"
     #define LV_PRIX32 "X"
+
+    #define LV_PRId64 "lld"
+    #define LV_PRIu64 "llu"
+    #define LV_PRIx64 "llx"
+    #define LV_PRIX64 "llX"
 #endif
 
 #include "../misc/lv_types.h"


### PR DESCRIPTION
uint32_t ：0 - 4,294,967,295
1s = 1,000,000,000 ns

```
#define TICK_TO_NSEC(tick) ((tick) * 1000 / cpu_freq)

static uint64_t tick_get_cb(void)
{
    static uint32_t prev_tick = 0;
    static uint64_t cur_tick_ns = 0;
    uint32_t act_time = up_perf_gettime();
    uint64_t elaps;

    /*If there is no overflow in sys_time simple subtract*/
    if(act_time >= prev_tick) {
        elaps = act_time - prev_tick;
    }
    else {
        elaps = UINT32_MAX - prev_tick + 1;
        elaps += act_time;
    }

    cur_tick_ns += TICK_TO_NSEC(elaps);
    prev_tick = act_time;
    return cur_tick_ns;
}
```

When the time exceeds 4.294967295 ms, it will overflow  (4.294967295 * 1000)


