### PR TITLE
docs:  fix Doxygen parsing of attribute prefixes

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2065,6 +2065,9 @@ PREDEFINED             = DOXYGEN                         \
                          LV_ATTRIBUTE_TICK_INC=          \
                          LV_ATTRIBUTE_TIMER_HANDLER=     \
                          LV_ATTRIBUTE_FLUSH_READY=       \
+                         LV_ATTRIBUTE_MEM_ALIGN=         \
+                         LV_ATTRIBUTE_LARGE_CONST=       \
+                         LV_ATTRIBUTE_LARGE_RAM_ARRAY=   \
                          LV_ATTRIBUTE_FAST_MEM=          \
                          LV_ATTRIBUTE_EXTERN_DATA=
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2060,12 +2060,12 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = DOXYGEN                        \
-                         LV_CONF_PATH="../../lv_conf.h" \
-                         LV_ATTRIBUTE_TICK_INC=         \
-                         LV_ATTRIBUTE_TIMER_HANDLER=    \
-                         LV_ATTRIBUTE_FLUSH_READY=      \
-                         LV_ATTRIBUTE_FAST_MEM=         \
+PREDEFINED             = DOXYGEN                         \
+                         LV_CONF_PATH="../../lv_conf.h"  \
+                         LV_ATTRIBUTE_TICK_INC=          \
+                         LV_ATTRIBUTE_TIMER_HANDLER=     \
+                         LV_ATTRIBUTE_FLUSH_READY=       \
+                         LV_ATTRIBUTE_FAST_MEM=          \
                          LV_ATTRIBUTE_EXTERN_DATA=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2060,7 +2060,13 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = DOXYGEN LV_CONF_PATH="../../lv_conf.h"
+PREDEFINED             = DOXYGEN                        \
+                         LV_CONF_PATH="../../lv_conf.h" \
+                         LV_ATTRIBUTE_TICK_INC=         \
+                         LV_ATTRIBUTE_TIMER_HANDLER=    \
+                         LV_ATTRIBUTE_FLUSH_READY=      \
+                         LV_ATTRIBUTE_FAST_MEM=         \
+                         LV_ATTRIBUTE_EXTERN_DATA=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/doxygen_xml.py
+++ b/docs/doxygen_xml.py
@@ -1562,7 +1562,6 @@ class DoxygenXml(object):
         cfg.set('XML_OUTPUT', "xml")
         cfg.set('HTML_OUTPUT', 'doxygen_html')
         cfg.set('INPUT', lvgl_src_dir)
-        cfg.set('PREDEFINED', f'DOXYGEN LV_CONF_PATH="{lv_conf_file}"')
         cfg.set('QUIET', 'YES')
         cfg.set('GENERATE_HTML', 'NO')
         cfg.set('GENERATE_DOCSET', 'NO')
@@ -1576,6 +1575,36 @@ class DoxygenXml(object):
         cfg.set('GENERATE_XML', 'YES')
         cfg.set('GENERATE_DOCBOOK', 'NO')
         cfg.set('GENERATE_PERLMOD', 'NO')
