### PR TITLE
fix(file_explorer): ensure current_path is null-terminated after appending '/'

### DIFF
--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -648,8 +648,11 @@ static void show_dir(lv_obj_t * obj, const char * path)
     lv_label_set_text_fmt(explorer->path_label, LV_SYMBOL_EYE_OPEN" %s", path);
 
     size_t current_path_len = lv_strlen(explorer->current_path);
-    if((explorer->current_path[current_path_len - 1] != '/') && (current_path_len < LV_FILE_EXPLORER_PATH_MAX_LEN)) {
-        *((explorer->current_path) + current_path_len) = '/';
+    if(current_path_len > 0 &&
+       explorer->current_path[current_path_len - 1] != '/' &&
+       current_path_len + 1 < sizeof(explorer->current_path)) {
+        explorer->current_path[current_path_len] = '/';
+        explorer->current_path[current_path_len + 1] = '\0';
     }
 }
 


### PR DESCRIPTION
## Description

This pull request addresses an issue where the `current_path` string in the `lv_file_explorer` component was not properly null-terminated after appending a `'/'`. This led to unexpected behavior when navigating back and reselecting folders.

### Changes Made

- Ensured that `current_path` is always null-terminated after modifying it.

### How to Verify

To verify this fix:

1. Navigate into a folder using the file explorer.
2. Press the back button to return to the previous directory.
3. Re-select the same folder; the `LV_EVENT_VALUE_CHANGED` event should now trigger correctly.