### PR TITLE
fix(font) overflow in load_cmaps_tables()

### DIFF
--- a/src/font/lv_font_loader.c
+++ b/src/font/lv_font_loader.c
@@ -261,7 +261,7 @@ static bool load_cmaps_tables(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_ds
 
         switch(cmap_table[i].format_type) {
             case LV_FONT_FMT_TXT_CMAP_FORMAT0_FULL: {
-                    uint8_t ids_size = sizeof(uint8_t) * cmap_table[i].data_entries_count;
+                    uint16_t ids_size = sizeof(uint8_t) * cmap_table[i].data_entries_count;
                     uint8_t * glyph_id_ofs_list = lv_mem_alloc(ids_size);
 
                     cmap->glyph_id_ofs_list = glyph_id_ofs_list;


### PR DESCRIPTION

# fix(font) load_cmaps_tables() overflow

- In load_cmaps_tables() in src/font/lv_font_loader.c, the "<ins>data entries count of subtable "format 0" data</ins>"  defined in [Bitmap fonts format for embedded systems](<https://github.com/lvgl/lv_font_conv/blob/master/doc/font_spec.md#subtable-header>) " can exceeds 255 depending on the font file and character area used, and copying it to the uint8_t will cause an overflow.
- For more details, see attached [font_mapping_issue_analysis.md](https://github.com/user-attachments/files/20648626/font_mapping_issue_analysis.md).