+
+        # The predefined definitions are:
+        # - DOXYGEN (defines it as 1 and allows conditional directives [e.g. #if]
+        #   to do special things when DOXYGEN is processing it, as opposed to
+        #   a C compiler.
+        # - LV_CONF_PATH predefines the path where `lv_conf_internal.h` will
+        #   include the `lv_conf.h` file.
+        # - All the others here are used when macros prefix a line of code like this:
+        #
+        #       LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
+        #
+        #   which occurs in `lv_obj.h`.  When add these to the PREDEFINED list as
+        #   "MACRO_NAME=" with no value, Doxygen expands the macro to an empty string
+        #   allowing Doxygen to correctly parse the line.  The additional macros that
+        #   are treated that way are found in the middle of `lv_conf_template.h` in a
+        #   section called "COMPILER SETTINGS" with no definitions, made for prefixing
+        #   various code.  (This works around Doxygen's failure to correctly deal with
+        #   macros that are defined with no values, as these are in lv_conf.h.)
+        #   This list is current as of 28-Apr-2025.
+        predefined_symbols = [
+            'DOXYGEN',
+            f'LV_CONF_PATH="{lv_conf_file}"',
+            'LV_ATTRIBUTE_TICK_INC=',
+            'LV_ATTRIBUTE_TIMER_HANDLER=',
+            'LV_ATTRIBUTE_FLUSH_READY=',
+            'LV_ATTRIBUTE_FAST_MEM=',
+            'LV_ATTRIBUTE_EXTERN_DATA=',
+        ]
+
+        cfg.set('PREDEFINED', predefined_symbols)
 
         # Include TAGFILES if requested.
         if doxy_tagfile:

--- a/docs/doxygen_xml.py
+++ b/docs/doxygen_xml.py
@@ -1586,7 +1586,7 @@ class DoxygenXml(object):
         #
         #       LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
         #
-        #   which occurs in `lv_obj.h`.  When add these to the PREDEFINED list as
+        #   which occurs in `lv_obj.h`.  When these are added to the PREDEFINED list as
         #   "MACRO_NAME=" with no value, Doxygen expands the macro to an empty string
         #   allowing Doxygen to correctly parse the line.  The additional macros that
         #   are treated that way are found in the middle of `lv_conf_template.h` in a
@@ -1600,6 +1600,9 @@ class DoxygenXml(object):
             'LV_ATTRIBUTE_TICK_INC=',
             'LV_ATTRIBUTE_TIMER_HANDLER=',
             'LV_ATTRIBUTE_FLUSH_READY=',
+            'LV_ATTRIBUTE_MEM_ALIGN=',
+            'LV_ATTRIBUTE_LARGE_CONST=',
+            'LV_ATTRIBUTE_LARGE_RAM_ARRAY=',
             'LV_ATTRIBUTE_FAST_MEM=',
             'LV_ATTRIBUTE_EXTERN_DATA=',
         ]

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -364,8 +364,6 @@ void lv_display_set_antialiasing(lv_display_t * disp, bool en);
  */
 bool lv_display_get_antialiasing(lv_display_t * disp);
 
-//! @cond Doxygen_Suppress
-
 /**
  * Call from the display driver when the flushing is finished
  * @param disp      pointer to display whose `flush_cb` was called
@@ -380,8 +378,6 @@ LV_ATTRIBUTE_FLUSH_READY void lv_display_flush_ready(lv_display_t * disp);
  *                  false: there are other areas too which will be refreshed soon
  */
 LV_ATTRIBUTE_FLUSH_READY bool lv_display_flush_is_last(lv_display_t * disp);
-
-//! @endcond
 
 bool lv_display_is_double_buffered(lv_display_t * disp);
 

--- a/src/draw/sw/lv_draw_sw_mask.h
+++ b/src/draw/sw/lv_draw_sw_mask.h
@@ -72,8 +72,6 @@ void lv_draw_sw_mask_init(void);
 
 void lv_draw_sw_mask_deinit(void);
 
-//! @cond Doxygen_Suppress
-
 /**
  * Apply the added buffers on a line. Used internally by the library's drawing routines.
  * @param masks the masks list to apply, must be ended with NULL pointer in array.
@@ -90,8 +88,6 @@ lv_draw_sw_mask_res_t /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_mask_apply(void * m
                                                                         int32_t abs_x,
                                                                         int32_t abs_y,
                                                                         int32_t len);
-
-//! @endcond
 
 /**
  * Free the data from the parameter.

--- a/src/misc/lv_math.h
+++ b/src/misc/lv_math.h
@@ -45,7 +45,6 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-//! @cond Doxygen_Suppress
 /**
  * Return with sinus of an angle
  * @param angle
@@ -54,8 +53,6 @@ typedef struct {
 int32_t /* LV_ATTRIBUTE_FAST_MEM */ lv_trigo_sin(int16_t angle);
 
 int32_t LV_ATTRIBUTE_FAST_MEM lv_trigo_cos(int16_t angle);
