### PR TITLE
fix(nxp/g2d): remove useless g2d_search_buf_map() when free buf

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_buf_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_buf_g2d.c
@@ -78,11 +78,7 @@ static void * _buf_malloc(size_t size_bytes, lv_color_format_t color_format)
 
 static void _buf_free(void * buf)
 {
-    // make sure items are in the hash table
-    struct g2d_buf * g2d_buf = g2d_search_buf_map(buf);
-    if(g2d_buf) {
-        g2d_free_item(buf);
-    }
+    g2d_free_item(buf);
 }
 
 static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)


### PR DESCRIPTION
Remove redundant codes mentioned [here](https://github.com/lvgl/lvgl/pull/7875#discussion_r2032996369).

@nicusorcitu 