### PR TITLE
fix(obj_style): fix possible memory leak

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -240,7 +240,13 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
         }
 
         obj->style_cnt--;
-        obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+        if (obj->style_cnt) {
+            obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+        }
+        else {
+            lv_free(obj->styles);
+            obj->styles = NULL;
+        }
 
         deleted = true;
         /*The style from the current `i` index is removed, so `i` points to the next style.

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -240,7 +240,7 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
         }
 
         obj->style_cnt--;
-        if (obj->style_cnt) {
+        if(obj->style_cnt) {
             obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
         }
         else {


### PR DESCRIPTION
Fixed a memory leak in function lv_obj_remove_style. When obj->style_cnt is 0, the original logic realloc a zero byte of memory, but some realloc implementations align the bytes upward instead of directly free, causing a memory leak of one aligned byte.