### PR TITLE
feat(dma2d): improve DMA2D Compatibility

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -211,72 +211,18 @@ void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuratio
 #if LV_DRAW_DMA2D_CACHE
 void lv_draw_dma2d_invalidate_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
-    if((SCB->CCR & SCB_CCR_DC_Msk) == 0) return; /* data cache is disabled */
-
-    uint32_t rows_remaining = mem_area->height;
-    uint32_t row_addr = (uint32_t)(uintptr_t) mem_area->first_byte;
-    uint32_t row_end_addr = 0;
-
-    __DSB();
-
-    while(rows_remaining) {
-        uint32_t addr = row_addr & ~(__SCB_DCACHE_LINE_SIZE - 1U);
-        uint32_t cache_lines = ((((row_addr + mem_area->width_bytes - 1) & ~(__SCB_DCACHE_LINE_SIZE - 1U)) - addr) /
-                                __SCB_DCACHE_LINE_SIZE) + 1;
-
-        if(addr == row_end_addr) {
-            addr += __SCB_DCACHE_LINE_SIZE;
-            cache_lines--;
-        }
-
-        while(cache_lines) {
-            SCB->DCIMVAC = addr;
-            addr += __SCB_DCACHE_LINE_SIZE;
-            cache_lines--;
-        }
-
-        row_end_addr = addr - __SCB_DCACHE_LINE_SIZE;
-        row_addr += mem_area->stride;
-        rows_remaining--;
-    };
-
-    __DSB();
-    __ISB();
+    if (SCB->CCR & SCB_CCR_DC_Msk)
+    {
+        SCB_CleanInvalidateDCache();
+    }
 }
 
 void lv_draw_dma2d_clean_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
-    if((SCB->CCR & SCB_CCR_DC_Msk) == 0) return;  /* data cache is disabled */
-
-    uint32_t rows_remaining = mem_area->height;
-    uint32_t row_addr = (uint32_t)(uintptr_t) mem_area->first_byte;
-    uint32_t row_end_addr = 0;
-
-    __DSB();
-
-    while(rows_remaining) {
-        uint32_t addr = row_addr & ~(__SCB_DCACHE_LINE_SIZE - 1U);
-        uint32_t cache_lines = ((((row_addr + mem_area->width_bytes - 1) & ~(__SCB_DCACHE_LINE_SIZE - 1U)) - addr) /
-                                __SCB_DCACHE_LINE_SIZE) + 1;
-
-        if(addr == row_end_addr) {
-            addr += __SCB_DCACHE_LINE_SIZE;
-            cache_lines--;
-        }
-
-        while(cache_lines) {
-            SCB->DCCMVAC = addr;
-            addr += __SCB_DCACHE_LINE_SIZE;
-            cache_lines--;
-        }
-
-        row_end_addr = addr - __SCB_DCACHE_LINE_SIZE;
-        row_addr += mem_area->stride;
-        rows_remaining--;
-    };
-
-    __DSB();
-    __ISB();
+    if (SCB->CCR & SCB_CCR_DC_Msk)
+    {
+        SCB_CleanInvalidateDCache();
+    }
 }
 #endif
 

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -212,14 +212,14 @@ void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuratio
 void lv_draw_dma2d_invalidate_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
     if(SCB->CCR & SCB_CCR_DC_Msk) {
-        SCB_CleanInvalidateDCache();
+        SCB_InvalidateDCache();
     }
 }
 
 void lv_draw_dma2d_clean_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
     if(SCB->CCR & SCB_CCR_DC_Msk) {
-        SCB_CleanInvalidateDCache();
+        SCB_CleanDCache();
     }
 }
 #endif

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -211,16 +211,14 @@ void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuratio
 #if LV_DRAW_DMA2D_CACHE
 void lv_draw_dma2d_invalidate_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
-    if (SCB->CCR & SCB_CCR_DC_Msk)
-    {
+    if(SCB->CCR & SCB_CCR_DC_Msk) {
         SCB_CleanInvalidateDCache();
     }
 }
 
 void lv_draw_dma2d_clean_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
-    if (SCB->CCR & SCB_CCR_DC_Msk)
-    {
+    if(SCB->CCR & SCB_CCR_DC_Msk) {
         SCB_CleanInvalidateDCache();
     }
 }

--- a/src/draw/dma2d/lv_draw_dma2d_fill.c
+++ b/src/draw/dma2d/lv_draw_dma2d_fill.c
@@ -117,6 +117,12 @@ void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32
         .bg_cf = (lv_draw_dma2d_fgbg_cf_t) output_cf
     };
 
+    /* Background alpha channel should be treated as 0xFF if the cf is XRGB */
+    if(cf == LV_COLOR_FORMAT_XRGB8888) {
+        conf.bg_alpha_mode = LV_DRAW_DMA2D_ALPHA_MODE_REPLACE_ALPHA_CHANNEL;
+        conf.bg_alpha = 0xff;
+    }
+
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }
 

