### PR TITLE
feat(label): support passing variadic list as param

### DIFF
--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -176,7 +176,7 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    lv_label_set_text_vfmt(obj,fmt, args);
+    lv_label_set_text_vfmt(obj, fmt, args);
     va_end(args);
 }
 

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -177,7 +177,7 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     va_list args;
     va_start(args, fmt);
     lv_label_set_text_vfmt(obj,fmt, args);
-    va_end(args);    
+    va_end(args);
 }
 
 void lv_label_set_text_vfmt(lv_obj_t * obj, const char * fmt, va_list args)
@@ -199,7 +199,7 @@ void lv_label_set_text_vfmt(lv_obj_t * obj, const char * fmt, va_list args)
         label->text = NULL;
     }
 
-    label->text = lv_text_set_text_vfmt(fmt, args);    
+    label->text = lv_text_set_text_vfmt(fmt, args);
     label->static_txt = 0; /*Now the text is dynamically allocated*/
 
     lv_label_refr_text(obj);

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -174,6 +174,14 @@ void lv_label_set_text(lv_obj_t * obj, const char * text)
 
 void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
+    va_list args;
+    va_start(args, fmt);
+    lv_label_set_text_vfmt(obj,fmt, args);
+    va_end(args);    
+}
+
+void lv_label_set_text_vfmt(lv_obj_t * obj, const char * fmt, va_list args)
+{
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);
 
@@ -191,10 +199,7 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
         label->text = NULL;
     }
 
-    va_list args;
-    va_start(args, fmt);
-    label->text = lv_text_set_text_vfmt(fmt, args);
-    va_end(args);
+    label->text = lv_text_set_text_vfmt(fmt, args);    
     label->static_txt = 0; /*Now the text is dynamically allocated*/
 
     lv_label_refr_text(obj);

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -100,6 +100,22 @@ void lv_label_set_text(lv_obj_t * obj, const char * text);
 void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTRIBUTE(2, 3);
 
 /**
+ * Set a new formatted text for a label. Memory will be allocated to store the text by the label.
+ * @param obj           pointer to a label object
+ * @param fmt           printf`-like format
+*  @param args          variadic argments list
+ *
+ * Example:
+ * @code
+ * va_list args;
+ * va_start(args, fmt);    
+ * lv_label_set_text_vfmt(label1, fmt, args);
+ * va_end(args);
+ * @endcode
+ */
+void lv_label_set_text_vfmt(lv_obj_t * obj, const char * fmt, va_list args);
+
+/**
  * Set a static text. It will not be saved by the label so the 'text' variable
  * has to be 'alive' while the label exists.
  * @param obj           pointer to a label object

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -108,7 +108,7 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTR
  * Example:
  * @code
  * va_list args;
- * va_start(args, fmt);    
+ * va_start(args, fmt);
  * lv_label_set_text_vfmt(label1, fmt, args);
  * va_end(args);
  * @endcode

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -102,8 +102,8 @@ void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTR
 /**
  * Set a new formatted text for a label. Memory will be allocated to store the text by the label.
  * @param obj           pointer to a label object
- * @param fmt           printf`-like format
-*  @param args          variadic argments list
+ * @param fmt           `printf`-like format
+ * @param args          variadic argments list
  *
  * Example:
  * @code


### PR DESCRIPTION
Hi,

In my application, I need to set a label's text using a printf-like format, but without exposing the LVGL label object to the higher-level application.   
To achieve this, I retrieve the variadic arguments in my function and need to forward them to an LVGL label formatting function.

Currently, **lv_label_set_text_fmt()** supports variadic arguments **(...)**, but it doesn't accept a **va_list**, which makes it unsuitable in this case.   
To work around this, I implemented a function called **lv_label_set_text_vfmt()** that formats the label text using a **va_list**.  

I believe it would be useful to officially add such a function to LVGL for scenarios where formatting needs to be done via **va_list**.

Best regards,
Henrique

## Proposal

```c++
    //Somewhere in my code.....
    va_list args;
    va_start(args, fmt);    
    lv_label_set_text_vfmt(uiLabel, fmt, args);
    va_end(args);
    //.....
```
In lv_label.c

```c++
void lv_label_set_text_vfmt(lv_obj_t * obj, const char * fmt, va_list args)
{
    LV_ASSERT_OBJ(obj, MY_CLASS);
    LV_ASSERT_NULL(fmt);

    lv_obj_invalidate(obj);
    lv_label_t * label = (lv_label_t *)obj;

    /*If text is NULL then refresh*/
    if(fmt == NULL) {
        lv_label_refr_text(obj);
        return;
    }

    if(label->text != NULL && label->static_txt == 0) {
        lv_free(label->text);
        label->text = NULL;
    }

    label->text = lv_text_set_text_vfmt(fmt, args);    
    label->static_txt = 0; /*Now the text is dynamically allocated*/

    lv_label_refr_text(obj);
}
```

The include file was also updated  

