### PR TITLE
docs(<dl><dd>):  fix definition-list indentation

### DIFF
--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -1003,13 +1003,13 @@ dl.field-list {
   display: grid;
   grid-template-columns: auto minmax(70%, 95%);
   margin-bottom: 1.5rem; /* Up from 16 */
-  gap: 1.5rem;
 }
 
 dl.field-list > dt {
   font-weight: 600;
   word-break: break-word;
-  margin-bottom: 0;
+  margin-right: 1em;
+  margin-bottom: 0.15em;
   display: inline-grid;
   grid-template-columns: max-content auto;
 }

--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -553,7 +553,7 @@ code.literal {
   font-weight: 700;
 }
 
-#furo-main-content dd {
+#furo-main-content dl[class]:not(.option-list):not(.field-list):not(.glossary):not(.simple) dd {
   margin-left: 2rem;
 }
 

--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -554,7 +554,7 @@ code.literal {
 }
 
 #furo-main-content dd {
-  margin-inline-start: 0;
+  margin-left: 2rem;
 }
 
 #furo-main-content blockquote {


### PR DESCRIPTION
The `margin-inline-start: 0;` for all `<dd>` elements appears to have inadvertently "cancelled" the natural indentation required for visually separating the DEFINITION blocks from the TERM blocks, which is especially important when the definitions contain nested formatting (like sub-lists, code blocks, notes, admonitions, etc.).

This change "tones down" the default browser indenting for the DEFINITION part of definition lists from about 3rem to 2rem (i.e. more "conservative") in keeping with the current modifications to the Furo theme (more conservative formatting).

This fixes the indenting problem for:

- plain definition lists
- glossary
- option lists

---

Note:  the below are NOT from the LVGL user docs, but sample text from Editor Docs that demonstrate the problem and the solution.

# BEFORE

<img width="754" height="604" alt="image" src="https://github.com/user-attachments/assets/e6122280-9bb7-4ac0-b9b2-f2c6861ed5ff" />

# AFTER FIXING INDENTATION

<img width="747" height="609" alt="image" src="https://github.com/user-attachments/assets/c77a9eea-a37c-42a1-a318-c3cdf76e1316" />

# AFTER FIXING FIELD-LIST SPACING

<img width="733" height="440" alt="image" src="https://github.com/user-attachments/assets/20d8a4b3-b957-481d-a578-687d9ea4d78c" />


---

# BEFORE

<img width="739" height="527" alt="image" src="https://github.com/user-attachments/assets/ef5b028a-dfed-4120-9595-e1be2caced0b" />

# AFTER

<img width="751" height="531" alt="image" src="https://github.com/user-attachments/assets/df652818-b293-4135-b025-fac5b0caf90f" />


cc:  @kisvegabor @richardgazdik 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
