### PR TITLE
feat(draw_buf): make buf_copy overwritable for GPU

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -133,6 +133,7 @@ extern "C" {
 #include "src/lv_api_map_v9_0.h"
 #include "src/lv_api_map_v9_1.h"
 #include "src/lv_api_map_v9_2.h"
+#include "src/lv_api_map_v9_3.h"
 
 #if LV_USE_PRIVATE_API
 #include "src/lvgl_private.h"

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -367,6 +367,7 @@ void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
 {
     LV_ASSERT_NULL(dest);
     LV_ASSERT_NULL(dest->handlers);
+    LV_ASSERT_NULL(dest->handlers->buf_copy_cb);
     LV_ASSERT_NULL(src);
 
     dest->handlers->buf_copy_cb(dest, dest_area, src, src_area);

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -29,6 +29,8 @@
  **********************/
 static void * buf_malloc(size_t size, lv_color_format_t color_format);
 static void buf_free(void * buf);
+static void buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
+                     const lv_draw_buf_t * src, const lv_area_t * src_area);
 static void * buf_align(void * buf, lv_color_format_t color_format);
 static void * draw_buf_malloc(const lv_draw_buf_handlers_t * handler, size_t size_bytes,
                               lv_color_format_t color_format);
@@ -58,20 +60,22 @@ void lv_draw_buf_init_handlers(void)
 
 void lv_draw_buf_init_with_default_handlers(lv_draw_buf_handlers_t * handlers)
 {
-    lv_draw_buf_handlers_init(handlers, buf_malloc, buf_free, buf_align, NULL, NULL, width_to_stride);
+    lv_draw_buf_handlers_init(handlers, buf_malloc, buf_free, buf_copy, buf_align, NULL, NULL, width_to_stride);
 }
 
 void lv_draw_buf_handlers_init(lv_draw_buf_handlers_t * handlers,
-                               lv_draw_buf_malloc_cb buf_malloc_cb,
-                               lv_draw_buf_free_cb buf_free_cb,
-                               lv_draw_buf_align_cb align_pointer_cb,
-                               lv_draw_buf_cache_operation_cb invalidate_cache_cb,
-                               lv_draw_buf_cache_operation_cb flush_cache_cb,
-                               lv_draw_buf_width_to_stride_cb width_to_stride_cb)
+                               lv_draw_buf_malloc_cb_t buf_malloc_cb,
+                               lv_draw_buf_free_cb_t buf_free_cb,
+                               lv_draw_buf_copy_cb_t buf_copy_cb,
+                               lv_draw_buf_align_cb_t align_pointer_cb,
+                               lv_draw_buf_cache_operation_cb_t invalidate_cache_cb,
+                               lv_draw_buf_cache_operation_cb_t flush_cache_cb,
+                               lv_draw_buf_width_to_stride_cb_t width_to_stride_cb)
 {
     lv_memzero(handlers, sizeof(lv_draw_buf_handlers_t));
     handlers->buf_malloc_cb = buf_malloc_cb;
     handlers->buf_free_cb = buf_free_cb;
+    handlers->buf_copy_cb = buf_copy_cb;
     handlers->align_pointer_cb = align_pointer_cb;
     handlers->invalidate_cache_cb = invalidate_cache_cb;
     handlers->flush_cache_cb = flush_cache_cb;
@@ -207,64 +211,6 @@ void lv_draw_buf_clear(lv_draw_buf_t * draw_buf, const lv_area_t * a)
         buf += stride;
     }
     lv_draw_buf_flush_cache(draw_buf, a);
