### PR TITLE
fix(image): fix unused var warning when LV_LOG_WARN isn't available

### DIFF
--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -187,11 +187,12 @@ void lv_image_set_src(lv_obj_t * obj, const void * src)
     lv_image_header_t header;
     lv_result_t res = lv_image_decoder_get_info(src, &header);
     if(res != LV_RESULT_OK) {
-#if LV_USE_LOG
-        char buf[24];
-        LV_LOG_WARN("failed to get image info: %s",
-                    src_type == LV_IMAGE_SRC_FILE ? (const char *)src : (lv_snprintf(buf, sizeof(buf), "%p", src), buf));
-#endif /*LV_USE_LOG*/
+        if(src_type == LV_IMAGE_SRC_FILE) {
+            LV_LOG_WARN("failed to get image info: %s", (const char *)src);
+        }
+        else {
+            LV_LOG_WARN("failed to get image info: %p", src);
+        }
         return;
     }
 


### PR DESCRIPTION
Caught here: https://github.com/lvgl/lvgl/actions/runs/16397979851/job/46333339072 (just search for `warning`)

```bash
/media/pi/pi_external/lv_ej_workspace/esp32s3/components/lvgl/src/widgets/image/lv_image.c: In function 'lv_image_set_src':
/media/pi/pi_external/lv_ej_workspace/esp32s3/components/lvgl/src/widgets/image/lv_image.c:191:14: warning: unused variable 'buf' [-Wunused-variable]
  191 |         char buf[24];
      |              ^~~
```
