### PR TITLE
build: remove pcpp dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,4 +16,3 @@ sphinx-rtd-dark-mode
 typing-extensions
 sphinx-reredirects
 dirsync
-pcpp

--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -81,6 +81,7 @@ execute_process(
   --input ${LVGL_ROOT_DIR}/src/lv_conf_internal.h
   --tmp_file ${CMAKE_CURRENT_BINARY_DIR}/tmp.h
   --output ${CMAKE_CURRENT_BINARY_DIR}/lv_conf_expanded.h
+  --workfolder ${CMAKE_CURRENT_BINARY_DIR}
   ${PCPP_ADDITIONAL_DEFS}
   --include ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/.. ${LVGL_ROOT_DIR}/src ${LV_CONF_DIR}
   RESULT_VARIABLE ret

--- a/scripts/install-prerequisites.bat
+++ b/scripts/install-prerequisites.bat
@@ -1,4 +1,4 @@
 vcpkg install vcpkg-tool-ninja libpng freetype opengl glfw3 glew
 if %errorlevel% neq 0 exit /b %errorlevel%
-pip install pypng lz4 kconfiglib pcpp
+pip install pypng lz4 kconfiglib
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -14,4 +14,4 @@ sudo apt install gcc gcc-multilib g++-multilib ninja-build \
     ruby-full gcovr cmake  python3 libinput-dev libxkbcommon-dev \
     libdrm-dev pkg-config wayland-protocols libwayland-dev libwayland-bin \
     libwayland-dev:i386 libxkbcommon-dev:i386 libudev-dev
-pip3 install pypng lz4 kconfiglib pcpp
+pip3 install pypng lz4 kconfiglib


### PR DESCRIPTION
Most of the issues around the new pcpp dependency have now been resolved, but I thought it’d be interesting to explore removing the requirement for users to have it pre-installed - and turns out, it wasn’t that hard!

This PR moves the pcpp dependency into a virtual environment that is created during the build process. That way, we avoid polluting the user’s global Python environment and make the experience smoother overall.

Of course this doesn't add any new dependencies - everything is handled using Python’s built-in venv module.

![image](https://github.com/user-attachments/assets/cad8a5bd-a588-435b-a01b-177dc4385151)