-    LV_PROFILER_DRAW_END;
-}
-
-void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
-                      const lv_draw_buf_t * src, const lv_area_t * src_area)
-{
-    LV_PROFILER_DRAW_BEGIN;
-    uint8_t * dest_bufc;
-    uint8_t * src_bufc;
-    int32_t line_width;
-
-    /*Source and dest color format must be same. Color conversion is not supported yet.*/
-    LV_ASSERT_FORMAT_MSG(dest->header.cf == src->header.cf, "Color format mismatch: %d != %d",
-                         dest->header.cf, src->header.cf);
-
-    if(dest_area == NULL) line_width = dest->header.w;
-    else line_width = lv_area_get_width(dest_area);
-
-    /* For indexed image, copy the palette if we are copying full image area*/
-    if(dest_area == NULL || src_area == NULL) {
-        if(LV_COLOR_FORMAT_IS_INDEXED(dest->header.cf)) {
-            lv_memcpy(dest->data, src->data, LV_COLOR_INDEXED_PALETTE_SIZE(dest->header.cf) * sizeof(lv_color32_t));
-        }
-    }
-
-    /*Check source and dest area have same width*/
-    if((src_area == NULL && line_width != src->header.w) || \
-       (src_area != NULL && line_width != lv_area_get_width(src_area))) {
-        LV_ASSERT_MSG(0, "Source and destination areas have different width");
-        LV_PROFILER_DRAW_END;
-        return;
-    }
-
-    if(src_area) src_bufc = lv_draw_buf_goto_xy(src, src_area->x1, src_area->y1);
-    else src_bufc = lv_draw_buf_goto_xy(src, 0, 0);
-
-    if(dest_area) dest_bufc = lv_draw_buf_goto_xy(dest, dest_area->x1, dest_area->y1);
-    else dest_bufc = lv_draw_buf_goto_xy(dest, 0, 0);
-
-    int32_t start_y, end_y;
-    if(dest_area) {
-        start_y = dest_area->y1;
-        end_y = dest_area->y2;
-    }
-    else {
-        start_y = 0;
-        end_y = dest->header.h - 1;
-    }
-
-    uint32_t dest_stride = dest->header.stride;
-    uint32_t src_stride = src->header.stride;
-    uint32_t line_bytes = (line_width * lv_color_format_get_bpp(dest->header.cf) + 7) >> 3;
-
-    for(; start_y <= end_y; start_y++) {
-        lv_memcpy(dest_bufc, src_bufc, line_bytes);
-        dest_bufc += dest_stride;
-        src_bufc += src_stride;
-    }
     LV_PROFILER_DRAW_END;
 }
 
@@ -414,6 +360,16 @@ void lv_draw_buf_destroy(lv_draw_buf_t * draw_buf)
         LV_LOG_ERROR("draw buffer is not allocated, ignored");
     }
     LV_PROFILER_DRAW_END;
+}
+
+void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
+                      const lv_draw_buf_t * src, const lv_area_t * src_area)
+{
+    LV_ASSERT_NULL(dest);
+    LV_ASSERT_NULL(dest->handlers);
+    LV_ASSERT_NULL(src);
+
+    dest->handlers->buf_copy_cb(dest, dest_area, src, src_area);
 }
 
 void * lv_draw_buf_goto_xy(const lv_draw_buf_t * buf, uint32_t x, uint32_t y)
