### PR TITLE
fix(nuttx): fix log level in NuttX driver to use LV_LOG_INFO for inte…

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -311,7 +311,7 @@ static void check_stack_size(void)
 {
     pthread_t tid = pthread_self();
     ssize_t stack_size = pthread_get_stacksize_np(tid);
-    LV_LOG_USER("tid: %d, Stack size : %zd", (int)tid, stack_size);
+    LV_LOG_INFO("tid: %d, Stack size : %zd", (int)tid, stack_size);
 
     if(stack_size < LV_NUTTX_MIN_STACK_SIZE) {
         LV_LOG_ERROR("Stack size is too small. Please increase it to %d bytes or more.",

--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -109,7 +109,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         LV_LOG_ERROR("Error: cannot open framebuffer device");
         return -errno;
     }
-    LV_LOG_USER("The framebuffer device was opened successfully");
+    LV_LOG_INFO("The framebuffer device was opened successfully");
 
     if(ioctl(dsc->fd, FBIOGET_VIDEOINFO, (unsigned long)((uintptr_t)&dsc->vinfo)) < 0) {
         LV_LOG_ERROR("ioctl(FBIOGET_VIDEOINFO) failed: %d", errno);
@@ -117,11 +117,11 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
         goto errout;
     }
 
-    LV_LOG_USER("VideoInfo:");
-    LV_LOG_USER("      fmt: %u", dsc->vinfo.fmt);
-    LV_LOG_USER("     xres: %u", dsc->vinfo.xres);
-    LV_LOG_USER("     yres: %u", dsc->vinfo.yres);
-    LV_LOG_USER("  nplanes: %u", dsc->vinfo.nplanes);
+    LV_LOG_INFO("VideoInfo:");
+    LV_LOG_INFO("      fmt: %u", dsc->vinfo.fmt);
+    LV_LOG_INFO("     xres: %u", dsc->vinfo.xres);
+    LV_LOG_INFO("     yres: %u", dsc->vinfo.yres);
+    LV_LOG_INFO("  nplanes: %u", dsc->vinfo.nplanes);
 
     if((ret = fbdev_get_pinfo(dsc->fd, &dsc->pinfo)) < 0) {
         goto errout;
@@ -175,7 +175,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
             goto errout;
         }
 
-        LV_LOG_USER("Use off-screen mode, memory: %p, size: %" LV_PRIu32, dsc->mem_off_screen, data_size);
+        LV_LOG_INFO("Use off-screen mode, memory: %p, size: %" LV_PRIu32, dsc->mem_off_screen, data_size);
         lv_draw_buf_init(&dsc->buf2, w, h, color_format, stride, dsc->mem_off_screen, data_size);
         lv_display_set_draw_buffers(disp, &dsc->buf2, NULL);
     }
@@ -189,7 +189,7 @@ int lv_nuttx_fbdev_set_file(lv_display_t * disp, const char * file)
     lv_display_set_matrix_rotation(disp, true);
 #endif
 
-    LV_LOG_USER("Resolution is set to %dx%d at %" LV_PRId32 "dpi",
+    LV_LOG_INFO("Resolution is set to %dx%d at %" LV_PRId32 "dpi",
                 dsc->vinfo.xres, dsc->vinfo.yres, lv_display_get_dpi(disp));
     return 0;
 
@@ -341,12 +341,12 @@ static int fbdev_get_pinfo(int fd, FAR struct fb_planeinfo_s * pinfo)
         return -errno;
     }
 
-    LV_LOG_USER("PlaneInfo (plane %d):", pinfo->display);
-    LV_LOG_USER("    mem: %p", pinfo->fbmem);
-    LV_LOG_USER("    fblen: %zu", pinfo->fblen);
-    LV_LOG_USER("   stride: %u", pinfo->stride);
-    LV_LOG_USER("  display: %u", pinfo->display);
-    LV_LOG_USER("      bpp: %u", pinfo->bpp);
+    LV_LOG_INFO("PlaneInfo (plane %d):", pinfo->display);
+    LV_LOG_INFO("    mem: %p", pinfo->fbmem);
+    LV_LOG_INFO("    fblen: %zu", pinfo->fblen);
+    LV_LOG_INFO("   stride: %u", pinfo->stride);
+    LV_LOG_INFO("  display: %u", pinfo->display);
+    LV_LOG_INFO("      bpp: %u", pinfo->bpp);
 
     return 0;
 }
