### PR TITLE
docs(readme): fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ This list will guide you to get started with LVGL step-by-step.
 
   4. Set up a [Simulator](https://docs.lvgl.io/master/details/integration/ide/pc-simulator.html#simulator) (10 minutes).
   5. Try out some [Examples](https://github.com/lvgl/lvgl/tree/master/examples).
-  6. Port LVGL to a board. See the [Porting](ttps://docs.lvgl.io/master/details/integration/adding-lvgl-to-your-project/index.html) guide or check out the ready-to-use [Projects](https://github.com/lvgl?q=lv_port_).
+  6. Port LVGL to a board. See the [Porting](https://docs.lvgl.io/master/details/integration/adding-lvgl-to-your-project/index.html) guide or check out the ready-to-use [Projects](https://github.com/lvgl?q=lv_port_).
 
 **Become a Pro**
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ Our team is ready to help you with graphics design, UI implementation and consul
 **Free and Portable**
   - A fully portable C (C++ compatible) library with no external dependencies.
   - Can be compiled to any MCU or MPU, with any (RT)OS.
-  - Supports monochrome, ePaper, OLED or TFT displays, or even monitors. [Displays](https://docs.lvgl.io/master/details/main-components/display.html)
+  - Supports monochrome, ePaper, OLED or TFT displays, or even monitors. [Displays](https://docs.lvgl.io/master/details/main-modules/display/index.html)
   - Distributed under the MIT license, so you can easily use it in commercial projects too.
   - Needs only 32kB RAM and 128 kB Flash, a frame buffer, and at least an 1/10 screen sized buffer for rendering.
   - OS, External memory and GPU are supported but not required.
 
 **Widgets, Styles, Layouts and more**
   - 30+ built-in [Widgets](https://docs.lvgl.io/master/details/widgets/index.html):  Button, Label, Slider, Chart, Keyboard, Meter, Arc, Table and many more.
-  - Flexible [Style system](https://docs.lvgl.io/master/details/base-widget/styles/style.html) with  ~100 style properties to customize any part of the widgets in any state.
-  - [Flexbox](https://docs.lvgl.io/master/details/base-widget/layouts/flex.html) and [Grid](https://docs.lvgl.io/master/details/base-widget/layouts/grid.html)-like layouts engines to automatically size and position the widgets in a responsive way.
+  - Flexible [Style system](https://docs.lvgl.io/master/details/common-widget-features/styles/index.html) with  ~100 style properties to customize any part of the widgets in any state.
+  - [Flexbox](https://docs.lvgl.io/master/details/common-widget-features/layouts/flex.html) and [Grid](https://docs.lvgl.io/master/details/common-widget-features/layouts/grid.html)-like layouts engines to automatically size and position the widgets in a responsive way.
   - Texts are rendered with UTF-8 encoding supporting CJK, Thai, Hindi, Arabic, Persian writing systems.
   - Word wrapping, kerning, text scrolling, sub-pixel rendering, Pinyin-IME Chinese input, Emojis in texts.
   - Rendering engine supporting animations, anti-aliasing, opacity, smooth scrolling, shadows, image transformation, etc  
-  - Supports Mouse, Touchpad, Keypad, Keyboard, External buttons, Encoder [Input devices](https://docs.lvgl.io/master/details/main-components/indev.html).
-  - [Multiple display](https://docs.lvgl.io/master/details/main-components/display.html#how-many-displays-can-lvgl-use) support.
+  - Supports Mouse, Touchpad, Keypad, Keyboard, External buttons, Encoder [Input devices](https://docs.lvgl.io/master/details/main-modules/indev.html).
+  - [Multiple display](https://docs.lvgl.io/master/details/main-modules/display/overview.html#how-many-displays-can-lvgl-use) support.
 
 **Binding and Build Support**
   - [MicroPython Binding](https://blog.lvgl.io/2019-02-20/micropython-bindings) exposes LVGL API
@@ -421,23 +421,23 @@ This list will guide you to get started with LVGL step-by-step.
 
   1. Check the [Online demos](https://lvgl.io/demos) to see LVGL in action (3 minutes).
   2. Read the [Introduction](https://docs.lvgl.io/master/intro/index.html) page of the documentation (5 minutes).
-  3. Get familiar with the basics on the [Quick overview](https://docs.lvgl.io/master/intro/basics.html) page (15 minutes).
+  3. Get familiar with the basics on the [Quick overview](https://docs.lvgl.io/master/intro/getting_started.html#lvgl-basics) page (15 minutes).
 
 **Start to Use LVGL**
 
   4. Set up a [Simulator](https://docs.lvgl.io/master/details/integration/ide/pc-simulator.html#simulator) (10 minutes).
   5. Try out some [Examples](https://github.com/lvgl/lvgl/tree/master/examples).
-  6. Port LVGL to a board. See the [Porting](https://docs.lvgl.io/master/intro/add-lvgl-to-your-project/index.html) guide or check out the ready-to-use [Projects](https://github.com/lvgl?q=lv_port_).
+  6. Port LVGL to a board. See the [Porting](ttps://docs.lvgl.io/master/details/integration/adding-lvgl-to-your-project/index.html) guide or check out the ready-to-use [Projects](https://github.com/lvgl?q=lv_port_).
 
 **Become a Pro**
 
-  7. Read the [Main-Components](https://docs.lvgl.io/master/details/main-components/index.html) page to get a better understanding of the library (2-3 hours)
+  7. Read the [Main-Modules](https://docs.lvgl.io/master/details/main-modules/index.html) page to get a better understanding of the library (2-3 hours)
   8. Check the documentation of the [Widgets](https://docs.lvgl.io/master/details/widgets/index.html) to see their features and usage
 
 **Get Help and Help Others**
 
   9. If you have questions go to the [Forum](http://forum.lvgl.io/)
-  10. Read the [Contributing](https://docs.lvgl.io/master/CONTRIBUTING.html) guide to see how you can help to improve LVGL (15 minutes)
+  10. Read the [Contributing](https://docs.lvgl.io/master/contributing/index.html) guide to see how you can help to improve LVGL (15 minutes)
 
 
 ## :handshake: Services
@@ -457,7 +457,7 @@ Check out our [Demos](https://lvgl.io/demos) as reference. For more information 
 ## :star2: Contributing
 LVGL is an open project and contribution is very welcome. There are many ways to contribute from simply speaking about your project, through writing examples, improving the documentation, fixing bugs or even hosting your own project under the LVGL organization.
 
-For a detailed description of contribution opportunities visit the [Contributing](https://docs.lvgl.io/master/CONTRIBUTING.html) section of the documentation.
+For a detailed description of contribution opportunities visit the [Contributing](https://docs.lvgl.io/master/contributing/index.html) section of the documentation.
 
 More than 300 people already left their fingerprint in LVGL. Be one them! See you here! :slightly_smiling_face:
 


### PR DESCRIPTION
There were many links that referenced pages that no longer exist, I've updated the English readme.

### Notes
- Replaced legacy links
