### PR TITLE
fix(wayland): call display_flush_ready on intermediate frames

### DIFF
--- a/src/drivers/wayland/lv_wl_dmabuf.c
+++ b/src/drivers/wayland/lv_wl_dmabuf.c
@@ -172,6 +172,11 @@ void lv_wayland_dmabuf_flush_full_mode(lv_display_t * disp, const lv_area_t * ar
         buf->busy             = 1;
         window->flush_pending = true;
     }
+    else {
+        /* Not the last frame yet, so tell lvgl to keep going
+         * For the last frame, we wait for the compositor instead */
+        lv_display_flush_ready(disp);
+    }
 
     return;
 }


### PR DESCRIPTION
Fixes a bug where the app looked like it was "freezing" because LVGL didn’t know it could start the next frame.

What’s happening is we collect all the parts of the screen that need updating, but we don’t actually send anything to the compositor until the final frame. When we reach that frame, we wait for the compositor to tell us it's okay to keep going - so we don’t call lv_display_flush_ready yet.

But for the earlier (intermediate) frames, since we haven’t sent anything off yet, we do need to call `lv_display_flush_ready`. Otherwise, LVGL gets stuck waiting, and everything grinds to a halt

This fixes the issue you reported previously @anaGrad. Could you try it out?