### PR TITLE
docs(doc-build warnings):  fix warnings caused by LV_FORMAT_ATTRIBUTE

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2070,7 +2070,7 @@ PREDEFINED             = DOXYGEN                         \
                          LV_ATTRIBUTE_LARGE_RAM_ARRAY=   \
                          LV_ATTRIBUTE_FAST_MEM=          \
                          LV_ATTRIBUTE_EXTERN_DATA=       \
-                         LV_FORMAT_ATTRIBUTE
+                         LV_FORMAT_ATTRIBUTE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2070,7 +2070,7 @@ PREDEFINED             = DOXYGEN                         \
                          LV_ATTRIBUTE_LARGE_RAM_ARRAY=   \
                          LV_ATTRIBUTE_FAST_MEM=          \
                          LV_ATTRIBUTE_EXTERN_DATA=       \
-                         LV_FORMAT_ATTRIBUTE=
+                         LV_FORMAT_ATTRIBUTE(fmt,va)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2069,7 +2069,8 @@ PREDEFINED             = DOXYGEN                         \
                          LV_ATTRIBUTE_LARGE_CONST=       \
                          LV_ATTRIBUTE_LARGE_RAM_ARRAY=   \
                          LV_ATTRIBUTE_FAST_MEM=          \
-                         LV_ATTRIBUTE_EXTERN_DATA=
+                         LV_ATTRIBUTE_EXTERN_DATA=       \
+                         LV_FORMAT_ATTRIBUTE
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/doxygen_xml.py
+++ b/docs/doxygen_xml.py
@@ -1605,6 +1605,7 @@ class DoxygenXml(object):
             'LV_ATTRIBUTE_LARGE_RAM_ARRAY=',
             'LV_ATTRIBUTE_FAST_MEM=',
             'LV_ATTRIBUTE_EXTERN_DATA=',
+            'LV_FORMAT_ATTRIBUTE=',
         ]
 
         cfg.set('PREDEFINED', predefined_symbols)

--- a/docs/doxygen_xml.py
+++ b/docs/doxygen_xml.py
@@ -1605,7 +1605,7 @@ class DoxygenXml(object):
             'LV_ATTRIBUTE_LARGE_RAM_ARRAY=',
             'LV_ATTRIBUTE_FAST_MEM=',
             'LV_ATTRIBUTE_EXTERN_DATA=',
-            'LV_FORMAT_ATTRIBUTE=',
+            'LV_FORMAT_ATTRIBUTE(fmt,va)=',
         ]
 
         cfg.set('PREDEFINED', predefined_symbols)


### PR DESCRIPTION
Some doc-build warnings were being generated (and API documentation involved omitted) because when Doxygen encountered the LV_FORMAT_ATTRIBUTE in 7 places, it didn't know what to do with it, and later when Breathe came along to parse the results Doxygen left, it also didn't know what to do with it, and so generated 7 warnings where it was used, and caused the resulting API documentation to erroneously include *part of* the `LV_FORMAT_ATTRIBUTE` macro.

These 2 changes make Doxygen parse the 7 function prototypes correctly, whether Doxygen is being run in the `./docs/` directory (useful for debugging Doxygen issues, or simply to have a Doxygen-format API HTML reference), or via the `build.py` script.

This eliminates 7 doc-gen warnings.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
