### PR TITLE
chore(api_doc_builder):  fix TOC ordering on API pages.

### DIFF
--- a/docs/api_doc_builder.py
+++ b/docs/api_doc_builder.py
@@ -698,6 +698,12 @@ def _recursively_create_api_rst_files(depth: int,
             elig_h_file_count += subdir_eligible_h_file_count
 
     if elig_h_file_count > 0:
+        # Sort both lists.
+        # Evidently the Linux-Python's implementation of `listdir()` does not
+        # automatically produce a sorted list.
+        elig_sub_dirs.sort()
+        elig_h_files.sort()
+
         # Create index.rst plus .RST files for any direct .H files in dir.
         _create_rst_files_for_dir(src_root_len,
                                   src_dir_bep,


### PR DESCRIPTION
Apparently the Python implementation of the `listdir()` function differs between Windows and Linux.  I suspect it uses a system setting under Windows where under "normal" circumstances, it provides a sorted list, whereas under Linux, it comes out in directory-entry order (typically creation sequence).  So sorting is introduced before the lists (especially .h-file list) so that when the TOCs are generated, they are in alphabetical order.

Fixes #8383

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
