### PR TITLE
fix(textarea): label scroll to the cursor pos when textarea size change

### DIFF
--- a/tests/src/test_cases/widgets/test_textarea.c
+++ b/tests/src/test_cases/widgets/test_textarea.c
@@ -66,6 +66,23 @@ void test_textarea_cursor_click_pos_field_update(void)
     TEST_ASSERT_FALSE(lv_textarea_get_cursor_click_pos(textarea));
 }
 
+void test_textarea_should_scroll_to_the_end(void)
+{
+    lv_textarea_set_one_line(textarea, true);
+    lv_textarea_add_text(textarea, "Hi this is a long text to test if the textarea scrolls to the end");
+    lv_obj_set_width(textarea, LV_DPI_DEF * 3);
+
+    int32_t cur_pos = (int32_t)lv_textarea_get_cursor_pos(textarea);
+    const lv_font_t * font = lv_obj_get_style_text_font(textarea, LV_PART_MAIN);
+    int32_t font_h = lv_font_get_line_height(font);
+    int32_t w = lv_obj_get_content_width(textarea);
+    if(cur_pos + font_h - lv_obj_get_scroll_left(textarea) > w) {
+        TEST_ASSERT_EQUAL_INT32(lv_obj_get_scroll_x(textarea) + 10, cur_pos - w + font_h);
+    }
+
+    TEST_ASSERT(lv_textarea_get_one_line(textarea));
+}
+
 void test_textarea_should_update_placeholder_text(void)
 {
     const char * new_placeholder = "LVGL Rocks!!!!!";


### PR DESCRIPTION
Fix incorrect text scroll position when input component size changes.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
