### PR TITLE
fix(txt): text command escaping

### DIFF
--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -146,7 +146,7 @@ bool lv_text_is_cmd(lv_text_cmd_state_t * state, uint32_t c)
             ret = true;
         }
         /*Other start char in parameter is escaped cmd. char*/
-        else if(*state == LV_TEXT_CMD_STATE_WAIT) {
+        else if(*state == LV_TEXT_CMD_STATE_PAR) {
             *state = LV_TEXT_CMD_STATE_WAIT;
         }
         /*Command end*/


### PR DESCRIPTION
Text commands were processed even when correctly escaped.
This resulted in several problems were the width of the text was calculated wrong, causing for example incorrect alignments.

Example:
A right aligned label with the text "XX##YY" would render partially out of the widget as only the "XX" is used to calculate the width of the text to align it. Rest of the text is skipped as it's considered a text command.
Note: the text that is rendered is correct, resulting in the expected text "XX##YY"