### PR TITLE
feat(drivers): allow passing user_data to mipi creation functions

### DIFF
--- a/docs/src/details/integration/driver/display/gen_mipi.rst
+++ b/docs/src/details/integration/driver/display/gen_mipi.rst
@@ -214,3 +214,36 @@ You can add a delay between the commands by using the pseudo-command ``LV_LCD_CM
 To terminate the command list you must use a delay with a value of ``LV_LCD_CMD_EOF``, as shown above.
 
 See an actual example of sending a command list `here <https://github.com/lvgl/lvgl/blob/master/src/drivers/display/st7789/lv_st7789.c>`__.
+
+Separate display and controller initialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :cpp:func:`lv_lcd_generic_mipi_create()` function initializes both the display and the LCD controller. However, in some cases it is useful to separate these two steps.
+
+To achieve this, you need to first call the :cpp:func:`lv_lcd_generic_mipi_create_display_no_init()` function to create the display object without initializing the controller, and then call the
+:cpp:func:`lv_lcd_generic_mipi_controller_init()` function to initialize the controller.
+
+For example, you may want to set up custom user data in the display object before the controller is initialized:
+
+.. code-block:: c
+
+	#include "src/drivers/display/st7789/lv_st7789.h"
+
+	#define LCD_H_RES               240
+	#define LCD_V_RES               320
+
+	lv_display_t *my_disp;
+
+	...
+
+	int main(int argc, char ** argv)
+	{
+		...
+
+		/* Create the LVGL display object and the LCD display driver */
+		my_disp = lv_lcd_generic_mipi_create_display_no_init(LCD_H_RES, LCD_V_RES);
+		lv_display_set_user_data(my_disp, my_user_data);
+		lv_lcd_generic_mipi_controller_init(my_disp, LV_LCD_FLAG_NONE, my_lcd_send_cmd, my_lcd_send_color);
+
+		...
+	}

--- a/docs/src/details/integration/driver/display/ili9341.rst
+++ b/docs/src/details/integration/driver/display/ili9341.rst
@@ -71,3 +71,27 @@ For additional details and a working example see the `generic MIPI driver docume
 
 	You can find a step-by-step guide and the actual implementation of the callbacks on an STM32F746 using STM32CubeIDE and the ST HAL libraries here: :ref:`lcd_stm32_guide`
 	
+Advanced topics
+---------------
+
+Pass user data to the display driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :cpp:func:`lv_ili9341_create_with_user_data()` is similar to the :cpp:func:`lv_ili9341_create()` function, but it allows passing a user data pointer to the display driver. 
+This pointer can be used to store any user-specific data that is needed by the display driver callbacks.
+
+.. code-block:: c
+
+	/**
+	* Create an LCD display with ILI9341 driver with user data
+	* @param hor_res       horizontal resolution
+	* @param ver_res       vertical resolution
+	* @param flags         default configuration settings (mirror, RGB ordering, etc.)
+	* @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+	* @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+	* @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
+	* @return              pointer to the created display
+	*/
+	lv_display_t * lv_ili9341_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+													lv_ili9341_send_cmd_cb_t send_cmd_cb, lv_ili9341_send_color_cb_t send_color_cb,
+													void * user_data);

--- a/docs/src/details/integration/driver/display/st7735.rst
+++ b/docs/src/details/integration/driver/display/st7735.rst
@@ -73,3 +73,27 @@ For additional details and a working example see the `generic MIPI driver docume
 
 	You can find a step-by-step guide and the actual implementation of the callbacks on an STM32F746 using STM32CubeIDE and the ST HAL libraries here: :ref:`lcd_stm32_guide`
 	
+Advanced topics
+---------------
+
+Pass user data to the display driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :cpp:func:`lv_st7735_create_with_user_data()` is similar to the :cpp:func:`lv_st7735_create()` function, but it allows passing a user data pointer to the display driver. 
+This pointer can be used to store any user-specific data that is needed by the display driver callbacks.
+
+.. code-block:: c
+
+	/**
+	* Create an LCD display with ST7735 driver with user data
+	* @param hor_res       horizontal resolution
+	* @param ver_res       vertical resolution
+	* @param flags         default configuration settings (mirror, RGB ordering, etc.)
+	* @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+	* @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+	* @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
+	* @return              pointer to the created display
+	*/
+	lv_display_t * lv_st7735_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+												lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb,
+												void * user_data);

