### PR TITLE
feat(tiny_ttf): add kerning cache

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1455,6 +1455,11 @@ menu "LVGL configuration"
 			depends on LV_USE_TINY_TTF
 		config LV_TINY_TTF_CACHE_GLYPH_CNT
 			bool "Tiny ttf cache entries count"
+			default 128
+			depends on LV_USE_TINY_TTF
+
+		config LV_TINY_TTF_CACHE_KERNING_CNT
+			bool "Tiny ttf kerning cache entries count"
 			default 256
 			depends on LV_USE_TINY_TTF
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -958,7 +958,8 @@
 #if LV_USE_TINY_TTF
     /* Enable loading TTF data from files */
     #define LV_TINY_TTF_FILE_SUPPORT 0
-    #define LV_TINY_TTF_CACHE_GLYPH_CNT 256
+    #define LV_TINY_TTF_CACHE_GLYPH_CNT 128
+    #define LV_TINY_TTF_CACHE_KERNING_CNT 256
 #endif
 
 /** Rlottie library */

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -55,7 +55,7 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position);
 typedef struct ttf_font_desc {
     lv_cache_t * glyph_cache;
     lv_cache_t * draw_data_cache;
-    lv_cache_t * kerning_cache; 
+    lv_cache_t * kerning_cache;
     stbtt_fontinfo info;
     lv_fs_file_t file;
 #if LV_TINY_TTF_FILE_SUPPORT != 0
@@ -117,7 +117,7 @@ static lv_cache_compare_res_t tiny_ttf_draw_data_cache_compare_cb(const tiny_ttf
 static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data);
 static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data);
 static lv_cache_compare_res_t tiny_ttf_kerning_cache_compare_cb(const tiny_ttf_kerning_cache_data_t * lhs,
-                                                                  const tiny_ttf_kerning_cache_data_t * rhs);
+                                                                const tiny_ttf_kerning_cache_data_t * rhs);
 
 static void lv_tiny_ttf_cache_create(ttf_font_desc_t * dsc);
 
@@ -173,7 +173,7 @@ void lv_tiny_ttf_set_size(lv_font_t * font, int32_t font_size)
         lv_cache_destroy(dsc->draw_data_cache, NULL);
         dsc->draw_data_cache = NULL;
     }
-    if(dsc->kerning_cache){
+    if(dsc->kerning_cache) {
         lv_cache_destroy(dsc->kerning_cache, NULL);
         dsc->kerning_cache = NULL;
     }
@@ -237,7 +237,8 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position)
 }
 #endif
 
