### PR TITLE
refactor(opengles): mainline usage of shader manager in opengl driver

### DIFF
--- a/src/drivers/opengles/assets/lv_opengles_standard_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_standard_shader.c
@@ -1,0 +1,139 @@
+#include "lv_opengles_standard_shader.h"
+
+#if LV_USE_OPENGLES
+
+#include "../../../stdlib/lv_sprintf.h"
+#include <string.h>
+
+static const lv_opengl_shader_t src_includes[] = {
+	{ "hsv_adjust.glsl", R"(
+        
+        uniform float u_Hue;
+        uniform float u_Saturation;
+        uniform float u_Value;
+
+        vec3 rgb2hsv(vec3 c){
+            float M = max(max(c.r,c.g),c.b);
+            float m = min(min(c.r,c.g),c.b);
+            float d = M - m;
+            float h = 0.0;
+            if(d > 0.00001){
+                if(M == c.r) h = mod((c.g - c.b)/d, 6.0);
+                else if(M == c.g) h = (c.b - c.r)/d + 2.0;
+                else h = (c.r - c.g)/d + 4.0;
+                h /= 6.0;
+            }
+            float s = (M <= 0.00001) ? 0.0 : d / M;
+            return vec3(h, s, M);
+        }
+
+        vec3 hsv2rgb(vec3 c){
+            float h = c.x * 6.0;
+            float i = floor(h);
+            float f = h - i;
+            float p = c.z * (1.0 - c.y);
+            float q = c.z * (1.0 - c.y * f);
+            float t = c.z * (1.0 - c.y * (1.0 - f));
+            if(i == 0.0) return vec3(c.z, t, p);
+            if(i == 1.0) return vec3(q, c.z, p);
+            if(i == 2.0) return vec3(p, c.z, t);
+            if(i == 3.0) return vec3(p, q, c.z);
+            if(i == 4.0) return vec3(t, p, c.z);
+            return vec3(c.z, p, q);
+        }
+
+        vec3 adjustHSV(vec3 color){
+            vec3 hsv = rgb2hsv(color);
+            hsv.x = fract(hsv.x + u_Hue);
+            hsv.y = clamp(hsv.y * u_Saturation, 0.0, 1.0);
+            hsv.z = clamp(hsv.z * u_Value, 0.0, 1.0);
+            return hsv2rgb(hsv);
+        }
+    )" },
+	{ "brightness_adjust.glsl", R"(
+        uniform float u_Brightness; // add/subtract in [ -1.0 .. +1.0 ], 0.0 = no change
+
+        vec3 adjustBrightness(vec3 color){
+            return clamp(color + vec3(u_Brightness), 0.0, 1.0);
+        }
+
+    )" },
+	{ "contrast_adjust.glsl", R"(
+        uniform float u_Contrast; // 0.0 = mid-gray, 1.0 = no change, >1.0 increases contrast
+
+        vec3 adjustContrast(vec3 color){
+            // shift to [-0.5..0.5], scale, shift back
+            return clamp(((color - 0.5) * u_Contrast) + 0.5, 0.0, 1.0);
+        }
+    )" },
+};
+
+static const char * src_vertex_shader = R"(
+    precision mediump float;
+    
+    in vec4 position;
+    in vec2 texCoord;
+    
+    out vec2 v_TexCoord;
+    
+    uniform mat3 u_VertexTransform;
+    
+    void main()
+    {
+        gl_Position = vec4((u_VertexTransform * vec3(position.xy, 1)).xy, position.zw);
+        v_TexCoord = texCoord;
+    }
+)";
+
+static const char *src_fragment_shader = R"(
+    precision lowp float;
+    
+    out vec4 color;
+    
+    in vec2 v_TexCoord;
+    
+    uniform sampler2D u_Texture;
+    uniform float u_ColorDepth;
+    uniform float u_Opa;
+    uniform bool u_IsFill;
+    uniform vec3 u_FillColor;
+    
+    void main()
+    {
+        vec4 texColor;
+        if (u_IsFill) {
+            texColor = vec4(u_FillColor, 1.0);
+        } else {
+            texColor = texture(u_Texture, v_TexCoord);
+        }
+        if (abs(u_ColorDepth - 8.0) < 0.1) {
+            float gray = texColor.r;
+            color = vec4(gray, gray, gray, u_Opa);
+        } else {
+            float combinedAlpha = texColor.a * u_Opa;
+            color = vec4(texColor.rgb * combinedAlpha, combinedAlpha);
+        }
+    }
+)";
+
+const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+char* lv_opengles_standard_shader_get_vertex(void) {
+    return lv_opengl_shader_manager_process_includes(src_vertex_shader, GLSL_VERSION_PREFIX, src_includes, src_includes_count );
+}
+
+char* lv_opengles_standard_shader_get_fragment(void) {
+    return lv_opengl_shader_manager_process_includes(src_fragment_shader, GLSL_VERSION_PREFIX, src_includes, src_includes_count);
+}
+
+void lv_opengles_standard_shader_get_src(lv_opengl_shader_portions_t *portions)
+{
+	portions->all = src_includes;
+	portions->count = sizeof(src_includes) / sizeof(src_includes[0]);
+}
+
+#endif /*LV_USE_OPENGLES*/

