### PR TITLE
test: fix syntax warning by using invalid escape sequence '\.'

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -182,7 +182,7 @@ def generate_code_coverage_report():
            '--root', root_dir, '--html-details', '--output',
            html_report_file, '--xml', 'report/coverage.xml',
            '-j', str(os.cpu_count()), '--print-summary',
-           '--html-title', 'LVGL Test Coverage', '--filter', os.path.join(root_dir, 'src/.*/lv_.*\.c')]
+           '--html-title', 'LVGL Test Coverage', '--filter', os.path.join(root_dir, 'src/.*/lv_.*\\.c')]
 
     subprocess.check_call(cmd)
     print("Done: See %s" % html_report_file, flush=True)


### PR DESCRIPTION
Fixes this error:

```bash
lvgl/tests/main.py:185: SyntaxWarning: invalid escape sequence '\.'
  '--html-title', 'LVGL Test Coverage', '--filter', os.path.join(root_dir, 'src/.*/lv_.*\.c')]
```
