### PR TITLE
fix(themes): Fix mono theme init

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -127,6 +127,13 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
     else {
         disp->theme = lv_theme_simple_get();
     }
+#elif LV_USE_THEME_MONO
+    if(lv_theme_mono_is_inited() == false) {
+        disp->theme = lv_theme_mono_init(disp, false, LV_FONT_DEFAULT);
+    }
+    else {
+        disp->theme = lv_theme_mono_get();
+    }
 #endif
 
     disp->bottom_layer = lv_obj_create(NULL); /*Create bottom layer on the display*/

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -515,6 +515,14 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 #endif
 }
 
+lv_theme_t * lv_theme_mono_get(void)
+{
+    if(!lv_theme_mono_is_inited()) {
+        return NULL;
+    }
+    return (lv_theme_t *)theme_def;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/themes/mono/lv_theme_mono.h
+++ b/src/themes/mono/lv_theme_mono.h
@@ -45,6 +45,12 @@ lv_theme_t * lv_theme_mono_init(lv_display_t * disp, bool dark_bg, const lv_font
 bool lv_theme_mono_is_inited(void);
 
 /**
+ * Get mono theme
+ * @return a pointer to mono theme, or NULL if this is not initialized
+ */
+lv_theme_t * lv_theme_mono_get(void);
+
+/**
  * Deinitialize the mono theme
  */
 void lv_theme_mono_deinit(void);


### PR DESCRIPTION
Fixes an issue where the theme initialization was missing in the display code resulting in bad rendering for I1 color format since the BG was not set to LV_OPA_COVER.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
