### PR TITLE
chore(lv_tree): Code reorganization for lv_tree.h

### DIFF
--- a/src/misc/lv_tree.h
+++ b/src/misc/lv_tree.h
@@ -25,27 +25,31 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
-struct _lv_tree_node_t;
+typedef struct _lv_tree_class_t lv_tree_class_t;
+typedef struct _lv_tree_node_t lv_tree_node_t;
+
+typedef void (*lv_tree_constructor_cb_t)(const lv_tree_class_t * class_p, lv_tree_node_t * node);
+typedef void (*lv_tree_destructor_cb_t)(const lv_tree_class_t * class_p, lv_tree_node_t * node);
 
 /**
  * Describe the common methods of every object.
  * Similar to a C++ class.
  */
-typedef struct _lv_tree_class_t {
-    const struct _lv_tree_class_t * base_class;
+struct _lv_tree_class_t {
+    const lv_tree_class_t * base_class;
     uint32_t instance_size;
-    void (*constructor_cb)(const struct _lv_tree_class_t * class_p, struct _lv_tree_node_t * node);
-    void (*destructor_cb)(const struct _lv_tree_class_t * class_p, struct _lv_tree_node_t * node);
-} lv_tree_class_t;
+    lv_tree_constructor_cb_t constructor_cb;
+    lv_tree_destructor_cb_t destructor_cb;
+};
 
 /** Description of a tree node*/
-typedef struct _lv_tree_node_t {
-    struct _lv_tree_node_t * parent;
-    struct _lv_tree_node_t ** children;
+struct _lv_tree_node_t {
+    lv_tree_node_t * parent;
+    lv_tree_node_t ** children;
     uint32_t child_cnt;
     uint32_t child_cap;
-    const struct _lv_tree_class_t * class_p;
-} lv_tree_node_t;
+    const lv_tree_class_t * class_p;
+};
 
 enum _lv_tree_walk_mode_t {
     LV_TREE_WALK_PRE_ORDER = 0,


### PR DESCRIPTION
***DO NOT MERGE THIS UNTIL AFTER OTHER CHANGES ARE POSSIBLY MADE**

This is done as per a private conversation with @kisvegabor.

I am not sure what standards have been put in place for documentation. Perhaps @vwheeler63 could chime in on this aspect of it and I can make the changes that are necessary to keep the documentation done right.

As a side question just to plant a suggestion... I see that there is no standard for the headings for callback functions and where they should be placed in a header file. I propose adding the following heading standard.

```c
/**********************
 * CALLBACK PROTOTYPES
 **********************/
```

and that heading standard should be placed after the typedef and structures are placed after that. If a structure that is passed as a parameter to the callback function and the declaration of that structure is done below where the prototype id declared then the structure MUST have a forward declaration made in the typedef section above the callback prototype. Basically how it is being done with the changes I have made here. This improves the code readability while also improving maintainability in other areas of LVGL (ie: JSON generator & building the documentation) declaring structures as a function parameter or declaring a callback function prototype as a field in a structure or as a parameter for a function exponentially increases the complexity of the code that is needed to read the header file programmatically. This added complexity becomes a possible spot for errors/problems.

I do not believe that having the forward declarations causes any change in compiled binary size. The compiler does what it does regardless of how the code it typed out. From a maintainability standpoint and a readability standpoint I feel this is a better way to go about it.

This is the code that should not be allowed in a structure/union or as a function parameter in any public facing piece of API.

```c
    const struct _lv_tree_class_t * base_class;
```

There should be a forward declaration for `_lv_tree_class_t` that types it to `lv_tree_class_t`

This is a suggestion that I feel if followed would reduce the number of potential issues that could arise in other areas of LVGL's code. It also looks cleaner when viewing the code in the header files and it will make it easier to document things as well.

