### PR TITLE
fix(bin_decoder): fix the crash when decoder A8 images and flush cache

### DIFF
--- a/src/libs/bin_decoder/lv_bin_decoder.c
+++ b/src/libs/bin_decoder/lv_bin_decoder.c
@@ -279,21 +279,14 @@ lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 res = decode_indexed(decoder, dsc);
             }
         }
-        else if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf)) {
-            if(cf == LV_COLOR_FORMAT_A8) {
-                res = LV_RESULT_OK;
-                use_directly = true;
-                dsc->decoded = (lv_draw_buf_t *)image;
+        else if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(cf) && cf != LV_COLOR_FORMAT_A8) {
+            /*Alpha only image will need decoder data to store pointer to decoded image, to free it when decoder closes*/
+            decoder_data_t * decoder_data = get_decoder_data(dsc);
+            if(decoder_data == NULL) {
+                return LV_RESULT_INVALID;
             }
-            else {
-                /*Alpha only image will need decoder data to store pointer to decoded image, to free it when decoder closes*/
-                decoder_data_t * decoder_data = get_decoder_data(dsc);
-                if(decoder_data == NULL) {
-                    return LV_RESULT_INVALID;
-                }
 
-                res = decode_alpha_only(decoder, dsc);
-            }
+            res = decode_alpha_only(decoder, dsc);
         }
         else {
             /*In case of uncompressed formats the image stored in the ROM/RAM.

--- a/tests/src/test_cases/libs/test_bin_decoder.c
+++ b/tests/src/test_cases/libs/test_bin_decoder.c
@@ -160,4 +160,53 @@ void test_bin_decoder_image_dsc_error_handling(void)
     bin_decoder(NULL, "libs/bin_decoder_empty_image.png");
 }
 
+void test_bin_decoder_flush_cache(void)
+{
+#if LV_BIN_DECODER_RAM_LOAD == 1
+    LV_IMAGE_DECLARE(test_I1_NONE_align64);
+    LV_IMAGE_DECLARE(test_I2_NONE_align64);
+    LV_IMAGE_DECLARE(test_I4_NONE_align64);
+    LV_IMAGE_DECLARE(test_I8_NONE_align64);
+    LV_IMAGE_DECLARE(test_A1_NONE_align64);
+    LV_IMAGE_DECLARE(test_A2_NONE_align64);
+    LV_IMAGE_DECLARE(test_A4_NONE_align64);
+    LV_IMAGE_DECLARE(test_A8_NONE_align64);
+    LV_IMAGE_DECLARE(test_RGB565A8_NONE_align64);
+    LV_IMAGE_DECLARE(test_RGB565_NONE_align64);
+    LV_IMAGE_DECLARE(test_RGB888_NONE_align64);
+    LV_IMAGE_DECLARE(test_XRGB8888_NONE_align64);
+    LV_IMAGE_DECLARE(test_ARGB8888_NONE_align64);
+
+    const lv_image_dsc_t * img_dscs[] = {
+        &test_I1_NONE_align64,
+        &test_I2_NONE_align64,
+        &test_I4_NONE_align64,
+        &test_I8_NONE_align64,
+        &test_A1_NONE_align64,
+        &test_A2_NONE_align64,
+        &test_A4_NONE_align64,
+        &test_A8_NONE_align64,
+        &test_RGB565A8_NONE_align64,
+        &test_RGB565_NONE_align64,
+        &test_RGB888_NONE_align64,
+        &test_XRGB8888_NONE_align64,
+        &test_ARGB8888_NONE_align64,
+    };
+    const lv_image_decoder_args_t args = {
+        .no_cache = true,
+        .premultiply = false,
+        .stride_align = false,
+        .use_indexed = true,
+        .flush_cache = true,
+    };
+
+    for(unsigned long i = 0; i < sizeof(img_dscs) / sizeof(img_dscs[0]); i++) {
+        lv_image_decoder_dsc_t decoder_dsc;
+        lv_result_t res = lv_image_decoder_open(&decoder_dsc, img_dscs[i], &args);
+        TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+        lv_image_decoder_close(&decoder_dsc);
+    }
+#endif
+}
+
 #endif


### PR DESCRIPTION
<!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->
When decoding A8 images, `draw_buf->handlers` is not set, it will crash in `lv_draw_buf_flush_cache`
```c
static void test(void)
{
    const lv_image_decoder_args_t args = {
        .no_cache = true,
        .premultiply = false,
        .stride_align = false,
        .use_indexed = true,
        .flush_cache = true,
    };

    LV_IMAGE_DECLARE(test_A8_NONE_align64);
    lv_image_decoder_dsc_t decoder_dsc;
    lv_image_decoder_open(&decoder_dsc, &test_A8_NONE_align64, &args);
    lv_image_decoder_close(&decoder_dsc);
}
```


<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
