### PR TITLE
Fixes  bug where multiple events with same callback couldn't be removed in single call.

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -144,6 +144,8 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
     uint32_t removed_count = 0;
     int32_t i;
     
+    if(event_cnt == 0) return 0;
+    
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
         if(dsc && dsc->cb == event_cb) {

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -142,8 +142,9 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
 
     uint32_t event_cnt = lv_obj_get_event_count(obj);
     uint32_t removed_count = 0;
-    uint32_t i;
-    for(i = 0; i < event_cnt; i++) {
+    int32_t i;
+    
+    for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
         if(dsc && dsc->cb == event_cb) {
             lv_obj_remove_event(obj, i);

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -143,9 +143,9 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
     uint32_t event_cnt = lv_obj_get_event_count(obj);
     uint32_t removed_count = 0;
     int32_t i;
-    
+
     if(event_cnt == 0) return 0;
-    
+
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
         if(dsc && dsc->cb == event_cb) {

--- a/tests/src/test_cases/test_event.c
+++ b/tests/src/test_cases/test_event.c
@@ -142,4 +142,39 @@ void test_event_delete_obj_in_recursive_event_call(void)
     lv_test_mouse_click_at(30, 30);
 }
 
+// Test event callback function
+static void test_event_cb_1(lv_event_t * e)
+{
+    LV_UNUSED(e);
+}
+
+void test_event_remove_event_cb(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+
+    // Register the same callback function twice with different event types
+    lv_obj_add_event_cb(obj, test_event_cb_1, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event_cb(obj, test_event_cb_1, LV_EVENT_PRESSED, NULL);
+
+    // Check event count after adding
+    uint32_t event_count_after_add = lv_obj_get_event_count(obj);
+
+    // Verify that 2 events were added
+    TEST_ASSERT_EQUAL_UINT32(2, event_count_after_add);
+
+    // Remove all events with test_event_cb_1 callback
+    uint32_t removed_count = lv_obj_remove_event_cb(obj, test_event_cb_1);
+
+    // Verify that 2 events were removed
+    TEST_ASSERT_EQUAL_UINT32(2, removed_count);
+
+    // Check event count after removal
+    uint32_t event_count_after_remove = lv_obj_get_event_count(obj);
+
+    // Verify that all events were removed
+    TEST_ASSERT_EQUAL_UINT32(0, event_count_after_remove);
+
+    lv_obj_delete(obj);
+}
+
 #endif


### PR DESCRIPTION
Fixes  bug where multiple events with same callback couldn't be removed in single call.

## Problem
The lv_obj_remove_event_cb function has a bug where it can only remove one event per call when multiple events share the same callback function, due to index skipping during forward iteration.

## Solution
Fixed by changing from forward to reverse iteration, following the same implementation pattern as lv_obj_remove_event_cb_with_user_data .

### Changes
- Changed loop from for(i = 0; i < event_cnt; i++) to for(i = event_cnt - 1; i >= 0; i--)
- Changed index type from uint32_t to int32_t
- Added explanatory comment
### Why This Works
Reverse iteration prevents index skipping when elements are removed from the array, ensuring all matching events are found and removed in a single call.

Reference : This fix aligns the implementation with lv_obj_remove_event_cb_with_user_data , which already uses reverse iteration correctly.

### Test Case
A simple test case demonstrates the issue:

```c
#include "lvgl.h"
#include <stdio.h>

// Test event callback function
static void test_event_cb_1(lv_event_t * e)
{
     (void)e;
     // Simple callback for testing
}

void test_lv_obj_remove_event_cb(void)
{
    printf("\n[TEST] ========== lv_obj_remove_event_cb Test ==========\n");
    
    // Create a test object
    lv_obj_t *test_obj = lv_obj_create(lv_screen_active());
    
    // Register the same callback function twice with different event types
    lv_obj_add_event_cb(test_obj, test_event_cb_1, LV_EVENT_CLICKED, NULL);
    lv_obj_add_event_cb(test_obj, test_event_cb_1, LV_EVENT_PRESSED, NULL);
    
    // Check event count after adding
    uint32_t event_count_after_add = lv_obj_get_event_count(test_obj);
    printf("[TEST] Event count after adding 2 events: %d\n", event_count_after_add);
    
    // Remove all events with test_event_cb_1 callback
    uint32_t removed_count = lv_obj_remove_event_cb(test_obj, test_event_cb_1);
    printf("[TEST] Removed event count: %d\n", removed_count);
    
    // Check event count after removal
    uint32_t event_count_after_remove = lv_obj_get_event_count(test_obj);
    printf("[TEST] Event count after removal: %d\n", event_count_after_remove);
    
    // Clean up
    lv_obj_delete(test_obj);
    
    printf("[TEST] ========== Test Complete ==========\n\n");
}
```