### PR TITLE
fix(EVE): fix EVE build break

### DIFF
--- a/src/draw/eve/lv_draw_eve.c
+++ b/src/draw/eve/lv_draw_eve.c
@@ -102,7 +102,7 @@ static int32_t eve_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     eve_execute_drawing(draw_eve_unit);
 
-    draw_eve_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_eve_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     draw_eve_unit->task_act = NULL;
 
     /*The draw unit is free now. Request a new dispatching as it can get a new task*/


### PR DESCRIPTION
Draw task state name was changed in #8512