### PR TITLE
fix(obj): add NULL pointer check in lv_obj_update_layout

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -281,6 +281,8 @@ bool lv_obj_is_layout_positioned(const lv_obj_t * obj)
 
 void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
 {
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
     obj->layout_inv = 1;
 
     /*Mark the screen as dirty too to mark that there is something to do on this screen*/
@@ -294,6 +296,8 @@ void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
 
 void lv_obj_update_layout(const lv_obj_t * obj)
 {
+    if(obj == NULL) return;
+
     if(update_layout_mutex) {
         LV_LOG_TRACE("Already running, returning");
         return;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -386,7 +386,7 @@ void lv_display_refr_timer(lv_timer_t * tmr)
     /*Refresh the screen's layout if required*/
     LV_PROFILER_LAYOUT_BEGIN_TAG("layout");
     lv_obj_update_layout(disp_refr->act_scr);
-    if(disp_refr->prev_scr) lv_obj_update_layout(disp_refr->prev_scr);
+    lv_obj_update_layout(disp_refr->prev_scr);
 
     lv_obj_update_layout(disp_refr->bottom_layer);
     lv_obj_update_layout(disp_refr->top_layer);


### PR DESCRIPTION
Prevent NULL-pointer de-reference.

Issue seen while debugging (version 8.3.2):

```
(gdb) bt
#0  0x7008e330 in lv_obj_get_screen (obj=0x0 <lv_obj_get_style_bg_color_filtered>) at /builds/3/zephyrproject/modules/lib/gui/lvgl/src/core/lv_obj_tree.c:257
#1  0x7008ae14 in lv_obj_update_layout (obj=<optimized out>) at /builds/3/zephyrproject/modules/lib/gui/lvgl/src/core/lv_obj_pos.c:310
#2  0x7008fce0 in _lv_disp_refr_timer (tmr=<optimized out>) at /builds/3/zephyrproject/modules/lib/gui/lvgl/src/core/lv_refr.c:308
#3  0x700aa9ae in lv_timer_exec (timer=0x20000384 <kheap_lvgl_mem_pool+900>) at /builds/3/zephyrproject/modules/lib/gui/lvgl/src/misc/lv_timer.c:313
#4  0x700aaa44 in lv_timer_handler () at /builds/3/zephyrproject/modules/lib/gui/lvgl/src/misc/lv_timer.c:109
#5  0x7002e254 in ui_run () at /builds/3/zephyrproject/app/src/ui.c:196
#6  0x7001df92 in main () at /builds/3/zephyrproject/app/src/main.c:121