### PR TITLE
docs(custom.css):  fix text color on view-on-github example buttons

### DIFF
--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -862,7 +862,7 @@ table.docutils th p {
 }
 
 /* Selects [View on GitHub] "button". */
-.lv-example-link-button {
+#furo-main-content .lv-example-link-button {
   display: inline-block;
   padding: 4px 8px;
   border-radius: 4px;


### PR DESCRIPTION
A recent increase in the specificity of styling rules for LINKs (`<a>` elements) caused this rule to be overridden, losing the color and the other styling it provided for the [View on GitHub] buttons that come with each example.  The result is that the text color is the LINK color (purple), whereas with this increase in specificity, it correctly overrides that color applying the styling styling originally intended for that button.

It should probably be investigated what else got unintentionally overridden by the `#furo-main-content` additions.

Fixes [View on GitHub] button text color:  purple => back to white again

cc:  @kisvegabor @liamHowatt 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
