### PR TITLE
fix(cache): make the cache module private

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -36,7 +36,6 @@ extern "C" {
 #include "src/misc/lv_iter.h"
 #include "src/misc/lv_circle_buf.h"
 #include "src/misc/lv_tree.h"
-#include "src/misc/cache/lv_cache.h"
 
 #include "src/tick/lv_tick.h"
 

--- a/lvgl_private.h
+++ b/lvgl_private.h
@@ -18,6 +18,7 @@ extern "C" {
 #include "src/display/lv_display_private.h"
 #include "src/indev/lv_indev_private.h"
 #include "src/misc/lv_text_private.h"
+#include "src/misc/cache/lv_cache.h"
 #include "src/misc/cache/lv_cache_entry_private.h"
 #include "src/misc/cache/lv_cache_private.h"
 #include "src/layouts/lv_layout_private.h"

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -17,7 +17,6 @@ extern "C" {
 
 #if LV_USE_DRAW_SDL
 
-#include "../../misc/cache/lv_cache.h"
 #include "../../misc/lv_area.h"
 #include "../../misc/lv_color.h"
 #include "../../display/lv_display.h"

--- a/src/libs/barcode/lv_barcode.c
+++ b/src/libs/barcode/lv_barcode.c
@@ -13,6 +13,7 @@
 #if LV_USE_BARCODE
 
 #include "code128.h"
+#include "../../misc/cache/lv_cache.h"
 
 /*********************
  *      DEFINES

--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -11,6 +11,7 @@
 
 #if LV_USE_QRCODE
 
+#include "../../misc/cache/lv_cache.h"
 #include "qrcodegen.h"
 
 /*********************

--- a/tests/src/test_cases/draw/test_draw_svg.c
+++ b/tests/src/test_cases/draw/test_draw_svg.c
@@ -1,5 +1,6 @@
 #if LV_BUILD_TEST
 #include "../lvgl.h"
+#include "../src/misc/cache/lv_cache.h"
 
 #include <string.h>
 


### PR DESCRIPTION
Fixes #8690  <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

We're making this module private as it should've never been made public in the first place

The other solution would be to create a `create` or a `get` function for each cache class but we don't see the value of making this module public