### PR TITLE
refactor(draw): use better names in lv_draw_task_state_t and handle queued vs in_progress

### DIFF
--- a/docs/src/details/main-modules/draw/draw_pipeline.rst
+++ b/docs/src/details/main-modules/draw/draw_pipeline.rst
@@ -113,18 +113,18 @@ For an example of how draw-unit creation and initialization is done, see
 :cpp:func:`lv_draw_sw_init` in lv_draw_sw.c_ or the other draw units whose ``init``
 functions are optionally called in :cpp:func:`lv_init`.
 
-Thread Priority 
---------------- 
+Thread Priority
+---------------
 
-All draw units operate with a configurable thread priority which can be set using the 
-:c:macro:`LV_DRAW_THREAD_PRIO` configuration option in ``lv_conf.h``. This allows you 
-to fine-tune the priority level across all drawing units, which is especially useful for 
-systems with limited priority levels. 
+All draw units operate with a configurable thread priority which can be set using the
+:c:macro:`LV_DRAW_THREAD_PRIO` configuration option in ``lv_conf.h``. This allows you
+to fine-tune the priority level across all drawing units, which is especially useful for
+systems with limited priority levels.
 
-By default, draw units use :c:macro:`LV_THREAD_PRIO_HIGH` as their thread priority. 
-This consistent approach ensures that all drawing units (software rendering, hardware 
-accelerators like STM32 DMA2D, NXP VGLite, etc.) use the same priority level unless 
-explicitly configured otherwise. 
+By default, draw units use :c:macro:`LV_THREAD_PRIO_HIGH` as their thread priority.
+This consistent approach ensures that all drawing units (software rendering, hardware
+accelerators like STM32 DMA2D, NXP VGLite, etc.) use the same priority level unless
+explicitly configured otherwise.
 
 .. _lv_draw_sw.c:  https://github.com/lvgl/lvgl/blob/master/src/draw/sw/lv_draw_sw.c
 
@@ -175,7 +175,7 @@ available it can take a Draw Task.
 :cpp:expr:`lv_draw_get_next_available_task(layer, previous_task, draw_unit_id)` is a
 useful helper function which is used by the ``dispatch_cb`` to get the next Draw Task
 it should act on.  If it handled the task, it sets the Draw Task's ``state`` field to
-:cpp:enumerator:`LV_DRAW_TASK_STATE_READY` (meaning "completed").  "Available" in
+:cpp:enumerator:`LV_DRAW_TASK_STATE_FINISHED` (meaning "completed").  "Available" in
 this context means that has been queued and assigned to a given Draw Unit and is
 ready to be carried out.  The ramifications of having multiple drawing threads are
 taken into account for this.

--- a/docs/src/details/main-modules/draw/draw_pipeline.rst
+++ b/docs/src/details/main-modules/draw/draw_pipeline.rst
@@ -175,7 +175,7 @@ available it can take a Draw Task.
 :cpp:expr:`lv_draw_get_next_available_task(layer, previous_task, draw_unit_id)` is a
 useful helper function which is used by the ``dispatch_cb`` to get the next Draw Task
 it should act on.  If it handled the task, it sets the Draw Task's ``state`` field to
-:cpp:enumerator:`LV_DRAW_TASK_STATE_FINISHED` (meaning "completed").  "Available" in
+:cpp:enumerator:`LV_DRAW_TASK_STATE_FINISHED`.  "Available" in
 this context means that has been queued and assigned to a given Draw Unit and is
 ready to be carried out.  The ramifications of having multiple drawing threads are
 taken into account for this.

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -307,7 +307,7 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     t->draw_unit = draw_unit;
     draw_dma2d_unit->task_act = t;
 
@@ -397,7 +397,7 @@ static void post_transfer_tasks(lv_draw_dma2d_unit_t * u)
 #if LV_DRAW_DMA2D_CACHE
     lv_draw_dma2d_invalidate_cache(&u->writing_area);
 #endif
