### PR TITLE
Do not squash: FFmpeg fixes

### DIFF
--- a/docs/src/details/libs/ffmpeg.rst
+++ b/docs/src/details/libs/ffmpeg.rst
@@ -62,6 +62,9 @@ Set the :c:macro:`LV_USE_FFMPEG` in ``lv_conf.h`` to ``1``.
 
 Also set :c:macro:`LV_FFMPEG_PLAYER_USE_LV_FS` in ``lv_conf.h`` to ``1`` if you want
 to integrate the LVGL :ref:`file_system` extension into FFmpeg.
+This library can load videos and images. The LVGL file system
+will always be used when an image is loaded with :cpp:func:`lv_image_set_src`
+regardless of the value of :c:macro:`LV_FFMPEG_PLAYER_USE_LV_FS`.
 
 See the examples below for how to correctly use this library.
 

--- a/examples/libs/ffmpeg/lv_example_ffmpeg_1.c
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_1.c
@@ -7,6 +7,9 @@
  */
 void lv_example_ffmpeg_1(void)
 {
+    /*It always uses the LVGL filesystem abstraction (not the OS filesystem)
+     *to open the image, unlike `lv_ffmpeg_player_set_src` which depends on
+     *the setting of `LV_FFMPEG_PLAYER_USE_LV_FS`.*/
     lv_obj_t * img = lv_image_create(lv_screen_active());
     lv_image_set_src(img, "./lvgl/examples/libs/ffmpeg/ffmpeg.png");
     lv_obj_center(img);

--- a/examples/libs/ffmpeg/lv_example_ffmpeg_2.c
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_2.c
@@ -9,6 +9,8 @@ void lv_example_ffmpeg_2(void)
 {
     /*birds.mp4 is downloaded from http://www.videezy.com (Free Stock Footage by Videezy!)
      *https://www.videezy.com/abstract/44864-silhouettes-of-birds-over-the-sunset*/
+    /*It will use the LVGL filesystem abstraction (not the OS filesystem)
+     *if `LV_FFMPEG_PLAYER_USE_LV_FS` is set.*/
     lv_obj_t * player = lv_ffmpeg_player_create(lv_screen_active());
     lv_ffmpeg_player_set_src(player, "./lvgl/examples/libs/ffmpeg/birds.mp4");
     lv_ffmpeg_player_set_auto_restart(player, true);

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -185,13 +185,17 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
     uint32_t data_size = 0;
 
     data_size = width * height * 4;
+    uint8_t * data = ffmpeg_get_image_data(player->ffmpeg_ctx);
+    lv_color_format_t cf = has_alpha ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_NATIVE;
+    uint32_t stride = width * lv_color_format_get_size(cf);
+    lv_memzero(data, stride * height);
 
     player->imgdsc.header.w = width;
     player->imgdsc.header.h = height;
     player->imgdsc.data_size = data_size;
-    player->imgdsc.header.cf = has_alpha ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_NATIVE;
-    player->imgdsc.header.stride = width * lv_color_format_get_size(player->imgdsc.header.cf);
-    player->imgdsc.data = ffmpeg_get_image_data(player->ffmpeg_ctx);
+    player->imgdsc.header.cf = cf;
+    player->imgdsc.header.stride = stride;
+    player->imgdsc.data = data;
 
     lv_image_set_src(&player->img.obj, &(player->imgdsc));
 

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -856,6 +856,7 @@ static void ffmpeg_close_src_ctx(struct ffmpeg_context_s * ffmpeg_ctx)
 {
     avcodec_free_context(&(ffmpeg_ctx->video_dec_ctx));
     avformat_close_input(&(ffmpeg_ctx->fmt_ctx));
+    av_packet_free(&ffmpeg_ctx->pkt);
     av_frame_free(&(ffmpeg_ctx->frame));
     if(ffmpeg_ctx->video_src_data[0] != NULL) {
         av_free(ffmpeg_ctx->video_src_data[0]);


### PR DESCRIPTION
Addressing something from issue #7892. Once this is reviewed, I will open a PR for `release/v9.2` to close the issue.

# `fix(ffmpeg): free packet`

```
Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7f3fa26706e5 in __interceptor_posix_memalign ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:217
    #1 0x556f13eb29d4 in av_malloc libavutil/mem.c:107
    #2 0x556f134f6665 in lv_ffmpeg_player_set_src /home/liam/lvgl/lvgl/src/libs/ffmpeg/lv_ffmpeg.c:176
    #3 0x556f1353ea33 in lv_example_ffmpeg_2 /home/liam/lvgl/lvgl/examples/libs/ffmpeg/lv_example_ffmpeg_2.c:13
    #4 0x556f133686fb in main /home/liam/lvgl/lvgl_workspace/main.c:4320
    #5 0x7f3fa0eb9082 in __libc_start_main ../csu/libc-start.c:308
```

# `fix(ffmpeg): clear the first image data`

By loading and unload the video, I see that the first frame has distortions. It was more noticeable with a video that took longer to load.

```diff
diff --git a/examples/libs/ffmpeg/lv_example_ffmpeg_2.c b/examples/libs/ffmpeg/lv_example_ffmpeg_2.c
index 73784910f..40eeea787 100644
--- a/examples/libs/ffmpeg/lv_example_ffmpeg_2.c
+++ b/examples/libs/ffmpeg/lv_example_ffmpeg_2.c
@@ -2,10 +2,7 @@
 #if LV_BUILD_EXAMPLES
 #if LV_USE_FFMPEG
 
-/**
- * Open a video from a file
- */
-void lv_example_ffmpeg_2(void)
+static void play(void)
 {
     /*birds.mp4 is downloaded from http://www.videezy.com (Free Stock Footage by Videezy!)
      *https://www.videezy.com/abstract/44864-silhouettes-of-birds-over-the-sunset*/
@@ -16,6 +13,29 @@ void lv_example_ffmpeg_2(void)
     lv_obj_center(player);
 }
 
+static void tim_cb(lv_timer_t * t)
+{
+    static bool x = true;
+    if(x){
+        LV_LOG_USER("play");
+        play();
+    } else {
+        LV_LOG_USER("clear");
+        lv_obj_clean(lv_screen_active());
+    }
+    x = !x;
+}
+
+/**
+ * Open a video from a file
+ */
+void lv_example_ffmpeg_2(void)
+{
+    lv_timer_t * tim = lv_timer_create(tim_cb, 1000, NULL);
+    lv_timer_set_repeat_count(tim, -1);
+    lv_timer_ready(tim);
+}
+
 #else
 
 void lv_example_ffmpeg_2(void)
```

Before:

https://github.com/user-attachments/assets/cac53727-3d16-47fa-a410-3da4421e0bec

After:

https://github.com/user-attachments/assets/71d7c6b3-5dd8-422d-8db0-d9cefb867b8a

I ensured this commit does not clear an image (since FFMPEG can load images too) after it's loaded.

# `docs(ffmpeg): images always loaded with lvgl fs`

See #7892. Images are always loaded with the LVGL filesystem regardless of `LV_FFMPEG_PLAYER_USE_LV_FS`.

<hr>

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
