### PR TITLE
chore(profiler): add built-in profiler default enable config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1546,6 +1546,10 @@ menu "LVGL configuration"
 			int "Default profiler trace buffer size in bytes"
 			depends on LV_USE_PROFILER_BUILTIN
 			default 16384
+		config LV_PROFILER_BUILTIN_DEFAULT_ENABLE
+			bool "Enable built-in profiler by default"
+			depends on LV_USE_PROFILER_BUILTIN
+			default y
 		config LV_PROFILER_INCLUDE
 			string "Header to include for the profiler"
 			default "lvgl/src/misc/lv_profiler_builtin.h"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1022,6 +1022,7 @@
     #if LV_USE_PROFILER_BUILTIN
         /** Default profiler trace buffer size */
         #define LV_PROFILER_BUILTIN_BUF_SIZE (16 * 1024)     /**< [bytes] */
+        #define LV_PROFILER_BUILTIN_DEFAULT_ENABLE 1
     #endif
 
     /** Header to include for profiler */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3225,6 +3225,17 @@
                 #define LV_PROFILER_BUILTIN_BUF_SIZE (16 * 1024)     /**< [bytes] */
             #endif
         #endif
+        #ifndef LV_PROFILER_BUILTIN_DEFAULT_ENABLE
+            #ifdef LV_KCONFIG_PRESENT
+                #ifdef CONFIG_LV_PROFILER_BUILTIN_DEFAULT_ENABLE
+                    #define LV_PROFILER_BUILTIN_DEFAULT_ENABLE CONFIG_LV_PROFILER_BUILTIN_DEFAULT_ENABLE
+                #else
+                    #define LV_PROFILER_BUILTIN_DEFAULT_ENABLE 0
+                #endif
+            #else
+                #define LV_PROFILER_BUILTIN_DEFAULT_ENABLE 1
+            #endif
+        #endif
     #endif
 
     /** Header to include for profiler */

--- a/src/misc/lv_profiler_builtin.c
+++ b/src/misc/lv_profiler_builtin.c
@@ -142,7 +142,7 @@ void lv_profiler_builtin_init(const lv_profiler_builtin_config_t * config)
         profiler_ctx->config.flush_cb("#\n");
     }
 
-    lv_profiler_builtin_set_enable(true);
+    lv_profiler_builtin_set_enable(LV_PROFILER_BUILTIN_DEFAULT_ENABLE);
 
     LV_LOG_INFO("init OK, item_num = %d", (int)num);
 }


### PR DESCRIPTION
Add a config to set the default switch of the built-in profiler. In most cases, we hope that it is turned off by default and turned on when needed.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
