### PR TITLE
docs(timer/indev): add example section about indev interrupts resuming the indev timer

### DIFF
--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -707,7 +707,7 @@ Care must be taken to avoid race conditions.
     void interrupt_handler(void)
     {
         interrupt_occurred = true;
-        lv_timer_resume(indev_timer);
+        if(indev_timer) lv_timer_resume(indev_timer);
     }
 
     uint32_t last_interrupt_tick;
@@ -724,7 +724,11 @@ Care must be taken to avoid race conditions.
         if(interrupt_occurred) {
             interrupt_occurred = false;
             last_interrupt_tick = tick_now;
-            /* bypass a race condition */
+            /* 
+             * Ensure the timer is running in case an interrupt occurred
+             * just after the timer was paused. Without this, a race condition
+             * could leave the timer paused and input events would not be processed.
+             */
             lv_timer_resume(indev_timer);
         }
 

--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -656,6 +656,9 @@ If the driver can provide precise timestamps for buffered events, it can
 overwrite ``data->timestamp``. By default, this is initialized to
 :cpp:func:`lv_tick_get()` just before invoking ``read_cb``.
 
+
+.. _indev event mode::
+
 Switching the Input Device to Event-Driven Mode
 -----------------------------------------------
 
@@ -679,6 +682,60 @@ You can do this by:
 .. note:: :cpp:func:`lv_indev_read`, :cpp:func:`lv_timer_handler` and :cpp:func:`_lv_display_refr_timer` cannot run at the same time.
 
 .. note:: For devices in event-driven mode, `data->continue_reading` is ignored.
+
+
+Pausing the Indev Timer
+-----------------------
+
+It's not always possible to take an indev reading directly inside
+a raw interrupt handler. Typically a flag would be set inside the interrupt handler
+which would be checked and reset inside the indev read callback where the reading
+would actually be taken. This works fine, but the indev read callback is constantly
+"polling" a flag which may go for long periods unset. We cannot use :ref:`indev event mode`
+because :cpp:func:`lv_indev_read` should not be called in an interrupt handler.
+
+For this situation you can use the timer-based indev read callback as usual but
+pause the indev timer if there hasn't been an interrupt in a while.
+Resuming a timer is typically safe in an interrupt handler.
+Care must be taken to avoid race conditions.
+
+.. code-block:: c
+
+    volatile bool interrupt_occurred;
+    lv_timer_t * volatile indev_timer;
+
+    void interrupt_handler(void)
+    {
+        interrupt_occurred = true;
+        lv_timer_resume(indev_timer);
+    }
+
+    uint32_t last_interrupt_tick;
+
+    void my_input_read(lv_indev_t * indev, lv_indev_data_t * data)
+    {
+        uint32_t tick_now = lv_tick_get();
+
+        /* if no interrupt has happened in the past 100 ms, pause the indev timer */
+        if(lv_tick_diff(tick_now, last_interrupt_tick) > 100) {
+            lv_timer_pause(indev_timer);
+        }
+
+        if(interrupt_occurred) {
+            interrupt_occurred = false;
+            last_interrupt_tick = tick_now;
+            /* bypass a race condition */
+            lv_timer_resume(indev_timer);
+        }
+
+        /* perform the reading */
+        /* ... */
+    }
+
+.. code-block:: c
+
+    /* in your setup code */
+    indev_timer = lv_indev_get_read_timer(indev);
 
 
 .. admonition::  Further Reading

--- a/docs/src/details/main-modules/indev.rst
+++ b/docs/src/details/main-modules/indev.rst
@@ -657,7 +657,7 @@ overwrite ``data->timestamp``. By default, this is initialized to
 :cpp:func:`lv_tick_get()` just before invoking ``read_cb``.
 
 
-.. _indev event mode::
+.. _indev event mode:
 
 Switching the Input Device to Event-Driven Mode
 -----------------------------------------------

--- a/src/misc/lv_timer.h
+++ b/src/misc/lv_timer.h
@@ -98,6 +98,7 @@ void lv_timer_delete(lv_timer_t * timer);
 
 /**
  * Pause a timer.
+ * It is typically safe to call from an interrupt handler or a different thread.
  * @param timer pointer to an lv_timer
  */
 void lv_timer_pause(lv_timer_t * timer);

--- a/src/misc/lv_timer_private.h
+++ b/src/misc/lv_timer_private.h
@@ -33,7 +33,7 @@ struct _lv_timer_t {
     lv_timer_cb_t timer_cb;    /**< Timer function */
     void * user_data;          /**< Custom user data */
     int32_t repeat_count;      /**< 1: One time;  -1 : infinity;  n>0: residual times */
-    uint32_t paused : 1;
+    volatile uint8_t paused;
     uint32_t auto_delete : 1;
 };
 
@@ -44,7 +44,7 @@ typedef struct {
     uint8_t idle_last;
     bool timer_deleted;
     bool timer_created;
-    uint32_t timer_time_until_next;
+    volatile uint32_t timer_time_until_next;
 
     bool already_running;
     uint32_t periodic_last_tick;

--- a/src/misc/lv_timer_private.h
+++ b/src/misc/lv_timer_private.h
@@ -33,7 +33,7 @@ struct _lv_timer_t {
     lv_timer_cb_t timer_cb;    /**< Timer function */
     void * user_data;          /**< Custom user data */
     int32_t repeat_count;      /**< 1: One time;  -1 : infinity;  n>0: residual times */
-    volatile uint8_t paused;
+    volatile int paused;
     uint32_t auto_delete : 1;
 };
 

--- a/src/tick/lv_tick.h
+++ b/src/tick/lv_tick.h
@@ -36,7 +36,8 @@ typedef void (*lv_delay_cb_t)(uint32_t ms);
  **********************/
 
 /**
- * You have to call this function periodically
+ * You have to call this function periodically.
+ * It is typically safe to call from an interrupt handler or a different thread.
  * @param tick_period   the call period of this function in milliseconds
  */
 LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period);

--- a/src/tick/lv_tick_private.h
+++ b/src/tick/lv_tick_private.h
@@ -25,7 +25,7 @@ extern "C" {
  **********************/
 
 typedef struct {
-    uint32_t sys_time;
+    volatile uint32_t sys_time;
     volatile uint8_t sys_irq_flag;
     lv_tick_get_cb_t tick_get_cb;
     lv_delay_cb_t delay_cb;


### PR DESCRIPTION
@kisvegabor asked me to document this use case of pausing an indev timer after inactivity and then resuming it from an interrupt handler. Please comment on correctness.

Partially addresses #7908

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
