### PR TITLE
docs(keyboard): fix typos and unify comments

### DIFF
--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -68,8 +68,8 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_keyboard_class;
 
 /**
  * Create a Keyboard object
- * @param parent    Pointer to an object. It will be the parent of the new keyboard.
- * @return          Pointer to the created keyboard object.
+ * @param parent    pointer to an object, it will be the parent of the new keyboard
+ * @return          pointer to the created keyboard object
  */
 lv_obj_t * lv_keyboard_create(lv_obj_t * parent);
 
@@ -79,32 +79,32 @@ lv_obj_t * lv_keyboard_create(lv_obj_t * parent);
 
 /**
  * Assign a text area to the keyboard. Pressed characters will be inserted there.
- * @param kb        Pointer to a keyboard object.
- * @param ta        Pointer to a text area object to write into.
+ * @param kb        pointer to a keyboard object
+ * @param ta        pointer to a text area object to write into
  */
 void lv_keyboard_set_textarea(lv_obj_t * kb, lv_obj_t * ta);
 
 /**
- * Set a new a mode (e.g., text, number, special characters).
- * @param kb        Pointer to a keyboard object.
- * @param mode      The desired mode (see 'lv_keyboard_mode_t').
+ * Set a new mode (e.g., text, number, special characters).
+ * @param kb        pointer to a keyboard object
+ * @param mode      the desired mode (see 'lv_keyboard_mode_t')
  */
 void lv_keyboard_set_mode(lv_obj_t * kb, lv_keyboard_mode_t mode);
 
 /**
  * Enable or disable popovers showing button titles on press.
- * @param kb        Pointer to a keyboard object.
- * @param en        True to enable popovers; false to disable.
+ * @param kb        pointer to a keyboard object
+ * @param en        true to enable popovers; false to disable
  */
 void lv_keyboard_set_popovers(lv_obj_t * kb, bool en);
 
 /**
  * Set a custom button map for the keyboard.
- * @param kb        Pointer to a keyboard object.
- * @param mode      The mode to assign the new map to (see 'lv_keyboard_mode_t').
- * @param map       Pointer to a string array describing the button map.
- *                  See 'lv_buttonmatrix_set_map()' for more details.
- * @param ctrl_map  Pointer to the control map. See 'lv_buttonmatrix_set_ctrl_map()'.
+ * @param kb        pointer to a keyboard object
+ * @param mode      the mode to assign the new map to (see 'lv_keyboard_mode_t')
+ * @param map       pointer to a string array describing the button map
+ *                  see 'lv_buttonmatrix_set_map()' for more details
+ * @param ctrl_map  pointer to the control map. See 'lv_buttonmatrix_set_ctrl_map()'
 
  */
 void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * const map[],
@@ -116,46 +116,46 @@ void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * co
 
 /**
  * Get the text area currently assigned to the keyboard.
- * @param kb        Pointer to a keyboard object.
- * @return          Pointer to the assigned text area object.
+ * @param kb        pointer to a keyboard object
+ * @return          pointer to the assigned text area object
  */
 lv_obj_t * lv_keyboard_get_textarea(const lv_obj_t * kb);
 
 /**
  * Get the current mode of the keyboard.
- * @param kb        Pointer to a keyboard object.
- * @return          The current mode (see 'lv_keyboard_mode_t').
+ * @param kb        pointer to a keyboard object
+ * @return          the current mode (see 'lv_keyboard_mode_t')
  */
 lv_keyboard_mode_t lv_keyboard_get_mode(const lv_obj_t * kb);
 
 /**
  * Check whether popovers are enabled on the keyboard.
- * @param obj       Pointer to a keyboard object.
- * @return          True if popovers are enabled; false otherwise.
+ * @param obj       pointer to a keyboard object
+ * @return          true if popovers are enabled; false otherwise
  */
 bool lv_keyboard_get_popovers(const lv_obj_t * obj);
 
 /**
  * Get the current button map of the keyboard.
- * @param kb        Pointer to a keyboard object.
- * @return          Pointer to the map array.
+ * @param kb        pointer to a keyboard object
+ * @return          pointer to the map array
  */
 const char * const * lv_keyboard_get_map_array(const lv_obj_t * kb);
 
 /**
  * Get the index of the last selected button (pressed, released, focused, etc.).
  * Useful in the `event_cb` to retrieve button text or properties.
- * @param obj       Pointer to a keyboard object.
- * @return          Index of the last interacted button.
- *                  Returns LV_BUTTONMATRIX_BUTTON_NONE if not set.
+ * @param obj       pointer to a keyboard object
+ * @return          index of the last interacted button
+ *                  returns LV_BUTTONMATRIX_BUTTON_NONE if not set
  */
 uint32_t lv_keyboard_get_selected_button(const lv_obj_t * obj);
 
 /**
  * Get the text of a button by index.
- * @param obj       Pointer to a keyboard object.
- * @param btn_id    Index of the button (excluding newline characters).
- * @return          Pointer to the text of the button.
+ * @param obj       pointer to a keyboard object
+ * @param btn_id    index of the button (excluding newline characters)
+ * @return          pointer to the text of the button
  */
 const char * lv_keyboard_get_button_text(const lv_obj_t * obj, uint32_t btn_id);
 
