### PR TITLE
fix(draw/pxp): fix alignment issue on cache flush.

### DIFF
--- a/src/draw/nxp/pxp/lv_draw_buf_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_buf_pxp.c
@@ -79,8 +79,8 @@ static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * 
     }
 
     const uint8_t * buf_u8 = draw_buf->data;
-    /* ARM require a 32 byte aligned address. */
-    uint8_t align_bytes = 32;
+    /*Cache management requires us to know the cache line size for proper alignment */
+    uint8_t align_bytes = __SCB_DCACHE_LINE_SIZE;
     uint8_t bits_per_pixel = lv_color_format_get_bpp(cf);
 
     uint16_t align_pixels = align_bytes * 8 / bits_per_pixel;

--- a/src/draw/nxp/pxp/lv_pxp_cfg.h
+++ b/src/draw/nxp/pxp/lv_pxp_cfg.h
@@ -27,6 +27,10 @@ extern "C" {
 #include "fsl_cache.h"
 #include "fsl_pxp.h"
 
+#if ((LV_DRAW_BUF_ALIGN % 32) != 0)
+#error "If PXP is enabled the draw buffers should be aligned to 32-byte boundary, please set LV_DRAW_BUF_ALIGN to a multiple of 32 in lv_conf.h"
+#endif
+
 #include "../../../misc/lv_log.h"
 
 /*********************


### PR DESCRIPTION
* Update PXP to raise an error if the draw buffer alignment does not meet PXP reqs.
* Use the target D-cache line size to calculate address alignment before flush

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
