### PR TITLE
fix(nuttx): incorrect draw buffer size for I1 color and bpp=1

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_lcd.c
+++ b/src/drivers/nuttx/lv_nuttx_lcd.c
@@ -138,12 +138,15 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area_p,
                      uint8_t * color_p)
 {
     lv_nuttx_lcd_t * lcd = disp->driver_data;
+    lv_color_format_t cf = lv_display_get_color_format(disp);
 
     lcd->area.row_start = area_p->y1;
     lcd->area.row_end = area_p->y2;
     lcd->area.col_start = area_p->x1;
     lcd->area.col_end = area_p->x2;
-    lcd->area.data = (uint8_t *)color_p;
+    lcd->area.stride = lv_draw_buf_width_to_stride(lcd->area.col_end - lcd->area.col_start + 1, cf);
+    lcd->area.data = (uint8_t *)color_p + (LV_COLOR_FORMAT_IS_INDEXED(cf) ?
+                                           LV_COLOR_INDEXED_PALETTE_SIZE(cf) * 4 : 0);
     ioctl(lcd->fd, LCDDEVIO_PUTAREA, (unsigned long) & (lcd->area));
     lv_display_flush_ready(disp);
 }


### PR DESCRIPTION
Fix incorrect draw buffer size in `lv_nuttx_lcd.c:lcd_init()` when color format is `I1` and `bpp=1`.

I also added some code to skip the color palette in `flush_cb()` before calling `ioctl(..., LCDDEVIO_PUTAREA,...)`. I'm not sure if this is the correct approach, maybe NuttX's `drivers/lcd/lcd_dev.c` must handle the palette information. 

Is it like a standard for `I1-I8` color formats to prepend the palette before the draw buffer? If so, then I think NuttX's lcd driver must handle it. 

### Description of Testing
I tested this with NuttX + LVGL configured to use LCD_DEV on a custom board with 1.54" e-INK display with SSD1681 controller.
You can check out my topic on LVGL forum where I investigated and found this fix, [topic here](https://forum.lvgl.io/t/lvgl9-nuttx-eink-cannot-render-anything-useful/20283). 
 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
