### PR TITLE
fix(draw_vector): ensure vector_graphic can be used if it's enabled

### DIFF
--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -12,6 +12,10 @@
 
 #if LV_USE_VECTOR_GRAPHIC
 
+#if !((LV_USE_DRAW_SW && LV_USE_THORVG) || LV_USE_DRAW_VG_LITE)
+    #error "LV_USE_VECTOR_GRAPHIC requires either (LV_USE_DRAW_SW and LV_USE_THORVG) or LV_USE_DRAW_VG_LITE"
+#endif
+
 #include "../misc/lv_ll.h"
 #include "../misc/lv_types.h"
 #include "../stdlib/lv_string.h"


### PR DESCRIPTION
Related to #8426

It's not a fix but at least makes it impossible to compile LVGL with `LV_USE_VECTOR_GRAPHIC` set to `1` unless we have a capable draw unit for it