### PR TITLE
docs(custom.css):  fix arrows in code blocks

### DIFF
--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -28,6 +28,7 @@
 body {
   --font-stack: "Inter", sans-serif;
   --font-stack--monospace: "Geist Mono", monospace;
+  font-variant-ligatures: none;
   --sidebar-item-font-size: 0.875rem;
   --sidebar-item-spacing-horizontal: 0.75rem;
   --sidebar-item-spacing-vertical: 0.5rem;


### PR DESCRIPTION
Previously, wherever the combination of "->" or "<-" appeared using the monospaced font, the font itself was translating the '>' or '<' into an arrow instead of an angle bracket.

This modification remedies that.  I do not believe that ligatures (combinations of characters) are used anywhere else, since the docs are in English.  Translations that use ligatures may need to apply this attribute less globally.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
