### PR TITLE
feat(draw_3d): added glfw window create_ex and window & 3d_texture h/v flip

### DIFF
--- a/src/draw/lv_draw_3d.c
+++ b/src/draw/lv_draw_3d.c
@@ -41,6 +41,8 @@ void lv_draw_3d_dsc_init(lv_draw_3d_dsc_t * dsc)
     lv_memzero(dsc, sizeof(lv_draw_3d_dsc_t));
     dsc->base.dsc_size = sizeof(lv_draw_3d_dsc_t);
     dsc->tex_id = LV_3DTEXTURE_ID_NULL;
+    dsc->h_flip = false;
+    dsc->v_flip = true;
     dsc->opa = LV_OPA_COVER;
 }
 

--- a/src/draw/lv_draw_3d.h
+++ b/src/draw/lv_draw_3d.h
@@ -30,6 +30,8 @@ extern "C" {
 typedef struct {
     lv_draw_dsc_base_t base;
     lv_3dtexture_id_t tex_id;
+    bool h_flip;
+    bool v_flip;
     lv_opa_t opa;
 } lv_draw_3d_dsc_t;
 

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -430,7 +430,13 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
     lv_draw_opengles_unit_t * u = (lv_draw_opengles_unit_t *)t->draw_unit;
     cache_data_t data_to_find;
     data_to_find.draw_dsc = (lv_draw_dsc_base_t *)t->draw_dsc;
-
+    bool h_flip = false;
+    bool v_flip = true;
+    if (t->type == LV_DRAW_TASK_TYPE_3D) {
+        lv_draw_3d_dsc_t* _3d_dsc = (lv_draw_3d_dsc_t *)t->draw_dsc;
+        h_flip = _3d_dsc->h_flip;
+        v_flip = _3d_dsc->v_flip;
+    }
     data_to_find.w = lv_area_get_width(&t->_real_area);
     data_to_find.h = lv_area_get_height(&t->_real_area);
     data_to_find.texture = 0;
@@ -503,7 +509,7 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
     lv_area_move(&t->clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
     lv_area_t render_area = t->_real_area;
     lv_area_move(&render_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
-    lv_opengles_render_texture(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, true);
+    lv_opengles_render_texture(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
 
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 
@@ -624,7 +630,7 @@ static void lv_draw_opengles_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc
     lv_area_t clip_area = t->clip_area;
     lv_area_move(&clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
 
-    lv_opengles_render_texture(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, true);
+    lv_opengles_render_texture(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, dsc->h_flip, dsc->v_flip);
 
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -432,8 +432,8 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
     data_to_find.draw_dsc = (lv_draw_dsc_base_t *)t->draw_dsc;
     bool h_flip = false;
     bool v_flip = true;
-    if (t->type == LV_DRAW_TASK_TYPE_3D) {
-        lv_draw_3d_dsc_t* _3d_dsc = (lv_draw_3d_dsc_t *)t->draw_dsc;
+    if(t->type == LV_DRAW_TASK_TYPE_3D) {
+        lv_draw_3d_dsc_t * _3d_dsc = (lv_draw_3d_dsc_t *)t->draw_dsc;
         h_flip = _3d_dsc->h_flip;
         v_flip = _3d_dsc->v_flip;
     }

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -74,13 +74,13 @@ static lv_ll_t glfw_window_ll;
 lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip,
                                             bool v_flip,  const char * window_title, const char * desktop_file_name)
 {
-    const char * _defaultTitle = "";
-    const char * _defaultSuffix = "[ LVGL Simulator ]";
-    const char * _default_desktop_file = "lvgl_simulator";
-    char * _title = (char *)_default_desktop_file;
+    const char * default_title = "";
+    const char * default_suffix = "[ LVGL Simulator ]";
+    const char * default_desktop_file = "lvgl_simulator";
+    char * title = (char *)default_desktop_file;
 
     if(desktop_file_name != NULL) {
-        _title = (char *)desktop_file_name;
+        title = (char *)desktop_file_name;
     }
 
     if(lv_glfw_init() != 0) {
@@ -94,7 +94,7 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
 
     /* Create window with graphics context */
     lv_glfw_window_t * existing_window = lv_ll_get_head(&glfw_window_ll);
-    window->window = glfwCreateWindow(hor_res, ver_res, _title, NULL,
+    window->window = glfwCreateWindow(hor_res, ver_res, title, NULL,
                                       existing_window ? existing_window->window : NULL);
     if(window->window == NULL) {
         LV_LOG_ERROR("glfwCreateWindow fail.");
@@ -103,14 +103,14 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
         return NULL;
     }
 
-    _title = (window_title != NULL) ? (char *)window_title : (char *)_defaultTitle;
+    title = (window_title != NULL) ? (char *)window_title : (char *)default_title;
     if(desktop_file_name == NULL) {
         char buffer[256];
-        sprintf(buffer, "%s %s", _title, _defaultSuffix);
+        sprintf(buffer, "%s %s", title, default_suffix);
         glfwSetWindowTitle(window->window, buffer);
     }
     else {
-        glfwSetWindowTitle(window->window, _title);
+        glfwSetWindowTitle(window->window, title);
     }
 
     window->h_flip = h_flip;

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -349,10 +349,10 @@ static void window_update_handler(lv_timer_t * t)
 
             lv_area_t clip_area = texture->area;
 #if LV_USE_DRAW_OPENGLES
-            lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+            lv_opengles_render_texture_dualflip(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
                                        &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip);
 #else
-            lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+            lv_opengles_render_texture_dualflip(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
                                        &clip_area, window->h_flip, window->v_flip);
 #endif
         }

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -68,9 +68,9 @@ static lv_ll_t glfw_window_ll;
  *   GLOBAL FUNCTIONS
  **********************/
 
-// Note: to enable taskbar window icon on Linux Wayland desktops, the window_title must match the
-// name of the applications/my_app.desktop file, minus the .desktop extension, at the time the
-// window is created (then it can be changed to whatever).  so 'my_app', in this example.
+/* Note: to enable taskbar window icon on Linux Wayland desktops, the window_title must match the
+   name of the applications/my_app.desktop file, minus the .desktop extension, at the time the
+   window is created (then it can be changed to whatever).  so 'my_app', in this example. */
 lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip,
                                             bool v_flip,  const char * window_title, const char * desktop_file_name)
 {

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -10,7 +10,7 @@
 #if LV_USE_OPENGLES
 #include <stdlib.h>
 #include "../../core/lv_refr.h"
-#include "../../stdlib/lv_snprintf.h"
+#include "../../stdlib/lv_sprintf.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
 #include "../../display/lv_display_private.h"

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -67,8 +67,19 @@ static lv_ll_t glfw_window_ll;
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool use_mouse_indev)
+// Note: to enable taskbar window icon on Linux Wayland desktops, the window_title must match the
+// name of the applications/my_app.desktop file, minus the .desktop extension, at the time the 
+// window is created (then it can be changed to whatever).  so 'my_app', in this example.
+lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip, bool v_flip,  const char* window_title, const char* desktop_file_name)
 {
+    const char * _defaultTitle = "";
+    const char * _defaultSuffix = "[ LVGL Simulator ]";
+    const char * _default_desktop_file = "lvgl_simulator";
+    char * _title = (char*)_default_desktop_file;
+
+    if (desktop_file_name != NULL) {
+        _title = (char *)desktop_file_name; }
+
     if(lv_glfw_init() != 0) {
         return NULL;
     }
@@ -80,7 +91,7 @@ lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool 
 
     /* Create window with graphics context */
     lv_glfw_window_t * existing_window = lv_ll_get_head(&glfw_window_ll);
-    window->window = glfwCreateWindow(hor_res, ver_res, "LVGL Simulator", NULL,
+    window->window = glfwCreateWindow(hor_res, ver_res, _title, NULL,
                                       existing_window ? existing_window->window : NULL);
     if(window->window == NULL) {
         LV_LOG_ERROR("glfwCreateWindow fail.");
@@ -89,6 +100,17 @@ lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool 
         return NULL;
     }
 
+    _title = (window_title != NULL) ? (char *)window_title : (char*)_defaultTitle;
+    if (desktop_file_name == NULL) {
+        const char buffer[256];
+        sprintf(buffer, "%s %s", _title, _defaultSuffix);
+        glfwSetWindowTitle(window->window, buffer );
+    } else {
+        glfwSetWindowTitle(window->window, _title );
+    }
+
+    window->h_flip = h_flip;
+    window->v_flip = v_flip;
     window->hor_res = hor_res;
     window->ver_res = ver_res;
     lv_ll_init(&window->textures, sizeof(lv_glfw_texture_t));
@@ -102,6 +124,11 @@ lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool 
     lv_opengles_init();
 
     return window;
+}
+
+lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool use_mouse_indev)
+{
+    return lv_glfw_window_create_ex(hor_res, ver_res, use_mouse_indev, false, false, NULL, NULL);
 }
 
 void lv_glfw_window_delete(lv_glfw_window_t * window)
@@ -125,6 +152,11 @@ void lv_glfw_window_delete(lv_glfw_window_t * window)
 void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window)
 {
     return (void *)(window->window);
+}
+
+void lv_glfw_window_set_flip(lv_glfw_window_t * window, bool h_flip, bool v_flip) {
+    window->h_flip = h_flip;
+    window->v_flip = v_flip;
 }
 
 lv_glfw_texture_t * lv_glfw_window_add_texture(lv_glfw_window_t * window, unsigned int texture_id, int32_t w, int32_t h)
@@ -308,10 +340,10 @@ static void window_update_handler(lv_timer_t * t)
             lv_area_t clip_area = texture->area;
 #if LV_USE_DRAW_OPENGLES
             lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                       &clip_area, texture_disp == NULL);
+                                       &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip );
 #else
             lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                       &clip_area, true);
+                                       &clip_area, window->h_flip, window->v_flip);
 #endif
         }
 
