### PR TITLE
refactor: add names to anonymous enums to remove sphinx warning

### DIFF
--- a/scripts/properties.py
+++ b/scripts/properties.py
@@ -184,7 +184,7 @@ typedef enum {{
                 f"    LV_PROPERTY_ID(STYLE, {name.upper() + ',' :25} {id_type+',' :28} LV_STYLE_{name.upper()}),\n"
             )
 
-        f.write('} _lv_property_style_id_t;\n\n')
+        f.write('} lv_property_style_id_t;\n\n')
         f.write('#endif\n')
         f.write('#endif\n')
 

--- a/scripts/properties.py
+++ b/scripts/properties.py
@@ -46,7 +46,7 @@ def read_widget_properties(directory):
 
     def match_properties(file_path):
         pattern = r'^\s*LV_PROPERTY_ID2?\((\w+),\s*(\w+),\s*(\w+)(,\s*(\w+))?,\s*(\d+)\)'
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding='utf-8') as file:
             for line in file.readlines():
                 match = re.match(pattern, line)
                 if match:
@@ -58,7 +58,7 @@ def read_widget_properties(directory):
 
     def match_styles(file_path):
         pattern = r'^\s+LV_STYLE_(\w+)\s*=\s*(\d+),'
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding='utf-8') as file:
             for line in file.readlines():
                 match = re.match(pattern, line)
                 if match:
@@ -173,7 +173,7 @@ def write_style_header(output, properties_by_widget):
 
 
 /* *INDENT-OFF* */
-enum {{
+typedef enum {{
 ''')
 
         for property in properties:
@@ -184,12 +184,13 @@ enum {{
                 f"    LV_PROPERTY_ID(STYLE, {name.upper() + ',' :25} {id_type+',' :28} LV_STYLE_{name.upper()}),\n"
             )
 
-        f.write('};\n\n')
+        f.write('} _lv_property_style_id_t;\n\n')
         f.write('#endif\n')
         f.write('#endif\n')
 
 
 def main(directory, output):
+    """Generate property names"""
     property = read_widget_properties(directory)
     write_widget_properties(output, property)
     write_style_header(output, property)

--- a/scripts/properties.py
+++ b/scripts/properties.py
@@ -173,7 +173,7 @@ def write_style_header(output, properties_by_widget):
 
 
 /* *INDENT-OFF* */
-typedef enum {{
+enum _lv_property_style_id_t {{
 ''')
 
         for property in properties:
@@ -184,7 +184,7 @@ typedef enum {{
                 f"    LV_PROPERTY_ID(STYLE, {name.upper() + ',' :25} {id_type+',' :28} LV_STYLE_{name.upper()}),\n"
             )
 
-        f.write('} lv_property_style_id_t;\n\n')
+        f.write('};\n\n')
         f.write('#endif\n')
         f.write('#endif\n')
 

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -209,7 +209,7 @@ typedef enum {
     LV_PROPERTY_ID(OBJ, INDEX,                      LV_PROPERTY_TYPE_INT,       73),
 
     LV_PROPERTY_OBJ_END,
-} _lv_signed_prop_id_t;
+} lv_signed_prop_id_t;
 #endif
 
 /**

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -59,7 +59,7 @@ typedef enum {
     LV_STATE_USER_4      =  0x8000,
 
     LV_STATE_ANY = 0xFFFF,    /**< Special value can be used in some functions to target all states*/
-} lv_obj_state_t;
+} lv_state_t;
 
 /**
  * The possible parts of widgets.

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -80,7 +80,7 @@ typedef enum {
     LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
 
     LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
-} lv_obj_part_t;
+} lv_part_t;
 
 /**
  * On/Off features controlling the object's behavior.

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -43,7 +43,7 @@ extern "C" {
  * Possible states of a widget.
  * OR-ed values are possible
  */
-enum {
+typedef enum {
     LV_STATE_DEFAULT     =  0x0000,
     LV_STATE_CHECKED     =  0x0001,
     LV_STATE_FOCUSED     =  0x0002,
@@ -59,7 +59,7 @@ enum {
     LV_STATE_USER_4      =  0x8000,
 
     LV_STATE_ANY = 0xFFFF,    /**< Special value can be used in some functions to target all states*/
-};
+} lv_obj_state_t;
 
 /**
  * The possible parts of widgets.
@@ -68,7 +68,7 @@ enum {
  * Not all parts are used by every widget
  */
 
-enum {
+typedef enum {
     LV_PART_MAIN         = 0x000000,   /**< A background like rectangle*/
     LV_PART_SCROLLBAR    = 0x010000,   /**< The scrollbar(s)*/
     LV_PART_INDICATOR    = 0x020000,   /**< Indicator, e.g. for slider, bar, switch, or the tick box of the checkbox*/
@@ -80,7 +80,7 @@ enum {
     LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
 
     LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
-};
+} lv_obj_part_t;
 
 /**
  * On/Off features controlling the object's behavior.
@@ -128,7 +128,7 @@ typedef enum {
 } lv_obj_flag_t;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     /*OBJ flag properties */
     LV_PROPERTY_ID(OBJ, FLAG_START,                 LV_PROPERTY_TYPE_INT,       0),
     LV_PROPERTY_ID(OBJ, FLAG_HIDDEN,                LV_PROPERTY_TYPE_INT,       0),
@@ -209,7 +209,7 @@ enum {
     LV_PROPERTY_ID(OBJ, INDEX,                      LV_PROPERTY_TYPE_INT,       73),
 
     LV_PROPERTY_OBJ_END,
-};
+} _lv_signed_prop_id_t;
 #endif
 
 /**

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -59,7 +59,7 @@ typedef enum {
     LV_STATE_USER_4      =  0x8000,
 
     LV_STATE_ANY = 0xFFFF,    /**< Special value can be used in some functions to target all states*/
-} lv_state_t;
+} _lv_state_t;
 
 /**
  * The possible parts of widgets.
@@ -80,7 +80,7 @@ typedef enum {
     LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
 
     LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
-} lv_part_t;
+} _lv_part_t;
 
 /**
  * On/Off features controlling the object's behavior.

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -43,7 +43,7 @@ extern "C" {
  * Possible states of a widget.
  * OR-ed values are possible
  */
