### PR TITLE
fix(EVE): image opa and recolor

### DIFF
--- a/src/draw/eve/lv_draw_eve_image.c
+++ b/src/draw/eve/lv_draw_eve_image.c
@@ -149,9 +149,10 @@ void lv_draw_eve_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
 
     lv_eve_save_context();
 
+    lv_eve_color_opa(draw_dsc->opa);
+
     if(draw_dsc->recolor_opa > LV_OPA_MIN) {
-        lv_eve_color_opa(draw_dsc->recolor_opa);
-        lv_eve_color(draw_dsc->recolor);
+        lv_eve_color(lv_color_mix(draw_dsc->recolor, lv_color_white(), draw_dsc->recolor_opa));
     }
 
     lv_eve_primitive(LV_EVE_PRIMITIVE_BITMAPS);


### PR DESCRIPTION
In EVE, image recolor opa should be controlled by mixing recolor color with white proportional to the desired opa.

Overall image opa is controlled by color opa.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
