### PR TITLE
<feat>(linux): Add OS function for process specific CPU usage on Linux

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -236,6 +236,8 @@ typedef struct _lv_global_t {
     lv_mutex_t lv_general_mutex;
 #if defined(__linux__)
     lv_proc_stat_t linux_last_proc_stat;
+    uint64_t linux_last_self_proc_time_ticks;
+    lv_proc_stat_t linux_last_system_total_ticks_stat;
 #endif
 #endif
 

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -29,6 +29,9 @@
 #define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
 
+#define LV_PROC_STAT_VAR_FORMAT        " %" SCNu64
+#define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" SCNu64
+
 #define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
 #define last_self_ticks LV_GLOBAL_DEFAULT()->linux_last_self_proc_time_ticks
 #define last_system_total_ticks_stat LV_GLOBAL_DEFAULT()->linux_last_system_total_ticks_stat
@@ -133,7 +136,7 @@ uint32_t lv_os_get_self_cpu_percent(void)
                                "%*d %*d %*d %*d %*d " /* skip ppid, pgrp, session, tty_nr, tpgid (fields 4-8) */
                                "%*u "         /* skip flags (field 9) */
                                "%*lu %*lu %*lu %*lu " /* skip minflt, cminflt, majflt, cmajflt (fields 10-13) */
-                               "%lu %lu",     /* read utime (field 14), stime (field 15) */
+                               LV_PROC_STAT_VAR_FORMAT LV_PROC_STAT_VAR_FORMAT,     /* read utime (field 14), stime (field 15) */
                                &utime, &stime);
 
     if(scanned_items != 2) {

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -15,17 +15,23 @@
 #include "../misc/lv_log.h"
 #include "lv_linux_private.h"
 #include <stdio.h>
+#include <string.h>
 
 /*********************
  *      DEFINES
  *********************/
 
 #define LV_UPTIME_MONITOR_FILE         "/proc/stat"
+#define LV_UPTIME_MONITOR_SELF         "/proc/self/stat"
+
+#define LV_SELF_PROC_STAT_BUFFER_SIZE 1024
 
 #define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
 
 #define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
+#define last_self_ticks LV_GLOBAL_DEFAULT()->linux_last_self_proc_time_ticks
+#define last_system_total_ticks_stat LV_GLOBAL_DEFAULT()->linux_last_system_total_ticks_stat
 
 /**********************
  *      TYPEDEFS
@@ -78,6 +84,96 @@ uint32_t lv_os_get_idle_percent(void)
     }
 
     return (proc_stat.fields.idle * 100) / total;
+}
+
+uint32_t lv_os_get_self_cpu_percent(void)
+{
+    uint64_t self_current_time_ticks = 0;
+    lv_proc_stat_t stat_current_system_total_ticks;
+    lv_proc_stat_t stat_delta_system_ticks;
+
+    FILE *self = fopen(LV_UPTIME_MONITOR_SELF, "r");
+    if (!self) {
+        LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_SELF);
+        return LV_RESULT_INVALID;
+    }
+
+    char self_stat_buffer[LV_SELF_PROC_STAT_BUFFER_SIZE];
+
+    if (!fgets(self_stat_buffer, sizeof(self_stat_buffer), self)) {
+        fclose(self);
+        LV_LOG_ERROR("Failed to read /proc/self/stat");
+        return UINT32_MAX;
+    }
+
+    fclose(self);
+    
+    /* The comm field can contain spaces and parentheses, so we need to find the last ')'
+     * Skip the whitespace after finding the last ')' */
+    char *p = strrchr(self_stat_buffer, ')');
+    if (!p) {
+        LV_LOG_ERROR("/proc/self/stat is missing the closing ')'");
+        return UINT32_MAX;
+    }
+
+    p++; /* move past the ')' */ 
+
+    while (*p && (*p == ' ' || *p == '\t'))
+        p++; /* skip whitespace after ')' */ 
+    if (!*p) {
+        LV_LOG_ERROR("/proc/self/stat unexpectedly ends after the closing ')'");
+        return UINT32_MAX;
+    }
+    
+    uint64_t utime = 0;
+    uint64_t stime = 0;
+    
+    int scanned_items = sscanf(p,
+                         "%*c "         /* skip state (field 3) */ 
+                         "%*d %*d %*d %*d %*d " /* skip ppid, pgrp, session, tty_nr, tpgid (fields 4-8) */ 
+                         "%*u "         /* skip flags (field 9) */ 
+                         "%*lu %*lu %*lu %*lu " /* skip minflt, cminflt, majflt, cmajflt (fields 10-13) */ 
+                         "%lu %lu",     /* read utime (field 14), stime (field 15) */ 
+                         &utime, &stime);
+
+    if (scanned_items != 2) {
+        LV_LOG_ERROR("Failed to parse utime/stime");
+        return UINT32_MAX;
+    }
+    
+    self_current_time_ticks = utime + stime;
+    
+    if (lv_read_proc_stat(&stat_current_system_total_ticks) != LV_RESULT_OK) {
+        LV_LOG_ERROR("lv_read_proc_stat failed");
+        return UINT32_MAX;
+    }
+    
+    /* no delta on the first call so return 0, next call will have actual values*/
+    if (last_self_ticks == 0) {
+        last_self_ticks = self_current_time_ticks;
+        last_system_total_ticks_stat = stat_current_system_total_ticks;
+
+        return 0;
+    }
+    
+    uint64_t delta_self_proc_ticks = self_current_time_ticks - last_self_ticks;
+    
+    for (size_t i = 0; i < LV_PROC_STAT_PARAMS_LEN; ++i) {
+        stat_delta_system_ticks.buffer[i] = stat_current_system_total_ticks.buffer[i] - last_system_total_ticks_stat.buffer[i];
+    }
+    
+    uint64_t delta_total_system_ticks = lv_proc_stat_get_total(&stat_delta_system_ticks);
+    
+    last_self_ticks = self_current_time_ticks;
+    last_system_total_ticks_stat = stat_current_system_total_ticks;
+    
+    if (delta_total_system_ticks == 0) {
+        return 0;
+    }
+    
+    uint32_t cpu_percent = (uint32_t)((delta_self_proc_ticks * 100ULL) / delta_total_system_ticks);
+
+    return cpu_percent;
 }
 
 /**********************

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -92,85 +92,85 @@ uint32_t lv_os_get_self_cpu_percent(void)
     lv_proc_stat_t stat_current_system_total_ticks;
     lv_proc_stat_t stat_delta_system_ticks;
 
-    FILE *self = fopen(LV_UPTIME_MONITOR_SELF, "r");
-    if (!self) {
+    FILE * self = fopen(LV_UPTIME_MONITOR_SELF, "r");
+    if(!self) {
         LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_SELF);
         return LV_RESULT_INVALID;
     }
 
     char self_stat_buffer[LV_SELF_PROC_STAT_BUFFER_SIZE];
 
-    if (!fgets(self_stat_buffer, sizeof(self_stat_buffer), self)) {
+    if(!fgets(self_stat_buffer, sizeof(self_stat_buffer), self)) {
         fclose(self);
         LV_LOG_ERROR("Failed to read /proc/self/stat");
         return UINT32_MAX;
     }
 
     fclose(self);
-    
+
     /* The comm field can contain spaces and parentheses, so we need to find the last ')'
      * Skip the whitespace after finding the last ')' */
