### PR TITLE
ci(docs): fix commit ref when workflow is triggered by master push

### DIFF
--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -67,10 +67,11 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"
             COMMIT_REF="${{ github.event.pull_request.head.sha }}"
-            ./scripts/build_html_examples.sh "$REPO_URL" "$COMMIT_REF"
           else
-            ./scripts/build_html_examples.sh
+            REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+            COMMIT_REF="${{ github.sha }}"
           fi
+          ./scripts/build_html_examples.sh "$REPO_URL" "$COMMIT_REF"
       - name: Build docs
         run: docs/build.py html
       - name: Remove .doctrees


### PR DESCRIPTION
The docs building CI is broken again because it's grabbing an old version of LVGL to build with the current docs
![image](https://github.com/user-attachments/assets/6a171d9b-dac9-47f4-841c-c83bb6db7aab)

The commit reference being used by the CI is the one currently being pointed by the lvgl submodule in [lv_web_emscripten](https://github.com/lvgl/lv_web_emscripten)

It looks like this issue has been around for a while but went unnoticed since it didn’t cause the CI to fail until now. I guess a bunch of minor issues with the docs CI all decided to surface at the same time.

This PR sets the repo url and commit reference explicitly for the build docs script

Sources for the variables used [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)

@liamHowatt @kisvegabor 