--- a/docs/src/details/integration/driver/display/st7789.rst
+++ b/docs/src/details/integration/driver/display/st7789.rst
@@ -72,3 +72,27 @@ For additional details and a working example see the `generic MIPI driver docume
 
 	You can find a step-by-step guide and the actual implementation of the callbacks on an STM32F746 using STM32CubeIDE and the ST HAL libraries here: :ref:`lcd_stm32_guide`
 	
+Advanced topics
+---------------
+
+Pass user data to the display driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :cpp:func:`lv_st7789_create_with_user_data()` is similar to the :cpp:func:`lv_st7789_create()` function, but it allows passing a user data pointer to the display driver. 
+This pointer can be used to store any user-specific data that is needed by the display driver callbacks.
+
+.. code-block:: c
+
+	/**
+	* Create an LCD display with ST7789 driver with user data
+	* @param hor_res       horizontal resolution
+	* @param ver_res       vertical resolution
+	* @param flags         default configuration settings (mirror, RGB ordering, etc.)
+	* @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+	* @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+	* @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
+	* @return              pointer to the created display
+	*/
+	lv_display_t * lv_st7789_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+												lv_st7789_send_cmd_cb_t send_cmd_cb, lv_st7789_send_color_cb_t send_color_cb,
+												void * user_data);

--- a/docs/src/details/integration/driver/display/st7796.rst
+++ b/docs/src/details/integration/driver/display/st7796.rst
@@ -73,3 +73,27 @@ For additional details and a working example see the `generic MIPI driver docume
 
 	You can find a step-by-step guide and the actual implementation of the callbacks on an STM32F746 using STM32CubeIDE and the ST HAL libraries here: :ref:`lcd_stm32_guide`
 	
+Advanced topics
+---------------
+
+Pass user data to the display driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :cpp:func:`lv_st7796_create_with_user_data()` is similar to the :cpp:func:`lv_st7796_create()` function, but it allows passing a user data pointer to the display driver. 
+This pointer can be used to store any user-specific data that is needed by the display driver callbacks.
+
+.. code-block:: c
+
+	/**
+	* Create an LCD display with ST7796 driver with user data
+	* @param hor_res       horizontal resolution
+	* @param ver_res       vertical resolution
+	* @param flags         default configuration settings (mirror, RGB ordering, etc.)
+	* @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+	* @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+	* @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
+	* @return              pointer to the created display
+	*/
+	lv_display_t * lv_st7796_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+												lv_st7796_send_cmd_cb_t send_cmd_cb, lv_st7796_send_color_cb_t send_color_cb,
+												void * user_data);

--- a/src/drivers/display/ili9341/lv_ili9341.c
+++ b/src/drivers/display/ili9341/lv_ili9341.c
@@ -90,6 +90,18 @@ lv_display_t * lv_ili9341_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag
     return disp;
 }
 
