### PR TITLE
fix(layout): size in cross direction was not updated when layout on parent was changed from grid to flex

### DIFF
--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -395,6 +395,10 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
             item = get_next_item(cont, f->rev, &item_first_id);
             continue;
         }
+
+        int16_t item_w_layout = item->w_layout;
+        int16_t item_h_layout = item->h_layout;
+
         int32_t grow_size = lv_obj_get_style_flex_grow(item, LV_PART_MAIN);
         if(grow_size) {
             int32_t s = 0;
@@ -428,6 +432,10 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
         else {
             item->w_layout = 0;
             item->h_layout = 0;
+        }
+
+        if(item->w_layout != item_w_layout || item->h_layout != item_h_layout) {
+            lv_obj_mark_layout_as_dirty(item);
         }
 
         int32_t cross_pos = 0;

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -396,8 +396,8 @@ static void children_repos(lv_obj_t * cont, flex_t * f, int32_t item_first_id, i
             continue;
         }
 
-        int16_t item_w_layout = item->w_layout;
-        int16_t item_h_layout = item->h_layout;
+        uint16_t item_w_layout = item->w_layout;
+        uint16_t item_h_layout = item->h_layout;
 
         int32_t grow_size = lv_obj_get_style_flex_grow(item, LV_PART_MAIN);
         if(grow_size) {

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -1,0 +1,95 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+#define NUM_OBJECTS 4
+
+static lv_obj_t * active_screen = NULL;
+static lv_obj_t *objects[NUM_OBJECTS] = {NULL};
+static int32_t grid_col_dsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+static int32_t grid_row_dsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+
+static void set_layout_grid(void)
+{
+    lv_obj_set_grid_dsc_array(active_screen, grid_col_dsc, grid_row_dsc);
+    lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
+
+    for (int i = 0; i < NUM_OBJECTS; i++)
+    {
+      lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
+    }
+    lv_obj_update_layout(active_screen);
+}
+
+static void set_layout_flex(lv_flex_flow_t flex_flow)
+{
+    lv_obj_set_layout(active_screen, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(active_screen, flex_flow);
+
+    void (*obj_set_dimension)(lv_obj_t *obj, int32_t value) = NULL;
+
+    switch(flex_flow)
+    {
+        case LV_FLEX_FLOW_COLUMN:
+        case LV_FLEX_FLOW_COLUMN_WRAP:
+        case LV_FLEX_FLOW_COLUMN_REVERSE:
+        case LV_FLEX_FLOW_COLUMN_WRAP_REVERSE:
+            obj_set_dimension = lv_obj_set_width;
+            break;
+        case LV_FLEX_FLOW_ROW:
+        case LV_FLEX_FLOW_ROW_WRAP:
+        case LV_FLEX_FLOW_ROW_REVERSE:
+        case LV_FLEX_FLOW_ROW_WRAP_REVERSE:
+            obj_set_dimension = lv_obj_set_height;
+            break;
+        default:
+            LV_LOG_ERROR("Invalid flex flow");    
+            return;
+    }
+
+    for (int i = 0; i < NUM_OBJECTS; i++)
+    {
+      lv_obj_set_flex_grow(objects[i], 1);
+      obj_set_dimension(objects[i], LV_PCT(100)); 
+    }
+
+    lv_obj_update_layout(active_screen);
+}
+
+void setUp(void)
+{
+    active_screen = lv_screen_active();
+    for (int i = 0; i < NUM_OBJECTS; i++)
+    {
+      objects[i] = lv_obj_create (active_screen);
+    }
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+void test_layout_switch(void)
+{
+    set_layout_flex(LV_FLEX_FLOW_COLUMN);
+    TEST_ASSERT_EQUAL(LV_LAYOUT_FLEX, lv_obj_get_style_layout(active_screen, LV_PART_MAIN));
+    TEST_ASSERT_EQUAL(1, active_screen->h_layout);
+    TEST_ASSERT_EQUAL(0, active_screen->w_layout);
+
+    set_layout_grid();
+    TEST_ASSERT_EQUAL(LV_LAYOUT_GRID, lv_obj_get_style_layout(active_screen, LV_PART_MAIN));
+    TEST_ASSERT_EQUAL(1, active_screen->h_layout);
+    TEST_ASSERT_EQUAL(1, active_screen->w_layout);
+
+    set_layout_flex(LV_FLEX_FLOW_ROW);
+    TEST_ASSERT_EQUAL(LV_LAYOUT_FLEX, lv_obj_get_style_layout(active_screen, LV_PART_MAIN));
+    TEST_ASSERT_EQUAL(0, active_screen->h_layout);
+    TEST_ASSERT_EQUAL(1, active_screen->w_layout);
+}
+
+
+#endif

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -16,7 +16,7 @@ static void set_layout_grid(void)
     lv_obj_set_grid_dsc_array(active_screen, grid_col_dsc, grid_row_dsc);
     lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
 
-    for (int i = 0; i < NUM_OBJECTS; i++) {
+    for(int i = 0; i < NUM_OBJECTS; i++) {
         lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
     }
     lv_obj_update_layout(active_screen);
@@ -47,7 +47,7 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
             return;
     }
 
-    for (int i = 0; i < NUM_OBJECTS; i++) {
+    for(int i = 0; i < NUM_OBJECTS; i++) {
         lv_obj_set_flex_grow(objects[i], 1);
         obj_set_dimension(objects[i], LV_PCT(100)); 
     }
@@ -58,7 +58,7 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
 void setUp(void)
 {
     active_screen = lv_screen_active();
-    for (int i = 0; i < NUM_OBJECTS; i++) {
+    for(int i = 0; i < NUM_OBJECTS; i++) {
         objects[i] = lv_obj_create (active_screen);
     }
 }

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -17,7 +17,7 @@ static void set_layout_grid(void)
     lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
 
     for (int i = 0; i < NUM_OBJECTS; i++) {
-      lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
+        lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
     }
     lv_obj_update_layout(active_screen);
 }
@@ -48,8 +48,8 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
     }
 
     for (int i = 0; i < NUM_OBJECTS; i++) {
-      lv_obj_set_flex_grow(objects[i], 1);
-      obj_set_dimension(objects[i], LV_PCT(100)); 
+        lv_obj_set_flex_grow(objects[i], 1);
+        obj_set_dimension(objects[i], LV_PCT(100)); 
     }
 
     lv_obj_update_layout(active_screen);
@@ -59,7 +59,7 @@ void setUp(void)
 {
     active_screen = lv_screen_active();
     for (int i = 0; i < NUM_OBJECTS; i++) {
-      objects[i] = lv_obj_create (active_screen);
+        objects[i] = lv_obj_create (active_screen);
     }
 }
 

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -49,7 +49,7 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
 
     for(int i = 0; i < NUM_OBJECTS; i++) {
         lv_obj_set_flex_grow(objects[i], 1);
-        obj_set_dimension(objects[i], LV_PCT(100)); 
+        obj_set_dimension(objects[i], LV_PCT(100));
     }
 
     lv_obj_update_layout(active_screen);

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -17,7 +17,7 @@ static void set_layout_grid(void)
     lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
 
     for(int i = 0; i < NUM_OBJECTS; i++) {
-        lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
+        lv_obj_set_grid_cell(objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
     }
     lv_obj_update_layout(active_screen);
 }
@@ -59,7 +59,7 @@ void setUp(void)
 {
     active_screen = lv_screen_active();
     for(int i = 0; i < NUM_OBJECTS; i++) {
-        objects[i] = lv_obj_create (active_screen);
+        objects[i] = lv_obj_create(active_screen);
     }
 }
 

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -7,7 +7,7 @@
 #define NUM_OBJECTS 4
 
 static lv_obj_t * active_screen = NULL;
-static lv_obj_t *objects[NUM_OBJECTS] = {NULL};
+static lv_obj_t * objects[NUM_OBJECTS] = {NULL};
 static int32_t grid_col_dsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
 static int32_t grid_row_dsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
 
@@ -16,8 +16,7 @@ static void set_layout_grid(void)
     lv_obj_set_grid_dsc_array(active_screen, grid_col_dsc, grid_row_dsc);
     lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
 
-    for (int i = 0; i < NUM_OBJECTS; i++)
-    {
+    for (int i = 0; i < NUM_OBJECTS; i++) {
       lv_obj_set_grid_cell (objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);
     }
     lv_obj_update_layout(active_screen);
@@ -28,10 +27,9 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
     lv_obj_set_layout(active_screen, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(active_screen, flex_flow);
 
-    void (*obj_set_dimension)(lv_obj_t *obj, int32_t value) = NULL;
+    void (*obj_set_dimension)(lv_obj_t * obj, int32_t value) = NULL;
 
-    switch(flex_flow)
-    {
+    switch(flex_flow) {
         case LV_FLEX_FLOW_COLUMN:
         case LV_FLEX_FLOW_COLUMN_WRAP:
         case LV_FLEX_FLOW_COLUMN_REVERSE:
@@ -45,12 +43,11 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
             obj_set_dimension = lv_obj_set_height;
             break;
         default:
-            LV_LOG_ERROR("Invalid flex flow");    
+            LV_LOG_ERROR("Invalid flex flow");
             return;
     }
 
-    for (int i = 0; i < NUM_OBJECTS; i++)
-    {
+    for (int i = 0; i < NUM_OBJECTS; i++) {
       lv_obj_set_flex_grow(objects[i], 1);
       obj_set_dimension(objects[i], LV_PCT(100)); 
     }
@@ -61,8 +58,7 @@ static void set_layout_flex(lv_flex_flow_t flex_flow)
 void setUp(void)
 {
     active_screen = lv_screen_active();
-    for (int i = 0; i < NUM_OBJECTS; i++)
-    {
+    for (int i = 0; i < NUM_OBJECTS; i++) {
       objects[i] = lv_obj_create (active_screen);
     }
 }

--- a/tests/src/test_layout_switch.c
+++ b/tests/src/test_layout_switch.c
@@ -14,7 +14,7 @@ static int32_t grid_row_dsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LA
 static void set_layout_grid(void)
 {
     lv_obj_set_grid_dsc_array(active_screen, grid_col_dsc, grid_row_dsc);
-    lv_obj_set_grid_align(active_screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_SPACE_BETWEEN);
+    lv_obj_set_grid_align(active_screen, LV_GRID_ALIGN_SPACE_BETWEEN, LV_GRID_ALIGN_SPACE_BETWEEN);
 
     for(int i = 0; i < NUM_OBJECTS; i++) {
         lv_obj_set_grid_cell(objects[i], LV_GRID_ALIGN_STRETCH, i % 2, 1, LV_GRID_ALIGN_STRETCH, i / 2, 1);


### PR DESCRIPTION
Fixes #8051

When switching layout from grid to flex the childrens dimensions are not updated in cross direction.

