### PR TITLE
fix(vg_lite): fix pending swap sequence error

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_pending.c
+++ b/src/draw/vg_lite/lv_vg_lite_pending.c
@@ -99,8 +99,8 @@ void lv_vg_lite_pending_remove_all(lv_vg_lite_pending_t * pending)
 
 void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending)
 {
-    lv_vg_lite_pending_remove_all(pending);
     pending->arr_act = (pending->arr_act == &pending->arr_1) ? &pending->arr_2 : &pending->arr_1;
+    lv_vg_lite_pending_remove_all(pending);
 }
 
 /**********************


### PR DESCRIPTION
When swapping, the reference to the previously drawn image should be removed instead of the reference to the image that has not yet been drawn.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
