### PR TITLE
fix(opengl): fix multiple issues with shader manipulation

### DIFF
--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -180,27 +180,17 @@ uint32_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * sha
     }
 
     /* Then hash the name with the permutations and see if we already compiled it */
-    size_t needed_buffer_size = 0;
+    char define[512];
+    uint32_t hash = lv_opengl_shader_hash(shader_identifier);
     for(size_t i = 0; i < permutations_len; ++i) {
         LV_ASSERT_NULL(permutations[i].name);
-        needed_buffer_size += strlen(permutations[i].name);
-        if(permutations[i].value) needed_buffer_size += strlen(permutations[i].value);
-    }
-
-    uint32_t hash = lv_opengl_shader_hash(shader_identifier);
-    if(needed_buffer_size > 0) {
-        needed_buffer_size += 1;
-        char * define = (char *)lv_malloc(needed_buffer_size);
-        for(size_t i = 0; i < permutations_len; ++i) {
-            if(permutations[i].value) {
-                lv_snprintf(define, needed_buffer_size, "%s%s", permutations[i].name, permutations[i].value);
-            }
-            else {
-                lv_snprintf(define, needed_buffer_size, "%s", permutations[i].name);
-            }
-            hash ^= lv_opengl_shader_hash(define);
+        if(permutations[i].value) {
+            lv_snprintf(define, sizeof(define), "%s%s", permutations[i].name, permutations[i].value);
         }
-        lv_free(define);
+        else {
+            lv_snprintf(define, sizeof(define), "%s", permutations[i].name);
+        }
+        hash ^= lv_opengl_shader_hash(define);
     }
     lv_opengl_compiled_shader_t shader_map_key = { hash, 0 };
     lv_rb_node_t * shader_map_node =

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -309,32 +309,28 @@ void lv_opengl_shader_manager_destroy(lv_opengl_shader_manager_t * manager)
 }
 
 char * lv_opengl_shader_manager_process_includes(const char * c_src, const char * defines,
-                                                 const lv_opengl_shader_t * includes_src, size_t num_items)
+                                                 const lv_opengl_shader_t * src_includes, size_t num_items)
 {
-    if(!c_src || !defines || !includes_src) {
+
+    if(!c_src || !defines || !src_includes) {
         return NULL;
     }
 
     char * rep = replace_word(c_src, GLSL_VERSION_PREFIX, defines);
-    if(!rep) return NULL;
+    if(!rep) {
+        return NULL;
+    }
 
-    const size_t needed_extra = strlen("\n#include <>") + 1;
+    char search_str[255];
+
     for(size_t i = 0; i < num_items; i++) {
-        char * search_str = (char *)lv_malloc(strlen(includes_src[i].name) + needed_extra);
-        if(!search_str) {
-            lv_free(rep);
-            return NULL;
-        }
+        lv_snprintf(search_str, sizeof(search_str), "\n#include <%s>", src_includes[i].name);
 
-        lv_snprintf(search_str, sizeof(search_str), "\n#include <%s>", includes_src[i].name);
-
-        char * new_rep = replace_word(rep, search_str, includes_src[i].source);
-        lv_free(search_str);
-        if(!new_rep) {
-            lv_free(rep);
-            return NULL;
-        }
+        char * new_rep = replace_word(rep, search_str, src_includes[i].source);
         lv_free(rep);
+        if(!new_rep) {
+            return NULL;
+        }
         rep = new_rep;
     }
 

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
@@ -5,7 +5,7 @@
 #include "../../../../stdlib/lv_sprintf.h"
 #include <string.h>
 
-const lv_opengl_shader_t src_includes[] = {
+static const lv_opengl_shader_t src_includes[] = {
 	{ "tonemapping.glsl", R"(
 
         uniform float u_Exposure;
@@ -2696,7 +2696,7 @@ const lv_opengl_shader_t src_includes[] = {
     )" },
 };
 
-static lv_opengl_shader_t env_src_includes[] = {
+static const lv_opengl_shader_t env_src_includes[] = {
 	{ "fullscreen.vert", R"(
         precision highp float;
 


### PR DESCRIPTION
Since f1faa9b1eed8efaec52a7a4436fecf0d09b79e25

Before:
```bash
[Error]	(0.152, +152)	lv_glew_init: glewInit fail: 4. lv_opengles_glfw.c:398
[Error]	(0.291, +139)	compile_shader: Failed to compile shader: 0(179) : error C0000: syntax error, unexpected '<', expecting "::" at token "<"
0(184) : error C1038: declaration of "STANDARD_GAMMA" conflicts with previous declaration at 0(45)
0(185) : error C1038: declaration of "GAMMA" conflicts with previous declaration at 0(46)
0(186) : error C1038: declaration of "INV_GAMMA" conflicts with previous declaration at 0(47)
0(190) : error C1038: declaration of "ACESInputMat" conflicts with previous declaration at 0(51)
0(199) : error C1038: declaration of "ACESOutputMat lv_opengl_shader_manager.c:443
[Error]	(0.291, +0)	compile_shader: Asserted at expression: shader_compiled (Couldn't compile shader) lv_opengl_shader_manager.c:444
```
Now:

![Uploading image.png…]()


This PR essentially reverts the changes done to these functions to allow the code to work again. It also fixes some minor issues with the version pre-f1faa9b1eed8efaec52a7a4436fecf0d09b79e25

cc @FishOfTheNorthStar 
