### PR TITLE
fix(drm): link GBM automatically if enabled, 

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1226,7 +1226,7 @@
      * shared across sub-systems and libraries using the Linux DMA-BUF API.
      * The GBM library aims to provide a platform independent memory management system
      * it supports the major GPU vendors - This option requires linking with libgbm */
-    #define LV_LINUX_DRM_GBM_BUFFERS 0
+    #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
 #endif
 
 /** Interface for TFT_eSPI */

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -25,7 +25,7 @@
 #include "../../../stdlib/lv_sprintf.h"
 #include "../../../draw/lv_draw_buf.h"
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     #include <gbm.h>
     #include <linux/dma-buf.h>
@@ -110,7 +110,7 @@ static void drm_dmabuf_set_active_buf(lv_event_t * event);
 
 static uint32_t tick_get_cb(void);
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     static int create_gbm_buffer(drm_dev_t * drm_dev, drm_buffer_t * buf);
 
@@ -120,7 +120,7 @@ static uint32_t tick_get_cb(void);
  *  STATIC VARIABLES
  **********************/
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     static struct gbm_device * gbm_device;
 
@@ -186,7 +186,7 @@ static void drm_dmabuf_set_active_buf(lv_event_t * event)
         }
 
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
         struct dma_buf_sync sync_req;
         sync_req.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_RW;
@@ -442,7 +442,7 @@ static int drm_dmabuf_set_plane(drm_dev_t * drm_dev, drm_buffer_t * buf)
     static int first = 1;
     uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     struct dma_buf_sync sync_req;
 
@@ -807,7 +807,7 @@ static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t conn
                 (fourcc >> 0) & 0xff, (fourcc >> 8) & 0xff, (fourcc >> 16) & 0xff, (fourcc >> 24) & 0xff);
 
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     /* Create GBM device and buffer */
     gbm_device = gbm_create_device(drm_dev->fd);
@@ -886,7 +886,7 @@ static int drm_allocate_dumb(drm_dev_t * drm_dev, drm_buffer_t * buf)
     return 0;
 }
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
 static int create_gbm_buffer(drm_dev_t * drm_dev, drm_buffer_t * buf)
 {
@@ -975,14 +975,14 @@ static int create_gbm_buffer(drm_dev_t * drm_dev, drm_buffer_t * buf)
 
 }
 
-#endif /* END LV_LINUX_DRM_GBM_BUFFERS */
+#endif /* END LV_USE_LINUX_DRM_GBM_BUFFERS */
 
 
 static int drm_setup_buffers(drm_dev_t * drm_dev)
 {
     int ret;
 
-#if LV_LINUX_DRM_GBM_BUFFERS
+#if LV_USE_LINUX_DRM_GBM_BUFFERS
 
     ret = create_gbm_buffer(drm_dev, &drm_dev->drm_bufs[0]);
     if(ret < 0) {

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3955,11 +3955,11 @@
      * shared across sub-systems and libraries using the Linux DMA-BUF API.
      * The GBM library aims to provide a platform independent memory management system
      * it supports the major GPU vendors - This option requires linking with libgbm */
-    #ifndef LV_LINUX_DRM_GBM_BUFFERS
-        #ifdef CONFIG_LV_LINUX_DRM_GBM_BUFFERS
-            #define LV_LINUX_DRM_GBM_BUFFERS CONFIG_LV_LINUX_DRM_GBM_BUFFERS
+    #ifndef LV_USE_LINUX_DRM_GBM_BUFFERS
+        #ifdef CONFIG_LV_USE_LINUX_DRM_GBM_BUFFERS
+            #define LV_USE_LINUX_DRM_GBM_BUFFERS CONFIG_LV_USE_LINUX_DRM_GBM_BUFFERS
         #else
-            #define LV_LINUX_DRM_GBM_BUFFERS 0
+            #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
         #endif
     #endif
 #endif


### PR DESCRIPTION
Rename `LV_LINUX_DRM_GBM_BUFFERS` to `LV_USE_LINUX_DRM_GBM_BUFFERS` 
Depends on https://github.com/lvgl/lvgl/pull/8193 and https://github.com/lvgl/lv_port_linux/pull/83
Then #8104 will be fixed