### PR TITLE
fix(dropdown): fix lv_dropdown_add_option using null

### DIFF
--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -274,7 +274,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     }
 
     /*Allocate space for the new option*/
-    size_t old_len = (dropdown->options == NULL) ? 0 : lv_strlen(dropdown->options);
+    size_t old_len = lv_strlen(dropdown->options);
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
     size_t ins_len = lv_strlen(option) + 1;
 #else
@@ -334,7 +334,7 @@ void lv_dropdown_clear_options(lv_obj_t * obj)
         lv_free(dropdown->options);
 
     dropdown->options = NULL;
-    dropdown->static_txt = 0;
+    dropdown->static_txt = 1;
     dropdown->option_cnt = 0;
 
     lv_obj_invalidate(obj);

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -262,7 +262,12 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     /*Convert static options to dynamic*/
     if(dropdown->static_txt != 0) {
         char * static_options = dropdown->options;
-        dropdown->options = lv_strdup(static_options);
+        if(dropdown->options) {
+            dropdown->options = lv_strdup(static_options);
+        }
+        else {
+            dropdown->options = lv_calloc(1); /*Allocate at least 1 byte for the NULL terminator*/
+        }
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;
         dropdown->static_txt = 0;

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -274,7 +274,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     }
 
     /*Allocate space for the new option*/
-    size_t old_len = lv_strlen(dropdown->options);
+    size_t old_len = (dropdown->options == NULL) ? 0 : lv_strlen(dropdown->options);
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
     size_t ins_len = lv_strlen(option) + 1;
 #else

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -274,7 +274,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     }
 
     /*Allocate space for the new option*/
-    size_t old_len = (dropdown->options == NULL) ? 0 : lv_strlen(dropdown->options);
+    size_t old_len = lv_strlen(dropdown->options);
 #if LV_USE_ARABIC_PERSIAN_CHARS == 0
     size_t ins_len = lv_strlen(option) + 1;
 #else

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -266,7 +266,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
             dropdown->options = lv_strdup(static_options);
         }
         else {
-            dropdown->options = lv_calloc(1); /*Allocate at least 1 byte for the NULL terminator*/
+            dropdown->options = lv_calloc(1, 1); /*Allocate at least 1 byte for the NULL terminator*/
         }
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;


### PR DESCRIPTION
Upon object creation, options are NULL.
lv_dropdown_add_option does not check for this, and leads to crash, etc.
