### PR TITLE
fix(port_releaser): always use remote when pushing and add token

### DIFF
--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -1,8 +1,6 @@
 name: Port repo release update
 
 on:
-  pull_request:
-    branches: [ master ]
   push:
     branches:
       - master

--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -1,6 +1,8 @@
 name: Port repo release update
 
 on:
+  pull_request:
+    branches: [ master ]
   push:
     branches:
       - master

--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -31,4 +31,6 @@ jobs:
           git config --global user.email 'lvgl-bot@users.noreply.github.com'
 
       - name: run the script
-        run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9
+        with:
+          GITHUB_TOKEN: ${{ secrets.PORT_RELEASER_GITHUB_TOKEN }}
+        run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github_token "$GITHUB_TOKEN"

--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -35,4 +35,4 @@ jobs:
       - name: run the script
         env:
           GITHUB_TOKEN: ${{ secrets.PORT_RELEASER_GITHUB_TOKEN }}
-        run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github_token "$GITHUB_TOKEN"
+        run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github-token "$GITHUB_TOKEN"

--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -33,6 +33,6 @@ jobs:
           git config --global user.email 'lvgl-bot@users.noreply.github.com'
 
       - name: run the script
-        with:
+        env:
           GITHUB_TOKEN: ${{ secrets.PORT_RELEASER_GITHUB_TOKEN }}
         run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github_token "$GITHUB_TOKEN"

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -13,6 +13,8 @@ import sys
 LOG = "[release_branch_updater.py]"
 
 def git_repository(repository: str, token: str):
+    if not token:
+        return f"https://{repository}"
     return f"https://{token}@{repository}"
 
 def main():

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -199,10 +199,7 @@ def main():
                 if dry_run:
                     print(LOG, "this is a dry run so nothing will be pushed")
                 else:
-                    subprocess.check_call(("git", "-C", port_clone_tmpdir, "push",
-                                           *(("-u",) if port_does_not_have_the_branch else ()),
-                                           "origin", fmt_release(port_branch),
-                                          ))
+                    subprocess.check_call(("git", "-C", port_clone_tmpdir, "push", "origin", fmt_release(port_branch)))
                     print(LOG, "the changes were pushed.")
             else:
                 print(LOG, "nothing to push for this release. it is up to date.")

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -35,6 +35,9 @@ def main():
     dry_run = args.dry_run
     oldest_major = args.oldest_major
 
+    if not args.github_token and not dry_run:
+        print(LOG, "Warning: No github token was provided for this production run. Continuing anyway...")
+
     lvgl_release_branches, lvgl_default_branch = get_release_branches(lvgl_path)
     print(LOG, "LVGL release branches:", ", ".join(fmt_release(br) for br in lvgl_release_branches) or "(none)")
     assert lvgl_default_branch is not None


### PR DESCRIPTION
This fixes the current CI problem, but won't fix the whole script ~~I believe~~ by just merging it

Since the script is pulling using `https`, github will ask for a username and a token. The `GITHUB_TOKEN` that github provides you inside the workflow won't allow you to push to a different repository even if it's part of the same organization

The way I would solve this is by generating a `fine-grained token`  associated with the `lvgl` organization with `write permissions` on the repositories you wish.

For this: 
1. Click on your profile icon on the top right
2. Go to settings
3. Scroll all the way down to  `Developer Settings`
4. `Personal Tokens` > `Fine-Grained Tokens` > `Generate New Token`
5. Select the `lvgl` organization
6. Select `All Repositories` or `Only Select Repositories` based on preference. I suggest `Only Select Repositories` since it's safer.
    - The `lvgl/lvgl` repository doesn't need to be added here, only the `lvgl/lv_port_XXX` repositories that you wish to update
7. Add the `Contents` read + write permission

Now add this token as a github secret to this repository

1. Go to this repository's settings 
2. `Secretes and Variables` > `Actions` > `New Repository Secret`
3. Add the token as a secret. Name it `PORT_RELEASER_GITHUB_TOKEN`

Now this new token can be used to clone the repositories with the correct permissions which will allow you to write i.e push to them by cloning them in this format `https://{token}@github.com/lvgl/lv_port...`

This PR updates the script according to my explanations above

## Some security concerns

**This secret could be leaked**. Github checks for the scripts outputs matching the secrets and redacts it but a malicious person could still get his hands on it if he tries really hard. See [here](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions).
 
Since this workflow is only ran when a merge to master happens, the reviewers just need to pay extra attention to the changes made to this script/ workflow and not merge anything that seems suspicious

~~Additionally, someone could potentially change the workflow and the CI to trigger on a PR, and leak the token this way, for this, the best way would be to not allow workflows to run when the workflow file is changed inside a PR. This can be done by using the `CODEOWNERS` feature [here](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)~~

The whole interaction with the secrets, scripts and workflows make this impossible to test reliably but I believe this PR fixes or at least gets you closer to having a working workflow

Hope this helps. Let me know if you have any questions

@kisvegabor @liamHowatt 