### PR TITLE
perf(draw): support draw task dsc alloc together to reduce the malloc call times

### DIFF
--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -57,7 +57,9 @@ typedef enum {
     LV_DRAW_TASK_TYPE_TRIANGLE,
     LV_DRAW_TASK_TYPE_MASK_RECTANGLE,
     LV_DRAW_TASK_TYPE_MASK_BITMAP,
+#if LV_USE_VECTOR_GRAPHIC
     LV_DRAW_TASK_TYPE_VECTOR,
+#endif
 } lv_draw_task_type_t;
 
 typedef enum {
@@ -167,7 +169,7 @@ void * lv_draw_create_unit(size_t size);
  * @return          the created draw task which needs to be
  *                  further configured e.g. by added a draw descriptor
  */
-lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords);
+lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords, lv_draw_task_type_t type);
 
 /**
  * Needs to be called when a draw task is created and configured.

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -62,12 +62,9 @@ void lv_draw_arc(lv_layer_t * layer, const lv_draw_arc_dsc_t * dsc)
     a.y1 = dsc->center.y - dsc->radius;
     a.x2 = dsc->center.x + dsc->radius - 1;
     a.y2 = dsc->center.y + dsc->radius - 1;
-    lv_draw_task_t * t = lv_draw_add_task(layer, &a);
+    lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_ARC);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_ARC;
 
     lv_draw_finalize_task_creation(layer, t);
 

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -108,12 +108,9 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_layer_t * layer, const lv_draw_label
     }
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_task_t * t = lv_draw_add_task(layer, coords);
+    lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_LABEL);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_LABEL;
 
     /*The text is stored in a local variable so malloc memory for it*/
     if(dsc->text_local) {
@@ -191,12 +188,9 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_letter(lv_layer_t * layer, lv_draw_letter_dsc
     dsc->pivot.x = g.adv_w / 2 ;
     dsc->pivot.y = font->line_height - font->base_line;
 
-    lv_draw_task_t * t = lv_draw_add_task(layer, &a);
+    lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LETTER);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_LETTER;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -63,12 +63,9 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_line(lv_layer_t * layer, const lv_draw_line_d
     a.y1 = (int32_t)LV_MIN(dsc->p1.y, dsc->p2.y) - dsc->width;
     a.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width;
 
-    lv_draw_task_t * t = lv_draw_add_task(layer, &a);
+    lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LINE);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_LINE;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -55,12 +55,9 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_mask_rect(lv_layer_t * layer, const lv_draw_m
     }
     LV_PROFILER_DRAW_BEGIN;
 
-    lv_draw_task_t * t = lv_draw_add_task(layer, &layer->buf_area);
+    lv_draw_task_t * t = lv_draw_add_task(layer, &layer->buf_area, LV_DRAW_TASK_TYPE_MASK_RECTANGLE);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_MASK_RECTANGLE;
 
     lv_draw_dsc_base_t * base_dsc = t->draw_dsc;
     base_dsc->layer = layer;

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -63,8 +63,6 @@ void lv_draw_fill_dsc_init(lv_draw_fill_dsc_t * dsc)
     dsc->base.dsc_size = sizeof(lv_draw_fill_dsc_t);
 }
 
-
-
 lv_draw_fill_dsc_t * lv_draw_task_get_fill_dsc(lv_draw_task_t * task)
 {
     return task->type == LV_DRAW_TASK_TYPE_FILL ? (lv_draw_fill_dsc_t *)task->draw_dsc : NULL;
@@ -75,12 +73,9 @@ void lv_draw_fill(lv_layer_t * layer, const lv_draw_fill_dsc_t * dsc, const lv_a
     if(dsc->opa <= LV_OPA_MIN) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_task_t * t = lv_draw_add_task(layer, coords);
+    lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_FILL);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_FILL;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;
@@ -104,12 +99,9 @@ void lv_draw_border(lv_layer_t * layer, const lv_draw_border_dsc_t * dsc, const 
     if(dsc->opa <= LV_OPA_MIN) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_task_t * t = lv_draw_add_task(layer, coords);
+    lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BORDER);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_BORDER;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;
@@ -132,12 +124,9 @@ void lv_draw_box_shadow(lv_layer_t * layer, const lv_draw_box_shadow_dsc_t * dsc
     if(dsc->opa <= LV_OPA_MIN) return;
 
     LV_PROFILER_DRAW_BEGIN;
-    lv_draw_task_t * t = lv_draw_add_task(layer, coords);
+    lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BOX_SHADOW);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_BOX_SHADOW;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;
@@ -195,10 +184,9 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
     /*Shadow*/
     if(has_shadow) {
         /*Check whether the shadow is visible*/
-        t = lv_draw_add_task(layer, coords);
-        lv_draw_box_shadow_dsc_t * shadow_dsc = lv_malloc(sizeof(lv_draw_box_shadow_dsc_t));
-        LV_ASSERT_MALLOC(shadow_dsc);
-        t->draw_dsc = shadow_dsc;
+        t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BOX_SHADOW);
+        lv_draw_box_shadow_dsc_t * shadow_dsc = t->draw_dsc;
+
         lv_area_increase(&t->_real_area, dsc->shadow_spread, dsc->shadow_spread);
         lv_area_increase(&t->_real_area, dsc->shadow_width, dsc->shadow_width);
         lv_area_move(&t->_real_area, dsc->shadow_offset_x, dsc->shadow_offset_y);
@@ -212,7 +200,6 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         shadow_dsc->ofs_x = dsc->shadow_offset_x;
         shadow_dsc->ofs_y = dsc->shadow_offset_y;
         shadow_dsc->bg_cover = bg_cover;
-        t->type = LV_DRAW_TASK_TYPE_BOX_SHADOW;
         lv_draw_finalize_task_creation(layer, t);
     }
 