@@ -371,8 +403,8 @@ static void proc_mouse(lv_glfw_window_t * window)
     LV_LL_READ_BACK(&window->textures, texture) {
         if(lv_area_is_point_on(&texture->area, &window->mouse_last_point, 0)) {
             /* adjust the mouse pointer coordinates so that they are relative to the texture */
-            texture->indev_last_point.x = window->mouse_last_point.x - texture->area.x1;
-            texture->indev_last_point.y = window->mouse_last_point.y - texture->area.y1;
+            texture->indev_last_point.x = window->h_flip ? ( texture->area.x2 - window->mouse_last_point.x  ) : ( window->mouse_last_point.x - texture->area.x1 );
+            texture->indev_last_point.y = window->v_flip ? ( texture->area.y2 - window->mouse_last_point.y ) : ( window->mouse_last_point.y - texture->area.y1 );
             texture->indev_last_state = window->mouse_last_state;
             lv_indev_read(texture->indev);
             break;

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -107,7 +107,7 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
     if(desktop_file_name == NULL) {
         char buffer[256];
         lv_snprintf(buffer, 255, "%s %s", title, default_suffix);
-        buffer[255]='\0';
+        buffer[255] = '\0';
         glfwSetWindowTitle(window->window, buffer);
     }
     else {

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -9,6 +9,7 @@
 #include "lv_glfw_window_private.h"
 #if LV_USE_OPENGLES
 #include <stdlib.h>
+#include <stdio.h>
 #include "../../core/lv_refr.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
@@ -68,17 +69,19 @@ static lv_ll_t glfw_window_ll;
  **********************/
 
 // Note: to enable taskbar window icon on Linux Wayland desktops, the window_title must match the
-// name of the applications/my_app.desktop file, minus the .desktop extension, at the time the 
+// name of the applications/my_app.desktop file, minus the .desktop extension, at the time the
 // window is created (then it can be changed to whatever).  so 'my_app', in this example.
-lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip, bool v_flip,  const char* window_title, const char* desktop_file_name)
+lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip,
+                                            bool v_flip,  const char * window_title, const char * desktop_file_name)
 {
     const char * _defaultTitle = "";
     const char * _defaultSuffix = "[ LVGL Simulator ]";
     const char * _default_desktop_file = "lvgl_simulator";
-    char * _title = (char*)_default_desktop_file;
+    char * _title = (char *)_default_desktop_file;
 
-    if (desktop_file_name != NULL) {
-        _title = (char *)desktop_file_name; }
+    if(desktop_file_name != NULL) {
+        _title = (char *)desktop_file_name;
+    }
 
     if(lv_glfw_init() != 0) {
         return NULL;
@@ -100,13 +103,14 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
         return NULL;
     }
 
-    _title = (window_title != NULL) ? (char *)window_title : (char*)_defaultTitle;
-    if (desktop_file_name == NULL) {
-        const char buffer[256];
+    _title = (window_title != NULL) ? (char *)window_title : (char *)_defaultTitle;
+    if(desktop_file_name == NULL) {
+        char buffer[256];
         sprintf(buffer, "%s %s", _title, _defaultSuffix);
-        glfwSetWindowTitle(window->window, buffer );
-    } else {
-        glfwSetWindowTitle(window->window, _title );
+        glfwSetWindowTitle(window->window, buffer);
+    }
+    else {
+        glfwSetWindowTitle(window->window, _title);
     }
 
     window->h_flip = h_flip;
@@ -129,6 +133,11 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
 lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool use_mouse_indev)
 {
     return lv_glfw_window_create_ex(hor_res, ver_res, use_mouse_indev, false, false, NULL, NULL);
+}
+
+void lv_glfw_window_set_title(lv_glfw_window_t * window, const char * new_title)
+{
+    glfwSetWindowTitle(window->window, new_title);
 }
 
 void lv_glfw_window_delete(lv_glfw_window_t * window)
@@ -154,7 +163,8 @@ void * lv_glfw_window_get_glfw_window(lv_glfw_window_t * window)
     return (void *)(window->window);
 }
 
-void lv_glfw_window_set_flip(lv_glfw_window_t * window, bool h_flip, bool v_flip) {
+void lv_glfw_window_set_flip(lv_glfw_window_t * window, bool h_flip, bool v_flip)
+{
     window->h_flip = h_flip;
     window->v_flip = v_flip;
 }
@@ -340,7 +350,7 @@ static void window_update_handler(lv_timer_t * t)
             lv_area_t clip_area = texture->area;
 #if LV_USE_DRAW_OPENGLES
             lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                       &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip );
+                                       &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip);
 #else
             lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
                                        &clip_area, window->h_flip, window->v_flip);
