### PR TITLE
fix(demos/smartwatch): fix image color format error

### DIFF
--- a/demos/smartwatch/assets/img_application_icon.c
+++ b/demos/smartwatch/assets/img_application_icon.c
@@ -34,6 +34,6 @@ const lv_img_dsc_t img_application_icon = {
    .header.w = 24,
    .header.h = 24,
    .data_size = sizeof(img_application_icon_data),
-   .header.cf = LV_COLOR_FORMAT_NATIVE_WITH_ALPHA,
+   .header.cf = LV_COLOR_FORMAT_RGB565A8,
    .data = img_application_icon_data};
 

--- a/demos/smartwatch/assets/img_chat_icon.c
+++ b/demos/smartwatch/assets/img_chat_icon.c
@@ -34,6 +34,6 @@ const lv_img_dsc_t img_chat_icon = {
    .header.w = 24,
    .header.h = 24,
    .data_size = sizeof(img_chat_icon_data),
-   .header.cf = LV_COLOR_FORMAT_NATIVE_WITH_ALPHA,
+   .header.cf = LV_COLOR_FORMAT_RGB565A8,
    .data = img_chat_icon_data};
 

--- a/demos/smartwatch/assets/img_cloud_icon.c
+++ b/demos/smartwatch/assets/img_cloud_icon.c
@@ -34,6 +34,6 @@ const lv_img_dsc_t img_cloud_icon = {
    .header.w = 24,
    .header.h = 24,
    .data_size = sizeof(img_cloud_icon_data),
-   .header.cf = LV_COLOR_FORMAT_NATIVE_WITH_ALPHA,
+   .header.cf = LV_COLOR_FORMAT_RGB565A8,
    .data = img_cloud_icon_data};
 

--- a/demos/smartwatch/assets/img_note_icon.c
+++ b/demos/smartwatch/assets/img_note_icon.c
@@ -34,6 +34,6 @@ const lv_img_dsc_t img_note_icon = {
    .header.w = 24,
    .header.h = 24,
    .data_size = sizeof(img_note_icon_data),
-   .header.cf = LV_COLOR_FORMAT_NATIVE_WITH_ALPHA,
+   .header.cf = LV_COLOR_FORMAT_RGB565A8,
    .data = img_note_icon_data};
 


### PR DESCRIPTION
Fix the mismatch between the image format and the image data, which will cause runtime errors when LV_COLOR_DEPTH=32.
![image](https://github.com/user-attachments/assets/3284f1d7-a924-4469-ad9f-bf3ee5de1fbd)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
