### PR TITLE
fix(xml): event bubbling chain breaks on tabview

### DIFF
--- a/src/others/xml/parsers/lv_xml_tabview_parser.c
+++ b/src/others/xml/parsers/lv_xml_tabview_parser.c
@@ -57,6 +57,12 @@ void lv_xml_tabview_apply(lv_xml_parser_state_t * state, const char ** attrs)
 
         if(lv_streq("active", name)) lv_tabview_set_active(item, lv_xml_atoi(value), 0);
         if(lv_streq("tab_bar_position", name)) lv_tabview_set_tab_bar_position(item, lv_xml_dir_to_enum(value));
+        if(lv_streq("event_bubble", name)) {
+			 lv_obj_t * cont = lv_tabview_get_content(item);
+			 if (cont) {
+				lv_obj_update_flag(cont, LV_OBJ_FLAG_EVENT_BUBBLE, lv_xml_to_bool(value));
+			 }
+		}
     }
 }
 


### PR DESCRIPTION
Fixes #8299 

This is not a proper fix, but it works for me. I’m sharing it because:

1. It helps illustrate the issue I encountered, effectively serving as a precise reproduction of the problem I reported earlier.

2. It might provide inspiration or a starting point for a proper fix.

3. Alternatively, if I misunderstood how LVGL is supposed to work, this PR could help others point out what I did wrong.