@@ -403,8 +413,10 @@ static void proc_mouse(lv_glfw_window_t * window)
     LV_LL_READ_BACK(&window->textures, texture) {
         if(lv_area_is_point_on(&texture->area, &window->mouse_last_point, 0)) {
             /* adjust the mouse pointer coordinates so that they are relative to the texture */
-            texture->indev_last_point.x = window->h_flip ? ( texture->area.x2 - window->mouse_last_point.x  ) : ( window->mouse_last_point.x - texture->area.x1 );
-            texture->indev_last_point.y = window->v_flip ? ( texture->area.y2 - window->mouse_last_point.y ) : ( window->mouse_last_point.y - texture->area.y1 );
+            texture->indev_last_point.x = window->h_flip ? (texture->area.x2 - window->mouse_last_point.x) :
+                                          (window->mouse_last_point.x - texture->area.x1);
+            texture->indev_last_point.y = window->v_flip ? (texture->area.y2 - window->mouse_last_point.y) :
+                                          (window->mouse_last_point.y - texture->area.y1);
             texture->indev_last_state = window->mouse_last_state;
             lv_indev_read(texture->indev);
             break;

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -9,8 +9,8 @@
 #include "lv_glfw_window_private.h"
 #if LV_USE_OPENGLES
 #include <stdlib.h>
-#include <stdio.h>
 #include "../../core/lv_refr.h"
+#include "../../stdlib/lv_snprintf.h"
 #include "../../stdlib/lv_string.h"
 #include "../../core/lv_global.h"
 #include "../../display/lv_display_private.h"
@@ -106,7 +106,8 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
     title = (window_title != NULL) ? (char *)window_title : (char *)default_title;
     if(desktop_file_name == NULL) {
         char buffer[256];
-        sprintf(buffer, "%s %s", title, default_suffix);
+        lv_snprintf(buffer, 255, "%s %s", title, default_suffix);
+        buffer[255]='\0';
         glfwSetWindowTitle(window->window, buffer);
     }
     else {
@@ -350,10 +351,10 @@ static void window_update_handler(lv_timer_t * t)
             lv_area_t clip_area = texture->area;
 #if LV_USE_DRAW_OPENGLES
             lv_opengles_render_texture_dualflip(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                       &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip);
+                                                &clip_area, window->h_flip, texture_disp == NULL ? !window->v_flip : window->v_flip);
 #else
             lv_opengles_render_texture_dualflip(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                       &clip_area, window->h_flip, window->v_flip);
+                                                &clip_area, window->h_flip, window->v_flip);
 #endif
         }
 

