### PR TITLE
feat(scripts): Add --name parameter to LVGLImage.py

### DIFF
--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -308,12 +308,11 @@ def write_c_array_file(
         stride: int,
         cf: ColorFormat,
         filename: str,
+        oname: str,
         premultiplied: bool,
         compress: CompressMethod,
         data: bytes):
-    varname = path.basename(filename).split('.')[0]
-    varname = varname.replace("-", "_")
-    varname = varname.replace(".", "_")
+    varname = path.basename(filename).split('.')[0].replace("-", "_").replace(".", "_") if oname is None else oname
 
     flags = "0"
     if compress is not CompressMethod.NONE:
@@ -773,7 +772,8 @@ class LVGLImage:
 
     def to_c_array(self,
                    filename: str,
-                   compress: CompressMethod = CompressMethod.NONE):
+                   compress: CompressMethod = CompressMethod.NONE,
+                   oname: str = None):
         self._check_ext(filename, ".c")
         self._check_dir(filename)
 
@@ -781,7 +781,7 @@ class LVGLImage:
             data = LVGLCompressData(self.cf, compress, self.data).compressed
         else:
             data = self.data
-        write_c_array_file(self.w, self.h, self.stride, self.cf, filename,
+        write_c_array_file(self.w, self.h, self.stride, self.cf, filename, oname,
                            self.premultiplied,
                            compress, data)
 
@@ -1231,10 +1231,11 @@ class RAWImage():
         self.data = data
 
     def to_c_array(self,
-                   filename: str):
+                   filename: str,
+                   oname: str = None):
         # Image size is set to zero, to let PNG or JPEG decoder to handle it
         # Stride is meaningless for RAW image
-        write_c_array_file(0, 0, 0, self.cf, filename,
+        write_c_array_file(0, 0, 0, self.cf, filename, oname,
                            False, CompressMethod.NONE, self.data)
 
     def from_file(self,
@@ -1282,22 +1283,30 @@ class PNGConverter:
         self.rgb565_dither = rgb565_dither
         self.nema_gfx = nema_gfx
 
-    def _replace_ext(self, input, ext):
+    def _replace_ext(self, input, ext, oname: str = None):
         if self.keep_folder:
             name, _ = path.splitext(input)
         else:
             name, _ = path.splitext(path.basename(input))
+
+        # change output name to 'oname', if specified
+        if oname is not None:
+            name = path.join(path.dirname(name), oname)
+
         output = name + ext
         output = path.join(self.output, output)
         return output
 
-    def convert(self):
+    def convert(self, oname: str):
+        if len(self.files) > 1 and oname is not None:
+            raise BaseException(f"Cannot specify 'oname' when converting more than one file.")
+
         output = []
         for f in self.files:
             if self.cf in (ColorFormat.RAW, ColorFormat.RAW_ALPHA):
                 # Process RAW image explicitly
                 img = RAWImage().from_file(f, self.cf)
-                img.to_c_array(self._replace_ext(f, ".c"))
+                img.to_c_array(self._replace_ext(f, ".c", oname), oname=oname)
             else:
                 img = LVGLImage().from_png(f, self.cf, background=self.background, rgb565_dither=self.rgb565_dither, nema_gfx=self.nema_gfx)
                 img.adjust_stride(align=self.align)
@@ -1309,8 +1318,9 @@ class PNGConverter:
                     img.to_bin(self._replace_ext(f, ".bin"),
                                compress=self.compress)
                 elif self.ofmt == OutputFormat.C_ARRAY:
-                    img.to_c_array(self._replace_ext(f, ".c"),
-                                   compress=self.compress)
+                    img.to_c_array(self._replace_ext(f, ".c", oname),
+                                   compress=self.compress,
+                                   oname=oname)
                 elif self.ofmt == OutputFormat.PNG_FILE:
                     img.to_png(self._replace_ext(f, ".png"))
 
@@ -1363,6 +1373,9 @@ def main():
                         '--output',
                         default="./output",
                         help="Select the output folder, default to ./output")
+    parser.add_argument('--name',
+                        default=None,
+                        help="Specify name for output file. Only applies when input is a file, not a directory. (Also used for variable name inside .c file when format is 'C')")
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument(
         'input', help="the filename or folder to be recursively converted")
@@ -1373,6 +1386,9 @@ def main():
         files = [args.input]
     elif path.isdir(args.input):
         files = list(Path(args.input).rglob("*.[pP][nN][gG]"))
+
+        if args.name is not None:
+            raise BaseException(f"invalid input: cannot specify --name when input is a directory")
     else:
         raise BaseException(f"invalid input: {args.input}")
 
@@ -1401,7 +1417,7 @@ def main():
                              keep_folder=False,
                              rgb565_dither=args.rgb565dither,
                              nema_gfx=args.nemagfx)
-    output = converter.convert()
+    output = converter.convert(args.name)
     for f, img in output:
         logging.info(f"len: {img.data_len} for {path.basename(f)} ")
 