-static inline uint16_t ttf_calculate_kerning_width(float scale, uint16_t adv_w, int k){
+static inline uint16_t ttf_calculate_kerning_width(float scale, uint16_t adv_w, int k)
+{
 
     /*Horizontal space required by the glyph in [px]*/;
     return (uint16_t)(scale * (adv_w + k) + 0.5f);
@@ -255,15 +256,16 @@ static uint16_t ttf_get_glyph_pair_kerning_width(const ttf_font_desc_t * dsc, ui
         .dsc = dsc,
     };
 
-    if(dsc->kerning_cache->max_size == 0){
+    if(dsc->kerning_cache->max_size == 0) {
         /* No cache, call the create function directly */
-        bool ret = tiny_ttf_kerning_cache_create_cb(&kerning_cache_search_key, (void*)&kerning_cache_create_data);
+        bool ret = tiny_ttf_kerning_cache_create_cb(&kerning_cache_search_key, (void *)&kerning_cache_create_data);
         LV_ASSERT(ret);
         return kerning_cache_search_key.adv_w16;
     }
 
     LV_ASSERT_NULL(dsc->kerning_cache);
-    lv_cache_entry_t * kerning_entry = lv_cache_acquire_or_create(dsc->kerning_cache, &kerning_cache_search_key, (void *)&kerning_cache_create_data);
+    lv_cache_entry_t * kerning_entry = lv_cache_acquire_or_create(dsc->kerning_cache, &kerning_cache_search_key,
+                                                                  (void *)&kerning_cache_create_data);
     LV_ASSERT_NULL(kerning_entry);
     tiny_ttf_kerning_cache_data_t * data = lv_cache_entry_get_data(kerning_entry);
     LV_ASSERT_NULL(data);
@@ -306,7 +308,7 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
 
             /*Kerning correction*/
             if(font->kerning == LV_FONT_KERNING_NORMAL &&
-                unicode_letter_next != 0) {
+               unicode_letter_next != 0) {
                 int g2 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter_next); /* not using cache, only do glyph id lookup */
                 if(g2) {
                     dsc_out->adv_w = ttf_get_glyph_pair_kerning_width(dsc, g1, g2, adv_w);
@@ -327,7 +329,7 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
 
     /*Kerning correction*/
     if(font->kerning == LV_FONT_KERNING_NORMAL &&
-        unicode_letter_next != 0) { /* check if we need to do any kerning calculations */
+       unicode_letter_next != 0) { /* check if we need to do any kerning calculations */
         uint32_t g1 = dsc_out->gid.index;
 
         int g2 = 0;
@@ -419,7 +421,8 @@ static void lv_tiny_ttf_cache_create(ttf_font_desc_t * dsc)
     });
     lv_cache_set_name(dsc->draw_data_cache, "TINY_TTF_DRAW_DATA");
 
-    dsc->kerning_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t), LV_TINY_TTF_CACHE_KERNING_CNT,
+    dsc->kerning_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t),
+                                         LV_TINY_TTF_CACHE_KERNING_CNT,
     (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t)tiny_ttf_kerning_cache_compare_cb,
         .create_cb = (lv_cache_create_cb_t)tiny_ttf_kerning_cache_create_cb,
@@ -482,7 +485,7 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
     if(kerning != LV_FONT_KERNING_NONE && stbtt_KernTableCheck(&dsc->info) == 0) {
         /* disable kerning if font has no tables. */
         LV_LOG_INFO("Disabling kerning as font doesn't support it.");
-        kerning = LV_FONT_KERNING_NONE; 
+        kerning = LV_FONT_KERNING_NONE;
     }
 
     dsc->kerning = kerning;
@@ -629,7 +632,8 @@ static lv_cache_compare_res_t tiny_ttf_draw_data_cache_compare_cb(const tiny_ttf
     return 0;
 }
 
-static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data) {
+static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data)
+{
     tiny_ttf_kerning_cache_create_data_t * create_data = (tiny_ttf_kerning_cache_create_data_t *)user_data;
     const ttf_font_desc_t * dsc = create_data->dsc;
     const int adv_w = create_data->adv_w;
@@ -638,13 +642,15 @@ static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * nod
     return true;
 }
 
-static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data) {
+static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data)
+{
     LV_UNUSED(node);
     LV_UNUSED(user_data);
 }
 
 static lv_cache_compare_res_t tiny_ttf_kerning_cache_compare_cb(const tiny_ttf_kerning_cache_data_t * lhs,
-                                                                  const tiny_ttf_kerning_cache_data_t * rhs) {
+                                                                const tiny_ttf_kerning_cache_data_t * rhs)
+{
     lv_cache_compare_res_t ret = lhs->glyph1_idx - rhs->glyph1_idx;
     if(ret == 0) {
         return lhs->glyph2_idx - rhs->glyph2_idx;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -270,6 +270,7 @@ static uint16_t ttf_get_glyph_pair_kerning_width(const ttf_font_desc_t * dsc, ui
     tiny_ttf_kerning_cache_data_t * data = lv_cache_entry_get_data(kerning_entry);
     LV_ASSERT_NULL(data);
 
+    lv_cache_release(dsc->glyph_cache, kerning_entry, NULL);
     return data->adv_w16;
 }
 

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -53,6 +53,7 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position);
  **********************/
 
 typedef struct ttf_font_desc {
+    lv_cache_t * kerning_cache; 
     lv_fs_file_t file;
 #if LV_TINY_TTF_FILE_SUPPORT != 0
     ttf_cb_stream_t stream;
@@ -77,11 +78,23 @@ typedef struct _tiny_ttf_glyph_cache_data_t {
     lv_font_glyph_dsc_t glyph_dsc;
 } tiny_ttf_glyph_cache_data_t;
 
+typedef struct  {
+    int glyph1_idx;
+    int glyph2_idx;
+    uint16_t adv_w16;
+} tiny_ttf_kerning_cache_data_t;
+
+typedef struct {
+    const ttf_font_desc_t * dsc;
+    int adv_w;
+} tiny_ttf_kerning_cache_create_data_t;
+
 typedef struct _lv_tiny_ttf_cache_data_t {
     uint32_t glyph_index;
     uint32_t size;
     lv_draw_buf_t * draw_buf;
 } tiny_ttf_cache_data_t;
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -102,6 +115,11 @@ static bool tiny_ttf_draw_data_cache_create_cb(tiny_ttf_cache_data_t * node, voi
 static void tiny_ttf_draw_data_cache_free_cb(tiny_ttf_cache_data_t * node, void * user_data);
 static lv_cache_compare_res_t tiny_ttf_draw_data_cache_compare_cb(const tiny_ttf_cache_data_t * lhs,
                                                                   const tiny_ttf_cache_data_t * rhs);
+
+static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data);
+static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data);
+static lv_cache_compare_res_t tiny_ttf_kerning_cache_compare_cb(const tiny_ttf_kerning_cache_data_t * lhs,
+                                                                  const tiny_ttf_kerning_cache_data_t * rhs);
 
 static void lv_tiny_ttf_cache_create(ttf_font_desc_t * dsc);
 
@@ -157,6 +175,10 @@ void lv_tiny_ttf_set_size(lv_font_t * font, int32_t font_size)
         lv_cache_destroy(dsc->draw_data_cache, NULL);
         dsc->draw_data_cache = NULL;
     }
