### PR TITLE
fix(refr): change clip area don't take effect on children and draw post

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -140,7 +140,7 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
     }
     lv_area_t clip_coords_for_children;
     bool refr_children = true;
-    if(!lv_area_intersect(&clip_coords_for_children, &clip_area_ori, obj_coords) || layer->opa <= LV_OPA_MIN) {
+    if(!lv_area_intersect(&clip_coords_for_children, &layer->_clip_area, obj_coords) || layer->opa <= LV_OPA_MIN) {
         refr_children = false;
     }
 
@@ -149,7 +149,6 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
         uint32_t child_cnt = lv_obj_get_child_count(obj);
         if(child_cnt == 0) {
             /*If the object was visible on the clip area call the post draw events too*/
-            layer->_clip_area = clip_coords_for_obj;
             /*If all the children are redrawn make 'post draw' draw*/
             lv_obj_send_event(obj, LV_EVENT_DRAW_POST_BEGIN, layer);
             lv_obj_send_event(obj, LV_EVENT_DRAW_POST, layer);
@@ -172,7 +171,6 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
                 }
 
                 /*If the object was visible on the clip area call the post draw events too*/
-                layer->_clip_area = clip_coords_for_obj;
                 /*If all the children are redrawn make 'post draw' draw*/
                 lv_obj_send_event(obj, LV_EVENT_DRAW_POST_BEGIN, layer);
                 lv_obj_send_event(obj, LV_EVENT_DRAW_POST, layer);
@@ -193,7 +191,7 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
 
                 lv_area_t bottom = obj->coords;
                 bottom.y1 = bottom.y2 - rout + 1;
-                if(lv_area_intersect(&bottom, &bottom, &clip_area_ori)) {
+                if(lv_area_intersect(&bottom, &bottom, &layer->_clip_area)) {
                     layer_children = lv_draw_layer_create(layer, LV_COLOR_FORMAT_ARGB8888, &bottom);
 
                     for(i = 0; i < child_cnt; i++) {
@@ -214,7 +212,7 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
 
                 lv_area_t top = obj->coords;
                 top.y2 = top.y1 + rout - 1;
-                if(lv_area_intersect(&top, &top, &clip_area_ori)) {
+                if(lv_area_intersect(&top, &top, &layer->_clip_area)) {
                     layer_children = lv_draw_layer_create(layer, LV_COLOR_FORMAT_ARGB8888, &top);
 
                     for(i = 0; i < child_cnt; i++) {
@@ -237,7 +235,7 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
                 lv_area_t mid = obj->coords;
                 mid.y1 += rout;
                 mid.y2 -= rout;
-                if(lv_area_intersect(&mid, &mid, &clip_area_ori)) {
+                if(lv_area_intersect(&mid, &mid, &layer->_clip_area)) {
                     layer->_clip_area = mid;
                     for(i = 0; i < child_cnt; i++) {
                         lv_obj_t * child = obj->spec_attr->children[i];


### PR DESCRIPTION
Fix the bug that clip area don't take effect on children
Test code:
```
static lv_obj_t* title = NULL;

static void event_cb(lv_event_t* e)
{
  lv_obj_t* obj = lv_event_get_target_obj(e);
  lv_area_t coords;
  lv_area_t title_coords;
  lv_area_t intersect_coords;
  lv_obj_get_coords(obj, &coords);
  lv_obj_get_coords(title, &title_coords);
  if(!lv_area_intersect(&intersect_coords, &coords, &title_coords)) {
    return;
  }
  lv_layer_t* layer = lv_event_get_layer(e);
  coords.y1 = title_coords.y2 + 1;
  lv_area_intersect(&layer->_clip_area, &layer->_clip_area, &coords);
}

void demo() {
  lv_obj_t* cont = lv_obj_create(lv_screen_active());
  lv_obj_set_size(cont, 200, 400);
  lv_obj_set_style_pad_top(cont, 100, 0);
  lv_obj_center(cont);
  lv_obj_t* case1 = lv_obj_create(cont);
  lv_obj_set_size(case1, 160, 200);
  lv_obj_set_style_bg_color(case1, lv_color_hex(0x666666), 0);
  lv_obj_t* label1 = lv_label_create(case1);
  lv_label_set_text(label1, "text1\ntext1\ntext1\ntext1\ntext1");

  lv_obj_t* case2 = lv_obj_create(cont);
  lv_obj_set_size(case2, 160, 200);
  lv_obj_set_style_bg_color(case2, lv_color_hex(0x666666), 0);
  lv_obj_align_to(case2, case1, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
  lv_obj_t* label2 = lv_label_create(case2);
  lv_label_set_text(label2, "text2");

  title = lv_obj_create(cont);
  lv_obj_remove_style_all(title);
  lv_obj_add_flag(title, LV_OBJ_FLAG_FLOATING);
  lv_obj_add_flag(title, LV_OBJ_FLAG_IGNORE_LAYOUT);
  lv_obj_set_y(title, - lv_obj_get_style_pad_top(cont, 0));
  lv_obj_set_style_opa(title, LV_OPA_20, 0);
  lv_obj_set_size(title, 160, 80);
  lv_obj_t* title_text = lv_label_create(title);
  lv_label_set_text(title_text, "title");
  lv_obj_center(title_text);

  lv_obj_add_event_cb(case1, event_cb, LV_EVENT_DRAW_MAIN_BEGIN, NULL);
  lv_obj_add_event_cb(case2, event_cb, LV_EVENT_DRAW_MAIN_BEGIN, NULL);
}
```
Before modification:
[before.webm](https://github.com/user-attachments/assets/eedfb332-960b-4f1f-9b4a-4b00f765e028)


After modification:
[after.webm](https://github.com/user-attachments/assets/136aef5c-d8a6-44ba-8afc-14a768e7b186)

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
