### PR TITLE
docs(introduction.rst):  fix bug in API links...

### DIFF
--- a/docs/src/intro/introduction.rst
+++ b/docs/src/intro/introduction.rst
@@ -328,6 +328,7 @@ Starting from v8, every minor release is supported for 1 year.
 
 API
 ***
-.. API equals:  LV_MEM_SIZE, lv_timer_handler, lv_tick_inc, lv_display_flush_ready,
+
+.. API equals:  LV_MEM_SIZE, lv_timer_handler, lv_tick_inc, lv_display_flush_wait_cb_t,
     LV_COLOR_DEPTH
 


### PR DESCRIPTION
The symbol `lv_display_flush_ready` was included in the guided-API-link syntax at the end of `introduction.rst` in order to generate an API-page link to the `lv_display.h` API page.  However, no such link was showing up!  As it turns out, this is not a bug in the guide-API-link logic, but instead it was discovered that Doxygen generated no documentation for this function, and that is the reason the API link was not there -- it was behaving as designed!  Why was Doxygen not generating documentation for it?  The prototype for that function in `lv_display.h`  (where the documentation is for that function) is, as well as the function itself in the `.c` file, is prefixed with the symbol `LV_ATTRIBUTE_FLUSH_READY`.  The code looks like this:

    /**
     * Call from the display driver when the flushing is finished
     * @param disp      pointer to display whose `flush_cb` was called
     */
    LV_ATTRIBUTE_FLUSH_READY void lv_display_flush_ready(lv_display_t * disp);

Unfortunately, this is tricking Doxygen into not being able to parse that line and so the documentation that goes with it never makes it into the Doxgen XML output.

The result is that the `lv_display_flush_ready` was not found in the symbol table known about by Doxygen, and that was causing the `lv_display.h` API link to be omitted from the bottom of the document!

Since this prefix appears to be vital (e.g. probably can be to be 'inline' or some other thing [perhaps connected to an interrupt?] for certain build environments), so the solution was simply to choose ANOTHER symbol from the `lv_display.h` file and replace `lv_display_flush_ready` with it to get the API-page link to `lv_display.h` to be added to the document.  The symbol chosen was `lv_display_flush_wait_cb_t`, and it is working now and reflected at the end of the on-line document [here](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/intro/introduction.html) (in the API section at the end).

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