-typedef enum {
+enum _lv_state_t {
     LV_STATE_DEFAULT     =  0x0000,
     LV_STATE_CHECKED     =  0x0001,
     LV_STATE_FOCUSED     =  0x0002,
@@ -59,7 +59,7 @@ typedef enum {
     LV_STATE_USER_4      =  0x8000,
 
     LV_STATE_ANY = 0xFFFF,    /**< Special value can be used in some functions to target all states*/
-} _lv_state_t;
+};
 
 /**
  * The possible parts of widgets.
@@ -68,7 +68,7 @@ typedef enum {
  * Not all parts are used by every widget
  */
 
-typedef enum {
+enum _lv_part_t {
     LV_PART_MAIN         = 0x000000,   /**< A background like rectangle*/
     LV_PART_SCROLLBAR    = 0x010000,   /**< The scrollbar(s)*/
     LV_PART_INDICATOR    = 0x020000,   /**< Indicator, e.g. for slider, bar, switch, or the tick box of the checkbox*/
@@ -80,7 +80,7 @@ typedef enum {
     LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
 
     LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
-} _lv_part_t;
+};
 
 /**
  * On/Off features controlling the object's behavior.
@@ -128,7 +128,7 @@ typedef enum {
 } lv_obj_flag_t;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_signed_prop_id_t {
     /*OBJ flag properties */
     LV_PROPERTY_ID(OBJ, FLAG_START,                 LV_PROPERTY_TYPE_INT,       0),
     LV_PROPERTY_ID(OBJ, FLAG_HIDDEN,                LV_PROPERTY_TYPE_INT,       0),
@@ -209,7 +209,7 @@ typedef enum {
     LV_PROPERTY_ID(OBJ, INDEX,                      LV_PROPERTY_TYPE_INT,       73),
 
     LV_PROPERTY_OBJ_END,
-} lv_signed_prop_id_t;
+};
 #endif
 
 /**

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -68,7 +68,7 @@ extern "C" {
 /**
  * Group of predefined widget ID start value.
  */
-typedef enum {
+enum _lv_prop_id_range_boundary_t {
     LV_PROPERTY_ID_INVALID      = 0,
 
     /*ID 0x01 to 0xff are style ID, check lv_style_prop_t*/
@@ -90,7 +90,7 @@ typedef enum {
     LV_PROPERTY_ID_BUILTIN_LAST = 0xffff, /*ID of 0x10000 ~ 0xfffffff is reserved for user*/
 
     LV_PROPERTY_ID_ANY          = 0x7ffffffe, /*Special ID used by lvgl to intercept all setter/getter call.*/
-} lv_prop_id_range_boundary_t;
+};
 
 struct _lv_property_name_t {
     const char * name;

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -38,7 +38,19 @@ extern "C" {
 
 #define LV_PROPERTY_TYPE_SHIFT          28
 #define LV_PROPERTY_TYPE2_SHIFT         24
+
+/* Example:
+ * LV_PROPERTY_ID(OBJ, FLAG_CLICKABLE, LV_PROPERTY_TYPE_INT, 1),
+ * produces
+ * LV_PROPERTY_OBJ_FLAG_CLICKABLE = (LV_PROPERTY_OBJ_START + (1)) | ((LV_PROPERTY_TYPE_INT) << LV_PROPERTY_TYPE_SHIFT)
+ */
 #define LV_PROPERTY_ID(clz, name, type, index)          LV_PROPERTY_## clz ##_##name = (LV_PROPERTY_## clz ##_START + (index)) | ((type) << LV_PROPERTY_TYPE_SHIFT)
+
+/* Example:
+ * LV_PROPERTY_ID2(SLIDER, VALUE, LV_PROPERTY_TYPE_INT, LV_PROPERTY_TYPE_BOOL, 0)
+ * produces
+ * LV_PROPERTY_SLIDER_VALUE = (LV_PROPERTY_SLIDER_START + (0)) | ((LV_PROPERTY_TYPE_INT) << LV_PROPERTY_TYPE_SHIFT) | ((LV_PROPERTY_TYPE_BOOL) << LV_PROPERTY_TYPE2_SHIFT)
+ */
 #define LV_PROPERTY_ID2(clz, name, type, type2, index)  LV_PROPERTY_ID(clz, name, type, index) | ((type2) << LV_PROPERTY_TYPE2_SHIFT)
 
 #define LV_PROPERTY_ID_TYPE(id) ((id) >> LV_PROPERTY_TYPE_SHIFT)
@@ -56,7 +68,7 @@ extern "C" {
 /**
  * Group of predefined widget ID start value.
  */
-enum {
+typedef enum {
     LV_PROPERTY_ID_INVALID      = 0,
 
     /*ID 0x01 to 0xff are style ID, check lv_style_prop_t*/
@@ -78,7 +90,7 @@ enum {
     LV_PROPERTY_ID_BUILTIN_LAST = 0xffff, /*ID of 0x10000 ~ 0xfffffff is reserved for user*/
 
     LV_PROPERTY_ID_ANY          = 0x7ffffffe, /*Special ID used by lvgl to intercept all setter/getter call.*/
-};
+} lv_prop_id_range_boundary_t;
 
 struct _lv_property_name_t {
     const char * name;

--- a/src/font/lv_symbol_def.h
+++ b/src/font/lv_symbol_def.h
@@ -348,7 +348,7 @@ typedef enum {
     LV_STR_SYMBOL_SD_CARD,
     LV_STR_SYMBOL_NEW_LINE,
     LV_STR_SYMBOL_DUMMY,
-} _lv_str_symbol_id_t;
+} lv_str_symbol_id_t;
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/font/lv_symbol_def.h
+++ b/src/font/lv_symbol_def.h
@@ -285,7 +285,7 @@ extern "C" {
  * The following list is generated using
  * cat src/font/lv_symbol_def.h | sed -E -n 's/^#define\s+LV_(SYMBOL_\w+).*".*$/    LV_STR_\1,/p'
  */
-typedef enum {
+enum _lv_str_symbol_id_t {
     LV_STR_SYMBOL_BULLET,
     LV_STR_SYMBOL_AUDIO,
     LV_STR_SYMBOL_VIDEO,
@@ -348,7 +348,7 @@ typedef enum {
     LV_STR_SYMBOL_SD_CARD,
     LV_STR_SYMBOL_NEW_LINE,
     LV_STR_SYMBOL_DUMMY,
-} lv_str_symbol_id_t;
+};
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/font/lv_symbol_def.h
+++ b/src/font/lv_symbol_def.h
@@ -285,7 +285,7 @@ extern "C" {
  * The following list is generated using
  * cat src/font/lv_symbol_def.h | sed -E -n 's/^#define\s+LV_(SYMBOL_\w+).*".*$/    LV_STR_\1,/p'
  */
-enum {
+typedef enum {
     LV_STR_SYMBOL_BULLET,
     LV_STR_SYMBOL_AUDIO,
     LV_STR_SYMBOL_VIDEO,
@@ -348,7 +348,7 @@ enum {
     LV_STR_SYMBOL_SD_CARD,
     LV_STR_SYMBOL_NEW_LINE,
     LV_STR_SYMBOL_DUMMY,
-};
+} _lv_str_symbol_id_t;
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/libs/svg/lv_svg.h
+++ b/src/libs/svg/lv_svg.h
@@ -21,7 +21,7 @@
 /**********************
  *      TYPEDEFS
  **********************/
-typedef enum {
+enum _lv_svg_tag_t {
     LV_SVG_TAG_INVALID = -1,
     LV_SVG_TAG_CONTENT,
     LV_SVG_TAG_SVG,
@@ -51,10 +51,10 @@ typedef enum {
     LV_SVG_TAG_TEXT,
     LV_SVG_TAG_TSPAN,
     LV_SVG_TAG_TEXT_AREA,
-} _lv_svg_tag_t;
+};
 typedef int8_t lv_svg_tag_t;
 
-typedef enum {
+enum _lv_svg_attr_type_t {
     LV_SVG_ATTR_INVALID = 0,
     LV_SVG_ATTR_ID,
     LV_SVG_ATTR_XML_ID,
@@ -133,50 +133,50 @@ typedef enum {
     LV_SVG_ATTR_ROTATE,
     LV_SVG_ATTR_TRANSFORM_TYPE,
 #endif
-} _lv_svg_attr_type_t;
+};
 typedef uint8_t lv_svg_attr_type_t;
 
-typedef enum {
+enum _lv_svg_transform_type_t {
     LV_SVG_TRANSFORM_TYPE_MATRIX = 1,
     LV_SVG_TRANSFORM_TYPE_TRANSLATE,
     LV_SVG_TRANSFORM_TYPE_ROTATE,
     LV_SVG_TRANSFORM_TYPE_SCALE,
     LV_SVG_TRANSFORM_TYPE_SKEW_X,
     LV_SVG_TRANSFORM_TYPE_SKEW_Y,
-} _lv_svg_transform_type_t;
+};
 typedef uint8_t lv_svg_transform_type_t;
 
 #if LV_USE_SVG_ANIMATION
-typedef enum {
+enum lv_svg_anim_action_t {
     LV_SVG_ANIM_REMOVE = 0,
     LV_SVG_ANIM_FREEZE,
-} lv_svg_anim_action_t;
+};
 
-typedef enum {
+enum _lv_svg_anim_restart_type_t {
     LV_SVG_ANIM_RESTART_ALWAYS = 0,
     LV_SVG_ANIM_RESTART_WHEN_NOT_ACTIVE,
     LV_SVG_ANIM_RESTART_NEVER,
-} lv_svg_anim_restart_type_t;
+};
 
-typedef enum {
+enum _lv_svg_anim_calc_mode_t {
     LV_SVG_ANIM_CALC_MODE_LINEAR = 0,
     LV_SVG_ANIM_CALC_MODE_PACED,
     LV_SVG_ANIM_CALC_MODE_SPLINE,
     LV_SVG_ANIM_CALC_MODE_DISCRETE,
-} lv_svg_anim_calc_mode_t;
+};
 
-typedef enum {
+enum _lv_svg_anim_additive_type_t {
     LV_SVG_ANIM_ADDITIVE_REPLACE = 0,
     LV_SVG_ANIM_ADDITIVE_SUM,
-} lv_svg_anim_additive_type_t;
+};
 
-typedef enum {
+enum _lv_svg_anim_accumulate_type_t {
     LV_SVG_ANIM_ACCUMULATE_NONE = 0,
     LV_SVG_ANIM_ACCUMULATE_SUM,
-} lv_svg_anim_accumulate_type_t;
+};
 #endif
 
-typedef enum {
+enum _lv_svg_aspect_ratio_t {
     LV_SVG_ASPECT_RATIO_NONE = 0,
     LV_SVG_ASPECT_RATIO_XMIN_YMIN = (1 << 1),
     LV_SVG_ASPECT_RATIO_XMID_YMIN = (2 << 1),
@@ -187,13 +187,13 @@ typedef enum {
     LV_SVG_ASPECT_RATIO_XMIN_YMAX = (7 << 1),
     LV_SVG_ASPECT_RATIO_XMID_YMAX = (8 << 1),
     LV_SVG_ASPECT_RATIO_XMAX_YMAX = (9 << 1),
-} _lv_svg_aspect_ratio_t;
+};
 typedef uint32_t lv_svg_aspect_ratio_t;
 
-typedef enum {
+enum _lv_svg_aspect_ratio_opt_t {
     LV_SVG_ASPECT_RATIO_OPT_MEET = 0,
     LV_SVG_ASPECT_RATIO_OPT_SLICE,
-} lv_svg_aspect_ratio_opt_t;
+};
 
 typedef struct {
     float x;
@@ -206,30 +206,30 @@ typedef struct {
 
 typedef uint32_t lv_svg_color_t;
 
-typedef enum {
+enum _lv_svg_fill_rule_t {
     LV_SVG_FILL_NONZERO = 0,
     LV_SVG_FILL_EVENODD,
-} _lv_svg_fill_rule_t;
+};
 typedef uint8_t lv_svg_fill_rule_t;
 
-typedef enum {
+enum _lv_svg_line_cap_t {
     LV_SVG_LINE_CAP_BUTT = 0,
     LV_SVG_LINE_CAP_SQUARE,
     LV_SVG_LINE_CAP_ROUND,
-} _lv_svg_line_cap_t;
+};
 typedef uint8_t lv_svg_line_cap_t;
 
-typedef enum {
+enum _lv_svg_line_join_t {
     LV_SVG_LINE_JOIN_MITER = 0,
     LV_SVG_LINE_JOIN_BEVEL,
     LV_SVG_LINE_JOIN_ROUND,
-} _lv_svg_line_join_t;
+};
 typedef uint8_t lv_svg_line_join_t;
 
-typedef enum {
+enum _lv_svg_gradient_units_t {
     LV_SVG_GRADIENT_UNITS_OBJECT = 0,
     LV_SVG_GRADIENT_UNITS_USER_SPACE,
-} _lv_svg_gradient_units_t;
+};
 typedef uint8_t lv_svg_gradient_units_t;
 
 typedef union {
@@ -250,13 +250,13 @@ typedef struct {
 } lv_svg_attr_values_list_t;
 
 /* https://www.w3.org/TR/SVGTiny12/svgudomidl.html */
-typedef enum {
+enum _lv_svg_path_cmd_t {
     LV_SVG_PATH_CMD_MOVE_TO = 77,
     LV_SVG_PATH_CMD_LINE_TO = 76,
     LV_SVG_PATH_CMD_CURVE_TO = 67,
     LV_SVG_PATH_CMD_QUAD_TO = 81,
     LV_SVG_PATH_CMD_CLOSE = 90,
-} lv_svg_path_cmd_t;
+};
 
 /*
  * to simplify list buffer management, allocate enough memory for all path data and cmd.
@@ -267,17 +267,17 @@ typedef struct {
     uint8_t data[1];
 } lv_svg_attr_path_value_t;
 
-typedef enum {
+enum _lv_svg_attr_value_type_t {
     LV_SVG_ATTR_VALUE_DATA = 0,
     LV_SVG_ATTR_VALUE_PTR,
-} _lv_svg_attr_value_type_t;
+};
 typedef uint8_t lv_svg_attr_value_type_t;
 
-typedef enum {
+enum _lv_svg_attr_value_class_t {
     LV_SVG_ATTR_VALUE_NONE = 0,
     LV_SVG_ATTR_VALUE_INITIAL,
     LV_SVG_ATTR_VALUE_INHERIT,
-} _lv_svg_attr_value_class_t;
+};
 typedef uint8_t lv_svg_attr_value_class_t;
 
 typedef struct {

--- a/src/libs/svg/lv_svg.h
+++ b/src/libs/svg/lv_svg.h
@@ -21,7 +21,7 @@
 /**********************
  *      TYPEDEFS
  **********************/
-enum {
+typedef enum {
     LV_SVG_TAG_INVALID = -1,
     LV_SVG_TAG_CONTENT,
     LV_SVG_TAG_SVG,
@@ -51,10 +51,10 @@ enum {
     LV_SVG_TAG_TEXT,
     LV_SVG_TAG_TSPAN,
     LV_SVG_TAG_TEXT_AREA,
-};
+} _lv_svg_tag_t;
 typedef int8_t lv_svg_tag_t;
 
-enum {
+typedef enum {
     LV_SVG_ATTR_INVALID = 0,
     LV_SVG_ATTR_ID,
     LV_SVG_ATTR_XML_ID,
@@ -133,50 +133,50 @@ enum {
     LV_SVG_ATTR_ROTATE,
     LV_SVG_ATTR_TRANSFORM_TYPE,
 #endif
-};
+} _lv_svg_attr_type_t;
 typedef uint8_t lv_svg_attr_type_t;
 
-enum {
+typedef enum {
     LV_SVG_TRANSFORM_TYPE_MATRIX = 1,
     LV_SVG_TRANSFORM_TYPE_TRANSLATE,
     LV_SVG_TRANSFORM_TYPE_ROTATE,
     LV_SVG_TRANSFORM_TYPE_SCALE,
     LV_SVG_TRANSFORM_TYPE_SKEW_X,
     LV_SVG_TRANSFORM_TYPE_SKEW_Y,
-};
+} _lv_svg_transform_type_t;
 typedef uint8_t lv_svg_transform_type_t;
 
 #if LV_USE_SVG_ANIMATION
-enum {
+typedef enum {
     LV_SVG_ANIM_REMOVE = 0,
     LV_SVG_ANIM_FREEZE,
-};
+} _lv_svg_anim_action_t;
 
-enum {
+typedef enum {
     LV_SVG_ANIM_RESTART_ALWAYS = 0,
     LV_SVG_ANIM_RESTART_WHEN_NOT_ACTIVE,
     LV_SVG_ANIM_RESTART_NEVER,
-};
+} _lv_svg_restart_type_t;
 
-enum {
+typedef enum {
     LV_SVG_ANIM_CALC_MODE_LINEAR = 0,
     LV_SVG_ANIM_CALC_MODE_PACED,
     LV_SVG_ANIM_CALC_MODE_SPLINE,
     LV_SVG_ANIM_CALC_MODE_DISCRETE,
-};
+} _lv_svg_anim_calc_mode_t;
 
-enum {
+typedef enum {
     LV_SVG_ANIM_ADDITIVE_REPLACE = 0,
     LV_SVG_ANIM_ADDITIVE_SUM,
-};
+} _lv_svg_anim_additive_type_t;
 
-enum {
+typedef enum {
     LV_SVG_ANIM_ACCUMULATE_NONE = 0,
     LV_SVG_ANIM_ACCUMULATE_SUM,
-};
+} _lv_svg_accumulate_type_t;
 #endif
 
-enum {
+typedef enum {
     LV_SVG_ASPECT_RATIO_NONE = 0,
     LV_SVG_ASPECT_RATIO_XMIN_YMIN = (1 << 1),
     LV_SVG_ASPECT_RATIO_XMID_YMIN = (2 << 1),
@@ -187,12 +187,12 @@ enum {
     LV_SVG_ASPECT_RATIO_XMIN_YMAX = (7 << 1),
     LV_SVG_ASPECT_RATIO_XMID_YMAX = (8 << 1),
     LV_SVG_ASPECT_RATIO_XMAX_YMAX = (9 << 1),
-};
+} _lv_svg_aspect_ratio_t;
 
-enum {
+typedef enum {
     LV_SVG_ASPECT_RATIO_OPT_MEET = 0,
     LV_SVG_ASPECT_RATIO_OPT_SLICE,
-};
+} _lv_svg_aspect_ratio_t;
 typedef uint32_t lv_svg_aspect_ratio_t;
 
 typedef struct {
@@ -206,30 +206,30 @@ typedef struct {
 
 typedef uint32_t lv_svg_color_t;
 
-enum {
+typedef enum {
     LV_SVG_FILL_NONZERO = 0,
     LV_SVG_FILL_EVENODD,
-};
+} _lv_svg_fill_rule_t;
 typedef uint8_t lv_svg_fill_rule_t;
 
-enum {
+typedef enum {
     LV_SVG_LINE_CAP_BUTT = 0,
     LV_SVG_LINE_CAP_SQUARE,
     LV_SVG_LINE_CAP_ROUND,
-};
+} _lv_svg_line_cap_t;
 typedef uint8_t lv_svg_line_cap_t;
 
-enum {
+typedef enum {
     LV_SVG_LINE_JOIN_MITER = 0,
     LV_SVG_LINE_JOIN_BEVEL,
     LV_SVG_LINE_JOIN_ROUND,
-};
+} _lv_svg_line_join_t;
 typedef uint8_t lv_svg_line_join_t;
 
-enum {
+typedef enum {
     LV_SVG_GRADIENT_UNITS_OBJECT = 0,
     LV_SVG_GRADIENT_UNITS_USER_SPACE,
-};
+} _lv_svg_gradient_units_t;
 typedef uint8_t lv_svg_gradient_units_t;
 
 typedef union {
@@ -250,13 +250,13 @@ typedef struct {
 } lv_svg_attr_values_list_t;
 
 /* https://www.w3.org/TR/SVGTiny12/svgudomidl.html */
-enum {
+typedef enum {
     LV_SVG_PATH_CMD_MOVE_TO = 77,
     LV_SVG_PATH_CMD_LINE_TO = 76,
     LV_SVG_PATH_CMD_CURVE_TO = 67,
     LV_SVG_PATH_CMD_QUAD_TO = 81,
     LV_SVG_PATH_CMD_CLOSE = 90,
-};
+} _lv_svg_path_cmd_t;
 
 /*
  * to simplify list buffer management, allocate enough memory for all path data and cmd.
@@ -267,17 +267,17 @@ typedef struct {
     uint8_t data[1];
 } lv_svg_attr_path_value_t;
 
-enum {
+typedef enum {
     LV_SVG_ATTR_VALUE_DATA = 0,
     LV_SVG_ATTR_VALUE_PTR,
-};
+} _lv_svg_attr_value_type_t;
 typedef uint8_t lv_svg_attr_value_type_t;
 
-enum {
+typedef enum {
     LV_SVG_ATTR_VALUE_NONE = 0,
     LV_SVG_ATTR_VALUE_INITIAL,
     LV_SVG_ATTR_VALUE_INHERIT,
-};
+} _lv_svg_attr_value_class_t;
 typedef uint8_t lv_svg_attr_value_class_t;
 
 typedef struct {

--- a/src/libs/svg/lv_svg.h
+++ b/src/libs/svg/lv_svg.h
@@ -156,7 +156,7 @@ typedef enum {
     LV_SVG_ANIM_RESTART_ALWAYS = 0,
     LV_SVG_ANIM_RESTART_WHEN_NOT_ACTIVE,
     LV_SVG_ANIM_RESTART_NEVER,
-} lv_svg_restart_type_t;
+} lv_svg_anim_restart_type_t;
 
 typedef enum {
     LV_SVG_ANIM_CALC_MODE_LINEAR = 0,
@@ -173,7 +173,7 @@ typedef enum {
 typedef enum {
     LV_SVG_ANIM_ACCUMULATE_NONE = 0,
     LV_SVG_ANIM_ACCUMULATE_SUM,
-} lv_svg_accumulate_type_t;
+} lv_svg_anim_accumulate_type_t;
 #endif
 
 typedef enum {

--- a/src/libs/svg/lv_svg.h
+++ b/src/libs/svg/lv_svg.h
@@ -192,7 +192,7 @@ typedef enum {
 typedef enum {
     LV_SVG_ASPECT_RATIO_OPT_MEET = 0,
     LV_SVG_ASPECT_RATIO_OPT_SLICE,
-} _lv_svg_aspect_ratio_t;
+} _lv_svg_aspect_ratio_opt_t;
 typedef uint32_t lv_svg_aspect_ratio_t;
 
 typedef struct {

--- a/src/libs/svg/lv_svg.h
+++ b/src/libs/svg/lv_svg.h
@@ -150,30 +150,30 @@ typedef uint8_t lv_svg_transform_type_t;
 typedef enum {
     LV_SVG_ANIM_REMOVE = 0,
     LV_SVG_ANIM_FREEZE,
-} _lv_svg_anim_action_t;
+} lv_svg_anim_action_t;
 
 typedef enum {
     LV_SVG_ANIM_RESTART_ALWAYS = 0,
     LV_SVG_ANIM_RESTART_WHEN_NOT_ACTIVE,
     LV_SVG_ANIM_RESTART_NEVER,
-} _lv_svg_restart_type_t;
+} lv_svg_restart_type_t;
 
 typedef enum {
     LV_SVG_ANIM_CALC_MODE_LINEAR = 0,
     LV_SVG_ANIM_CALC_MODE_PACED,
     LV_SVG_ANIM_CALC_MODE_SPLINE,
     LV_SVG_ANIM_CALC_MODE_DISCRETE,
-} _lv_svg_anim_calc_mode_t;
+} lv_svg_anim_calc_mode_t;
 
 typedef enum {
     LV_SVG_ANIM_ADDITIVE_REPLACE = 0,
     LV_SVG_ANIM_ADDITIVE_SUM,
-} _lv_svg_anim_additive_type_t;
+} lv_svg_anim_additive_type_t;
 
 typedef enum {
     LV_SVG_ANIM_ACCUMULATE_NONE = 0,
     LV_SVG_ANIM_ACCUMULATE_SUM,
-} _lv_svg_accumulate_type_t;
+} lv_svg_accumulate_type_t;
 #endif
 
 typedef enum {
@@ -188,12 +188,12 @@ typedef enum {
     LV_SVG_ASPECT_RATIO_XMID_YMAX = (8 << 1),
     LV_SVG_ASPECT_RATIO_XMAX_YMAX = (9 << 1),
 } _lv_svg_aspect_ratio_t;
+typedef uint32_t lv_svg_aspect_ratio_t;
 
 typedef enum {
     LV_SVG_ASPECT_RATIO_OPT_MEET = 0,
     LV_SVG_ASPECT_RATIO_OPT_SLICE,
-} _lv_svg_aspect_ratio_opt_t;
-typedef uint32_t lv_svg_aspect_ratio_t;
+} lv_svg_aspect_ratio_opt_t;
 
 typedef struct {
     float x;
@@ -256,7 +256,7 @@ typedef enum {
     LV_SVG_PATH_CMD_CURVE_TO = 67,
     LV_SVG_PATH_CMD_QUAD_TO = 81,
     LV_SVG_PATH_CMD_CLOSE = 90,
-} _lv_svg_path_cmd_t;
+} lv_svg_path_cmd_t;
 
 /*
  * to simplify list buffer management, allocate enough memory for all path data and cmd.

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -37,7 +37,7 @@ LV_EXPORT_CONST_INT(LV_COLOR_DEPTH);
  * Opacity percentages.
  */
 
-enum {
+typedef enum {
     LV_OPA_TRANSP = 0,
     LV_OPA_0      = 0,
     LV_OPA_10     = 25,
@@ -51,7 +51,7 @@ enum {
     LV_OPA_90     = 229,
     LV_OPA_100    = 255,
     LV_OPA_COVER  = 255,
-};
+} lv_opacity_level_t;
 
 #define LV_OPA_MIN 2    /**< Fully transparent if opa <= LV_OPA_MIN */
 #define LV_OPA_MAX 253  /**< Fully cover if opa >= LV_OPA_MAX */

--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -37,7 +37,7 @@ LV_EXPORT_CONST_INT(LV_COLOR_DEPTH);
  * Opacity percentages.
  */
 
-typedef enum {
+enum _lv_opacity_level_t {
     LV_OPA_TRANSP = 0,
     LV_OPA_0      = 0,
     LV_OPA_10     = 25,
@@ -51,7 +51,7 @@ typedef enum {
     LV_OPA_90     = 229,
     LV_OPA_100    = 255,
     LV_OPA_COVER  = 255,
-} lv_opacity_level_t;
+};
 
 #define LV_OPA_MIN 2    /**< Fully transparent if opa <= LV_OPA_MIN */
 #define LV_OPA_MAX 253  /**< Fully cover if opa >= LV_OPA_MAX */

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -132,7 +132,7 @@ typedef union {
  *
  * Props are split into groups of 16. When adding a new prop to a group, ensure it does not overflow into the next one.
  */
-typedef enum {
+enum _lv_style_id_t {
     LV_STYLE_PROP_INV               = 0,
 
     /*Group 0*/
@@ -290,7 +290,7 @@ typedef enum {
 
     LV_STYLE_PROP_ANY                = 0xFF,
     LV_STYLE_PROP_CONST             = 0xFF /* magic value for const styles */
-} lv_style_id_t;
+};
 
 typedef enum {
     LV_STYLE_RES_NOT_FOUND,

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -132,7 +132,7 @@ typedef union {
  *
  * Props are split into groups of 16. When adding a new prop to a group, ensure it does not overflow into the next one.
  */
-enum {
+typedef enum {
     LV_STYLE_PROP_INV               = 0,
 
     /*Group 0*/
@@ -290,7 +290,7 @@ enum {
 
     LV_STYLE_PROP_ANY                = 0xFF,
     LV_STYLE_PROP_CONST             = 0xFF /* magic value for const styles */
-};
+} _lv_style_id_t;
 
 typedef enum {
     LV_STYLE_RES_NOT_FOUND,

--- a/src/misc/lv_style.h
+++ b/src/misc/lv_style.h
@@ -290,7 +290,7 @@ typedef enum {
 
     LV_STYLE_PROP_ANY                = 0xFF,
     LV_STYLE_PROP_CONST             = 0xFF /* magic value for const styles */
-} _lv_style_id_t;
+} lv_style_id_t;
 
 typedef enum {
     LV_STYLE_RES_NOT_FOUND,

--- a/src/misc/lv_tree.h
+++ b/src/misc/lv_tree.h
@@ -47,10 +47,10 @@ typedef struct _lv_tree_node_t {
     const struct _lv_tree_class_t * class_p;
 } lv_tree_node_t;
 
-typedef enum {
+enum _lv_tree_walk_mode_t {
     LV_TREE_WALK_PRE_ORDER = 0,
     LV_TREE_WALK_POST_ORDER,
-} _lv_tree_walk_mode_t;
+};
 typedef uint8_t lv_tree_walk_mode_t;
 
 typedef bool (*lv_tree_traverse_cb_t)(const lv_tree_node_t * node, void * user_data);

--- a/src/misc/lv_tree.h
+++ b/src/misc/lv_tree.h
@@ -47,10 +47,10 @@ typedef struct _lv_tree_node_t {
     const struct _lv_tree_class_t * class_p;
 } lv_tree_node_t;
 
-enum {
+typedef enum {
     LV_TREE_WALK_PRE_ORDER = 0,
     LV_TREE_WALK_POST_ORDER,
-};
+} _lv_tree_walk_mode_t;
 typedef uint8_t lv_tree_walk_mode_t;
 
 typedef bool (*lv_tree_traverse_cb_t)(const lv_tree_node_t * node, void * user_data);

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -42,7 +42,7 @@ typedef enum {
     LV_PROPERTY_ID(ANIMIMAGE, REPEAT_COUNT, LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(ANIMIMAGE, SRC_COUNT,    LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_ANIMIMAGE_END,
-} _lv_property_animimage_id_t;
+} lv_property_animimage_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_animimg_class;

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -36,13 +36,13 @@ extern "C" {
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_animimage_id_t {
     LV_PROPERTY_ID2(ANIMIMAGE, SRC,         LV_PROPERTY_TYPE_POINTER,  LV_PROPERTY_TYPE_INT,  0),
     LV_PROPERTY_ID(ANIMIMAGE, DURATION,     LV_PROPERTY_TYPE_INT,   1),
     LV_PROPERTY_ID(ANIMIMAGE, REPEAT_COUNT, LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(ANIMIMAGE, SRC_COUNT,    LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_ANIMIMAGE_END,
-} lv_property_animimage_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_animimg_class;

--- a/src/widgets/animimage/lv_animimage.h
+++ b/src/widgets/animimage/lv_animimage.h
@@ -36,13 +36,13 @@ extern "C" {
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID2(ANIMIMAGE, SRC,         LV_PROPERTY_TYPE_POINTER,  LV_PROPERTY_TYPE_INT,  0),
     LV_PROPERTY_ID(ANIMIMAGE, DURATION,     LV_PROPERTY_TYPE_INT,   1),
     LV_PROPERTY_ID(ANIMIMAGE, REPEAT_COUNT, LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(ANIMIMAGE, SRC_COUNT,    LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_ANIMIMAGE_END,
-};
+} _lv_property_animimage_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_animimg_class;

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -44,7 +44,7 @@ typedef enum {
     LV_PROPERTY_ID(DROPDOWN, LIST,                LV_PROPERTY_TYPE_OBJ,   8),
     LV_PROPERTY_ID(DROPDOWN, IS_OPEN,             LV_PROPERTY_TYPE_BOOL,  9),
     LV_PROPERTY_DROPDOWN_END,
-} _lv_property_dropdown_id_t;
+} lv_property_dropdown_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_dropdown_class;

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -32,7 +32,7 @@ extern "C" {
 LV_EXPORT_CONST_INT(LV_DROPDOWN_POS_LAST);
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID(DROPDOWN, TEXT,                LV_PROPERTY_TYPE_TEXT,  0),
     LV_PROPERTY_ID(DROPDOWN, OPTIONS,             LV_PROPERTY_TYPE_TEXT,  1),
     LV_PROPERTY_ID(DROPDOWN, OPTION_COUNT,        LV_PROPERTY_TYPE_INT,   2),
@@ -44,7 +44,7 @@ enum {
     LV_PROPERTY_ID(DROPDOWN, LIST,                LV_PROPERTY_TYPE_OBJ,   8),
     LV_PROPERTY_ID(DROPDOWN, IS_OPEN,             LV_PROPERTY_TYPE_BOOL,  9),
     LV_PROPERTY_DROPDOWN_END,
-};
+} _lv_property_dropdown_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_dropdown_class;

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -32,7 +32,7 @@ extern "C" {
 LV_EXPORT_CONST_INT(LV_DROPDOWN_POS_LAST);
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_dropdown_id_t {
     LV_PROPERTY_ID(DROPDOWN, TEXT,                LV_PROPERTY_TYPE_TEXT,  0),
     LV_PROPERTY_ID(DROPDOWN, OPTIONS,             LV_PROPERTY_TYPE_TEXT,  1),
     LV_PROPERTY_ID(DROPDOWN, OPTION_COUNT,        LV_PROPERTY_TYPE_INT,   2),
@@ -44,7 +44,7 @@ typedef enum {
     LV_PROPERTY_ID(DROPDOWN, LIST,                LV_PROPERTY_TYPE_OBJ,   8),
     LV_PROPERTY_ID(DROPDOWN, IS_OPEN,             LV_PROPERTY_TYPE_BOOL,  9),
     LV_PROPERTY_DROPDOWN_END,
-} lv_property_dropdown_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_dropdown_class;

--- a/src/widgets/image/lv_image.h
+++ b/src/widgets/image/lv_image.h
@@ -58,7 +58,7 @@ typedef enum {
 } lv_image_align_t;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_image_id_t {
     LV_PROPERTY_ID(IMAGE, SRC,          LV_PROPERTY_TYPE_IMGSRC,    0),
     LV_PROPERTY_ID(IMAGE, OFFSET_X,     LV_PROPERTY_TYPE_INT,       1),
     LV_PROPERTY_ID(IMAGE, OFFSET_Y,     LV_PROPERTY_TYPE_INT,       2),
@@ -71,7 +71,7 @@ typedef enum {
     LV_PROPERTY_ID(IMAGE, ANTIALIAS,    LV_PROPERTY_TYPE_INT,       9),
     LV_PROPERTY_ID(IMAGE, INNER_ALIGN,  LV_PROPERTY_TYPE_INT,       10),
     LV_PROPERTY_IMAGE_END,
-} lv_property_image_id_t;
+};
 #endif
 
 /**********************

--- a/src/widgets/image/lv_image.h
+++ b/src/widgets/image/lv_image.h
@@ -71,7 +71,7 @@ typedef enum {
     LV_PROPERTY_ID(IMAGE, ANTIALIAS,    LV_PROPERTY_TYPE_INT,       9),
     LV_PROPERTY_ID(IMAGE, INNER_ALIGN,  LV_PROPERTY_TYPE_INT,       10),
     LV_PROPERTY_IMAGE_END,
-} _lv_property_image_id_t;
+} lv_property_image_id_t;
 #endif
 
 /**********************

--- a/src/widgets/image/lv_image.h
+++ b/src/widgets/image/lv_image.h
@@ -58,7 +58,7 @@ typedef enum {
 } lv_image_align_t;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID(IMAGE, SRC,          LV_PROPERTY_TYPE_IMGSRC,    0),
     LV_PROPERTY_ID(IMAGE, OFFSET_X,     LV_PROPERTY_TYPE_INT,       1),
     LV_PROPERTY_ID(IMAGE, OFFSET_Y,     LV_PROPERTY_TYPE_INT,       2),
@@ -71,7 +71,7 @@ enum {
     LV_PROPERTY_ID(IMAGE, ANTIALIAS,    LV_PROPERTY_TYPE_INT,       9),
     LV_PROPERTY_ID(IMAGE, INNER_ALIGN,  LV_PROPERTY_TYPE_INT,       10),
     LV_PROPERTY_IMAGE_END,
-};
+} _lv_property_image_id_t;
 #endif
 
 /**********************

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -51,13 +51,13 @@ typedef enum {
 } lv_keyboard_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID(KEYBOARD, TEXTAREA,            LV_PROPERTY_TYPE_OBJ,   0),
     LV_PROPERTY_ID(KEYBOARD, MODE,                LV_PROPERTY_TYPE_INT,   1),
     LV_PROPERTY_ID(KEYBOARD, POPOVERS,            LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(KEYBOARD, SELECTED_BUTTON,     LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_KEYBOARD_END,
-};
+} _lv_property_keyboard_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_keyboard_class;

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -57,7 +57,7 @@ typedef enum {
     LV_PROPERTY_ID(KEYBOARD, POPOVERS,            LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(KEYBOARD, SELECTED_BUTTON,     LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_KEYBOARD_END,
-} _lv_property_keyboard_id_t;
+} lv_property_keyboard_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_keyboard_class;

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -51,13 +51,13 @@ typedef enum {
 } lv_keyboard_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_keyboard_id_t {
     LV_PROPERTY_ID(KEYBOARD, TEXTAREA,            LV_PROPERTY_TYPE_OBJ,   0),
     LV_PROPERTY_ID(KEYBOARD, MODE,                LV_PROPERTY_TYPE_INT,   1),
     LV_PROPERTY_ID(KEYBOARD, POPOVERS,            LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ID(KEYBOARD, SELECTED_BUTTON,     LV_PROPERTY_TYPE_INT,   3),
     LV_PROPERTY_KEYBOARD_END,
-} lv_property_keyboard_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_keyboard_class;

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -54,13 +54,13 @@ typedef enum {
 } lv_label_long_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID(LABEL, TEXT,                   LV_PROPERTY_TYPE_TEXT,      0),
     LV_PROPERTY_ID(LABEL, LONG_MODE,              LV_PROPERTY_TYPE_INT,       1),
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_START,   LV_PROPERTY_TYPE_INT,       2),
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_END,     LV_PROPERTY_TYPE_INT,       3),
     LV_PROPERTY_LABEL_END,
-};
+} _lv_property_label_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_label_class;

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -54,13 +54,13 @@ typedef enum {
 } lv_label_long_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_label_id_t {
     LV_PROPERTY_ID(LABEL, TEXT,                   LV_PROPERTY_TYPE_TEXT,      0),
     LV_PROPERTY_ID(LABEL, LONG_MODE,              LV_PROPERTY_TYPE_INT,       1),
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_START,   LV_PROPERTY_TYPE_INT,       2),
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_END,     LV_PROPERTY_TYPE_INT,       3),
     LV_PROPERTY_LABEL_END,
-} lv_property_label_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_label_class;

--- a/src/widgets/label/lv_label.h
+++ b/src/widgets/label/lv_label.h
@@ -60,7 +60,7 @@ typedef enum {
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_START,   LV_PROPERTY_TYPE_INT,       2),
     LV_PROPERTY_ID(LABEL, TEXT_SELECTION_END,     LV_PROPERTY_TYPE_INT,       3),
     LV_PROPERTY_LABEL_END,
-} _lv_property_label_id_t;
+} lv_property_label_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_label_class;

--- a/src/widgets/property/lv_style_properties.h
+++ b/src/widgets/property/lv_style_properties.h
@@ -11,7 +11,7 @@
 
 
 /* *INDENT-OFF* */
-typedef enum {
+enum _lv_property_style_id_t {
     LV_PROPERTY_ID(STYLE, ALIGN,                    LV_PROPERTY_TYPE_INT,        LV_STYLE_ALIGN),
     LV_PROPERTY_ID(STYLE, ANIM,                     LV_PROPERTY_TYPE_INT,        LV_STYLE_ANIM),
     LV_PROPERTY_ID(STYLE, ANIM_DURATION,            LV_PROPERTY_TYPE_INT,        LV_STYLE_ANIM_DURATION),
@@ -132,7 +132,7 @@ typedef enum {
     LV_PROPERTY_ID(STYLE, WIDTH,                    LV_PROPERTY_TYPE_INT,        LV_STYLE_WIDTH),
     LV_PROPERTY_ID(STYLE, X,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_X),
     LV_PROPERTY_ID(STYLE, Y,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_Y),
-} lv_property_style_id_t;
+};
 
 #endif
 #endif

--- a/src/widgets/property/lv_style_properties.h
+++ b/src/widgets/property/lv_style_properties.h
@@ -11,7 +11,7 @@
 
 
 /* *INDENT-OFF* */
-enum {
+typedef enum {
     LV_PROPERTY_ID(STYLE, ALIGN,                    LV_PROPERTY_TYPE_INT,        LV_STYLE_ALIGN),
     LV_PROPERTY_ID(STYLE, ANIM,                     LV_PROPERTY_TYPE_INT,        LV_STYLE_ANIM),
     LV_PROPERTY_ID(STYLE, ANIM_DURATION,            LV_PROPERTY_TYPE_INT,        LV_STYLE_ANIM_DURATION),
@@ -132,7 +132,7 @@ enum {
     LV_PROPERTY_ID(STYLE, WIDTH,                    LV_PROPERTY_TYPE_INT,        LV_STYLE_WIDTH),
     LV_PROPERTY_ID(STYLE, X,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_X),
     LV_PROPERTY_ID(STYLE, Y,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_Y),
-};
+} _lv_property_style_id_t;
 
 #endif
 #endif

--- a/src/widgets/property/lv_style_properties.h
+++ b/src/widgets/property/lv_style_properties.h
@@ -132,7 +132,7 @@ typedef enum {
     LV_PROPERTY_ID(STYLE, WIDTH,                    LV_PROPERTY_TYPE_INT,        LV_STYLE_WIDTH),
     LV_PROPERTY_ID(STYLE, X,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_X),
     LV_PROPERTY_ID(STYLE, Y,                        LV_PROPERTY_TYPE_INT,        LV_STYLE_Y),
-} _lv_property_style_id_t;
+} lv_property_style_id_t;
 
 #endif
 #endif

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -39,12 +39,12 @@ typedef enum {
 } lv_roller_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_roller_id_t {
     LV_PROPERTY_ID2(ROLLER, OPTIONS,            LV_PROPERTY_TYPE_TEXT,  LV_PROPERTY_TYPE_INT,   0),
     LV_PROPERTY_ID2(ROLLER, SELECTED,           LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_INT, 1),
     LV_PROPERTY_ID(ROLLER, VISIBLE_ROW_COUNT,   LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ROLLER_END,
-} lv_property_roller_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_roller_class;

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -44,7 +44,7 @@ typedef enum {
     LV_PROPERTY_ID2(ROLLER, SELECTED,           LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_INT, 1),
     LV_PROPERTY_ID(ROLLER, VISIBLE_ROW_COUNT,   LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ROLLER_END,
-} _lv_property_roller_id_t;
+} lv_property_roller_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_roller_class;

--- a/src/widgets/roller/lv_roller.h
+++ b/src/widgets/roller/lv_roller.h
@@ -39,12 +39,12 @@ typedef enum {
 } lv_roller_mode_t;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID2(ROLLER, OPTIONS,            LV_PROPERTY_TYPE_TEXT,  LV_PROPERTY_TYPE_INT,   0),
     LV_PROPERTY_ID2(ROLLER, SELECTED,           LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_INT, 1),
     LV_PROPERTY_ID(ROLLER, VISIBLE_ROW_COUNT,   LV_PROPERTY_TYPE_INT,   2),
     LV_PROPERTY_ROLLER_END,
-};
+} _lv_property_roller_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_roller_class;

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -44,7 +44,7 @@ typedef enum {
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_slider_class;
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID2(SLIDER, VALUE,          LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_BOOL,  0),
     LV_PROPERTY_ID2(SLIDER, LEFT_VALUE,     LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_BOOL,  1),
     LV_PROPERTY_ID2(SLIDER, RANGE,          LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_INT,   2),
@@ -54,7 +54,7 @@ enum {
     LV_PROPERTY_ID(SLIDER, IS_DRAGGED,      LV_PROPERTY_TYPE_BOOL,      7),
     LV_PROPERTY_ID(SLIDER, IS_SYMMETRICAL,  LV_PROPERTY_TYPE_BOOL,      8),
     LV_PROPERTY_SLIDER_END,
-};
+} _lv_property_slider_id_t;
 #endif
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -54,7 +54,7 @@ typedef enum {
     LV_PROPERTY_ID(SLIDER, IS_DRAGGED,      LV_PROPERTY_TYPE_BOOL,      7),
     LV_PROPERTY_ID(SLIDER, IS_SYMMETRICAL,  LV_PROPERTY_TYPE_BOOL,      8),
     LV_PROPERTY_SLIDER_END,
-} _lv_property_slider_id_t;
+} lv_property_slider_id_t;
 #endif
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/slider/lv_slider.h
+++ b/src/widgets/slider/lv_slider.h
@@ -44,7 +44,7 @@ typedef enum {
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_slider_class;
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_slider_id_t {
     LV_PROPERTY_ID2(SLIDER, VALUE,          LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_BOOL,  0),
     LV_PROPERTY_ID2(SLIDER, LEFT_VALUE,     LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_BOOL,  1),
     LV_PROPERTY_ID2(SLIDER, RANGE,          LV_PROPERTY_TYPE_INT,   LV_PROPERTY_TYPE_INT,   2),
@@ -54,7 +54,7 @@ typedef enum {
     LV_PROPERTY_ID(SLIDER, IS_DRAGGED,      LV_PROPERTY_TYPE_BOOL,      7),
     LV_PROPERTY_ID(SLIDER, IS_SYMMETRICAL,  LV_PROPERTY_TYPE_BOOL,      8),
     LV_PROPERTY_SLIDER_END,
-} lv_property_slider_id_t;
+};
 #endif
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -34,7 +34,7 @@ LV_EXPORT_CONST_INT(LV_TEXTAREA_CURSOR_LAST);
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-enum {
+typedef enum {
     LV_PROPERTY_ID(TEXTAREA, TEXT,              LV_PROPERTY_TYPE_TEXT,  0),
     LV_PROPERTY_ID(TEXTAREA, PLACEHOLDER_TEXT,  LV_PROPERTY_TYPE_TEXT,  1),
     LV_PROPERTY_ID(TEXTAREA, CURSOR_POS,        LV_PROPERTY_TYPE_INT,   2),
@@ -51,14 +51,14 @@ enum {
     LV_PROPERTY_ID(TEXTAREA, TEXT_IS_SELECTED,  LV_PROPERTY_TYPE_INT,   13),
     LV_PROPERTY_ID(TEXTAREA, CURRENT_CHAR,      LV_PROPERTY_TYPE_INT,   14),
     LV_PROPERTY_TEXTAREA_END,
-};
+} _lv_property_textarea_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_textarea_class;
 
-enum {
+typedef enum {
     LV_PART_TEXTAREA_PLACEHOLDER = LV_PART_CUSTOM_FIRST,
-};
+} _lv_textarea_part_id_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -51,14 +51,14 @@ typedef enum {
     LV_PROPERTY_ID(TEXTAREA, TEXT_IS_SELECTED,  LV_PROPERTY_TYPE_INT,   13),
     LV_PROPERTY_ID(TEXTAREA, CURRENT_CHAR,      LV_PROPERTY_TYPE_INT,   14),
     LV_PROPERTY_TEXTAREA_END,
-} _lv_property_textarea_id_t;
+} lv_property_textarea_id_t;
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_textarea_class;
 
 typedef enum {
     LV_PART_TEXTAREA_PLACEHOLDER = LV_PART_CUSTOM_FIRST,
-} _lv_textarea_part_id_t;
+} lv_textarea_part_id_t;
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -34,7 +34,7 @@ LV_EXPORT_CONST_INT(LV_TEXTAREA_CURSOR_LAST);
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-typedef enum {
+enum _lv_property_textarea_id_t {
     LV_PROPERTY_ID(TEXTAREA, TEXT,              LV_PROPERTY_TYPE_TEXT,  0),
     LV_PROPERTY_ID(TEXTAREA, PLACEHOLDER_TEXT,  LV_PROPERTY_TYPE_TEXT,  1),
     LV_PROPERTY_ID(TEXTAREA, CURSOR_POS,        LV_PROPERTY_TYPE_INT,   2),
@@ -51,14 +51,14 @@ typedef enum {
     LV_PROPERTY_ID(TEXTAREA, TEXT_IS_SELECTED,  LV_PROPERTY_TYPE_INT,   13),
     LV_PROPERTY_ID(TEXTAREA, CURRENT_CHAR,      LV_PROPERTY_TYPE_INT,   14),
     LV_PROPERTY_TEXTAREA_END,
-} lv_property_textarea_id_t;
+};
 #endif
 
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_textarea_class;
 
-typedef enum {
+enum _lv_part_textarea_id_t {
     LV_PART_TEXTAREA_PLACEHOLDER = LV_PART_CUSTOM_FIRST,
-} lv_textarea_part_id_t;
+};
 
 /**********************
  * GLOBAL PROTOTYPES


### PR DESCRIPTION
...work around a Breathe-library bug which expects a name for `enum` definitions.  This eliminates 34 Sphinx warnings.

Additionally, I added the comment at line 42 and 49 of lv_obj_property.h for the sake of both LVGL users and maintainers because every time I encounter those 2 macros and have to work out what they are doing, I lose the same 10-15 minutes over and over again, and certain firmware developers will NEED to understand that in greater depth than the average LVGL user, who doesn't need to know HOW it works.  After the 3rd time, I documented it so that others don't need to lose this time in the future.

cc:  @kisvegabor @liamHowatt 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
