### PR TITLE
fix(label): make long dot mode compatible with static text

### DIFF
--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1277,12 +1277,12 @@ static void lv_label_refr_text(lv_obj_t * obj)
 static void lv_label_revert_dots(lv_obj_t * obj)
 {
     lv_label_t * label = (lv_label_t *)obj;
-    if(label->dot_begin != LV_LABEL_DOT_BEGIN_INV) {
+    if(label->dot_begin != LV_LABEL_DOT_BEGIN_INV && !label->static_txt) {
         for(int i = 0; i < LV_LABEL_DOT_NUM + 1 && label->dot[i]; i++) {
             label->text[label->dot_begin + i] = label->dot[i];
         }
-        label->dot_begin = LV_LABEL_DOT_BEGIN_INV;
     }
+    label->dot_begin = LV_LABEL_DOT_BEGIN_INV;
 }
 
 static void lv_label_set_dots(lv_obj_t * obj, uint32_t dot_begin)
@@ -1290,6 +1290,13 @@ static void lv_label_set_dots(lv_obj_t * obj, uint32_t dot_begin)
     lv_label_t * label = (lv_label_t *)obj;
     LV_ASSERT_MSG(label->dot_begin == LV_LABEL_DOT_BEGIN_INV, "Label dots already set");
     if(dot_begin != LV_LABEL_DOT_BEGIN_INV) {
+        /* setting dots modifies the string so the string must be modifiable */
+        if(label->static_txt) {
+            label->text = lv_strdup(label->text);
+            LV_ASSERT_MALLOC(label->text);
+            label->static_txt = 0;
+        }
+
         /*Save characters*/
         lv_strncpy(label->dot, &label->text[dot_begin], LV_LABEL_DOT_NUM + 1);
         label->dot_begin = dot_begin;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1290,16 +1290,15 @@ static void lv_label_set_dots(lv_obj_t * obj, uint32_t dot_begin)
     lv_label_t * label = (lv_label_t *)obj;
     LV_ASSERT_MSG(label->dot_begin == LV_LABEL_DOT_BEGIN_INV, "Label dots already set");
     if(dot_begin != LV_LABEL_DOT_BEGIN_INV) {
-        /* setting dots modifies the string so the string must be modifiable */
+        label->dot_begin = dot_begin;
+
         if(label->static_txt) {
-            label->text = lv_strdup(label->text);
-            LV_ASSERT_MALLOC(label->text);
-            label->static_txt = 0;
+            LV_LOG_WARN("Long mode \"dots\" is not supported with static text.");
+            return;
         }
 
         /*Save characters*/
         lv_strncpy(label->dot, &label->text[dot_begin], LV_LABEL_DOT_NUM + 1);
-        label->dot_begin = dot_begin;
 
         /*Overwrite up to LV_LABEL_DOT_NUM + 1 characters with dots and null terminator*/
         int i = 0;


### PR DESCRIPTION
```c
lv_obj_t * preview = lv_label_create(lv_screen_active());
lv_obj_set_width(preview, LV_PCT(100));
lv_label_set_long_mode(preview, LV_LABEL_LONG_MODE_DOTS);
lv_label_set_text_static(preview, "Loading");
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