-    u->task_act->state = LV_DRAW_TASK_STATE_READY;
+    u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     u->task_act = NULL;
 }
 

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -307,7 +307,7 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     t->draw_unit = draw_unit;
     draw_dma2d_unit->task_act = t;
 

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -183,13 +183,15 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(!t || t->preferred_draw_unit_id != DRAW_UNIT_ID_PPA) return LV_DRAW_UNIT_IDLE;
     if(!lv_draw_layer_alloc_buf(layer)) return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     u->task_act = t;
     u->task_act->draw_unit = draw_unit;
 
     ppa_execute_drawing(u);
 
 #if !LV_PPA_NONBLOCKING_OPS
+    u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
+    u->task_act = NULL;
     lv_draw_dispatch_request();
 #endif
 
@@ -243,7 +245,7 @@ static void ppa_thread(void * arg)
             lv_thread_sync_wait(&u->interrupt_signal);
         } while(u->task_act != NULL);
 
-        u->task_act->state = LV_DRAW_TASK_STATE_READY;
+        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
         u->task_act = NULL;
         lv_draw_dispatch_request();
     }

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -174,7 +174,7 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
             return LV_DRAW_UNIT_IDLE;
         }
         else {
-            u->task_act->state = LV_DRAW_TASK_STATE_READY;
+            u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
             u->task_act = NULL;
         }
     }

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -183,7 +183,7 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(!t || t->preferred_draw_unit_id != DRAW_UNIT_ID_PPA) return LV_DRAW_UNIT_IDLE;
     if(!lv_draw_layer_alloc_buf(layer)) return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;
     u->task_act->draw_unit = draw_unit;
 

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -349,8 +349,6 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
 
     lv_draw_task_t * t = t_prev ? t_prev->next : layer->draw_task_head;
     while(t) {
-        bool good = false;
-
         /*Find a draw task for this draw unit which is waiting and independent?*/
         if(t->preferred_draw_unit_id == draw_unit_id &&
            t->state == LV_DRAW_TASK_STATE_WAITING &&

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -34,7 +34,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check);
+static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check, uint8_t draw_unit_id);
 static void cleanup_task(lv_draw_task_t * t, lv_display_t * disp);
 static inline size_t get_draw_dsc_size(lv_draw_task_type_t type);
 static lv_draw_task_t * get_first_available_task(lv_layer_t * layer);
