### PR TITLE
fix(scripts): correct parsing of LVGL config file

### DIFF
--- a/scripts/generate_cmake_variables.py
+++ b/scripts/generate_cmake_variables.py
@@ -98,7 +98,7 @@ def generate_cmake_variables(path_input: str, path_output: str, kconfig: bool):
                 continue
 
             name = parts[1]
-            value = parts[2].strip()
+            value = " ".join(parts[2:]).strip()
 
             fout.write(f'set({CONFIG_PREFIX}{name} {value})\n')
 


### PR DESCRIPTION
## Description

- Modify the parsing logic to join multiple values with a space

### Background

when I parse this configuration like this:

```cpp
#define LV_USE_SYSMON   (LV_USE_MEM_MONITOR | LV_USE_PERF_MONITOR)
```

I got an error:

### Error
<img width="872" alt="image" src="https://github.com/user-attachments/assets/69ad1655-3fab-4812-8398-e312794427ed" />

### Reason

The script parsing like this:
```cpp
['#define', 'LV_USE_SYSMON', '(LV_USE_MEM_MONITOR', '|', 'LV_USE_PERF_MONITOR)']
```

But it only takes the first 3 element. So it causes this error.

## Fix

join the rest parts together to avoid this problem

### Before:

```bash
set(CONFIG_LV_USE_SYSMON (LV_USE_MEM_MONITOR
```

### After:

```bash
set(CONFIG_LV_USE_SYSMON (LV_USE_MEM_MONITOR | LV_USE_PERF_MONITOR))
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
