### PR TITLE
fix(draw asm): replace attribute syntax for asm arm files

### DIFF
--- a/src/draw/sw/blend/helium/lv_blend_helium.S
+++ b/src/draw/sw/blend/helium/lv_blend_helium.S
@@ -11,8 +11,9 @@
 
 /*GCC Workaround: missing .note.GNU-stack section implies executable stack*/
 #ifdef __ELF__
-.section .note.GNU-stack,"",@progbits
-#endif
+.section .note.GNU-stack,"",%progbits
+#endif /* __ELF__ */
+
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM && defined(__ARM_FEATURE_MVE) && __ARM_FEATURE_MVE && LV_USE_NATIVE_HELIUM_ASM
 

--- a/src/draw/sw/blend/neon/lv_blend_neon.S
+++ b/src/draw/sw/blend/neon/lv_blend_neon.S
@@ -12,8 +12,8 @@
 
 /*Workaround: missing .note.GNU-stack section implies executable stack*/
 #ifdef __ELF__
-.section .note.GNU-stack,"",@progbits
-#endif
+.section .note.GNU-stack,"",%progbits
+#endif /* __ELF__ */
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 


### PR DESCRIPTION
Bug introduced by 8cd79ac42110f26e1a0045d7e9f0a1881633c706.

Building with the `arm-none-eabi` toolchain produces these errors when trying to build lvgl:

```bash
/home/andre/dev/so3/usr/lib/lvgl/src/draw/sw/blend/helium/lv_blend_helium.S: Assembler messages:
/home/andre/dev/so3/usr/lib/lvgl/src/draw/sw/blend/helium/lv_blend_helium.S:14: Error: junk at end of line, first unrecognized character is `,'
[ 31%] Building C object lib/lvgl/CMakeFiles/lvgl.dir/src/draw/sw/lv_draw_sw_arc.c.obj
make[2]: *** [lib/lvgl/CMakeFiles/lvgl.dir/build.make:1195: lib/lvgl/CMakeFiles/lvgl.dir/src/draw/sw/blend/helium/lv_blend_helium.S.obj] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 32%] Building C object lib/lvgl/CMakeFiles/lvgl.dir/src/draw/sw/lv_draw_sw_border.c.obj
/home/andre/dev/so3/usr/lib/lvgl/src/draw/sw/blend/neon/lv_blend_neon.S: Assembler messages:
/home/andre/dev/so3/usr/lib/lvgl/src/draw/sw/blend/neon/lv_blend_neon.S:15: Error: junk at end of line, first unrecognized character is `,'
```

The `@` symbol is used for comments in arm assembly so the `@progbits` part doesn't actually work for arm