### PR TITLE
feat(font_manager): check resource leak before removing source

### DIFF
--- a/src/others/font_manager/lv_font_manager_recycle.c
+++ b/src/others/font_manager/lv_font_manager_recycle.c
@@ -145,6 +145,22 @@ void lv_font_manager_recycle_set_reuse(lv_font_manager_recycle_t * manager, lv_f
     LV_LOG_INFO("insert font: %s(%d) to reuse list", ft_info->name, ft_info->size);
 }
 
+void lv_font_recycle_remove_fonts(lv_font_manager_recycle_t * manager, const char * name)
+{
+    LV_ASSERT_NULL(manager);
+    LV_ASSERT_NULL(name);
+
+    lv_font_recycle_t * next;
+    lv_font_recycle_t * recycle = lv_ll_get_head(&manager->recycle_ll);
+    while(recycle != NULL) {
+        next = lv_ll_get_next(&manager->recycle_ll, recycle);
+        if(lv_strcmp(recycle->name, name) == 0) {
+            lv_font_recycle_close(manager, recycle);
+        }
+        recycle = next;
+    }
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/others/font_manager/lv_font_manager_recycle.h
+++ b/src/others/font_manager/lv_font_manager_recycle.h
@@ -65,6 +65,13 @@ lv_font_t * lv_font_manager_recycle_get_reuse(lv_font_manager_recycle_t * manage
 void lv_font_manager_recycle_set_reuse(lv_font_manager_recycle_t * manager, lv_font_t * font,
                                        const lv_font_info_t * ft_info);
 
+/**
+ * Remove fonts with name from recycle manager.
+ * @param manager pointer to font recycle manager.
+ * @param name font name.
+ */
+void lv_font_recycle_remove_fonts(lv_font_manager_recycle_t * manager, const char * name);
+
 /**********************
  *      MACROS
  **********************/

--- a/tests/src/test_cases/test_font_manager.c
+++ b/tests/src/test_cases/test_font_manager.c
@@ -198,12 +198,20 @@ static void test_font_manager_src(add_src_cb_t add_src_cb)
     bool delete_result = lv_font_manager_delete(g_font_manager);
     TEST_ASSERT_FALSE(delete_result);
 
+    /* Source should not be removed successfully, because it is used by the fonts */
+    delete_result = lv_font_manager_remove_src(g_font_manager, "Montserrat");
+    TEST_ASSERT_FALSE(delete_result);
+
     lv_obj_delete(label);
     lv_font_manager_delete_font(g_font_manager, font_14);
     lv_font_manager_delete_font(g_font_manager, font_32);
     lv_font_manager_delete_font(g_font_manager, font_40);
     lv_font_manager_delete_font(g_font_manager, font_file_20);
     lv_font_manager_delete_font(g_font_manager, font_buffer_20);
+
+    /* Source should be removed successfully, now that it's not used by any fonts */
+    delete_result = lv_font_manager_remove_src(g_font_manager, "Montserrat");
+    TEST_ASSERT_TRUE(delete_result);
 
     /* Trying to delete a font that was not created by the font manager, it needs to handle this situation */
     lv_font_manager_delete_font(g_font_manager, (lv_font_t *)LV_FONT_DEFAULT);


### PR DESCRIPTION
Currently a call to `lv_font_manager_remove_src` will remove the font source from font manager even if there are fonts that are using this source and this will crash the program on next redraw if there are still labels using a font with removed source.

This pull request:

- adds a check that there are no active fonts using the font source (similar to how it's done in `lv_font_manager_delete`)
- removes any font in recycle manager that uses the font source which will be removed