### PR TITLE
fix(NemaGFX): get the static bitmap even if bpp is not 8

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -812,16 +812,20 @@ static void _draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  const l
             }
         }
 
-        /* always request raw bitmaps */
+        /* Performance Optimization for lv_font_fmt_txt_dsc_t fonts, always request raw bitmaps */
         /*Exception for w*h >= NEMA_COORD_LIMIT due to HW limitation on data handling*/
-        is_raw_bitmap = g.box_h * g.box_w <= NEMA_COORD_LIMIT && lv_font_has_static_bitmap(font);
+        is_raw_bitmap = false;
+        if(g.box_h * g.box_w <= NEMA_COORD_LIMIT) {
+            g.req_raw_bitmap = 1;
+            if(font->get_glyph_bitmap == lv_font_get_bitmap_fmt_txt) {
+                lv_font_fmt_txt_dsc_t * fdsc = (lv_font_fmt_txt_dsc_t *)font->dsc;
+                if(fdsc->bitmap_format == LV_FONT_FMT_TXT_PLAIN) {
+                    is_raw_bitmap = true;
+                }
+            }
+        }
 
-        if(is_raw_bitmap) {
-            dsc->glyph_data = (void *)lv_font_get_glyph_static_bitmap(&g);
-        }
-        else {
-            dsc->glyph_data = (void *)lv_font_get_glyph_bitmap(&g, draw_buf);
-        }
+        dsc->glyph_data = (void *)lv_font_get_glyph_bitmap(&g, draw_buf);
 
         dsc->format = dsc->glyph_data ? g.format : LV_FONT_GLYPH_FORMAT_NONE;
     }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -825,7 +825,7 @@ static void _draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  const l
             }
         }
 
-        dsc->glyph_data = (void *)lv_font_get_glyph_bitmap(&g, draw_buf);
+        dsc->glyph_data = g.resolved_font->get_glyph_bitmap(&g, draw_buf);
 
         dsc->format = dsc->glyph_data ? g.format : LV_FONT_GLYPH_FORMAT_NONE;
     }


### PR DESCRIPTION
Revering part of #8332, which was a response to #8156.

See the two separate commits for clarity.

The nema draw unit still wants the raw bitmap even if the stride is not aligned.

Can't use `lv_font_get_glyph_static_bitmap` because it's an error to call it if `lv_font_has_static_bitmap` (aka `font->static_bitmap`) is `false`. See:

https://github.com/lvgl/lvgl/pull/8156/files#diff-1a46cb69b417a79b59be1ea00e2b669665df16a3a351b5d663e0d5c0a9cfcd52

The "Screen sized text" scene of the bechmark saw a large regression with #8332, which prompted me to open this follow-up.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
