### PR TITLE
fix(span): add assertion for bidi text buffer allocation

### DIFF
--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -1149,6 +1149,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
             char * bidi_txt;
             if(base_dir == LV_BASE_DIR_RTL) {
                 bidi_txt = lv_malloc(pinfo->bytes + 1);
+                LV_ASSERT_MALLOC(bidi_txt);
                 lv_memcpy(bidi_txt, pinfo->txt, (size_t)pinfo->bytes);
                 label_draw_dsc.bidi_dir = base_dir;
                 label_draw_dsc.has_bided = true;
@@ -1211,6 +1212,7 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
                 if(base_dir == LV_BASE_DIR_RTL) {
                     if(txt_bytes > label_draw_dsc.text_length) {
                         char * tmp_txt = lv_malloc(label_draw_dsc.text_length + 1);
+                        LV_ASSERT_MALLOC(tmp_txt);
 
                         if(lv_bidi_detect_base_dir(bidi_txt) == LV_BASE_DIR_RTL) {
                             lv_memcpy(tmp_txt, bidi_txt + (txt_bytes - label_draw_dsc.text_length), (size_t)label_draw_dsc.text_length);


### PR DESCRIPTION
Fixes add assertion for bidi text buffer allocation <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
