### PR TITLE
fix(examples): add casts and change int types to fix checker warnings

### DIFF
--- a/examples/anim/lv_example_anim_3.c
+++ b/examples/anim/lv_example_anim_3.c
@@ -19,8 +19,8 @@ struct {
     lv_obj_t * p2_slider;
     lv_obj_t * p2_label;
     lv_obj_t * run_btn;
-    uint16_t p1;
-    uint16_t p2;
+    int32_t p1;
+    int32_t p2;
     lv_anim_t a;
 } ginfo;
 
@@ -64,7 +64,7 @@ void lv_example_anim_3(void)
 
 static int32_t anim_path_bezier3_cb(const lv_anim_t * a)
 {
-    uint32_t t = lv_map(a->act_time, 0, a->duration, 0, 1024);
+    int32_t t = lv_map(a->act_time, 0, a->duration, 0, 1024);
     int32_t step = lv_bezier3(t, 0, ginfo.p1, ginfo.p2, 1024);
     int32_t new_value;
     new_value = step * (a->end_value - a->start_value);
@@ -76,7 +76,7 @@ static int32_t anim_path_bezier3_cb(const lv_anim_t * a)
 static void refer_chart_cubic_bezier(void)
 {
     for(uint16_t i = 0; i <= CHART_POINTS_NUM; i ++) {
-        uint32_t t = i * (1024 / CHART_POINTS_NUM);
+        int32_t t = i * (1024 / CHART_POINTS_NUM);
         int32_t step = lv_bezier3(t, 0, ginfo.p1, ginfo.p2, 1024);
         lv_chart_set_series_value_by_id2(ginfo.chart, ginfo.ser1, i, t, step);
     }

--- a/examples/anim/lv_example_anim_timeline_1.c
+++ b/examples/anim/lv_example_anim_timeline_1.c
@@ -40,7 +40,7 @@ static void slider_prg_event_handler(lv_event_t * e)
     lv_obj_t * slider = lv_event_get_current_target_obj(e);
     lv_anim_timeline_t * anim_timeline = lv_event_get_user_data(e);
     int32_t progress = lv_slider_get_value(slider);
-    lv_anim_timeline_set_progress(anim_timeline, progress);
+    lv_anim_timeline_set_progress(anim_timeline, (uint16_t) progress);
 }
 
 /**

--- a/examples/event/lv_example_event_draw.c
+++ b/examples/event/lv_example_event_draw.c
@@ -2,7 +2,7 @@
 
 #if LV_BUILD_EXAMPLES
 
-static uint32_t size = 0;
+static int32_t size = 0;
 static bool size_dec = false;
 
 static void timer_cb(lv_timer_t * timer)

--- a/examples/grad/lv_example_grad_1.c
+++ b/examples/grad/lv_example_grad_1.c
@@ -32,7 +32,7 @@ static void frac_1_event_cb(lv_event_t * e)
 
         lv_obj_t * bullet = lv_event_get_target(e);
         lv_obj_t * parent = lv_obj_get_parent(bullet);
-        dsc->stops[0].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
+        dsc->stops[0].frac = (uint8_t)LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
 
         lv_obj_invalidate(parent);
     }
@@ -54,7 +54,7 @@ static void frac_2_event_cb(lv_event_t * e)
         lv_obj_t * bullet = lv_event_get_target(e);
         lv_obj_t * parent = lv_obj_get_parent(bullet);
 
-        dsc->stops[1].frac = LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
+        dsc->stops[1].frac = (uint8_t)LV_CLAMP(0, p.x * 255 / lv_obj_get_width(parent), 255);
         lv_obj_invalidate(parent);
     }
 }

--- a/examples/layouts/grid/lv_example_grid_1.c
+++ b/examples/layouts/grid/lv_example_grid_1.c
@@ -20,7 +20,7 @@ void lv_example_grid_1(void)
     lv_obj_t * label;
     lv_obj_t * obj;
 
-    uint32_t i;
+    uint8_t i;
     for(i = 0; i < 9; i++) {
         uint8_t col = i % 3;
         uint8_t row = i / 3;

--- a/examples/layouts/grid/lv_example_grid_3.c
+++ b/examples/layouts/grid/lv_example_grid_3.c
@@ -24,7 +24,7 @@ void lv_example_grid_3(void)
 
     lv_obj_t * label;
     lv_obj_t * obj;
-    uint32_t i;
+    uint8_t i;
     for(i = 0; i < 9; i++) {
         uint8_t col = i % 3;
         uint8_t row = i / 3;

--- a/examples/layouts/grid/lv_example_grid_4.c
+++ b/examples/layouts/grid/lv_example_grid_4.c
@@ -20,7 +20,7 @@ void lv_example_grid_4(void)
 
     lv_obj_t * label;
     lv_obj_t * obj;
-    uint32_t i;
+    uint8_t i;
     for(i = 0; i < 9; i++) {
         uint8_t col = i % 3;
         uint8_t row = i / 3;

--- a/examples/layouts/grid/lv_example_grid_5.c
+++ b/examples/layouts/grid/lv_example_grid_5.c
@@ -29,7 +29,7 @@ void lv_example_grid_5(void)
 
     lv_obj_t * label;
     lv_obj_t * obj;
-    uint32_t i;
+    uint8_t i;
     for(i = 0; i < 9; i++) {
         uint8_t col = i % 3;
         uint8_t row = i / 3;

--- a/examples/layouts/grid/lv_example_grid_6.c
+++ b/examples/layouts/grid/lv_example_grid_6.c
@@ -19,7 +19,7 @@ void lv_example_grid_6(void)
 
     lv_obj_t * label;
     lv_obj_t * obj;
-    uint32_t i;
+    uint8_t i;
     for(i = 0; i < 9; i++) {
         uint8_t col = i % 3;
         uint8_t row = i / 3;

--- a/examples/scroll/lv_example_scroll_6.c
+++ b/examples/scroll/lv_example_scroll_6.c
@@ -10,8 +10,8 @@ static void scroll_event_cb(lv_event_t * e)
     int32_t cont_y_center = cont_a.y1 + lv_area_get_height(&cont_a) / 2;
 
     int32_t r = lv_obj_get_height(cont) * 7 / 10;
-    uint32_t i;
-    uint32_t child_cnt = lv_obj_get_child_count(cont);
+    int32_t i;
+    int32_t child_cnt = (int32_t)lv_obj_get_child_count(cont);
     for(i = 0; i < child_cnt; i++) {
         lv_obj_t * child = lv_obj_get_child(cont, i);
         lv_area_t child_a;
@@ -40,7 +40,7 @@ static void scroll_event_cb(lv_event_t * e)
         lv_obj_set_style_translate_x(child, x, 0);
 
         /*Use some opacity with larger translations*/
-        lv_opa_t opa = lv_map(x, 0, r, LV_OPA_TRANSP, LV_OPA_COVER);
+        lv_opa_t opa = (lv_opa_t)lv_map(x, 0, r, LV_OPA_TRANSP, LV_OPA_COVER);
         lv_obj_set_style_opa(child, LV_OPA_COVER - opa, 0);
     }
 }

