### PR TITLE
Add null check for free_cb in lv_vg_lite_pending_array_clear

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_pending.c
+++ b/src/draw/vg_lite/lv_vg_lite_pending.c
@@ -101,7 +101,7 @@ void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending)
 
 static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t * pending, lv_array_t * arr)
 {
-    LV_ASSERT_NULL(pending->free_cb);
+    if (!pending->free_cb) return; // fail-safe
 
     uint32_t size = lv_array_size(arr);
     if(size == 0) {


### PR DESCRIPTION
Adds a null check in lv_vg_lite_pending_array_clear to prevent a potential crash when free_cb is not set.

Bug Fix in Source Code:
In src/draw/vg_lite/lv_vg_lite_pending.c, the following line was added to prevent a potential crash when no cleanup callback is configured:

if (!pending->free_cb) return; // fail-safe

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
