### PR TITLE
fix(txt): getting letter after next letter

### DIFF
--- a/src/lv_misc/lv_txt.c
+++ b/src/lv_misc/lv_txt.c
@@ -754,7 +754,7 @@ static uint32_t lv_txt_iso8859_1_conv_wc(uint32_t c)
  */
 static uint32_t lv_txt_iso8859_1_next(const char * txt, uint32_t * i)
 {
-    if(i == NULL) return txt[1]; /*Get the next char */
+    if(i == NULL) return txt[0];
 
     uint8_t letter = txt[*i];
     (*i)++;


### PR DESCRIPTION
This PR fix logical mistake in lv_txt_get_width() function. Function try to get next letter, but in reality it get letter after next letter.
This caused the pointer to go out of bound of string.

https://github.com/lvgl/lvgl/blob/416fa2a6ae8f7cecdf3540b28db03ba96a521470/src/lv_misc/lv_txt.c#L355-L356