### PR TITLE
feat(NemaGFX): encoded images

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
@@ -41,9 +41,9 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
-
-static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords);
+static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                               const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                               const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
 static uint32_t lv_nemagfx_mask_cf_to_nema(lv_color_format_t cf);
 
@@ -51,80 +51,29 @@ static uint32_t lv_nemagfx_mask_cf_to_nema(lv_color_format_t cf);
  *  STATIC FUNCTIONS
  **********************/
 
-static void _draw_nema_gfx_tile(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
-{
-
-    lv_image_decoder_dsc_t decoder_dsc;
-    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, NULL);
-    if(res != LV_RESULT_OK) {
-        LV_LOG_ERROR("Failed to open image");
-        return;
-    }
-
-    int32_t img_w = dsc->header.w;
-    int32_t img_h = dsc->header.h;
-
-    lv_area_t tile_area;
-    if(lv_area_get_width(&dsc->image_area) >= 0) {
-        tile_area = dsc->image_area;
-    }
-    else {
-        tile_area = *coords;
-    }
-    lv_area_set_width(&tile_area, img_w);
-    lv_area_set_height(&tile_area, img_h);
-
-    int32_t tile_x_start = tile_area.x1;
-
-    while(tile_area.y1 <= t->clip_area.y2) {
-        while(tile_area.x1 <= t->clip_area.x2) {
-
-            lv_area_t clipped_img_area;
-            if(lv_area_intersect(&clipped_img_area, &tile_area, &t->clip_area)) {
-                _draw_nema_gfx_img(t, dsc, &tile_area);
-            }
-
-            tile_area.x1 += img_w;
-            tile_area.x2 += img_w;
-        }
-
-        tile_area.y1 += img_h;
-        tile_area.y2 += img_h;
-        tile_area.x1 = tile_x_start;
-        tile_area.x2 = tile_x_start + img_w - 1;
-    }
-
-    lv_image_decoder_close(&decoder_dsc);
-}
-
-static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
+static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                               const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                               const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
     if(dsc->opa <= LV_OPA_MIN) return;
 
     lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = (lv_draw_nema_gfx_unit_t *)t->draw_unit;
 
     lv_layer_t * layer = t->target_layer;
-    const lv_image_dsc_t * img_dsc = dsc->src;
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    const lv_image_header_t * header = &decoded->header;
 
     bool masked = dsc->bitmap_mask_src != NULL;
 
-    lv_area_t blend_area;
-    /*Let's get the blend area which is the intersection of the area to fill and the clip area.*/
-    if(!lv_area_intersect(&blend_area, coords, &t->clip_area))
-        return; /*Fully clipped, nothing to do*/
-
     lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, &t->clip_area);
