### PR TITLE
feat(linux): Add function which provides cpu usage of the app itself

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1011,6 +1011,15 @@
 #if LV_USE_SYSMON
     /** Get the idle percentage. E.g. uint32_t my_get_idle(void); */
     #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
+    #if LV_USE_OS == LV_OS_PTHREAD
+        /** Get the applications idle percentage.
+         * - Requires `LV_USE_OS == LV_OS_PTHREAD` */
+        #define LV_SYSMON_GET_PROC_IDLE lv_os_get_self_idle_percent
+        #define LV_SYSMON_PROC_IDLE_AVAILABLE 1
+    #else
+        /** A separate application idle percentage function is not available on bare metal as it's the same*/
+        #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
+    #endif
 
     /** 1: Show CPU usage and FPS count.
      *  - Requires `LV_USE_SYSMON = 1` */

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1011,15 +1011,13 @@
 #if LV_USE_SYSMON
     /** Get the idle percentage. E.g. uint32_t my_get_idle(void); */
     #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
-    #if LV_USE_OS == LV_OS_PTHREAD
+    /** 1: Enable usage of lv_os_get_proc_idle_percent.*/
+    #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
+    #if LV_SYSMON_PROC_IDLE_AVAILABLE
         /** Get the applications idle percentage.
          * - Requires `LV_USE_OS == LV_OS_PTHREAD` */
