### PR TITLE
ci(micropython): fix MicroPython github build action

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         git clone https://github.com/lvgl/lv_micropython.git .
         git checkout master
-    - name: Initialize lv_bindings submodule
+    - name: Initialize LVGL bindings submodule
       run: git submodule update --init --recursive user_modules/lv_binding_micropython
     - name: Update ${{ matrix.port }} port submodules
       if:  matrix.port != 'rp2'
@@ -57,7 +57,7 @@ jobs:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
     - name: Build STM32 port
       if: matrix.port == 'stm32'
-      run: make -j $(nproc) -C ports/stm32 BOARD=STM32F7DISC
+      run: make -j $(nproc) -C ports/stm32 BOARD=STM32F7DISC USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
     - name: Build Raspberry Pi PICO port
       if: matrix.port == 'rp2'
       run: |

--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -59,6 +59,7 @@ jobs:
       if: matrix.port == 'stm32'
       run: |
         source tools/ci.sh && ci_stm32_setup
+        make -C ports/stm32 BOARD=STM32F7DISC USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake submodules
         make -j $(nproc) -C ports/stm32 BOARD=STM32F7DISC USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
 
     # Raspberry Pi Pico port

--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -18,27 +18,32 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        port: ['unix', 'stm32', 'rp2']
+        port: ['unix', 'stm32', 'rp2', 'esp32']
     steps:
     - uses: ammaraskar/gcc-problem-matcher@master
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+
     - name: Install Dependencies
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
         sudo apt-get update -y -qq
         sudo apt-get install libsdl2-dev parallel libfreetype-dev librlottie-dev libavformat-dev libavcodec-dev libswscale-dev libavutil-dev doxygen
         python3 -m pip install pycparser
+
     - name: Clone lv_micropython
       run: |
         git clone https://github.com/lvgl/lv_micropython.git .
         git checkout master
+
     - name: Initialize LVGL bindings submodule
       run: git submodule update --init --recursive user_modules/lv_binding_micropython
+
     - name: Update ${{ matrix.port }} port submodules
       if:  matrix.port != 'rp2'
       run: make -C ports/${{ matrix.port }} DEBUG=1 USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake submodules
+
     - name: Checkout LVGL submodule
       working-directory: ./user_modules/lv_binding_micropython/lvgl
       run: |
@@ -49,79 +54,46 @@ jobs:
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
 
-    # STM32 & RPi Pico port
-    - name: arm-none-eabi-gcc
-      if: matrix.port == 'stm32' || matrix.port == 'rp2'
-      uses: carlosperate/arm-none-eabi-gcc-action@v1.10.0
-      with:
-        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+    # STM32 port
     - name: Build STM32 port
       if: matrix.port == 'stm32'
-      run: make -j $(nproc) -C ports/stm32 BOARD=STM32F7DISC USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
+      run: |
+        source tools/ci.sh && ci_stm32_setup
+        make -j $(nproc) -C ports/stm32 BOARD=STM32F7DISC USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
+
+    # Raspberry Pi Pico port
     - name: Build Raspberry Pi PICO port
       if: matrix.port == 'rp2'
       run: |
+        source tools/ci.sh && ci_rp2_setup
         make -C ports/rp2 BOARD=RPI_PICO submodules
         make -j $(nproc) -C ports/rp2 BOARD=RPI_PICO USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
+
+    # ESP32 port
+    - name: Build ESP32 port
+      if: matrix.port == 'esp32'
+      run: |
+        source tools/ci.sh && ci_esp32_idf_setup
+        source tools/ci.sh && ci_esp32_build_cmod_spiram_s2
+        source tools/ci.sh && ci_esp32_build_s3_c3
+
     # Unix port
     - name: Build Unix port
       if: matrix.port == 'unix'
       run: make -j $(nproc) -C ports/unix DEBUG=1 VARIANT=lvgl LV_CFLAGS="-DMICROPY_LV_USE_LOG=0"
+
     - name: Install requirements for the test
       run: |
         python3 -m pip install pillow
         mkdir user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
