### PR TITLE
docs(doc-gen):  eliminate several breathe errors...

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -815,7 +815,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.h    \
+FILE_PATTERNS          = lv*.h  \
                          *.hh   \
                          *.hxx  \
                          *.hpp  \
@@ -850,18 +850,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */libs/barcode/code*      \
-                         */libs/expat/*asciitab.h  \
-                         */libs/expat/latin1tab.h  \
-                         */libs/expat/utf8tab.h    \
-                         */libs/freetype/ft*       \
-                         */libs/gif/gif*           \
-                         */libs/lodepng/lode*      \
-                         */libs/qrcode/qr*         \
-                         */libs/thorvg/*           \
-                         */libs/tiny_ttf/stb*      \
-                         */libs/tjpgd/tjp*         \
-                         */others/vg_lite_tvg/vg*
+EXCLUDE_PATTERNS       =
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -851,6 +851,9 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */libs/barcode/code*      \
+                         */libs/expat/*asciitab.h  \
+                         */libs/expat/latin1tab.h  \
+                         */libs/expat/utf8tab.h    \
                          */libs/freetype/ft*       \
                          */libs/gif/gif*           \
                          */libs/lodepng/lode*      \


### PR DESCRIPTION
In `./src/libs/expat/`, four `.h` files were being used like macros, containing table values, but not the surrounding C constructs -- they were instead used by xmltok.c by optionally `#include`-ing them based on configuration options.

API pages were being generated for them, and later `breathe` tried to parse them as C constructs and (of course) failed.  As these need not be separately documented, they are excluded from this eventuality.  This is done by simply excluding them from being parsed by Doxygen, since the later API-page-generation logic will not create an API page unless Doxygen parsed it.

cc:  @kisvegabor

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  Done.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
