### PR TITLE
feat(vg_lite): add static bitmap font support

### DIFF
--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -26,7 +26,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
+static void init_handlers(lv_draw_buf_handlers_t * handlers);
 
 /**********************
  *  STATIC VARIABLES
@@ -42,17 +42,41 @@ static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format);
 
 void lv_draw_buf_vg_lite_init_handlers(void)
 {
-    lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
-    handlers->width_to_stride_cb = width_to_stride;
+    init_handlers(lv_draw_buf_get_handlers());
+    init_handlers(lv_draw_buf_get_font_handlers());
+    init_handlers(lv_draw_buf_get_image_handlers());
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
+static void * align_pointer_cb(void * buf, lv_color_format_t color_format)
+{
+    if(!buf) {
+        return NULL;
+    }
+
+    uint32_t align = LV_DRAW_BUF_ALIGN;
+
+    /* To avoid warnings when constructing draw_buf for static bitmap fonts */
+    if(color_format == LV_COLOR_FORMAT_A8) {
+        align = 16;
+    }
+
+    return (void *)LV_ROUND_UP((lv_uintptr_t)buf, align);
+}
+
+static uint32_t width_to_stride_cb(uint32_t w, lv_color_format_t color_format)
 {
     return lv_vg_lite_width_to_stride(w, lv_vg_lite_vg_fmt(color_format));
+}
+
+static void init_handlers(lv_draw_buf_handlers_t * handlers)
+{
+    LV_ASSERT_NULL(handlers);
+    handlers->align_pointer_cb = align_pointer_cb;
+    handlers->width_to_stride_cb = width_to_stride_cb;
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/draw/vg_lite/lv_draw_buf_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_buf_vg_lite.c
@@ -51,23 +51,7 @@ void lv_draw_buf_vg_lite_init_handlers(void)
  *   STATIC FUNCTIONS
  **********************/
 
-static void * align_pointer_cb(void * buf, lv_color_format_t color_format)
-{
-    if(!buf) {
-        return NULL;
-    }
-
-    uint32_t align = LV_DRAW_BUF_ALIGN;
-
-    /* To avoid warnings when constructing draw_buf for static bitmap fonts */
-    if(color_format == LV_COLOR_FORMAT_A8) {
-        align = 16;
-    }
-
-    return (void *)LV_ROUND_UP((lv_uintptr_t)buf, align);
-}
-
-static uint32_t width_to_stride_cb(uint32_t w, lv_color_format_t color_format)
+static uint32_t width_to_stride(uint32_t w, lv_color_format_t color_format)
 {
     return lv_vg_lite_width_to_stride(w, lv_vg_lite_vg_fmt(color_format));
 }
@@ -75,8 +59,7 @@ static uint32_t width_to_stride_cb(uint32_t w, lv_color_format_t color_format)
 static void init_handlers(lv_draw_buf_handlers_t * handlers)
 {
     LV_ASSERT_NULL(handlers);
-    handlers->align_pointer_cb = align_pointer_cb;
-    handlers->width_to_stride_cb = width_to_stride_cb;
+    handlers->width_to_stride_cb = width_to_stride;
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -744,7 +744,14 @@ void lv_vg_lite_buffer_init(
                              "width : %" LV_PRId32 ", height : %" LV_PRId32, width, height);
     }
 
-    buffer->image_mode = VG_LITE_NORMAL_IMAGE_MODE;
+    /* Alpha image need to be multiplied by color */
+    if(format == VG_LITE_A8 || format == VG_LITE_A4) {
+        buffer->image_mode = VG_LITE_MULTIPLY_IMAGE_MODE;
+    }
+    else {
+        buffer->image_mode = VG_LITE_NORMAL_IMAGE_MODE;
+    }
+
     buffer->transparency_mode = VG_LITE_IMAGE_OPAQUE;
     buffer->width = width;
     buffer->height = height;
@@ -795,11 +802,6 @@ void lv_vg_lite_buffer_from_draw_buf(vg_lite_buffer_t * buffer, const lv_draw_bu
     lv_vg_lite_buffer_init(buffer, ptr,
                            width, height, stride, format,
                            lv_draw_buf_has_flag(draw_buf, LV_VG_LITE_IMAGE_FLAGS_TILED));
-
-    /* Alpha image need to be multiplied by color */
-    if(LV_COLOR_FORMAT_IS_ALPHA_ONLY(draw_buf->header.cf)) {
-        buffer->image_mode = VG_LITE_MULTIPLY_IMAGE_MODE;
-    }
 }
 
 void lv_vg_lite_image_matrix(vg_lite_matrix_t * matrix, int32_t x, int32_t y, const lv_draw_image_dsc_t * dsc)

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -725,9 +725,6 @@ void lv_vg_lite_buffer_init(
     vg_lite_buffer_format_t format,
     bool tiled)
 {
-    uint32_t mul;
-    uint32_t div;
-    uint32_t align;
     LV_ASSERT_NULL(buffer);
     LV_ASSERT_NULL(ptr);
 
@@ -740,13 +737,19 @@ void lv_vg_lite_buffer_init(
     else {
         buffer->tiled = VG_LITE_LINEAR;
     }
+
+    if(buffer->tiled) {
+        LV_ASSERT_FORMAT_MSG(LV_VG_LITE_IS_ALIGNED(width, 4) &&
+                             LV_VG_LITE_IS_ALIGNED(height, 4),
+                             "width : %" LV_PRId32 ", height : %" LV_PRId32, width, height);
+    }
+
     buffer->image_mode = VG_LITE_NORMAL_IMAGE_MODE;
     buffer->transparency_mode = VG_LITE_IMAGE_OPAQUE;
     buffer->width = width;
     buffer->height = height;
     if(stride == LV_STRIDE_AUTO) {
-        lv_vg_lite_buffer_format_bytes(buffer->format, &mul, &div, &align);
-        buffer->stride = LV_VG_LITE_ALIGN((buffer->width * mul / div), align);
+        buffer->stride = lv_vg_lite_width_to_stride(width, buffer->format);
     }
     else {
         buffer->stride = stride;

--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -2598,7 +2598,9 @@ static Result picture_load(vg_lite_ctx * ctx, std::unique_ptr<Picture> & picture
                            vg_lite_color_t color)
 {
     vg_lite_uint32_t * image_buffer;
-    LV_ASSERT(VG_LITE_IS_ALIGNED(source->memory, LV_VG_LITE_THORVG_BUF_ADDR_ALIGN));
+
+    /* At least 8-byte alignment */
+    LV_ASSERT(VG_LITE_IS_ALIGNED(source->memory, 8));
 
     /**
      * Since ThorVG's picture->load does not support stride,


### PR DESCRIPTION
Added support for static bitmap font rendering, enabling zero-copy text rendering.

Related Discussions: https://github.com/lvgl/lvgl/pull/8642

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
