### PR TITLE
fix(demos/widgets): add missing aligned font resource declarations

### DIFF
--- a/demos/widgets/lv_demo_widgets_components.c
+++ b/demos/widgets/lv_demo_widgets_components.c
@@ -47,6 +47,15 @@ const lv_font_t * font_normal;
 
 void lv_demo_widgets_components_init(void)
 {
+#if LV_USE_DEMO_BENCHMARK && LV_DEMO_BENCHMARK_ALIGNED_FONTS
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_12_aligned)
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_14_aligned)
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_16_aligned)
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_18_aligned)
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_20_aligned)
+    LV_FONT_DECLARE(lv_font_benchmark_montserrat_24_aligned)
+#define USE_ALOGNED_FONTS
+#endif
 
     if(LV_HOR_RES <= 320) disp_size = DISP_SMALL;
     else if(LV_HOR_RES < 720) disp_size = DISP_MEDIUM;
@@ -56,14 +65,14 @@ void lv_demo_widgets_components_init(void)
     font_normal = LV_FONT_DEFAULT;
 
     if(disp_size == DISP_LARGE) {
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_24_aligned;
 #elif LV_FONT_MONTSERRAT_24
         font_large     = &lv_font_montserrat_24;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_24 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_16_aligned;
 #elif LV_FONT_MONTSERRAT_16
         font_normal    = &lv_font_montserrat_16;
@@ -72,14 +81,14 @@ void lv_demo_widgets_components_init(void)
 #endif
     }
     else if(disp_size == DISP_MEDIUM) {
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_20_aligned;
 #elif LV_FONT_MONTSERRAT_20
         font_large     = &lv_font_montserrat_20;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_20 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_14_aligned;
 #elif LV_FONT_MONTSERRAT_14
         font_normal    = &lv_font_montserrat_14;
@@ -88,14 +97,14 @@ void lv_demo_widgets_components_init(void)
 #endif
     }
     else {   /* disp_size == DISP_SMALL */
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_18_aligned;
 #elif LV_FONT_MONTSERRAT_18
         font_large     = &lv_font_montserrat_18;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_18 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#if LV_DEMO_BENCHMARK_ALIGNED_FONTS
+#ifdef USE_ALOGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_12_aligned;
 #elif LV_FONT_MONTSERRAT_12
         font_normal    = &lv_font_montserrat_12;

--- a/demos/widgets/lv_demo_widgets_components.c
+++ b/demos/widgets/lv_demo_widgets_components.c
@@ -54,7 +54,7 @@ void lv_demo_widgets_components_init(void)
     LV_FONT_DECLARE(lv_font_benchmark_montserrat_18_aligned)
     LV_FONT_DECLARE(lv_font_benchmark_montserrat_20_aligned)
     LV_FONT_DECLARE(lv_font_benchmark_montserrat_24_aligned)
-#define USE_ALOGNED_FONTS
+#define USE_ALIGNED_FONTS
 #endif
 
     if(LV_HOR_RES <= 320) disp_size = DISP_SMALL;
@@ -65,14 +65,14 @@ void lv_demo_widgets_components_init(void)
     font_normal = LV_FONT_DEFAULT;
 
     if(disp_size == DISP_LARGE) {
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_24_aligned;
 #elif LV_FONT_MONTSERRAT_24
         font_large     = &lv_font_montserrat_24;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_24 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_16_aligned;
 #elif LV_FONT_MONTSERRAT_16
         font_normal    = &lv_font_montserrat_16;
@@ -81,14 +81,14 @@ void lv_demo_widgets_components_init(void)
 #endif
     }
     else if(disp_size == DISP_MEDIUM) {
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_20_aligned;
 #elif LV_FONT_MONTSERRAT_20
         font_large     = &lv_font_montserrat_20;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_20 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_14_aligned;
 #elif LV_FONT_MONTSERRAT_14
         font_normal    = &lv_font_montserrat_14;
@@ -97,14 +97,14 @@ void lv_demo_widgets_components_init(void)
 #endif
     }
     else {   /* disp_size == DISP_SMALL */
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_large     = &lv_font_benchmark_montserrat_18_aligned;
 #elif LV_FONT_MONTSERRAT_18
         font_large     = &lv_font_montserrat_18;
 #else
         LV_LOG_WARN("LV_FONT_MONTSERRAT_18 or LV_DEMO_BENCHMARK_ALIGNED_FONTS is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead.");
 #endif
-#ifdef USE_ALOGNED_FONTS
+#ifdef USE_ALIGNED_FONTS
         font_normal    = &lv_font_benchmark_montserrat_12_aligned;
 #elif LV_FONT_MONTSERRAT_12
         font_normal    = &lv_font_montserrat_12;


### PR DESCRIPTION
Fixed compilation error that occurred when `LV_USE_DEMO_WIDGETS` and `LV_USE_DEMO_BENCHMARK` and `LV_DEMO_BENCHMARK_ALIGNED_FONTS` were both enabled.

```bash
lvgl/demos/widgets/lv_demo_widgets_components.c: In function ‘lv_demo_widgets_components_init’:
lvgl/demos/widgets/lv_demo_widgets_components.c:60:27: error: ‘lv_font_benchmark_montserrat_24_aligned’ undeclared (first use in this function)
   60 |         font_large     = &lv_font_benchmark_montserrat_24_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/demos/widgets/lv_demo_widgets_components.c:60:27: note: each undeclared identifier is reported only once for each function it appears in
lvgl/demos/widgets/lv_demo_widgets_components.c:67:27: error: ‘lv_font_benchmark_montserrat_16_aligned’ undeclared (first use in this function)
   67 |         font_normal    = &lv_font_benchmark_montserrat_16_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/demos/widgets/lv_demo_widgets_components.c:76:27: error: ‘lv_font_benchmark_montserrat_20_aligned’ undeclared (first use in this function)
   76 |         font_large     = &lv_font_benchmark_montserrat_20_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/demos/widgets/lv_demo_widgets_components.c:83:27: error: ‘lv_font_benchmark_montserrat_14_aligned’ undeclared (first use in this function)
   83 |         font_normal    = &lv_font_benchmark_montserrat_14_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/demos/widgets/lv_demo_widgets_components.c:92:27: error: ‘lv_font_benchmark_montserrat_18_aligned’ undeclared (first use in this function)
   92 |         font_large     = &lv_font_benchmark_montserrat_18_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lvgl/demos/widgets/lv_demo_widgets_components.c:99:27: error: ‘lv_font_benchmark_montserrat_12_aligned’ undeclared (first use in this function)
   99 |         font_normal    = &lv_font_benchmark_montserrat_12_aligned;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [build_lvgl/CMakeFiles/lvgl_demos.dir/build.make:1196：build_lvgl/CMakeFiles/lvgl_demos.dir/demos/widgets/lv_demo_widgets_components.c.o] 错误 1
make[2]: *** 正在等待未完成的任务....
make[1]: *** [CMakeFiles/Makefile2:255：build_lvgl/CMakeFiles/lvgl_demos.dir/all] 错误 2
make: *** [Makefile:156：all] 错误 2
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
