### PR TITLE
fix(evdev): calibrate pointer device for touch screen device (#8282)

### DIFF
--- a/.github/workflows/check_conf.yml
+++ b/.github/workflows/check_conf.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.12
       - name: Generate lv_conf_internal.h
         run: python lv_conf_internal_gen.py
         working-directory: scripts

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -179,6 +179,25 @@ lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path)
         goto err_after_open;
     }
 
+    /* Detect the minimum and maximum values of the input device for calibration. */
+    if(indev_type == LV_INDEV_TYPE_POINTER) {
+        struct input_absinfo absinfo;
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_X), &absinfo) == 0) {
+            dsc->min_x = absinfo.minimum;
+            dsc->max_x = absinfo.maximum;
+        }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_X) failed: %s", strerror(errno));
+        }
+        if(ioctl(dsc->fd, EVIOCGABS(ABS_Y), &absinfo) == 0) {
+            dsc->min_y = absinfo.minimum;
+            dsc->max_y = absinfo.maximum;
+        }
+        else {
+            LV_LOG_ERROR("ioctl EVIOCGABS(ABS_Y) failed: %s", strerror(errno));
+        }
+    }
+
     lv_indev_t * indev = lv_indev_create();
     if(indev == NULL) goto err_after_open;
     lv_indev_set_type(indev, indev_type);


### PR DESCRIPTION
Port #8282 to v9.1

This fix is missing from v9.1.

v9.0 :heavy_check_mark:
v9.1 :x:
v9.2 :heavy_check_mark:

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
