### PR TITLE
fix(tests): explicitly install libudev dependency #7983

### DIFF
--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -13,5 +13,5 @@ sudo apt install gcc gcc-multilib g++-multilib ninja-build \
     libpng-dev:i386 libjpeg-dev:i386 libfreetype6-dev:i386 \
     ruby-full gcovr cmake  python3 libinput-dev libxkbcommon-dev \
     libdrm-dev pkg-config wayland-protocols libwayland-dev libwayland-bin \
-    libwayland-dev:i386 libxkbcommon-dev:i386
+    libwayland-dev:i386 libxkbcommon-dev:i386 libudev-dev
 pip3 install pypng lz4 kconfiglib


### PR DESCRIPTION


Fixes #7983

<!-- A clear and concise description of what the bug or new feature is.-->
Explicitly include libudev-dev as a testing dependency.