@@ -410,7 +410,7 @@ static int fbdev_init_mem2(lv_nuttx_fb_t * dsc)
     }
     dsc->mem2 = mem2;
 
-    LV_LOG_USER("Use of %sconsecutive mem2 = %p, yoffset = %" LV_PRIu32, is_consecutive ? "" : "non-", dsc->mem2,
+    LV_LOG_INFO("Use of %sconsecutive mem2 = %p, yoffset = %" LV_PRIu32, is_consecutive ? "" : "non-", dsc->mem2,
                 dsc->mem2_yoffset);
 
     return 0;
@@ -457,13 +457,13 @@ static int fbdev_init_mem3(lv_nuttx_fb_t * dsc)
     if(buf_offset == 0) {
         dsc->mem3_yoffset = dsc->vinfo.yres * 2;
         dsc->mem3 = pinfo.fbmem + dsc->mem3_yoffset * pinfo.stride;
-        LV_LOG_USER("Use consecutive mem3 = %p, yoffset = %" LV_PRIu32,
+        LV_LOG_INFO("Use consecutive mem3 = %p, yoffset = %" LV_PRIu32,
                     dsc->mem3, dsc->mem3_yoffset);
     }
     else {
         dsc->mem3_yoffset = buf_offset / dsc->pinfo.stride;
         dsc->mem3 = pinfo.fbmem;
-        LV_LOG_USER("Use non-consecutive mem3 = %p, yoffset = %" LV_PRIu32,
+        LV_LOG_INFO("Use non-consecutive mem3 = %p, yoffset = %" LV_PRIu32,
                     dsc->mem3, dsc->mem3_yoffset);
     }
 
@@ -491,7 +491,7 @@ static void display_release_cb(lv_event_t * e)
 
         lv_free(dsc);
     }
-    LV_LOG_USER("Done");
+    LV_LOG_INFO("Done");
 }
 
 #endif /*LV_USE_NUTTX*/

--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -156,16 +156,16 @@ static bool defer_init(void)
     struct mallinfo info  = mm_mallinfo(ctx->heap);
     ctx->heap_size = info.arena;
 
-    LV_LOG_USER("heap info:");
-    LV_LOG_USER("  heap: %p", ctx->heap);
-    LV_LOG_USER("  mem: %p", ctx->mem);
-    LV_LOG_USER("  mem_size: %" LV_PRIu32, ctx->mem_size);
-    LV_LOG_USER("  arena: %d", info.arena);
-    LV_LOG_USER("  ordblks: %d", info.ordblks);
-    LV_LOG_USER("  aordblks: %d", info.aordblks);
-    LV_LOG_USER("  mxordblk: %d", info.mxordblk);
-    LV_LOG_USER("  uordblks: %d", info.uordblks);
-    LV_LOG_USER("  fordblks: %d", info.fordblks);
+    LV_LOG_INFO("heap info:");
+    LV_LOG_INFO("  heap: %p", ctx->heap);
+    LV_LOG_INFO("  mem: %p", ctx->mem);
+    LV_LOG_INFO("  mem_size: %" LV_PRIu32, ctx->mem_size);
+    LV_LOG_INFO("  arena: %d", info.arena);
+    LV_LOG_INFO("  ordblks: %d", info.ordblks);
+    LV_LOG_INFO("  aordblks: %d", info.aordblks);
+    LV_LOG_INFO("  mxordblk: %d", info.mxordblk);
+    LV_LOG_INFO("  uordblks: %d", info.uordblks);
+    LV_LOG_INFO("  fordblks: %d", info.fordblks);
 
     ctx->initialized = true;
     return true;

--- a/src/drivers/nuttx/lv_nuttx_lcd.c
+++ b/src/drivers/nuttx/lv_nuttx_lcd.c
@@ -74,14 +74,14 @@ lv_display_t * lv_nuttx_lcd_create(const char * dev_path)
 
     LV_ASSERT_NULL(dev_path);
 
-    LV_LOG_USER("lcd %s opening", dev_path);
+    LV_LOG_INFO("lcd %s opening", dev_path);
     fd = open(dev_path, 0);
     if(fd < 0) {
         perror("Error: cannot open lcd device");
         return NULL;
     }
 
-    LV_LOG_USER("lcd %s open success", dev_path);
+    LV_LOG_INFO("lcd %s open success", dev_path);
 
     ret = ioctl(fd, LCDDEVIO_GETVIDEOINFO,
                 (unsigned long)((uintptr_t)&vinfo));
@@ -232,7 +232,7 @@ static void display_release_cb(lv_event_t * e)
             dsc->fd = -1;
         }
         lv_free(dsc);
