### PR TITLE
feat(opengl): add support for creating an LVGL OpenGL texture display from an existing texture

### DIFF
--- a/docs/src/details/integration/embedded_linux/drivers/index.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/index.rst
@@ -9,7 +9,7 @@ Drivers
 
     fbdev
     drm
-    opengl
+    opengl_driver
     glfw
     egl
     wayland

--- a/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
@@ -57,8 +57,8 @@ Basic Usage
         //lv_display_t * texture = lv_opengles_texture_create_from_texture_id(WIDTH, HEIGHT, my_texture_id);
 
         /* Set the display render mode and flush callback 
-         * lv_display_set_render_mode(display, LV_DISPLAY_RENDER_MODE_FULL);
-         * lv_display_set_flush_cb(display, flush_cb);
+         * lv_display_set_render_mode(texture, LV_DISPLAY_RENDER_MODE_FULL);
+         * lv_display_set_flush_cb(texture, flush_cb);
          */
 
         /* get the texture ID for use in your application */

--- a/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
@@ -43,6 +43,24 @@ Basic Usage
     #define WIDTH 640
     #define HEIGHT 480
 
+    /* This flush callback works with both FULL and DIRECT render modes*/
+    static void flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
+    {
+        if (lv_display_flush_is_last(disp)) {
+            const int32_t disp_width = lv_display_get_horizontal_resolution(disp);
+            const int32_t disp_height = lv_display_get_vertical_resolution(disp);
+            /* The texture occupies the full screen even if `area` is not the full screen which happens with RENDER_MODE_DIRECT */
+            lv_area_t full_area;
+            lv_area_set(&full_area, 0, 0, disp_width, disp_height);
+
+            /* Get the texture id containing LVGL generated UI */
+            unsigned int texture_id = lv_opengles_texture_get_texture_id(disp);
+            /* This function will render to the current context */
+            lv_opengles_render_texture(texture_id, &full_area, LV_OPA_COVER, disp_width, disp_height, &full_area, false, true);
+        }
+        lv_display_flush_ready(disp);
+    }
+
     int main()
     {
         /* initialize lvgl */

--- a/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
@@ -69,15 +69,14 @@ Basic Usage
 
         /* NOTE: OpenGL context must be created before this point */
 
-        /* create a display that flushes to a texture */
+        /* Create a display that flushes to a texture. The OpenGL texture will be created for you */
         lv_display_t * texture = lv_opengles_texture_create(WIDTH, HEIGHT);
-        /*  If you already have an OpenGL texture ready, you can create a LVGL display from it. */
-        //lv_display_t * texture = lv_opengles_texture_create_from_texture_id(WIDTH, HEIGHT, my_texture_id);
+        /* If you already have an OpenGL texture ready, you can use it instead:
+         * lv_display_t * texture = lv_opengles_texture_create_from_texture_id(WIDTH, HEIGHT, my_texture_id); */
 
         /* Set the display render mode and flush callback 
          * lv_display_set_render_mode(texture, LV_DISPLAY_RENDER_MODE_FULL);
-         * lv_display_set_flush_cb(texture, flush_cb);
-         */
+         * lv_display_set_flush_cb(texture, flush_cb); */
 
         /* get the texture ID for use in your application */
         unsigned int texture_id = lv_opengles_texture_get_texture_id(texture);

--- a/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/opengl_driver.rst
@@ -1,8 +1,8 @@
 .. _opengl_driver:
 
-==============
+=============
 OpenGL Driver
-==============
+=============
 
 Overview
 --------
@@ -47,12 +47,19 @@ Basic Usage
     {
         /* initialize lvgl */
         lv_init();
+        /* Don't forget the tick callback */
 
         /* NOTE: OpenGL context must be created before this point */
 
         /* create a display that flushes to a texture */
         lv_display_t * texture = lv_opengles_texture_create(WIDTH, HEIGHT);
-        lv_display_set_default(texture);
+        /*  If you already have an OpenGL texture ready, you can create a LVGL display from it. */
+        //lv_display_t * texture = lv_opengles_texture_create_from_texture_id(WIDTH, HEIGHT, my_texture_id);
+
+        /* Set the display render mode and flush callback 
+         * lv_display_set_render_mode(display, LV_DISPLAY_RENDER_MODE_FULL);
+         * lv_display_set_flush_cb(display, flush_cb);
+         */
 
         /* get the texture ID for use in your application */
         unsigned int texture_id = lv_opengles_texture_get_texture_id(texture);
@@ -65,9 +72,6 @@ Basic Usage
             uint32_t time_until_next = lv_timer_handler();
             if(time_until_next == LV_NO_TIMER_READY) time_until_next = LV_DEF_REFR_PERIOD;
             lv_delay_ms(time_until_next);
-            
-            /* use texture_id in your OpenGL rendering */
-            your_opengl_render_function(texture_id);
         }
 
         return 0;

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -327,7 +327,9 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
     /* create a display that flushes to a texture */
     lv_display_t * texture = lv_opengles_texture_create(hor_res, ver_res);
     lv_display_set_default(texture);
-
+#if LV_USE_DRAW_OPENGLES
+    lv_display_delete_refr_timer(texture);
+#endif
     /* add the texture to the window */
     unsigned int texture_id = lv_opengles_texture_get_texture_id(texture);
     lv_opengles_window_add_texture(window, texture_id, hor_res, ver_res);

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -27,7 +27,9 @@
 
 typedef struct {
     unsigned int texture_id;
+#if !LV_USE_DRAW_OPENGLES
     uint8_t * fb1;
+#endif /*!LV_USE_DRAW_OPENGLES*/
 } lv_opengles_texture_t;
 
 /**********************
@@ -174,7 +176,9 @@ static void release_disp_cb(lv_event_t * e)
 {
     lv_display_t * disp = lv_event_get_user_data(e);
     lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
+#if !LV_USE_DRAW_OPENGLES
     free(dsc->fb1);
+#endif /*!LV_USE_DRAW_OPENGLES*/
     GL_CALL(glDeleteTextures(1, &dsc->texture_id));
     lv_free(dsc);
 }

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -71,7 +71,6 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
 
 lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, unsigned int texture_id)
 {
-
     lv_display_t * disp = lv_opengles_texture_create_common(w, h);
     if(!disp) {
         return NULL;
@@ -80,7 +79,6 @@ lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, 
     dsc->texture_id = texture_id;
     dsc->is_texture_owner = false;
     return disp;
-
 }
 
 unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
@@ -104,7 +102,6 @@ lv_display_t * lv_opengles_texture_get_from_texture_id(unsigned int texture_id)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
 
 static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h)
 {

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -115,10 +115,6 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
 
 unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
 {
-    if(disp->flush_cb != flush_cb) {
-        return 0;
-    }
-
     lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
     return dsc->texture_id;
 }

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -66,6 +66,19 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     return disp;
 }
 
+lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, unsigned int texture_id)
+{
+
+    lv_display_t * disp = lv_opengles_texture_create_common(w, h);
+    if(!disp) {
+        return NULL;
+    }
+    lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
+    dsc->texture_id = texture_id;
+    return disp;
+
+}
+
 unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
 {
     lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -31,6 +31,7 @@ typedef struct {
 #if !LV_USE_DRAW_OPENGLES
     uint8_t * fb1;
 #endif /*!LV_USE_DRAW_OPENGLES*/
+    bool is_texture_owner;
 } lv_opengles_texture_t;
 
 /**********************
@@ -64,6 +65,7 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
     unsigned int texture_id = create_texture(w, h);
     dsc->texture_id = texture_id;
+    dsc->is_texture_owner = true;
     return disp;
 }
 
@@ -76,6 +78,7 @@ lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, 
     }
     lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
     dsc->texture_id = texture_id;
+    dsc->is_texture_owner = false;
     return disp;
 
 }
@@ -213,7 +216,9 @@ static void release_disp_cb(lv_event_t * e)
 #if !LV_USE_DRAW_OPENGLES
     free(dsc->fb1);
 #endif /*!LV_USE_DRAW_OPENGLES*/
-    GL_CALL(glDeleteTextures(1, &dsc->texture_id));
+    if(dsc->is_texture_owner) {
+        GL_CALL(glDeleteTextures(1, &dsc->texture_id));
+    }
     lv_free(dsc);
 }
 

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -110,10 +110,6 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     lv_display_set_driver_data(disp, dsc);
     lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
 
-#if LV_USE_DRAW_OPENGLES
-    lv_display_delete_refr_timer(disp);
-#endif
-
     return disp;
 }
 

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -36,6 +36,8 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 
+static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h);
+static unsigned int create_texture(int32_t w, int32_t h);
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
 static void release_disp_cb(lv_event_t * e);
 
@@ -51,7 +53,43 @@ static void release_disp_cb(lv_event_t * e);
  *   GLOBAL FUNCTIONS
  **********************/
 
+
 lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
+{
+    lv_display_t * disp = lv_opengles_texture_create_common(w, h);
+    if(!disp) {
+        return NULL;
+    }
+    lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
+    unsigned int texture_id = create_texture(w, h);
+    dsc->texture_id = texture_id;
+    return disp;
+}
+
+unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
+{
+    lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
+    return dsc->texture_id;
+}
+
+lv_display_t * lv_opengles_texture_get_from_texture_id(unsigned int texture_id)
+{
+    lv_display_t * disp = NULL;
+    while(NULL != (disp = lv_display_get_next(disp))) {
+        unsigned int disp_texture_id = lv_opengles_texture_get_texture_id(disp);
+        if(disp_texture_id == texture_id) {
+            return disp;
+        }
+    }
+    return NULL;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+
+static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h)
 {
     lv_display_t * disp = lv_display_create(w, h);
     if(disp == NULL) {
@@ -79,9 +117,17 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     }
     lv_display_set_buffers(disp, dsc->fb1, NULL, buf_size, LV_DISPLAY_RENDER_MODE_DIRECT);
 #endif
+    lv_display_set_flush_cb(disp, flush_cb);
+    lv_display_set_driver_data(disp, dsc);
+    lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
+    return disp;
+}
 
