### PR TITLE
fix(area): test and fix lv_area_diff edge case

### DIFF
--- a/src/misc/lv_area.c
+++ b/src/misc/lv_area.c
@@ -151,7 +151,7 @@ int8_t lv_area_diff(lv_area_t res_p[], const lv_area_t * a1_p, const lv_area_t *
 
     /*Compute the left rectangle*/
     int32_t lw = a2_p->x1 - a1_p->x1;
-    if(lw > 0 && sh > 0) {
+    if(lw > 0 && sh >= 0) {
         n.x1 = a1_p->x1;
         n.y1 = y1;
         n.x2 = a1_p->x1 + lw - 1;
@@ -161,7 +161,7 @@ int8_t lv_area_diff(lv_area_t res_p[], const lv_area_t * a1_p, const lv_area_t *
 
     /*Compute the right rectangle*/
     int32_t rw = a1_w - (a2_p->x2 - a1_p->x1);
-    if(rw > 0) {
+    if(rw > 0 && sh >= 0) {
         n.x1 = a2_p->x2 + 1;
         n.y1 = y1;
         n.x2 = a2_p->x2 + rw;


### PR DESCRIPTION
There is an edge case (literally :smile:) where `lv_area_diff()` fails to produce side rectangles of height 1 (i.e., `y2 - y1 == 0`).

This sometimes leads to thin horizontal lines failing to be refreshed, particularly near arcs which often invalidate small rectangles.

Example input:

```
ooo..
oor..
.....
```

`lv_area_diff(x, o, r)` should result in:

```
xxx..
xx...
.....
```

But actually results in:


```
xxx..
.....
.....
```

This is a regression due to #7696. That patch correctly removes the overlap, but previously the overlap was hiding this issue.

Adds a test case that randomly enumerates example scenarios and checks the results are equal to the results of an inefficient but trivial algorithm. Also verifies that `lv_area_diff()` produces no useless overlap (via `assert_change`).