### PR TITLE
chore: use filename to better match mpk and json files

### DIFF
--- a/scripts/perf/benchmark_results_comment.py
+++ b/scripts/perf/benchmark_results_comment.py
@@ -98,6 +98,7 @@ physical hardware. The measurements are intended for comparative analysis only.
 
 import argparse
 import json
+import os
 import msgpack
 
 
@@ -179,13 +180,15 @@ def main():
             with open(results_path, "rb") as f:
                 previousb = f.read()
                 rs: list = msgpack.unpackb(previousb)
-                previous_results_map[results_path] = rs
+                # We store the filename so it's easier to match with the related results
+                previous_results_map[os.path.basename(results_path)] = rs
 
     new_results: dict[str, list[dict]] = {}
     for results_path in results_paths:
         with open(results_path, "r") as f:
             r: list[dict] = json.load(f)
-            new_results[results_path] = r
+            # We store the filename so it's easier to match with the related results
+            new_results[os.path.basename(results_path)] = r
 
     comment = "Hi :wave:, thank you for your PR!\n\n"
     comment += "We've run benchmarks in an emulated environment."


### PR DESCRIPTION
Follow up #8515 Right now the comments are still showing up because the script is not able to match the history with the new result file

See the "Prepare Comment" from this workflow run: https://github.com/lvgl/lvgl/actions/runs/16026653306/job/45216226069

This fixes it by simply using the filename instead of the full path
