### PR TITLE
feat(animimage): support images play in a reversed order

### DIFF
--- a/docs/src/details/widgets/animimg.rst
+++ b/docs/src/details/widgets/animimg.rst
@@ -31,7 +31,7 @@ Image sources
 -------------
 
 To set the image animation images sources, use
-:cpp:expr:`lv_animimg_set_src(animimg, dsc[], num)`.
+:cpp:expr:`lv_animimg_set_src(animimg, dsc[], num, reverse)`.
 
 Using the inner animation
 -------------------------

--- a/examples/widgets/animimg/lv_example_animimg_1.c
+++ b/examples/widgets/animimg/lv_example_animimg_1.c
@@ -14,7 +14,7 @@ void lv_example_animimg_1(void)
 {
     lv_obj_t * animimg0 = lv_animimg_create(lv_screen_active());
     lv_obj_center(animimg0);
-    lv_animimg_set_src(animimg0, (const void **) anim_imgs, 3);
+    lv_animimg_set_src(animimg0, (const void **) anim_imgs, 3, false);
     lv_animimg_set_duration(animimg0, 1000);
     lv_animimg_set_repeat_count(animimg0, LV_ANIM_REPEAT_INFINITE);
     lv_animimg_start(animimg0);

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -3,6 +3,10 @@
  *
  */
 
+/**
+ * Modified by NXP in 2025
+ */
+
 /*********************
  *      INCLUDES
  *********************/
@@ -103,13 +107,18 @@ lv_obj_t * lv_animimg_create(lv_obj_t * parent)
     return obj;
 }
 
-void lv_animimg_set_src(lv_obj_t * obj, const void * dsc[], size_t num)
+void lv_animimg_set_src(lv_obj_t * obj, const void * dsc[], size_t num, bool reverse)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
     animimg->dsc = dsc;
     animimg->pic_count = num;
-    lv_anim_set_values(&animimg->anim, 0, (int32_t)num);
+    if(reverse) {
+        lv_anim_set_values(&animimg->anim, (int32_t)num, 0);
+    }
+    else {
+        lv_anim_set_values(&animimg->anim, 0, (int32_t)num);
+    }
 }
 
 void lv_animimg_start(lv_obj_t * obj)
@@ -117,6 +126,13 @@ void lv_animimg_start(lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
     lv_anim_start(&animimg->anim);
+}
+
+bool lv_animimg_delete(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    return lv_anim_delete(animimg, NULL);
 }
 
 /*=====================
@@ -136,6 +152,34 @@ void lv_animimg_set_repeat_count(lv_obj_t * obj, uint32_t count)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
     lv_anim_set_repeat_count(&animimg->anim, count);
+}
+
+void lv_animimg_set_reverse_duration(lv_obj_t * obj, uint32_t duration)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_set_reverse_duration(&animimg->anim, duration);
+}
+
+void lv_animimg_set_reverse_delay(lv_obj_t * obj, uint32_t duration)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_set_reverse_delay(&animimg->anim, duration);
+}
+
+void lv_animimg_set_start_cb(lv_obj_t * obj, lv_anim_start_cb_t start_cb)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_set_start_cb(&animimg->anim, start_cb);
+}
+
+void lv_animimg_set_completed_cb(lv_obj_t * obj, lv_anim_completed_cb_t completed_cb)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_set_completed_cb(&animimg->anim, completed_cb);
 }
 
 /*=====================

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -3,6 +3,10 @@
  *
  */
 
+/**
+ * Modified by NXP in 2025
+ */
+
 #ifndef LV_ANIMIMAGE_H
 #define LV_ANIMIMAGE_H
 
@@ -65,11 +69,12 @@ lv_obj_t * lv_animimg_create(lv_obj_t * parent);
 
 /**
  * Set the image animation images source.
- * @param img   pointer to an animation image object
- * @param dsc   pointer to a series images
- * @param num   images' number
+ * @param obj       pointer to an animation image object
+ * @param dsc       pointer to a series images
+ * @param num       images' number
+ * @param reverse   Set the flip playback of the image animation
  */
-void lv_animimg_set_src(lv_obj_t * img, const void * dsc[], size_t num);
+void lv_animimg_set_src(lv_obj_t * obj, const void * dsc[], size_t num, bool reverse);
 
 /**
  * Startup the image animation.
@@ -78,18 +83,52 @@ void lv_animimg_set_src(lv_obj_t * img, const void * dsc[], size_t num);
 void lv_animimg_start(lv_obj_t * obj);
 
 /**
+ * Delete the image animation.
+ * @param obj   pointer to an animation image object
+ */
+bool lv_animimg_delete(lv_obj_t * obj);
+
+/**
  * Set the image animation duration time. unit:ms
- * @param img       pointer to an animation image object
+ * @param obj       pointer to an animation image object
  * @param duration  the duration in milliseconds
  */
