### PR TITLE
fix(wayland) - support version 2 of the XDG protocol

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -1226,24 +1226,9 @@ static void xdg_toplevel_handle_close(void * data, struct xdg_toplevel * xdg_top
     LV_UNUSED(xdg_toplevel);
 }
 
-static void xdg_toplevel_handle_configure_bounds(void * data, struct xdg_toplevel * xdg_toplevel,
-                                                 int32_t width, int32_t height)
-{
-
-    LV_UNUSED(width);
-    LV_UNUSED(height);
-    LV_UNUSED(data);
-    LV_UNUSED(xdg_toplevel);
-
-    /* Optional: Could set window width/height upper bounds, however, currently
-     *           we'll honor the set width/height.
-     */
-}
-
 static const struct xdg_toplevel_listener xdg_toplevel_listener = {
     .configure = xdg_toplevel_handle_configure,
     .close = xdg_toplevel_handle_close,
-    .configure_bounds = xdg_toplevel_handle_configure_bounds
 };
 
 static void xdg_wm_base_ping(void * data, struct xdg_wm_base * xdg_wm_base, uint32_t serial)
@@ -1291,8 +1276,8 @@ static void handle_global(void * data, struct wl_registry * registry,
 #endif
 #if LV_WAYLAND_XDG_SHELL
     else if(strcmp(interface, xdg_wm_base_interface.name) == 0) {
-        /* Explicitly support version 4 of the xdg protocol */
-        app->xdg_wm = wl_registry_bind(app->registry, name, &xdg_wm_base_interface, 4);
+        /* supporting version 2 of the XDG protocol - ensures greater compatibility */
+        app->xdg_wm = wl_registry_bind(app->registry, name, &xdg_wm_base_interface, 2);
         xdg_wm_base_add_listener(app->xdg_wm, &xdg_wm_base_listener, app);
     }
 #endif


### PR DESCRIPTION
fix lv_port_linux#62 By supporting an older version of the wayland XDG shell protocol, to make it function on RaspberryPi OS without patches.