### PR TITLE
fix(release_updater): push: if branch is specified, remote must be specified too

### DIFF
--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -200,8 +200,8 @@ def main():
                     print(LOG, "this is a dry run so nothing will be pushed")
                 else:
                     subprocess.check_call(("git", "-C", port_clone_tmpdir, "push",
-                                           *(("-u", "origin") if port_does_not_have_the_branch else ()),
-                                           fmt_release(port_branch),
+                                           *(("-u",) if port_does_not_have_the_branch else ()),
+                                           "origin", fmt_release(port_branch),
                                           ))
                     print(LOG, "the changes were pushed.")
             else:


### PR DESCRIPTION
Fix the CI.

https://github.com/lvgl/lvgl/actions/runs/13537935484/job/37832863803

```
fatal: 'release/v9.0' does not appear to be a git repository
...
Traceback (most recent call last):
  File "/home/runner/work/lvgl/lvgl/lvgl/scripts/release_branch_updater.py", line 241, in <module>
  File "/home/runner/work/lvgl/lvgl/lvgl/scripts/release_branch_updater.py", line 202, in main
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('git', '-C', 'port_tmpdir', 'push', 'release/v9.0')' returned non-zero exit status 128.
```


```
       git push [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]
                  [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]
                  [-u | --set-upstream] [-o <string> | --push-option=<string>]
                  [--[no-]signed|--signed=(true|false|if-asked)]
                  [--force-with-lease[=<refname>[:<expect>]]]
                  [--no-verify] [<repository> [<refspec>...]]
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
