### PR TITLE
fix(draw_sw): incompatible pointers, variable redefinitions and missing include v9.2

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -14,6 +14,7 @@
 #include "../../display/lv_display_private.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
+#include "../../misc/lv_area_private.h"
 
 #if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
     #if LV_USE_THORVG_EXTERNAL
@@ -553,14 +554,12 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
             draw_unit_tmp = draw_unit_tmp->next;
             idx++;
         }
-        lv_draw_rect_dsc_t rect_dsc;
-        lv_draw_rect_dsc_init(&rect_dsc);
-        rect_dsc.bg_color = lv_palette_main(idx % LV_PALETTE_LAST);
-        rect_dsc.border_color = rect_dsc.bg_color;
-        rect_dsc.bg_opa = LV_OPA_10;
-        rect_dsc.border_opa = LV_OPA_80;
-        rect_dsc.border_width = 1;
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &draw_area);
+
+        lv_draw_fill_dsc_t fill_dsc;
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
+        fill_dsc.opa = LV_OPA_10;
+        lv_draw_sw_fill((lv_draw_unit_t *)u, &fill_dsc, &draw_area);
 
         lv_point_t txt_size;
         lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
@@ -571,9 +570,9 @@ static void execute_drawing(lv_draw_sw_unit_t * u)
         txt_area.x2 = draw_area.x1 + txt_size.x - 1;
         txt_area.y2 = draw_area.y1 + txt_size.y - 1;
 
-        lv_draw_rect_dsc_init(&rect_dsc);
-        rect_dsc.bg_color = lv_color_white();
-        lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &txt_area);
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_color_white();
+        lv_draw_sw_fill((lv_draw_unit_t *)u, &fill_dsc, &txt_area);
 
         char buf[8];
         lv_snprintf(buf, sizeof(buf), "%d", idx);

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -103,62 +103,64 @@ void lv_draw_sw_layer(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * dr
 #endif
 
 #if LV_USE_LAYER_DEBUG
-    lv_draw_fill_dsc_t fill_dsc;
-    lv_draw_fill_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
-    fill_dsc.opa = LV_OPA_20;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+    {
+        lv_draw_fill_dsc_t fill_dsc;
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_color_hex(layer_to_draw->color_format == LV_COLOR_FORMAT_ARGB8888 ? 0xff0000 : 0x00ff00);
+        fill_dsc.opa = LV_OPA_20;
+        lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
 
-    lv_draw_border_dsc_t border_dsc;
-    lv_draw_border_dsc_init(&border_dsc);
-    border_dsc.color = fill_dsc.color;
-    border_dsc.opa = LV_OPA_60;
-    border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
-
+        lv_draw_border_dsc_t border_dsc;
+        lv_draw_border_dsc_init(&border_dsc);
+        border_dsc.color = fill_dsc.color;
+        border_dsc.opa = LV_OPA_60;
+        border_dsc.width = 2;
+        lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+    }
 #endif
 
 #if LV_USE_PARALLEL_DRAW_DEBUG
-    uint32_t idx = 0;
-    lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
-    while(draw_unit_tmp != draw_unit) {
-        draw_unit_tmp = draw_unit_tmp->next;
-        idx++;
+    {
+        uint32_t idx = 0;
+        lv_draw_unit_t * draw_unit_tmp = _draw_info.unit_head;
+        while(draw_unit_tmp != draw_unit) {
+            draw_unit_tmp = draw_unit_tmp->next;
+            idx++;
+        }
+        lv_draw_fill_dsc_t fill_dsc;
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
+        fill_dsc.opa = LV_OPA_10;
+        lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
+
+        lv_draw_border_dsc_t border_dsc;
+        lv_draw_border_dsc_init(&border_dsc);
+        border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
+        border_dsc.opa = LV_OPA_100;
+        border_dsc.width = 2;
+        lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
+
+        lv_point_t txt_size;
+        lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
+
+        lv_area_t txt_area;
+        txt_area.x1 = draw_area.x1;
+        txt_area.x2 = draw_area.x1 + txt_size.x - 1;
+        txt_area.y2 = draw_area.y2;
+        txt_area.y1 = draw_area.y2 - txt_size.y + 1;
+
+        lv_draw_fill_dsc_init(&fill_dsc);
+        fill_dsc.color = lv_color_black();
+        lv_draw_sw_fill(draw_unit, &fill_dsc, &txt_area);
+
+        char buf[8];
+        lv_snprintf(buf, sizeof(buf), "%d", idx);
+        lv_draw_label_dsc_t label_dsc;
+        lv_draw_label_dsc_init(&label_dsc);
+        label_dsc.color = lv_color_white();
+        label_dsc.text = buf;
+        lv_draw_sw_label(draw_unit, &label_dsc, &txt_area);
     }
-
-    lv_draw_fill_dsc_t fill_dsc;
-    lv_draw_rect_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
-    fill_dsc.opa = LV_OPA_10;
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &area_rot);
-
-    lv_draw_border_dsc_t border_dsc;
-    lv_draw_border_dsc_init(&border_dsc);
-    border_dsc.color = lv_palette_main(idx % LV_PALETTE_LAST);
-    border_dsc.opa = LV_OPA_100;
-    border_dsc.width = 2;
-    lv_draw_sw_border(draw_unit, &border_dsc, &area_rot);
-
-    lv_point_t txt_size;
-    lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
-
-    lv_area_t txt_area;
-    txt_area.x1 = draw_area.x1;
-    txt_area.x2 = draw_area.x1 + txt_size.x - 1;
-    txt_area.y2 = draw_area.y2;
-    txt_area.y1 = draw_area.y2 - txt_size.y + 1;
-
-    lv_draw_fill_dsc_init(&fill_dsc);
-    fill_dsc.color = lv_color_black();
-    lv_draw_sw_fill(draw_unit, &fill_dsc, &txt_area);
-
-    char buf[8];
-    lv_snprintf(buf, sizeof(buf), "%d", idx);
-    lv_draw_label_dsc_t label_dsc;
-    lv_draw_label_dsc_init(&label_dsc);
-    label_dsc.color = lv_color_white();
-    label_dsc.text = buf;
-    lv_draw_sw_label(draw_unit, &label_dsc, &txt_area);
 #endif
 }
 


