### PR TITLE
fix(g2d): calculate stride because it may not be set in the image descriptor

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -91,8 +91,8 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
     src_area.y1 = blend_area.y1 - (coords->y1 - layer->buf_area.y1);
     src_area.x2 = src_area.x1 + lv_area_get_width(&blend_area);
     src_area.y2 = src_area.y1 + lv_area_get_height(&blend_area);
-    int32_t src_stride = img_dsc->header.stride / (lv_color_format_get_bpp(img_dsc->header.cf) / 8);
     lv_color_format_t src_cf = img_dsc->header.cf;
+    int32_t src_stride = lv_draw_buf_width_to_stride(img_dsc->header.w, src_cf) / (lv_color_format_get_bpp(src_cf) / 8);
 
     /* Source image */
     struct g2d_buf * src_buf = _g2d_handle_src_buf(img_dsc);


### PR DESCRIPTION
Fix for https://github.com/lvgl/lvgl/issues/8477. After using the image converter the generated c file may still not contain a stride. This fix makes it so it doesn't directly grab the stride from the image descriptor where it may be zero but calculate it using the width and cf.

I just went with the calculation instead of checking if the stride is zero. I could also do it this way if requested.

Thanks

krembed