### PR TITLE
Fix(cache): Use strcmp for file paths in lv_img_cache_invalidate_src (v6)

### DIFF
--- a/src/lv_core/lv_refr.c
+++ b/src/lv_core/lv_refr.c
@@ -510,7 +510,7 @@ static void lv_refr_obj(lv_obj_t * obj, const lv_area_t * mask_ori_p)
     obj_area.y2 += ext_size;
     union_ok = lv_area_intersect(&obj_ext_mask, mask_ori_p, &obj_area);
 
-    /*Draw the parent and its children only if they ore on 'mask_parent'*/
+    /*Draw the parent and its children only if they are on 'mask_parent'*/
     if(union_ok != false) {
 
         /* Redraw the object */

--- a/src/lv_draw/lv_img_cache.c
+++ b/src/lv_draw/lv_img_cache.c
@@ -190,7 +190,15 @@ void lv_img_cache_invalidate_src(const void * src)
 
     uint16_t i;
     for(i = 0; i < entry_cnt; i++) {
-        if(cache[i].dec_dsc.src == src || src == NULL) {
+        bool match = false;
+        lv_img_src_t src_type = lv_img_src_get_type(cache[i].dec_dsc.src);
+        if(src_type == LV_IMG_SRC_VARIABLE) {
+            if(cache[i].dec_dsc.src == src) match = true;
+        } else if(src_type == LV_IMG_SRC_FILE) {
+            if(strcmp(cache[i].dec_dsc.src, src) == 0) match = true;
+        }
+
+        if(match || src == NULL) {
             if(cache[i].dec_dsc.src != NULL) {
                 lv_img_decoder_close(&cache[i].dec_dsc);
             }


### PR DESCRIPTION
Fix(cache): Use strcmp for file paths in lv_img_cache_invalidate_src (v6)

The original implementation of lv_img_cache_invalidate_src used direct pointer comparison (==) to find the cache entry to invalidate. This
works correctly for image sources of type LV_IMG_SRC_VARIABLE (pointers to lv_img_dsc_t), but fails for sources of type LV_IMG_SRC_FILE
(pointers to file path strings). Comparing string pointers directly does not guarantee matching content.

This bug can lead to issues in scenarios involving rapid interactions with UI elements that use images loaded from files via a file system
driver. For example, pressing one image button (Btn1) and quickly sliding to an adjacent image button (Btn2) without releasing can trigger the following sequence:
1. Btn1 PRESSED -> open_cb(Btn1_path) -> Btn1 info cached (no img_data).
2. Slide -> Btn1 PRESS_LOST -> open_cb(Btn1_path).
3. After Point 2. -> Btn2 PRESSED -> open_cb(Btn2_path) -> FS ready for Btn2.
4. LVGL redraws Btn1 due to state change.
5. lv_img_cache_open(Btn1_path) hits the stale cache entry for Btn1.
6. lv_img_draw_core proceeds to read Btn1 line-by-line.
7. lv_img_decoder_read_line reads from the file system, which is now positioned for Btn2 due to the last open_cb call.
8. Btn1 is incorrectly drawn using Btn2's image data.

This commit fixes lv_img_cache_invalidate_src by:
- Checking the source type using lv_img_src_get_type.
- Using strcmp() to compare paths if the source type is LV_IMG_SRC_FILE.
- Retaining the pointer comparison for LV_IMG_SRC_VARIABLE.

This fix allows developers to reliably invalidate cache entries based on file paths, enabling workarounds in custom fs_open_cb functions (like invalidating the previous path's cache before opening a new one) to prevent the described rendering artifacts.
