### PR TITLE
fix(wayland): throw error when using dmabuf without 2 draw buffers

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -18,6 +18,10 @@
     #error "Wayland doesn't support more than 1 LV_WAYLAND_BUF_COUNT without DMABUF"
 #endif
 
+#if LV_WAYLAND_USE_DMABUF && LV_WAYLAND_BUF_COUNT != 2
+    #error "Wayland with DMABUF only supports 2 LV_WAYLAND_BUF_COUNT"
+#endif
+
 #if LV_WAYLAND_USE_DMABUF && !LV_USE_DRAW_G2D
     #error "LV_WAYLAND_USE_DMABUF requires LV_USE_DRAW_G2D"
 #endif


### PR DESCRIPTION
When using wayland with dmabuf, the application freezes if we're using a single draw buffer.
In the future we should remove this limitation but for now this PR prevents compiling an application with an invalid configuration that won't work in runtime