--- a/src/drivers/glfw/lv_glfw_window.c
+++ b/src/drivers/glfw/lv_glfw_window.c
@@ -106,8 +106,7 @@ lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bo
     title = (window_title != NULL) ? (char *)window_title : (char *)default_title;
     if(desktop_file_name == NULL) {
         char buffer[256];
-        lv_snprintf(buffer, 255, "%s %s", title, default_suffix);
-        buffer[255] = '\0';
+        lv_snprintf(buffer, sizeof(buffer), "%s %s", title, default_suffix);
         glfwSetWindowTitle(window->window, buffer);
     }
     else {

--- a/src/drivers/glfw/lv_glfw_window.h
+++ b/src/drivers/glfw/lv_glfw_window.h
@@ -47,12 +47,20 @@ lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool 
  * @param ver_res            height in pixels of the window
  * @param use_mouse_indev    send pointer indev input to LVGL display textures
  * @param h_flip             Should the window contents be horizontally mirrored?
- * @param v_flip             Should the window contents be vertically mirrored? 
+ * @param v_flip             Should the window contents be vertically mirrored?
  * @param window_title       NULL or, user window title (default suffix applied if next parameter is null)
  * @param desktop_file_name  NULL or, to enable taskbar window icon on Linux Wayland desktops, this parameter must match the name of the applications/my_app.desktop file, minus the .desktop extension.
  * @return                   the new GLFW window handle
  */
-lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip, bool v_flip, const char* window_title, const char* desktop_file_name);
+lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip,
+                                            bool v_flip, const char * window_title, const char * desktop_file_name);
+
+/**
+ * Set the window's title text
+ * @param window     GLFW window to configure
+ * @param new_title  The new title text
+ */
+void lv_glfw_window_set_title(lv_glfw_window_t * window, const char * new_title);
 
 /**
  * Delete a GLFW window. If it is the last one, the process will exit

--- a/src/drivers/glfw/lv_glfw_window.h
+++ b/src/drivers/glfw/lv_glfw_window.h
@@ -42,10 +42,31 @@ extern "C" {
 lv_glfw_window_t * lv_glfw_window_create(int32_t hor_res, int32_t ver_res, bool use_mouse_indev);
 
 /**
+ * Create a GLFW window with no textures and initialize OpenGL
+ * @param hor_res            width in pixels of the window
+ * @param ver_res            height in pixels of the window
+ * @param use_mouse_indev    send pointer indev input to LVGL display textures
+ * @param h_flip             Should the window contents be horizontally mirrored?
+ * @param v_flip             Should the window contents be vertically mirrored? 
+ * @param window_title       NULL or, user window title (default suffix applied if next parameter is null)
+ * @param desktop_file_name  NULL or, to enable taskbar window icon on Linux Wayland desktops, this parameter must match the name of the applications/my_app.desktop file, minus the .desktop extension.
+ * @return                   the new GLFW window handle
+ */
+lv_glfw_window_t * lv_glfw_window_create_ex(int32_t hor_res, int32_t ver_res, bool use_mouse_indev, bool h_flip, bool v_flip, const char* window_title, const char* desktop_file_name);
+
+/**
  * Delete a GLFW window. If it is the last one, the process will exit
  * @param window    GLFW window to delete
  */
 void lv_glfw_window_delete(lv_glfw_window_t * window);
