### PR TITLE
fix(thorvg.h): ensure can use standard ints #7988

### DIFF
--- a/src/libs/thorvg/thorvg.h
+++ b/src/libs/thorvg/thorvg.h
@@ -13,6 +13,7 @@
 
 
 #include <functional>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <list>


### PR DESCRIPTION


Fixes #7988
<!-- A clear and concise description of what the bug or new feature is.-->
Compatibility with newer C compilers.
