### PR TITLE
feat(disp): allow rotation with `FULL` render mode

### DIFF
--- a/docs/src/details/main-modules/display/rotation.rst
+++ b/docs/src/details/main-modules/display/rotation.rst
@@ -21,10 +21,13 @@ according to the current rotation settings of the display.
 Note that in :cpp:enumerator:`LV_DISPLAY_RENDER_MODE_DIRECT` the small changed areas
 are rendered directly in the frame buffer so they cannot be
 rotated later. Therefore in direct mode only the whole frame buffer can be rotated.
-The same is true for :cpp:enumerator:`LV_DISPLAY_RENDER_MODE_FULL`.
 
 In the case of :cpp:enumerator:`LV_DISPLAY_RENDER_MODE_PARTIAL` the small rendered areas
 can be rotated on their own before flushing to the frame buffer.
+
+:cpp:enumerator:`LV_DISPLAY_RENDER_MODE_FULL` can work with rotation if the buffer(s)
+being rendered to are different than the buffer(s) being rotated to in the flush callback
+and the buffers being rendered to do not have a stride requirement.
 
 Below is an example for rotating when the rendering mode is
 :cpp:enumerator:`LV_DISPLAY_RENDER_MODE_PARTIAL` and the rotated image should be sent to a

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -679,9 +679,14 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
         /*In direct mode and full mode the the buffer area is always the whole screen, not considering rotation*/
         layer->buf_area.x1 = 0;
         layer->buf_area.y1 = 0;
+#if LV_DRAW_TRANSFORM_USE_MATRIX
         layer->buf_area.x2 = lv_display_get_original_horizontal_resolution(disp_refr) - 1;
         layer->buf_area.y2 = lv_display_get_original_vertical_resolution(disp_refr) - 1;
-        layer_reshape_draw_buf(layer, layer->draw_buf->header.stride);
+#else
+        layer->buf_area.x2 = lv_display_get_horizontal_resolution(disp_refr) - 1;
+        layer->buf_area.y2 = lv_display_get_vertical_resolution(disp_refr) - 1;
+#endif
+        layer_reshape_draw_buf(layer, disp_refr->stride_is_auto ? LV_STRIDE_AUTO : layer->draw_buf->header.stride);
     }
 
     /*Try to divide the area to smaller tiles*/

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -679,13 +679,14 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
         /*In direct mode and full mode the the buffer area is always the whole screen, not considering rotation*/
         layer->buf_area.x1 = 0;
         layer->buf_area.y1 = 0;
-#if LV_DRAW_TRANSFORM_USE_MATRIX
-        layer->buf_area.x2 = lv_display_get_original_horizontal_resolution(disp_refr) - 1;
-        layer->buf_area.y2 = lv_display_get_original_vertical_resolution(disp_refr) - 1;
-#else
-        layer->buf_area.x2 = lv_display_get_horizontal_resolution(disp_refr) - 1;
-        layer->buf_area.y2 = lv_display_get_vertical_resolution(disp_refr) - 1;
-#endif
+        if(lv_display_get_matrix_rotation(disp_refr)) {
+            layer->buf_area.x2 = lv_display_get_original_horizontal_resolution(disp_refr) - 1;
+            layer->buf_area.y2 = lv_display_get_original_vertical_resolution(disp_refr) - 1;
+        }
+        else {
+            layer->buf_area.x2 = lv_display_get_horizontal_resolution(disp_refr) - 1;
+            layer->buf_area.y2 = lv_display_get_vertical_resolution(disp_refr) - 1;
+        }
         layer_reshape_draw_buf(layer, disp_refr->stride_is_auto ? LV_STRIDE_AUTO : layer->draw_buf->header.stride);
     }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -439,6 +439,8 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
     disp->buf_1 = buf1;
     disp->buf_2 = buf2;
     disp->buf_act = disp->buf_1;
+
+    disp->stride_is_auto = 0;
 }
 
 void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
@@ -469,11 +471,19 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
     lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
     lv_display_set_render_mode(disp, render_mode);
+
+    /* the stride was not set explicitly */
+    disp->stride_is_auto = 1;
 }
 
 void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
                                         uint32_t stride, lv_display_render_mode_t render_mode)
 {
+    if(stride == LV_STRIDE_AUTO) {
+        lv_display_set_buffers(disp, buf1, buf2, buf_size, render_mode);
+        return;
+    }
+
     LV_ASSERT_MSG(buf1 != NULL, "Null buffer");
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t w = lv_display_get_original_horizontal_resolution(disp);
@@ -494,6 +504,8 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
     lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
     lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
     lv_display_set_render_mode(disp, render_mode);
+
+    disp->stride_is_auto = 0;
 }
 
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode)

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -92,6 +92,7 @@ struct _lv_display_t {
     lv_display_render_mode_t render_mode;
     uint32_t antialiasing : 1;       /**< 1: anti-aliasing is enabled on this display.*/
     uint32_t tile_cnt     : 8;       /**< Divide the display buffer into these number of tiles */
+    uint32_t stride_is_auto : 1;     /**< 1: The stride of the buffers was not set explicitly. */
 
 
     /** 1: The current screen rendering is in progress*/


### PR DESCRIPTION
Fixes #7660
Fixes #7797

See the issues for more context.

Test in SDL with this:
https://github.com/liamHowatt/lvgl/commit/8f4241abb044cb047a48b4892672a8b15af15db9
I am not committing the SDL changes because it would make `FULL` slower for the non-rotated case.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