--- a/src/drivers/opengles/assets/lv_opengles_standard_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_standard_shader.c
@@ -116,7 +116,7 @@ static const char *src_fragment_shader = R"(
     }
 )";
 
-const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
+static const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
 
 /**********************
  *   GLOBAL FUNCTIONS

--- a/src/drivers/opengles/assets/lv_opengles_standard_shader.h
+++ b/src/drivers/opengles/assets/lv_opengles_standard_shader.h
@@ -1,0 +1,38 @@
+/**
+ * @file lv_opengles_standard_shader.h
+ *
+ */
+
+#ifndef LV_OPENGLES_STANDARD_SHADER_H
+#define LV_OPENGLES_STANDARD_SHADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../opengl_shader/lv_opengl_shader_internal.h"
+
+#if LV_USE_OPENGLES
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+char *lv_opengles_standard_shader_get_vertex(void);
+char *lv_opengles_standard_shader_get_fragment(void);
+void lv_opengles_standard_shader_get_src(lv_opengl_shader_portions_t *portions);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_OPENGLES*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_OPENGLES_STANDARD_SHADER_H*/

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -17,6 +17,8 @@
 
 #include "../../display/lv_display.h"
 #include "../../misc/lv_area_private.h"
+#include "opengl_shader/lv_opengl_shader_internal.h"
+#include "assets/lv_opengles_standard_shader.h"
 
 /*********************
  *      DEFINES
@@ -49,8 +51,8 @@ static void lv_opengles_index_buffer_deinit(void);
 static unsigned int lv_opengles_index_buffer_get_count(void);
 static void lv_opengles_index_buffer_bind(void);
 static void lv_opengles_index_buffer_unbind(void);
-static unsigned int lv_opengles_shader_compile(unsigned int type, const char * source);
-static unsigned int lv_opengles_shader_create(const char * vertexShader, const char * fragmentShader);
+static void lv_opengles_shader_manager_init(void);
+static void lv_opengles_shader_program_init(void);
 static void lv_opengles_shader_init(void);
 static void lv_opengles_shader_deinit(void);
 static void lv_opengles_shader_bind(void);
@@ -72,6 +74,8 @@ static float lv_opengles_map_float(float x, float min_in, float max_in, float mi
  **********************/
 static bool is_init;
 
+static lv_opengl_shader_manager_t * shader_manager;
+
 static unsigned int vertex_buffer_id = 0;
 
 static unsigned int vertex_array_id = 0;
@@ -83,56 +87,6 @@ static unsigned int shader_id;
 
 static const char * shader_names[] = { "u_Texture", "u_ColorDepth", "u_VertexTransform", "u_Opa", "u_IsFill", "u_FillColor" };
 static int shader_location[] = { 0, 0, 0, 0, 0, 0 };