### PR DESCRIPTION
Compiling v9.2 with :

```c
#define LV_USE_LAYER_DEBUG 1
#define LV_USE_PARALLEL_DRAW_DEBUG 1
```
Produces the following errors:

```bash
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.c: In function ‘execute_drawing’:
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.c:548:13: error: implicit declaration of function ‘lv_area_intersect’; did you mean ‘lv_area_increase’? [-Wimplicit-function-declaration]
  548 |         if(!lv_area_intersect(&draw_area, &t->area, u->base_unit.clip_area)) return;
      |             ^~~~~~~~~~~~~~~~~
      |             lv_area_increase
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.c:563:46: error: passing argument 2 of ‘lv_draw_sw_fill’ from incompatible pointer type [-Wincompatible-pointer-types]
  563 |         lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &draw_area);
      |                                              ^~~~~~~~~
      |                                              |
      |                                              lv_draw_rect_dsc_t *
In file included from /home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_private.h:17,
                 from /home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.c:9:
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.h:56:71: note: expected ‘lv_draw_fill_dsc_t *’ but argument is of type ‘lv_draw_rect_dsc_t *’
   56 | void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
      |                                                  ~~~~~~~~~~~~~~~~~~~~~^~~
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.c:576:46: error: passing argument 2 of ‘lv_draw_sw_fill’ from incompatible pointer type [-Wincompatible-pointer-types]
  576 |         lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &txt_area);
      |                                              ^~~~~~~~~
      |                                              |
      |                                              lv_draw_rect_dsc_t *
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.h:56:71: note: expected ‘lv_draw_fill_dsc_t *’ but argument is of type ‘lv_draw_rect_dsc_t *’
   56 | void lv_draw_sw_fill(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * dsc, const lv_area_t * coords);
      |                                                  ~~~~~~~~~~~~~~~~~~~~~^~~
make[2]: *** [lvgl/CMakeFiles/lvgl.dir/build.make:1012: lvgl/CMakeFiles/lvgl.dir/src/draw/sw/lv_draw_sw.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:162: lvgl/CMakeFiles/lvgl.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

```bash
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c: In function ‘lv_draw_sw_layer’:
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:129:24: error: redeclaration of ‘fill_dsc’ with no linkage
  129 |     lv_draw_fill_dsc_t fill_dsc;
      |                        ^~~~~~~~
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:106:24: note: previous declaration of ‘fill_dsc’ with type ‘lv_draw_fill_dsc_t’
  106 |     lv_draw_fill_dsc_t fill_dsc;
      |                        ^~~~~~~~
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:130:27: error: passing argument 1 of ‘lv_draw_rect_dsc_init’ from incompatible pointer type [-Wincompatible-pointer-types]
  130 |     lv_draw_rect_dsc_init(&fill_dsc);
      |                           ^~~~~~~~~
      |                           |
      |                           lv_draw_fill_dsc_t *
In file included from /home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/../lv_draw_triangle.h:16,
                 from /home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw.h:25,
                 from /home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:14:
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/../lv_draw_rect.h:116:77: note: expected ‘lv_draw_rect_dsc_t *’ but argument is of type ‘lv_draw_fill_dsc_t *’
  116 | void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc);
      |                                                        ~~~~~~~~~~~~~~~~~~~~~^~~
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:135:26: error: redeclaration of ‘border_dsc’ with no linkage
  135 |     lv_draw_border_dsc_t border_dsc;
      |                          ^~~~~~~~~~
/home/andre/dev/lv_port_pc_vscode/lvgl/src/draw/sw/lv_draw_sw_img.c:112:26: note: previous declaration of ‘border_dsc’ with type ‘lv_draw_border_dsc_t’
  112 |     lv_draw_border_dsc_t border_dsc;
      |                          ^~~~~~~~~~
make[2]: *** [lvgl/CMakeFiles/lvgl.dir/build.make:1096: lvgl/CMakeFiles/lvgl.dir/src/draw/sw/lv_draw_sw_img.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:162: lvgl/CMakeFiles/lvgl.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

The missing include and variable redefinitions were fixed for master in #8109
The invalid pointer type was fixed during #6761 

This PR adds the necessary fixes to the v9.2 branch