### PR TITLE
[Don't squash] Fix font flush cache

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_cache.c
@@ -19,6 +19,7 @@
  *      DEFINES
  *********************/
 #define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
+#define font_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->font_draw_buf_handlers)
 
 /**********************
  *      TYPEDEFS
@@ -52,6 +53,10 @@ void lv_nuttx_cache_init(void)
     handlers = image_cache_draw_buf_handlers;
     handlers->invalidate_cache_cb = invalidate_cache;
     handlers->flush_cache_cb = flush_cache;
+
+    handlers = font_draw_buf_handlers;
+    handlers->invalidate_cache_cb = invalidate_cache;
+    handlers->flush_cache_cb = flush_cache;
 }
 
 void lv_nuttx_cache_deinit(void)
@@ -61,6 +66,10 @@ void lv_nuttx_cache_deinit(void)
     handlers->flush_cache_cb = NULL;
 
     handlers = image_cache_draw_buf_handlers;
+    handlers->invalidate_cache_cb = NULL;
+    handlers->flush_cache_cb = NULL;
+
+    handlers = font_draw_buf_handlers;
     handlers->invalidate_cache_cb = NULL;
     handlers->flush_cache_cb = NULL;
 }

--- a/src/drivers/nuttx/lv_nuttx_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_cache.c
@@ -18,6 +18,7 @@
 /*********************
  *      DEFINES
  *********************/
+#define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
 
 /**********************
  *      TYPEDEFS
@@ -47,11 +48,19 @@ void lv_nuttx_cache_init(void)
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
     handlers->invalidate_cache_cb = invalidate_cache;
     handlers->flush_cache_cb = flush_cache;
+
+    handlers = image_cache_draw_buf_handlers;
+    handlers->invalidate_cache_cb = invalidate_cache;
+    handlers->flush_cache_cb = flush_cache;
 }
 
 void lv_nuttx_cache_deinit(void)
 {
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
+    handlers->invalidate_cache_cb = NULL;
+    handlers->flush_cache_cb = NULL;
+
+    handlers = image_cache_draw_buf_handlers;
     handlers->invalidate_cache_cb = NULL;
     handlers->flush_cache_cb = NULL;
 }

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -180,6 +180,8 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
                 bitmap_out_tmp += stride;
             }
         }
+
+        lv_draw_buf_flush_cache(draw_buf, NULL);
         return draw_buf;
     }
     /*Handle compressed bitmap*/
@@ -188,6 +190,7 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
         bool prefilter = fdsc->bitmap_format == LV_FONT_FMT_TXT_COMPRESSED;
         decompress(&fdsc->glyph_bitmap[gdsc->bitmap_index], bitmap_out, gdsc->box_w, gdsc->box_h,
                    (uint8_t)fdsc->bpp, prefilter);
+        lv_draw_buf_flush_cache(draw_buf, NULL);
         return draw_buf;
 #else /*!LV_USE_FONT_COMPRESSED*/
         LV_LOG_WARN("Compressed fonts is used but LV_USE_FONT_COMPRESSED is not enabled in lv_conf.h");

--- a/src/libs/freetype/lv_freetype_image.c
+++ b/src/libs/freetype/lv_freetype_image.c
@@ -187,12 +187,14 @@ static bool freetype_image_create_cb(lv_freetype_image_cache_data_t * data, void
     uint32_t pitch = glyph_bitmap->bitmap.pitch;
     uint32_t stride = lv_draw_buf_width_to_stride(box_w, col_format);
     data->draw_buf = lv_draw_buf_create_ex(font_draw_buf_handlers, box_w, box_h, col_format, stride);
+    lv_draw_buf_clear(data->draw_buf, NULL);
 
     for(int y = 0; y < box_h; ++y) {
         lv_memcpy((uint8_t *)(data->draw_buf->data) + y * stride, glyph_bitmap->bitmap.buffer + y * pitch,
                   pitch);
     }
 
+    lv_draw_buf_flush_cache(data->draw_buf, NULL);
     FT_Done_Glyph(glyph);
     lv_mutex_unlock(&dsc->cache_node->face_lock);
     LV_PROFILER_FONT_END;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -530,6 +530,7 @@ static bool tiny_ttf_draw_data_cache_create_cb(tiny_ttf_cache_data_t * node, voi
     uint32_t stride = draw_buf->header.stride;
     stbtt_MakeGlyphBitmap(info, draw_buf->data, w, h, stride, dsc->scale, dsc->scale, g1);
 
+    lv_draw_buf_flush_cache(draw_buf, NULL);
     node->draw_buf = draw_buf;
     return true;
 }


### PR DESCRIPTION
For bitmap fonts, after the CPU finishes writing to the memory, the D-Cache data needs to be flushed to the physical memory to ensure that the GPU accesses the complete image.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
