### PR TITLE
docs:  remove outdated doc material

### DIFF
--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -639,13 +639,6 @@ The default value of the following parameters can be changed in :cpp:type:`lv_in
   can be changed by calling ``lv_timer_...()`` functions. :c:macro:`LV_DEF_REFR_PERIOD`
   in ``lv_conf.h`` sets the default read period.
 
-Feedback
---------
-
-Besides ``read_cb`` a ``feedback_cb`` callback can be also specified in
-:cpp:type:`lv_indev_t`. ``feedback_cb`` is called when any type of event is sent
-by input devices (independently of their type). This allows generating feedback for the user, e.g., to play a sound on :cpp:enumerator:`LV_EVENT_CLICKED`.
-
 Buffered Reading
 ----------------
 

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -352,7 +352,6 @@ static lv_result_t event_send_core(lv_event_t * e)
 {
     LV_TRACE_EVENT("Sending event %d to %p with %p param", e->code, (void *)e->original_target, e->param);
 
-    /*Call the input device's feedback callback if set*/
     lv_indev_t * indev_act = lv_indev_active();
     if(indev_act) {
         if(e->stop_processing) return LV_RESULT_OK;


### PR DESCRIPTION
As correctly pointed out in Issue #8514, the Feedback section of `indev.rst` no longer applies because the `feedback_cb` field no longer exists in `lv_indev_t` since v9.0.0.

Further, I found a comment in `lv_obj_event.c` related to this same topic that no longer applies to the code it "labels".

Original code (v8.4):

```c
    /*Call the input device's feedback callback if set*/
    if(indev_act) {
        if(indev_act->driver->feedback_cb) indev_act->driver->feedback_cb(indev_act->driver, e->code);
        if(e->stop_processing) return LV_RES_OK;
        if(e->deleted) return LV_RES_INV;
    }
```

v9.0.0 code:

```c
    /*Call the input device's feedback callback if set*/
    if(indev_act) {
        if(e->stop_processing) return LV_RES_OK;
        if(e->deleted) return LV_RES_INV;
    }
```

As you can see, the code was removed, but the comment remained, probably because it was placed over the whole IF block instead of over the line that it referred to.

I removed the comment.

Fixes: #8514

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
