### PR TITLE
fix(tree): add NULL check

### DIFF
--- a/src/misc/lv_tree.c
+++ b/src/misc/lv_tree.c
@@ -77,6 +77,8 @@ static uint32_t get_instance_size(const lv_tree_class_t * class_p)
     while(base && base->instance_size == 0)
         base = base->base_class;
 
+    LV_ASSERT_NULL(base);
+
     return base->instance_size;
 }
 


### PR DESCRIPTION
In get_instance_size() the value of the "base" pointer is not checked prior to be dereferenced.  Add check to make sure the value is not NULL.