-void lv_animimg_set_duration(lv_obj_t * img, uint32_t duration);
+void lv_animimg_set_duration(lv_obj_t * obj, uint32_t duration);
 
 /**
  * Set the image animation repeatedly play times.
- * @param img       pointer to an animation image object
+ * @param obj       pointer to an animation image object
  * @param count     the number of times to repeat the animation
  */
-void lv_animimg_set_repeat_count(lv_obj_t * img, uint32_t count);
+void lv_animimg_set_repeat_count(lv_obj_t * obj, uint32_t count);
+
+/**
+ * Make the image animation to play back to when the forward direction is ready.
+ * @param obj   pointer to an animation image object
+ * @param duration   the duration of the playback image animation in milliseconds. 0: disable playback
+ */
+void lv_animimg_set_reverse_duration(lv_obj_t * obj, uint32_t duration);
+
+/**
+ * Make the image animation to play back to when the forward direction is ready.
+ * @param obj   pointer to an animation image object
+ * @param duration   delay in milliseconds before starting the playback image animation.
+ */
+void lv_animimg_set_reverse_delay(lv_obj_t * obj, uint32_t duration);
+
+/**
+ * Set a function call when the animation image really starts (considering `delay`)
+ * @param obj   pointer to an animation image object
+ * @param start_cb   a function call when the animation is start
+ */
+void lv_animimg_set_start_cb(lv_obj_t * obj, lv_anim_start_cb_t start_cb);
+
+/**
+ * Set a function call when the animation is completed
+ * @param obj pointer to an animation image object
+ * @param completed_cb  a function call when the animation is completed
+ */
+void lv_animimg_set_completed_cb(lv_obj_t * obj, lv_anim_completed_cb_t completed_cb);
 
 /*=====================
  * Getter functions
@@ -97,38 +136,38 @@ void lv_animimg_set_repeat_count(lv_obj_t * img, uint32_t count);
 
 /**
  * Get the image animation images source.
- * @param img   pointer to an animation image object
- * @return a    pointer that will point to a series images
+ * @param obj   pointer to an animation image object
+ * @return a     pointer that will point to a series images
  */
-const void ** lv_animimg_get_src(lv_obj_t * img);
+const void ** lv_animimg_get_src(lv_obj_t * obj);
 
 /**
  * Get the image animation images source.
- * @param img   pointer to an animation image object
+ * @param obj   pointer to an animation image object
  * @return      the number of source images
  */
-uint8_t lv_animimg_get_src_count(lv_obj_t * img);
+uint8_t lv_animimg_get_src_count(lv_obj_t * obj);
 
 /**
  * Get the image animation duration time. unit:ms
- * @param img   pointer to an animation image object
+ * @param obj   pointer to an animation image object
  * @return      the animation duration time
  */
-uint32_t lv_animimg_get_duration(lv_obj_t * img);
+uint32_t lv_animimg_get_duration(lv_obj_t * obj);
 
 /**
  * Get the image animation repeat play times.
- * @param img   pointer to an animation image object
+ * @param obj   pointer to an animation image object
  * @return      the repeat count
  */
-uint32_t lv_animimg_get_repeat_count(lv_obj_t * img);
+uint32_t lv_animimg_get_repeat_count(lv_obj_t * obj);
 
 /**
  * Get the image animation underlying animation.
- * @param img   pointer to an animation image object
+ * @param obj   pointer to an animation image object
  * @return      the animation reference
  */
-lv_anim_t * lv_animimg_get_anim(lv_obj_t * img);
+lv_anim_t * lv_animimg_get_anim(lv_obj_t * obj);
 
 #endif /*LV_USE_ANIMIMG*/
 

--- a/tests/src/test_cases/widgets/test_animimg.c
+++ b/tests/src/test_cases/widgets/test_animimg.c
@@ -44,14 +44,14 @@ void test_animimg_successful_create(void)
 
 void test_animimg_set_src(void)
 {
-    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3);
+    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3, false);
 
     TEST_ASSERT_NOT_NULL(animimg);
 }
 
 void test_animimg_get_src(void)
 {
-    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3);
+    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3, false);
 
     const void ** actual_dsc = lv_animimg_get_src(animimg);
 
@@ -63,7 +63,7 @@ void test_animimg_get_src_count(void)
 {
     uint8_t expected_count = 3;
 
-    lv_animimg_set_src(animimg, (const void **) anim_imgs, expected_count);
+    lv_animimg_set_src(animimg, (const void **) anim_imgs, expected_count, false);
 
     uint8_t actual_count = lv_animimg_get_src_count(animimg);
 
@@ -94,7 +94,7 @@ void test_animimg_start(void)
 {
     // for lv_animimg_start() to actually work,
     // we need to properly setup the widget beforehand
-    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3);
+    lv_animimg_set_src(animimg, (const void **) anim_imgs, 3, false);
     lv_animimg_set_duration(animimg, 1000);
     lv_animimg_set_repeat_count(animimg, LV_ANIM_REPEAT_INFINITE);
 


### PR DESCRIPTION
Add a "reverse" parameter for "lv_animimg_set_src" function to support playing the animimage in a reversed order.