### PR TITLE
ci(hw): cancel workflow if there are no ej builders available

### DIFF
--- a/.github/workflows/build_hardware.yml
+++ b/.github/workflows/build_hardware.yml
@@ -33,8 +33,30 @@ jobs:
             COMMIT_REF="${{ github.sha }}"
           fi
 
+          set +e
           ejlv dispatch-build \
             --socket /ejd/ejd.sock \
             --commit-hash $COMMIT_REF \
             --remote-url $REPO_URL \
             --seconds 1800
+
+          EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            exit 0
+          fi
+          
+          echo "ejlv returned exit code " $EXIT_CODE ", cancelling workflow"
+          echo "SHOULD_CANCEL=true" >> $GITHUB_ENV
+          exit 0
+
+      - name: Cancel workflow if needed
+        if: env.SHOULD_CANCEL == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
