### PR TITLE
fix(rollor): code quality INTEGER_OVERFLOW

### DIFF
--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -800,8 +800,13 @@ static lv_result_t release_handler(lv_obj_t * obj)
             int32_t label_y1 = label->coords.y1 + sum;
             int32_t id = (mid - label_y1) / label_unit;
 
-            if(id < 0) id = 0;
-            if(id >= (int32_t)roller->option_cnt) id = roller->option_cnt - 1;
+            if(roller->option_cnt == 0) {
+                id = 0;
+            }
+            else {
+                if(id < 0) id = 0;
+                if(id >= (int32_t)roller->option_cnt) id = roller->option_cnt - 1;
+            }
 
             new_opt = id;
         }


### PR DESCRIPTION
overflow_const: Expression id, which is equal to 4294967295, where roller->option_cnt - 1UL is known to be equal to 4294967295, overflows the type that receives it, a signed integer 32 bits wide.

Change-Id: I8ea1004f6941abf91e6dc55411d7242dd80140fa

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
