### PR TITLE
feat(workflows): add gcover report

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -177,7 +177,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
-        path: report/
+        path: tests/report/
 
     - name: Comment coverage results on PR
       if: github.event_name == 'pull_request'
@@ -186,17 +186,33 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
-          const coverageSummary = fs.readFileSync('report/index.html', 'utf8');
-          const coverageLines = coverageSummary.match(/Lines: \d+\.\d+% \(\d+\/\d+\)/g);
-          const coverageBranches = coverageSummary.match(/Branches: \d+\.\d+% \(\d+\/\d+\)/g);
-          
-          const comment = `### Code Coverage Report
-          **Lines:** ${coverageLines[0]}
-          **Branches:** ${coverageBranches[0]}
-          
-          [Detailed Coverage Report](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+          let comment;
+          try {
+            if (fs.existsSync('tests/report/index.html')) {
+              const coverageSummary = fs.readFileSync('tests/report/index.html', 'utf8');
 
-          github.rest.issues.createComment({
+              const coverageLines = coverageSummary.match(/Lines: \d+(?:\.\d+)?% \(\d+\/\d+\)/g) || ['N/A'];
+              const coverageBranches = coverageSummary.match(/Branches: \d+(?:\.\d+)?% \(\d+\/\d+\)/g) || ['N/A'];
+
+              const comment = `### Code Coverage Report
+              **Lines:** ${coverageLines[0]}
+              **Branches:** ${coverageBranches[0]}
+
+              [Detailed Coverage Report](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+            } else {
+              comment = `### Code Coverage Report
+              Coverage report not found. The coverage report could not be generated or is missing.
+
+              [Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+            }
+          } catch (error) {
+            comment = `### Code Coverage Report
+            Error reading coverage report: ${error.message}
+
+            [Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+          }
+
+          await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -173,7 +173,7 @@ jobs:
         exit 1
 
     - name: Upload coverage reports as artifacts
-      if: always()  
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: coverage-reports-${{ matrix.build_config }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -172,3 +172,34 @@ jobs:
         echo "Failing the build due to newly generated reference images."
         exit 1
 
+    - name: Upload coverage report
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: report/
+
+    - name: Comment coverage results on PR
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs');
+          const coverageSummary = fs.readFileSync('report/index.html', 'utf8');
+          const coverageLines = coverageSummary.match(/Lines: \d+\.\d+% \(\d+\/\d+\)/g);
+          const coverageBranches = coverageSummary.match(/Branches: \d+\.\d+% \(\d+\/\d+\)/g);
+          
+          const comment = `### Code Coverage Report
+          **Lines:** ${coverageLines[0]}
+          **Branches:** ${coverageBranches[0]}
+          
+          [Detailed Coverage Report](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment
+          });
+

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -172,50 +172,9 @@ jobs:
         echo "Failing the build due to newly generated reference images."
         exit 1
 
-    - name: Upload coverage report
-      if: github.event_name == 'pull_request'
+    - name: Upload coverage reports as artifacts
+      if: always()  
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report
+        name: coverage-reports-${{ matrix.build_config }}
         path: tests/report/
-
-    - name: Comment coverage results on PR
-      if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const fs = require('fs');
-          let comment;
-          try {
-            if (fs.existsSync('tests/report/index.html')) {
-              const coverageSummary = fs.readFileSync('tests/report/index.html', 'utf8');
-
-              const coverageLines = coverageSummary.match(/Lines: \d+(?:\.\d+)?% \(\d+\/\d+\)/g) || ['N/A'];
-              const coverageBranches = coverageSummary.match(/Branches: \d+(?:\.\d+)?% \(\d+\/\d+\)/g) || ['N/A'];
-
-              const comment = `### Code Coverage Report
-              **Lines:** ${coverageLines[0]}
-              **Branches:** ${coverageBranches[0]}
-
-              [Detailed Coverage Report](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
-            } else {
-              comment = `### Code Coverage Report
-              Coverage report not found. The coverage report could not be generated or is missing.
-
-              [Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
-            }
-          } catch (error) {
-            comment = `### Code Coverage Report
-            Error reading coverage report: ${error.message}
-
-            [Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
-          }
-
-          await github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: comment
-          });
-

--- a/tests/main.py
+++ b/tests/main.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
     if args.report:
         generate_code_coverage_report()
 
-    # Clean the all build directory after report
+    # Clean all build directories after report
     for build_dir in clean_build_dirs:
         print(f"Removing {build_dir}")
         shutil.rmtree(build_dir)

--- a/tests/main.py
+++ b/tests/main.py
@@ -213,6 +213,17 @@ def generate_test_images():
                     print(f"converting {os.path.basename(png)}, format: {fmt.name}, compress: {compress_name}")
 
 
+def clean_build_dirs_with_filter(build_dir, filter_name):
+    for entry in os.listdir(build_dir):
+        entry_path = os.path.join(build_dir, entry)
+        if entry == filter_name:
+            continue
+        if os.path.isfile(entry_path):
+            os.remove(entry_path)
+        elif os.path.isdir(entry_path):
+            shutil.rmtree(entry_path)
+
+
 if __name__ == "__main__":
     epilog = '''This program builds and optionally runs the LVGL test programs.
     There are two types of LVGL tests: "build", and "test". The build-only
@@ -256,6 +267,7 @@ if __name__ == "__main__":
         else:
             options_to_build = test_options
 
+    clean_build_dirs = []
     for options_name in options_to_build:
         is_test = options_name in test_options
         is_perf_test = options_name in perf_test_options
@@ -274,10 +286,23 @@ if __name__ == "__main__":
                 run_tests(options_name, args.test_suite)
             except subprocess.CalledProcessError as e:
                 sys.exit(e.returncode)
+
         if args.auto_clean:
             build_dir = get_build_dir(options_name)
-            print("Removing " + build_dir)
-            shutil.rmtree(build_dir)
+
+            # Clean the build directory without CMakeFiles directory for report
+            if args.report:
+                clean_build_dirs_with_filter(build_dir, 'CMakeFiles')
+                print(f"Append {build_dir} to clean list")
+                clean_build_dirs.append(build_dir)
+            else:
+                print(f"Removing {build_dir}")
+                shutil.rmtree(build_dir)
 
     if args.report:
         generate_code_coverage_report()
+
+    # Clean the all build directory after report
+    for build_dir in clean_build_dirs:
+        print(f"Removing {build_dir}")
+        shutil.rmtree(build_dir)

--- a/tests/main.py
+++ b/tests/main.py
@@ -213,11 +213,13 @@ def generate_test_images():
                     print(f"converting {os.path.basename(png)}, format: {fmt.name}, compress: {compress_name}")
 
 
-def clean_build_dirs_with_filter(build_dir, filter_name):
+def clean_build_dirs_with_filter(build_dir, clean_filters):
     for entry in os.listdir(build_dir):
         entry_path = os.path.join(build_dir, entry)
-        if entry == filter_name:
+
+        if any(entry.endswith(filter) for filter in clean_filters):
             continue
+
         if os.path.isfile(entry_path):
             os.remove(entry_path)
         elif os.path.isdir(entry_path):
@@ -290,12 +292,15 @@ if __name__ == "__main__":
         if args.auto_clean:
             build_dir = get_build_dir(options_name)
 
-            # Clean the build directory without CMakeFiles directory for report
             if args.report:
-                clean_build_dirs_with_filter(build_dir, 'CMakeFiles')
+                # Keep the files that gcovr analysis depends on and delete
+                # the rest to solve the storage capacity limit of GitHub CI
+                clean_filters = ['CMakeFiles', '.c']
+                clean_build_dirs_with_filter(build_dir, clean_filters)
                 print(f"Append {build_dir} to clean list")
                 clean_build_dirs.append(build_dir)
             else:
+                # Remove all build directories directly
                 print(f"Removing {build_dir}")
                 shutil.rmtree(build_dir)
 


### PR DESCRIPTION
1. Add the gcover automatic reporting workflow.
2. Fixed the issue of automatically cleaning up and prematurely deleting gcov dependency files.
3. Temporarily retain CMakeFiles for generating report files, and delete other files to address the limitation of Github CI hard disk space.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
