### PR TITLE
fix(nuttx_fbdev): fix memory buffer handling

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -328,27 +328,26 @@ static int fbdev_get_pinfo(int fd, FAR struct fb_planeinfo_s * pinfo)
 
 static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
 {
-    uintptr_t buf_offset;
     struct fb_planeinfo_s pinfo;
-    int ret;
-    void * mem2;
+    void * phy_mem1;
+    void * phy_mem2;
 
+    int ret;
+
+    /* Get display[0] planeinfo */
     lv_memzero(&pinfo, sizeof(pinfo));
+    pinfo.display = dsc->pinfo.display;
+    if((ret = fbdev_get_pinfo(dsc->fd, &pinfo)) < 0) return ret;
+    phy_mem1 = pinfo.fbmem;
 
     /* Get display[1] planeinfo */
-
+    lv_memzero(&pinfo, sizeof(pinfo));
     pinfo.display = dsc->pinfo.display + 1;
+    if((ret = fbdev_get_pinfo(dsc->fd, &pinfo)) < 0) return ret;
+    phy_mem2 = pinfo.fbmem;
 
-    if((ret = fbdev_get_pinfo(dsc->fd, &pinfo)) < 0) {
-        return ret;
-    }
-
-    mem2 = mmap(NULL, pinfo.fblen, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FILE, dsc->fd, 0);
-
-    if(mem2 == MAP_FAILED) {
-        LV_LOG_ERROR("ERROR: mmap failed: %d\n", errno);
-        return -errno;
-    }
+    lv_uintptr_t offset = (lv_uintptr_t)phy_mem2 - (lv_uintptr_t)phy_mem1;
+    bool is_consecutive = offset == 0;
 
     /* Check bpp */
 
@@ -361,29 +360,33 @@ static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
      * It needs to be divisible by pinfo.stride
      */
 
-    buf_offset = mem2 - dsc->mem;
-
-    if((buf_offset % dsc->pinfo.stride) != 0) {
+    if((offset % dsc->pinfo.stride) != 0) {
         LV_LOG_WARN("It is detected that buf_offset(%" PRIuPTR ") "
                     "and stride(%d) are not divisible, please ensure "
                     "that the driver handles the address offset by itself.",
-                    buf_offset, dsc->pinfo.stride);
+                    offset, dsc->pinfo.stride);
     }
 
     /* Calculate the address and yoffset of mem2 */
 
-    if(buf_offset == 0) {
+    if(is_consecutive) {
         dsc->mem2_yoffset = dsc->vinfo.yres;
-        dsc->mem2 = mem2 + dsc->mem2_yoffset * pinfo.stride;
-        LV_LOG_USER("Use consecutive mem2 = %p, yoffset = %" LV_PRIu32,
-                    dsc->mem2, dsc->mem2_yoffset);
+        offset = dsc->vinfo.yres * pinfo.stride;
     }
     else {
-        dsc->mem2_yoffset = buf_offset / dsc->pinfo.stride;
-        dsc->mem2 = mem2;
-        LV_LOG_USER("Use non-consecutive mem2 = %p, yoffset = %" LV_PRIu32,
-                    dsc->mem2, dsc->mem2_yoffset);
+        dsc->mem2_yoffset = offset / dsc->pinfo.stride;
     }
+
+    uint32_t fblen = is_consecutive ? pinfo.fblen / 2 : pinfo.fblen;
+    void * mem2 = mmap(NULL, fblen, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FILE, dsc->fd, offset);
+    if(mem2 == MAP_FAILED) {
+        LV_LOG_ERROR("ERROR: mmap failed: %d, offset: %" PRIuPTR, errno, offset);
+        return -errno;
+    }
+    dsc->mem2 = mem2;
+
+    LV_LOG_USER("Use of %sconsecutive mem2 = %p, yoffset = %" LV_PRIu32, is_consecutive ? "" : "non-", dsc->mem2,
+                dsc->mem2_yoffset);
 
     return 0;
 }


### PR DESCRIPTION
mmap fb mem addr

Improved the memory buffer handling in the framebuffer device driver for NuttX.

This change adjusts the calculation of the buffer offset and ensures that the framebuffer memory is correctly mapped.

consecutive: The **offset** of the `fbmem` address **between** two `displays` in the **same** `panel` is 0.

- For consecutive address cases
    - Calculate the `offset` based on `yoffset`.
    - Since the `fblen` is the size of two buffers when addresses are **consecutive**, it needs to be divided by **2**.
- For non-continuous address cases
    - Use the difference between the `fbmem` address **offsets** of the two displays as the `offset` directly.
    - `fblen` is an independent value for each.

Perform `mmap` operations based on the `offset` and `fblen`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