+lv_display_t * lv_ili9341_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                                lv_ili9341_send_cmd_cb_t send_cmd_cb, lv_ili9341_send_color_cb_t send_color_cb,
+                                                void * user_data)
+{
+    lv_display_t * disp = lv_lcd_generic_mipi_create_display_no_init(hor_res, ver_res);
+    lv_display_set_user_data(disp, user_data);
+    lv_lcd_generic_mipi_controller_init(disp, flags, send_cmd_cb, send_color_cb);
+
+    lv_lcd_generic_mipi_send_cmd_list(disp, init_cmd_list);
+    return disp;
+}
+
 void lv_ili9341_set_gap(lv_display_t * disp, uint16_t x, uint16_t y)
 {
     lv_lcd_generic_mipi_set_gap(disp, x, y);

--- a/src/drivers/display/ili9341/lv_ili9341.h
+++ b/src/drivers/display/ili9341/lv_ili9341.h
@@ -54,7 +54,7 @@ lv_display_t * lv_ili9341_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
  * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
  * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
- * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
  * @return              pointer to the created display
  */
 lv_display_t * lv_ili9341_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/src/drivers/display/ili9341/lv_ili9341.h
+++ b/src/drivers/display/ili9341/lv_ili9341.h
@@ -48,6 +48,20 @@ lv_display_t * lv_ili9341_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag
                                  lv_ili9341_send_cmd_cb_t send_cmd_cb, lv_ili9341_send_color_cb_t send_color_cb);
 
 /**
+ * Create an LCD display with ILI9341 driver with user data
+ * @param hor_res       horizontal resolution
+ * @param ver_res       vertical resolution
+ * @param flags         default configuration settings (mirror, RGB ordering, etc.)
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @return              pointer to the created display
+ */
+lv_display_t * lv_ili9341_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                                lv_ili9341_send_cmd_cb_t send_cmd_cb, lv_ili9341_send_color_cb_t send_color_cb,
+                                                void * user_data);
+
+/**
  * Set gap, i.e., the offset of the (0,0) pixel in the VRAM
  * @param disp          display object
  * @param x             x offset

--- a/src/drivers/display/lcd/lv_lcd_generic_mipi.c
+++ b/src/drivers/display/lcd/lv_lcd_generic_mipi.c
@@ -48,6 +48,14 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 lv_display_t * lv_lcd_generic_mipi_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
                                           lv_lcd_send_cmd_cb_t send_cmd_cb, lv_lcd_send_color_cb_t send_color_cb)
 {
+    lv_display_t * disp = lv_lcd_generic_mipi_create_display_no_init(hor_res, ver_res);
+    lv_lcd_generic_mipi_controller_init(disp, flags, send_cmd_cb, send_color_cb);
+
+    return disp;
+}
+
+lv_display_t * lv_lcd_generic_mipi_create_display_no_init(uint32_t hor_res, uint32_t ver_res)
+{
     lv_display_t * disp = lv_display_create(hor_res, ver_res);
     if(disp == NULL) {
         return NULL;
@@ -61,9 +69,22 @@ lv_display_t * lv_lcd_generic_mipi_create(uint32_t hor_res, uint32_t ver_res, lv
 
     /* init driver struct */
     drv->disp = disp;
