### PR TITLE
fix(buttonmatrix): fix odd memory allocation for text.

### DIFF
--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -744,7 +744,7 @@ static void draw_main(lv_event_t * e)
 
         /*Draw the text*/
         draw_label_dsc_act.text = txt;
-        draw_label_dsc_act.text_local = true;
+        draw_label_dsc_act.text_local = false;
         draw_label_dsc_act.base.id1 = btn_i;
         lv_draw_label(layer, &draw_label_dsc_act, &btn_area);
     }


### PR DESCRIPTION
The text for buttons was treated as stored locally. Changed that to avoid unnecessary allocation of space for the string that are actually managed by callee.
 
Fixes #7781
