### PR TITLE
fix: var redeclaration 

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -14,6 +14,7 @@
 #include "../../display/lv_display_private.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
+#include "../../misc/lv_area_private.h"
 
 #if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
     #if LV_USE_THORVG_EXTERNAL

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -134,57 +134,61 @@ void lv_draw_sw_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc, 
 #endif
 
 #if LV_USE_LAYER_DEBUG
-    lv_draw_fill_dsc_t fill_dsc;
-    lv_draw_fill_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
-    fill_dsc.opa = LV_OPA_20;
-    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
+    {
+        lv_draw_fill_dsc_t fill_dsc;
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
+        fill_dsc.opa = LV_OPA_20;
+        lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
-    lv_draw_border_dsc_t border_dsc;
-    lv_draw_border_dsc_init(&border_dsc);
-    border_dsc.color = fill_dsc.color;
-    border_dsc.opa = LV_OPA_60;
-    border_dsc.width = 2;
-    lv_draw_sw_border(t, &border_dsc, &area_rot);
+        lv_draw_border_dsc_t border_dsc;
+        lv_draw_border_dsc_init(&border_dsc);
+        border_dsc.color = fill_dsc.color;
+        border_dsc.opa = LV_OPA_60;
+        border_dsc.width = 2;
+        lv_draw_sw_border(t, &border_dsc, &area_rot);
+    }
 
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    int32_t idx = t->draw_unit->idx;
+    {
+        int32_t idx = t->draw_unit->idx;
 
-    lv_draw_fill_dsc_t fill_dsc;
-    lv_draw_fill_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
-    fill_dsc.opa = LV_OPA_10;
-    lv_draw_sw_fill(t, &fill_dsc, &area_rot);
+        lv_draw_fill_dsc_t fill_dsc;
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
+        fill_dsc.opa = LV_OPA_10;
+        lv_draw_sw_fill(t, &fill_dsc, &area_rot);
 
-    lv_draw_border_dsc_t border_dsc;
-    lv_draw_border_dsc_init(&border_dsc);
-    border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
-    border_dsc.opa = LV_OPA_60;
-    border_dsc.width = 1;
-    lv_draw_sw_border(t, &border_dsc, &area_rot);
+        lv_draw_border_dsc_t border_dsc;
+        lv_draw_border_dsc_init(&border_dsc);
+        border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
+        border_dsc.opa = LV_OPA_60;
+        border_dsc.width = 1;
+        lv_draw_sw_border(t, &border_dsc, &area_rot);
 
-    lv_point_t txt_size;
-    lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
+        lv_point_t txt_size;
+        lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
 
-    lv_area_t txt_area;
-    txt_area.x1 = draw_area.x1;
-    txt_area.x2 = draw_area.x1 + txt_size.x - 1;
-    txt_area.y2 = draw_area.y2;
-    txt_area.y1 = draw_area.y2 - txt_size.y + 1;
+        lv_area_t txt_area;
+        txt_area.x1 = draw_area.x1;
+        txt_area.x2 = draw_area.x1 + txt_size.x - 1;
+        txt_area.y2 = draw_area.y2;
+        txt_area.y1 = draw_area.y2 - txt_size.y + 1;
 
-    lv_draw_fill_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_color_black();
-    lv_draw_sw_fill(t, &fill_dsc, &txt_area);
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_color_black();
+        lv_draw_sw_fill(t, &fill_dsc, &txt_area);
 
-    char buf[8];
-    lv_snprintf(buf, sizeof(buf), "%d", idx);
-    lv_draw_label_dsc_t label_dsc;
-    lv_draw_label_dsc_init(&label_dsc);
-    label_dsc.color = lv_color_white();
-    label_dsc.text = buf;
-    lv_draw_sw_label(t, &label_dsc, &txt_area);
+        char buf[8];
+        lv_snprintf(buf, sizeof(buf), "%d", idx);
+        lv_draw_label_dsc_t label_dsc;
+        lv_draw_label_dsc_init(&label_dsc);
+        label_dsc.color = lv_color_white();
+        label_dsc.text = buf;
+        lv_draw_sw_label(t, &label_dsc, &txt_area);
+    }
 #endif
 }
 


### PR DESCRIPTION
Fixes #8097

Along with the var redeclaration error i was also getting a implicit-function-declaration error because of a missing include when `LV_USE_PARALLEL_DRAW_DEBUG` is set to 1 in the lv_draw_sw.c file:

```bash
src/draw/sw/lv_draw_sw.c:431:13: error: implicit declaration of function ‘lv_area_intersect’; did you mean ‘lv_area_increase’? [-Wimplicit-function-declaration]
  431 |         if(!lv_area_intersect(&draw_area, &t->area, &t->clip_area)) return;
      |             ^~~~~~~~~~~~~~~~~
      |             lv_area_increase
```