-        LV_LOG_USER("Done");
+        LV_LOG_INFO("Done");
     }
 }
 #endif /*LV_USE_NUTTX_LCD*/

--- a/src/drivers/nuttx/lv_nuttx_libuv.c
+++ b/src/drivers/nuttx/lv_nuttx_libuv.c
@@ -115,7 +115,7 @@ void lv_nuttx_uv_deinit(void ** data)
     lv_nuttx_uv_fb_deinit(uv_ctx);
     lv_nuttx_uv_timer_deinit(uv_ctx);
     *data = NULL;
-    LV_LOG_USER("Done");
+    LV_LOG_INFO("Done");
 }
 
 /**********************
@@ -170,7 +170,7 @@ static void lv_nuttx_uv_deinit_cb(uv_handle_t * handle)
 {
     lv_nuttx_uv_ctx_t * uv_ctx = handle->data;
     if(--uv_ctx->ref_count <= 0) {
-        LV_LOG_USER("Done");
+        LV_LOG_INFO("Done");
         lv_free(uv_ctx);
     }
 }
@@ -179,7 +179,7 @@ static void lv_nuttx_uv_timer_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
 {
     lv_timer_handler_set_resume_cb(NULL, NULL);
     uv_close((uv_handle_t *)&uv_ctx->uv_timer, lv_nuttx_uv_deinit_cb);
-    LV_LOG_USER("Done");
+    LV_LOG_INFO("Done");
 }
 
 static void lv_nuttx_uv_vsync_poll_cb(uv_poll_t * handle, int status, int events)
@@ -252,7 +252,7 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_c
     fb_ctx->fd = *(int *)lv_display_get_driver_data(disp);
 
     if(fb_ctx->fd <= 0) {
-        LV_LOG_USER("skip uv fb init.");
+        LV_LOG_INFO("skip uv fb init.");
         return 0;
     }
 
@@ -274,7 +274,7 @@ static int lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_c
     uv_ctx->ref_count++;
     lv_display_add_event_cb(disp, lv_nuttx_uv_disp_vsync_request_cb, LV_EVENT_VSYNC_REQUEST, fb_ctx);
 
-    LV_LOG_USER("lvgl fb loop start OK");
+    LV_LOG_INFO("lvgl fb loop start OK");
 
     /* Register for the invalidate area event */
     lv_display_add_event_cb(disp, lv_nuttx_uv_disp_refr_req_cb, LV_EVENT_REFR_REQUEST, fb_ctx);
@@ -290,7 +290,7 @@ static void lv_nuttx_uv_fb_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
         uv_close((uv_handle_t *)&fb_ctx->fb_poll, lv_nuttx_uv_deinit_cb);
         uv_close((uv_handle_t *)&fb_ctx->vsync_poll, lv_nuttx_uv_deinit_cb);
     }
-    LV_LOG_USER("Done");
+    LV_LOG_INFO("Done");
 }
 
 static void lv_nuttx_uv_input_poll_cb(uv_poll_t * handle, int status, int events)