@@ -662,6 +618,64 @@ static void * buf_malloc(size_t size_bytes, lv_color_format_t color_format)
 static void buf_free(void * buf)
 {
     lv_free(buf);
+}
+
+static void buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
+                     const lv_draw_buf_t * src, const lv_area_t * src_area)
+{
+    LV_PROFILER_DRAW_BEGIN;
+    uint8_t * dest_bufc;
+    uint8_t * src_bufc;
+    int32_t line_width;
+
+    /*Source and dest color format must be same. Color conversion is not supported yet.*/
+    LV_ASSERT_FORMAT_MSG(dest->header.cf == src->header.cf, "Color format mismatch: %d != %d",
+                         dest->header.cf, src->header.cf);
+
+    if(dest_area == NULL) line_width = dest->header.w;
+    else line_width = lv_area_get_width(dest_area);
+
+    /* For indexed image, copy the palette if we are copying full image area*/
+    if(dest_area == NULL || src_area == NULL) {
+        if(LV_COLOR_FORMAT_IS_INDEXED(dest->header.cf)) {
+            lv_memcpy(dest->data, src->data, LV_COLOR_INDEXED_PALETTE_SIZE(dest->header.cf) * sizeof(lv_color32_t));
+        }
+    }
+
+    /*Check source and dest area have same width*/
+    if((src_area == NULL && line_width != src->header.w) || \
+       (src_area != NULL && line_width != lv_area_get_width(src_area))) {
+        LV_ASSERT_MSG(0, "Source and destination areas have different width");
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+
+    if(src_area) src_bufc = lv_draw_buf_goto_xy(src, src_area->x1, src_area->y1);
+    else src_bufc = lv_draw_buf_goto_xy(src, 0, 0);
+
+    if(dest_area) dest_bufc = lv_draw_buf_goto_xy(dest, dest_area->x1, dest_area->y1);
+    else dest_bufc = lv_draw_buf_goto_xy(dest, 0, 0);
+
+    int32_t start_y, end_y;
+    if(dest_area) {
+        start_y = dest_area->y1;
+        end_y = dest_area->y2;
+    }
+    else {
+        start_y = 0;
+        end_y = dest->header.h - 1;
+    }
+
+    uint32_t dest_stride = dest->header.stride;
+    uint32_t src_stride = src->header.stride;
+    uint32_t line_bytes = (line_width * lv_color_format_get_bpp(dest->header.cf) + 7) >> 3;
+
+    for(; start_y <= end_y; start_y++) {
+        lv_memcpy(dest_bufc, src_bufc, line_bytes);
+        dest_bufc += dest_stride;
+        src_bufc += src_stride;
+    }
+    LV_PROFILER_DRAW_END;
 }
 
 static void * buf_align(void * buf, lv_color_format_t color_format)

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -75,15 +75,18 @@ LV_EXPORT_CONST_INT(LV_STRIDE_AUTO);
  *      TYPEDEFS
  **********************/
 
-typedef void * (*lv_draw_buf_malloc_cb)(size_t size, lv_color_format_t color_format);
+typedef void * (*lv_draw_buf_malloc_cb_t)(size_t size, lv_color_format_t color_format);
 
-typedef void (*lv_draw_buf_free_cb)(void * draw_buf);
+typedef void (*lv_draw_buf_free_cb_t)(void * draw_buf);
 
-typedef void * (*lv_draw_buf_align_cb)(void * buf, lv_color_format_t color_format);
+typedef void (*lv_draw_buf_copy_cb_t)(lv_draw_buf_t * dest, const lv_area_t * dest_area,
+                                      const lv_draw_buf_t * src, const lv_area_t * src_area);
 
-typedef void (*lv_draw_buf_cache_operation_cb)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+typedef void * (*lv_draw_buf_align_cb_t)(void * buf, lv_color_format_t color_format);
 
-typedef uint32_t (*lv_draw_buf_width_to_stride_cb)(uint32_t w, lv_color_format_t color_format);
+typedef void (*lv_draw_buf_cache_operation_cb_t)(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+
+typedef uint32_t (*lv_draw_buf_width_to_stride_cb_t)(uint32_t w, lv_color_format_t color_format);
 
 struct _lv_draw_buf_t {
     lv_image_header_t header;
@@ -110,18 +113,20 @@ void lv_draw_buf_init_with_default_handlers(lv_draw_buf_handlers_t * handlers);
  * @param handlers             the draw buffer handlers to set
  * @param buf_malloc_cb        the callback to allocate memory for the buffer
  * @param buf_free_cb          the callback to free memory of the buffer
+ * @param buf_copy_cb          the callback to copy a draw buffer to an other
  * @param align_pointer_cb     the callback to align the buffer
  * @param invalidate_cache_cb  the callback to invalidate the cache of the buffer
  * @param flush_cache_cb       the callback to flush buffer
  * @param width_to_stride_cb   the callback to calculate the stride based on the width and color format
  */
 void lv_draw_buf_handlers_init(lv_draw_buf_handlers_t * handlers,
-                               lv_draw_buf_malloc_cb buf_malloc_cb,
-                               lv_draw_buf_free_cb buf_free_cb,
-                               lv_draw_buf_align_cb align_pointer_cb,
-                               lv_draw_buf_cache_operation_cb invalidate_cache_cb,
-                               lv_draw_buf_cache_operation_cb flush_cache_cb,
-                               lv_draw_buf_width_to_stride_cb width_to_stride_cb);
+                               lv_draw_buf_malloc_cb_t buf_malloc_cb,
+                               lv_draw_buf_free_cb_t buf_free_cb,
+                               lv_draw_buf_copy_cb_t buf_copy_cb,
+                               lv_draw_buf_align_cb_t align_pointer_cb,
+                               lv_draw_buf_cache_operation_cb_t invalidate_cache_cb,
+                               lv_draw_buf_cache_operation_cb_t flush_cache_cb,
+                               lv_draw_buf_width_to_stride_cb_t width_to_stride_cb);
 
 /**
  * Get the struct which holds the callbacks for draw buf management.
@@ -192,17 +197,6 @@ uint32_t lv_draw_buf_width_to_stride_ex(const lv_draw_buf_handlers_t * handlers,
  */
 void lv_draw_buf_clear(lv_draw_buf_t * draw_buf, const lv_area_t * a);
 
-/**
- * Copy an area from a buffer to another
- * @param dest      pointer to the destination draw buffer
- * @param dest_area the area to copy from the destination buffer, if NULL, use the whole buffer
- * @param src       pointer to the source draw buffer
- * @param src_area  the area to copy from the destination buffer, if NULL, use the whole buffer
- * @note `dest_area` and `src_area` should have the same width and height
- * @note  `dest` and `src` should have same color format. Color converting is not supported fow now.
- */
-void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
-                      const lv_draw_buf_t * src, const lv_area_t * src_area);
 
 /**
  * Note: Eventually, lv_draw_buf_malloc/free will be kept as private.
@@ -284,6 +278,18 @@ lv_draw_buf_t * lv_draw_buf_reshape(lv_draw_buf_t * draw_buf, lv_color_format_t 
  * @param draw_buf  the draw buffer to destroy
  */
 void lv_draw_buf_destroy(lv_draw_buf_t * draw_buf);
+
+/**
+ * Copy an area from a buffer to another
+ * @param dest      pointer to the destination draw buffer
+ * @param dest_area the area to copy from the destination buffer, if NULL, use the whole buffer
+ * @param src       pointer to the source draw buffer
+ * @param src_area  the area to copy from the destination buffer, if NULL, use the whole buffer
+ * @note `dest_area` and `src_area` should have the same width and height
+ * @note  `dest` and `src` should have same color format. Color converting is not supported now.
+ */
+void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
+                      const lv_draw_buf_t * src, const lv_area_t * src_area);
 
 /**
  * Return pointer to the buffer at the given coordinates

--- a/src/draw/lv_draw_buf.h
+++ b/src/draw/lv_draw_buf.h
@@ -286,7 +286,8 @@ void lv_draw_buf_destroy(lv_draw_buf_t * draw_buf);
  * @param src       pointer to the source draw buffer
  * @param src_area  the area to copy from the destination buffer, if NULL, use the whole buffer
  * @note `dest_area` and `src_area` should have the same width and height
- * @note  `dest` and `src` should have same color format. Color converting is not supported now.
+ * @note  The default copy function required `dest` and `src` to have the same color format.
+ * Overwriting dest->handlers->buf_copy_cb can resolve this limitation.
  */
 void lv_draw_buf_copy(lv_draw_buf_t * dest, const lv_area_t * dest_area,
                       const lv_draw_buf_t * src, const lv_area_t * src_area);