@@ -227,18 +214,16 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
             bg_coords.y2 -= (dsc->border_side & LV_BORDER_SIDE_BOTTOM) ? 1 : 0;
         }
 
-        t = lv_draw_add_task(layer, &bg_coords);
-        lv_draw_fill_dsc_t * bg_dsc = lv_malloc(sizeof(lv_draw_fill_dsc_t));
-        LV_ASSERT_MALLOC(bg_dsc);
+        t = lv_draw_add_task(layer, &bg_coords, LV_DRAW_TASK_TYPE_FILL);
+        lv_draw_fill_dsc_t * bg_dsc = t->draw_dsc;
+
         lv_draw_fill_dsc_init(bg_dsc);
-        t->draw_dsc = bg_dsc;
         bg_dsc->base = dsc->base;
         bg_dsc->base.dsc_size = sizeof(lv_draw_fill_dsc_t);
         bg_dsc->radius = dsc->radius;
         bg_dsc->color = dsc->bg_color;
         bg_dsc->grad = dsc->bg_grad;
         bg_dsc->opa = dsc->bg_opa;
-        t->type = LV_DRAW_TASK_TYPE_FILL;
 
         lv_draw_finalize_task_creation(layer, t);
     }
@@ -263,18 +248,17 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
             if(src_type == LV_IMAGE_SRC_VARIABLE || src_type == LV_IMAGE_SRC_FILE) {
 
                 if(dsc->bg_image_tiled) {
-                    t = lv_draw_add_task(layer, coords);
+                    t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_IMAGE);
                 }
                 else {
                     lv_area_t a = {0, 0, header.w - 1, header.h - 1};
                     lv_area_align(coords, &a, LV_ALIGN_CENTER, 0, 0);
-                    t = lv_draw_add_task(layer, &a);
+                    t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_IMAGE);
                 }
 
-                lv_draw_image_dsc_t * bg_image_dsc = lv_malloc(sizeof(lv_draw_image_dsc_t));
-                LV_ASSERT_MALLOC(bg_image_dsc);
+                lv_draw_image_dsc_t * bg_image_dsc = t->draw_dsc;
+
                 lv_draw_image_dsc_init(bg_image_dsc);
-                t->draw_dsc = bg_image_dsc;
                 bg_image_dsc->base = dsc->base;
                 bg_image_dsc->base.dsc_size = sizeof(lv_draw_image_dsc_t);
                 bg_image_dsc->src = dsc->bg_image_src;
@@ -285,7 +269,6 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                 bg_image_dsc->header = header;
                 bg_image_dsc->clip_radius = dsc->radius;
                 bg_image_dsc->image_area = *coords;
-                t->type = LV_DRAW_TASK_TYPE_IMAGE;
                 lv_draw_finalize_task_creation(layer, t);
             }
             else {
@@ -294,12 +277,11 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
 
                 lv_area_t a = {0, 0, s.x - 1, s.y - 1};
                 lv_area_align(coords, &a, LV_ALIGN_CENTER, 0, 0);
-                t = lv_draw_add_task(layer, &a);
+                t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LABEL);
 
-                lv_draw_label_dsc_t * bg_label_dsc = lv_malloc(sizeof(lv_draw_label_dsc_t));
-                LV_ASSERT_MALLOC(bg_label_dsc);
+                lv_draw_label_dsc_t * bg_label_dsc = t->draw_dsc;
+
                 lv_draw_label_dsc_init(bg_label_dsc);
