### PR TITLE
ci: build docs on pr

### DIFF
--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -1,5 +1,6 @@
 name: Build docs
 on:
+  pull_request:
   push:
     branches:
     - master
@@ -72,6 +73,7 @@ jobs:
           echo "::set-output name=VERSION_NAME::$(scripts/find_version.sh)"
         id: version
       - name: Deploy to subfolder
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           token: ${{ secrets.LVGL_BOT_TOKEN }}
@@ -83,7 +85,7 @@ jobs:
           git-config-email: lvgl-bot@users.noreply.github.com
           single-commit: true
       - name: Deploy to master
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           token: ${{ secrets.LVGL_BOT_TOKEN }}

--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -63,7 +63,14 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
       - name: Build examples (with cache)
-        run: scripts/build_html_examples.sh
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"
+            COMMIT_REF="${{ github.event.pull_request.head.sha }}"
+            ./scripts/build_html_examples.sh "$REPO_URL" "$COMMIT_REF"
+          else
+            ./scripts/build_html_examples.sh
+          fi
       - name: Build docs
         run: docs/build.py html
       - name: Remove .doctrees

--- a/docs/build.py
+++ b/docs/build.py
@@ -243,7 +243,7 @@ def cmd(cmd_str, start_dir=None, exit_on_error=True):
 
     if return_code != 0 and exit_on_error:
         announce(__file__, "Exiting build due to previous error.")
-        sys.exit(return_code)
+        sys.exit(1)
 
 
 def intermediate_dir_contents_exists(dir):

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -16,10 +16,7 @@
 # documentation root, use os.path.abspath() to make it absolute, as shown here.
 import os
 import sys
-import re
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinxawesome_theme.postprocess import Icons
-aaa = Icons.permalinks_icon
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 # Add path to import link_roles.py and lv_example.py

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
+
 set -e
+
+# These variables allow us to specify an alternate repository URL and commit reference
+# This is particularly useful when running in CI environments for pull requests
+# where we need to build from the contributor's forked repository
+REPO_URL="${1:-}"
+COMMIT_REF="${2:-}"
+
 export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-CURRENT_REF="$(git rev-parse HEAD)"
 rm -rf emscripten_builder
 git clone https://github.com/lvgl/lv_sim_emscripten.git emscripten_builder
 scripts/genexamplelist.sh > emscripten_builder/examplelist.c
 cd emscripten_builder
 git submodule update --init -- lvgl
 cd lvgl
-git checkout $CURRENT_REF
+if [ -n "$REPO_URL" ] && [ -n "$COMMIT_REF" ]; then
+  echo "Using provided repo URL: $REPO_URL and commit ref: $COMMIT_REF for lvgl submodule"
+  git remote set-url origin "$REPO_URL"
+  git fetch origin
+  git checkout "$COMMIT_REF"
+else
+  CURRENT_REF="$(git rev-parse HEAD)"
+  echo "Using current commit ref: $CURRENT_REF for lvgl"
+  git checkout "$CURRENT_REF"
+fi
 cd ..
 mkdir cmbuild
 cd cmbuild


### PR DESCRIPTION
Doc building CI errors happen often because they aren't automatically checked by the CI on pull requests

This will fail until the current CI errors are fixed by https://github.com/lvgl/lv_web_emscripten/pull/27