+    if(dsc->kerning_cache){
+        lv_cache_destroy(dsc->kerning_cache, NULL);
+        dsc->kerning_cache = NULL;
+    }
 
     lv_tiny_ttf_cache_create(dsc);
 }
@@ -174,6 +196,7 @@ void lv_tiny_ttf_destroy(lv_font_t * font)
 #endif
         lv_cache_destroy(ttf->glyph_cache, NULL);
         lv_cache_destroy(ttf->draw_data_cache, NULL);
+        lv_cache_destroy(ttf->kerning_cache, NULL);
         lv_free(ttf);
         font->dsc = NULL;
     }
@@ -216,6 +239,40 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position)
 }
 #endif
 
+static inline uint16_t ttf_calculate_kerning_width(float scale, uint16_t adv_w, int k){
+
+    /*Horizontal space required by the glyph in [px]*/;
+    return (uint16_t)(scale * (adv_w + k) + 0.5f);
+}
+
+static uint16_t ttf_get_glyph_pair_kerning_width(const ttf_font_desc_t * dsc, uint32_t g1, uint32_t g2, int adv_w)
+{
+    tiny_ttf_kerning_cache_data_t kerning_cache_search_key = {
+        .glyph1_idx = g1,
+        .glyph2_idx = g2,
+    };
+
+    tiny_ttf_kerning_cache_create_data_t kerning_cache_create_data = {
+        .adv_w = adv_w,
+        .dsc = dsc,
+    };
+
+    if(dsc->kerning_cache->max_size == 0){
+        /* No cache, call the create function directly */
+        bool ret = tiny_ttf_kerning_cache_create_cb(&kerning_cache_search_key, (void*)&kerning_cache_create_data);
+        LV_ASSERT(ret);
+        return kerning_cache_search_key.adv_w16;
+    }
+
+    LV_ASSERT_NULL(dsc->kerning_cache);
+    lv_cache_entry_t * kerning_entry = lv_cache_acquire_or_create(dsc->kerning_cache, &kerning_cache_search_key, (void *)&kerning_cache_create_data);
+    LV_ASSERT_NULL(kerning_entry);
+    tiny_ttf_kerning_cache_data_t * data = lv_cache_entry_get_data(kerning_entry);
+    LV_ASSERT_NULL(data);
+
+    return data->adv_w16;
+}
+
 static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                  uint32_t unicode_letter_next)
 {
@@ -253,9 +310,7 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
                unicode_letter_next != 0) {
                 int g2 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter_next); /* not using cache, only do glyph id lookup */
                 if(g2) {
-                    int k = stbtt_GetGlyphKernAdvance(&dsc->info, g1, g2);
-                    dsc_out->adv_w = (uint16_t)floor((((float)adv_w + (float)k) * dsc->scale) +
-                                                     0.5f); /*Horizontal space required by the glyph in [px]*/
+                    dsc_out->adv_w = ttf_get_glyph_pair_kerning_width(dsc, g1, g2, adv_w);
                 }
             }
 
