### PR TITLE
Docs/toc size adjustments

### DIFF
--- a/docs/api_doc_builder.py
+++ b/docs/api_doc_builder.py
@@ -161,8 +161,8 @@ def _add_startswith_matches(strings: [str], genned_link_set, editor_link_set):
             for key in symbol_dict:
                 if key is None:
                     # Dictionary `enums` has a key `None` which contains
-                    # all enumvalues from all unnamed enums, and each
-                    # enumvalue has a `file_name` field.
+                    # all enum values from all unnamed enums, and each
+                    # enum value has a `file_name` field.
                     enum_values_list = symbol_dict[None].members
                     for enum_val in enum_values_list:
                         if enum_val.name.startswith(partial_symbol):
@@ -397,7 +397,7 @@ def _build_one_local_dictionary(local_dict, remote_dict):
     """
     for symbol in remote_dict:
         # Note:  symbol `None` is actually a valid symbol in the
-        # `enums` dictionary, containing all enumvalue symbols
+        # `enums` dictionary, containing all enum-value symbols
         # for enums without names.
         if symbol is None or not symbol.startswith('_lv'):
             loc_symbol = symbol
@@ -587,7 +587,7 @@ def _create_rst_files_for_dir(src_root_dir_len: int,
         f.write(subdir_stem + '\n')
         f.write(section_line)
         f.write('\n')
-        f.write('.. toctree::\n    :maxdepth: 2\n\n')
+        f.write('.. toctree::\n    :maxdepth: 1\n\n')
 
         # One entry per `.rst` file
         for h_file in elig_h_files:

--- a/docs/src/details/auxiliary-modules/index.rst
+++ b/docs/src/details/auxiliary-modules/index.rst
@@ -5,7 +5,7 @@ Auxiliary Modules
 =================
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     file_explorer
     font_manager
@@ -16,7 +16,7 @@ Auxiliary Modules
     monkey
     obj_id
     obj_property
-    observer
+    observer/index
     snapshot
     test
     xml/index

--- a/docs/src/details/auxiliary-modules/observer/index.rst
+++ b/docs/src/details/auxiliary-modules/observer/index.rst
@@ -1,0 +1,11 @@
+.. _observer:
+
+========
+Observer
+========
+
+.. toctree::
+    :maxdepth: 2
+
+    observer
+    observer_examples

--- a/docs/src/details/auxiliary-modules/observer/observer.rst
+++ b/docs/src/details/auxiliary-modules/observer/observer.rst
@@ -1,8 +1,8 @@
-.. _observer:
+.. _observer_how_to_use:
 
-========
-Observer
-========
+==========
+How to Use
+==========
 
 .. _observer_overview:
 
@@ -537,15 +537,6 @@ user's direct interaction with the Drop-Down Widget updates the Subject's value 
 vice versa.  (Requires :c:macro:`LV_USE_DROPDOWN` to be configured to ``1``.)
 
 - :cpp:expr:`lv_dropdown_bind_value(dropdown, &subject)`
-
-
-
-.. _observer_example:
-
-Examples
-********
-
-.. include:: ../../examples/others/observer/index.rst
 
 
 

--- a/docs/src/details/auxiliary-modules/observer/observer_examples.rst
+++ b/docs/src/details/auxiliary-modules/observer/observer_examples.rst
@@ -1,0 +1,8 @@
+.. _observer examples:
+
+========
+Examples
+========
+
+.. include:: ../../../examples/others/observer/index.rst
+


### PR DESCRIPTION
The Furo theme, but having a TOC on the right that shows the structure of the current document, exposed a few places where the document's own TOC was a bit too long and made the TOC on the right less useful.

The changes herein remedy those.  (There were only a few.)

To make adjustments to the nature of the API-page TOCs, the `api_doc_builder.py` portion of the doc-build toolchain needed an adjustment in the part that generated the `.rst` files for the API pages.

The appearance of the updates is visible [here](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/details/auxiliary-modules/index.html) and [here](http://crystal-clear-research.com/for_gabor/demo/docs.lvgl.io/master/API/index.html).

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
