### PR TITLE
fix(SVG): fix SVG decoder memory leak. close decoder

### DIFF
--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -180,6 +180,8 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
             }
 
         }
+
+        lv_image_decoder_close(&decoder_dsc);
     }
 
     LV_PROFILER_DRAW_END;

--- a/tests/src/test_cases/libs/test_svg_decoder.c
+++ b/tests/src/test_cases/libs/test_svg_decoder.c
@@ -27,7 +27,7 @@ static void assert_screenshot(const char * path)
 #endif
 }
 
-void test_svg_decoder(void)
+void svg_decoder(void)
 {
     LV_IMAGE_DECLARE(test_image_svg);
     lv_obj_t * img = lv_image_create(lv_screen_active());
@@ -36,9 +36,20 @@ void test_svg_decoder(void)
     lv_image_set_src(img, &test_image_svg);
     lv_obj_align(img, LV_ALIGN_CENTER, 0, 0);
     assert_screenshot("svg_decoder_1");
+
+    lv_obj_clean(lv_screen_active());
+    lv_image_cache_drop(NULL);
 }
 
-void test_svg_decoder_file(void)
+void test_svg_decoder(void)
+{
+    svg_decoder();
+    size_t mem_before = lv_test_get_free_mem();
+    svg_decoder();
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+}
+
+static void svg_decoder_file(void)
 {
     lv_obj_t * img = lv_image_create(lv_screen_active());
     lv_obj_set_size(img, lv_pct(100), lv_pct(100));
@@ -47,9 +58,20 @@ void test_svg_decoder_file(void)
     lv_image_set_scale(img, 96);
     lv_obj_align(img, LV_ALIGN_CENTER, 0, 0);
     assert_screenshot("svg_decoder_2");
+
+    lv_obj_clean(lv_screen_active());
+    lv_image_cache_drop(NULL);
 }
 
-void test_svg_snapshot(void)
+void test_svg_decoder_file(void)
+{
+    svg_decoder_file();
+    size_t mem_before = lv_test_get_free_mem();
+    svg_decoder_file();
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+}
+
+void svg_snapshot(void)
 {
     LV_IMAGE_DECLARE(test_image_svg);
     lv_obj_t * img = lv_image_create(lv_screen_active());
@@ -65,6 +87,17 @@ void test_svg_snapshot(void)
     lv_obj_center(img2);
     assert_screenshot("svg_decoder_3");
     lv_draw_buf_destroy(draw_buf);
+
+    lv_obj_clean(lv_screen_active());
+    lv_image_cache_drop(NULL);
+}
+
+void test_svg_snapshot(void)
+{
+    svg_snapshot();
+    size_t mem_before = lv_test_get_free_mem();
+    svg_snapshot();
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
 }
 
 #endif


### PR DESCRIPTION
Fixes #8589

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
