### PR TITLE
fix(sdl): The default size is fixed

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -368,7 +368,7 @@ static void window_create(lv_display_t * disp)
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
     dsc->zoom = 1.0;
 
-    int flag = SDL_WINDOW_RESIZABLE;
+    int flag = 0;
 #if LV_SDL_FULLSCREEN
     flag |= SDL_WINDOW_FULLSCREEN;
 #endif


### PR DESCRIPTION
Under tiling window managers like awesome, newly created windows immediately resize. Since we haven't provided an API for setting window sizes, this makes it impossible to precisely configure window dimensions in such environments. Therefore, resizing must be disabled by default.