### PR TITLE
feat(wayland): generate xdg-shell protocol sources during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,47 @@ if (MSVC)
     PRIVATE LV_ATTRIBUTE_EXTERN_DATA=__declspec\(dllexport\)
   )
 endif()
+
+if(LV_GENERATE_XDG)
+  # Locate wayland-scanner tool
+  find_program(WAYLAND_SCANNER_EXECUTABLE wayland-scanner REQUIRED)
+
+  # Set the path to the xdg-shell.xml (allow override via cache)
+  set(XDG_SHELL_XML_PATH
+    "${CMAKE_SYSROOT}/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml"
+    CACHE FILEPATH "Path to the xdg-shell.xml protocol definition")
+
+  # Output path for generated files
+  set(GENERATED_WAYLAND_DIR "${CMAKE_BINARY_DIR}/generated-wayland")
+  file(MAKE_DIRECTORY "${GENERATED_WAYLAND_DIR}")
+
+  # Generated files
+  set(XDG_SHELL_HEADER "${GENERATED_WAYLAND_DIR}/xdg-shell-client-protocol.h")
+  set(XDG_SHELL_CODE   "${GENERATED_WAYLAND_DIR}/xdg-shell-protocol.c")
+
+  # Generate header
+  add_custom_command(
+    OUTPUT ${XDG_SHELL_HEADER}
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header ${XDG_SHELL_XML_PATH} ${XDG_SHELL_HEADER}
+    DEPENDS ${XDG_SHELL_XML_PATH}
+    COMMENT "Generating xdg-shell-client-protocol.h"
+  )
+
+  # Generate code
+  add_custom_command(
+    OUTPUT ${XDG_SHELL_CODE}
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} private-code ${XDG_SHELL_XML_PATH} ${XDG_SHELL_CODE}
+    DEPENDS ${XDG_SHELL_XML_PATH}
+    COMMENT "Generating xdg-shell-protocol.c"
+  )
+
+  # Mark files as generated
+  set_source_files_properties(${XDG_SHELL_HEADER} ${XDG_SHELL_CODE} PROPERTIES GENERATED TRUE)
+
+  # Build a static library for the generated files
+  add_library(lv_xdg_shell STATIC ${XDG_SHELL_HEADER} ${XDG_SHELL_CODE})
+
+  target_include_directories(lv_xdg_shell INTERFACE ${GENERATED_WAYLAND_DIR})
+  target_link_libraries(lvgl PRIVATE lv_xdg_shell)
+
+endif()


### PR DESCRIPTION
### Summary

This PR introduces build-time generation of the `xdg-shell` Wayland protocol files (`xdg-shell-client-protocol.h` and `xdg-shell-protocol.c`) using `wayland-scanner`. These files are required for the Wayland backend in `lvgl`.

### Motivation

Previously, the protocol sources were expected to be pre-generated and copied into the source tree. This PR automates the process using CMake and ensures that they are always up-to-date with the system's installed Wayland protocols.

### Changes

- Locates `wayland-scanner`
- Uses it to generate header and source files from the system-installed `xdg-shell.xml`
- Builds the generated code into a new `lv_xdg_shell` static library
- Links this library into the main `lvgl` target
- The path to `xdg-shell.xml` can be overridden via the `XDG_SHELL_XML` CMake cache variable for maximum portability (e.g. non-standard sysroot, SDK builds, etc.).
- The generated files are marked with `GENERATED` to ensure CMake handles them properly.

### Benefits

- Keeps source tree clean from generated protocol files
- Makes the build more portable and reproducible
- Follows standard Wayland practices

### Notes

This change is modular and does not introduce new external dependencies beyond `wayland-scanner` (already required for Wayland development).

Tested with LVGL 9.2 on a system with the `wayland-protocols` package installed.

---

Let me know if you'd like this split into a separate CMake module or other approach.