-    char *p = strrchr(self_stat_buffer, ')');
-    if (!p) {
+    char * p = strrchr(self_stat_buffer, ')');
+    if(!p) {
         LV_LOG_ERROR("/proc/self/stat is missing the closing ')'");
         return UINT32_MAX;
     }
 
-    p++; /* move past the ')' */ 
+    p++; /* move past the ')' */
 
-    while (*p && (*p == ' ' || *p == '\t'))
-        p++; /* skip whitespace after ')' */ 
-    if (!*p) {
+    while(*p && (*p == ' ' || *p == '\t'))
+        p++; /* skip whitespace after ')' */
+    if(!*p) {
         LV_LOG_ERROR("/proc/self/stat unexpectedly ends after the closing ')'");
         return UINT32_MAX;
     }
-    
+
     uint64_t utime = 0;
     uint64_t stime = 0;
-    
-    int scanned_items = sscanf(p,
-                         "%*c "         /* skip state (field 3) */ 
-                         "%*d %*d %*d %*d %*d " /* skip ppid, pgrp, session, tty_nr, tpgid (fields 4-8) */ 
-                         "%*u "         /* skip flags (field 9) */ 
-                         "%*lu %*lu %*lu %*lu " /* skip minflt, cminflt, majflt, cmajflt (fields 10-13) */ 
-                         "%lu %lu",     /* read utime (field 14), stime (field 15) */ 
-                         &utime, &stime);
 
-    if (scanned_items != 2) {
+    int scanned_items = sscanf(p,
+                               "%*c "         /* skip state (field 3) */
+                               "%*d %*d %*d %*d %*d " /* skip ppid, pgrp, session, tty_nr, tpgid (fields 4-8) */
+                               "%*u "         /* skip flags (field 9) */
+                               "%*lu %*lu %*lu %*lu " /* skip minflt, cminflt, majflt, cmajflt (fields 10-13) */
+                               "%lu %lu",     /* read utime (field 14), stime (field 15) */
+                               &utime, &stime);
+
+    if(scanned_items != 2) {
         LV_LOG_ERROR("Failed to parse utime/stime");
         return UINT32_MAX;
     }
-    
+
     self_current_time_ticks = utime + stime;
-    
-    if (lv_read_proc_stat(&stat_current_system_total_ticks) != LV_RESULT_OK) {
+
+    if(lv_read_proc_stat(&stat_current_system_total_ticks) != LV_RESULT_OK) {
         LV_LOG_ERROR("lv_read_proc_stat failed");
         return UINT32_MAX;
     }
-    
+
     /* no delta on the first call so return 0, next call will have actual values*/
-    if (last_self_ticks == 0) {
+    if(last_self_ticks == 0) {
         last_self_ticks = self_current_time_ticks;
         last_system_total_ticks_stat = stat_current_system_total_ticks;
 
         return 0;
     }
-    
+
     uint64_t delta_self_proc_ticks = self_current_time_ticks - last_self_ticks;
-    
-    for (size_t i = 0; i < LV_PROC_STAT_PARAMS_LEN; ++i) {
+
+    for(size_t i = 0; i < LV_PROC_STAT_PARAMS_LEN; ++i) {
         stat_delta_system_ticks.buffer[i] = stat_current_system_total_ticks.buffer[i] - last_system_total_ticks_stat.buffer[i];
     }
-    
+
     uint64_t delta_total_system_ticks = lv_proc_stat_get_total(&stat_delta_system_ticks);
-    
+
     last_self_ticks = self_current_time_ticks;
     last_system_total_ticks_stat = stat_current_system_total_ticks;
-    
-    if (delta_total_system_ticks == 0) {
+
+    if(delta_total_system_ticks == 0) {
         return 0;
     }
-    
+
     uint32_t cpu_percent = (uint32_t)((delta_self_proc_ticks * 100ULL) / delta_total_system_ticks);
 
     return cpu_percent;

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -65,6 +65,8 @@ typedef enum {
  * @return the idle percentage since the last call
  */
 uint32_t lv_os_get_idle_percent(void);
+uint32_t lv_os_get_self_cpu_percent(void)
+
 
 #if LV_USE_OS != LV_OS_NONE
 


### PR DESCRIPTION
As mentioned in https://github.com/lvgl/lvgl/issues/8333#issue-3100027808, this function is supposed to provide a way for an application to determine its own CPU consumption. 

- Adds <string.h>
- Adds two new global variables
- Returns CPU usage in % relative to the systems capacity (nproc)

This PR is still missing some additions.
`lv_conf.h` contains the following line `#define LV_SYSMON_GET_IDLE lv_os_get_idle_percent`. Should there be a new define for this func e.g. `#define LV_SYSMON_GET_SELF lv_os_get_self_cpu_percent`?

Should `lv_sysmon_perf_info_t` be adjusted to contain a new field in calculted e.g. `cpu_self`?
Should `perf_update_timer_cb` be adjusted to check for the defines in case someone wants to use both `lv_os_get_idle_percent` and `lv_os_get_self_cpu_percent`? If we define e.g. `LV_SYSMON_GET_SELF` we could simply do something like
`info->calculated.cpu_self = LV_SYSMON_GET_SELF()`

Thanks,

krembed
