### PR TITLE
fix(examples):  fix #warning causing examples build to fail.

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -597,8 +597,8 @@
 #define LV_FONT_DEJAVU_16_PERSIAN_HEBREW    0  /**< Hebrew, Arabic, Persian letters and all their forms */
 #define LV_FONT_SIMSUN_14_CJK               0  /**< 1000 most common CJK radicals */
 #define LV_FONT_SIMSUN_16_CJK               0  /**< 1000 most common CJK radicals */
-#define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK   0  /**< 1000 most common CJK radicals */
-#define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK   0  /**< 1000 most common CJK radicals */
+#define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK   0  /**< 1338 most common CJK radicals */
+#define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK   0  /**< 1338 most common CJK radicals */
 
 /** Pixel perfect monospaced fonts */
 #define LV_FONT_UNSCII_8  0

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -304,14 +304,10 @@ LV_FONT_DECLARE(lv_font_dejavu_16_persian_hebrew)
 #endif
 
 #if LV_FONT_SIMSUN_14_CJK
-#warning  "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead."
-
 LV_FONT_DECLARE(lv_font_simsun_14_cjk)
 #endif
 
 #if LV_FONT_SIMSUN_16_CJK
-#warning  "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead."
-
 LV_FONT_DECLARE(lv_font_simsun_16_cjk)
 #endif
 

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -304,13 +304,13 @@ LV_FONT_DECLARE(lv_font_dejavu_16_persian_hebrew)
 #endif
 
 #if LV_FONT_SIMSUN_14_CJK
-#warning  "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead."
+#pragma message ( "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead." )
 
 LV_FONT_DECLARE(lv_font_simsun_14_cjk)
 #endif
 
 #if LV_FONT_SIMSUN_16_CJK
-#warning  "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead."
+#pragma message ( "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead." )
 
 LV_FONT_DECLARE(lv_font_simsun_16_cjk)
 #endif

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -304,13 +304,13 @@ LV_FONT_DECLARE(lv_font_dejavu_16_persian_hebrew)
 #endif
 
 #if LV_FONT_SIMSUN_14_CJK
-#pragma message ( "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead." )
+#warning  "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead."
 
 LV_FONT_DECLARE(lv_font_simsun_14_cjk)
 #endif
 
 #if LV_FONT_SIMSUN_16_CJK
-#pragma message ( "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead." )
+#warning  "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead."
 
 LV_FONT_DECLARE(lv_font_simsun_16_cjk)
 #endif

--- a/src/font/lv_font_simsun_14_cjk.c
+++ b/src/font/lv_font_simsun_14_cjk.c
@@ -20760,6 +20760,12 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
  *  PUBLIC FONT
  *----------------*/
 
+#ifdef _MSC_VER
+    #pragma deprecated(lv_font_simsun_14_cjk)
+#else
+    #warning "LV_FONT_SIMSUN_14_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_14_CJK instead."
+#endif
+
 /*Initialize a public general font descriptor*/
 #if LVGL_VERSION_MAJOR >= 8
 const lv_font_t lv_font_simsun_14_cjk = {

--- a/src/font/lv_font_simsun_16_cjk.c
+++ b/src/font/lv_font_simsun_16_cjk.c
@@ -24125,6 +24125,12 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
  *  PUBLIC FONT
  *----------------*/
 
+#ifdef _MSC_VER
+    #pragma deprecated(lv_font_simsun_16_cjk)
+#else
+    #warning "LV_FONT_SIMSUN_16_CJK is deprecated, use LV_FONT_SOURCE_HAN_SANS_SC_16_CJK instead."
+#endif
+
 /*Initialize a public general font descriptor*/
 #if LVGL_VERSION_MAJOR >= 8
 const lv_font_t lv_font_simsun_16_cjk = {

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1794,14 +1794,14 @@
     #ifdef CONFIG_LV_FONT_SOURCE_HAN_SANS_SC_14_CJK
         #define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK CONFIG_LV_FONT_SOURCE_HAN_SANS_SC_14_CJK
     #else
-        #define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK   0  /**< 1000 most common CJK radicals */
+        #define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK   0  /**< 1338 most common CJK radicals */
     #endif
 #endif
 #ifndef LV_FONT_SOURCE_HAN_SANS_SC_16_CJK
     #ifdef CONFIG_LV_FONT_SOURCE_HAN_SANS_SC_16_CJK
         #define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK CONFIG_LV_FONT_SOURCE_HAN_SANS_SC_16_CJK
     #else
-        #define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK   0  /**< 1000 most common CJK radicals */
+        #define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK   0  /**< 1338 most common CJK radicals */
     #endif
 #endif
 


### PR DESCRIPTION
When the docs build, the "Build examples" step is done by compiling the code examples with "everything turned on".  That means that

are both set to 1.

Simultaneously, in `lv_font.h`, there is a

for both of those fonts, but Visual Studio WILL NOT build LVGL because MSVC does not yet support the #warning preprocessor directive.  MSVC considers it an error and so does not even generate the output object files.

However

still works, and is a legitimate way to get the message across for developers using the CJK fonts to switch over to the new font without breaking their builds.

This handles both problems.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