-        #define LV_SYSMON_GET_PROC_IDLE lv_os_get_self_idle_percent
-        #define LV_SYSMON_PROC_IDLE_AVAILABLE 1
-    #else
-        /** A separate application idle percentage function is not available on bare metal as it's the same*/
-        #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
-    #endif
+        #define LV_SYSMON_GET_PROC_IDLE lv_os_get_proc_idle_percent
+    #endif 
 
     /** 1: Show CPU usage and FPS count.
      *  - Requires `LV_USE_SYSMON = 1` */

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -236,6 +236,8 @@ typedef struct _lv_global_t {
     lv_mutex_t lv_general_mutex;
 #if defined(__linux__)
     lv_proc_stat_t linux_last_proc_stat;
+    uint64_t linux_last_self_proc_time_ticks;
+    lv_proc_stat_t linux_last_system_total_ticks_stat;
 #endif
 #endif
 

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -236,8 +236,10 @@ typedef struct _lv_global_t {
     lv_mutex_t lv_general_mutex;
 #if defined(__linux__)
     lv_proc_stat_t linux_last_proc_stat;
+#if defined LV_SYSMON_PROC_IDLE_AVAILABLE
     uint64_t linux_last_self_proc_time_ticks;
     lv_proc_stat_t linux_last_system_total_ticks_stat;
+#endif
 #endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3206,37 +3206,25 @@
             #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
         #endif
     #endif
-    #if LV_USE_OS == LV_OS_PTHREAD
+    /** 1: Enable usage of lv_os_get_proc_idle_percent which gets the applications idle percentage.*/
+    #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
+        #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+            #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+        #else
+            #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
+        #endif
+    #endif
+    #if LV_SYSMON_PROC_IDLE_AVAILABLE
         /** Get the applications idle percentage.
          * - Requires `LV_USE_OS == LV_OS_PTHREAD` */
         #ifndef LV_SYSMON_GET_PROC_IDLE
             #ifdef CONFIG_LV_SYSMON_GET_PROC_IDLE
                 #define LV_SYSMON_GET_PROC_IDLE CONFIG_LV_SYSMON_GET_PROC_IDLE
             #else
-                #define LV_SYSMON_GET_PROC_IDLE lv_os_get_self_idle_percent
+                #define LV_SYSMON_GET_PROC_IDLE lv_os_get_proc_idle_percent
             #endif
         #endif
-        #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
-            #ifdef LV_KCONFIG_PRESENT
-                #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
-                    #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
-                #else
-                    #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
-                #endif
-            #else
-                #define LV_SYSMON_PROC_IDLE_AVAILABLE 1
-            #endif
-        #endif
-    #else
-        /** A separate application idle percentage function is not available on bare metal as it's the same*/
-        #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
-            #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
-                #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
-            #else
-                #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
-            #endif
-        #endif
-    #endif
+    #endif 
 
     /** 1: Show CPU usage and FPS count.
      *  - Requires `LV_USE_SYSMON = 1` */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3206,7 +3206,7 @@
             #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
         #endif
     #endif
-    /** 1: Enable usage of lv_os_get_proc_idle_percent which gets the applications idle percentage.*/
+    /** 1: Enable usage of lv_os_get_proc_idle_percent.*/
     #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
         #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
             #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3206,6 +3206,37 @@
             #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent
         #endif
     #endif
+    #if LV_USE_OS == LV_OS_PTHREAD
+        /** Get the applications idle percentage.
+         * - Requires `LV_USE_OS == LV_OS_PTHREAD` */
+        #ifndef LV_SYSMON_GET_PROC_IDLE
+            #ifdef CONFIG_LV_SYSMON_GET_PROC_IDLE
+                #define LV_SYSMON_GET_PROC_IDLE CONFIG_LV_SYSMON_GET_PROC_IDLE
+            #else
+                #define LV_SYSMON_GET_PROC_IDLE lv_os_get_self_idle_percent
+            #endif
+        #endif
+        #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
+            #ifdef LV_KCONFIG_PRESENT
+                #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+                    #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+                #else
+                    #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
+                #endif
+            #else
+                #define LV_SYSMON_PROC_IDLE_AVAILABLE 1
+            #endif
+        #endif
+    #else
+        /** A separate application idle percentage function is not available on bare metal as it's the same*/
+        #ifndef LV_SYSMON_PROC_IDLE_AVAILABLE
+            #ifdef CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+                #define LV_SYSMON_PROC_IDLE_AVAILABLE CONFIG_LV_SYSMON_PROC_IDLE_AVAILABLE
+            #else
+                #define LV_SYSMON_PROC_IDLE_AVAILABLE 0
+            #endif
+        #endif
+    #endif
 
     /** 1: Show CPU usage and FPS count.
      *  - Requires `LV_USE_SYSMON = 1` */

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -31,7 +31,7 @@
 #define last_self_ticks LV_GLOBAL_DEFAULT()->linux_last_self_proc_time_ticks
 #define last_system_total_ticks_stat LV_GLOBAL_DEFAULT()->linux_last_system_total_ticks_stat
 
-#define LV_SELF_PROC_STAT_BUFFER_SIZE 1024
+#define LV_SELF_PROC_STAT_BUFFER_SIZE 512
 /**********************
  *      TYPEDEFS
  **********************/
@@ -85,7 +85,7 @@ uint32_t lv_os_get_idle_percent(void)
     return (proc_stat.fields.idle * 100) / total;
 }
 
-uint32_t lv_os_get_self_idle_percent(void)
+uint32_t lv_os_get_proc_idle_percent(void)
 {
     uint64_t self_current_time_ticks = 0;
     lv_proc_stat_t stat_current_system_total_ticks;
@@ -94,7 +94,7 @@ uint32_t lv_os_get_self_idle_percent(void)
     FILE * self = fopen(LV_UPTIME_MONITOR_SELF_FILE, "r");
     if(!self) {
         LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_SELF_FILE);
-        return LV_RESULT_INVALID;
+        return UINT32_MAX;
     }
 
     char self_stat_buffer[LV_SELF_PROC_STAT_BUFFER_SIZE];

--- a/src/osal/lv_linux.c
+++ b/src/osal/lv_linux.c
@@ -15,18 +15,23 @@
 #include "../misc/lv_log.h"
 #include "lv_linux_private.h"
 #include <stdio.h>
+#include <string.h>
 
 /*********************
  *      DEFINES
  *********************/
 
 #define LV_UPTIME_MONITOR_FILE         "/proc/stat"
+#define LV_UPTIME_MONITOR_SELF         "/proc/self/stat"
 
 #define LV_PROC_STAT_VAR_FORMAT        " %" PRIu32
 #define LV_PROC_STAT_IGNORE_VAR_FORMAT " %*" PRIu32
 
 #define last_proc_stat LV_GLOBAL_DEFAULT()->linux_last_proc_stat
+#define last_self_ticks LV_GLOBAL_DEFAULT()->linux_last_self_proc_time_ticks
+#define last_system_total_ticks_stat LV_GLOBAL_DEFAULT()->linux_last_system_total_ticks_stat
 
+#define LV_SELF_PROC_STAT_BUFFER_SIZE 1024
 /**********************
  *      TYPEDEFS
  **********************/
@@ -78,6 +83,92 @@ uint32_t lv_os_get_idle_percent(void)
     }
 
     return (proc_stat.fields.idle * 100) / total;