+
+/**
+ * Set the horizontal / vertical flipping of a GLFW window
+ * @param window    GLFW window to configure
+ * @param h_flip    Should the window contents be horizontally mirrored?
+ * @param v_flip    Should the window contents be vertically mirrored?
+ */
+void lv_glfw_window_set_flip(lv_glfw_window_t * window, bool h_flip, bool v_flip);
 
 /**
  * Get the GLFW window handle for an lv_glfw_window

--- a/src/drivers/glfw/lv_glfw_window_private.h
+++ b/src/drivers/glfw/lv_glfw_window_private.h
@@ -36,6 +36,8 @@ struct _lv_glfw_window_t {
     GLFWwindow * window;
     int32_t hor_res;
     int32_t ver_res;
+    bool h_flip;
+    bool v_flip;
     lv_ll_t textures;
     lv_point_t mouse_last_point;
     lv_indev_state_t mouse_last_state;

--- a/src/drivers/glfw/lv_opengles_driver.c
+++ b/src/drivers/glfw/lv_opengles_driver.c
@@ -28,7 +28,7 @@
  *  STATIC PROTOTYPES
  **********************/
 static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area, 
+                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
                                         bool h_flip, bool v_flip, lv_color_t fill_color);
 static void lv_opengles_enable_blending(void);
 static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size);
