### PR TITLE
feat(font): Enable dynamic glyph bitmap loading with font_loader

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -667,6 +667,10 @@ menu "LVGL configuration"
         config LV_USE_FONT_PLACEHOLDER
             bool "Enable drawing placeholders when glyph dsc is not found."
             default y
+
+        config LV_USE_FONT_DYNAMIC_LOAD
+            bool "Enable dynamic glyph bitmap loading with font_loader"
+            default n
     endmenu
 
     menu "Text Settings"

--- a/env_support/cmsis-pack/lv_conf_cmsis.h
+++ b/env_support/cmsis-pack/lv_conf_cmsis.h
@@ -407,6 +407,9 @@
 /*Enable drawing placeholders when glyph dsc is not found*/
 #define LV_USE_FONT_PLACEHOLDER 1
 
+/* Enable dynamic loading of fonts */
+#define LV_USE_FONT_DYNAMIC_LOAD 0
+
 /*=================
  *  TEXT SETTINGS
  *=================*/

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -422,6 +422,9 @@
 /*Enable drawing placeholders when glyph dsc is not found*/
 #define LV_USE_FONT_PLACEHOLDER 1
 
+/* Enable dynamic loading of fonts */
+#define LV_USE_FONT_DYNAMIC_LOAD 0
+
 /*=================
  *  TEXT SETTINGS
  *=================*/

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -87,7 +87,15 @@ const uint8_t * lv_font_get_bitmap_fmt_txt(const lv_font_t * font, uint32_t unic
     const lv_font_fmt_txt_glyph_dsc_t * gdsc = &fdsc->glyph_dsc[gid];
 
     if(fdsc->bitmap_format == LV_FONT_FMT_TXT_PLAIN) {
+#if LV_USE_FONT_DYNAMIC_LOAD
+        lv_font_fmt_txt_glyph_loader_t * loader =
+            (lv_font_fmt_txt_glyph_loader_t *)fdsc->loader;
+
+        return loader ? loader->get_glyph_bitmap_cb(fdsc,
+                                                    gdsc) : &fdsc->glyph_bitmap[gdsc->bitmap_index];
+#else
         return &fdsc->glyph_bitmap[gdsc->bitmap_index];
+#endif
     }
     /*Handle compressed bitmap*/
     else {

--- a/src/font/lv_font_fmt_txt.h
+++ b/src/font/lv_font_fmt_txt.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdbool.h>
 #include "lv_font.h"
+#include "../misc/lv_fs.h"
 
 /*********************
  *      DEFINES
@@ -156,6 +157,31 @@ typedef struct {
     uint32_t last_glyph_id;
 } lv_font_fmt_txt_glyph_cache_t;
 
+#if LV_USE_FONT_DYNAMIC_LOAD
+typedef struct {
+    /* Callback to get the glyph bitmap */
+    uint8_t * (*get_glyph_bitmap_cb)(void * fmt_dsc, void * glyph_dsc);
+
+    /* File pointer for font file */
+    lv_fs_file_t * fp;
+
+    /* Number of glyphs */
+    uint32_t loca_count;
+
+    /* Array of glyph offsets */
+    uint32_t * glyph_offset;
+
+    /* Start offset of glyph data */
+    uint32_t glyph_start;
+
+    /* Length of glyph data */
+    uint32_t glyph_length;
+
+    /* Total bits per glyph */
+    uint32_t glyph_per_bits;
+} lv_font_fmt_txt_glyph_loader_t;
+#endif
+
 /*Describe store additional data for fonts*/
 typedef struct {
     /*The bitmaps of all glyphs*/
@@ -195,6 +221,11 @@ typedef struct {
 
     /*Cache the last letter and is glyph id*/
     lv_font_fmt_txt_glyph_cache_t * cache;
+
+#if LV_USE_FONT_DYNAMIC_LOAD
+    /* Glyph loader for dynamic bitmap loading */
+    lv_font_fmt_txt_glyph_loader_t * loader;
+#endif
 } lv_font_fmt_txt_dsc_t;
 
 /**********************

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1270,6 +1270,15 @@
     #endif
 #endif
 
+/* Enable dynamic loading of fonts */
+#ifndef LV_USE_FONT_DYNAMIC_LOAD
+    #ifdef CONFIG_LV_USE_FONT_DYNAMIC_LOAD
+        #define LV_USE_FONT_DYNAMIC_LOAD CONFIG_LV_USE_FONT_DYNAMIC_LOAD
+    #else
+        #define LV_USE_FONT_DYNAMIC_LOAD 0
+    #endif
+#endif
+
 /*=================
  *  TEXT SETTINGS
  *=================*/


### PR DESCRIPTION
### Description
This pull request enables dynamic glyph bitmap loading with the `font_loader`. 

### Changes include:
- **Dynamic loading of glyph bitmaps**: Glyph bitmaps will now be loaded on-demand using the font loader.
- **Performance improvements**: Reduced memory usage when handling large fonts or multiple fonts.

Depends on #8086

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
