### PR TITLE
chore(kconfig): add missing LV_OS_SDL2 option to LV_USE_OS

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -143,6 +143,8 @@ menu "LVGL configuration"
 				bool "5: WINDOWS"
 			config LV_OS_MQX
 				bool "6: MQX"
+			config LV_OS_SDL2
+				bool "7: SDL2"
 			config LV_OS_CUSTOM
 				bool "255: CUSTOM"
 		endchoice


### PR DESCRIPTION
Add missing LV_OS_SDL2 option to Kconfig under the LV_USE_OS choice to match src/lv_conf_internal.h.