### PR TITLE
feat(barcode): support raw code 128

### DIFF
--- a/docs/src/details/libs/barcode.rst
+++ b/docs/src/details/libs/barcode.rst
@@ -23,7 +23,14 @@ Use :cpp:func:`lv_barcode_create` to create a barcode object, and use
 Call :cpp:func:`lv_barcode_set_scale` to adjust scaling,
 call :cpp:func:`lv_barcode_set_dark_color` and :cpp:func:`lv_barcode_set_light_color`
 adjust colors.  Call :cpp:func:`lv_barcode_set_direction` to set the bar code's
-orientation.  After any of a bar code's settings have changed, call
+orientation.
+
+By default, :cpp:enumerator:`LV_BARCODE_ENCODING_CODE128_GS1` encoding is used
+and strips ``[FCN1]`` and spaces. Optionally use
+:cpp:func:`lv_barcode_set_encoding` to set
+:cpp:enumerator:`LV_BARCODE_ENCODING_CODE128_RAW`.
+
+After any of a bar code's settings have changed, call
 :cpp:func:`lv_barcode_update` again to regenerate it.
 
 

--- a/src/libs/barcode/lv_barcode.c
+++ b/src/libs/barcode/lv_barcode.c
@@ -105,6 +105,14 @@ void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled)
     lv_image_set_inner_align(obj, tiled ? LV_IMAGE_ALIGN_TILE : LV_IMAGE_ALIGN_DEFAULT);
 }
 
+void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+    barcode->encoding = encoding;
+}
+
 lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -127,10 +135,19 @@ lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
         return LV_RESULT_INVALID;
     }
 
-    int32_t barcode_w = (int32_t) code128_encode_gs1(data, out_buf, len);
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    int32_t barcode_w = 0;
+    switch(barcode->encoding) {
+        case LV_BARCODE_ENCODING_CODE128_GS1:
+            barcode_w = (int32_t) code128_encode_gs1(data, out_buf, len);
+            break;
+        case LV_BARCODE_ENCODING_CODE128_RAW:
+            barcode_w = (int32_t) code128_encode_raw(data, out_buf, len);
+            break;
+    }
     LV_LOG_INFO("barcode width = %" LV_PRId32, barcode_w);
 
-    lv_barcode_t * barcode = (lv_barcode_t *)obj;
     LV_ASSERT(barcode->scale > 0);
     uint16_t scale = barcode->scale;
 
@@ -235,6 +252,14 @@ uint16_t lv_barcode_get_scale(lv_obj_t * obj)
     return barcode->scale;
 }
 
+lv_barcode_encoding_t lv_barcode_get_encoding(const lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    const lv_barcode_t * barcode = (const lv_barcode_t *)obj;
+    return barcode->encoding;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -248,6 +273,7 @@ static void lv_barcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     barcode->light_color = lv_color_white();
     barcode->scale = 1;
     barcode->direction = LV_DIR_HOR;
+    barcode->encoding = LV_BARCODE_ENCODING_CODE128_GS1;
     lv_image_set_inner_align(obj, LV_IMAGE_ALIGN_DEFAULT);
 }
 

--- a/src/libs/barcode/lv_barcode.h
+++ b/src/libs/barcode/lv_barcode.h
@@ -28,6 +28,17 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef enum {
+    /**
+     * Code 128 with GS1 encoding. Strips `[FCN1]` and spaces.
+     */
+    LV_BARCODE_ENCODING_CODE128_GS1,
+    /**
+     * Code 128 with raw encoding.
+     */
+    LV_BARCODE_ENCODING_CODE128_RAW,
+} lv_barcode_encoding_t;
+
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_barcode_class;
 
 /**********************
@@ -77,6 +88,13 @@ void lv_barcode_set_direction(lv_obj_t * obj, lv_dir_t direction);
 void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled);
 
 /**
+ * Set the encoding of a barcode object
+ * @param obj pointer to barcode object
+ * @param encoding encoding (default is `LV_BARCODE_CODE128_GS1`)
+ */
+void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding);
+
+/**
  * Set the data of a barcode object
  * @param obj pointer to barcode object
  * @param data data to display
@@ -104,6 +122,13 @@ lv_color_t lv_barcode_get_light_color(lv_obj_t * obj);
  * @return scale factor
  */
 uint16_t lv_barcode_get_scale(lv_obj_t * obj);
+
+/**
+ * Get the encoding of a barcode object
+ * @param obj pointer to barcode object
+ * @return encoding
+ */
+lv_barcode_encoding_t lv_barcode_get_encoding(const lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/src/libs/barcode/lv_barcode_private.h
+++ b/src/libs/barcode/lv_barcode_private.h
@@ -35,6 +35,7 @@ struct _lv_barcode_t {
     uint16_t scale;
     lv_dir_t direction;
     bool tiled;
+    lv_barcode_encoding_t encoding;
 };
 
 


### PR DESCRIPTION
Sometimes spaces are needed in bar codes, but the default GS1 encoding strips them. Also support the raw encoding, which is already implemented in the underlying library.