--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -308,11 +308,11 @@ def write_c_array_file(
         stride: int,
         cf: ColorFormat,
         filename: str,
-        oname: str,
+        outputname: str,
         premultiplied: bool,
         compress: CompressMethod,
         data: bytes):
-    varname = path.basename(filename).split('.')[0].replace("-", "_").replace(".", "_") if oname is None else oname
+    varname = path.basename(filename).split('.')[0].replace("-", "_").replace(".", "_") if outputname is None else outputname
 
     flags = "0"
     if compress is not CompressMethod.NONE:
@@ -773,7 +773,7 @@ class LVGLImage:
     def to_c_array(self,
                    filename: str,
                    compress: CompressMethod = CompressMethod.NONE,
-                   oname: str = None):
+                   outputname: str = None):
         self._check_ext(filename, ".c")
         self._check_dir(filename)
 
@@ -781,7 +781,7 @@ class LVGLImage:
             data = LVGLCompressData(self.cf, compress, self.data).compressed
         else:
             data = self.data
-        write_c_array_file(self.w, self.h, self.stride, self.cf, filename, oname,
+        write_c_array_file(self.w, self.h, self.stride, self.cf, filename, outputname,
                            self.premultiplied,
                            compress, data)
 
@@ -1232,10 +1232,10 @@ class RAWImage():
 
     def to_c_array(self,
                    filename: str,
-                   oname: str = None):
+                   outputname: str = None):
         # Image size is set to zero, to let PNG or JPEG decoder to handle it
         # Stride is meaningless for RAW image
-        write_c_array_file(0, 0, 0, self.cf, filename, oname,
+        write_c_array_file(0, 0, 0, self.cf, filename, outputname,
                            False, CompressMethod.NONE, self.data)
 
     def from_file(self,
@@ -1283,30 +1283,30 @@ class PNGConverter:
         self.rgb565_dither = rgb565_dither
         self.nema_gfx = nema_gfx
 
-    def _replace_ext(self, input, ext, oname: str = None):
+    def _replace_ext(self, input, ext, outputname: str = None):
         if self.keep_folder:
             name, _ = path.splitext(input)
         else:
             name, _ = path.splitext(path.basename(input))
 
-        # change output name to 'oname', if specified
-        if oname is not None:
-            name = path.join(path.dirname(name), oname)
+        # change output name to 'outputname', if specified
+        if outputname is not None:
+            name = path.join(path.dirname(name), outputname)
 
         output = name + ext
         output = path.join(self.output, output)
         return output
 
-    def convert(self, oname: str):
-        if len(self.files) > 1 and oname is not None:
-            raise BaseException(f"Cannot specify 'oname' when converting more than one file.")
+    def convert(self, outputname: str):
+        if len(self.files) > 1 and outputname is not None:
+            raise BaseException(f"Cannot specify output nam when converting more than one file.")
 
         output = []
         for f in self.files:
             if self.cf in (ColorFormat.RAW, ColorFormat.RAW_ALPHA):
                 # Process RAW image explicitly
                 img = RAWImage().from_file(f, self.cf)
-                img.to_c_array(self._replace_ext(f, ".c", oname), oname=oname)
+                img.to_c_array(self._replace_ext(f, ".c", outputname), outputname=outputname)
             else:
                 img = LVGLImage().from_png(f, self.cf, background=self.background, rgb565_dither=self.rgb565_dither, nema_gfx=self.nema_gfx)
                 img.adjust_stride(align=self.align)
@@ -1318,9 +1318,9 @@ class PNGConverter:
                     img.to_bin(self._replace_ext(f, ".bin"),
                                compress=self.compress)
                 elif self.ofmt == OutputFormat.C_ARRAY:
-                    img.to_c_array(self._replace_ext(f, ".c", oname),
+                    img.to_c_array(self._replace_ext(f, ".c", outputname),
                                    compress=self.compress,
-                                   oname=oname)
+                                   outputname=outputname)
                 elif self.ofmt == OutputFormat.PNG_FILE:
                     img.to_png(self._replace_ext(f, ".png"))
 

--- a/scripts/LVGLImage.py
+++ b/scripts/LVGLImage.py
@@ -1299,7 +1299,7 @@ class PNGConverter:
 
     def convert(self, outputname: str):
         if len(self.files) > 1 and outputname is not None:
-            raise BaseException(f"Cannot specify output nam when converting more than one file.")
+            raise BaseException(f"Cannot specify output name when converting more than one file.")
 
         output = []
         for f in self.files:


### PR DESCRIPTION
Add --name parameter to image conversion script `LVGLImage.py`. This allows for directing the name of the output file, as well as the variable name when the output format is C.

Example:

```sh
python3 LVGLImage.py ~/some-folder/image.png --ofmt C --output ~/some-folder --name image_data

# output file will be ~/some-folder/image_data.c
# the name of the variable in `image_data.c` will be `image_data`
```

NOTE: This only applies to converting single files. Specifying --name when converting an entire directory is not allowed.