### PR TITLE
refactor(opengl): move opengl shader manager to opengles driver

### DIFF
--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -26,6 +26,8 @@ extern "C" {
  *      DEFINES
  *********************/
 
+#define GLSL_VERSION_PREFIX "#version 300 es\n"
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -78,7 +80,8 @@ typedef struct _lv_shader_program {
  * GLOBAL PROTOTYPES
  **********************/
 
-char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines);
+char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines,
+                                                 const lv_opengl_shader_t * includes_src, size_t num_items);
 
 lv_opengl_shader_program_t * lv_opengl_shader_program_create(uint32_t id);
 void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -8,7 +8,7 @@
 
 #include "../../../lv_conf_internal.h"
 
-#if LV_USE_GLTF
+#if LV_USE_OPENGLES
 #include "../lv_opengles_private.h"
 #include "../lv_opengles_debug.h"
 #include "../../../misc/lv_types.h"
@@ -78,6 +78,8 @@ typedef struct _lv_shader_program {
  * GLOBAL PROTOTYPES
  **********************/
 
+char* lv_opengl_shader_manager_process_includes(const char* c_src, const char* defines);
+
 lv_opengl_shader_program_t * lv_opengl_shader_program_create(uint32_t id);
 void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program);
 GLuint lv_opengl_shader_program_get_id(lv_opengl_shader_program_t * program);
@@ -105,5 +107,5 @@ lv_opengl_shader_program_t * lv_opengl_shader_manager_get_program(lv_opengl_shad
 } /*extern "C"*/
 #endif
 
-#endif /*LV_USE_GLTF*/
+#endif /*LV_USE_OPENGLES*/
 #endif /*LV_OPENGL_SHADER_INTERNAL_H*/

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -6,11 +6,11 @@
 #ifndef LV_OPENGL_SHADER_INTERNAL_H
 #define LV_OPENGL_SHADER_INTERNAL_H
 
-#include "../../../lv_conf_internal.h"
+#include "../../../../lv_conf_internal.h"
 
 #if LV_USE_GLTF
-#include "../../../drivers/opengles/lv_opengles_private.h"
-#include "../../../drivers/opengles/lv_opengles_debug.h"
+#include "../lv_opengles_private.h"
+#include "../lv_opengles_debug.h"
 #include "../../../misc/lv_types.h"
 #include "../../../misc/lv_rb_private.h"
 

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -6,7 +6,7 @@
 #ifndef LV_OPENGL_SHADER_INTERNAL_H
 #define LV_OPENGL_SHADER_INTERNAL_H
 
-#include "../../../../lv_conf_internal.h"
+#include "../../../lv_conf_internal.h"
 
 #if LV_USE_GLTF
 #include "../lv_opengles_private.h"

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -78,7 +78,7 @@ typedef struct _lv_shader_program {
  * GLOBAL PROTOTYPES
  **********************/
 
-char* lv_opengl_shader_manager_process_includes(const char* c_src, const char* defines);
+char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines);
 
 lv_opengl_shader_program_t * lv_opengl_shader_program_create(uint32_t id);
 void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -45,7 +45,7 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 
-static char* replace_word(const char* s, const char* f, const char* r);
+static char * replace_word(const char * s, const char * f, const char * r);
 
 static lv_rb_compare_res_t
 shader_source_compare_cb(const lv_opengl_shader_source_t * lhs,
@@ -321,25 +321,25 @@ void lv_opengl_shader_manager_destroy(lv_opengl_shader_manager_t * manager)
 }
 
 char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines,
