### PR TITLE
fix(kconfig): Fix depends clauses for LV_USE_OS

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -203,7 +203,7 @@ menu "LVGL configuration"
 		config LV_DRAW_THREAD_STACK_SIZE
 			int "Stack size of draw thread in bytes"
 			default 8192
-			depends on LV_USE_OS > 0
+			depends on !LV_OS_NONE
 			help
 				If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
 
@@ -211,7 +211,7 @@ menu "LVGL configuration"
 			int "Thread priority for the drawing thread"
 			range 0 4
 			default 3
-			depends on LV_USE_OS > 0
+			depends on !LV_OS_NONE
 			help
 				Thread priority controls the relative importance of the drawing threads.
 				Values correspond to lv_thread_prio_t enum in lv_os.h:
@@ -378,7 +378,7 @@ menu "LVGL configuration"
 
 		config LV_USE_VGLITE_DRAW_THREAD
 			bool "Use additional draw thread for VG-Lite processing"
-			depends on LV_USE_DRAW_VGLITE && LV_USE_OS > 0
+			depends on LV_USE_DRAW_VGLITE && !LV_OS_NONE
 			default y
 
 		config LV_USE_VGLITE_DRAW_ASYNC
@@ -414,7 +414,7 @@ menu "LVGL configuration"
 
 		config LV_USE_PXP_DRAW_THREAD
 			bool "Use additional draw thread for PXP processing"
-			depends on LV_USE_DRAW_PXP && LV_USE_OS > 0
+			depends on LV_USE_DRAW_PXP && !LV_OS_NONE
 			default y
 
 		config LV_USE_PXP_ASSERT
@@ -434,7 +434,7 @@ menu "LVGL configuration"
 
 		config LV_USE_G2D_DRAW_THREAD
 			bool "Use additional draw thread for G2D processing"
-			depends on LV_USE_DRAW_G2D && LV_USE_OS > 0
+			depends on LV_USE_DRAW_G2D && !LV_OS_NONE
 			default y
 
 		config LV_USE_G2D_ASSERT
@@ -1968,7 +1968,7 @@ menu "LVGL configuration"
 
 		config LV_USE_NUTTX_LIBUV
 			bool "Use uv loop to replace default timer loop and other fb/indev timers"
-			depends on LV_USE_NUTTX && LIBUV
+			depends on LV_USE_NUTTX
 			default n
 
 		config LV_USE_NUTTX_CUSTOM_INIT


### PR DESCRIPTION
Fix issue in Kconfig where LV_USE_OS is a choice symbol and therefore can not be used in numerical compare expressions. Also fix refrence to LIBUV symbol which is not present.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
