### PR TITLE
fix(drivers): fix compile error for st ltdc

### DIFF
--- a/src/drivers/display/st_ltdc/lv_st_ltdc.c
+++ b/src/drivers/display/st_ltdc/lv_st_ltdc.c
@@ -13,15 +13,17 @@
 #include "lv_st_ltdc.h"
 #include "../../../display/lv_display_private.h"
 #include "../../../draw/sw/lv_draw_sw.h"
-#include "ltdc.h"
+#include "main.h"
 
 #if LV_ST_LTDC_USE_DMA2D_FLUSH
     #if LV_USE_DRAW_DMA2D
         #error cannot use LV_ST_LTDC_USE_DMA2D_FLUSH with LV_USE_DRAW_DMA2D
     #endif /*LV_USE_DRAW_DMA2D*/
 
-    #include "dma2d.h"
+    extern DMA2D_HandleTypeDef hdma2d;
 #endif /*LV_ST_LTDC_USE_DMA2D_FLUSH*/
+
+extern LTDC_HandleTypeDef hltdc;
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
If the option of "Generate peripheral initialization as a pair of '.c/.h' files per peripheral" for STM32CubeMX is not checked, the two files, ltdc.h and dma2d.h, were not generated.