@@ -313,7 +313,7 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * u
     lv_indev_t * indev = uv_info->indev;
 
     if(indev == NULL) {
-        LV_LOG_USER("skip uv input init.");
+        LV_LOG_INFO("skip uv input init.");
         return 0;
     }
 
@@ -340,7 +340,7 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * u
     uv_ctx->ref_count++;
     uv_poll_start(&input_ctx->input_poll, UV_READABLE, lv_nuttx_uv_input_poll_cb);
 
-    LV_LOG_USER("lvgl input loop start OK");
+    LV_LOG_INFO("lvgl input loop start OK");
 
     return 0;
 }
@@ -351,7 +351,7 @@ static void lv_nuttx_uv_input_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
     if(input_ctx->fd > 0) {
         uv_close((uv_handle_t *)&input_ctx->input_poll, lv_nuttx_uv_deinit_cb);
     }
-    LV_LOG_USER("Done");
+    LV_LOG_INFO("Done");
 }
 
 #endif /*LV_USE_NUTTX_LIBUV*/

--- a/src/drivers/nuttx/lv_nuttx_mouse.c
+++ b/src/drivers/nuttx/lv_nuttx_mouse.c
@@ -61,14 +61,14 @@ lv_indev_t * lv_nuttx_mouse_create(const char * dev_path)
     int fd;
 
     LV_ASSERT_NULL(dev_path);
-    LV_LOG_USER("mouse %s opening", dev_path);
+    LV_LOG_INFO("mouse %s opening", dev_path);
     fd = open(dev_path, O_RDONLY | O_NONBLOCK);
     if(fd < 0) {
         LV_LOG_ERROR("Error: cannot open mouse device");
         return NULL;
     }
 
-    LV_LOG_USER("mouse %s open success", dev_path);
+    LV_LOG_INFO("mouse %s open success", dev_path);
 
     indev = mouse_init(fd);
 
@@ -145,7 +145,7 @@ static void mouse_delete_cb(lv_event_t * e)
             mouse->fd = -1;
         }
         lv_free(mouse);
-        LV_LOG_USER("done");
+        LV_LOG_INFO("done");
     }
 }
 

--- a/src/drivers/nuttx/lv_nuttx_profiler.c
+++ b/src/drivers/nuttx/lv_nuttx_profiler.c
@@ -53,7 +53,7 @@ void lv_nuttx_profiler_init(void)
         LV_LOG_ERROR("Failed to get CPU frequency");
         return;
     }
-    LV_LOG_USER("CPU frequency: %" LV_PRIu32 " MHz", cpu_freq);
+    LV_LOG_INFO("CPU frequency: %" LV_PRIu32 " MHz", cpu_freq);
 
     lv_profiler_builtin_config_t config;
     lv_profiler_builtin_config_init(&config);

--- a/src/drivers/nuttx/lv_nuttx_touchscreen.c
+++ b/src/drivers/nuttx/lv_nuttx_touchscreen.c
@@ -66,14 +66,14 @@ lv_indev_t * lv_nuttx_touchscreen_create(const char * dev_path)
     int fd;
 
     LV_ASSERT_NULL(dev_path);
-    LV_LOG_USER("touchscreen %s opening", dev_path);
+    LV_LOG_INFO("touchscreen %s opening", dev_path);
     fd = open(dev_path, O_RDONLY | O_NONBLOCK);
     if(fd < 0) {
         perror("Error: cannot open touchscreen device");
         return NULL;
     }
 
-    LV_LOG_USER("touchscreen %s open success", dev_path);
+    LV_LOG_INFO("touchscreen %s open success", dev_path);
 
     indev = touchscreen_init(fd);
 
@@ -198,7 +198,7 @@ static void touchscreen_delete_cb(lv_event_t * e)
             touchscreen->fd = -1;
         }
         lv_free(touchscreen);
-        LV_LOG_USER("done");
+        LV_LOG_INFO("done");
     }
 }
 


### PR DESCRIPTION
…rnal messages

Fixes LV_LOG_INFO is more appropriate for driver-level code as it belongs to the framework's internal logging system, while LV_LOG_USER should be reserved for application-level custom messages.
 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
