### PR TITLE
fix(draw/convert): fix duplicate c declaration symbol during docs build

### DIFF
--- a/src/draw/convert/helium/lv_draw_buf_convert_helium.h
+++ b/src/draw/convert/helium/lv_draw_buf_convert_helium.h
@@ -13,6 +13,8 @@ extern "C" {
 #include "../../../misc/lv_color.h"
 #include "../../lv_draw_buf.h"
 
+#if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM
+
 /*********************
  *      DEFINES
  *********************/
@@ -47,6 +49,7 @@ lv_result_t _lv_draw_buf_convert_premultiply_indexed_helium(lv_draw_buf_t * buf)
  */
 lv_result_t _lv_draw_buf_convert_premultiply_argb8888_helium(lv_draw_buf_t * buf);
 
+#endif /*LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM*/
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/draw/convert/neon/lv_draw_buf_convert_neon.h
+++ b/src/draw/convert/neon/lv_draw_buf_convert_neon.h
@@ -13,6 +13,8 @@ extern "C" {
 #include "../../../misc/lv_color.h"
 #include "../../lv_draw_buf.h"
 
+#if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
+
 /*********************
  *      DEFINES
  *********************/
@@ -47,7 +49,7 @@ lv_result_t _lv_draw_buf_convert_premultiply_indexed_neon(lv_draw_buf_t * buf);
  * @param buf     pointer to a draw buf
  */
 lv_result_t _lv_draw_buf_convert_premultiply_argb8888_neon(lv_draw_buf_t * buf);
-
+#endif /*LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON*/
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Fixes current CI failure https://github.com/lvgl/lvgl/actions/runs/17496374483/job/49698146788

```bash
/home/runner/work/lvgl/lvgl/docs/intermediate/API/draw/convert/neon/lv_draw_buf_convert_neon_h.rst:7: WARNING: Duplicate C declaration, also defined at API/draw/convert/helium/lv_draw_buf_convert_helium_h:7.
75
Declaration is '.. c:macro:: LV_DRAW_CONVERT_PREMULTIPLY_INDEXED(buf)'. [duplicate_declaration.c]
76
/home/runner/work/lvgl/lvgl/docs/intermediate/API/draw/convert/neon/lv_draw_buf_convert_neon_h.rst:7: WARNING: Duplicate C declaration, also defined at API/draw/convert/helium/lv_draw_buf_convert_helium_h:7.
```