@@ -181,7 +181,8 @@ void lv_opengles_deinit(void)
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
-    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip, lv_color_black());
+    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
+                                lv_color_black());
 }
 
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
@@ -228,22 +229,24 @@ static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * 
     };
 
     if(texture != 0) {
-        float x_coef = 1.0f / (float)(2 * lv_area_get_width(texture_area));
-        float y_coef = 1.0f / (float)(2 * lv_area_get_height(texture_area));
-        float tex_clip_x1 = h_flip  ? lv_opengles_map_float(texture_clip_area->x2, texture_area->x2, texture_area->x1, x_coef, 1.0f - x_coef)
-                                    : lv_opengles_map_float(texture_clip_area->x1, texture_area->x1, texture_area->x2, x_coef, 1.0f - x_coef);
-        float tex_clip_x2 = h_flip  ? lv_opengles_map_float(texture_clip_area->x1, texture_area->x2, texture_area->x1, x_coef, 1.0f - x_coef)
-                                    : lv_opengles_map_float(texture_clip_area->x2, texture_area->x1, texture_area->x2, x_coef, 1.0f - x_coef);
-        float tex_clip_y1 = v_flip  ? lv_opengles_map_float(texture_clip_area->y1, texture_area->y1, texture_area->y2, y_coef, 1.0f - y_coef)
-                                    : lv_opengles_map_float(texture_clip_area->y2, texture_area->y2, texture_area->y1, y_coef, 1.0f - y_coef);
-        float tex_clip_y2 = v_flip  ? lv_opengles_map_float(texture_clip_area->y2, texture_area->y1, texture_area->y2, y_coef, 1.0f - y_coef)
-                                    : lv_opengles_map_float(texture_clip_area->y1, texture_area->y2, texture_area->y1, y_coef, 1.0f - y_coef);
+        float x_co = 1.0f / (float)(2 * lv_area_get_width(texture_area));
+        float y_co = 1.0f / (float)(2 * lv_area_get_height(texture_area));
+        float ix_co = 1.0f - x_co;
+        float iy_co = 1.0f - y_co;
+        float _clip_x1 = h_flip ? lv_opengles_map_float(texture_clip_area->x2, texture_area->x2, texture_area->x1, x_co, ix_co)
+                         : lv_opengles_map_float(texture_clip_area->x1, texture_area->x1, texture_area->x2, x_co, ix_co);
+        float _clip_x2 = h_flip ? lv_opengles_map_float(texture_clip_area->x1, texture_area->x2, texture_area->x1, x_co, ix_co)
+                         : lv_opengles_map_float(texture_clip_area->x2, texture_area->x1, texture_area->x2, x_co, ix_co);
+        float _clip_y1 = v_flip ? lv_opengles_map_float(texture_clip_area->y1, texture_area->y1, texture_area->y2, y_co, iy_co)
+                         : lv_opengles_map_float(texture_clip_area->y2, texture_area->y2, texture_area->y1, y_co, iy_co);
+        float _clip_y2 = v_flip ? lv_opengles_map_float(texture_clip_area->y2, texture_area->y1, texture_area->y2, y_co, iy_co)
+                         : lv_opengles_map_float(texture_clip_area->y1, texture_area->y2, texture_area->y1, y_co, iy_co);
 
         float positions[LV_OPENGLES_VERTEX_BUFFER_LEN] = {
-            -1.0f,  1.0f,  tex_clip_x1, tex_clip_y2,
-            1.0f,  1.0f,  tex_clip_x2, tex_clip_y2,
-            1.0f, -1.0f,  tex_clip_x2, tex_clip_y1,
-            -1.0f, -1.0f,  tex_clip_x1, tex_clip_y1
+            -1.f,  1.0f, _clip_x1, _clip_y2,
+            1.0f,  1.0f, _clip_x2, _clip_y2,
+            1.0f, -1.0f, _clip_x2, _clip_y1,
+            -1.f, -1.0f, _clip_x1, _clip_y1
         };
         lv_opengles_vertex_buffer_init(positions, sizeof(positions));
     }