+}
+
+uint32_t lv_os_get_self_cpu_percent(void)
+{
+    uint64_t self_current_time_ticks = 0;
+    lv_proc_stat_t stat_current_system_total_ticks;
+    lv_proc_stat_t stat_delta_system_ticks;
+
+    FILE * self = fopen(LV_UPTIME_MONITOR_SELF, "r");
+    if(!self) {
+        LV_LOG_ERROR("Failed to open " LV_UPTIME_MONITOR_SELF);
+        return LV_RESULT_INVALID;
+    }
+
+    char self_stat_buffer[LV_SELF_PROC_STAT_BUFFER_SIZE];
+
+    if(!fgets(self_stat_buffer, sizeof(self_stat_buffer), self)) {
+        fclose(self);
+        LV_LOG_ERROR("Failed to read /proc/self/stat");
+        return UINT32_MAX;
+    }
+
+    fclose(self);
+
+    /* The comm field can contain spaces and parentheses, so we find the last ')'
+     * Skip the whitespace after finding the last ')' */
+    char * p = strrchr(self_stat_buffer, ')');
+    if(!p) {
+        LV_LOG_ERROR("/proc/self/stat is missing the closing ')'");
+        return UINT32_MAX;
+    }
+    p++; /* move past the ')' */
+    while(*p && (*p == ' ' || *p == '\t'))
+        p++; /* skip whitespace after ')' */
+    if(!*p) {
+        LV_LOG_ERROR("/proc/self/stat unexpectedly ends after the closing ')'");
+        return UINT32_MAX;
+    }
+
+    uint64_t utime = 0;
+    uint64_t stime = 0;
+
+    int scanned_items = sscanf(p,
+                               "%*c "                          // state (field 3)
+                               "%*d %*d %*d %*d %*d "         // ppid, pgrp, session, tty_nr, tpgid (fields 4-8)
+                               "%*u "                         // flags (field 9)
+                               "%*" SCNu64 " %*" SCNu64 " %*" SCNu64 " %*" SCNu64 // minflt, cminflt, majflt, cmajflt (fields 10-13)
+                               " %" SCNu64 "  %" SCNu64,        // utime, stime (fields 14-15)
+                               &utime, &stime);
+
+    if(scanned_items != 2) {
+        LV_LOG_ERROR("Failed to parse utime/stime");
+        return UINT32_MAX;
+    }
+
+    self_current_time_ticks = utime + stime;
+
+    if(lv_read_proc_stat(&stat_current_system_total_ticks) != LV_RESULT_OK) {
+        LV_LOG_ERROR("lv_read_proc_stat failed");
+        return UINT32_MAX;
+    }
+
+    /* no delta on the first call so return 0, next call will have actual values*/
+    if(last_self_ticks == 0) {
+        last_self_ticks = self_current_time_ticks;
+        last_system_total_ticks_stat = stat_current_system_total_ticks;
+
+        return 0;
+    }
+
+    uint64_t delta_self_proc_ticks = self_current_time_ticks - last_self_ticks;
+
+    for(size_t i = 0; i < LV_PROC_STAT_PARAMS_LEN; ++i) {
+        stat_delta_system_ticks.buffer[i] = stat_current_system_total_ticks.buffer[i] - last_system_total_ticks_stat.buffer[i];
+    }
+
+    uint64_t delta_total_system_ticks = lv_proc_stat_get_total(&stat_delta_system_ticks);
+
+    last_self_ticks = self_current_time_ticks;
+    last_system_total_ticks_stat = stat_current_system_total_ticks;
+
+    if(delta_total_system_ticks == 0) return 0;
+
+    uint32_t cpu_percent = (uint32_t)((delta_self_proc_ticks * 100ULL) / delta_total_system_ticks);
+
+    return cpu_percent;
 }
 
 /**********************

--- a/src/osal/lv_linux_private.h
+++ b/src/osal/lv_linux_private.h
@@ -45,6 +45,8 @@ typedef union {
  * GLOBAL PROTOTYPES
  **********************/
 
