### PR TITLE
patch(lv_draw_opengles.c) : added function to lv_glfw_window

### DIFF
--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -275,6 +275,10 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
         lv_obj_remove_flag(obj, LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS);
     }
 
+    lv_draw_dsc_base_t * base_dsc = task->draw_dsc;
+    cache_data->draw_dsc = lv_malloc(base_dsc->dsc_size);
+    lv_memcpy((void *)cache_data->draw_dsc, base_dsc, base_dsc->dsc_size);
+
     switch(task->type) {
         case LV_DRAW_TASK_TYPE_FILL: {
                 lv_draw_fill_dsc_t * fill_dsc = task->draw_dsc;
@@ -355,6 +359,8 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
                 break;
             }
         default:
+ 		/*The malloced cache_data->draw_dsc will be freed automatically on failure
+	 	 *in opengles_texture_cache_free_cb*/
             return false;
     }
 
@@ -367,10 +373,6 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
 
     unsigned int texture = create_texture(texture_w, texture_h, u->render_draw_buf.data);
 
-    lv_draw_dsc_base_t * base_dsc = task->draw_dsc;
-
-    cache_data->draw_dsc = lv_malloc(base_dsc->dsc_size);
-    lv_memcpy((void *)cache_data->draw_dsc, base_dsc, base_dsc->dsc_size);
     cache_data->w = texture_w;
     cache_data->h = texture_h;
     cache_data->texture = texture;

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -359,8 +359,8 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
                 break;
             }
         default:
- 		/*The malloced cache_data->draw_dsc will be freed automatically on failure
-	 	 *in opengles_texture_cache_free_cb*/
+            /*The malloced cache_data->draw_dsc will be freed automatically on failure
+            *in opengles_texture_cache_free_cb*/
             return false;
     }
 

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -122,6 +122,10 @@ void lv_glfw_window_delete(lv_glfw_window_t * window)
     }
 }
 
+void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window) {
+    return (void*)(window->window);
+}
+
 lv_glfw_texture_t * lv_glfw_window_add_texture(lv_glfw_window_t * window, unsigned int texture_id, int32_t w, int32_t h)
 {
     lv_glfw_texture_t * texture = lv_ll_ins_tail(&window->textures);

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -122,7 +122,8 @@ void lv_glfw_window_delete(lv_glfw_window_t * window)
     }
 }
 
-void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window) {
+void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window)
+{
     return (void*)(window->window);
 }
 

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -124,7 +124,7 @@ void lv_glfw_window_delete(lv_glfw_window_t * window)
 
 void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window)
 {
-    return (void*)(window->window);
+    return (void *)(window->window);
 }
 
 lv_glfw_texture_t * lv_glfw_window_add_texture(lv_glfw_window_t * window, unsigned int texture_id, int32_t w, int32_t h)

--- a/src/drivers/glfw/lv_glfw_window.h
+++ b/src/drivers/glfw/lv_glfw_window.h
@@ -49,8 +49,8 @@ void lv_glfw_window_delete(lv_glfw_window_t * window);
 
 /**
  * Get the GLFW window handle for an lv_glfw_window
- * @param window    	GLFW window to return the handle of
- * @return 		the GLFW window handle
+ * @param window        GLFW window to return the handle of
+ * @return              the GLFW window handle
  */
 void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window);
 

--- a/src/drivers/glfw/lv_glfw_window.h
+++ b/src/drivers/glfw/lv_glfw_window.h
@@ -48,6 +48,13 @@ lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool 
 void lv_glfw_window_delete(lv_glfw_window_t * window);
 
 /**
+ * Get the GLFW window handle for an lv_glfw_window
+ * @param window    	GLFW window to return the handle of
+ * @return 		the GLFW window handle
+ */
+void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window);
+
+/**
  * Add a texture to the GLFW window. It can be an LVGL display texture, or any OpenGL texture
  * @param window        GLFW window
  * @param texture_id    OpenGL texture ID


### PR DESCRIPTION
Fixes issue with OpenGL render textures freeing memory that didn't get allocated in some situations.  

Adds a function to lv_glfw_window to return the GLFW native window handle.  This allows for changing the window title, size, position, and aspect through GLFW calls.