-                                                 const lv_opengl_shader_t * includes_src, size_t num_items )
+                                                 const lv_opengl_shader_t * includes_src, size_t num_items)
 {
     if(!c_src || !defines || !includes_src) {
         return NULL;
     }
-    
+
     char * rep = replace_word(c_src, GLSL_VERSION_PREFIX, defines);
     if(!rep) return NULL;
 
-    const size_t needed_extra = strlen("\n#include <>") + 1;    
-    for (size_t i = 0; i < num_items; i++) {
-        char * search_str = (char *)lv_malloc( strlen(includes_src[i].name) + needed_extra);
+    const size_t needed_extra = strlen("\n#include <>") + 1;
+    for(size_t i = 0; i < num_items; i++) {
+        char * search_str = (char *)lv_malloc(strlen(includes_src[i].name) + needed_extra);
         if(!search_str) {
             free(rep);
             return NULL;
         }
 
         lv_snprintf(search_str, sizeof(search_str), "\n#include <%s>", includes_src[i].name);
-        
+
         char * new_rep = replace_word(rep, search_str, includes_src[i].source);
         lv_free(search_str);
         if(!new_rep) {
@@ -349,7 +349,7 @@ char * lv_opengl_shader_manager_process_includes(const char * c_src, const char 
         lv_free(rep);
         rep = new_rep;
     }
-    
+
     return rep;
 }
 
@@ -362,39 +362,39 @@ static char * replace_word(const char * source, const char * f, const char * r)
     if(!source || !f || !r || strlen(f) == 0 || strcmp(f, r) == 0 || !strstr(source, f)) {
         return lv_strdup(source);
     }
-    
+
     size_t s_len = strlen(source);
     size_t f_len = strlen(f);
     size_t r_len = strlen(r);
-    
+
     size_t count = 0;
     const char * temp = source;
     while((temp = strstr(temp, f)) != NULL) {
         count++;
         temp += f_len;
     }
-    
+
     size_t new_size = s_len + count * (r_len - f_len) + 1;
     char * result = lv_malloc(new_size);
     LV_ASSERT_MALLOC(result);
-    
+
     char * dest = result;
     const char * src = source;
     const char * pos;
-    
+
     while((pos = strstr(src, f)) != NULL) {
         size_t prefix_len = pos - src;
         memcpy(dest, src, prefix_len);
         dest += prefix_len;
-        
+
         memcpy(dest, r, r_len);
         dest += r_len;
-        
+
         src = pos + f_len;
     }
-    
+
     strcpy(dest, src);
-    
+
     return result;
 }
 

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -190,9 +190,9 @@ uint32_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * sha
     }
 
     uint32_t hash = lv_opengl_shader_hash(shader_identifier);
-    if (needed_buffer_size > 0) {
+    if(needed_buffer_size > 0) {
         needed_buffer_size += 1;
-        char* define = (char *)lv_malloc(needed_buffer_size);
+        char * define = (char *)lv_malloc(needed_buffer_size);
         for(size_t i = 0; i < permutations_len; ++i) {
             if(permutations[i].value) {
                 lv_snprintf(define, needed_buffer_size, "%s%s", permutations[i].name, permutations[i].value);
@@ -320,13 +320,46 @@ void lv_opengl_shader_manager_destroy(lv_opengl_shader_manager_t * manager)
 
 }
 
+char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines,
+                                                 const lv_opengl_shader_t * includes_src, size_t num_items )
+{
+    if(!c_src || !defines || !includes_src) {
+        return NULL;
+    }
+    
+    char * rep = replace_word(c_src, GLSL_VERSION_PREFIX, defines);
+    if(!rep) return NULL;
+
+    const size_t needed_extra = strlen("\n#include <>") + 1;    
+    for (size_t i = 0; i < num_items; i++) {
+        char * search_str = (char *)lv_malloc( strlen(includes_src[i].name) + needed_extra);
+        if(!search_str) {
+            free(rep);
+            return NULL;
+        }
+
+        lv_snprintf(search_str, sizeof(search_str), "\n#include <%s>", includes_src[i].name);
+        
+        char * new_rep = replace_word(rep, search_str, includes_src[i].source);
+        lv_free(search_str);
+        if(!new_rep) {
+            free(rep);
+            return NULL;
+        }
+        lv_free(rep);
+        rep = new_rep;
+    }
+    
+    return rep;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static char* replace_word(const char* source, const char* f, const char* r)
+static char * replace_word(const char * source, const char * f, const char * r)
 {
-    if (!source || !f || !r || strlen(f) == 0 || strcmp(f, r) == 0 || !strstr(source, f)) {
+    if(!source || !f || !r || strlen(f) == 0 || strcmp(f, r) == 0 || !strstr(source, f)) {
         return lv_strdup(source);
     }
     
@@ -335,21 +368,21 @@ static char* replace_word(const char* source, const char* f, const char* r)
     size_t r_len = strlen(r);
     
     size_t count = 0;
-    const char* temp = source;
-    while ((temp = strstr(temp, f)) != NULL) {
+    const char * temp = source;
+    while((temp = strstr(temp, f)) != NULL) {
         count++;
         temp += f_len;
     }
     
     size_t new_size = s_len + count * (r_len - f_len) + 1;
-    char* result = lv_malloc(new_size);
+    char * result = lv_malloc(new_size);
     LV_ASSERT_MALLOC(result);
     
-    char* dest = result;
-    const char* src = source;
-    const char* pos;
+    char * dest = result;
+    const char * src = source;
+    const char * pos;
     
-    while ((pos = strstr(src, f)) != NULL) {
+    while((pos = strstr(src, f)) != NULL) {
         size_t prefix_len = pos - src;
         memcpy(dest, src, prefix_len);
         dest += prefix_len;
@@ -363,32 +396,6 @@ static char* replace_word(const char* source, const char* f, const char* r)
     strcpy(dest, src);
     
     return result;
-}
-
-char* lv_opengl_shader_manager_process_includes(const char* c_src, const char* defines, const lv_opengl_shader_t *includes_src, size_t num_items )
-{
-    if (!c_src || !defines || !includes_src) {
-        return NULL;
-    }
-    
-    char* rep = replace_word(c_src, GLSL_VERSION_PREFIX, defines);
-    if (!rep) return NULL;
-
-    const size_t needed_extra = strlen("\n#include <>") + 1;    
-    for (size_t i = 0; i < num_items; i++) {
-        char *search_str = (char *)lv_malloc( strlen(includes_src[i].name) + needed_extra );
-        if (!search_str) { free(rep); return NULL; }
-
-        lv_snprintf(search_str, sizeof(search_str),"\n#include <%s>",includes_src[i].name);
-        
-        char* new_rep = replace_word(rep, search_str, includes_src[i].source);
-        lv_free(search_str);
-        if (!new_rep) { free(rep); return NULL; }
-        lv_free(rep);
-        rep = new_rep;
-    }
-    
-    return rep;
 }
 
 static lv_rb_compare_res_t

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -7,6 +7,7 @@
 /*********************
  *      INCLUDES
  *********************/
+
 #include "../../../lv_conf_internal.h"
 #if LV_USE_OPENGLES
 #include "lv_opengl_shader_internal.h"

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -8,7 +8,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_conf_internal.h"
+#include "../../../../lv_conf_internal.h"
 #if LV_USE_GLTF
 #include "lv_opengl_shader_internal.h"
 #include "../../../misc/lv_assert.h"

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -7,8 +7,7 @@
 /*********************
  *      INCLUDES
  *********************/
-
-#include "../../../../lv_conf_internal.h"
+#include "../../../lv_conf_internal.h"
 #if LV_USE_GLTF
 #include "lv_opengl_shader_internal.h"
 #include "../../../misc/lv_assert.h"

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -21,8 +21,6 @@
 #include "../lv_opengles_debug.h"
 #include "../../../stdlib/lv_string.h"
 
-#include <GL/glew.h>
-//#include <GLFW/glfw3.h>
 #include <string.h>
 
 /*********************
@@ -334,7 +332,7 @@ char * lv_opengl_shader_manager_process_includes(const char * c_src, const char 
     for(size_t i = 0; i < num_items; i++) {
         char * search_str = (char *)lv_malloc(strlen(includes_src[i].name) + needed_extra);
         if(!search_str) {
-            free(rep);
+            lv_free(rep);
             return NULL;
         }
 
@@ -343,7 +341,7 @@ char * lv_opengl_shader_manager_process_includes(const char * c_src, const char 
         char * new_rep = replace_word(rep, search_str, includes_src[i].source);
         lv_free(search_str);
         if(!new_rep) {
-            free(rep);
+            lv_free(rep);
             return NULL;
         }
         lv_free(rep);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
@@ -11,8 +11,8 @@
 
 #if LV_USE_GLTF
 
-#include "../../../drivers/opengles/lv_opengles_private.h"
-#include "../../../drivers/opengles/lv_opengles_debug.h"
+#include "../lv_opengles_private.h"
+#include "../lv_opengles_debug.h"
 #include "../../../misc/lv_assert.h"
 #include "../../../stdlib/lv_mem.h"
 /*********************

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
@@ -9,7 +9,7 @@
 
 #include "lv_opengl_shader_internal.h"
 
-#if LV_USE_GLTF
+#if LV_USE_OPENGLES
 
 #include "../lv_opengles_private.h"
 #include "../lv_opengles_debug.h"
@@ -118,4 +118,4 @@ static void update_uniform_1f(lv_opengl_shader_program_t * program, const char *
     GL_CALL(glUniform1f(location, value));
 }
 
-#endif /*LV_USE_GLTF*/
+#endif /*LV_USE_OPENGLES*/

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
@@ -5,7 +5,7 @@
 #if LV_USE_GLTF
 #include <GL/glew.h>
 #include <GL/gl.h>
-#include "../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 #include "../../../draw/lv_image_dsc.h"
 #include "../../../misc/lv_types.h"
 

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
@@ -13,8 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-
-#include "../../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
@@ -21,8 +21,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define GLSL_VERSION_PREFIX "#version 300 es\n"
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
@@ -17,7 +17,7 @@
 #include "../../../../drivers/opengles/lv_opengles_private.h"
 #include "../../../../drivers/opengles/lv_opengles_debug.h"
 
-#include "../../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 #include "../lv_gltf_view_internal.h"
 #include "../assets/lv_gltf_view_shader.h"
 

--- a/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.h
+++ b/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #if LV_USE_GLTF
 #include "../../../../misc/lv_types.h"
-#include "../../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 #include "../lv_gltf_view_internal.h"
 
 /*********************

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -16,7 +16,7 @@
 
 #include "lv_gltf.h"
 #include "../../../misc/lv_types.h"
-#include "../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 #include "../../../widgets/3dtexture/lv_3dtexture_private.h"
 #include "../gltf_data/lv_gltf_data_internal.h"
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -12,7 +12,7 @@
 #include "fastgltf/types.hpp"
 #include "../gltf_data/lv_gltf_data_internal.hpp"
 #include "../gltf_data/lv_gltf_data_internal.h"
-#include "../opengl_shader/lv_opengl_shader_internal.h"
+#include "../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"
 #include "../../../misc/lv_array.h"
 #include "../../../misc/lv_assert.h"
 #include "../../../misc/lv_types.h"


### PR DESCRIPTION
Moved to better implement the opengl shader in other parts of LVGL.  This is setup for future PRs which will phase-in more optimized shaders.  It will enable them to use preprocessor blocks to create shader variants per GPU logic branch, which removes those checks from the runtime overhead.