+uint32_t lv_os_get_self_cpu_percent(void);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/osal/lv_linux_private.h
+++ b/src/osal/lv_linux_private.h
@@ -45,7 +45,7 @@ typedef union {
  * GLOBAL PROTOTYPES
  **********************/
 
-uint32_t lv_os_get_self_idle_percent(void);
+uint32_t lv_os_get_proc_idle_percent(void);
 
 /**********************
  *      MACROS

--- a/src/osal/lv_linux_private.h
+++ b/src/osal/lv_linux_private.h
@@ -45,7 +45,7 @@ typedef union {
  * GLOBAL PROTOTYPES
  **********************/
 
-uint32_t lv_os_get_self_cpu_percent(void);
+uint32_t lv_os_get_self_idle_percent(void);
 
 /**********************
  *      MACROS

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -65,6 +65,7 @@ typedef enum {
  * @return the idle percentage since the last call
  */
 uint32_t lv_os_get_idle_percent(void);
+uint32_t lv_os_get_self_cpu_percent(void);
 
 #if LV_USE_OS != LV_OS_NONE
 

--- a/src/osal/lv_os.h
+++ b/src/osal/lv_os.h
@@ -65,7 +65,6 @@ typedef enum {
  * @return the idle percentage since the last call
  */
 uint32_t lv_os_get_idle_percent(void);
-uint32_t lv_os_get_self_cpu_percent(void);
 
 #if LV_USE_OS != LV_OS_NONE
 

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -238,6 +238,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     lv_display_t * disp = lv_timer_get_user_data(t);
 
     uint32_t LV_SYSMON_GET_IDLE(void);
+    uint32_t LV_SYSMON_GET_SELF(void);
 
     lv_sysmon_perf_info_t * info = &disp->perf_sysmon_info;
     info->calculated.run_cnt++;
@@ -251,6 +252,8 @@ static void perf_update_timer_cb(lv_timer_t * t)
                                   1000 / disp_refr_period);   /*Limit due to possible off-by-one error*/
 
     info->calculated.cpu = 100 - LV_SYSMON_GET_IDLE();
+    info->calculated.cpu_self = LV_SYSMON_GET_SELF();
+
     info->calculated.refr_avg_time = info->measured.refr_cnt ? (info->measured.refr_elaps_sum / info->measured.refr_cnt) :
                                      0;
 
@@ -273,6 +276,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     lv_memzero(info, sizeof(lv_sysmon_perf_info_t));
     info->measured.refr_start = prev_info.measured.refr_start;
     info->calculated.cpu_avg_total = prev_info.calculated.cpu_avg_total;
+    info->calculated.cpu_self = prev_info.calculated.cpu_self;
     info->calculated.fps_avg_total = prev_info.calculated.fps_avg_total;
     info->calculated.run_cnt = prev_info.calculated.run_cnt;
 
@@ -296,9 +300,9 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
     lv_obj_t * label = lv_observer_get_target(observer);
     lv_label_set_text_fmt(
         label,
-        "%" LV_PRIu32" FPS, %" LV_PRIu32 "%% CPU\n"
+        "%" LV_PRIu32" FPS, %" LV_PRIu32 "%% CPU, %" LV_PRIu32 "%% Self\n"
         "%" LV_PRIu32" ms (%" LV_PRIu32" | %" LV_PRIu32")",
-        perf->calculated.fps, perf->calculated.cpu,
+        perf->calculated.fps, perf->calculated.cpu, perf->calculated.cpu_self,
         perf->calculated.render_avg_time + perf->calculated.flush_avg_time,
         perf->calculated.render_avg_time, perf->calculated.flush_avg_time
     );

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -238,7 +238,7 @@ static void perf_update_timer_cb(lv_timer_t * t)
     lv_display_t * disp = lv_timer_get_user_data(t);
 
     uint32_t LV_SYSMON_GET_IDLE(void);
-    uint32_t LV_SYSMON_GET_SELF(void);
+
 
     lv_sysmon_perf_info_t * info = &disp->perf_sysmon_info;
     info->calculated.run_cnt++;
@@ -252,8 +252,10 @@ static void perf_update_timer_cb(lv_timer_t * t)
                                   1000 / disp_refr_period);   /*Limit due to possible off-by-one error*/
 
     info->calculated.cpu = 100 - LV_SYSMON_GET_IDLE();
-    info->calculated.cpu_self = LV_SYSMON_GET_SELF();
-
+#if LV_SYSMON_PROC_IDLE_AVAILABLE
+    uint32_t LV_SYSMON_GET_PROC_IDLE(void);
+    info->calculated.cpu_proc = 100 - LV_SYSMON_GET_PROC_IDLE();
+#endif /*LV_SYSMON_PROC_IDLE_AVAILABLE*/
     info->calculated.refr_avg_time = info->measured.refr_cnt ? (info->measured.refr_elaps_sum / info->measured.refr_cnt) :
                                      0;
 
@@ -276,7 +278,9 @@ static void perf_update_timer_cb(lv_timer_t * t)
     lv_memzero(info, sizeof(lv_sysmon_perf_info_t));
     info->measured.refr_start = prev_info.measured.refr_start;
     info->calculated.cpu_avg_total = prev_info.calculated.cpu_avg_total;
