### PR TITLE
fix(scale): remove dangling reference to stack buffer

### DIFF
--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -787,6 +787,12 @@ static void scale_draw_label(lv_obj_t * obj, lv_event_t * event, lv_draw_label_d
     else {
         lv_draw_label(layer, label_dsc, &label_coords);
     }
+
+    if(label_dsc->text_local) {
+        /* clear the reference to the text buffer on the stack */
+        label_dsc->text = NULL;
+        label_dsc->text_local = false;
+    }
 }
 
 static void scale_calculate_main_compensation(lv_obj_t * obj)


### PR DESCRIPTION
In scale_draw_label(), when a label text is created for a tick value, a buffer allocated on the stack is used to set the text string.  When the scale_draw_label() returns, a pointer in the label descriptor is still pointing at this stack buffer.  Add code to remove the reference to the stack buffer before scale_draw_label() returns.

