### PR TITLE
fix(xmls): fixed division lines in Chart XML API

### DIFF
--- a/xmls/lv_chart.xml
+++ b/xmls/lv_chart.xml
@@ -32,8 +32,8 @@
 
 	    <prop name="point_count" type="int" help=""/>
 	    <prop name="update_mode" type="enum:lv_chart_update_mode" help=""/>
-	    <prop name="nor_div_line_count" help=""/>
-	    <prop name="ver_div_line_count" help=""/>
+	    <prop name="hor_div_line_count" type="int" help="number of horizontal division lines"/>
+	    <prop name="ver_div_line_count" type="int" help="number of vertical division lines"/>
 
 	    <element name="series" type="lv_chart_series" access="add">
 	        <arg name="color" type="color" help=""/>


### PR DESCRIPTION
This PR fixes the division lines in XML API for the Chart widget. Currently they do not work in the UI Editor. Code generation fails with error message _The type of a property is undefined_ for the division line properties, and horizontal division lines do not show up in the editor (presumably because of the typo in the property name).