-
-static const char * vertex_shader =
-    "#version 300 es\n"
-    "\n"
-    "precision mediump float;\n"
-    "\n"
-    "in vec4 position;\n"
-    "in vec2 texCoord;\n"
-    "\n"
-    "out vec2 v_TexCoord;\n"
-    "\n"
-    "uniform mat3 u_VertexTransform;\n"
-    "\n"
-    "void main()\n"
-    "{\n"
-    "    gl_Position = vec4((u_VertexTransform * vec3(position.xy, 1)).xy, position.zw);\n"
-    "    v_TexCoord = texCoord;\n"
-    "}\n";
-
-static const char * fragment_shader =
-    "#version 300 es\n"
-    "\n"
-    "precision lowp float;\n"
-    "\n"
-    "out vec4 color;\n"
-    "\n"
-    "in vec2 v_TexCoord;\n"
-    "\n"
-    "uniform sampler2D u_Texture;\n"
-    "uniform float u_ColorDepth;\n"
-    "uniform float u_Opa;\n"
-    "uniform bool u_IsFill;\n"
-    "uniform vec3 u_FillColor;\n"
-    "\n"
-    "void main()\n"
-    "{\n"
-    "    vec4 texColor;\n"
-    "    if (u_IsFill) {\n"
-    "        texColor = vec4(u_FillColor, 1.0);\n"
-    "    } else {\n"
-    "        texColor = texture(u_Texture, v_TexCoord);\n"
-    "    }\n"
-    "    if (abs(u_ColorDepth - 8.0) < 0.1) {\n"
-    "        float gray = texColor.r;\n"
-    "        color = vec4(gray, gray, gray, u_Opa);\n"
-    "    } else {\n"
-    "        float combinedAlpha = texColor.a * u_Opa;\n"
-    "        color = vec4(texColor.rgb * combinedAlpha, combinedAlpha);\n"
-    "    }\n"
-    "}\n";
 
 /**********************
  *      MACROS
@@ -374,57 +328,35 @@ static void lv_opengles_index_buffer_unbind(void)
     GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
 }
 
-static unsigned int lv_opengles_shader_compile(unsigned int type, const char * source)
+static void lv_opengles_shader_manager_init(void)
 {
-    unsigned int id;
-    GL_CALL(id = glCreateShader(type));
-    const char * src = source;
-    GL_CALL(glShaderSource(id, 1, &src, NULL));
-    GL_CALL(glCompileShader(id));
-
-    int result;
-    GL_CALL(glGetShaderiv(id, GL_COMPILE_STATUS, &result));
-    if(result == GL_FALSE) {
-        LV_LOG_ERROR("Failed to compile %s shader!", type == GL_VERTEX_SHADER ? "vertex" : "fragment");
-        int length = 0;
-        GL_CALL(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
-        if(length > 0) {
-            char * message = lv_malloc_zeroed(length * sizeof(char));
-            LV_ASSERT_MALLOC(message);
-            GL_CALL(glGetShaderInfoLog(id, length, &length, message));
-
-            LV_LOG_ERROR("%s", message);
-            lv_free(message);
-        }
-
-        GL_CALL(glDeleteShader(id));
-        return 0;
-    }
-
-    return id;
+    lv_opengles_standard_shader_get_src(&portions);
+    char * vertex_shader = lv_opengles_standard_shader_get_vertex();
+    char * frag_shader = lv_opengles_standard_shader_get_fragment();
+    shader_manager = lv_opengl_shader_manager_create(portions.all, portions.count, vertex_shader, frag_shader);
+    lv_free(vertex_shader);
+    lv_free(frag_shader);
 }
 
-static unsigned int lv_opengles_shader_create(const char * vertexShader, const char * fragmentShader)
+static void lv_opengles_shader_program_init(void)
 {
-    unsigned int program;
-    GL_CALL(program = glCreateProgram());
-    unsigned int vs = lv_opengles_shader_compile(GL_VERTEX_SHADER, vertexShader);
-    unsigned int fs = lv_opengles_shader_compile(GL_FRAGMENT_SHADER, fragmentShader);
+    /* To add defines:  lv_opengl_shader_define_t frag_defs[1] = { { "PLACEHOLDER", NULL, false} }; */
 
-    GL_CALL(glAttachShader(program, vs));
-    GL_CALL(glAttachShader(program, fs));
-    GL_CALL(glLinkProgram(program));
-    GL_CALL(glValidateProgram(program));
+    uint32_t frag_shader_hash = lv_opengl_shader_manager_select_shader(shader_manager, "__MAIN__.frag", NULL, 0);
+    uint32_t vert_shader_hash = lv_opengl_shader_manager_select_shader(shader_manager, "__MAIN__.vert", NULL, 0);
 
-    GL_CALL(glDeleteShader(vs));
-    GL_CALL(glDeleteShader(fs));
+    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(shader_manager, frag_shader_hash,
+                                                                                vert_shader_hash);
 
-    return program;
+    shader_id = lv_opengl_shader_program_get_id(program);
 }
 
 static void lv_opengles_shader_init(void)
 {
-    if(shader_id == 0) shader_id = lv_opengles_shader_create(vertex_shader, fragment_shader);
+    if(shader_id == 0) {
+        lv_opengles_shader_manager_init();
+        lv_opengles_shader_program_init();
+    }
 }
 
 static void lv_opengles_shader_deinit(void)

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -52,7 +52,7 @@ static unsigned int lv_opengles_index_buffer_get_count(void);
 static void lv_opengles_index_buffer_bind(void);
 static void lv_opengles_index_buffer_unbind(void);
 static void lv_opengles_shader_manager_init(void);
-static void lv_opengles_shader_program_init(void);
+static unsigned int lv_opengles_shader_program_init(void);
 static void lv_opengles_shader_init(void);
 static void lv_opengles_shader_deinit(void);
 static void lv_opengles_shader_bind(void);