@@ -287,11 +342,8 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
             g2 = data_next->glyph_dsc.gid.index;
             lv_cache_release(dsc->glyph_cache, entry_next, NULL);
         }
-
         if(g2) {
-            int k = stbtt_GetGlyphKernAdvance(&dsc->info, g1, g2);
-            dsc_out->adv_w = (uint16_t)floor((((float)adv_w + (float)k) * dsc->scale) +
-                                             0.5f); /*Horizontal space required by the glyph in [px]*/
+            dsc_out->adv_w = ttf_get_glyph_pair_kerning_width(dsc, g1, g2, adv_w);
         }
     }
 
@@ -366,6 +418,14 @@ static void lv_tiny_ttf_cache_create(ttf_font_desc_t * dsc)
         .free_cb = (lv_cache_free_cb_t)tiny_ttf_draw_data_cache_free_cb,
     });
     lv_cache_set_name(dsc->draw_data_cache, "TINY_TTF_DRAW_DATA");
+
+    dsc->kerning_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t), LV_TINY_TTF_CACHE_KERNING_CNT,
+    (lv_cache_ops_t) {
+        .compare_cb = (lv_cache_compare_cb_t)tiny_ttf_kerning_cache_compare_cb,
+        .create_cb = (lv_cache_create_cb_t)tiny_ttf_kerning_cache_create_cb,
+        .free_cb = (lv_cache_free_cb_t)tiny_ttf_kerning_cache_free_cb,
+    });
+    lv_cache_set_name(dsc->kerning_cache, "TINY_TTF_KERNING_DATA");
 }
 
 static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size_t data_size, int32_t font_size,
