### PR TITLE
ci(docs): remove concurrency clause

### DIFF
--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -19,7 +19,6 @@ jobs:
   build-and-deploy:
     if: github.repository == 'lvgl/lvgl'
     runs-on: ubuntu-24.04
-    concurrency: docs-build-and-deploy
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Yet another take at fixing the CI. Current issue is the concurrency clause that prevents multiple instances of the workflow to run at the same time. Since we now have this workflow running on PRs we need to remove this line. Note that the concurrency is still handled here allowing parallel execution as long as it’s not targeting the same branch 

https://github.com/lvgl/lvgl/blob/16332fa8dcc4ae087784918f09e90c398094b042/.github/workflows/compile_docs.yml#L9-L13

Sorry about this mess guys

@kisvegabor @liamHowatt 