-    GL_CALL(glGenTextures(1, &dsc->texture_id));
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, dsc->texture_id));
+static unsigned int create_texture(int32_t w, int32_t h)
+{
+    unsigned int texture;
+    GL_CALL(glGenTextures(1, &texture));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
@@ -91,14 +137,14 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     /* set the dimensions and format to complete the texture */
     /* Color depth: 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888) */
 #if LV_COLOR_DEPTH == 8
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, disp->hor_res, disp->ver_res, 0, GL_RED, GL_UNSIGNED_BYTE, NULL));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, NULL));
 #elif LV_COLOR_DEPTH == 16
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, w, h, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
                          NULL));
 #elif LV_COLOR_DEPTH == 24
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, disp->hor_res, disp->ver_res, 0, GL_BGR, GL_UNSIGNED_BYTE, NULL));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_BGR, GL_UNSIGNED_BYTE, NULL));
 #elif LV_COLOR_DEPTH == 32
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL));
 #else
 #error("Unsupported color format")
 #endif
@@ -107,36 +153,9 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 20));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+    return texture;
 
-    lv_display_set_flush_cb(disp, flush_cb);
-    lv_display_set_driver_data(disp, dsc);
-    lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
-
-    return disp;
 }
-
-unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
-{
-    lv_opengles_texture_t * dsc = lv_display_get_driver_data(disp);
-    return dsc->texture_id;
-}
-
-lv_display_t * lv_opengles_texture_get_from_texture_id(unsigned int texture_id)
-{
-    lv_display_t * disp = NULL;
-    while(NULL != (disp = lv_display_get_next(disp))) {
-        unsigned int disp_texture_id = lv_opengles_texture_get_texture_id(disp);
-        if(disp_texture_id == texture_id) {
-            return disp;
-        }
-    }
-    return NULL;
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
 {
     LV_UNUSED(area);

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -13,6 +13,7 @@
 #include "lv_opengles_debug.h"
 #include "lv_opengles_private.h"
 
+#include "lv_opengles_driver.h"
 #include "../../display/lv_display_private.h"
 
 #include <stdlib.h>
@@ -133,6 +134,7 @@ static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h)
     lv_display_set_flush_cb(disp, flush_cb);
     lv_display_set_driver_data(disp, dsc);
     lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
+    lv_opengles_init();
     return disp;
 }
 

--- a/src/drivers/opengles/lv_opengles_texture.h
+++ b/src/drivers/opengles/lv_opengles_texture.h
@@ -33,11 +33,24 @@ extern "C" {
 
 /**
  * Create a display that flushes to an OpenGL texture
+ * If you already have a texture and want to bind it to the display,
+ *    see `lv_opengles_texture_create_from_texture_id`
  * @param w    width in pixels of the texture
  * @param h    height in pixels of the texture
  * @return     the new display
  */
 lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h);
+
+/**
+ * Create a display that flushes to the provided OpenGL texture
+ * If you don't have a texture to bind it to the display,
+ *    see `lv_opengles_texture_create`
+ * @param w         width in pixels of the texture
+ * @param h         height in pixels of the texture
+ * @param texture_id    the texture LVGL will render to
+ * @return          the new display
+ */
+lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, unsigned int texture_id);
 
 /**
  * Get the OpenGL texture ID of the display

--- a/src/drivers/opengles/lv_opengles_texture.h
+++ b/src/drivers/opengles/lv_opengles_texture.h
@@ -37,7 +37,7 @@ extern "C" {
  *    see `lv_opengles_texture_create_from_texture_id`
  * @param w    width in pixels of the texture
  * @param h    height in pixels of the texture
- * @return     the new display
+ * @return     the new display or NULL on failure
  */
 lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h);
 
@@ -48,7 +48,7 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h);
  * @param w         width in pixels of the texture
  * @param h         height in pixels of the texture
  * @param texture_id    the texture LVGL will render to
- * @return          the new display
+ * @return     the new display or NULL on failure
  */
 lv_display_t * lv_opengles_texture_create_from_texture_id(int32_t w, int32_t h, unsigned int texture_id);
 


### PR DESCRIPTION
- Fix some issues with the opengl driver that were making it unusable with an externally managed context
  - Manly the deletion of the refresh timer
  - The check for the flush callback inside `lv_opengles_texture_get_texture_id`
- Add support for creating an lvgl display from an already existing texture