### PR TITLE
fix(gif): free memory on error

### DIFF
--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -598,6 +598,7 @@ read_image_data(gd_GIF * gif, int interlace)
         str_len = entry.length;
 	if(frm_off + str_len > frm_size){
 		LV_LOG_WARN("LZW table token overflows the frame buffer");
+		lv_free(table);
 		return -1;
 	}
         for(i = 0; i < str_len; i++) {


### PR DESCRIPTION
Fixes #7891

[@whc6716](https://github.com/whc6716) has found a memory leak: if there is an error during reading GIF, then an allocated memory is not freed up.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
