### PR TITLE
fix(tests): fix gcovr report generation failure

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -176,13 +176,13 @@ def generate_code_coverage_report():
     os.chdir(lvgl_test_dir)
     delete_dir_ignore_missing('report')
     os.mkdir('report')
-    root_dir = os.pardir
+    root_dir = os.path.dirname(lvgl_test_dir)  # Get parent directory of tests (lvgl directory)
     html_report_file = 'report/index.html'
-    cmd = ['gcovr', '--gcov-ignore-parse-errors', 'negative_hits.warn', 
+    cmd = ['gcovr', '--gcov-ignore-parse-errors', 
            '--root', root_dir, '--html-details', '--output',
            html_report_file, '--xml', 'report/coverage.xml',
            '-j', str(os.cpu_count()), '--print-summary',
-           '--html-title', 'LVGL Test Coverage', '--filter', r'../src/.*/lv_.*\.c']
+           '--html-title', 'LVGL Test Coverage', '--filter', os.path.join(root_dir, 'src/.*/lv_.*\.c')]
 
     subprocess.check_call(cmd)
     print("Done: See %s" % html_report_file, flush=True)


### PR DESCRIPTION
1. Fix incorrect parameter: `negative_hits.warn`:

```bash
================================
Generating code coverage reports
================================

(INFO) - MainThread - Reading coverage data...
(WARNING) - Thread-2 (worker) - Unrecognized GCOV output for /media/admin/huge/LVGL/lv_sim_eclipse_sdl/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c
          6096487029:  131:static inline void _out_buffer(char character, void * buffer, size_t idx, size_t maxlen)
          6096487029:  133:    if(idx < maxlen) {
          6096487029:  133-block  0
          branch  0 taken 6096487029 (fallthrough)
          6096487029:  134:        ((char *)buffer)[idx] = character;
          6096487029:  134-block  0
          6096487029:  136:}
          call    0 returned 6096487029
        This is indicative of a gcov output parse error.
        Please report this to the gcovr developers
        at <https://github.com/gcovr/gcovr/issues>.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  131:static inline void _out_buffer(char character, void * buffer, size_t idx, size_t maxlen)' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  133:    if(idx < maxlen) {' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  133-block  0' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line 'branch  0 taken 6096487029 (fallthrough)' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  134:        ((char *)buffer)[idx] = character;' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  134-block  0' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  136:}' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        KeyError: 132
(ERROR) - Thread-2 (worker) - Exiting because of parse errors.
        You can run gcovr with --gcov-ignore-parse-errors=...
        to continue anyway.
(WARNING) - Thread-4 (worker) - Unrecognized GCOV output for /media/admin/huge/LVGL/lv_sim_eclipse_sdl/lvgl/src/core/lv_obj.c
          7871440960: 1104:    for(i = 0; i < child_cnt; i++) {
          7871440960: 1104-block  2
        This is indicative of a gcov output parse error.
        Please report this to the gcovr developers
        at <https://github.com/gcovr/gcovr/issues>.
(WARNING) - Thread-4 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '7871440960: 1104:    for(i = 0; i < child_cnt; i++) {' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-4 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line '7871440960: 1104-block  2' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(ERROR) - Thread-4 (worker) - Exiting because of parse errors.
        You can run gcovr with --gcov-ignore-parse-errors=...
        to continue anyway.
(ERROR) - MainThread - Traceback (most recent call last):
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/workers.py", line 95, in worker
    work(*args, **kwargs)
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 471, in process_datafile
    done = run_gcov_and_process_files(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 832, in run_gcov_and_process_files
    process_gcov_text_data(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 260, in process_gcov_text_data
    coverage, source_lines = text.parse_coverage(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 362, in parse_coverage
    _report_lines_with_errors(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 536, in _report_lines_with_errors
    raise errors[0]  # guaranteed to have at least one exception
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 305, in parse_coverage
    _parse_line(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 718, in _parse_line
    hits = check_hits(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/common.py", line 166, in check_hits
    SuspiciousHits.raise_if_not_ignored(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/common.py", line 142, in raise_if_not_ignored
    raise SuspiciousHits(line)
gcovr.formats.gcov.parser.common.SuspiciousHits: Got suspicious hit value in gcov line '6096487029:  131:static inline void _out_buffer(char character, void * buffer, size_t idx, size_t maxlen)' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.

(ERROR) - MainThread - Traceback (most recent call last):
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/workers.py", line 95, in worker
    work(*args, **kwargs)
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 471, in process_datafile
    done = run_gcov_and_process_files(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 832, in run_gcov_and_process_files
    process_gcov_text_data(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 260, in process_gcov_text_data
    coverage, source_lines = text.parse_coverage(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 362, in parse_coverage
    _report_lines_with_errors(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 536, in _report_lines_with_errors
    raise errors[0]  # guaranteed to have at least one exception
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 305, in parse_coverage
    _parse_line(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/text.py", line 718, in _parse_line
    hits = check_hits(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/common.py", line 166, in check_hits
    SuspiciousHits.raise_if_not_ignored(
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/parser/common.py", line 142, in raise_if_not_ignored
    raise SuspiciousHits(line)
gcovr.formats.gcov.parser.common.SuspiciousHits: Got suspicious hit value in gcov line '7871440960: 1104:    for(i = 0; i < child_cnt; i++) {' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.

(ERROR) - MainThread - Error occurred while reading reports:
Traceback (most recent call last):
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/__main__.py", line 384, in main
    covdata = gcovr_formats.read_reports(options)
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/__init__.py", line 99, in read_reports
    covdata = GcovHandler(options).read_report()
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/__init__.py", line 233, in read_report
    return read_report(self.options)
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/read.py", line 96, in read_report
    contexts = pool.wait()
  File "/home/admin/.local/lib/python3.10/site-packages/gcovr/formats/gcov/workers.py", line 181, in wait
    raise RuntimeError(
RuntimeError: Worker thread raised exception, workers canceled.

Traceback (most recent call last):
  File "/media/admin/huge/LVGL/lv_sim_eclipse_sdl/lvgl/tests/./main.py", line 283, in <module>
    generate_code_coverage_report()
  File "/media/admin/huge/LVGL/lv_sim_eclipse_sdl/lvgl/tests/./main.py", line 187, in generate_code_coverage_report
    subprocess.check_call(cmd)
  File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['gcovr', '--gcov-ignore-parse-errors', 'negative_hits.warn', '--root', '..', '--html-details', '--output', 'report/index.html', '--xml', 'report/coverage.xml', '-j', '24', '--print-summary', '--html-title', 'LVGL Test Coverage', '--filter', '../src/.*/lv_.*\\.c']' returned non-zero exit status 64.
```

2. Fixed the failure of executing `./tests/main.py --report test` in the lvgl directory.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
