### PR TITLE
doc(freetype) add ftstroke.c to example Makefile

### DIFF
--- a/docs/src/details/libs/freetype.rst
+++ b/docs/src/details/libs/freetype.rst
@@ -69,6 +69,7 @@ save limited FLASH space.
    FT_CSRCS += freetype/src/base/ftdebug.c
    FT_CSRCS += freetype/src/base/ftglyph.c
    FT_CSRCS += freetype/src/base/ftinit.c
+   FT_CSRCS += freetype/src/base/ftstroke.c
    FT_CSRCS += freetype/src/cache/ftcache.c
    FT_CSRCS += freetype/src/gzip/ftgzip.c
    FT_CSRCS += freetype/src/sfnt/sfnt.c


### PR DESCRIPTION
Update the documentation on freetype add missing source file (ftstroke.c) to the example Makefile.