+    lv_display_set_driver_data(disp, (void *)drv);
+
+    return disp;
+}
+
+void lv_lcd_generic_mipi_controller_init(lv_display_t * disp, lv_lcd_flag_t flags, lv_lcd_send_cmd_cb_t send_cmd_cb,
+                                         lv_lcd_send_color_cb_t send_color_cb)
+{
+    lv_lcd_generic_mipi_driver_t * drv = (lv_lcd_generic_mipi_driver_t *)lv_display_get_driver_data(disp);
+    if(drv == NULL) {
+        return;
+    }
+
+    /* init driver struct */
     drv->send_cmd = send_cmd_cb;
     drv->send_color = send_color_cb;
-    lv_display_set_driver_data(disp, (void *)drv);
 
     /* init controller */
     init(drv, flags);
@@ -73,8 +94,6 @@ lv_display_t * lv_lcd_generic_mipi_create(uint32_t hor_res, uint32_t ver_res, lv
 
     /* register flush callback */
     lv_display_set_flush_cb(disp, flush_cb);
-
-    return disp;
 }
 
 void lv_lcd_generic_mipi_set_gap(lv_display_t * disp, uint16_t x, uint16_t y)

--- a/src/drivers/display/lcd/lv_lcd_generic_mipi.h
+++ b/src/drivers/display/lcd/lv_lcd_generic_mipi.h
@@ -187,6 +187,32 @@ lv_display_t * lv_lcd_generic_mipi_create(uint32_t hor_res, uint32_t ver_res, lv
                                           lv_lcd_send_cmd_cb_t send_cmd_cb, lv_lcd_send_color_cb_t send_color_cb);
 
 /**
+ * Create a MIPI DCS compatible LCD display without initializing the controller.
+ * This is useful if the user needs to set user_data before the controller is initialized.
+ * @param hor_res       horizontal resolution
+ * @param ver_res       vertical resolution
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer).
+ *                      `lv_display_flush_ready` must be called after the transfer has finished.
+ * @return              pointer to the created display
+ */
+lv_display_t * lv_lcd_generic_mipi_create_display_no_init(uint32_t hor_res, uint32_t ver_res);
+
+/**
+ * Initialize a MIPI DCS compatible LCD controller after the display object has been created.
+ * This function is used to initialize the controller after the display object has been created using lv_lcd_generic_mipi_create_display_no_init.
+ * @param disp          pointer to the display object
+ * @param flags         default configuration settings (mirror, RGB ordering, etc.)
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer).
+ *                      `lv_display_flush_ready` must be called after the transfer has finished.
+ */
+void lv_lcd_generic_mipi_controller_init(lv_display_t * disp, lv_lcd_flag_t flags, lv_lcd_send_cmd_cb_t send_cmd_cb,
+                                         lv_lcd_send_color_cb_t send_color_cb);
+
+
+
+/**
  * Set gap, i.e., the offset of the (0,0) pixel in the VRAM
  * @param disp          display object
  * @param x             x offset

--- a/src/drivers/display/st7735/lv_st7735.c
+++ b/src/drivers/display/st7735/lv_st7735.c
@@ -86,6 +86,18 @@ lv_display_t * lv_st7735_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
     return disp;
 }
 
+lv_display_t * lv_st7735_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb,
+                                               void * user_data)
+{
+    lv_display_t * disp = lv_lcd_generic_mipi_create_display_no_init(hor_res, ver_res);
+    lv_display_set_user_data(disp, user_data);
+    lv_lcd_generic_mipi_controller_init(disp, flags, send_cmd_cb, send_color_cb);
+
+    lv_lcd_generic_mipi_send_cmd_list(disp, init_cmd_list);
+    return disp;
+}
+
 void lv_st7735_set_gap(lv_display_t * disp, uint16_t x, uint16_t y)
 {
     lv_lcd_generic_mipi_set_gap(disp, x, y);

--- a/src/drivers/display/st7735/lv_st7735.h
+++ b/src/drivers/display/st7735/lv_st7735.h
@@ -48,6 +48,20 @@ lv_display_t * lv_st7735_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
                                 lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb);
 
 /**
+ * Create an LCD display with ST7735 driver with user data
+ * @param hor_res       horizontal resolution
+ * @param ver_res       vertical resolution
+ * @param flags         default configuration settings (mirror, RGB ordering, etc.)
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @return              pointer to the created display
+ */
+lv_display_t * lv_st7735_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb,
+                                               void * user_data);
+
+/**
  * Set gap, i.e., the offset of the (0,0) pixel in the VRAM
  * @param disp          display object
  * @param x             x offset

--- a/src/drivers/display/st7735/lv_st7735.h
+++ b/src/drivers/display/st7735/lv_st7735.h
@@ -54,7 +54,7 @@ lv_display_t * lv_st7735_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
  * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
  * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
- * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7735_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/src/drivers/display/st7789/lv_st7789.c
+++ b/src/drivers/display/st7789/lv_st7789.c
@@ -89,6 +89,18 @@ lv_display_t * lv_st7789_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
     return disp;
 }
 
+lv_display_t * lv_st7789_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7789_send_cmd_cb_t send_cmd_cb, lv_st7789_send_color_cb_t send_color_cb,
+                                               void * user_data)
+{
+    lv_display_t * disp = lv_lcd_generic_mipi_create_display_no_init(hor_res, ver_res);
+    lv_display_set_user_data(disp, user_data);
+    lv_lcd_generic_mipi_controller_init(disp, flags, send_cmd_cb, send_color_cb);
+
+    lv_lcd_generic_mipi_send_cmd_list(disp, init_cmd_list);
+    return disp;
+}
+
 void lv_st7789_set_gap(lv_display_t * disp, uint16_t x, uint16_t y)
 {
     lv_lcd_generic_mipi_set_gap(disp, x, y);

--- a/src/drivers/display/st7789/lv_st7789.h
+++ b/src/drivers/display/st7789/lv_st7789.h
@@ -54,7 +54,7 @@ lv_display_t * lv_st7789_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
  * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
  * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
- * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7789_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/src/drivers/display/st7789/lv_st7789.h
+++ b/src/drivers/display/st7789/lv_st7789.h
@@ -48,6 +48,20 @@ lv_display_t * lv_st7789_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
                                 lv_st7789_send_cmd_cb_t send_cmd_cb, lv_st7789_send_color_cb_t send_color_cb);
 
 /**
+ * Create an LCD display with ST7789 driver with user data
+ * @param hor_res       horizontal resolution
+ * @param ver_res       vertical resolution
+ * @param flags         default configuration settings (mirror, RGB ordering, etc.)
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @return              pointer to the created display
+ */
+lv_display_t * lv_st7789_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7789_send_cmd_cb_t send_cmd_cb, lv_st7789_send_color_cb_t send_color_cb,
+                                               void * user_data);
+
+/**
  * Set gap, i.e., the offset of the (0,0) pixel in the VRAM
  * @param disp          display object
  * @param x             x offset

--- a/src/drivers/display/st7796/lv_st7796.c
+++ b/src/drivers/display/st7796/lv_st7796.c
@@ -92,6 +92,18 @@ lv_display_t * lv_st7796_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
     return disp;
 }
 
+lv_display_t * lv_st7796_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7796_send_cmd_cb_t send_cmd_cb, lv_st7796_send_color_cb_t send_color_cb,
+                                               void * user_data)
+{
+    lv_display_t * disp = lv_lcd_generic_mipi_create_display_no_init(hor_res, ver_res);
+    lv_display_set_user_data(disp, user_data);
+    lv_lcd_generic_mipi_controller_init(disp, flags, send_cmd_cb, send_color_cb);
+
+    lv_lcd_generic_mipi_send_cmd_list(disp, init_cmd_list);
+    return disp;
+}
+
 void lv_st7796_set_gap(lv_display_t * disp, uint16_t x, uint16_t y)
 {
     lv_lcd_generic_mipi_set_gap(disp, x, y);

--- a/src/drivers/display/st7796/lv_st7796.h
+++ b/src/drivers/display/st7796/lv_st7796.h
@@ -48,6 +48,20 @@ lv_display_t * lv_st7796_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
                                 lv_st7796_send_cmd_cb_t send_cmd_cb, lv_st7796_send_color_cb_t send_color_cb);
 
 /**
+ * Create an LCD display with ST7796 driver with user data
+ * @param hor_res       horizontal resolution
+ * @param ver_res       vertical resolution
+ * @param flags         default configuration settings (mirror, RGB ordering, etc.)
+ * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @return              pointer to the created display
+ */
+lv_display_t * lv_st7796_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
+                                               lv_st7796_send_cmd_cb_t send_cmd_cb, lv_st7796_send_color_cb_t send_color_cb,
+                                               void * user_data);
+
+/**
  * Set gap, i.e., the offset of the (0,0) pixel in the VRAM
  * @param disp          display object
  * @param x             x offset

--- a/src/drivers/display/st7796/lv_st7796.h
+++ b/src/drivers/display/st7796/lv_st7796.h
@@ -54,7 +54,7 @@ lv_display_t * lv_st7796_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
  * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
  * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
- * @param user_data     user data to be passed to the send_cmd and send_color functions
+ * @param user_data     user data to be set for the display. It can be accessed in send_cmd and send_color functions with `lv_display_get_user_data`
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7796_create_with_user_data(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,


### PR DESCRIPTION
This change splits the lv_lcd_generic_mipi_create function into two functions for display creation and controller initialization. It also adds lv_*_create_with_user_data functions to all drivers using the new mipi functions.

Fixes: Generic MIPI display driver and `user_data` access #7822