### PR TITLE
feat(obj_tree): indent printed object data according to its depth 

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -634,7 +634,7 @@ static void dump_tree_core(lv_obj_t * obj, int32_t depth)
 #endif
 
     /*id of `obj0` is an invalid id for builtin id*/
-    LV_LOG_USER("%*sparent:%p, obj:%p, id:%s;", 2 * depth, "", (void *)(obj ? obj->parent : NULL), (void *)obj, id);
+    LV_LOG_USER("%*sobj:%p, id:%s;", 2 * depth, "", (void *)obj, id);
 #endif /*LV_USE_LOG*/
 
     if(obj && obj->spec_attr && obj->spec_attr->child_cnt) {

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -634,7 +634,7 @@ static void dump_tree_core(lv_obj_t * obj, int32_t depth)
 #endif
 
     /*id of `obj0` is an invalid id for builtin id*/
-    LV_LOG_USER("parent:%p, obj:%p, id:%s;", (void *)(obj ? obj->parent : NULL), (void *)obj, id);
+    LV_LOG_USER("%*sparent:%p, obj:%p, id:%s;", 2 * depth, "", (void *)(obj ? obj->parent : NULL), (void *)obj, id);
 #endif /*LV_USE_LOG*/
 
     if(obj && obj->spec_attr && obj->spec_attr->child_cnt) {


### PR DESCRIPTION
Hi, I've found myself using `lv_obj_dump_tree` in recent days, I think it is more visually appealing to indent each object according to it's parent (using the depth argument). this is a small thing, but might be worthwhile, let me know what you think.

before:
``` log
[LVGL] [User]   (36.088, +8)     dump_tree_core: parent:0x7ffff6ba9fd8, obj:0x7ffff6baa500, id:nameless8; lv_obj_tree.c:637
[LVGL] [User]   (36.097, +9)     dump_tree_core: parent:0x7ffff6baa500, obj:0x7ffff6baa7a0, id:btn12; lv_obj_tree.c:637
[LVGL] [User]   (36.105, +8)     dump_tree_core: parent:0x7ffff6baa7a0, obj:0x7ffff6baa9f8, id:label25; lv_obj_tree.c:637
[LVGL] [User]   (36.113, +8)     dump_tree_core: parent:0x7ffff6baa500, obj:0x7ffff6baab38, id:btn13; lv_obj_tree.c:637
[LVGL] [User]   (36.120, +7)     dump_tree_core: parent:0x7ffff6baab38, obj:0x7ffff6baad70, id:label26; lv_obj_tree.c:637
```

after:
``` log
[LVGL] [User]   (36.088, +8)     dump_tree_core: parent:0x7ffff6ba9fd8, obj:0x7ffff6baa500, id:nameless8; lv_obj_tree.c:637
[LVGL] [User]   (36.097, +9)     dump_tree_core:   parent:0x7ffff6baa500, obj:0x7ffff6baa7a0, id:btn12; lv_obj_tree.c:637
[LVGL] [User]   (36.105, +8)     dump_tree_core:     parent:0x7ffff6baa7a0, obj:0x7ffff6baa9f8, id:label25; lv_obj_tree.c:637
[LVGL] [User]   (36.113, +8)     dump_tree_core:   parent:0x7ffff6baa500, obj:0x7ffff6baab38, id:btn13; lv_obj_tree.c:637
[LVGL] [User]   (36.120, +7)     dump_tree_core:     parent:0x7ffff6baab38, obj:0x7ffff6baad70, id:label26; lv_obj_tree.c:637
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
