### PR TITLE
fix(draw): Fix unused function warning for blending

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
@@ -91,7 +91,9 @@ static inline void /* LV_ATTRIBUTE_FAST_MEM */ blend_non_normal_pixel(lv_color32
 
 static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * buf, uint32_t stride);
 
-static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -1350,6 +1352,7 @@ static inline void * LV_ATTRIBUTE_FAST_MEM drawbuf_next_row(const void * buf, ui
     return (void *)((uint8_t *)buf + stride);
 }
 
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
 static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t raw)
 {
     lv_color16_t c;
@@ -1358,6 +1361,7 @@ static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t ra
     c.blue = raw & 0x1F;
     return c;
 }
+#endif
 
 #endif /* LV_DRAW_SW_SUPPORT_ARGB8888 */
 

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
@@ -78,7 +78,9 @@ static inline uint8_t /* LV_ATTRIBUTE_FAST_MEM */ get_bit(const uint8_t * buf, i
 
 static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * buf, uint32_t stride);
 
-static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -1271,6 +1273,7 @@ static inline uint8_t LV_ATTRIBUTE_FAST_MEM get_bit(const uint8_t * buf, int32_t
     return (buf[bit_idx / 8] >> (7 - (bit_idx % 8))) & 1;
 }
 
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
 static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t raw)
 {
     lv_color16_t c;
@@ -1279,5 +1282,6 @@ static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t ra
     c.blue = raw & 0x1F;
     return c;
 }
+#endif
 
 #endif

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
@@ -74,7 +74,9 @@ static inline void /* LV_ATTRIBUTE_FAST_MEM */ blend_non_normal_pixel(uint8_t * 
 
 static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * buf, uint32_t stride);
 
-static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -1005,6 +1007,7 @@ static inline void * LV_ATTRIBUTE_FAST_MEM drawbuf_next_row(const void * buf, ui
     return (void *)((uint8_t *)buf + stride);
 }
 
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
 static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t raw)
 {
     lv_color16_t c;
@@ -1013,6 +1016,7 @@ static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t ra
     c.blue = raw & 0x1F;
     return c;
 }
+#endif
 
 #endif
 

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -79,7 +79,9 @@ static inline uint16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color_24_16_mix(const uint
 
 static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * buf, uint32_t stride);
 
-static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -1497,6 +1499,7 @@ static inline void * LV_ATTRIBUTE_FAST_MEM drawbuf_next_row(const void * buf, ui
     return (void *)((uint8_t *)buf + stride);
 }
 
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
 static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t raw)
 {
     lv_color16_t c;
@@ -1505,6 +1508,7 @@ static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t ra
     c.blue = raw & 0x1F;
     return c;
 }
+#endif
 
 #endif /*LV_DRAW_SW_SUPPORT_RGB565*/
 


### PR DESCRIPTION
Fixes an unused function warning by guarding declaration and implementation with a preprocessor check.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
