### PR TITLE
fix(font): fix stride calculation of fonts

### DIFF
--- a/src/draw/sw/lv_draw_sw_letter.c
+++ b/src/draw/sw/lv_draw_sw_letter.c
@@ -170,6 +170,11 @@ static void LV_ATTRIBUTE_FAST_MEM draw_letter_cb(lv_draw_task_t * t, lv_draw_gly
                         }
                         else {
                             glyph_draw_dsc->glyph_data = lv_font_get_glyph_bitmap(glyph_draw_dsc->g, glyph_draw_dsc->_draw_buf);
+                            if(glyph_draw_dsc->glyph_data == NULL) {
+                                LV_LOG_WARN("Couldn't get the bitmap of a glyph");
+                                break;
+                            }
+
                             mask_area.x2 = mask_area.x1 + lv_draw_buf_width_to_stride(lv_area_get_width(&mask_area), LV_COLOR_FORMAT_A8) - 1;
                             lv_draw_sw_blend_dsc_t blend_dsc;
                             lv_memzero(&blend_dsc, sizeof(blend_dsc));

--- a/src/font/lv_font.h
+++ b/src/font/lv_font.h
@@ -36,7 +36,7 @@ extern "C" {
 typedef enum {
     LV_FONT_GLYPH_FORMAT_NONE   = 0, /**< Maybe not visible*/
 
-    /**< Legacy simple formats with no byte padding at end of the lines*/
+    /**< Legacy simple formats*/
     LV_FONT_GLYPH_FORMAT_A1     = 0x01, /**< 1 bit per pixel*/
     LV_FONT_GLYPH_FORMAT_A2     = 0x02, /**< 2 bit per pixel*/
     LV_FONT_GLYPH_FORMAT_A3     = 0x03, /**< 3 bit per pixel*/

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -103,7 +103,8 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
     int32_t gsize = (int32_t) gdsc->box_w * gdsc->box_h;
     if(gsize == 0) return NULL;
 
-    uint16_t stride_in = g_dsc->stride;
+    uint32_t stride_in = g_dsc->stride;
+
 
     if(fdsc->bitmap_format == LV_FONT_FMT_TXT_PLAIN) {
         const uint8_t * bitmap_in = &fdsc->glyph_bitmap[gdsc->bitmap_index];
@@ -139,7 +140,7 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
         }
         else if(fdsc->bpp == 2) {
             for(y = 0; y < gdsc->box_h; y ++) {
-                uint16_t line_rem = stride_in != 0 ? stride_in : gdsc->box_w;
+                uint32_t line_rem = stride_in != 0 ? stride_in : gdsc->box_w;
                 for(x = 0; x < gdsc->box_w; x++, i++) {
                     i = i & 0x3;
                     if(i == 0) bitmap_out_tmp[x] = opa2_table[(*bitmap_in) >> 6];
@@ -257,9 +258,13 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
 
     if(fdsc->stride == 0) dsc_out->stride = 0;
     else {
-        /*e.g. font_dsc stride ==  4 means align to 4 byte boundary.
+        /*E.g. w = 5, bpp = 2, means 2 bytes/line*/
+        uint32_t bit_count = dsc_out->box_w * fdsc->bpp;
+        uint32_t width_in_bytes = (bit_count + 7) >> 3; /*No division round up*/
+
+        /*E.g. font_dsc stride == 4 means align to 4 byte boundary.
          *In glyph_dsc store the actual line length in bytes*/
-        dsc_out->stride = LV_ROUND_UP(dsc_out->box_w, fdsc->stride);
+        dsc_out->stride = LV_ROUND_UP(width_in_bytes, fdsc->stride);
     }
 
     dsc_out->format = (uint8_t)fdsc->bpp;


### PR DESCRIPTION
It also requires these font converter changes: https://github.com/lvgl/lv_font_conv/pull/144

This the new behavior (I think it was the expected so far too):
 - `--stride 0`: with bpp < 8, do not respect byte boundaries at line endings. The whole gylph bitmap is a continuous bit stream 
 - `--stride 1`: lines are always byte aligned
 - `--stride 32`: ( or anything else) makes the lines aligned to these number of bytes

cc @giobauermeister 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