--- a/examples/scroll/lv_example_scroll_8.c
+++ b/examples/scroll/lv_example_scroll_8.c
@@ -15,9 +15,9 @@ static int32_t get_content_width(lv_obj_t * cont)
 {
     int32_t w = 0;
     int32_t pad_column = lv_obj_get_style_pad_column(cont, LV_PART_MAIN); // 列间距
-    int total = lv_obj_get_child_count(cont);
+    int32_t total = (int32_t)lv_obj_get_child_count(cont);
 
-    for(int i = 0; i < total; i++) {
+    for(int32_t i = 0; i < total; i++) {
         w += lv_obj_get_width(lv_obj_get_child(cont, i));
         if(i < total - 1) w += pad_column;
     }
@@ -41,13 +41,13 @@ static void cont_row_scroll_event_cb(lv_event_t * e)
         const int32_t item_width = ITEM_SIZE;
 
         if(scroll_x <= 0) {
-            lv_obj_t * last_child = lv_obj_get_child(cont, lv_obj_get_child_count(cont) - 1);
+            lv_obj_t * last_child = lv_obj_get_child(cont, (int32_t)(lv_obj_get_child_count(cont) - 1));
             lv_obj_move_to_index(last_child, 0);
             lv_obj_scroll_to_x(cont, scroll_x + item_width, LV_ANIM_OFF);
         }
         else if(scroll_x > content_w - cont_w) {
             lv_obj_t * first_child = lv_obj_get_child(cont, 0);
-            lv_obj_move_to_index(first_child, lv_obj_get_child_count(cont) - 1);
+            lv_obj_move_to_index(first_child, (int32_t)(lv_obj_get_child_count(cont) - 1));
             lv_obj_scroll_to_x(cont, scroll_x - item_width, LV_ANIM_OFF);
         }
         is_adjusting = false;
@@ -59,7 +59,7 @@ static int32_t get_content_height(lv_obj_t * cont)
 {
     int32_t h = 0;
     int32_t pad_row = lv_obj_get_style_pad_row(cont, LV_PART_MAIN);
-    int total = lv_obj_get_child_count(cont);
+    int32_t total = (int32_t)lv_obj_get_child_count(cont);
 
     for(int i = 0; i < total; i++) {
         h += lv_obj_get_height(lv_obj_get_child(cont, i));
@@ -85,13 +85,13 @@ static void cont_col_scroll_event_cb(lv_event_t * e)
         const int32_t item_height = ITEM_SIZE;
 
         if(scroll_y <= 0) {
-            lv_obj_t * last_child = lv_obj_get_child(cont, lv_obj_get_child_count(cont) - 1);
+            lv_obj_t * last_child = lv_obj_get_child(cont, (int32_t)(lv_obj_get_child_count(cont) - 1));
             lv_obj_move_to_index(last_child, 0);
             lv_obj_scroll_to_y(cont, scroll_y + item_height, LV_ANIM_OFF);
         }
         else if(scroll_y > content_h - cont_h) {
             lv_obj_t * first_child = lv_obj_get_child(cont, 0);
-            lv_obj_move_to_index(first_child, lv_obj_get_child_count(cont) - 1);
+            lv_obj_move_to_index(first_child, (int32_t)(lv_obj_get_child_count(cont) - 1));
             lv_obj_scroll_to_y(cont, scroll_y - item_height, LV_ANIM_OFF);
         }
         is_adjusting = false;

--- a/examples/widgets/canvas/lv_example_canvas_10.c
+++ b/examples/widgets/canvas/lv_example_canvas_10.c
@@ -6,9 +6,9 @@
 
 static void timer_cb(lv_timer_t * timer)
 {
-    static int32_t counter = 0;
+    static int16_t counter = 0;
     const char * string = "windstorrrrrrrrrrrrrrrrm~>>>";
-    const int16_t string_len = lv_strlen(string);
+    const int16_t string_len = (int16_t)lv_strlen(string);
 
     lv_obj_t * canvas = (lv_obj_t *)lv_timer_get_user_data(timer);
     lv_layer_t layer;
@@ -28,7 +28,7 @@ static void timer_cb(lv_timer_t * timer)
         int32_t pre_x = CURVE2_X(-1);
         int32_t pre_y = CURVE2_Y(-1, 0);
         for(int16_t i = 0; i < string_len; i++) {
-            const int32_t angle = i * 5;
+            const int16_t angle = (int16_t)(i * 5);
             const int32_t x = CURVE2_X(angle);
             const int32_t y = CURVE2_Y(angle + 30, counter / 2);
             const lv_point_t point = { .x = x, .y = y };

--- a/examples/widgets/canvas/lv_example_canvas_2.c
+++ b/examples/widgets/canvas/lv_example_canvas_2.c
@@ -24,8 +24,8 @@ void lv_example_canvas_2(void)
     lv_canvas_fill_bg(canvas, lv_palette_main(LV_PALETTE_BLUE), LV_OPA_COVER);
 
     /*Create hole on the canvas*/
-    uint32_t x;
-    uint32_t y;
+    int32_t x;
+    int32_t y;
     for(y = 10; y < 20; y++) {
         for(x = 5; x < 75; x++) {
             lv_canvas_set_px(canvas, x, y, lv_palette_main(LV_PALETTE_BLUE), LV_OPA_50);

--- a/examples/widgets/canvas/lv_example_canvas_9.c
+++ b/examples/widgets/canvas/lv_example_canvas_9.c
@@ -6,9 +6,9 @@
 
 static void timer_cb(lv_timer_t * timer)
 {
-    static int32_t counter = 0;
+    static int16_t counter = 0;
     const char * string = "lol~ I'm wavvvvvvving~>>>";
-    const int16_t string_len = lv_strlen(string);
+    const int16_t string_len = (int16_t)lv_strlen(string);
 
     lv_obj_t * canvas = (lv_obj_t *)lv_timer_get_user_data(timer);
     lv_layer_t layer;
@@ -28,7 +28,7 @@ static void timer_cb(lv_timer_t * timer)
         int32_t pre_x = CURVE2_X(-1);
         int32_t pre_y = CURVE2_Y(-1);
         for(int16_t i = 0; i < string_len; i++) {
-            const int32_t angle = i * 5;
+            const int16_t angle = (int16_t)(i * 5);
             const int32_t x = CURVE2_X(angle);
             const int32_t y = CURVE2_Y(angle + counter / 2);
             const lv_point_t point = { .x = x, .y = y };

--- a/examples/widgets/chart/lv_example_chart_1.c
+++ b/examples/widgets/chart/lv_example_chart_1.c
@@ -21,10 +21,10 @@ void lv_example_chart_1(void)
     uint32_t i;
     for(i = 0; i < 10; i++) {
         /*Set the next points on 'ser1'*/
-        lv_chart_set_next_value(chart, ser1, lv_rand(10, 50));
+        lv_chart_set_next_value(chart, ser1, (int32_t)lv_rand(10, 50));
 
         /*Directly set points on 'ser2'*/
-        ser2_y_points[i] = lv_rand(50, 90);
+        ser2_y_points[i] = (int32_t)lv_rand(50, 90);
     }
 
     lv_chart_refresh(chart); /*Required after direct set*/

--- a/examples/widgets/chart/lv_example_chart_2.c
+++ b/examples/widgets/chart/lv_example_chart_2.c
@@ -47,8 +47,8 @@ void lv_example_chart_2(void)
     /*Set the next points on 'ser1'*/
     uint32_t i;
     for(i = 0; i < 12; i++) {
-        lv_chart_set_next_value(chart, ser1, lv_rand(10, 60));
-        lv_chart_set_next_value(chart, ser2, lv_rand(50, 90));
+        lv_chart_set_next_value(chart, ser1, (int32_t)lv_rand(10, 60));
+        lv_chart_set_next_value(chart, ser2, (int32_t)lv_rand(50, 90));
     }
     lv_chart_refresh(chart); /*Required after direct set*/
 }

--- a/examples/widgets/chart/lv_example_chart_3.c
+++ b/examples/widgets/chart/lv_example_chart_3.c
@@ -14,7 +14,7 @@ static void event_cb(lv_event_t * e)
         *s = LV_MAX(*s, 20);
     }
     else if(code == LV_EVENT_DRAW_POST_END) {
-        int32_t id = lv_chart_get_pressed_point(chart);
+        uint32_t id = lv_chart_get_pressed_point(chart);
         if(id == LV_CHART_POINT_NONE) return;
 
         LV_LOG_USER("Selected point %d", (int)id);
@@ -89,8 +89,8 @@ void lv_example_chart_3(void)
     lv_chart_series_t * ser2 = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_GREEN), LV_CHART_AXIS_PRIMARY_Y);
     uint32_t i;
     for(i = 0; i < 10; i++) {
-        lv_chart_set_next_value(chart, ser1, lv_rand(60, 90));
-        lv_chart_set_next_value(chart, ser2, lv_rand(10, 40));
+        lv_chart_set_next_value(chart, ser1, (int32_t)lv_rand(60, 90));
+        lv_chart_set_next_value(chart, ser2, (int32_t)lv_rand(10, 40));
     }
 }
 

--- a/examples/widgets/chart/lv_example_chart_4.c
+++ b/examples/widgets/chart/lv_example_chart_4.c
@@ -17,7 +17,7 @@ static void draw_event_cb(lv_event_t * e)
         int32_t * y_array = lv_chart_get_series_y_array(chart, lv_chart_get_series_next(chart, NULL));
         int32_t v = y_array[base_dsc->id2];
 
-        uint32_t ratio = v * 255 / 100;
+        uint8_t ratio = (uint8_t)(v * 255 / 100);
         fill_dsc->color = lv_color_mix(lv_palette_main(LV_PALETTE_GREEN), lv_palette_main(LV_PALETTE_RED), ratio);
     }
 }
@@ -41,7 +41,7 @@ void lv_example_chart_4(void)
 
     uint32_t i;
     for(i = 0; i < 24; i++) {
-        lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+        lv_chart_set_next_value(chart, ser, (int32_t)lv_rand(10, 90));
     }
 }
 

--- a/examples/widgets/chart/lv_example_chart_5.c
+++ b/examples/widgets/chart/lv_example_chart_5.c
@@ -29,7 +29,7 @@ void lv_example_chart_5(void)
 
     uint32_t i;
     for(i = 0; i < 10; i++) {
-        lv_chart_set_next_value(chart, ser, lv_rand(10, 80));
+        lv_chart_set_next_value(chart, ser, (int32_t)lv_rand(10, 80));
     }
 }
 
@@ -77,10 +77,10 @@ static void add_faded_area(lv_event_t * e)
     int32_t fract_uppter = (int32_t)(LV_MIN(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - coords.y1) * 255 / full_h;
     int32_t fract_lower = (int32_t)(LV_MAX(draw_line_dsc->p1.y, draw_line_dsc->p2.y) - coords.y1) * 255 / full_h;
     tri_dsc.bg_grad.stops[0].color = ser_color;
-    tri_dsc.bg_grad.stops[0].opa = 255 - fract_uppter;
+    tri_dsc.bg_grad.stops[0].opa = (lv_opa_t)(255 - fract_uppter);
     tri_dsc.bg_grad.stops[0].frac = 0;
     tri_dsc.bg_grad.stops[1].color = ser_color;
-    tri_dsc.bg_grad.stops[1].opa = 255 - fract_lower;
+    tri_dsc.bg_grad.stops[1].opa = (lv_opa_t)(255 - fract_lower);
     tri_dsc.bg_grad.stops[1].frac = 255;
 
     lv_draw_triangle(base_dsc->layer, &tri_dsc);
@@ -91,7 +91,7 @@ static void add_faded_area(lv_event_t * e)
     rect_dsc.bg_grad.dir = LV_GRAD_DIR_VER;
     rect_dsc.bg_grad.stops[0].color = ser_color;
     rect_dsc.bg_grad.stops[0].frac = 0;
-    rect_dsc.bg_grad.stops[0].opa = 255 - fract_lower;
+    rect_dsc.bg_grad.stops[0].opa = (lv_opa_t)(255 - fract_lower);
     rect_dsc.bg_grad.stops[1].color = ser_color;
     rect_dsc.bg_grad.stops[1].frac = 255;
     rect_dsc.bg_grad.stops[1].opa = 0;

--- a/examples/widgets/chart/lv_example_chart_6.c
+++ b/examples/widgets/chart/lv_example_chart_6.c
@@ -7,7 +7,7 @@ static lv_chart_cursor_t * cursor;
 
 static void value_changed_event_cb(lv_event_t * e)
 {
-    static int32_t last_id = -1;
+    uint32_t last_id;
     lv_obj_t * obj = lv_event_get_target_obj(e);
 
     last_id = lv_chart_get_pressed_point(obj);
@@ -36,7 +36,7 @@ void lv_example_chart_6(void)
     ser = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_RED), LV_CHART_AXIS_PRIMARY_Y);
     uint32_t i;
     for(i = 0; i < 10; i++) {
-        lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+        lv_chart_set_next_value(chart, ser, (int32_t)lv_rand(10, 90));
     }
 
     //    lv_chart_set_scale_x(chart, 500);

--- a/examples/widgets/chart/lv_example_chart_7.c
+++ b/examples/widgets/chart/lv_example_chart_7.c
@@ -12,7 +12,7 @@ static void draw_event_cb(lv_event_t * e)
         uint32_t cnt = lv_chart_get_point_count(obj);
 
         /*Make older value more transparent*/
-        rect_draw_dsc->bg_opa = (LV_OPA_COVER * base_dsc->id2) / (cnt - 1);
+        rect_draw_dsc->bg_opa = (lv_opa_t)((LV_OPA_COVER * base_dsc->id2) / (cnt - 1));
 
         /*Make smaller values blue, higher values red*/
         int32_t * x_array = lv_chart_get_series_x_array(obj, ser);
@@ -20,8 +20,8 @@ static void draw_event_cb(lv_event_t * e)
         /*dsc->id is the tells drawing order, but we need the ID of the point being drawn.*/
         uint32_t start_point = lv_chart_get_x_start_point(obj, ser);
         uint32_t p_act = (start_point + base_dsc->id2) % cnt; /*Consider start point to get the index of the array*/
-        lv_opa_t x_opa = (x_array[p_act] * LV_OPA_50) / 200;
-        lv_opa_t y_opa = (y_array[p_act] * LV_OPA_50) / 1000;
+        lv_opa_t x_opa = (lv_opa_t)((x_array[p_act] * LV_OPA_50) / 200);
+        lv_opa_t y_opa = (lv_opa_t)((y_array[p_act] * LV_OPA_50) / 1000);
 
         rect_draw_dsc->bg_color = lv_color_mix(lv_palette_main(LV_PALETTE_RED),
                                                lv_palette_main(LV_PALETTE_BLUE),
@@ -32,7 +32,8 @@ static void draw_event_cb(lv_event_t * e)
 static void add_data(lv_timer_t * timer)
 {
     lv_obj_t * chart = (lv_obj_t *)lv_timer_get_user_data(timer);
-    lv_chart_set_next_value2(chart, lv_chart_get_series_next(chart, NULL), lv_rand(0, 200), lv_rand(0, 1000));
+    lv_chart_set_next_value2(chart, lv_chart_get_series_next(chart, NULL), (int32_t)lv_rand(0, 200),
+                             (int32_t)lv_rand(0, 1000));
 }
 
 /**
@@ -57,7 +58,7 @@ void lv_example_chart_7(void)
     lv_chart_series_t * ser = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_RED), LV_CHART_AXIS_PRIMARY_Y);
     uint32_t i;
     for(i = 0; i < 50; i++) {
-        lv_chart_set_next_value2(chart, ser, lv_rand(0, 200), lv_rand(0, 1000));
+        lv_chart_set_next_value2(chart, ser, (int32_t)lv_rand(0, 200), (int32_t)lv_rand(0, 1000));
     }
 
     lv_timer_create(add_data, 100, chart);

--- a/examples/widgets/chart/lv_example_chart_8.c
+++ b/examples/widgets/chart/lv_example_chart_8.c
@@ -6,10 +6,10 @@ static void add_data(lv_timer_t * t)
     lv_obj_t * chart = (lv_obj_t *)lv_timer_get_user_data(t);
     lv_chart_series_t * ser = lv_chart_get_series_next(chart, NULL);
 
-    lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+    lv_chart_set_next_value(chart, ser, (int32_t)lv_rand(10, 90));
 
-    uint16_t p = lv_chart_get_point_count(chart);
-    uint16_t s = lv_chart_get_x_start_point(chart, ser);
+    uint32_t p = lv_chart_get_point_count(chart);
+    uint32_t s = lv_chart_get_x_start_point(chart, ser);
     int32_t * a = lv_chart_get_series_y_array(chart, ser);
 
     a[(s + 1) % p] = LV_CHART_POINT_NONE;
@@ -36,7 +36,7 @@ void lv_example_chart_8(void)
     /*Prefill with data*/
     uint32_t i;
     for(i = 0; i < 80; i++) {
-        lv_chart_set_next_value(chart, ser, lv_rand(10, 90));
+        lv_chart_set_next_value(chart, ser, (int32_t)lv_rand(10, 90));
     }
 
     lv_timer_create(add_data, 300, chart);

--- a/examples/widgets/checkbox/lv_example_checkbox_2.c
+++ b/examples/widgets/checkbox/lv_example_checkbox_2.c
@@ -3,12 +3,12 @@
 
 static lv_style_t style_radio;
 static lv_style_t style_radio_chk;
-static uint32_t active_index_1 = 0;
-static uint32_t active_index_2 = 0;
+static int32_t active_index_1 = 0;
+static int32_t active_index_2 = 0;
 
 static void radio_event_handler(lv_event_t * e)
 {
-    uint32_t * active_id = (uint32_t *)lv_event_get_user_data(e);
+    int32_t * active_id = (int32_t *)lv_event_get_user_data(e);
     lv_obj_t * cont = (lv_obj_t *)lv_event_get_current_target(e);
     lv_obj_t * act_cb = lv_event_get_target_obj(e);
     lv_obj_t * old_cb = lv_obj_get_child(cont, *active_id);

--- a/examples/widgets/image/lv_example_image_2.c
+++ b/examples/widgets/image/lv_example_image_2.c
@@ -42,9 +42,10 @@ static void slider_event_cb(lv_event_t * e)
     LV_UNUSED(e);
 
     /*Recolor the image based on the sliders' values*/
-    lv_color_t color  = lv_color_make(lv_slider_get_value(red_slider), lv_slider_get_value(green_slider),
-                                      lv_slider_get_value(blue_slider));
-    lv_opa_t intense = lv_slider_get_value(intense_slider);
+    lv_color_t color  = lv_color_make((uint8_t)lv_slider_get_value(red_slider),
+                                      (uint8_t)lv_slider_get_value(green_slider),
+                                      (uint8_t)lv_slider_get_value(blue_slider));
+    lv_opa_t intense = (lv_opa_t)lv_slider_get_value(intense_slider);
     lv_obj_set_style_image_recolor_opa(img1, intense, 0);
     lv_obj_set_style_image_recolor(img1, color, 0);
 }

--- a/examples/widgets/list/lv_example_list_2.c
+++ b/examples/widgets/list/lv_example_list_2.c
@@ -20,8 +20,8 @@ static void event_handler(lv_event_t * e)
             currentButton = obj;
         }
         lv_obj_t * parent = lv_obj_get_parent(obj);
-        uint32_t i;
-        for(i = 0; i < lv_obj_get_child_count(parent); i++) {
+        int32_t i;
+        for(i = 0; i < (int32_t)lv_obj_get_child_count(parent); i++) {
             lv_obj_t * child = lv_obj_get_child(parent, i);
             if(child == currentButton) {
                 lv_obj_add_state(child, LV_STATE_CHECKED);
@@ -48,7 +48,7 @@ static void event_handler_up(lv_event_t * e)
     lv_event_code_t code = lv_event_get_code(e);
     if((code == LV_EVENT_CLICKED) || (code == LV_EVENT_LONG_PRESSED_REPEAT)) {
         if(currentButton == NULL) return;
-        uint32_t index = lv_obj_get_index(currentButton);
+        int32_t index = lv_obj_get_index(currentButton);
         if(index <= 0) return;
         lv_obj_move_to_index(currentButton, index - 1);
         lv_obj_scroll_to_view(currentButton, LV_ANIM_ON);
@@ -62,7 +62,7 @@ static void event_handler_center(lv_event_t * e)
         if(currentButton == NULL) return;
 
         lv_obj_t * parent = lv_obj_get_parent(currentButton);
-        const uint32_t pos = lv_obj_get_child_count(parent) / 2;
+        const int32_t pos = (int32_t)lv_obj_get_child_count(parent) / 2;
 
         lv_obj_move_to_index(currentButton, pos);
 
@@ -75,7 +75,7 @@ static void event_handler_dn(lv_event_t * e)
     const lv_event_code_t code = lv_event_get_code(e);
     if((code == LV_EVENT_CLICKED) || (code == LV_EVENT_LONG_PRESSED_REPEAT)) {
         if(currentButton == NULL) return;
-        const uint32_t index = lv_obj_get_index(currentButton);
+        const int32_t index = lv_obj_get_index(currentButton);
 
         lv_obj_move_to_index(currentButton, index + 1);
         lv_obj_scroll_to_view(currentButton, LV_ANIM_ON);
@@ -100,8 +100,8 @@ static void event_handler_swap(lv_event_t * e)
         uint32_t cnt = lv_obj_get_child_count(list1);
         for(int i = 0; i < 100; i++)
             if(cnt > 1) {
-                lv_obj_t * obj = lv_obj_get_child(list1, lv_rand(0, cnt));
-                lv_obj_move_to_index(obj, lv_rand(0, cnt));
+                lv_obj_t * obj = lv_obj_get_child(list1, (int32_t)lv_rand(0, cnt));
+                lv_obj_move_to_index(obj, (int32_t)lv_rand(0, cnt));
                 if(currentButton != NULL) {
                     lv_obj_scroll_to_view(currentButton, LV_ANIM_ON);
                 }

--- a/examples/widgets/scale/lv_example_scale_7.c
+++ b/examples/widgets/scale/lv_example_scale_7.c
@@ -20,7 +20,7 @@ static void draw_event_cb(lv_event_t * e)
                 lv_palette_main(LV_PALETTE_BLUE),
                 lv_palette_main(LV_PALETTE_PURPLE),
             };
-            uint8_t major_tick = lv_scale_get_major_tick_every(obj);
+            uint32_t major_tick = lv_scale_get_major_tick_every(obj);
             label_draw_dsc->color = color_idx[base_dsc->id1 / major_tick];
 
             /*Free the previously allocated text if needed*/
@@ -29,7 +29,7 @@ static void draw_event_cb(lv_event_t * e)
             /*Malloc the text and set text_local as 1 to make LVGL automatically free the text.
              * (Local texts are malloc'd internally by LVGL. Mimic this behavior here too)*/
             char tmp_buffer[20] = {0}; /* Big enough buffer */
-            lv_snprintf(tmp_buffer, sizeof(tmp_buffer), "%.1f", base_dsc->id2 * 1.0f);
+            lv_snprintf(tmp_buffer, sizeof(tmp_buffer), "%.1f", (double)base_dsc->id2);
             label_draw_dsc->text = lv_strdup(tmp_buffer);
             label_draw_dsc->text_local = 1;
 


### PR DESCRIPTION
In the example sources, change variable types to match the function argument and return types.  Where this is not possible, add explicit casts to promote the value to the correct type for the function.