-                t->draw_dsc = bg_label_dsc;
                 bg_label_dsc->base = dsc->base;
                 bg_label_dsc->base.dsc_size = sizeof(lv_draw_label_dsc_t);
                 bg_label_dsc->color = dsc->bg_image_recolor;
@@ -313,10 +295,9 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
 
     /*Border*/
     if(has_border) {
-        t = lv_draw_add_task(layer, coords);
-        lv_draw_border_dsc_t * border_dsc = lv_malloc(sizeof(lv_draw_border_dsc_t));
-        LV_ASSERT_MALLOC(border_dsc);
-        t->draw_dsc = border_dsc;
+        t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BORDER);
+        lv_draw_border_dsc_t * border_dsc = t->draw_dsc;
+
         border_dsc->base = dsc->base;
         border_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
         border_dsc->radius = dsc->radius;
@@ -324,7 +305,6 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         border_dsc->opa = dsc->border_opa;
         border_dsc->width = dsc->border_width;
         border_dsc->side = dsc->border_side;
-        t->type = LV_DRAW_TASK_TYPE_BORDER;
         lv_draw_finalize_task_creation(layer, t);
     }
 
@@ -332,10 +312,8 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
     if(has_outline) {
         lv_area_t outline_coords = *coords;
         lv_area_increase(&outline_coords, dsc->outline_width + dsc->outline_pad, dsc->outline_width + dsc->outline_pad);
-        t = lv_draw_add_task(layer, &outline_coords);
-        lv_draw_border_dsc_t * outline_dsc = lv_malloc(sizeof(lv_draw_border_dsc_t));
-        LV_ASSERT_MALLOC(outline_dsc);
-        t->draw_dsc = outline_dsc;
+        t = lv_draw_add_task(layer, &outline_coords, LV_DRAW_TASK_TYPE_BORDER);
+        lv_draw_border_dsc_t * outline_dsc = t->draw_dsc;
         lv_area_increase(&t->_real_area, dsc->outline_width, dsc->outline_width);
         lv_area_increase(&t->_real_area, dsc->outline_pad, dsc->outline_pad);
         outline_dsc->base = dsc->base;
@@ -346,7 +324,6 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         outline_dsc->opa = dsc->outline_opa;
         outline_dsc->width = dsc->outline_width;
         outline_dsc->side = LV_BORDER_SIDE_FULL;
-        t->type = LV_DRAW_TASK_TYPE_BORDER;
         lv_draw_finalize_task_creation(layer, t);
     }
 

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -69,12 +69,9 @@ void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
     a.x2 = (int32_t)LV_MAX3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
     a.y2 = (int32_t)LV_MAX3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);
 
-    lv_draw_task_t * t = lv_draw_add_task(layer, &a);
+    lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_TRIANGLE);
 
-    t->draw_dsc = lv_malloc(sizeof(*dsc));
-    LV_ASSERT_MALLOC(t->draw_dsc);
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
-    t->type = LV_DRAW_TASK_TYPE_TRIANGLE;
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -754,9 +754,7 @@ void lv_draw_vector(lv_vector_dsc_t * dsc)
 
     lv_layer_t * layer = dsc->layer;
 
-    lv_draw_task_t * t = lv_draw_add_task(layer, &(layer->_clip_area));
-    t->type = LV_DRAW_TASK_TYPE_VECTOR;
-    t->draw_dsc = lv_malloc(sizeof(lv_draw_vector_task_dsc_t));
+    lv_draw_task_t * t = lv_draw_add_task(layer, &(layer->_clip_area), LV_DRAW_TASK_TYPE_VECTOR);
     lv_memcpy(t->draw_dsc, &(dsc->tasks), sizeof(lv_draw_vector_task_dsc_t));
     lv_draw_finalize_task_creation(layer, t);
     dsc->tasks.task_list = NULL;

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -246,7 +246,9 @@ static int32_t nema_gfx_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * ta
         case LV_DRAW_TASK_TYPE_BOX_SHADOW:
         case LV_DRAW_TASK_TYPE_MASK_RECTANGLE:
         case LV_DRAW_TASK_TYPE_MASK_BITMAP:
+#if LV_USE_VECTOR_GRAPHIC
         case LV_DRAW_TASK_TYPE_VECTOR:
+#endif
         default:
             break;
     }


### PR DESCRIPTION
Improve the performance of draw task create.

Previously, draw task and dsc were allocated separately, 
Now they can be allocated together to reduce the number of `lv_malloc `call times.
And `lv_draw_add_task` still support allocated separately if the type is `LV_DRAW_TASK_TYPE_NONE`

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
