### PR TITLE
fix(draw/sw_img): fix missing handling of LV_IMAGE_FLAGS_PREMULTIPLIED

### DIFF
--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -229,7 +229,11 @@ static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_d
     lv_color_format_t cf = decoded->header.cf;
 
     if(cf == LV_COLOR_FORMAT_ARGB8888 && lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_PREMULTIPLIED)) {
+#if LV_DRAW_SW_SUPPORT_ARGB8888_PREMULTIPLIED
         cf = LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED;
+#else
+        LV_LOG_WARN("LV_DRAW_SW_SUPPORT_ARGB8888_PREMULTIPLIED is not enabled. Falling back to ARGB8888");
+#endif
     }
 
     lv_draw_sw_blend_dsc_t blend_dsc;

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -228,6 +228,10 @@ static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_d
     uint32_t img_stride = decoded->header.stride;
     lv_color_format_t cf = decoded->header.cf;
 
+    if(cf == LV_COLOR_FORMAT_ARGB8888 && lv_draw_buf_has_flag(decoded, LV_IMAGE_FLAGS_PREMULTIPLIED)) {
+        cf = LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED;
+    }
+
     lv_draw_sw_blend_dsc_t blend_dsc;
     lv_memzero(&blend_dsc, sizeof(lv_draw_sw_blend_dsc_t));
     blend_dsc.opa = draw_dsc->opa;

--- a/tests/src/test_cases/widgets/test_lottie.c
+++ b/tests/src/test_cases/widgets/test_lottie.c
@@ -28,29 +28,11 @@ void tearDown(void)
 
 void test_lottie_simple(void)
 {
-    lv_draw_buf_t draw_buf;
-    lv_draw_buf_init(
-        &draw_buf, 100, 100,
-        LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED,
-        LV_STRIDE_AUTO,
-        buf, sizeof(buf));
-
     lv_obj_t * lottie = lv_lottie_create(lv_screen_active());
-    lv_lottie_set_draw_buf(lottie, &draw_buf);
+    lv_lottie_set_buffer(lottie, 100, 100, lv_draw_buf_align(buf, LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED));
     lv_lottie_set_src_data(lottie, test_lottie_approve, test_lottie_approve_size);
     lv_obj_center(lottie);
-    TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_1.png");
 
-    /**
-     * lv_lottie will add the LV_IMAGE_FLAGS_PREMULTIPLIED flag to the drawing buffer,
-     * which should have the same effect as LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED.
-     */
-    lv_draw_buf_init(
-        &draw_buf, 100, 100,
-        LV_COLOR_FORMAT_ARGB8888,
-        LV_STRIDE_AUTO,
-        buf, sizeof(buf));
-    lv_lottie_set_draw_buf(lottie, &draw_buf);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_1.png");
 
     /*Wait a little*/
@@ -187,6 +169,25 @@ void test_lottie_no_jump_when_visible_again(void)
     lv_test_fast_forward(750);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_3.png");
 
+}
+
+void test_lottie_set_draw_buf(void)
+{
+    /**
+     * lv_lottie will add the LV_IMAGE_FLAGS_PREMULTIPLIED flag to the drawing buffer,
+     * which should have the same effect as LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED.
+     */
+    lv_draw_buf_t draw_buf;
+    lv_draw_buf_init(
+        &draw_buf, 100, 100,
+        LV_COLOR_FORMAT_ARGB8888,
+        LV_STRIDE_AUTO,
+        lv_draw_buf_align(buf, LV_COLOR_FORMAT_ARGB8888), sizeof(buf));
+    lv_obj_t * lottie = lv_lottie_create(lv_screen_active());
+    lv_lottie_set_draw_buf(lottie, &draw_buf);
+    lv_lottie_set_src_data(lottie, test_lottie_approve, test_lottie_approve_size);
+    lv_obj_center(lottie);
+    TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_1.png");
 }
 
 #endif

--- a/tests/src/test_cases/widgets/test_lottie.c
+++ b/tests/src/test_cases/widgets/test_lottie.c
@@ -28,11 +28,29 @@ void tearDown(void)
 
 void test_lottie_simple(void)
 {
+    lv_draw_buf_t draw_buf;
+    lv_draw_buf_init(
+        &draw_buf, 100, 100,
+        LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED,
+        LV_STRIDE_AUTO,
+        buf, sizeof(buf));
+
     lv_obj_t * lottie = lv_lottie_create(lv_screen_active());
-    lv_lottie_set_buffer(lottie, 100, 100, lv_draw_buf_align(buf, LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED));
+    lv_lottie_set_draw_buf(lottie, &draw_buf);
     lv_lottie_set_src_data(lottie, test_lottie_approve, test_lottie_approve_size);
     lv_obj_center(lottie);
+    TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_1.png");
 
+    /**
+     * lv_lottie will add the LV_IMAGE_FLAGS_PREMULTIPLIED flag to the drawing buffer,
+     * which should have the same effect as LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED.
+     */
+    lv_draw_buf_init(
+        &draw_buf, 100, 100,
+        LV_COLOR_FORMAT_ARGB8888,
+        LV_STRIDE_AUTO,
+        buf, sizeof(buf));
+    lv_lottie_set_draw_buf(lottie, &draw_buf);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_1.png");
 
     /*Wait a little*/


### PR DESCRIPTION
`LV_COLOR_FORMAT_ARGB8888`+`LV_IMAGE_FLAGS_PREMULTIPLIED` should be equivalent to `LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED`.
For new formats with premultiplication in the future, `LV_IMAGE_FLAGS_PREMULTIPLIED` should be used to mark them instead of adding new formats to reduce the adaptation workload of other backends.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