+
+    # Tests
     - name: Run tests
       if: success() && matrix.port == 'unix'
       run: |
         export XDG_RUNTIME_DIR=/tmp
         python3 user_modules/lv_binding_micropython/lvgl/tests/micropy_test/__init__.py --artifact-path=user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts --mpy-path=ports/unix/build-lvgl/micropython
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-artifacts
-        path: user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
-
-  build-esp32:
-    runs-on: ubuntu-22.04
-    name: Build esp32 port
-    continue-on-error: true
-    steps:
-    - uses: ammaraskar/gcc-problem-matcher@master
-    - name: Install Dependencies
-      run: |
-        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
-        sudo apt-get update -y -qq
-        sudo apt-get install libsdl2-dev parallel libfreetype-dev librlottie-dev libavformat-dev libavcodec-dev libswscale-dev libavutil-dev doxygen
-        python3 -m pip install pycparser
-    - name: Clone lv_micropython
-      run: |
-        git clone https://github.com/lvgl/lv_micropython.git .
-        git checkout master
-    - name: Initialize lv_bindings submodule
-      run: git submodule update --init --recursive user_modules/lv_binding_micropython
-    - name: Update ESP32 port submodules
-      run: make -C ports/esp32 DEBUG=1 USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake submodules
-    - name: Checkout LVGL submodule
-      working-directory: ./user_modules/lv_binding_micropython/lvgl
-      run: |
-        git fetch --force ${{ github.event.repository.html_url }} "+refs/heads/*:refs/remotes/origin/*"
-        git fetch --force ${{ github.event.repository.html_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
-        git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
-        git submodule update --init --recursive
-    - name: Build mpy-cross
-      run: make -j $(nproc) -C mpy-cross
-    - name: Setup ESP-IDF
-      run: |
-        source tools/ci.sh && ci_esp32_idf_setup
-    - name: Build ESP32 port
-      run: |
-        source tools/ci.sh && ci_esp32_build_cmod_spiram_s2
-    - name: Install requirements for the test
-      run: |
-        python3 -m pip install pillow
-        mkdir user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -35,12 +35,12 @@ jobs:
         git clone https://github.com/lvgl/lv_micropython.git .
         git checkout master
     - name: Initialize lv_bindings submodule
-      run: git submodule update --init --recursive lib/lv_bindings
+      run: git submodule update --init --recursive user_modules/lv_binding_micropython
     - name: Update ${{ matrix.port }} port submodules
       if:  matrix.port != 'rp2'
-      run: make -C ports/${{ matrix.port }} DEBUG=1 USER_C_MODULES=../../lib/lv_bindings/bindings.cmake submodules
+      run: make -C ports/${{ matrix.port }} DEBUG=1 USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake submodules
     - name: Checkout LVGL submodule
-      working-directory: ./lib/lv_bindings/lvgl
+      working-directory: ./user_modules/lv_binding_micropython/lvgl
       run: |
         git fetch --force ${{ github.event.repository.html_url }} "+refs/heads/*:refs/remotes/origin/*"
         git fetch --force ${{ github.event.repository.html_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
@@ -61,27 +61,27 @@ jobs:
     - name: Build Raspberry Pi PICO port
       if: matrix.port == 'rp2'
       run: |
-        make -C ports/rp2 BOARD=PICO submodules
-        make -j $(nproc) -C ports/rp2 BOARD=PICO USER_C_MODULES=../../lib/lv_bindings/bindings.cmake
+        make -C ports/rp2 BOARD=RPI_PICO submodules
+        make -j $(nproc) -C ports/rp2 BOARD=RPI_PICO USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake
     # Unix port
     - name: Build Unix port
       if: matrix.port == 'unix'
-      run: make -j $(nproc) -C ports/unix DEBUG=1 LV_CFLAGS="-DMICROPY_LV_USE_LOG=0"
+      run: make -j $(nproc) -C ports/unix DEBUG=1 VARIANT=lvgl LV_CFLAGS="-DMICROPY_LV_USE_LOG=0"
     - name: Install requirements for the test
       run: |
         python3 -m pip install pillow
-        mkdir lib/lv_bindings/lvgl/tests/micropy_test/artifacts
+        mkdir user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
     - name: Run tests
       if: success() && matrix.port == 'unix'
       run: |
         export XDG_RUNTIME_DIR=/tmp
-        python3 lib/lv_bindings/lvgl/tests/micropy_test/__init__.py --artifact-path=lib/lv_bindings/lvgl/tests/micropy_test/artifacts --mpy-path=ports/unix/build-standard/micropython
+        python3 user_modules/lv_binding_micropython/lvgl/tests/micropy_test/__init__.py --artifact-path=user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts --mpy-path=ports/unix/build-lvgl/micropython
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: test-artifacts
-        path: lib/lv_bindings/lvgl/tests/micropy_test/artifacts
+        path: user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
 
   build-esp32:
     runs-on: ubuntu-22.04
@@ -100,11 +100,11 @@ jobs:
         git clone https://github.com/lvgl/lv_micropython.git .
         git checkout master
     - name: Initialize lv_bindings submodule
-      run: git submodule update --init --recursive lib/lv_bindings
-    - name: Update ${{ matrix.port }} port submodules
-      run: make -C ports/esp32 DEBUG=1 USER_C_MODULES=../../lib/lv_bindings/bindings.cmake submodules
+      run: git submodule update --init --recursive user_modules/lv_binding_micropython
+    - name: Update ESP32 port submodules
+      run: make -C ports/esp32 DEBUG=1 USER_C_MODULES=../../user_modules/lv_binding_micropython/micropython.cmake submodules
     - name: Checkout LVGL submodule
-      working-directory: ./lib/lv_bindings/lvgl
+      working-directory: ./user_modules/lv_binding_micropython/lvgl
       run: |
         git fetch --force ${{ github.event.repository.html_url }} "+refs/heads/*:refs/remotes/origin/*"
         git fetch --force ${{ github.event.repository.html_url }} "+refs/pull/*:refs/remotes/origin/pr/*"
@@ -114,16 +114,16 @@ jobs:
       run: make -j $(nproc) -C mpy-cross
     - name: Setup ESP-IDF
       run: |
-        source tools/ci.sh && ci_esp32_idf44_setup
+        source tools/ci.sh && ci_esp32_idf_setup
     - name: Build ESP32 port
       run: |
-        source tools/ci.sh && ci_esp32_build
+        source tools/ci.sh && ci_esp32_build_cmod_spiram_s2
     - name: Install requirements for the test
       run: |
         python3 -m pip install pillow
-        mkdir lib/lv_bindings/lvgl/tests/micropy_test/artifacts
+        mkdir user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: test-artifacts
-        path: lib/lv_bindings/lvgl/tests/micropy_test/artifacts
+        path: user_modules/lv_binding_micropython/lvgl/tests/micropy_test/artifacts


### PR DESCRIPTION
Fixes #7940 

Update LVGL MicroPython github build action.

[lv_micropython](https://github.com/lvgl/lv_micropython) and [lv_binding_micropython](https://github.com/lvgl/lv_binding_micropython) repos are updated to use [MicroPython version 1.24.1](https://github.com/micropython/micropython/tree/v1.24.1)

LVGL is used as [MicroPython external/user C module](https://docs.micropython.org/en/latest/develop/cmodules.html), so CI build is also updated.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
