### PR TITLE
fix(draw/sw_mask): fix potential buffer overflow

### DIFF
--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -1209,7 +1209,7 @@ static void circ_calc_aa4(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t radiu
     while(i < cir_size) {
         c->opa_start_on_y[y] = i;
         c->x_start_on_y[y] = cir_x[i];
-        for(; cir_y[i] == y && i < (int32_t)cir_size; i++) {
+        for(; i < (int32_t)cir_size && cir_y[i] == y; i++) {
             c->x_start_on_y[y] = LV_MIN(c->x_start_on_y[y], cir_x[i]);
         }
         y++;


### PR DESCRIPTION
Reorder check so limit is checked before using i.

==2380185== Conditional jump or move depends on uninitialised value(s)
==2380185==    at 0x4929591: circ_calc_aa4 (lv_draw_sw_mask.c:1212)

Reported as https://github.com/lvgl/lvgl/issues/8475

Fixes #8475

<!-- A clear and concise description of what the bug or new feature is.-->
Reorder check so limit is checked before using i to avoid valgrind errors and potential segfaults.
