### PR TITLE
fix(font): allow non-constant LV_FONT_DEFAULT again (fixes #7788)

### DIFF
--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -34,8 +34,6 @@
  *  GLOBAL VARIABLES
  **********************/
 
-const lv_font_t * const lv_font_default = LV_FONT_DEFAULT;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -153,7 +151,7 @@ int32_t lv_font_get_line_height(const lv_font_t * font)
 
 const lv_font_t * lv_font_get_default(void)
 {
-    return lv_font_default;
+    return LV_FONT_DEFAULT;
 }
 
 /**********************

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -300,11 +300,6 @@ LV_FONT_DECLARE(lv_font_unscii_16)
 LV_FONT_CUSTOM_DECLARE
 #endif
 
-/**
- * Set to LV_FONT_DEFAULT as macros might not be available in bindings or other places
- */
-extern const lv_font_t * const lv_font_default;
-
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/others/xml/lv_xml.c
+++ b/src/others/xml/lv_xml.c
@@ -69,7 +69,7 @@ void lv_xml_init(void)
 {
     lv_xml_component_init();
 
-    lv_xml_register_font(NULL, "lv_font_default", lv_font_default);
+    lv_xml_register_font(NULL, "lv_font_default", lv_font_get_default());
 
     lv_xml_widget_register("lv_obj", lv_xml_obj_create, lv_xml_obj_apply);
     lv_xml_widget_register("lv_button", lv_xml_button_create, lv_xml_button_apply);


### PR DESCRIPTION
Fixes #7788.

Allows `#define LV_FONT_DEFAULT MyDefaultFont()` again after ad8a9d95873c05474905eb498b9d6b5118b9e866.