--- a/src/drivers/glfw/lv_opengles_driver.c
+++ b/src/drivers/glfw/lv_opengles_driver.c
@@ -185,8 +185,9 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
                                 lv_color_black());
 }
 
-void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
+void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                         int32_t disp_w,
+                                         int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
     lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
                                 lv_color_black());

--- a/src/drivers/glfw/lv_opengles_driver.c
+++ b/src/drivers/glfw/lv_opengles_driver.c
@@ -179,6 +179,13 @@ void lv_opengles_deinit(void)
 }
 
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+                                int32_t disp_h, const lv_area_t * texture_clip_area, bool v_flip)
+{
+    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, false, v_flip,
+                                lv_color_black());
+}
+
+void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
     lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,

--- a/src/drivers/glfw/lv_opengles_driver.h
+++ b/src/drivers/glfw/lv_opengles_driver.h
@@ -45,16 +45,30 @@ void lv_opengles_init(void);
 void lv_opengles_deinit(void);
 
 /**
- * Render a texture
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         should the texture output vertically flipped?
- * @param v_flip         and/or should the texture output horizontally flipped?
+ * Render a texture with option to flip vertically
+ * @param texture            OpenGL texture ID
+ * @param texture_area       the area in the window to render the texture in
+ * @param opa                opacity to blend the texture with existing contents
+ * @param disp_w             width of the window/framebuffer being rendered to
+ * @param disp_h             height of the window/framebuffer being rendered to
+ * @param texture_clip_area  source area to be rendered into the region defined by texture_area
+ * @param v_flip             and/or should the texture output horizontally flipped?
  */
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+                                int32_t disp_h, const lv_area_t * texture_clip_area, bool v_flip);
+
+/**
+ * Render a texture with options to flip horizontally and/or vertically
+ * @param texture            OpenGL texture ID
+ * @param texture_area       the area in the window to render the texture in
+ * @param opa                opacity to blend the texture with existing contents
+ * @param disp_w             width of the window/framebuffer being rendered to
+ * @param disp_h             height of the window/framebuffer being rendered to
+ * @param texture_clip_area  source area to be rendered into the region defined by texture_area
+ * @param h_flip             should the texture output vertically flipped?
+ * @param v_flip             and/or should the texture output horizontally flipped?
+ */
+void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 
 /**

--- a/src/drivers/glfw/lv_opengles_driver.h
+++ b/src/drivers/glfw/lv_opengles_driver.h
@@ -68,9 +68,9 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
  * @param h_flip             should the texture output vertically flipped?
  * @param v_flip             and/or should the texture output horizontally flipped?
  */
-void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
-
+void lv_opengles_render_texture_dualflip(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                         int32_t disp_w,
+                                         int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 /**
  * Render a fill
  * @param color          the color of the fill

--- a/src/drivers/glfw/lv_opengles_driver.h
+++ b/src/drivers/glfw/lv_opengles_driver.h
@@ -51,9 +51,11 @@ void lv_opengles_deinit(void);
  * @param opa            opacity to blend the texture with existing contents
  * @param disp_w         width of the window/framebuffer being rendered to
  * @param disp_h         height of the window/framebuffer being rendered to
+ * @param h_flip         should the texture output vertically flipped?
+ * @param v_flip         and/or should the texture output horizontally flipped?
  */
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                int32_t disp_h, const lv_area_t * texture_clip_area, bool flip);
+                                int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 
 /**
  * Render a fill

--- a/src/widgets/3dtexture/lv_3dtexture.c
+++ b/src/widgets/3dtexture/lv_3dtexture.c
@@ -76,12 +76,12 @@ void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_3dtexture_t * tex = (lv_3dtexture_t *)obj;
-    
+
     if(tex->h_flip == h_flip && tex->v_flip == v_flip) return;
-    
+
     tex->h_flip = h_flip;
     tex->v_flip = v_flip;
-    
+
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/3dtexture/lv_3dtexture.c
+++ b/src/widgets/3dtexture/lv_3dtexture.c
@@ -76,8 +76,13 @@ void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip)
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_3dtexture_t * tex = (lv_3dtexture_t *)obj;
+    
+    if(tex->h_flip == h_flip && tex->v_flip == v_flip) return;
+    
     tex->h_flip = h_flip;
     tex->v_flip = v_flip;
+    
+    lv_obj_invalidate(obj);
 }
 
 /*======================

--- a/src/widgets/3dtexture/lv_3dtexture.c
+++ b/src/widgets/3dtexture/lv_3dtexture.c
@@ -71,7 +71,7 @@ void lv_3dtexture_set_src(lv_obj_t * obj, lv_3dtexture_id_t id)
     tex->id = id;
 }
 
-void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip)
+void lv_3dtexture_set_flip(lv_obj_t * obj, bool h_flip, bool v_flip)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 

--- a/src/widgets/3dtexture/lv_3dtexture.c
+++ b/src/widgets/3dtexture/lv_3dtexture.c
@@ -71,6 +71,15 @@ void lv_3dtexture_set_src(lv_obj_t * obj, lv_3dtexture_id_t id)
     tex->id = id;
 }
 
+void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_3dtexture_t * tex = (lv_3dtexture_t *)obj;
+    tex->h_flip = h_flip;
+    tex->v_flip = v_flip;
+}
+
 /*======================
  * Add/remove functions
  *=====================*/
