### PR TITLE
feat(indev): implement direction key to navigation key mapping (#8455)

### DIFF
--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -489,7 +489,23 @@ The most important special keys in your :cpp:func:`read_cb` function are:
 - :cpp:enumerator:`LV_KEY_RIGHT`
 
 You should translate some of your keys to these special keys to support navigation
-in a group and interact with selected Widgets.
+in a group and interact with selected Widgets. Translation of direction key events (eg.
+:cpp:enumerator:`LV_KEY_LEFT`) into move focus events (eg. :cpp:enumerator:`LV_KEY_PREV`) can be
+accomplished using the :cpp:expr:`lv_indev_nav_map` function:
+
+.. code-block:: c
+
+  /* Map LV_KEY_LEFT/RIGHT into LV_KEY_PREV/NEXT */
+  lv_indev_nav_map(indev, LV_INDEV_NAV_MAP_HOR);
+
+  /* Map LV_KEY_LEFT/RIGHT into LV_KEY_NEXT/PREV */
+  lv_indev_nav_map(indev, LV_INDEV_NAV_MAP_HOR_REV);
+
+  /* Map LV_KEY_UP/DOWN into LV_KEY_PREV/NEXT */
+  lv_indev_nav_map(indev, LV_INDEV_NAV_MAP_VER);
+
+  /* Disable mamping */
+  lv_indev_nav_map(indev, 0);
 
 Usually, it's enough to use only :cpp:enumerator:`LV_KEY_LEFT` and :cpp:enumerator:`LV_KEY_RIGHT` because most
 Widgets can be fully controlled with them.

--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -504,7 +504,7 @@ accomplished using the :cpp:expr:`lv_indev_nav_map` function:
   /* Map LV_KEY_UP/DOWN into LV_KEY_PREV/NEXT */
   lv_indev_nav_map(indev, LV_INDEV_NAV_MAP_VER);
 
-  /* Disable mamping */
+  /* Disable mapping */
   lv_indev_nav_map(indev, 0);
 
 Usually, it's enough to use only :cpp:enumerator:`LV_KEY_LEFT` and :cpp:enumerator:`LV_KEY_RIGHT` because most

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -683,6 +683,13 @@ lv_result_t lv_indev_send_event(lv_indev_t * indev, lv_event_code_t code, void *
     return res;
 }
 
+void lv_indev_nav_map(lv_indev_t * indev, uint8_t map)
+{
+    LV_ASSERT_NULL(indev);
+
+    indev->nav_map = map;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -755,6 +762,24 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     i->pointer.last_point.y = i->pointer.act_point.y;
 }
 
+static inline bool indev_keypad_key_is_next(lv_indev_t * indev, uint32_t key)
+{
+    return key == LV_KEY_NEXT ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_HOR) && (key == LV_KEY_RIGHT)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_HOR_REV) && (key == LV_KEY_LEFT)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_VER) && (key == LV_KEY_UP)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_VER_REV) && (key == LV_KEY_DOWN));
+}
+
+static inline bool indev_keypad_key_is_prev(lv_indev_t * indev, uint32_t key)
+{
+    return key == LV_KEY_PREV ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_HOR) && (key == LV_KEY_LEFT)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_HOR_REV) && (key == LV_KEY_RIGHT)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_VER) && (key == LV_KEY_DOWN)) ||
+           ((indev->nav_map & LV_INDEV_NAV_MAP_VER_REV) && (key == LV_KEY_UP));
+}
+
 /**
  * Process a new point from LV_INDEV_TYPE_KEYPAD input device
  * @param i pointer to an input device
@@ -795,13 +820,13 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
         i->pr_timestamp = lv_tick_get();
 
         /*Move the focus on NEXT*/
-        if(data->key == LV_KEY_NEXT) {
+        if(indev_keypad_key_is_next(i, data->key)) {
             lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
             lv_group_focus_next(g);
             if(indev_reset_check(i)) return;
         }
         /*Move the focus on PREV*/
-        else if(data->key == LV_KEY_PREV) {
+        else if(indev_keypad_key_is_prev(i, data->key)) {
             lv_group_set_editing(g, false); /*Editing is not used by KEYPAD is be sure it is disabled*/
             lv_group_focus_prev(g);
             if(indev_reset_check(i)) return;

--- a/src/indev/lv_indev.h
+++ b/src/indev/lv_indev.h
@@ -59,6 +59,13 @@ typedef enum {
     LV_INDEV_GESTURE_CNT,               /* Total number of gestures types */
 } lv_indev_gesture_type_t;
 
+typedef enum {
+    LV_INDEV_NAV_MAP_HOR = 1 << 0,
+    LV_INDEV_NAV_MAP_HOR_REV = 1 << 1,
+    LV_INDEV_NAV_MAP_VER = 1 << 2,
+    LV_INDEV_NAV_MAP_VER_REV = 1 << 3,
+} lv_indev_nav_map_t;
+
 /** Data structure passed to an input driver to fill*/
 typedef struct {
     lv_indev_gesture_type_t gesture_type[LV_INDEV_GESTURE_CNT]; /* Current gesture types, per gesture */
@@ -440,6 +447,13 @@ uint32_t lv_indev_remove_event_cb_with_user_data(lv_indev_t * indev, lv_event_cb
  * @return              LV_RESULT_OK: indev wasn't deleted in the event.
  */
 lv_result_t lv_indev_send_event(lv_indev_t * indev, lv_event_code_t code, void * param);
+
+/**
+ * Map directional keys to group navigation events
+ * @param indev pointer to a keypad input device
+ * @param map mapping bitfield (see lv_indev_nav_map_t), use 0 to disable mapping
+ */
+void lv_indev_nav_map(lv_indev_t * indev, uint8_t map);
 
 /**********************
  *      MACROS

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -118,6 +118,8 @@ struct _lv_indev_t {
     lv_event_list_t event_list;
     lv_anim_t * scroll_throw_anim;
 
+    uint8_t nav_map; /**< Navigation key mapping */
+
 #if LV_USE_GESTURE_RECOGNITION
     lv_indev_gesture_recognizer_t recognizers[LV_INDEV_GESTURE_CNT];
     lv_indev_gesture_type_t cur_gesture;


### PR DESCRIPTION
Fixes #8455

Adds a function for indev objects that lets you remap directional keys (eg. `LV_KEY_LEFT`) into navigation keys (`LV_KEY_PREV`).