### PR TITLE
docs(doc-biuld):  fix current doc-build error

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -18,8 +18,6 @@ import os
 import sys
 import re
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinxawesome_theme.postprocess import Icons
-aaa = Icons.permalinks_icon
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 # Add path to import link_roles.py and lv_example.py


### PR DESCRIPTION
I inadvertently left an "experiment" in `conf.py` and it didn't show up until today because of earlier doc-build errors that are now solved.

Note -- we're not using any part of "SphinxAwesome" theme, so André, the requirement should be removed from `requirements.txt`.  I simply removed the import statement -- it was not serving any purpose.  I added that as a local experiment and forgot to remove it.  It wasn't erring on my system because I do have that theme installed on my system, but am not using it.

cc:  @AndreCostaaa @liamHowatt @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
