### PR TITLE
fix(snapshot): correctly set driver.ver_res

### DIFF
--- a/src/extra/others/snapshot/lv_snapshot.c
+++ b/src/extra/others/snapshot/lv_snapshot.c
@@ -121,7 +121,7 @@ lv_res_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_img_cf_t cf, lv_img_dsc_t * 
     lv_disp_drv_init(&driver);
     /*In lack of a better idea use the resolution of the object's display*/
     driver.hor_res = lv_disp_get_hor_res(obj_disp);
-    driver.ver_res = lv_disp_get_hor_res(obj_disp);
+    driver.ver_res = lv_disp_get_ver_res(obj_disp);
     lv_disp_drv_use_generic_set_px_cb(&driver, cf);
 
     lv_disp_t fake_disp;


### PR DESCRIPTION
Fixes #8576

lv_snapshot.c - lv_disp_get_hor_res instead of lv_disp_get_ver_res 