@@ -98,6 +107,8 @@ static void lv_3dtexture_constructor(const lv_obj_class_t * class_p, lv_obj_t * 
 
     lv_3dtexture_t * tex = (lv_3dtexture_t *)obj;
     tex->id = LV_3DTEXTURE_ID_NULL;
+    tex->h_flip = false;
+    tex->v_flip = true;
 
     LV_TRACE_OBJ_CREATE("finished");
 }
@@ -135,6 +146,8 @@ static void draw_3dtexture(lv_event_t * e)
     lv_draw_3d_dsc_t dsc;
     lv_draw_3d_dsc_init(&dsc);
     dsc.tex_id = tex->id;
+    dsc.h_flip = tex->h_flip;
+    dsc.v_flip = tex->v_flip;
     dsc.opa = lv_obj_get_style_opa(obj, 0);
     lv_area_t coords;
     lv_obj_get_coords(obj, &coords);

--- a/src/widgets/3dtexture/lv_3dtexture.h
+++ b/src/widgets/3dtexture/lv_3dtexture.h
@@ -55,7 +55,7 @@ void lv_3dtexture_set_src(lv_obj_t * obj, lv_3dtexture_id_t id);
  * @param h_flip   true to flip horizontally.
  * @param v_flip   true to flip vertically.
  */
-void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip);
+void lv_3dtexture_set_flip(lv_obj_t * obj, bool h_flip, bool v_flip);
 
 /*======================
  * Add/remove functions

--- a/src/widgets/3dtexture/lv_3dtexture.h
+++ b/src/widgets/3dtexture/lv_3dtexture.h
@@ -49,6 +49,14 @@ lv_obj_t * lv_3dtexture_create(lv_obj_t * parent);
  */
 void lv_3dtexture_set_src(lv_obj_t * obj, lv_3dtexture_id_t id);
 
+/**
+ * Set the flipping behavior of the widget.
+ * @param obj      the 3dtexture widget
+ * @param h_flip   true to flip horizontally.
+ * @param v_flip   true to flip vertically.
+ */
+void lv_3dtexture_set_src_flip(lv_obj_t * obj, bool h_flip, bool v_flip);
+
 /*======================
  * Add/remove functions
  *=====================*/

--- a/src/widgets/3dtexture/lv_3dtexture_private.h
+++ b/src/widgets/3dtexture/lv_3dtexture_private.h
@@ -31,6 +31,8 @@ extern "C" {
 struct _lv_3dtexture_t {
     lv_obj_t obj;
     lv_3dtexture_id_t id;
+    bool h_flip;
+    bool v_flip;
 };
 
 /**********************


### PR DESCRIPTION
Added additional window title and content flipping options to lv_glfw_window_create, so to maintain compatibility, I renamed that function to lv_glfw_window_create_ex and then created a new copy of the original create function which now calls the _ex suffix version with default values for the additional parameters.

Windows or 3d textures can have their h_flip and v_flip properties changed at creation time or during runtime.  Input mouse events from indev will have their co-ordinates adjusted to line up with the current mirror/flip settings.

We may need to finesse this some to correct any coding style differences or errors I didn't catch.  Also, to help minimize the number of files that were changed in this PR, I haven't tried to build this, just migrated my other LVGL folders changes into this fork and hopefully I did actually migrate all changes.  But I'm going to put the PR in, and let the tests catch any problems, and I'll probably have to work through that a couple times in case I missed anything.