### PR TITLE
WIP: draw: espressif: ppa: use PPA driver in non-blocking mode

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa_fill.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_fill.c
@@ -35,12 +35,8 @@ void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
             .fill_cm        = lv_color_format_to_ppa_fill(draw_buf->header.cf),
         },
 
-#if LV_PPA_NONBLOCKING_OPS
         .mode            = PPA_TRANS_MODE_NON_BLOCKING,
         .user_data       = u,
-#else
-        .mode            = PPA_TRANS_MODE_BLOCKING,
-#endif
     };
 
     esp_err_t ret = ppa_do_fill(u->fill_client, &cfg);

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -62,12 +62,8 @@ void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
         .fg_alpha_fix_val = dsc->opa,
         .bg_ck_en              = false,
         .fg_ck_en              = false,
-#if LV_PPA_NONBLOCKING_OPS
         .mode            = PPA_TRANS_MODE_NON_BLOCKING,
         .user_data       = u,
-#else
-        .mode            = PPA_TRANS_MODE_BLOCKING,
-#endif
     };
 
     esp_err_t ret = ppa_do_blend(u->blend_client, &cfg);

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -95,7 +95,7 @@ static inline bool ppa_src_cf_supported(lv_color_format_t cf)
     switch(cf) {
         case LV_COLOR_FORMAT_RGB565:
         case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
+        case LV_COLOR_FORMAT_ARGB8888:
             is_cf_supported = true;
             break;
         default:
@@ -113,7 +113,6 @@ static inline bool ppa_dest_cf_supported(lv_color_format_t cf)
         case LV_COLOR_FORMAT_RGB565:
         case LV_COLOR_FORMAT_RGB888:
         case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
             is_cf_supported = true;
             break;
         default:


### PR DESCRIPTION
and return immediately if the draw unit is busy

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