@@ -349,13 +349,16 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
 
     lv_draw_task_t * t = t_prev ? t_prev->next : layer->draw_task_head;
     while(t) {
-        /*Find a queued and independent task*/
-        if(t->state == LV_DRAW_TASK_STATE_WAITING &&
-           (t->preferred_draw_unit_id == LV_DRAW_UNIT_NONE || t->preferred_draw_unit_id == draw_unit_id) &&
-           is_independent(layer, t)) {
+        bool good = false;
+
+        /*Find a draw task for this draw unit which is waiting and independent?*/
+        if(t->preferred_draw_unit_id == draw_unit_id &&
+           t->state == LV_DRAW_TASK_STATE_WAITING &&
+           is_independent(layer, t, draw_unit_id)) {
             LV_PROFILER_DRAW_END;
             return t;
         }
+
         t = t->next;
     }
 
@@ -518,23 +521,30 @@ void lv_draw_task_get_area(const lv_draw_task_t * t, lv_area_t * area)
 
 /**
  * Check if there are older draw task overlapping the area of `t_check`
- * @param layer      the draw ctx to search in
+ * @param layer         the draw ctx to search in
  * @param t_check       check this task if it overlaps with the older ones
+ * @param draw_unit_id  draw unit ID for which the independence check is called
  * @return              true: `t_check` is not overlapping with older tasks so it's independent
  */
-static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check)
+static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check, uint8_t draw_unit_id)
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = layer->draw_task_head;
 
     /*If t_check is outside of the older tasks then it's independent*/
     while(t && t != t_check) {
-        if(t->state != LV_DRAW_TASK_STATE_FINISHED) {
-            lv_area_t a;
-            if(lv_area_intersect(&a, &t->_real_area, &t_check->_real_area)) {
-                LV_PROFILER_DRAW_END;
-                return false;
-            }
+        /*It's independent of finished draw tasks, and queued draw tasks of the same draw unit,
+         *so no need to check it*/
+        if(t->state == LV_DRAW_TASK_STATE_FINISHED ||
+           (t->state == LV_DRAW_TASK_STATE_QUEUED && t->preferred_draw_unit_id == draw_unit_id)) {
+            t = t->next;
+            continue;
+        }
+
+        lv_area_t a;
+        if(lv_area_intersect(&a, &t->_real_area, &t_check->_real_area)) {
+            LV_PROFILER_DRAW_END;
+            return false;
         }
         t = t->next;
     }
@@ -666,12 +676,12 @@ static lv_draw_task_t * get_first_available_task(lv_layer_t * layer)
      * so it can be blended normally.*/
     lv_draw_task_t * t = layer->draw_task_head;
     while(t) {
-        /*Not queued yet, leave this layer while the first task is queued*/
+        /*Not waiting to be rendered, leave this layer while the first task is ready (i.e. not blocked)*/
         if(t->state != LV_DRAW_TASK_STATE_WAITING) {
             t = NULL;
             break;
         }
-        /*It's a supported and queued task, process it*/
+        /*Waiting to be rendered, use it*/
         else {
             break;
         }

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -350,7 +350,7 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
     lv_draw_task_t * t = t_prev ? t_prev->next : layer->draw_task_head;
     while(t) {
         /*Find a draw task for this draw unit which is waiting and independent?*/
-        if(t->preferred_draw_unit_id == draw_unit_id &&
+        if((t->preferred_draw_unit_id == draw_unit_id || t->preferred_draw_unit_id == LV_DRAW_UNIT_NONE) &&
            t->state == LV_DRAW_TASK_STATE_WAITING &&
            is_independent(layer, t, draw_unit_id)) {
             LV_PROFILER_DRAW_END;

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -113,7 +113,7 @@ lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords, 
     new_task->opa = layer->opa;
     new_task->type = type;
     new_task->draw_dsc = (uint8_t *)new_task + LV_ALIGN_UP(sizeof(lv_draw_task_t), 8);
-    new_task->state = LV_DRAW_TASK_STATE_QUEUED;
+    new_task->state = LV_DRAW_TASK_STATE_WAITING;
 
     /*Find the tail*/
     if(layer->draw_task_head == NULL) {
@@ -166,7 +166,7 @@ void lv_draw_finalize_task_creation(lv_layer_t * layer, lv_draw_task_t * t)
         }
         if(t->preferred_draw_unit_id == LV_DRAW_UNIT_NONE) {
             LV_LOG_WARN("the draw task was not taken by any units");
-            t->state = LV_DRAW_TASK_STATE_READY;
+            t->state = LV_DRAW_TASK_STATE_FINISHED;
         }
         else {
             lv_draw_dispatch();
@@ -240,7 +240,7 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
     bool remove_task = false;
     while(t) {
         t_next = t->next;
-        if(t->state == LV_DRAW_TASK_STATE_READY) {
+        if(t->state == LV_DRAW_TASK_STATE_FINISHED) {
             cleanup_task(t, disp);
             remove_task = true;
             if(t_prev != NULL)
@@ -261,10 +261,10 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
         /*Find a draw task with TYPE_LAYER in the layer where the src is this layer*/
         lv_draw_task_t * t_src = layer->parent->draw_task_head;
         while(t_src) {
-            if(t_src->type == LV_DRAW_TASK_TYPE_LAYER && t_src->state == LV_DRAW_TASK_STATE_WAITING) {
+            if(t_src->type == LV_DRAW_TASK_TYPE_LAYER && t_src->state == LV_DRAW_TASK_STATE_BLOCKED) {
                 lv_draw_image_dsc_t * draw_dsc = t_src->draw_dsc;
                 if(draw_dsc->src == layer) {
-                    t_src->state = LV_DRAW_TASK_STATE_QUEUED;
+                    t_src->state = LV_DRAW_TASK_STATE_WAITING;
                     lv_draw_dispatch_request();
                     break;
                 }
@@ -339,7 +339,7 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
         int32_t hor_res = lv_display_get_horizontal_resolution(lv_refr_get_disp_refreshing());
         int32_t ver_res = lv_display_get_vertical_resolution(lv_refr_get_disp_refreshing());
         lv_draw_task_t * t = layer->draw_task_head;
-        if(t->state != LV_DRAW_TASK_STATE_QUEUED &&
+        if(t->state != LV_DRAW_TASK_STATE_WAITING &&
            t->area.x1 <= 0 && t->area.x2 >= hor_res - 1 &&
            t->area.y1 <= 0 && t->area.y2 >= ver_res - 1) {
             LV_PROFILER_DRAW_END;
@@ -350,7 +350,7 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
     lv_draw_task_t * t = t_prev ? t_prev->next : layer->draw_task_head;
     while(t) {
         /*Find a queued and independent task*/
-        if(t->state == LV_DRAW_TASK_STATE_QUEUED &&
+        if(t->state == LV_DRAW_TASK_STATE_WAITING &&
            (t->preferred_draw_unit_id == LV_DRAW_UNIT_NONE || t->preferred_draw_unit_id == draw_unit_id) &&
            is_independent(layer, t)) {
             LV_PROFILER_DRAW_END;
@@ -373,7 +373,7 @@ uint32_t lv_draw_get_dependent_count(lv_draw_task_t * t_check)
 
     lv_draw_task_t * t = t_check->next;
     while(t) {
-        if((t->state == LV_DRAW_TASK_STATE_QUEUED || t->state == LV_DRAW_TASK_STATE_WAITING) &&
+        if((t->state == LV_DRAW_TASK_STATE_WAITING || t->state == LV_DRAW_TASK_STATE_BLOCKED) &&
            lv_area_is_on(&t_check->area, &t->area)) {
             cnt++;
         }
@@ -529,7 +529,7 @@ static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check)
 
     /*If t_check is outside of the older tasks then it's independent*/
     while(t && t != t_check) {
-        if(t->state != LV_DRAW_TASK_STATE_READY) {
+        if(t->state != LV_DRAW_TASK_STATE_FINISHED) {
             lv_area_t a;
             if(lv_area_intersect(&a, &t->_real_area, &t_check->_real_area)) {
                 LV_PROFILER_DRAW_END;
@@ -662,12 +662,12 @@ static lv_draw_task_t * get_first_available_task(lv_layer_t * layer)
      * all its tasks are ready. As other areas might be on top of that
      * layer-to-blend don't skip it. Instead stop there, so that the
      * draw tasks of that layer can be consumed and can be finished.
-     * After that this layer-to-blenf will have `LV_DRAW_TASK_STATE_QUEUED`
+     * After that this layer-to-blenf will have `LV_DRAW_TASK_STATE_WAITING`
      * so it can be blended normally.*/
     lv_draw_task_t * t = layer->draw_task_head;
     while(t) {
         /*Not queued yet, leave this layer while the first task is queued*/
-        if(t->state != LV_DRAW_TASK_STATE_QUEUED) {
+        if(t->state != LV_DRAW_TASK_STATE_WAITING) {
             t = NULL;
             break;
         }

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -74,17 +74,17 @@ typedef enum {
     /** The draw task is added to the layers list and waits to be rendered. */
     LV_DRAW_TASK_STATE_WAITING,
 
-    /** The draw task is being rendered now or added to the command queue of the draw unit.
+    /** The draw task is added to the command queue of the draw unit.
      * As the queued task are executed in order it's possible to queue multiple draw task
      * (for the same draw unit) even if they are depending on each other.
      * Therefore `lv_draw_get_available_task` and `lv_draw_get_next_available_task` can return
      * draw task for the same draw unit even if a dependent draw task is not finished ready yet.*/
-    LV_DRAW_TASK_STATE_IN_PROGRESS,
+    LV_DRAW_TASK_STATE_QUEUED,
 
     /** The draw task is being rendered. This draw task needs to be finished before
      * `lv_draw_get_available_task` and `lv_draw_get_next_available_task` would
      * return any depending draw tasks.*/
-    LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING,
+    LV_DRAW_TASK_STATE_IN_PROGRESS,
 
     /** The draw task is rendered. It will be removed from the draw task list of the layer
      * and freed automatically. */

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -66,10 +66,29 @@ typedef enum {
 } lv_draw_task_type_t;
 
 typedef enum {
-    LV_DRAW_TASK_STATE_WAITING,     /*Waiting for something to be finished. E.g. rendering a layer*/
-    LV_DRAW_TASK_STATE_QUEUED,
+    /** Waiting for an other task to be finished.
+     * For example in case of `LV_DRAW_TASK_TYPE_LAYER` (used to blend a layer)
+     * is blocked until all the draw tasks of the layer is rendered. */
+    LV_DRAW_TASK_STATE_BLOCKED,
+
+    /** The draw task is added to the layers list and waits to be rendered. */
+    LV_DRAW_TASK_STATE_WAITING,
+
+    /** The draw task is being rendered now or added to the command queue of the draw unit.
+     * As the queued task are executed in order it's possible to queue multiple draw task
+     * (for the same draw unit) even if they are depending on each other.
+     * Therefore `lv_draw_get_available_task` and `lv_draw_get_next_available_task` can return
+     * draw task for the same draw unit even if a dependent draw task is not finished ready yet.*/
     LV_DRAW_TASK_STATE_IN_PROGRESS,
-    LV_DRAW_TASK_STATE_READY,
+
+    /** The draw task is being rendered. This draw task needs to be finished before
+     * `lv_draw_get_available_task` and `lv_draw_get_next_available_task` would
+     * return any depending draw tasks.*/
+    LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING,
+
+    /** The draw task is rendered. It will be removed from the draw task list of the layer
+     * and freed automatically. */
+    LV_DRAW_TASK_STATE_FINISHED,
 } lv_draw_task_state_t;
 
 struct _lv_layer_t  {

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -76,7 +76,7 @@ void lv_draw_layer(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_LAYER);
     lv_draw_image_dsc_t * new_image_dsc = t->draw_dsc;
     lv_memcpy(new_image_dsc, dsc, sizeof(*dsc));
-    t->state = LV_DRAW_TASK_STATE_WAITING;
+    t->state = LV_DRAW_TASK_STATE_BLOCKED;
 
     lv_image_buf_get_transformed_area(&t->_real_area, lv_area_get_width(coords), lv_area_get_height(coords),
                                       dsc->rotation, dsc->scale_x, dsc->scale_y, &dsc->pivot);

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -275,7 +275,7 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(buf == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_nema_gfx_unit->task_act = t;
 
 #if LV_USE_OS

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -275,7 +275,7 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(buf == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_nema_gfx_unit->task_act = t;
 
 #if LV_USE_OS
@@ -285,7 +285,7 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 #else
     nema_gfx_execute_drawing(draw_nema_gfx_unit);
 
-    draw_nema_gfx_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_nema_gfx_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_nema_gfx_unit->task_act = NULL;
 
     /* The draw unit is free now. Request a new dispatching as it can get a new task. */
@@ -388,7 +388,7 @@ static void nema_gfx_render_thread_cb(void * ptr)
             nema_gfx_execute_drawing(u);
         }
         /* Signal the ready state to dispatcher. */
-        u->task_act->state = LV_DRAW_TASK_STATE_READY;
+        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
         /* Cleanup. */
         u->task_act = NULL;
 

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -229,7 +229,7 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     t->draw_unit = draw_unit;
 
 #if LV_USE_G2D_DRAW_THREAD
@@ -243,7 +243,7 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     _g2d_execute_drawing(t);
 
-    draw_g2d_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_g2d_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_g2d_unit->task_act = NULL;
 
     /* The draw unit is free now. Request a new dispatching as it can get a new task. */
@@ -318,7 +318,7 @@ static void _g2d_render_thread_cb(void * ptr)
         _g2d_execute_drawing(thread_dsc->task_act);
 
         /* Signal the ready state to dispatcher. */
-        thread_dsc->task_act->state = LV_DRAW_TASK_STATE_READY;
+        thread_dsc->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
 
         /* Cleanup. */
         thread_dsc->task_act = NULL;

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -229,7 +229,7 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     t->draw_unit = draw_unit;
 
 #if LV_USE_G2D_DRAW_THREAD

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -340,7 +340,7 @@ static int32_t _pxp_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_pxp_unit->task_act = t;
 
 #if LV_USE_PXP_DRAW_THREAD

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -340,7 +340,7 @@ static int32_t _pxp_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_pxp_unit->task_act = t;
 
 #if LV_USE_PXP_DRAW_THREAD
@@ -350,7 +350,7 @@ static int32_t _pxp_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 #else
     _pxp_execute_drawing(draw_pxp_unit);
 
-    draw_pxp_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_pxp_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_pxp_unit->task_act = NULL;
 
     /* The draw unit is free now. Request a new dispatching as it can get a new task. */
@@ -482,7 +482,7 @@ static void _pxp_render_thread_cb(void * ptr)
         _pxp_execute_drawing(u);
 
         /* Signal the ready state to dispatcher. */
-        u->task_act->state = LV_DRAW_TASK_STATE_READY;
+        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
 
         /* Cleanup. */
         u->task_act = NULL;

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -329,7 +329,7 @@ static int32_t _vglite_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_vglite_unit->task_act = vglite_task;
 
 #if LV_USE_VGLITE_DRAW_THREAD

--- a/src/draw/nxp/vglite/lv_draw_vglite.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite.c
@@ -315,7 +315,7 @@ static int32_t _vglite_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         }
         else {
             /* Fake unsupported tasks as ready. */
-            t->state = LV_DRAW_TASK_STATE_READY;
+            t->state = LV_DRAW_TASK_STATE_FINISHED;
             /* Request a new dispatching as it can get a new task. */
             lv_draw_dispatch_request();
 
@@ -329,7 +329,7 @@ static int32_t _vglite_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     if(lv_draw_layer_alloc_buf(layer) == NULL)
         return LV_DRAW_UNIT_IDLE;
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_vglite_unit->task_act = vglite_task;
 
 #if LV_USE_VGLITE_DRAW_THREAD
@@ -339,7 +339,7 @@ static int32_t _vglite_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 #else
     _vglite_execute_drawing(draw_vglite_unit);
 
-    draw_vglite_unit->task_act->t->state = LV_DRAW_TASK_STATE_READY;
+    draw_vglite_unit->task_act->t->state = LV_DRAW_TASK_STATE_FINISHED;
     _vglite_cleanup_task(draw_vglite_unit->task_act);
     draw_vglite_unit->task_act = NULL;
 
@@ -526,7 +526,7 @@ static inline void _vglite_queue_task(vglite_draw_task_t * task)
 static inline void _vglite_signal_task_ready(vglite_draw_task_t * task)
 {
     /* Signal the ready state to dispatcher. */
-    task->t->state = LV_DRAW_TASK_STATE_READY;
+    task->t->state = LV_DRAW_TASK_STATE_FINISHED;
     _head = (_head + 1) % VGLITE_TASK_BUF_SIZE;
 
     _vglite_cleanup_task(task);
@@ -611,7 +611,7 @@ static void _vglite_render_thread_cb(void * ptr)
         }
 #else
         /* Signal the ready state to dispatcher. */
-        u->task_act->t->state = LV_DRAW_TASK_STATE_READY;
+        u->task_act->t->state = LV_DRAW_TASK_STATE_FINISHED;
         _vglite_cleanup_task(u->task_act);
 #endif
 

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -205,7 +205,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         }
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_opengles_unit->task_act = t;
 
     execute_drawing(draw_opengles_unit);

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -205,12 +205,12 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         }
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_opengles_unit->task_act = t;
 
     execute_drawing(draw_opengles_unit);
 
-    draw_opengles_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_opengles_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_opengles_unit->task_act = NULL;
 
     /*The draw unit is free now. Request a new dispatching as it can get a new task*/

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -397,7 +397,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     *p_new_list_entry = t;
 #endif
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_dave2d_unit->task_act = t;
 
 #if LV_USE_OS

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -360,7 +360,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     lv_draw_task_t * t = NULL;
     t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_DAVE2D);
     while(t && t->preferred_draw_unit_id != DRAW_UNIT_ID_DAVE2D) {
-        t->state = LV_DRAW_TASK_STATE_READY;
+        t->state = LV_DRAW_TASK_STATE_FINISHED;
         t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_DAVE2D);
     }
 
@@ -397,7 +397,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     *p_new_list_entry = t;
 #endif
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_dave2d_unit->task_act = t;
 
 #if LV_USE_OS
@@ -406,7 +406,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
 #else
     execute_drawing(draw_dave2d_unit);
 #if  (D2_RENDER_EACH_OPERATION)
-    draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
 #endif
     draw_dave2d_unit->task_act = NULL;
 
@@ -433,7 +433,7 @@ static void _dave2d_render_thread_cb(void * ptr)
 
         /*Cleanup*/
 #if  (D2_RENDER_EACH_OPERATION)
-        u->task_act->state = LV_DRAW_TASK_STATE_READY;
+        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
 #endif
         u->task_act = NULL;
 
@@ -602,7 +602,7 @@ void dave2d_execute_dlist_and_flush(void)
     while(false == lv_ll_is_empty(&_ll_Dave2D_Tasks)) {
         p_list_entry = lv_ll_get_tail(&_ll_Dave2D_Tasks);
         p_list_entry1 = *p_list_entry;
-        p_list_entry1->state = LV_DRAW_TASK_STATE_READY;
+        p_list_entry1->state = LV_DRAW_TASK_STATE_FINISHED;
         lv_ll_remove(&_ll_Dave2D_Tasks, p_list_entry);
         lv_free(p_list_entry);
     }

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -158,12 +158,12 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
                                              SDL_TEXTUREACCESS_TARGET, w, h);
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_sdl_unit->task_act = t;
 
     execute_drawing(draw_sdl_unit);
 
-    draw_sdl_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_sdl_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_sdl_unit->task_act = NULL;
 
     /*The draw unit is free now. Request a new dispatching as it can get a new task*/

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -158,7 +158,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
                                              SDL_TEXTUREACCESS_TARGET, w, h);
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_sdl_unit->task_act = t;
 
     execute_drawing(draw_sdl_unit);

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -295,7 +295,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         /*Take the task*/
         all_idle = false;
         taken_cnt++;
-        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
         thread_dsc->task_act = t;
 
         /*Let the render thread work*/
@@ -325,7 +325,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;  /*Couldn't start rendering*/
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_sw_unit->task_act = t;
 
     execute_drawing(t);

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -295,7 +295,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         /*Take the task*/
         all_idle = false;
         taken_cnt++;
-        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
         thread_dsc->task_act = t;
 
         /*Let the render thread work*/
@@ -325,11 +325,11 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;  /*Couldn't start rendering*/
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     draw_sw_unit->task_act = t;
 
     execute_drawing(t);
-    draw_sw_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_sw_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_sw_unit->task_act = NULL;
 
     /*The draw unit is free now. Request a new dispatching as it can get a new task*/
@@ -366,7 +366,7 @@ static void render_thread_cb(void * ptr)
 #if LV_USE_PARALLEL_DRAW_DEBUG
         parallel_debug_draw(thread_dsc->task_act, thread_dsc->idx);
 #endif
-        thread_dsc->task_act->state = LV_DRAW_TASK_STATE_READY;
+        thread_dsc->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
         thread_dsc->task_act = NULL;
 
         /*The draw unit is free now. Request a new dispatching as it can get a new task*/

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -218,12 +218,12 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
     u->task_act = t;
 
     draw_execute(u);
 
-    u->task_act->state = LV_DRAW_TASK_STATE_READY;
+    u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     u->task_act = NULL;
 
     /*The draw unit is free now. Request a new dispatching as it can get a new task*/

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -218,7 +218,7 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
     }
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS_BLOCKING;
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;
 
     draw_execute(u);


### PR DESCRIPTION
Many files changed but all of them are only search and replace, except `lv_draw.c` where there are "real" minor changes.

This PR introduces the differentiation of a draw task states if they are
- in progress: rendered now, so not depending draw task can be started
- queued: added to the command list of GPU, so even a dependent draw task (for the same GPU) can added to the queue.

It prepares the ground for a solution for hacks like this:
https://github.com/lvgl/lvgl/blob/5934a45a0b26994083818032fcfaf66bb8f90bc9/src/draw/nema_gfx/lv_draw_nema_gfx.c#L387-L391
Here (and in other GPUs too) right after queuing the task is marked as ready. It works if there is only one GPU, but e.g. if the background fill is queued, in the meantime SW will think that it can also draw (as the background fill is ready, but it's not). In this case the GPU and SW will draw the same area at the same time.

No GPU specific changes are introduced here, but at least now we have a draw task state for queued.

The next step will be to add a mechanism to mark queued draw tasks as finished when they are ready. It might happen in a GPU interrupt, but in this case we need a reference to the draw task which was finished. Anyway, it's for another PR to keep changes easy to review.  

cc @uLipe @liamHowatt @FASTSHIFT @nicusorcitu @anaGrad @cosmindanielradu19 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
