### PR TITLE
fix(draw_sw_vector): fix thorvg canvas colorspace

### DIFF
--- a/src/draw/sw/lv_draw_sw_vector.c
+++ b/src/draw/sw/lv_draw_sw_vector.c
@@ -494,7 +494,7 @@ void lv_draw_sw_vector(lv_draw_task_t * t, const lv_draw_vector_task_dsc_t * dsc
     }
 
     Tvg_Canvas * canvas = tvg_swcanvas_create();
-    tvg_swcanvas_set_target(canvas, buf, stride / 4, width, height, TVG_COLORSPACE_ARGB8888S);
+    tvg_swcanvas_set_target(canvas, buf, stride / 4, width, height, TVG_COLORSPACE_ARGB8888);
 
     _tvg_rect rc;
     lv_area_to_tvg(&rc, &t->clip_area);


### PR DESCRIPTION
Colors from LVGL are normally alpha-premultiplied, so ThorVG don't need to recompute them.