### PR TITLE
fix(obj): modify style_cnt to uint16_t

### DIFF
--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -65,11 +65,11 @@ struct _lv_obj_t {
     lv_area_t coords;
     lv_obj_flag_t flags;
     lv_state_t state;
+    uint16_t style_cnt;
     uint16_t layout_inv : 1;
     uint16_t readjust_scroll_after_layout : 1;
     uint16_t scr_layout_inv : 1;
     uint16_t skip_trans : 1;
-    uint16_t style_cnt  : 6;
     uint16_t h_layout   : 1;
     uint16_t w_layout   : 1;
     uint16_t is_deleting : 1;

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -65,11 +65,11 @@ struct _lv_obj_t {
     lv_area_t coords;
     lv_obj_flag_t flags;
     lv_state_t state;
-    uint16_t style_cnt;
     uint16_t layout_inv : 1;
     uint16_t readjust_scroll_after_layout : 1;
     uint16_t scr_layout_inv : 1;
     uint16_t skip_trans : 1;
+    uint16_t style_cnt  : 9;
     uint16_t h_layout   : 1;
     uint16_t w_layout   : 1;
     uint16_t is_deleting : 1;

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -97,7 +97,7 @@ void lv_obj_style_deinit(void)
 
 void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
-    LV_ASSERT(obj->style_cnt < UINT16_MAX - 1);
+    LV_ASSERT(obj->style_cnt < 511);
 
     trans_delete(obj, selector, LV_STYLE_PROP_ANY, NULL);
 

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -97,7 +97,7 @@ void lv_obj_style_deinit(void)
 
 void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
-    LV_ASSERT(obj->style_cnt < 63);
+    LV_ASSERT(obj->style_cnt < UINT16_MAX - 1);
 
     trans_delete(obj, selector, LV_STYLE_PROP_ANY, NULL);
 


### PR DESCRIPTION
There are many combinations of `state `and `part` in widget. We should expand `style_cnt `so that each `selector `has a corresponding `style`. <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
