### PR TITLE
perf(label): reduce the time of calling lv_text_get_size when drawing

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -200,6 +200,7 @@ void lv_draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_label_ds
                                       const lv_area_t * coords,
                                       lv_draw_glyph_cb_t cb)
 {
+    lv_draw_dsc_base_t * base_dsc = t->draw_dsc;
     const lv_font_t * font = dsc->font;
     int32_t w;
 
@@ -218,10 +219,15 @@ void lv_draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_label_ds
     }
     else {
         /*If EXPAND is enabled then not limit the text's width to the object's width*/
-        lv_point_t p;
-        lv_text_get_size(&p, dsc->text, dsc->font, dsc->letter_space, dsc->line_space, LV_COORD_MAX,
-                         dsc->flag);
-        w = p.x;
+        if(base_dsc->obj && !lv_obj_has_flag(base_dsc->obj, LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS)) {
+            w = dsc->text_size.x;
+        }
+        else {
+            lv_point_t p;
+            lv_text_get_size(&p, dsc->text, dsc->font, dsc->letter_space, dsc->line_space, LV_COORD_MAX,
+                             dsc->flag);
+            w = p.x;
+        }
     }
 
     int32_t line_height_font = lv_font_get_line_height(font);

--- a/src/draw/lv_draw_label.h
+++ b/src/draw/lv_draw_label.h
@@ -35,6 +35,9 @@ typedef struct {
     /**The text to draw*/
     const char * text;
 
+    /**The size of the text*/
+    lv_point_t text_size;
+
     /**The font to use. Fallback fonts are also handled.*/
     const lv_font_t * font;
 

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -823,6 +823,7 @@ static void draw_main(lv_event_t * e)
     label_draw_dsc.text_static = label->static_txt;
     label_draw_dsc.ofs_x = label->offset.x;
     label_draw_dsc.ofs_y = label->offset.y;
+    label_draw_dsc.text_size = label->text_size;
 #if LV_LABEL_LONG_TXT_HINT
     if(label->long_mode != LV_LABEL_LONG_MODE_SCROLL_CIRCULAR &&
        lv_area_get_height(&txt_coords) >= LV_LABEL_HINT_HEIGHT_LIMIT) {
@@ -852,9 +853,7 @@ static void draw_main(lv_event_t * e)
      * (In addition, they will create misalignment in this situation)*/
     if((label->long_mode == LV_LABEL_LONG_MODE_SCROLL || label->long_mode == LV_LABEL_LONG_MODE_SCROLL_CIRCULAR) &&
        (label_draw_dsc.align == LV_TEXT_ALIGN_CENTER || label_draw_dsc.align == LV_TEXT_ALIGN_RIGHT)) {
-        lv_point_t size;
-        lv_text_get_size(&size, label->text, label_draw_dsc.font, label_draw_dsc.letter_space, label_draw_dsc.line_space,
-                         LV_COORD_MAX, flag);
+        lv_point_t size = label->text_size;
         if(size.x > lv_area_get_width(&txt_coords)) {
 #if LV_USE_BIDI
             const lv_base_dir_t base_dir = lv_obj_get_style_base_dir(obj, LV_PART_MAIN);
@@ -892,9 +891,7 @@ static void draw_main(lv_event_t * e)
     layer->_clip_area = txt_clip;
 
     if(label->long_mode == LV_LABEL_LONG_MODE_SCROLL_CIRCULAR) {
-        lv_point_t size;
-        lv_text_get_size(&size, label->text, label_draw_dsc.font, label_draw_dsc.letter_space, label_draw_dsc.line_space,
-                         LV_COORD_MAX, flag);
+        lv_point_t size = label->text_size;
 
         /*Draw the text again on label to the original to make a circular effect */
         if(size.x > lv_area_get_width(&txt_coords)) {
@@ -968,6 +965,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
 
     lv_label_revert_dots(obj);
     lv_text_get_size(&size, label->text, font, letter_space, line_space, max_w, flag);
+    label->text_size = size;
 
     lv_obj_refresh_self_size(obj);
 

--- a/src/widgets/label/lv_label_private.h
+++ b/src/widgets/label/lv_label_private.h
@@ -50,6 +50,8 @@ struct _lv_label_t {
     uint8_t recolor : 1;                /**< Enable in-line letter re-coloring*/
     uint8_t expand : 1;                 /**< Ignore real width (used by the library with LV_LABEL_LONG_MODE_SCROLL) */
     uint8_t invalid_size_cache : 1;     /**< 1: Recalculate size and update cache */
+
+    lv_point_t text_size;
 };
 
 


### PR DESCRIPTION
When drawing a label,  `lv_text_get_size` may be called multiple times to get the size of the text, which may affect the frame rate. However, the size is calculated once when setting the label, the calculation here can be omitted.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