+    lv_area_copy(&rel_clip_area, clipped_img_area);
     lv_area_move(&rel_clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
     bool has_transform = (dsc->rotation != 0 || dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE);
     bool recolor = (dsc->recolor_opa > LV_OPA_MIN);
 
-    /*Make the blend area relative to the buffer*/
-    lv_area_move(&blend_area, -layer->buf_area.x1, -layer->buf_area.y1);
-
-    uint32_t tex_w = lv_area_get_width(coords);
-    uint32_t tex_h = lv_area_get_height(coords);
+    uint32_t tex_w = header->w;
+    uint32_t tex_h = header->h;
 
     nema_set_clip(rel_clip_area.x1, rel_clip_area.y1, lv_area_get_width(&rel_clip_area),
                   lv_area_get_height(&rel_clip_area));
@@ -132,11 +81,11 @@ static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * d
     lv_color_format_t dst_cf = layer->draw_buf->header.cf;
     uint32_t dst_nema_cf = lv_nemagfx_cf_to_nema(dst_cf);
 
-    const void * src_buf = img_dsc->data;
+    const void * src_buf = decoded->data;
 
     uint32_t blending_mode = lv_nemagfx_blending_mode(dsc->blend_mode);
 
-    lv_color_format_t src_cf = img_dsc->header.cf;
+    lv_color_format_t src_cf = header->cf;
 
     /*Image contains Alpha*/
     if(src_cf == LV_COLOR_FORMAT_ARGB8888 || src_cf == LV_COLOR_FORMAT_XRGB8888) {
@@ -146,7 +95,7 @@ static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * d
     uint32_t src_nema_cf = lv_nemagfx_cf_to_nema(src_cf);
     /* the stride should be computed internally for NEMA_TSC images and images missing a stride value */
     int32_t src_stride = (src_cf >= LV_COLOR_FORMAT_NEMA_TSC_START && src_cf <= LV_COLOR_FORMAT_NEMA_TSC_END)
-                         || img_dsc->header.stride == 0 ? -1 : (int32_t)img_dsc->header.stride;
+                         || header->stride == 0 ? -1 : (int32_t)header->stride;
 
     int32_t stride = (dst_cf >= LV_COLOR_FORMAT_NEMA_TSC_START && dst_cf <= LV_COLOR_FORMAT_NEMA_TSC_END) ?
                      -1 : lv_area_get_width(&(layer->buf_area)) * lv_color_format_get_size(dst_cf);
@@ -189,13 +138,13 @@ static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * d
 
             const lv_area_t * image_area;
             lv_area_t mask_area;
-            if(lv_area_get_width(&dsc->image_area) < 0) image_area = coords;
+            if(lv_area_get_width(&dsc->image_area) < 0) image_area = img_coords;
             else image_area = &dsc->image_area;
 
             lv_area_set(&mask_area, 0, 0, dsc->bitmap_mask_src->header.w - 1, dsc->bitmap_mask_src->header.h - 1);
             lv_area_align(image_area, &mask_area, LV_ALIGN_CENTER, 0, 0);
 
-            mask_buf += dsc->bitmap_mask_src->header.w * (coords->y1 - mask_area.y1) + (coords->x1 - mask_area.x1);
+            mask_buf += dsc->bitmap_mask_src->header.w * (img_coords->y1 - mask_area.y1) + (img_coords->x1 - mask_area.x1);
 
             nema_bind_tex(NEMA_TEX3, (uintptr_t)NEMA_VIRT2PHYS(mask_buf), mask->header.w, mask->header.h,
                           lv_nemagfx_mask_cf_to_nema(mask->header.cf),
@@ -206,13 +155,13 @@ static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * d
     nema_set_blend_blit(blending_mode);
 
     if(!has_transform) {
-        nema_blit_rect((coords->x1 - layer->buf_area.x1),
-                       (coords->y1 - layer->buf_area.y1), tex_w, tex_h);
+        nema_blit_rect((img_coords->x1 - layer->buf_area.x1),
+                       (img_coords->y1 - layer->buf_area.y1), tex_w, tex_h);
     }
     else {
         /*Calculate the transformed points*/
-        float x0 = (coords->x1 - layer->buf_area.x1);
-        float y0 = (coords->y1 - layer->buf_area.y1);
+        float x0 = (img_coords->x1 - layer->buf_area.x1);
+        float y0 = (img_coords->y1 - layer->buf_area.y1);
         float x1 = x0 + tex_w  ;
         float y1 = y0;
         float x2 = x0 + tex_w  ;
@@ -273,10 +222,10 @@ void lv_draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, c
 {
 
     if(!dsc->tile) {
-        _draw_nema_gfx_img(t, dsc, coords);
+        lv_draw_image_normal_helper(t, dsc, coords, _draw_nema_gfx_img);
     }
     else {
-        _draw_nema_gfx_tile(t, dsc, coords);
+        lv_draw_image_tiled_helper(t, dsc, coords, _draw_nema_gfx_img);
     }
 
 }


### PR DESCRIPTION
Fixes #8460

Part 2 of 2.

Use `lv_draw_image_normal_helper` and `lv_draw_image_tiled_helper` in the NemaGFX driver so that RLE and LZ4 encoded images can be automatically decoded and drawn.

cc @apedersen00

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
