### PR TITLE
fix(opengles): fix widget Y coordinate being reversed

### DIFF
--- a/src/drivers/glfw/lv_opengles_driver.c
+++ b/src/drivers/glfw/lv_opengles_driver.c
@@ -220,7 +220,7 @@ static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * 
     float hor_scale = tex_w / (float)disp_w;
     float ver_scale = tex_h / (float)disp_h;
     float hor_translate = (float)intersection.x1 / (float)disp_w * 2.0f - (1.0f - hor_scale);
-    float ver_translate = -((float)intersection.y1 / (float)disp_h * 2.0f - (1.0f - ver_scale));
+    float ver_translate = (float)intersection.y1 / (float)disp_h * 2.0f - (1.0f - ver_scale);
     hor_scale = h_flip ? -hor_scale : hor_scale;
     ver_scale = v_flip ? -ver_scale : ver_scale;
     float matrix[9] = {


### PR DESCRIPTION
I’m not sure if this is a bug, or an intentional design, or an issue with my OpenGL environment?
Here's my configuration file: [lv_conf.zip](https://github.com/user-attachments/files/22070662/lv_conf.zip)

This is the OpenGL initialization method I wrote based on the documentation:

```c
static lv_disp_t* hal_init(int32_t w, int32_t h)
{
#if LV_USE_DRAW_OPENGLES
    /* create a window and initialize OpenGL */
    lv_glfw_window_t * window = lv_glfw_window_create(w, h, true);

    /* create a display that flushes to a texture */
    lv_display_t * disp = lv_opengles_texture_create(w, h);
    lv_display_set_default(disp);

    /* add the texture to the window */
    unsigned int texture_id = lv_opengles_texture_get_texture_id(disp);
    lv_glfw_texture_t * window_texture = lv_glfw_window_add_texture(window, texture_id, w, h);

    /* get the mouse indev of the window texture */
    lv_indev_t * mouse = lv_glfw_texture_get_mouse_indev(window_texture);
    lv_indev_set_group(mouse, lv_group_get_default());
    lv_indev_set_disp(mouse, disp);
#endif

    return disp;
}
```

Before fix:

<img width="500" height="535" alt="image" src="https://github.com/user-attachments/assets/b3b8fafa-3226-42f5-b62d-508de3e86979" />

After fix:

<img width="500" height="535" alt="image" src="https://github.com/user-attachments/assets/e8ef1a19-f682-43ad-8730-b625738002bf" />

It seems there's still a problem with the clipping process:

<img width="500" height="535" alt="image" src="https://github.com/user-attachments/assets/2a01fa60-ea8a-4ac9-97ee-25fc0d64a34b" />

I guess it is caused by the inconsistency of the default Y-axis direction between OpenGL and LVGL.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
