### PR TITLE
fix(vg_lite): reset the scissor area when rendering with vg_lite.

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -135,12 +135,15 @@ static void draw_execute(lv_draw_vg_lite_unit_t * u)
     lv_vg_lite_matrix_multiply(&u->global_matrix, &layer_matrix);
 
     /* Crop out extra pixels drawn due to scaling accuracy issues */
+    lv_area_t scissor_area = layer->phy_clip_area;
+    lv_area_move(&scissor_area, -layer->buf_area.x1, -layer->buf_area.y1);
+#else
+    lv_area_t scissor_area = layer->_clip_area;
+#endif
+
     if(vg_lite_query_feature(gcFEATURE_BIT_VG_SCISSOR)) {
-        lv_area_t scissor_area = layer->phy_clip_area;
-        lv_area_move(&scissor_area, -layer->buf_area.x1, -layer->buf_area.y1);
         lv_vg_lite_set_scissor_area(&scissor_area);
     }
-#endif
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_LETTER:


### PR DESCRIPTION
The scissor area should be cleared each time you render to prevent the scissor area set in the last rendering from continuing to take effect.<!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
