### PR TITLE
fix(vg_lite): remove the 16px width limit for image tile drawing mode

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -155,9 +155,7 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
 
     vg_lite_matrix_t path_matrix = u->global_matrix;
 
-    /* When alignment requirements are not met, use repeated drawing to simulate tile drawing effects. */
-    /* vg_lite_tvg does not support VG_LITE_PATTERN_REPEAT */
-    if(dsc->tile && (LV_USE_VG_LITE_THORVG || (img_w % 16 != 0 && lv_vg_lite_16px_align()))) {
+    if(dsc->tile) {
         lv_area_t tile_area;
         if(lv_area_get_width(&dsc->image_area) >= 0) {
             tile_area = dsc->image_area;
@@ -168,9 +166,15 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
         lv_area_set_width(&tile_area, img_w);
         lv_area_set_height(&tile_area, img_h);
 
+        /**
+         * vg_lite_tvg does not support VG_LITE_PATTERN_REPEAT,
+         * use looping texture for simulation.
+         */
+#if LV_USE_VG_LITE_THORVG
         const int32_t tile_x_start = tile_area.x1;
         while(tile_area.y1 <= coords->y2) {
             while(tile_area.x1 <= coords->x2) {
+#endif
                 vg_lite_matrix_t tile_matrix;
                 vg_lite_identity(&tile_matrix);
                 vg_lite_translate(tile_area.x1 - coords->x1, tile_area.y1 - coords->y1, &tile_matrix);
@@ -179,7 +183,7 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                 lv_vg_lite_matrix_multiply(&pattern_matrix, &tile_matrix);
 
                 lv_area_t clipped_img_area;
-                if(lv_area_intersect(&clipped_img_area, &tile_area, coords)) {
+                if(!LV_USE_VG_LITE_THORVG || lv_area_intersect(&clipped_img_area, &tile_area, coords)) {
                     lv_vg_lite_draw_pattern(
                         &u->target_buffer,
                         lv_vg_lite_path_get_path(path),
@@ -188,12 +192,13 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                         &src_buf,
                         &pattern_matrix,
                         blend,
-                        VG_LITE_PATTERN_COLOR,
+                        VG_LITE_PATTERN_REPEAT,
                         0,
                         color,
                         filter);
                 }
 
+#if LV_USE_VG_LITE_THORVG
                 tile_area.x1 += img_w;
                 tile_area.x2 += img_w;
             }
@@ -203,6 +208,7 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
             tile_area.x1 = tile_x_start;
             tile_area.x2 = tile_x_start + img_w - 1;
         }
+#endif
     }
     else {
         lv_vg_lite_draw_pattern(
@@ -213,7 +219,7 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
             &src_buf,
             &matrix,
             blend,
-            dsc->tile ? VG_LITE_PATTERN_REPEAT : VG_LITE_PATTERN_COLOR,
+            VG_LITE_PATTERN_COLOR,
             0,
             color,
             filter);

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -114,8 +114,6 @@ void lv_vg_lite_buffer_format_bytes(
 
 uint32_t lv_vg_lite_width_to_stride(uint32_t w, vg_lite_buffer_format_t color_format);
 
-uint32_t lv_vg_lite_width_align(uint32_t w);
-
 void lv_vg_lite_buffer_init(
     vg_lite_buffer_t * buffer,
     const void * ptr,
@@ -162,8 +160,6 @@ bool lv_vg_lite_matrix_check(const vg_lite_matrix_t * matrix);
 /* Wrapper */
 
 bool lv_vg_lite_support_blend_normal(void);
-
-bool lv_vg_lite_16px_align(void);
 
 void lv_vg_lite_matrix_multiply(vg_lite_matrix_t * matrix, const vg_lite_matrix_t * mult);
 


### PR DESCRIPTION
Removed the 16px width alignment restriction for tile image rendering, fully utilizing the GPU to achieve the tile effect.

Related Discussions: https://github.com/lvgl/lvgl/pull/8642

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
