### PR TITLE
fix(color): add cast to LV_OPA_MIX macros

### DIFF
--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -230,8 +230,8 @@ typedef enum {
 
 #define LV_COLOR_MAKE(r8, g8, b8) {b8, g8, r8}
 
-#define LV_OPA_MIX2(a1, a2) (((int32_t)(a1) * (a2)) >> 8)
-#define LV_OPA_MIX3(a1, a2, a3) (((int32_t)(a1) * (a2) * (a3)) >> 16)
+#define LV_OPA_MIX2(a1, a2) ((lv_opa_t)(((int32_t)(a1) * (a2)) >> 8))
+#define LV_OPA_MIX3(a1, a2, a3) ((lv_opa_t)(((int32_t)(a1) * (a2) * (a3)) >> 16))
 
 /**********************
  * GLOBAL PROTOTYPES


### PR DESCRIPTION
Add cast to the result of the LV_OPA_MIX2 and LV_OPA_MIX3 macros so the result is lv_opa_t type.

