### PR TITLE
feat(chart): implement get_index_from_x() for LV_CHART_TYPE_SCATTER

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1300,6 +1300,22 @@ static uint32_t get_index_from_x(lv_obj_t * obj, int32_t x)
     if(x > w) return chart->point_cnt - 1;
     if(chart->type == LV_CHART_TYPE_LINE) return (x * (chart->point_cnt - 1) + w / 2) / w;
     if(chart->type == LV_CHART_TYPE_BAR) return (x * chart->point_cnt) / w;
+    if(chart->type == LV_CHART_TYPE_SCATTER) {
+        /*For scatter charts, the nearest id could be different depending on the series. Just check the first series.*/
+        lv_chart_series_t * ser = lv_chart_get_series_next(obj, NULL);
+        if(ser) {
+            int32_t best_dist = INT32_MAX;
+            uint32_t best_index = 0;
+            for(uint32_t i = 0; i < chart->point_cnt; i++) {
+                int32_t dist = LV_ABS(x - lv_map(ser->x_points[i], chart->xmin[ser->x_axis_sec], chart->xmax[ser->x_axis_sec], 0, w));
+                if(dist < best_dist) {
+                    best_dist = dist;
+                    best_index = i;
+                }
+            }
+            return best_index;
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
Currently `LV_EVENT_VALUE_CHANGED` and `lv_chart_get_pressed_point()` are not supported for scatter charts. Support them at least for the first series of scatter charts by handling `LV_CHART_TYPE_SCATTER` in `get_index_from_x()`.