--- a/src/draw/lv_draw_buf_private.h
+++ b/src/draw/lv_draw_buf_private.h
@@ -25,12 +25,13 @@ extern "C" {
  **********************/
 
 struct _lv_draw_buf_handlers_t {
-    lv_draw_buf_malloc_cb buf_malloc_cb;
-    lv_draw_buf_free_cb buf_free_cb;
-    lv_draw_buf_align_cb align_pointer_cb;
-    lv_draw_buf_cache_operation_cb invalidate_cache_cb;
-    lv_draw_buf_cache_operation_cb flush_cache_cb;
-    lv_draw_buf_width_to_stride_cb width_to_stride_cb;
+    lv_draw_buf_malloc_cb_t buf_malloc_cb;
+    lv_draw_buf_free_cb_t buf_free_cb;
+    lv_draw_buf_copy_cb_t buf_copy_cb;
+    lv_draw_buf_align_cb_t align_pointer_cb;
+    lv_draw_buf_cache_operation_cb_t invalidate_cache_cb;
+    lv_draw_buf_cache_operation_cb_t flush_cache_cb;
+    lv_draw_buf_width_to_stride_cb_t width_to_stride_cb;
 };
 
 /**********************

--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -42,12 +42,12 @@ typedef struct {
     bool initialized;
     bool independent_image_heap;
 
-    lv_draw_buf_malloc_cb malloc_cb;
-    lv_draw_buf_free_cb free_cb;
+    lv_draw_buf_malloc_cb_t malloc_cb;
+    lv_draw_buf_free_cb_t free_cb;
 
 #if LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
-    lv_draw_buf_malloc_cb malloc_cb_default;
-    lv_draw_buf_free_cb free_cb_default;
+    lv_draw_buf_malloc_cb_t malloc_cb_default;
+    lv_draw_buf_free_cb_t free_cb_default;
 #endif
 } lv_nuttx_ctx_image_cache_t;
 /**********************

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -345,7 +345,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         lv_draw_buf_set_flag(decoded, LV_IMAGE_FLAGS_MODIFIABLE);
 
         /* Empty handlers to avoid decoder asserts */
-        lv_draw_buf_handlers_init(&ffmpeg_ctx->draw_buf_handlers, NULL, NULL, NULL, NULL, NULL, NULL);
+        lv_draw_buf_handlers_init(&ffmpeg_ctx->draw_buf_handlers, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
         decoded->handlers = &ffmpeg_ctx->draw_buf_handlers;
 
         if(dsc->args.premultiply && ffmpeg_ctx->has_alpha) {

--- a/src/lv_api_map_v9_3.h
+++ b/src/lv_api_map_v9_3.h
@@ -1,0 +1,47 @@
+/**
+ * @file lv_api_map_v9_3.h
+ *
+ */
+
+#ifndef LV_API_MAP_V9_3_H
+#define LV_API_MAP_V9_3_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "misc/lv_types.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#define lv_draw_buf_malloc_cb               lv_draw_buf_malloc_cb_t
+#define lv_draw_buf_free_cb                 lv_draw_buf_free_cb_t
+#define lv_draw_buf_copy_cb                 lv_draw_buf_copy_cb_t
+#define lv_draw_buf_align_cb                lv_draw_buf_align_cb_t
+#define lv_draw_buf_cache_operation_cb      lv_draw_buf_cache_operation_cb_t
+#define lv_draw_buf_cache_operation_cb      lv_draw_buf_cache_operation_cb_t
+#define lv_draw_buf_width_to_stride_cb      lv_draw_buf_width_to_stride_cb_t
+
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* LV_API_MAP_V9_3_H */

--- a/src/lv_api_map_v9_3.h
+++ b/src/lv_api_map_v9_3.h
@@ -36,7 +36,6 @@ extern "C" {
 #define lv_draw_buf_copy_cb                 lv_draw_buf_copy_cb_t
 #define lv_draw_buf_align_cb                lv_draw_buf_align_cb_t
 #define lv_draw_buf_cache_operation_cb      lv_draw_buf_cache_operation_cb_t
-#define lv_draw_buf_cache_operation_cb      lv_draw_buf_cache_operation_cb_t
 #define lv_draw_buf_width_to_stride_cb      lv_draw_buf_width_to_stride_cb_t
 
 


### PR DESCRIPTION
see https://github.com/lvgl/lvgl/issues/8444#issuecomment-3141898304

You can set new GPU accelerated buffer copy for direct mode like this:
```c
  my_display->buf_1->handlers->buf_copy_cb = my_gpu_copy
  my_display->buf_2->handlers->buf_copy_cb = my_gpu_copy
```

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
