### PR TITLE
fix(gif): fix bounds check (#7675)

### DIFF
--- a/src/libs/gif/gifdec.c
+++ b/src/libs/gif/gifdec.c
@@ -596,7 +596,7 @@ read_image_data(gd_GIF * gif, int interlace)
         if(ret == 1) key_size++;
         entry = table->entries[key];
         str_len = entry.length;
-	if(frm_off + str_len >= frm_size){
+	if(frm_off + str_len > frm_size){
 		LV_LOG_WARN("LZW table token overflows the frame buffer");
 		return -1;
 	}


### PR DESCRIPTION
This is a simple cherry pick of https://github.com/lvgl/lvgl/pull/7675, which in turn fixed a regression introduced in https://github.com/lvgl/lvgl/pull/6863. Having this backported to the v9.2 branch would make other able to use the latest v9.2 version without issues to the GIF library.