### PR TITLE
chore: use keyword arguments in regex calls to avoid warnings

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -133,9 +133,9 @@ for line in fin.read().splitlines():
     indent = r[1]
 
     name = r[3]
-    name = re.sub(r'\(.*?\)', '', name, 1)    #remove parentheses from macros. E.g. MY_FUNC(5) -> MY_FUNC
+    name = re.sub(r'\(.*?\)', '', name, count=1)    #remove parentheses from macros. E.g. MY_FUNC(5) -> MY_FUNC
 
-    line = re.sub(r'[\s]*', '', line, 1)
+    line = re.sub(r'[\s]*', '', line, count=1)
 
     #If the value should be 1 (enabled) by default use a more complex structure for Kconfig checks because
     #if a not defined CONFIG_... value should be interpreted as 0 and not the LVGL default


### PR DESCRIPTION
# PR Summary
This small PR resolves the regex library warnings showing in Python3.13:
```python
DeprecationWarning: 'count' is passed as positional argument
```