-    info->calculated.cpu_self = prev_info.calculated.cpu_self;
+#if LV_SYSMON_PROC_IDLE_AVAILABLE
+    info->calculated.cpu_proc = prev_info.calculated.cpu_proc;
+#endif  /*LV_SYSMON_PROC_IDLE_AVAILABLE*/
     info->calculated.fps_avg_total = prev_info.calculated.fps_avg_total;
     info->calculated.run_cnt = prev_info.calculated.run_cnt;
 
@@ -298,14 +302,25 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
            perf->calculated.cpu);
 #else
     lv_obj_t * label = lv_observer_get_target(observer);
+#if LV_SYSMON_PROC_IDLE_AVAILABLE
     lv_label_set_text_fmt(
         label,
         "%" LV_PRIu32" FPS, %" LV_PRIu32 "%% CPU, %" LV_PRIu32 "%% Self\n"
         "%" LV_PRIu32" ms (%" LV_PRIu32" | %" LV_PRIu32")",
-        perf->calculated.fps, perf->calculated.cpu, perf->calculated.cpu_self,
+        perf->calculated.fps, perf->calculated.cpu, perf->calculated.cpu_proc,
         perf->calculated.render_avg_time + perf->calculated.flush_avg_time,
         perf->calculated.render_avg_time, perf->calculated.flush_avg_time
     );
+#else
+    lv_label_set_text_fmt(
+        label,
+        "%" LV_PRIu32" FPS, %" LV_PRIu32 "%% CPU\n"
+        "%" LV_PRIu32" ms (%" LV_PRIu32" | %" LV_PRIu32")",
+        perf->calculated.fps, perf->calculated.cpu,
+        perf->calculated.render_avg_time + perf->calculated.flush_avg_time,
+        perf->calculated.render_avg_time, perf->calculated.flush_avg_time
+    );
+#endif /*LV_SYSMON_PROC_IDLE_AVAILABLE*/
 #endif /*LV_USE_PERF_MONITOR_LOG_MODE*/
 }
 

--- a/src/others/sysmon/lv_sysmon_private.h
+++ b/src/others/sysmon/lv_sysmon_private.h
@@ -53,7 +53,9 @@ struct _lv_sysmon_perf_info_t {
     struct {
         uint32_t fps;
         uint32_t cpu;
+#if LV_SYSMON_PROC_IDLE_AVAILABLE
         uint32_t cpu_proc;              /** The applications idle time percentage */
+#endif
         uint32_t refr_avg_time;
         uint32_t render_avg_time;       /**< Pure rendering time without flush time*/
         uint32_t flush_avg_time;        /**< Pure flushing time without rendering time*/

--- a/src/others/sysmon/lv_sysmon_private.h
+++ b/src/others/sysmon/lv_sysmon_private.h
@@ -53,7 +53,7 @@ struct _lv_sysmon_perf_info_t {
     struct {
         uint32_t fps;
         uint32_t cpu;
-        uint32_t cpu_self;
+        uint32_t cpu_proc;              /** The applications idle time percentage */
         uint32_t refr_avg_time;
         uint32_t render_avg_time;       /**< Pure rendering time without flush time*/
         uint32_t flush_avg_time;        /**< Pure flushing time without rendering time*/

--- a/src/others/sysmon/lv_sysmon_private.h
+++ b/src/others/sysmon/lv_sysmon_private.h
@@ -53,6 +53,7 @@ struct _lv_sysmon_perf_info_t {
     struct {
         uint32_t fps;
         uint32_t cpu;
+        uint32_t cpu_self;
         uint32_t refr_avg_time;
         uint32_t render_avg_time;       /**< Pure rendering time without flush time*/
         uint32_t flush_avg_time;        /**< Pure flushing time without rendering time*/


### PR DESCRIPTION
This function is supposed to provide a way for an application to determine its own CPU consumption.

- Adds `string.h` to `lv_linux.h` so we can check for the last ')' in `proc/self/stat` 
- Two new global variables
- Returns CPU usage in % relative to the systems capacity, so spread over all cores

I have closed the previous PR in order to add the changes that I have suggested.
- Add `cpu_self` member to `lv_sysmon_perf_info_t `
- Add `LV_SYSMON_GET_SELF ` to `lv_conf.h` 
- Adjust `perf_update_timer_cb` to include `cpu_self`
- Show both `perf->calculated.cpu` and `perf->calculated.cpu_self` in `perf_observer_cb` because I think it could be useful to see the app cpu usage relative to the total

One test would probably fail due to a compiler warning
`warning: use of assignment suppression and length modifier together in gnu_scanf format`, though I am not exactly sure how to fix it at the moment. I have tried with filling in dummy values for skipped values which hasn't changed anything before.

If some tests fail I will wait for a response before doing any further changes.

Thanks,

krembed
