### PR TITLE
fix(mem): change variable attribute location

### DIFF
--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -79,7 +79,7 @@ void lv_mem_init(void)
     state.tlsf = lv_tlsf_create_with_pool((void *)LV_MEM_POOL_ALLOC(LV_MEM_SIZE), LV_MEM_SIZE);
 #else
     /*Allocate a large array to store the dynamically allocated data*/
-    static LV_ATTRIBUTE_LARGE_RAM_ARRAY MEM_UNIT work_mem_int[LV_MEM_SIZE / sizeof(MEM_UNIT)];
+    static MEM_UNIT work_mem_int[LV_MEM_SIZE / sizeof(MEM_UNIT)] LV_ATTRIBUTE_LARGE_RAM_ARRAY;
     state.tlsf = lv_tlsf_create_with_pool((void *)work_mem_int, LV_MEM_SIZE);
 #endif
 #else


### PR DESCRIPTION
Fixes #8494 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->
Modified variable attribute location for the builtin memory manager's memory pool to support IAR compiler. Referenced [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-section-variable-attribute) to confirm new location also works for GCC.
