### PR TITLE
fix(vg_lite): fix strict alias warning with higher optimization levels

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_math.c
+++ b/src/draw/vg_lite/lv_vg_lite_math.c
@@ -39,19 +39,14 @@
 
 float math_fast_inv_sqrtf(float number)
 {
-    const float threehalfs = 1.5f;
-
-    float x2 = number * 0.5f;
-    float y = number;
-    int32_t i = *(int32_t *)&y; /* evil floating point bit level hacking */
-
-    i = 0x5f3759df /* floating-point representation of an approximation of {\sqrt {2^{127}}}} see https://en.wikipedia.org/wiki/Fast_inverse_square_root. */
-        - (i >>
-           1);
-    y = *(float *)&i;
-    y = y * (threehalfs - (x2 * y * y)); /* 1st iteration */
-
-    return y;
+    /* From https://en.wikipedia.org/wiki/Fast_inverse_square_root#Avoiding_undefined_behavior */
+    union {
+        float   f;
+        int32_t i;
+    } conv = { .f = number };
+    conv.i  = 0x5f3759df - (conv.i >> 1);
+    conv.f *= 1.5F - (number * 0.5F * conv.f * conv.f);
+    return conv.f;
 }
 
 /**********************


### PR DESCRIPTION
With certain combinations of compiler and flags, the function `math_fast_inv_sqrtf`  will sometimes fail to compile. I am able to recreate this with the build test suite by doing a release build instead of a debug build. [1]
```
lv_vg_lite_math.c:46:18: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
```
Using the example from the wiki page mentioned in the code we can avoid the issue using a union.

[1]: https://github.com/lvgl/lvgl/blob/master/tests/main.py#L261

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
