### PR TITLE
fix(canvas): add the missing D-Cache flush

### DIFF
--- a/demos/render/lv_demo_render.c
+++ b/demos/render/lv_demo_render.c
@@ -821,6 +821,12 @@ static void blend_mode_cb(lv_obj_t * parent)
     LV_DRAW_BUF_DEFINE_STATIC(buf_argb8888, 36, 30, LV_COLOR_FORMAT_ARGB8888);
     LV_DRAW_BUF_DEFINE_STATIC(buf_argb8888_premul, 36, 30, LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED);
 
+    LV_DRAW_BUF_INIT_STATIC(buf_rgb565);
+    LV_DRAW_BUF_INIT_STATIC(buf_rgb888);
+    LV_DRAW_BUF_INIT_STATIC(buf_xrgb8888);
+    LV_DRAW_BUF_INIT_STATIC(buf_argb8888);
+    LV_DRAW_BUF_INIT_STATIC(buf_argb8888_premul);
+
     /*The canvas will stay in the top left corner to show the original image*/
     lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
 

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -92,6 +92,11 @@ void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(draw_buf);
 
+    if(!draw_buf->handlers) {
+        LV_LOG_ERROR("draw_buf has no handlers, maybe not initialized");
+        return;
+    }
+
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     canvas->draw_buf = draw_buf;
 
@@ -365,6 +370,7 @@ void lv_canvas_fill_bg(lv_obj_t * obj, lv_color_t color, lv_opa_t opa)
         }
     }
 
+    lv_draw_buf_flush_cache(canvas->draw_buf, NULL);
     lv_obj_invalidate(obj);
 }
 

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -46,10 +46,21 @@ void test_canvas_functions_invalidate(void)
     TEST_ASSERT(draw_counter == 0);
 
     LV_DRAW_BUF_DEFINE_STATIC(draw_buf, 100, 100, LV_COLOR_FORMAT_NATIVE);
+
+    /* test uninitialized draw buffer, it should fail.*/
+    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    TEST_ASSERT_NULL(lv_canvas_get_draw_buf(canvas));
+    TEST_ASSERT_NULL(lv_canvas_get_image(canvas));
+    TEST_ASSERT_NULL(lv_canvas_get_buf(canvas));
+
     LV_DRAW_BUF_INIT_STATIC(draw_buf);
     canvas_draw_buf_reshape(&draw_buf);
 
     lv_canvas_set_draw_buf(canvas, &draw_buf);
+    TEST_ASSERT_EQUAL_PTR(lv_canvas_get_draw_buf(canvas), &draw_buf);
+    TEST_ASSERT_EQUAL_PTR(lv_canvas_get_image(canvas), &draw_buf);
+    TEST_ASSERT_EQUAL_PTR(lv_canvas_get_buf(canvas), draw_buf.unaligned_data);
+
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 1);
 


### PR DESCRIPTION
1. Fixed `demo_render` uninitialized draw buffer issue.
2. Added `draw_buf->handlers` check.
3. Added D-cache synchronization.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