@@ -74,7 +74,7 @@ static float lv_opengles_map_float(float x, float min_in, float max_in, float mi
  **********************/
 static bool is_init;
 
-static lv_opengl_shader_manager_t * shader_manager;
+static lv_opengl_shader_manager_t shader_manager;
 
 static unsigned int vertex_buffer_id = 0;
 
@@ -333,36 +333,37 @@ static void lv_opengles_shader_manager_init(void)
     lv_opengles_standard_shader_get_src(&portions);
     char * vertex_shader = lv_opengles_standard_shader_get_vertex();
     char * frag_shader = lv_opengles_standard_shader_get_fragment();
-    shader_manager = lv_opengl_shader_manager_create(portions.all, portions.count, vertex_shader, frag_shader);
+    lv_opengl_shader_manager_init(&shader_manager, portions.all, portions.count, vertex_shader, frag_shader);
     lv_free(vertex_shader);
     lv_free(frag_shader);
 }
 
-static void lv_opengles_shader_program_init(void)
+static unsigned int lv_opengles_shader_program_init(void)
 {
     /* To add defines:  lv_opengl_shader_define_t frag_defs[1] = { { "PLACEHOLDER", NULL, false} }; */
 
-    uint32_t frag_shader_hash = lv_opengl_shader_manager_select_shader(shader_manager, "__MAIN__.frag", NULL, 0);
-    uint32_t vert_shader_hash = lv_opengl_shader_manager_select_shader(shader_manager, "__MAIN__.vert", NULL, 0);
+    uint32_t frag_shader_hash = lv_opengl_shader_manager_select_shader(&shader_manager, "__MAIN__.frag", NULL, 0);
+    uint32_t vert_shader_hash = lv_opengl_shader_manager_select_shader(&shader_manager, "__MAIN__.vert", NULL, 0);
 
-    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(shader_manager, frag_shader_hash,
+    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(&shader_manager, frag_shader_hash,
                                                                                 vert_shader_hash);
 
-    shader_id = lv_opengl_shader_program_get_id(program);
+    return lv_opengl_shader_program_get_id(program);
 }
 
 static void lv_opengles_shader_init(void)
 {
     if(shader_id == 0) {
         lv_opengles_shader_manager_init();
-        lv_opengles_shader_program_init();
+        shader_id = lv_opengles_shader_program_init();
     }
 }
 
 static void lv_opengles_shader_deinit(void)
 {
     if(shader_id == 0) return;
-    GL_CALL(glDeleteProgram(shader_id));
+    /* The program is part of the manager and as such will be destroyed inside */
+    lv_opengl_shader_manager_deinit(&shader_manager);
     shader_id = 0;
 }
 

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -38,6 +38,11 @@ typedef struct {
 } lv_opengl_shader_t;
 
 typedef struct {
+    const lv_opengl_shader_t * all;
+    uint32_t count;
+} lv_opengl_shader_portions_t;
+
+typedef struct {
     const char * name;
     const char * value;
     bool value_allocated;

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -92,10 +92,10 @@ lv_opengl_shader_program_t * lv_opengl_shader_program_create(uint32_t id);
 void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program);
 GLuint lv_opengl_shader_program_get_id(lv_opengl_shader_program_t * program);
 
-lv_opengl_shader_manager_t * lv_opengl_shader_manager_create(const lv_opengl_shader_t * sources,
-                                                             size_t len, const char * vert_src,
-                                                             const char * frag_src);
-void lv_opengl_shader_manager_destroy(lv_opengl_shader_manager_t * manager);
+void lv_opengl_shader_manager_init(lv_opengl_shader_manager_t * manager, const lv_opengl_shader_t * sources,
+                                   size_t len, const char * vert_src,
+                                   const char * frag_src);
+void lv_opengl_shader_manager_deinit(lv_opengl_shader_manager_t * manager);
 uint32_t lv_opengl_shader_hash(const char * value);
 GLuint lv_opengl_shader_manager_get_texture(lv_opengl_shader_manager_t * manager, uint32_t hash);
 void lv_opengl_shader_manager_store_texture(lv_opengl_shader_manager_t * manager, uint32_t hash, GLuint id);

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
@@ -3404,39 +3404,6 @@ static const char *src_fragment_shader = R"(
 
 const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
 
-/**
- * @file lv_templ.c
- *
- */
-
-/*********************
- *      INCLUDES
- *********************/
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-
-/*********************
- *      DEFINES
- *********************/
-
-/**********************
- *      TYPEDEFS
- **********************/
-
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-
-/**********************
- *  STATIC VARIABLES
- **********************/
-
-/**********************
- *      MACROS
- **********************/
-
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
@@ -3449,15 +3416,15 @@ char* lv_gltf_view_shader_get_fragment(void) {
     return lv_opengl_shader_manager_process_includes(src_fragment_shader, GLSL_VERSION_PREFIX, src_includes, src_includes_count);
 }
 
-void lv_gltf_view_shader_get_src(lv_gltf_view_shader_t *shaders)
+void lv_gltf_view_shader_get_src(lv_opengl_shader_portions_t *portions)
 {
-	shaders->shader_list = src_includes;
-	shaders->count = sizeof(src_includes) / sizeof(src_includes[0]);
+	portions->all = src_includes;
+	portions->count = sizeof(src_includes) / sizeof(src_includes[0]);
 }
-void lv_gltf_view_shader_get_env(lv_gltf_view_shader_t *shaders)
+void lv_gltf_view_shader_get_env(lv_opengl_shader_portions_t *portions)
 {
-	shaders->shader_list = env_src_includes;
-	shaders->count = sizeof(env_src_includes) / sizeof(env_src_includes[0]);
+	portions->all = env_src_includes;
+	portions->count = sizeof(env_src_includes) / sizeof(env_src_includes[0]);
 }
 
 #endif /*LV_USE_GLTF*/

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
@@ -3402,7 +3402,7 @@ static const char *src_fragment_shader = R"(
 
 )";
 
