### PR TITLE
fix(draw/sw): draw outline span wrong init.

### DIFF
--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -337,7 +337,7 @@ static void freetype_outline_event_cb(lv_event_t * e)
 
     if(lv_event_get_code(e) == LV_EVENT_CREATE) {
 
-        glyph_paths = lv_malloc(sizeof(lv_draw_sw_letter_outlines_t));
+        glyph_paths = lv_malloc_zeroed(sizeof(lv_draw_sw_letter_outlines_t));
         LV_ASSERT_NULL(glyph_paths);
 
         glyph_paths->cur_path = lv_vector_path_create(LV_VECTOR_PATH_QUALITY_HIGH);

--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -338,7 +338,7 @@ static void freetype_outline_event_cb(lv_event_t * e)
     if(lv_event_get_code(e) == LV_EVENT_CREATE) {
 
         glyph_paths = lv_malloc_zeroed(sizeof(lv_draw_sw_letter_outlines_t));
-        LV_ASSERT_NULL(glyph_paths);
+        LV_ASSERT_MALLOC(glyph_paths);
 
         glyph_paths->cur_path = lv_vector_path_create(LV_VECTOR_PATH_QUALITY_HIGH);
         glyph_paths->inside_path = glyph_paths->cur_path;


### PR DESCRIPTION
Fixes pr #7560

When I'm working on adding new cases for benchmark, this happened:
![20250327-114801](https://github.com/user-attachments/assets/19e4c0d4-2bc7-44f7-81d9-155427020652)
![20250327-114806](https://github.com/user-attachments/assets/0829dc3b-a301-4090-adad-5780626655af)
Find out to be incorrect use of lv_malloc_zeroed and lv_malloc.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