@@ -475,16 +535,14 @@ static bool tiny_ttf_glyph_cache_create_cb(tiny_ttf_glyph_cache_data_t * node, v
 
     stbtt_GetGlyphBitmapBox(&dsc->info, g1, dsc->scale, dsc->scale, &x1, &y1, &x2, &y2);
 
-    int advw, lsb;
+    int advw;
+    int lsb;
     stbtt_GetGlyphHMetrics(&dsc->info, g1, &advw, &lsb);
     if(dsc->kerning != LV_FONT_KERNING_NORMAL) { /* calculate default advance */
-        int k = stbtt_GetGlyphKernAdvance(&dsc->info, g1, 0);
-        dsc_out->adv_w = (uint16_t)floor((((float)advw + (float)k) * dsc->scale) +
-                                         0.5f); /*Horizontal space required by the glyph in [px]*/
+        dsc_out->adv_w = ttf_get_glyph_pair_kerning_width(dsc, g1, 0, advw);
     }
     else {
-        dsc_out->adv_w = (uint16_t)floor(((float)advw * dsc->scale) +
-                                         0.5f); /*Horizontal space required by the glyph in [px]*/;
+        dsc_out->adv_w = ttf_calculate_kerning_width(dsc->scale, advw, 0);
     }
     /* precalculate no kerning value */
     node->adv_w = advw;
@@ -567,6 +625,29 @@ static lv_cache_compare_res_t tiny_ttf_draw_data_cache_compare_cb(const tiny_ttf
     }
 
     return 0;
+}
+
+static bool tiny_ttf_kerning_cache_create_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data) {
+    tiny_ttf_kerning_cache_create_data_t * create_data = (tiny_ttf_kerning_cache_create_data_t *)user_data;
+    const ttf_font_desc_t * dsc = create_data->dsc;
+    const int adv_w = create_data->adv_w;
+    const int k = stbtt_GetGlyphKernAdvance(&dsc->info, node->glyph1_idx, node->glyph2_idx);
+    node->adv_w16 = ttf_calculate_kerning_width(dsc->scale, adv_w, k);
+    return true;
+}
+
+static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node, void * user_data) {
+    LV_UNUSED(node);
+    LV_UNUSED(user_data);
+}
+
+static lv_cache_compare_res_t tiny_ttf_kerning_cache_compare_cb(const tiny_ttf_kerning_cache_data_t * lhs,
+                                                                  const tiny_ttf_kerning_cache_data_t * rhs) {
+    lv_cache_compare_res_t ret = lhs->glyph1_idx - rhs->glyph1_idx;
+    if(ret == 0) {
+        return lhs->glyph2_idx - rhs->glyph2_idx;
+    }
+    return ret;
 }
 
 static lv_font_t * tiny_ttf_font_create_cb(const lv_font_info_t * info, const void * src)

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -53,29 +53,27 @@ static void ttf_cb_stream_seek(ttf_cb_stream_t * stream, size_t position);
  **********************/
 
 typedef struct ttf_font_desc {
+    lv_cache_t * glyph_cache;
+    lv_cache_t * draw_data_cache;
     lv_cache_t * kerning_cache; 
+    stbtt_fontinfo info;
     lv_fs_file_t file;
 #if LV_TINY_TTF_FILE_SUPPORT != 0
     ttf_cb_stream_t stream;
 #else
     const uint8_t * stream;
 #endif
-    stbtt_fontinfo info;
     float scale;
     int ascent;
     int descent;
-
-    lv_font_kerning_t kerning;
-
     int cache_size;
-    lv_cache_t * glyph_cache;
-    lv_cache_t * draw_data_cache;
+    lv_font_kerning_t kerning;
 } ttf_font_desc_t;
 
 typedef struct _tiny_ttf_glyph_cache_data_t {
+    lv_font_glyph_dsc_t glyph_dsc;
     uint32_t unicode;
     int adv_w;
-    lv_font_glyph_dsc_t glyph_dsc;
 } tiny_ttf_glyph_cache_data_t;
 
 typedef struct  {
@@ -90,9 +88,9 @@ typedef struct {
 } tiny_ttf_kerning_cache_create_data_t;
 
 typedef struct _lv_tiny_ttf_cache_data_t {
+    lv_draw_buf_t * draw_buf;
     uint32_t glyph_index;
     uint32_t size;
-    lv_draw_buf_t * draw_buf;
 } tiny_ttf_cache_data_t;
 
 /**********************

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -421,7 +421,7 @@ static void lv_tiny_ttf_cache_create(ttf_font_desc_t * dsc)
     });
     lv_cache_set_name(dsc->draw_data_cache, "TINY_TTF_DRAW_DATA");
 
-    dsc->kerning_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_cache_data_t),
+    dsc->kerning_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(tiny_ttf_kerning_cache_data_t),
                                          LV_TINY_TTF_CACHE_KERNING_CNT,
     (lv_cache_ops_t) {
         .compare_cb = (lv_cache_compare_cb_t)tiny_ttf_kerning_cache_compare_cb,

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -293,19 +293,20 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
         .unicode = unicode_letter,
     };
 
+
     int adv_w;
     lv_cache_entry_t * entry = lv_cache_acquire_or_create(dsc->glyph_cache, &search_key, (void *)dsc);
 
     if(entry == NULL) {
         if(!dsc->cache_size) {  /* no cache, do everything directly */
-            uint32_t g1 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter);
+            int g1 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter);
             tiny_ttf_glyph_cache_create_cb(&search_key, dsc);
             *dsc_out = search_key.glyph_dsc;
             adv_w = search_key.adv_w;
 
             /*Kerning correction*/
             if(font->kerning == LV_FONT_KERNING_NORMAL &&
-               unicode_letter_next != 0) {
+                unicode_letter_next != 0) {
                 int g2 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter_next); /* not using cache, only do glyph id lookup */
                 if(g2) {
                     dsc_out->adv_w = ttf_get_glyph_pair_kerning_width(dsc, g1, g2, adv_w);
@@ -326,15 +327,16 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
 
     /*Kerning correction*/
     if(font->kerning == LV_FONT_KERNING_NORMAL &&
-       unicode_letter_next != 0) { /* check if we need to do any kerning calculations */
+        unicode_letter_next != 0) { /* check if we need to do any kerning calculations */
         uint32_t g1 = dsc_out->gid.index;
 
         int g2 = 0;
         search_key.unicode = unicode_letter_next; /* reuse search key */
         lv_cache_entry_t * entry_next = lv_cache_acquire_or_create(dsc->glyph_cache, &search_key, (void *)dsc);
 
-        if(entry_next == NULL)
+        if(entry_next == NULL) {
             g2 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter_next);
+        }
         else {
             tiny_ttf_glyph_cache_data_t * data_next = lv_cache_entry_get_data(entry_next);
             g2 = data_next->glyph_dsc.gid.index;

--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -479,8 +479,10 @@ static lv_font_t * lv_tiny_ttf_create(const char * path, const void * data, size
     }
 
     /* check if font  has kerning tables to use, else disable kerning automatically. */
-    if(stbtt_KernTableCheck(&dsc->info) == 0) {
-        kerning = LV_FONT_KERNING_NONE; /* disable kerning if font has no tables. */
+    if(kerning != LV_FONT_KERNING_NONE && stbtt_KernTableCheck(&dsc->info) == 0) {
+        /* disable kerning if font has no tables. */
+        LV_LOG_INFO("Disabling kerning as font doesn't support it.");
+        kerning = LV_FONT_KERNING_NONE; 
     }
 
     dsc->kerning = kerning;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3061,7 +3061,14 @@
         #ifdef CONFIG_LV_TINY_TTF_CACHE_GLYPH_CNT
             #define LV_TINY_TTF_CACHE_GLYPH_CNT CONFIG_LV_TINY_TTF_CACHE_GLYPH_CNT
         #else
-            #define LV_TINY_TTF_CACHE_GLYPH_CNT 256
+            #define LV_TINY_TTF_CACHE_GLYPH_CNT 128
+        #endif
+    #endif
+    #ifndef LV_TINY_TTF_CACHE_KERNING_CNT
+        #ifdef CONFIG_LV_TINY_TTF_CACHE_KERNING_CNT
+            #define LV_TINY_TTF_CACHE_KERNING_CNT CONFIG_LV_TINY_TTF_CACHE_KERNING_CNT
+        #else
+            #define LV_TINY_TTF_CACHE_KERNING_CNT 256
         #endif
     #endif
 #endif


### PR DESCRIPTION
Performance measured using this example code:

```c
	static lv_style_t style;
	lv_style_init(&style);
	lv_font_t *font = lv_tiny_ttf_create_file("A:myriadpro.ttf", 30);
	lv_style_set_text_font(&style, font);
	lv_style_set_text_align(&style, LV_TEXT_ALIGN_CENTER);

	/*Create a label with the new style*/
	lv_obj_t *label = lv_label_create(lv_screen_active());
	lv_obj_add_style(label, &style, 0)
        lv_label_set_text(
	        label,
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos."
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos."
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos."
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos."
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos."
	        "Lorem ipsum dolor sit amet consectetur adipiscing elit."
	        "Quisque faucibus ex sapien vitae pellentesque sem placerat."
	        "In id cursus mi pretium tellus duis convallis."
	        "Tempus leo eu aenean sed diam urna tempor."
	        "Pulvinar vivamus fringilla lacus nec metus bibendum egestas."
	        "Iaculis massa nisl malesuada lacinia integer nunc posuere."
	        "Ut hendrerit semper vel class aptent taciti sociosqu."
	        "Ad litora torquent per conubia nostra inceptos himenaeos.");

	lv_obj_center(label);
	lv_refr_now(NULL); /*Update layouts and render*/
	lv_obj_invalidate(lv_screen_active());

	const uint32_t t = lv_tick_get();
	lv_refr_now(NULL); /*Render only*/
	LV_LOG_USER("%u ms\n", lv_tick_elaps(t));

	return 0;
```

Measured with `LV_TINY_TTF_CACHE_KERNING_CNT == 0` (no caching) and `LV_TINY_TTF_CACHE_KERNING_CNT == 256` (so extra 3072 bytes in RAM)

Application start time reduced from 1.62s to 236ms
Render time improved from ~95ms to ~7ms
Flamegraph shows kerning value fetch dropped from 50% to just 0.91% of total CPU cycles

![Screenshot From 2025-05-27 16-07-51](https://github.com/user-attachments/assets/2e5e9c08-f32e-43d5-8778-61327e261b29)
![Screenshot From 2025-05-27 16-10-33](https://github.com/user-attachments/assets/d7ddfc9c-5726-45f6-8ce5-8c50314fd35b)
![Screenshot From 2025-05-27 16-14-48](https://github.com/user-attachments/assets/eb46ec6d-aa4e-4520-a426-03edf99fe405)


