### PR TITLE
Dont' Squash: improvements and fixes to the emulated performance workflow 

### DIFF
--- a/.github/workflows/perf_emulation.yml
+++ b/.github/workflows/perf_emulation.yml
@@ -45,11 +45,11 @@ jobs:
         include:
         - image_type: 32b
           image_version : |
-            main@sha256:9c4587f5852be856aed4548fcb8b505290410de837bb87fb2ba8e1b778f10bec
+            main@sha256:61e287d63b19a503cc4505c13bd93f5e05e19513a947feb048d75662c398c862
           config : lv_conf_perf32b
         - image_type: 64b
           image_version: |
-            main@sha256:7e4c0a883dec21e2e9c027fe21188b2b009e46a1b3eb9f02499ca02ed7914e4a
+            main@sha256:e8663d9c138e98b78d12cc8ad056b7d4b0cc4ad233c6f54202e40ce7606c2670
           config : lv_conf_perf64b
     steps:
       - name: Checkout

--- a/.github/workflows/perf_emulation_handle_results.yml
+++ b/.github/workflows/perf_emulation_handle_results.yml
@@ -46,11 +46,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Results
+      - name: Download Results from master
+        if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master' }}
         uses: dawidd6/action-download-artifact@v9
         with:
           workflow: perf_emulation.yml
           path: artifacts
+          allow_forks: false
+
+
+      - name: Download Results from PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: perf_emulation.yml
+          path: artifacts
+          # The artifact needs to be downloaded from a PR run that comes from a forked repository
+          allow_forks: true 
 
       - name: Move JSON files to a single folder
         run: |

--- a/.github/workflows/perf_emulation_handle_results.yml
+++ b/.github/workflows/perf_emulation_handle_results.yml
@@ -130,4 +130,5 @@ jobs:
           files: output/results*.mpk
           tag_name: emulated-benchmark-latest
           prerelease: true
+          body: This pre-release is automatically generated and serves as a repository for benchmark results.
 


### PR DESCRIPTION
This adds a message to the benchmark results pre-release https://github.com/lvgl/lvgl/releases/tag/emulated-benchmark-latest and also updates the image versions where the emulated tests are run to a more stable version