@@ -167,7 +167,7 @@ const char * lv_keyboard_get_button_text(const lv_obj_t * obj, uint32_t btn_id);
  * Default keyboard event callback to handle button presses.
  * Adds characters to the text area and switches map if needed.
  * If a custom `event_cb` is used, this function can be called within it.
- * @param e         The triggering event.
+ * @param e         the triggering event
  */
 void lv_keyboard_def_event_cb(lv_event_t * e);
 

--- a/src/widgets/keyboard/lv_keyboard.h
+++ b/src/widgets/keyboard/lv_keyboard.h
@@ -68,8 +68,8 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_keyboard_class;
 
 /**
  * Create a Keyboard object
- * @param parent    pointer to an object, it will be the parent of the new keyboard
- * @return          pointer to the created keyboard
+ * @param parent    Pointer to an object. It will be the parent of the new keyboard.
+ * @return          Pointer to the created keyboard object.
  */
 lv_obj_t * lv_keyboard_create(lv_obj_t * parent);
 
@@ -78,33 +78,33 @@ lv_obj_t * lv_keyboard_create(lv_obj_t * parent);
  *====================*/
 
 /**
- * Assign a Text Area to the Keyboard. The pressed characters will be put there.
- * @param kb        pointer to a Keyboard object
- * @param ta        pointer to a Text Area object to write there
+ * Assign a text area to the keyboard. Pressed characters will be inserted there.
+ * @param kb        Pointer to a keyboard object.
+ * @param ta        Pointer to a text area object to write into.
  */
 void lv_keyboard_set_textarea(lv_obj_t * kb, lv_obj_t * ta);
 
 /**
- * Set a new a mode (text or number map)
- * @param kb        pointer to a Keyboard object
- * @param mode      the mode from 'lv_keyboard_mode_t'
+ * Set a new a mode (e.g., text, number, special characters).
+ * @param kb        Pointer to a keyboard object.
+ * @param mode      The desired mode (see 'lv_keyboard_mode_t').
  */
 void lv_keyboard_set_mode(lv_obj_t * kb, lv_keyboard_mode_t mode);
 
 /**
- * Show the button title in a popover when pressed.
- * @param kb        pointer to a Keyboard object
- * @param en        whether "popovers" mode is enabled
+ * Enable or disable popovers showing button titles on press.
+ * @param kb        Pointer to a keyboard object.
+ * @param en        True to enable popovers; false to disable.
  */
 void lv_keyboard_set_popovers(lv_obj_t * kb, bool en);
 
 /**
- * Set a new map for the keyboard
- * @param kb        pointer to a Keyboard object
- * @param mode      keyboard map to alter 'lv_keyboard_mode_t'
- * @param map       pointer to a string array to describe the map.
- *                  See 'lv_buttonmatrix_set_map()' for more info.
- * @param ctrl_map  See 'lv_buttonmatrix_set_ctrl_map()' for more info.
+ * Set a custom button map for the keyboard.
+ * @param kb        Pointer to a keyboard object.
+ * @param mode      The mode to assign the new map to (see 'lv_keyboard_mode_t').
+ * @param map       Pointer to a string array describing the button map.
+ *                  See 'lv_buttonmatrix_set_map()' for more details.
+ * @param ctrl_map  Pointer to the control map. See 'lv_buttonmatrix_set_ctrl_map()'.
 
  */
 void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * const map[],
