### PR TITLE
feat(svg): add API for getting original width and height

### DIFF
--- a/src/libs/svg/lv_svg_render.c
+++ b/src/libs/svg/lv_svg_render.c
@@ -2429,6 +2429,27 @@ uint32_t lv_svg_render_get_size(const lv_svg_render_obj_t * render)
     return size;
 }
 
+lv_result_t lv_svg_render_get_viewport_size(const lv_svg_render_obj_t * render, float * width, float * height)
+{
+    if(!render) {
+        LV_LOG_WARN("Invalid render object");
+        return LV_RESULT_INVALID;
+    }
+
+    if(render->clz != &svg_viewport_class) {
+        LV_LOG_WARN("Invalid render object type");
+        return LV_RESULT_INVALID;
+    }
+    const lv_svg_render_viewport_t * cur = (const lv_svg_render_viewport_t *)render;
+    if(width) {
+        *width = cur->width;
+    }
+    if(height) {
+        *height = cur->height;
+    }
+    return LV_RESULT_OK;
+}
+
 void lv_draw_svg_render(lv_vector_dsc_t * dsc, const lv_svg_render_obj_t * render)
 {
     if(!render || !dsc) {

--- a/src/libs/svg/lv_svg_render.c
+++ b/src/libs/svg/lv_svg_render.c
@@ -2436,7 +2436,7 @@ lv_result_t lv_svg_render_get_viewport_size(const lv_svg_render_obj_t * render, 
         return LV_RESULT_INVALID;
     }
 
-    if(render->clz != &svg_viewport_class) {
+    if(render->clz != &svg_viewport_class){
         LV_LOG_WARN("Invalid render object type");
         return LV_RESULT_INVALID;
     }

--- a/src/libs/svg/lv_svg_render.c
+++ b/src/libs/svg/lv_svg_render.c
@@ -2436,7 +2436,7 @@ lv_result_t lv_svg_render_get_viewport_size(const lv_svg_render_obj_t * render, 
         return LV_RESULT_INVALID;
     }
 
-    if(render->clz != &svg_viewport_class){
+    if(render->clz != &svg_viewport_class) {
         LV_LOG_WARN("Invalid render object type");
         return LV_RESULT_INVALID;
     }

--- a/src/libs/svg/lv_svg_render.h
+++ b/src/libs/svg/lv_svg_render.h
@@ -94,6 +94,15 @@ void lv_svg_render_delete(lv_svg_render_obj_t * render);
 uint32_t lv_svg_render_get_size(const lv_svg_render_obj_t * render);
 
 /**
+ * @brief Get viewport's width and height of the render object
+ * @param render pointer to the SVG render object
+ * @param width pointer to save the width of the viewport of the SVG render object
+ * @param height pointer to save the height of the viewport of the SVG render object
+ * @return lv_result_t, LV_RESULT_OK if success, LV_RESULT_INVALID if fail
+ */
+lv_result_t lv_svg_render_get_viewport_size(const lv_svg_render_obj_t * render, float * width, float * height);
+
+/**
  * @brief Render an SVG object to a vector graphics
  * @param dsc pointer to the vector graphics descriptor
  * @param render pointer to the SVG render object to render

--- a/tests/src/test_cases/test_svg.c
+++ b/tests/src/test_cases/test_svg.c
@@ -140,6 +140,17 @@ void testSvgElement(void)
     TEST_ASSERT_EQUAL_FLOAT((LV_ARRAY_GET(&svg_node_wh5->attrs, 1, lv_svg_attr_t))->value.fval, 1.0f);
     lv_svg_node_delete(svg_node_wh5);
 
+    const char * svg_wh6 = \
+                           "<svg width=\"2048\" height=\"1023.549\"></svg>";
+    lv_svg_node_t * svg_node_wh6 = lv_svg_load_data(svg_wh6, lv_strlen(svg_wh6));
+    lv_svg_render_obj_t * draw_list = lv_svg_render_create(svg_node_wh6);
+    float svg_wh6_w, svg_wh6_h;
+    lv_svg_render_get_viewport_size(draw_list, &svg_wh6_w, &svg_wh6_h);
+    TEST_ASSERT_EQUAL_FLOAT(svg_wh6_w, 2048.0f);
+    TEST_ASSERT_EQUAL_FLOAT(svg_wh6_h, 1023.549f);
+    lv_svg_render_delete(draw_list);
+    lv_svg_node_delete(svg_node_wh6);
+
     /* preserveAspectRatio */
 
     const char * svg_ar0 = \


### PR DESCRIPTION
This API can help user set the scale when creating a SVG object.

When the user want their SVG fit the framebuffer, this could help.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
