### PR TITLE
fix(evdev): fix touch point reading failure

### DIFF
--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -179,6 +179,25 @@ lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path)
         goto err_after_open;
     }
 
+     /* Detect the minimum and maximum values of the input device for calibration. */
+     if(indev_type == LV_INDEV_TYPE_POINTER) {
+        struct input_absinfo absinfo;
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_X), &absinfo) == 0) {
+            dsc->min_x = absinfo.minimum;
+            dsc->max_x = absinfo.maximum;
+        }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_X) failed: %s", strerror(errno));
+        }
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_Y), &absinfo) == 0) {
+            dsc->min_y = absinfo.minimum;
+            dsc->max_y = absinfo.maximum;
+        }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_Y) failed: %s", strerror(errno));
+        }
+    }
+    
     lv_indev_t * indev = lv_indev_create();
     if(indev == NULL) goto err_after_open;
     lv_indev_set_type(indev, indev_type);


### PR DESCRIPTION
1、When I was using lvgl release v9.0, I found that my touch screen had no touch feedback, but i can get touch coordinates from /dev/inputt/envent2. I added debugging information and found that the values of dsc->min_x, dsc->max_x, dsc->min_y, and dsc->max_y are all 0. This caused _evdev_calibrate to miscalculate, causing the reported screen coordinates to be wrong and the screen touch to fail.

2、So get the absinfo assignment for the x and y axes of the event device to dsc->min_x, dsc->max_x, dsc->min_y, dsc->max_y can fixes this error.

3、By the way, the latest release v9.2 does not have this bug.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