@@ -115,46 +115,47 @@ void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * co
  *====================*/
 
 /**
- * Assign a Text Area to the Keyboard. The pressed characters will be put there.
- * @param kb        pointer to a Keyboard object
- * @return          pointer to the assigned Text Area object
+ * Get the text area currently assigned to the keyboard.
+ * @param kb        Pointer to a keyboard object.
+ * @return          Pointer to the assigned text area object.
  */
 lv_obj_t * lv_keyboard_get_textarea(const lv_obj_t * kb);
 
 /**
- * Set a new a mode (text or number map)
- * @param kb        pointer to a Keyboard object
- * @return          the current mode from 'lv_keyboard_mode_t'
+ * Get the current mode of the keyboard.
+ * @param kb        Pointer to a keyboard object.
+ * @return          The current mode (see 'lv_keyboard_mode_t').
  */
 lv_keyboard_mode_t lv_keyboard_get_mode(const lv_obj_t * kb);
 
 /**
- * Tell whether "popovers" mode is enabled or not.
- * @param obj       pointer to a Keyboard object
- * @return          true: "popovers" mode is enabled; false: disabled
+ * Check whether popovers are enabled on the keyboard.
+ * @param obj       Pointer to a keyboard object.
+ * @return          True if popovers are enabled; false otherwise.
  */
 bool lv_keyboard_get_popovers(const lv_obj_t * obj);
 
 /**
- * Get the current map of a keyboard
- * @param kb        pointer to a keyboard object
- * @return          the current map
+ * Get the current button map of the keyboard.
+ * @param kb        Pointer to a keyboard object.
+ * @return          Pointer to the map array.
  */
 const char * const * lv_keyboard_get_map_array(const lv_obj_t * kb);
 
 /**
- * Get the index of the lastly "activated" button by the user (pressed, released, focused etc)
- * Useful in the `event_cb` to get the text of the button, check if hidden etc.
- * @param obj       pointer to button matrix object
- * @return          index of the last released button (LV_BUTTONMATRIX_BUTTON_NONE: if unset)
+ * Get the index of the last selected button (pressed, released, focused, etc.).
+ * Useful in the `event_cb` to retrieve button text or properties.
+ * @param obj       Pointer to a keyboard object.
+ * @return          Index of the last interacted button.
+ *                  Returns LV_BUTTONMATRIX_BUTTON_NONE if not set.
  */
 uint32_t lv_keyboard_get_selected_button(const lv_obj_t * obj);
 
 /**
- * Get the button's text
- * @param obj       pointer to button matrix object
- * @param btn_id    the index a button not counting new line characters.
- * @return          text of btn_index` button
+ * Get the text of a button by index.
+ * @param obj       Pointer to a keyboard object.
+ * @param btn_id    Index of the button (excluding newline characters).
+ * @return          Pointer to the text of the button.
  */
 const char * lv_keyboard_get_button_text(const lv_obj_t * obj, uint32_t btn_id);
 
@@ -163,10 +164,10 @@ const char * lv_keyboard_get_button_text(const lv_obj_t * obj, uint32_t btn_id);
  *====================*/
 
 /**
- * Default keyboard event to add characters to the Text area and change the map.
- * If a custom `event_cb` is added to the keyboard this function can be called from it to handle the
- * button clicks
- * @param e the triggering event
+ * Default keyboard event callback to handle button presses.
+ * Adds characters to the text area and switches map if needed.
+ * If a custom `event_cb` is used, this function can be called within it.
+ * @param e         The triggering event.
  */
 void lv_keyboard_def_event_cb(lv_event_t * e);
 


### PR DESCRIPTION
Improved documentation in lv_keyboard.h

- Fixed typos and awkward phrasing in function comments
- Unified style and terminology across function descriptions (e.g. Set/Get/Assign)
- Clarified parameter and return value descriptions
- Added helpful context for proper usage of some functions

These changes aim to improve readability and consistency of the public API documentation, without modifying any functional behavior.