### PR TITLE
fix(list): check that LV_USE_FLEX is enabled when using LV_LIST

### DIFF
--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -18,7 +18,7 @@ extern "C" {
 #if LV_USE_LIST
 
 #if LV_USE_FLEX == 0
-#error "LV_USE_FLEX needs to be enabled"
+#error "LV_LIST requires LV_USE_FLEX to be enabled"
 #endif
 
 /*********************

--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -18,7 +18,7 @@ extern "C" {
 #if LV_USE_LIST
 
 #if LV_USE_FLEX == 0
-#error "LV_LIST requires LV_USE_FLEX to be enabled"
+#error "lv_list: lv_flex is required. Enable it in lv_conf.h (LV_USE_FLEX 1)"
 #endif
 
 /*********************

--- a/src/widgets/list/lv_list.h
+++ b/src/widgets/list/lv_list.h
@@ -17,6 +17,10 @@ extern "C" {
 
 #if LV_USE_LIST
 
+#if LV_USE_FLEX == 0
+#error "LV_USE_FLEX needs to be enabled"
+#endif
+
 /*********************
  *      DEFINES
  *********************/

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -18,7 +18,7 @@ extern "C" {
 #if LV_USE_MENU
 
 #if LV_USE_FLEX == 0
-#error "LV_MENU requires LV_USE_FLEX to be enabled"
+#error "lv_menu: lv_flex is required. Enable it in lv_conf.h (LV_USE_FLEX 1)"
 #endif
 
 /*********************

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -18,7 +18,7 @@ extern "C" {
 #if LV_USE_MENU
 
 #if LV_USE_FLEX == 0
-#error "LV_USE_FLEX needs to be enabled"
+#error "LV_MENU requires LV_USE_FLEX to be enabled"
 #endif
 
 /*********************


### PR DESCRIPTION
Fixes include error when using `LV_LIST` but `LV_USE_FLEX` isn't set. Same way as how `lv_menu.h` checks for it.