### PR TITLE
fix(nxp/g2d): fix memory management error in G2D buffer mapping

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_buf_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_buf_g2d.c
@@ -78,7 +78,11 @@ static void * _buf_malloc(size_t size_bytes, lv_color_format_t color_format)
 
 static void _buf_free(void * buf)
 {
-    g2d_free_item(buf);
+    // make sure items are in the hash table
+    struct g2d_buf * g2d_buf = g2d_search_buf_map(buf);
+    if(g2d_buf) {
+        g2d_free_item(buf);
+    }
 }
 
 static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.c
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.c
@@ -243,7 +243,6 @@ static lv_map_item_t * _map_create_item(void * key, struct g2d_buf * value)
 static void _map_free_item(lv_map_item_t * item)
 {
     /* Also free the g2d_buf. */
-    lv_free(item->key);
     g2d_free(item->value);
     item->key = NULL;
     item->value = NULL;


### PR DESCRIPTION
Fix a critical memory management error in the G2D buffer mapping hash table implementation that causes the program to attempt freeing a memory address that was not malloc()-ed. The issue occurred in the _map_free_item function where it incorrectly tried to free item->key, which is just a reference and not memory allocated through lv_malloc.

AddressSanitizer Log:
<details>
<summary>Click to expand</summary>

``` 
=================================================================
==463==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0xffff8b7d6000 in thread T0
#0 0xffff8b8ba5a0 in interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
#1 0xaaaac92667c4 in lv_free_core (/frontend+0x267c4)
#2 0xaaaac9266d90 in lv_free (/frontend+0x26d90)
#3 0xaaaac92bf3f0 in mapfree_item (/frontend+0x7f3f0)
#4 0xaaaac92beefc in g2d_free_item (/frontend+0x7eefc)
#5 0xaaaac92df594 in buffree (/frontend+0x9f594)
#6 0xaaaac924bb88 in draw_buf_free (/frontend+0xbb88)
#7 0xaaaac924ad48 in lv_draw_buf_destroy (/frontend+0xad48)
#8 0xaaaac9249bec in lv_cleanup_task (/frontend+0x9bec)
#9 0xaaaac92491ec in lv_draw_dispatch_layer (/frontend+0x91ec)
#10 0xaaaac9249130 in lv_draw_dispatch (/frontend+0x9130)
#11 0xaaaac9249024 in lv_draw_finalize_task_creation (/frontend+0x9024)
#12 0xaaaac924e408 in lv_draw_rect (/frontend+0xe408)
#13 0xaaaac92a4e24 in lv_obj_draw (/frontend+0x64e24)
#14 0xaaaac92a5910 in lv_obj_event (/frontend+0x65910)
#15 0xaaaac92a839c in lv_obj_event_base (/frontend+0x6839c)
#16 0xaaaac92a8ff4 in event_send_core (/frontend+0x68ff4)
#17 0xaaaac92a82d4 in lv_obj_send_event (/frontend+0x682d4)
#18 0xaaaac92b84fc in lv_obj_redraw (/frontend+0x784fc)
#19 0xaaaac92ba7cc in refr_obj (/frontend+0x7a7cc)
#20 0xaaaac92b84b0 in lv_obj_redraw (/frontend+0x784b0)
#21 0xaaaac92ba600 in refr_obj (/frontend+0x7a600)
#22 0xaaaac92ba23c in refr_obj_and_children (/frontend+0x7a23c)
#23 0xaaaac92ba034 in refr_configured_layer (/frontend+0x7a034)
#24 0xaaaac92b9afc in refr_area (/frontend+0x79afc)
#25 0xaaaac92b9634 in refr_invalid_areas (/frontend+0x79634)
#26 0xaaaac92b8d30 in lv_display_refr_timer (/frontend+0x78d30)
#27 0xaaaac9265524 in lv_timer_exec (/frontend+0x25524)
#28 0xaaaac9264bb4 in lv_timer_handler (/frontend+0x24bb4)
#29 0xaaaac924581c in lv_linux_run_loop (/frontend+0x581c)
#30 0xaaaac9245854 in main (/frontend+0x5854)
#31 0xffff8acc773c in libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
#32 0xffff8acc7814 in libc_start_main_impl ../csu/libc-start.c:360
#33 0xaaaac92456ec in _start (/frontend+0x56ec)
Address 0xffff8b7d6000 is a wild pointer inside of access range of size 0x000000000001.
SUMMARY: AddressSanitizer: bad-free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52 in interceptor_free
==463==ABORTING
``` 

</details>