### PR TITLE
fix(drivers/evdev): process pointer coordinates in unrotated frame

### DIFF
--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -31,6 +31,7 @@
 #include "../../stdlib/lv_mem.h"
 #include "../../stdlib/lv_string.h"
 #include "../../display/lv_display.h"
+#include "../../display/lv_display_private.h"
 #include "../../widgets/image/lv_image.h"
 
 /*********************
@@ -129,10 +130,10 @@ static lv_point_t _evdev_process_pointer(lv_indev_t * indev, int x, int y)
     int swapped_x = dsc->swap_axes ? y : x;
     int swapped_y = dsc->swap_axes ? x : y;
 
-    int offset_x = lv_display_get_offset_x(disp);
-    int offset_y = lv_display_get_offset_y(disp);
-    int width = lv_display_get_horizontal_resolution(disp);
-    int height = lv_display_get_vertical_resolution(disp);
+    int offset_x = disp->offset_x;
+    int offset_y = disp->offset_y;
+    int width = disp->hor_res;
+    int height = disp->ver_res;
 
     lv_point_t p;
     p.x = _evdev_calibrate(swapped_x, dsc->min_x, dsc->max_x, offset_x, offset_x + width - 1);


### PR DESCRIPTION
When the display is rotated `_evdev_process_pointer` gets the wrong offset and dimensions to correctly calculate the pointer coordinates. Using the internal, unrotated values from the display gives the correct results, as the transformation is applied later during input processing.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
