### PR TITLE
fix(circle_buf): don't clear array on reset

### DIFF
--- a/src/misc/lv_circle_buf.c
+++ b/src/misc/lv_circle_buf.c
@@ -178,7 +178,6 @@ void lv_circle_buf_reset(lv_circle_buf_t * circle_buf)
 {
     LV_ASSERT_NULL(circle_buf);
 
-    lv_array_clear(&circle_buf->array);
     circle_buf->head = 0;
     circle_buf->tail = 0;
 }

--- a/tests/src/test_cases/test_circle_buf.c
+++ b/tests/src/test_cases/test_circle_buf.c
@@ -164,4 +164,48 @@ void test_circle_buf_read_after_read_and_write(void)
     }
 }
 
+void test_circle_buf_reset(void)
+{
+    /**
+     * Reset the circle buffer, now the buffer should be empty just like lv_circle_buf_create.
+     */
+    lv_circle_buf_reset(circle_buf);
+
+    TEST_ASSERT_EQUAL_UINT32(lv_circle_buf_capacity(circle_buf), circle_buf_CAPACITY);
+    TEST_ASSERT_EQUAL_UINT32(0, lv_circle_buf_size(circle_buf));
+
+    /**
+     * Write values to the circle buffer. The max size of the buffer is circle_buf_CAPACITY.
+     * When the buffer is full, the write operation should return LV_RESULT_INVALID.
+     */
+    for(int32_t i = 0; i < circle_buf_CAPACITY * 2; i++) {
+        const lv_result_t res = lv_circle_buf_write(circle_buf, &i);
+
+        if(i < circle_buf_CAPACITY) TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+        else TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+    }
+
+    /**
+     * After writing values to the buffer, the size of the buffer should be equal to the capacity.
+     */
+    TEST_ASSERT_EQUAL_UINT32(lv_circle_buf_size(circle_buf), circle_buf_CAPACITY);
+
+    /**
+     * Read values from the circle buffer. The max size of the buffer is circle_buf_CAPACITY.
+     * When the buffer is empty, the read operation should return LV_RESULT_INVALID.
+     */
+    for(int32_t i = 0; i < circle_buf_CAPACITY * 2; i++) {
+        int32_t value;
+        const lv_result_t res = lv_circle_buf_read(circle_buf, &value);
+
+        if(i < circle_buf_CAPACITY) {
+            TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+            TEST_ASSERT_EQUAL_INT32(i, value);
+        }
+        else {
+            TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
Setting head and tail to 0 is enough for reset, clear the array will make array size to 0. But circle buf needs array's size to be same as its capacity (see `circle_buf_prepare_empty`).

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
