### PR TITLE
fix(evdev): mark unused variable as unused

### DIFF
--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -294,6 +294,7 @@ static bool _evdev_discovery_inotify_try_init_watcher(int inotify_fd)
 
 static void _evdev_discovery_timer_cb(lv_timer_t * tim)
 {
+    LV_UNUSED(tim);
     lv_evdev_discovery_t * ed = evdev_discovery;
     LV_ASSERT_NULL(ed);
 


### PR DESCRIPTION
Trying to compile with EVDEV supports while treating warnings as errors produces the following error:

```c
/workdir/lvgl/src/drivers/evdev/lv_evdev.c: In function '_evdev_discovery_timer_cb':
/workdir/lvgl/src/drivers/evdev/lv_evdev.c:295:52: error: unused parameter 'tim' [-Werror=unused-parameter]
  295 | static void _evdev_discovery_timer_cb(lv_timer_t * tim)
      |                                       ~~~~~~~~~~~~~^~~
```