-
-//! @endcond
 
 /**
  * Calculate the y value of cubic-bezier(x1, y1, x2, y2) function as specified x.
@@ -88,8 +85,6 @@ int32_t lv_bezier3(int32_t t, int32_t u0, uint32_t u1, int32_t u2, int32_t u3);
  */
 uint16_t lv_atan2(int x, int y);
 
-//! @cond Doxygen_Suppress
-
 /**
  * Get the square root of a number
  * @param x integer which square root should be calculated
@@ -101,8 +96,6 @@ uint16_t lv_atan2(int x, int y);
  * Else: mask = 0x8000
  */
 void /* LV_ATTRIBUTE_FAST_MEM */ lv_sqrt(uint32_t x, lv_sqrt_res_t * q, uint32_t mask);
-
-//! @endcond
 
 /**
  * Alternative (fast, approximate) implementation for getting the square root of an integer.

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -44,15 +44,11 @@ typedef void (*lv_timer_handler_resume_cb_t)(void * data);
  * GLOBAL PROTOTYPES
  **********************/
 
-//! @cond Doxygen_Suppress
-
 /**
  * Call it periodically to handle lv_timers.
  * @return time till it needs to be run next (in ms)
  */
 LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void);
-
-//! @endcond
 
 /**
  * Call it in the super-loop of main() or threads. It will run lv_timer_handler()

--- a/src/others/monkey/lv_monkey.h
+++ b/src/others/monkey/lv_monkey.h
@@ -28,18 +28,16 @@ extern "C" {
 typedef struct _lv_monkey_t lv_monkey_t;
 
 struct _lv_monkey_config_t {
-    /**< Input device type*/
+    /** Input device type */
     lv_indev_type_t type;
 
-    /**< Monkey execution period*/
+    /** Monkey execution period */
     struct {
-        //! @cond Doxygen_Suppress
         uint32_t min;
         uint32_t max;
-        //! @endcond
     } period_range;
 
-    /**< The range of input value*/
+    /** The range of input value */
     struct {
         int32_t min;
         int32_t max;


### PR DESCRIPTION
In LVGL some functions and variable definitions (and prototypes and declarations respectively) are prefixed by a macro which can be used by end users to add special meaning to those functions where they apply (e.g. interrupt service routines, memory areas, RAM functions, etc.).  The macros that do this are:

- LV_ATTRIBUTE_TICK_INC
- LV_ATTRIBUTE_TIMER_HANDLER
- LV_ATTRIBUTE_FLUSH_READY
- LV_ATTRIBUTE_FAST_MEM
- LV_ATTRIBUTE_EXTERN_DATA

By default, these are defined in `lv_conf_template.h` (and thus `lv_conf.h`) as having no values so the C preprocessor replaces them with an empty string.

However, Doxygen has a problem wherein even if there is a

    #define  SOME_MACRO

with no value, such macros (with no values) are NOT expanded by Doxygen's preprocessor.  This causes such functions and variables to not be parsed correctly by Doxygen.  To handle this, we must tell Doxygen about these macros in its configuration file (Doxyfile) using the `PREDEFINED` list. Naming the macro with an `=` after it and no value accomplishes the desired result.

All the functions affected are now properly document as reflected [here](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/). Note that in the [display page](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/details/main-modules/display/setup.html) the `lv_display_flush_ready()` function now links to API documentation, which it did not before (because it previously didn't exist because Doxygen wasn't parsing it).  All the other functions and variables have similar results.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.  Done.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.  n/a
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.  n/a
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).  n/a
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).  n/a
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.  Done
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.  n/a
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