--- a/src/draw/dma2d/lv_draw_dma2d_fill.c
+++ b/src/draw/dma2d/lv_draw_dma2d_fill.c
@@ -93,8 +93,9 @@ void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32
 #endif
 
     uint32_t output_offset = (stride / cf_size) - w;
+
     lv_draw_dma2d_configuration_t conf = {
-        .mode = LV_DRAW_DMA2D_MODE_MEMORY_TO_MEMORY_WITH_BLENDING_AND_FIXED_COLOR_FG,
+        .mode = LV_DRAW_DMA2D_MODE_MEMORY_TO_MEMORY_WITH_BLENDING,
         .w = w,
         .h = h,
 
@@ -103,19 +104,18 @@ void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32
         .output_cf = output_cf,
 
         .fg_color = lv_color_to_u32(color),
+        .fg_address = first_pixel,
+        .fg_offset = output_offset,
         .fg_alpha_mode = LV_DRAW_DMA2D_ALPHA_MODE_REPLACE_ALPHA_CHANNEL,
         .fg_alpha = opa,
+        .fg_cf = LV_DRAW_DMA2D_FGBG_CF_A8,
 
         .bg_address = first_pixel,
         .bg_offset = output_offset,
+        .bg_alpha_mode = LV_DRAW_DMA2D_ALPHA_MODE_NO_MODIFY_IMAGE_ALPHA_CHANNEL,
+        .bg_alpha = opa,
         .bg_cf = (lv_draw_dma2d_fgbg_cf_t) output_cf
     };
-
-    /* Background alpha channel should be treated as 0xFF if the cf is XRGB */
-    if(cf == LV_COLOR_FORMAT_XRGB8888) {
-        conf.bg_alpha_mode = LV_DRAW_DMA2D_ALPHA_MODE_REPLACE_ALPHA_CHANNEL;
-        conf.bg_alpha = 0xff;
-    }
 
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -31,7 +31,7 @@ extern "C" {
 #define LV_DRAW_DMA2D_ASYNC 0
 #endif
 
-#if defined(__CORTEX_M) && (__CORTEX_M == 7)
+#if defined(__CORTEX_M) && ((__CORTEX_M == 7) || (__CORTEX_M == 55))
 #define LV_DRAW_DMA2D_CACHE 1
 #else
 #define LV_DRAW_DMA2D_CACHE 0


### PR DESCRIPTION
While working with LVGL on STM32F7 and STM32N6 I have discovered several compatibility issues that I've attempted to fix.

## DMA2D Cache for CM55 (bdfdb17238e1)

For the DMA2D to draw without issues on STM32N6, `LV_DRAW_DMA2D_CACHE = 1` must be set. This internal check fails as previously this was only necessary for targets with a CM7.

## DMA2D Cache Invalidation and Cleaning for STM32F7 (cad6985ac86a)

The current `lv_draw_dma2d_invalidate_cache` and `lv_draw_dma2d_clean_cache` are quite complex and fail to build for a STM32F769 target due to the `__SCB_DCACHE_LINE_SIZE` define not being present in the F7 CMSIS package.

Maybe there's a good reason for the added complexity, but simply using `SCB_CleanInvalidateDCache()` seems to work well. This should build for all STM32 targets, and I weren't able to measure a performance difference between the two implementations on STM32N6.

## DMA2D Fill with Blending (3ad477b2a40a)

There seems to exist several revisions of the DMA2D IP in different STM32 targets. The current implementation in LVGL relies on a newer revision that has 6 "modes":

![image](https://github.com/user-attachments/assets/3b8e3d8b-b556-4b24-8eba-1124b3054fad)
_STM32H7RS Reference Manual_

However, older revisions only support the first four modes:

![image](https://github.com/user-attachments/assets/9edef1c0-9407-44e9-b586-3b6518a0f12b)
_STM32F7 Reference Manual_

This only causes issues for `lv_draw_dma2d_fill`, as LVGL uses the _Memory-to-memory with PFC, blending and fixed FG color_ mode. This results in fills that won't be drawn on older targets such as STM32F7. 

I have rewritten `lv_draw_dma2d_fill` to perform the fixed-fg blending by using the A8 color mode for the fg. I have verified that the color-blending works correct in a simple demo of three overlapping rectangles with both 16 and 32BPP. This should probably be tested by others, but I can't immediately see any issues.

![image](https://github.com/user-attachments/assets/7ff2a23d-fe03-4138-a355-02d87010e9fe)
_FB Dump of new new DMA2D fill implementation._

## Benchmarks

I suspected that the complex cache invalidation and flushing functions might be for performance. I did some quick measurements of the LVGL benchmark on STM32N6. It would probably have been better to benchmark on a slower platform, but it was what I had available today.

- SW: Default Software Rendering
- DMA2D Default: Default DMA2D Implementation (only bdfdb17238e1)
- DMA2D Cache: DMA2D with simpler cache cleaning/flushing (bdfdb17238e1 and cad6985ac86a)
- DMA2D Draw: DMA2D with new fill implementation (bdfdb17238e1 and cad6985ac86a and 3ad477b2a40a)

![image](https://github.com/user-attachments/assets/fd8b8959-bc8a-4ba2-a885-51426a392169)