-const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
+static const size_t src_includes_count = sizeof src_includes / sizeof src_includes[0];
 
 /**********************
  *   GLOBAL FUNCTIONS

--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.h
@@ -17,27 +17,14 @@ extern "C" {
 
 #if LV_USE_GLTF
 
-/*********************
- *      DEFINES
- *********************/
-
-/**********************
- *      TYPEDEFS
- **********************/
-
-typedef struct {
-	const lv_opengl_shader_t *shader_list;
-	size_t count;
-} lv_gltf_view_shader_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
 char *lv_gltf_view_shader_get_vertex(void);
 char *lv_gltf_view_shader_get_fragment(void);
-void lv_gltf_view_shader_get_src(lv_gltf_view_shader_t *shaders);
-void lv_gltf_view_shader_get_env(lv_gltf_view_shader_t *shaders);
+void lv_gltf_view_shader_get_src(lv_opengl_shader_portions_t *shaders);
+void lv_gltf_view_shader_get_env(lv_opengl_shader_portions_t *shaders);
 
 /**********************
  *      MACROS

--- a/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
@@ -108,9 +108,10 @@ static void ibl_sampler_init(lv_gltf_ibl_sampler_t * sampler)
     sampler->lut_resolution = 1024;
     sampler->lut_sample_count = 64;
     sampler->scale_value = 1.0;
-    lv_gltf_view_shader_t env_shader;
-    lv_gltf_view_shader_get_env(&env_shader);
-    sampler->shader_manager = lv_opengl_shader_manager_create(env_shader.shader_list, env_shader.count, NULL, NULL);
+    lv_opengl_shader_portions_t env_shader_portions;
+    lv_gltf_view_shader_get_env(&env_shader_portions);
+    sampler->shader_manager = lv_opengl_shader_manager_create(env_shader_portions.all, env_shader_portions.count, NULL,
+                                                              NULL);
 }
 
 static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)

--- a/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.c
@@ -49,13 +49,13 @@ static void ibl_texture_from_image(lv_gltf_ibl_sampler_t * sampler, lv_gltf_ibl_
 static GLuint ibl_load_texture_hdr(lv_gltf_ibl_sampler_t * sampler, const lv_gltf_ibl_image_t * image);
 static GLuint ibl_create_cubemap_texture(const lv_gltf_ibl_sampler_t * sampler, bool with_mipmaps);
 static uint32_t ibl_create_lut_texture(const lv_gltf_ibl_sampler_t * sampler);
-static void ibl_panorama_to_cubemap(const lv_gltf_ibl_sampler_t * sampler);
-static void ibl_apply_filter(const lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, float roughness,
+static void ibl_panorama_to_cubemap(lv_gltf_ibl_sampler_t * sampler);
+static void ibl_apply_filter(lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, float roughness,
                              uint32_t target_mip_level, GLuint target_texture, uint32_t sample_count, float lod_bias);
-static void ibl_cubemap_to_lambertian(const lv_gltf_ibl_sampler_t * sampler);
-static void ibl_cubemap_to_ggx(const lv_gltf_ibl_sampler_t * sampler);
-static void ibl_cubemap_to_sheen(const lv_gltf_ibl_sampler_t * sampler);
-static void ibl_sample_lut(const lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, uint32_t targetTexture,
+static void ibl_cubemap_to_lambertian(lv_gltf_ibl_sampler_t * sampler);
+static void ibl_cubemap_to_ggx(lv_gltf_ibl_sampler_t * sampler);
+static void ibl_cubemap_to_sheen(lv_gltf_ibl_sampler_t * sampler);
+static void ibl_sample_lut(lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, uint32_t targetTexture,
                            uint32_t currentTextureSize);
 static void ibl_sample_ggx_lut(lv_gltf_ibl_sampler_t * sampler);
 static void ibl_sample_charlie_lut(lv_gltf_ibl_sampler_t * sampler);
@@ -110,8 +110,8 @@ static void ibl_sampler_init(lv_gltf_ibl_sampler_t * sampler)
     sampler->scale_value = 1.0;
     lv_opengl_shader_portions_t env_shader_portions;
     lv_gltf_view_shader_get_env(&env_shader_portions);
-    sampler->shader_manager = lv_opengl_shader_manager_create(env_shader_portions.all, env_shader_portions.count, NULL,
-                                                              NULL);
+    lv_opengl_shader_manager_init(&sampler->shader_manager, env_shader_portions.all, env_shader_portions.count, NULL,
+                                  NULL);
 }
 
 static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
@@ -192,7 +192,7 @@ static void ibl_sampler_filter(lv_gltf_ibl_sampler_t * sampler)
 }
 static void ibl_sampler_destroy(lv_gltf_ibl_sampler_t * sampler)
 {
-    lv_opengl_shader_manager_destroy(sampler->shader_manager);
+    lv_opengl_shader_manager_deinit(&sampler->shader_manager);
 }
 
 static void ibl_texture_from_image(lv_gltf_ibl_sampler_t * sampler, lv_gltf_ibl_texture_t * texture,
@@ -301,7 +301,7 @@ static GLuint ibl_create_lut_texture(const lv_gltf_ibl_sampler_t * sampler)
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     return texture;
 }
-static void ibl_panorama_to_cubemap(const lv_gltf_ibl_sampler_t * sampler)
+static void ibl_panorama_to_cubemap(lv_gltf_ibl_sampler_t * sampler)
 {
     for(int32_t i = 0; i < 6; ++i) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, sampler->framebuffer));
@@ -318,10 +318,10 @@ static void ibl_panorama_to_cubemap(const lv_gltf_ibl_sampler_t * sampler)
         GL_CALL(glClearColor(1.0, 0.0, 0.0, 0.0));
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
         uint32_t frag_shader =
-            lv_opengl_shader_manager_select_shader(sampler->shader_manager, "panorama_to_cubemap.frag", NULL, 0);
-        uint32_t vert_shader = lv_opengl_shader_manager_select_shader(sampler->shader_manager, "fullscreen.vert", NULL, 0);
+            lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "panorama_to_cubemap.frag", NULL, 0);
+        uint32_t vert_shader = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0);
         lv_opengl_shader_program_t * program =
-            lv_opengl_shader_manager_get_program(sampler->shader_manager, frag_shader, vert_shader);
+            lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader, vert_shader);
         GLuint program_id = lv_opengl_shader_program_get_id(program);
 
         GL_CALL(glUseProgram(program_id));
@@ -340,7 +340,7 @@ static void ibl_panorama_to_cubemap(const lv_gltf_ibl_sampler_t * sampler)
     GL_CALL(glBindTexture(GL_TEXTURE_CUBE_MAP, sampler->cubemap_texture_id));
     GL_CALL(glGenerateMipmap(GL_TEXTURE_CUBE_MAP));
 }
-static void ibl_apply_filter(const lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, float roughness,
+static void ibl_apply_filter(lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, float roughness,
                              uint32_t target_mip_level, GLuint target_texture, uint32_t sample_count, float lod_bias)
 {
     uint32_t current_texture_size = sampler->texture_size >> target_mip_level;
@@ -354,10 +354,10 @@ static void ibl_apply_filter(const lv_gltf_ibl_sampler_t * sampler, uint32_t dis
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
         uint32_t frag_shader =
-            lv_opengl_shader_manager_select_shader(sampler->shader_manager, "ibl_filtering.frag", NULL, 0);
-        uint32_t vert_shader = lv_opengl_shader_manager_select_shader(sampler->shader_manager, "fullscreen.vert", NULL, 0);
+            lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "ibl_filtering.frag", NULL, 0);
+        uint32_t vert_shader = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0);
         lv_opengl_shader_program_t * program =
-            lv_opengl_shader_manager_get_program(sampler->shader_manager, frag_shader, vert_shader);
+            lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader, vert_shader);
         GLuint program_id = lv_opengl_shader_program_get_id(program);
 
         GL_CALL(glUseProgram(program_id));
@@ -383,11 +383,11 @@ static void ibl_apply_filter(const lv_gltf_ibl_sampler_t * sampler, uint32_t dis
         GL_CALL(glDrawArrays(GL_TRIANGLES, 0, 3));
     }
 }
-static void ibl_cubemap_to_lambertian(const lv_gltf_ibl_sampler_t * sampler)
+static void ibl_cubemap_to_lambertian(lv_gltf_ibl_sampler_t * sampler)
 {
     ibl_apply_filter(sampler, 0, 0.0, 0, sampler->lambertian_texture_id, sampler->lambertian_sample_count, 0.0);
 }
-static void ibl_cubemap_to_ggx(const lv_gltf_ibl_sampler_t * sampler)
+static void ibl_cubemap_to_ggx(lv_gltf_ibl_sampler_t * sampler)
 {
     LV_ASSERT(sampler->mipmap_levels != 1);
     for(uint32_t current_mip_level = 0; current_mip_level <= sampler->mipmap_levels; ++current_mip_level) {
@@ -396,7 +396,7 @@ static void ibl_cubemap_to_ggx(const lv_gltf_ibl_sampler_t * sampler)
                          0.0);
     }
 }
-static void ibl_cubemap_to_sheen(const lv_gltf_ibl_sampler_t * sampler)
+static void ibl_cubemap_to_sheen(lv_gltf_ibl_sampler_t * sampler)
 {
     LV_ASSERT(sampler->mipmap_levels != 1);
     for(uint32_t current_mip_level = 0; current_mip_level <= sampler->mipmap_levels; ++current_mip_level) {
@@ -405,7 +405,7 @@ static void ibl_cubemap_to_sheen(const lv_gltf_ibl_sampler_t * sampler)
                          sampler->sheen_sample_count, 0.0);
     }
 }
-static void ibl_sample_lut(const lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, uint32_t targetTexture,
+static void ibl_sample_lut(lv_gltf_ibl_sampler_t * sampler, uint32_t distribution, uint32_t targetTexture,
                            uint32_t currentTextureSize)
 {
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, sampler->framebuffer));
@@ -415,9 +415,9 @@ static void ibl_sample_lut(const lv_gltf_ibl_sampler_t * sampler, uint32_t distr
     GL_CALL(glClearColor(0.0, 1.0, 1.0, 0.0));
     GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
-    uint32_t frag_shader = lv_opengl_shader_manager_select_shader(sampler->shader_manager, "ibl_filtering.frag", NULL, 0);
-    uint32_t vert_shader = lv_opengl_shader_manager_select_shader(sampler->shader_manager, "fullscreen.vert", NULL, 0);
-    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(sampler->shader_manager, frag_shader,
+    uint32_t frag_shader = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "ibl_filtering.frag", NULL, 0);
+    uint32_t vert_shader = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0);
+    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader,
                                                                                 vert_shader);
     GLuint program_id = lv_opengl_shader_program_get_id(program);
 

--- a/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.h
+++ b/src/libs/gltf/gltf_view/ibl/lv_gltf_ibl_sampler.h
@@ -56,7 +56,7 @@ typedef struct {
     float scale_value;
     uint32_t mipmap_levels;
 
-    lv_opengl_shader_manager_t * shader_manager;
+    lv_opengl_shader_manager_t shader_manager;
 } lv_gltf_ibl_sampler_t;
 
 typedef struct {

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -468,11 +468,11 @@ static void lv_gltf_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     view->texture.v_flip = false;
     new(&view->ibm_by_skin_then_node) std::map<int32_t, std::map<fastgltf::Node *, fastgltf::math::fmat4x4>>;
 
-    lv_gltf_view_shader_t shaders;
-    lv_gltf_view_shader_get_src(&shaders);
+    lv_opengl_shader_portions_t portions;
+    lv_gltf_view_shader_get_src(&portions);
     char * vertex_shader = lv_gltf_view_shader_get_vertex();
     char * frag_shader = lv_gltf_view_shader_get_fragment();
-    view->shader_manager = lv_opengl_shader_manager_create(shaders.shader_list, shaders.count, vertex_shader, frag_shader);
+    view->shader_manager = lv_opengl_shader_manager_create(portions.all, portions.count, vertex_shader, frag_shader);
     lv_free(vertex_shader);
     lv_free(frag_shader);
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -101,7 +101,7 @@ lv_gltf_model_t * lv_gltf_load_model_from_file(lv_obj_t * obj, const char * path
     LV_ASSERT_NULL(obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_gltf_t * viewer = (lv_gltf_t *)obj;
-    lv_gltf_model_t * model = lv_gltf_data_load_from_file(path, viewer->shader_manager);
+    lv_gltf_model_t * model = lv_gltf_data_load_from_file(path, &viewer->shader_manager);
     return lv_gltf_add_model(viewer, model);
 }
 
@@ -110,7 +110,7 @@ lv_gltf_model_t * lv_gltf_load_model_from_bytes(lv_obj_t * obj, const uint8_t * 
     LV_ASSERT_NULL(obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_gltf_t * viewer = (lv_gltf_t *)obj;
-    lv_gltf_model_t * model = lv_gltf_data_load_from_bytes(bytes, len, viewer->shader_manager);
+    lv_gltf_model_t * model = lv_gltf_data_load_from_bytes(bytes, len, &viewer->shader_manager);
     return lv_gltf_add_model(viewer, model);
 }
 
@@ -472,7 +472,7 @@ static void lv_gltf_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     lv_gltf_view_shader_get_src(&portions);
     char * vertex_shader = lv_gltf_view_shader_get_vertex();
     char * frag_shader = lv_gltf_view_shader_get_fragment();
-    view->shader_manager = lv_opengl_shader_manager_create(portions.all, portions.count, vertex_shader, frag_shader);
+    lv_opengl_shader_manager_init(&view->shader_manager, portions.all, portions.count, vertex_shader, frag_shader);
     lv_free(vertex_shader);
     lv_free(frag_shader);
 
@@ -507,7 +507,7 @@ static void lv_gltf_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
     LV_UNUSED(class_p);
     lv_gltf_t * view = (lv_gltf_t *)obj;
-    lv_opengl_shader_manager_destroy(view->shader_manager);
+    lv_opengl_shader_manager_deinit(&view->shader_manager);
     using IbmBySkinThenNodeMap = std::map<int32_t, std::map<fastgltf::Node *, fastgltf::math::fmat4x4>>;
 
     view->ibm_by_skin_then_node.~IbmBySkinThenNodeMap();
@@ -611,7 +611,7 @@ static void lv_gltf_parse_model(lv_gltf_t * viewer, lv_gltf_model_t * model)
         }
     };
 
-    setup_compile_and_load_bg_shader(viewer->shader_manager);
+    setup_compile_and_load_bg_shader(&viewer->shader_manager);
     fastgltf::iterateSceneNodes(model->asset, 0, fastgltf::math::fmat4x4(), iterate_callback);
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -105,7 +105,7 @@ struct _lv_gltf_t {
     lv_gltf_view_state_t state;
     lv_gltf_view_desc_t desc;
     lv_gltf_view_desc_t last_desc;
-    lv_opengl_shader_manager_t * shader_manager;
+    lv_opengl_shader_manager_t shader_manager;
     lv_gltf_view_env_textures_t env_textures;
     fastgltf::math::fmat4x4 view_matrix;
     fastgltf::math::fmat4x4 projection_matrix;

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -253,7 +253,7 @@ static GLuint lv_gltf_view_render_model(lv_gltf_t * viewer, lv_gltf_model_t * mo
         }
 
         if(opt_draw_bg) {
-            setup_draw_environment_background(viewer->shader_manager, viewer, view_desc->blur_bg);
+            setup_draw_environment_background(&viewer->shader_manager, viewer, view_desc->blur_bg);
         }
 
         render_materials(viewer, model, model->opaque_nodes_by_material_index);
@@ -288,7 +288,7 @@ static GLuint lv_gltf_view_render_model(lv_gltf_t * viewer, lv_gltf_model_t * mo
         return vstate->render_state.texture;
     }
     if(opt_draw_bg)
-        setup_draw_environment_background(viewer->shader_manager, viewer, view_desc->blur_bg);
+        setup_draw_environment_background(&viewer->shader_manager, viewer, view_desc->blur_bg);
     render_materials(viewer, model, model->opaque_nodes_by_material_index);
 
     for(const auto & node_distance_pair : distance_sort_nodes) {

--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -302,13 +302,13 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
 lv_gltf_shaderset_t lv_gltf_view_shader_compile_program(lv_gltf_t * view, const lv_opengl_shader_define_t * defines,
                                                         size_t n)
 {
-    uint32_t frag_shader_hash = lv_opengl_shader_manager_select_shader(view->shader_manager, "__MAIN__.frag",
+    uint32_t frag_shader_hash = lv_opengl_shader_manager_select_shader(&view->shader_manager, "__MAIN__.frag",
                                                                        defines, n);
 
-    uint32_t vert_shader_hash = lv_opengl_shader_manager_select_shader(view->shader_manager, "__MAIN__.vert",
+    uint32_t vert_shader_hash = lv_opengl_shader_manager_select_shader(&view->shader_manager, "__MAIN__.vert",
                                                                        defines, n);
     lv_opengl_shader_program_t * program =
-        lv_opengl_shader_manager_get_program(view->shader_manager, frag_shader_hash, vert_shader_hash);
+        lv_opengl_shader_manager_get_program(&view->shader_manager, frag_shader_hash, vert_shader_hash);
 
     LV_ASSERT_NULL(program);
 


### PR DESCRIPTION
Replaces the old system of compiling a shader with the new shader manager, utilizing the same actual shader code.