### PR TITLE
fix(anim): fix the crash caused by delete anim in cb

### DIFF
--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -172,10 +172,10 @@ void test_anim_pause_for_resume(void)
     TEST_ASSERT_EQUAL(19, var);
 }
 
-static void event_cb(lv_event_t* e)
+static void event_cb(lv_event_t * e)
 {
-    lv_obj_t* obj = lv_event_get_target_obj(e);
-    int* var = lv_event_get_user_data(e);
+    lv_obj_t * obj = lv_event_get_target_obj(e);
+    int * var = lv_event_get_user_data(e);
     lv_anim_delete(obj, NULL);
     *var += 1;
 }
@@ -183,7 +183,7 @@ static void event_cb(lv_event_t* e)
 void test_scroll_anim_delete(void)
 {
     int var = 0;
-    lv_obj_t* obj = lv_obj_create(lv_screen_active());
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
     lv_obj_add_event_cb(obj, event_cb, LV_EVENT_SCROLL_END, &var);
     lv_obj_scroll_by(obj, 0, 100, LV_ANIM_ON);
     lv_test_wait(20);

--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -13,6 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
 }
 
 static void exec_cb(void * var, int32_t v)
@@ -170,4 +171,25 @@ void test_anim_pause_for_resume(void)
     lv_test_wait(20);
     TEST_ASSERT_EQUAL(19, var);
 }
+
+static void event_cb(lv_event_t* e)
+{
+    lv_obj_t* obj = lv_event_get_target_obj(e);
+    int* var = lv_event_get_user_data(e);
+    lv_anim_delete(obj, NULL);
+    *var += 1;
+}
+
+void test_scroll_anim_delete(void)
+{
+    int var = 0;
+    lv_obj_t* obj = lv_obj_create(lv_screen_active());
+    lv_obj_add_event_cb(obj, event_cb, LV_EVENT_SCROLL_END, &var);
+    lv_obj_scroll_by(obj, 0, 100, LV_ANIM_ON);
+    lv_test_wait(20);
+    lv_obj_scroll_by(obj, 0, 100, LV_ANIM_ON);
+
+    TEST_ASSERT_EQUAL(1, var);
+}
+
 #endif

--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -14,6 +14,7 @@ void tearDown(void)
 {
     /* Function run after every test */
     lv_obj_clean(lv_screen_active());
+    lv_anim_delete_all();
 }
 
 static void exec_cb(void * var, int32_t v)


### PR DESCRIPTION
I encountered a crash problem. Here is the case to reproduce it.
 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->
```c
static void event_cb(lv_event_t* e)
{
    lv_obj_t* obj = lv_event_get_target_obj(e);
    lv_anim_delete(obj, NULL);
}

static void test(void)
{
    lv_obj_t* obj = lv_obj_create(lv_screen_active());
    lv_obj_add_event_cb(obj, event_cb, LV_EVENT_SCROLL_END, NULL);
    lv_obj_scroll_by(obj, 0, 10, LV_ANIM_ON);
    usleep(10* 1000);
    lv_timer_handler();
    lv_obj_scroll_by(obj, 0, 10, LV_ANIM_ON);
}
```
The cause of the problem is that `new_anim` is free in `remove_concurrent_anims`. Although this problem can be circumvented by users, I think we should fix it.
<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
