### PR TITLE
ci(release_updater): Add bi-weekly schedule. Only update master branches on schedule

### DIFF
--- a/.github/workflows/release_branch_updater.yml
+++ b/.github/workflows/release_branch_updater.yml
@@ -1,6 +1,9 @@
 name: Port repo release update
 
 on:
+  schedule:
+    # Runs at 00:00 UTC on the 1st and 15th day of each month
+    - cron: '0 0 1,15 * *'
   push:
     branches:
       - master
@@ -30,7 +33,14 @@ jobs:
           git config --global user.name 'lvgl-bot'
           git config --global user.email 'lvgl-bot@users.noreply.github.com'
 
-      - name: run the script
+      - name: run the script for release branches (not master)
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PORT_RELEASER_GITHUB_TOKEN }}
+        run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github-token "$GITHUB_TOKEN" --skip-master
+
+      - name: run the script for release branches and master
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.PORT_RELEASER_GITHUB_TOKEN }}
         run: python3 lvgl/scripts/release_branch_updater.py --oldest-major 9 --github-token "$GITHUB_TOKEN"

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -210,10 +210,10 @@ def main():
             if port_does_not_have_the_branch or port_submodule_was_updated or port_lv_conf_h_was_updated:
                 print(LOG, "changes were made. ready to push.")
                 # keep it brief for commit message 50 character limit suggestion.
-                # max length will be 46 characters in this case: "CI bot: new branch. LVGL submodule. lv_conf.h."
+                # max length will be 50 characters in this case: "bot: New branch. Update LVGL submodule. lv_conf.h."
                 commit_msg = ("CI bot:"
-                              + (" new branch." if port_does_not_have_the_branch else "")
-                              + (" LVGL submodule." if port_submodule_was_updated else "")
+                              + (" New branch." if port_does_not_have_the_branch else "")
+                              + (" Update LVGL submodule." if port_submodule_was_updated else "")
                               + (" lv_conf.h." if port_lv_conf_h_was_updated else "")
                              )
                 print(LOG, f"commit message: '{commit_msg}'")

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -26,6 +26,7 @@ def main():
     arg_parser.add_argument("--dry-run", action="store_true")
     arg_parser.add_argument("--oldest-major", type=int)
     arg_parser.add_argument("--github-token", type=str)
+    arg_parser.add_argument("--skip-master", action="store_true")
 
     args = arg_parser.parse_args()
 
@@ -34,6 +35,7 @@ def main():
     lvgl_path = args.lvgl_path
     dry_run = args.dry_run
     oldest_major = args.oldest_major
+    skip_master = args.skip_master
 
     if not args.github_token and not dry_run:
         print(LOG, "Warning: No github token was provided for this production run. Continuing anyway...")
@@ -78,8 +80,12 @@ def main():
         # 2. update the LVGL submodule to match the LVGL's release branch version
         # 3. update the lv_conf.h based on the lv_conf.defaults
 
+        branches_to_update = lvgl_release_branches
+        if not skip_master:
+            branches_to_update += [lvgl_default_branch]
+
         # from oldest to newest release...
-        for lvgl_branch in lvgl_release_branches + [lvgl_default_branch]:
+        for lvgl_branch in branches_to_update:
             if isinstance(lvgl_branch, tuple):
                 port_branch = lvgl_branch
                 print(LOG, f"attempting to update release branch {fmt_release(port_branch)} ...")

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -211,7 +211,7 @@ def main():
                 print(LOG, "changes were made. ready to push.")
                 # keep it brief for commit message 50 character limit suggestion.
                 # max length will be 50 characters in this case: "bot: New branch. Update LVGL submodule. lv_conf.h."
-                commit_msg = ("CI bot:"
+                commit_msg = ("bot:"
                               + (" New branch." if port_does_not_have_the_branch else "")
                               + (" Update LVGL submodule." if port_submodule_was_updated else "")
                               + (" lv_conf.h." if port_lv_conf_h_was_updated else "")

--- a/scripts/release_branch_updater.py
+++ b/scripts/release_branch_updater.py
@@ -210,10 +210,10 @@ def main():
             if port_does_not_have_the_branch or port_submodule_was_updated or port_lv_conf_h_was_updated:
                 print(LOG, "changes were made. ready to push.")
                 # keep it brief for commit message 50 character limit suggestion.
-                # max length will be 50 characters in this case: "CI release edit: new branch. submodule. lv_conf.h."
-                commit_msg = ("CI release edit:"
+                # max length will be 46 characters in this case: "CI bot: new branch. LVGL submodule. lv_conf.h."
+                commit_msg = ("CI bot:"
                               + (" new branch." if port_does_not_have_the_branch else "")
-                              + (" submodule." if port_submodule_was_updated else "")
+                              + (" LVGL submodule." if port_submodule_was_updated else "")
                               + (" lv_conf.h." if port_lv_conf_h_was_updated else "")
                              )
                 print(LOG, f"commit message: '{commit_msg}'")


### PR DESCRIPTION
Port repo `master`/`main` branches are flooded with commits because the LVGL submodule is updated every time a PR is merged into LVGL's `master`.

Only update port repo `master`/`main` branches biweekly or on manual dispatch.

Change the bot commit message from "`CI release edit: submodule.`" to "`CI bot: LVGL submodule.`" to emphasize that the LVGL submodule was the submodule that got updated, as suggested by @kisvegabor

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
