### PR TITLE
feat(draw): add event_cb in draw unit

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -12,6 +12,7 @@
  *********************/
 #include "../misc/lv_area_private.h"
 #include "../misc/lv_assert.h"
+#include "../misc/lv_event_private.h"
 #include "lv_draw_private.h"
 #include "lv_draw_mask_private.h"
 #include "lv_draw_vector_private.h"
@@ -383,6 +384,29 @@ uint32_t lv_draw_get_dependent_count(lv_draw_task_t * t_check)
     }
     LV_PROFILER_DRAW_END;
     return cnt;
+}
+
+void lv_draw_unit_send_event(const char * name, lv_event_code_t code, void * param)
+{
+    LV_PROFILER_DRAW_BEGIN;
+
+    lv_event_t event = { 0 };
+    event.code = code;
+    event.param = param;
+    lv_draw_unit_t * u = _draw_info.unit_head;
+    while(u) {
+        if(u->event_cb && (!name || lv_strcmp(name, u->name) == 0)) {
+            event.current_target = event.original_target = u;
+            LV_PROFILER_DRAW_BEGIN_TAG("event_cb");
+            LV_PROFILER_DRAW_BEGIN_TAG(u->name);
+            u->event_cb(&event);
+            LV_PROFILER_DRAW_END_TAG(u->name);
+            LV_PROFILER_DRAW_END_TAG("event_cb");
+        }
+        u = u->next;
+    }
+
+    LV_PROFILER_DRAW_END;
 }
 
 void lv_layer_init(lv_layer_t * layer)

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -24,6 +24,7 @@ extern "C" {
 #include "../misc/lv_text.h"
 #include "../misc/lv_profiler.h"
 #include "../misc/lv_matrix.h"
+#include "../misc/lv_event.h"
 #include "lv_image_decoder.h"
 #include "lv_draw_buf.h"
 
@@ -270,6 +271,15 @@ lv_draw_task_t * lv_draw_get_next_available_task(lv_layer_t * layer, lv_draw_tas
  * @return          number of tasks depending on `t_check`
  */
 uint32_t lv_draw_get_dependent_count(lv_draw_task_t * t_check);
+
+
+/**
+ * Send an event to the draw units
+ * @param name              the name of the draw unit to send the event to
+ * @param code              the event code
+ * @param param             the event parameter
+ */
+void lv_draw_unit_send_event(const char * name, lv_event_code_t code, void * param);
 
 /**
  * Initialize a layer

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -174,6 +174,12 @@ struct _lv_draw_unit_t {
      * @return
      */
     int32_t (*delete_cb)(lv_draw_unit_t * draw_unit);
+
+    /**
+     * Called when an event is sent to the draw unit.
+     * @param event pointer to the event descriptor
+     */
+    void (*event_cb)(lv_event_t * event);
 };
 
 typedef struct {

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -40,6 +40,8 @@ static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 
 static int32_t draw_delete(lv_draw_unit_t * draw_unit);
 
+static void draw_event_cb(lv_event_t * e);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -70,6 +72,7 @@ void lv_draw_vg_lite_init(void)
     unit->base_unit.dispatch_cb = draw_dispatch;
     unit->base_unit.evaluate_cb = draw_evaluate;
     unit->base_unit.delete_cb = draw_delete;
+    unit->base_unit.event_cb = draw_event_cb;
     unit->base_unit.name = "VG_LITE";
 
     lv_vg_lite_image_dsc_init(unit);
@@ -299,6 +302,28 @@ static int32_t draw_delete(lv_draw_unit_t * draw_unit)
     lv_vg_lite_decoder_deinit();
     lv_draw_vg_lite_label_deinit(unit);
     return 1;
+}
+
+static void draw_event_cb(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+
+    switch(code) {
+        case LV_EVENT_CANCEL: {
+                /**
+                 * Because VG-Lite will deinitialize the context (including the GPU independent heap)
+                 * before the GPU goes to sleep, it is necessary to first discard and dereference
+                 * all caches that depend on the independent heap.
+                 */
+                lv_draw_vg_lite_unit_t * unit = lv_event_get_current_target(e);
+                lv_cache_drop_all(lv_vg_lite_grad_ctx_get_cache(unit->grad_ctx), NULL);
+                lv_cache_drop_all(unit->stroke_cache, NULL);
+                LV_LOG_INFO("dropt all cache");
+            }
+            break;
+        default:
+            break;
+    }
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -140,6 +140,12 @@ struct _lv_vg_lite_pending_t * lv_vg_lite_grad_ctx_get_pending(struct _lv_vg_lit
     return ctx->pending;
 }
 
+struct _lv_cache_t * lv_vg_lite_grad_ctx_get_cache(struct _lv_vg_lite_grad_ctx_t * ctx)
+{
+    LV_ASSERT_NULL(ctx);
+    return ctx->cache;
+}
+
 bool lv_vg_lite_draw_grad(
     struct _lv_vg_lite_grad_ctx_t * ctx,
     vg_lite_buffer_t * buffer,

--- a/src/draw/vg_lite/lv_vg_lite_grad.h
+++ b/src/draw/vg_lite/lv_vg_lite_grad.h
@@ -52,6 +52,12 @@ void lv_vg_lite_grad_ctx_delete(struct _lv_vg_lite_grad_ctx_t * ctx);
 struct _lv_vg_lite_pending_t * lv_vg_lite_grad_ctx_get_pending(struct _lv_vg_lite_grad_ctx_t * ctx);
 
 /**
+ * @brief Get the cache of gradient items
+ * @param ctx the gradient context
+ */
+struct _lv_cache_t * lv_vg_lite_grad_ctx_get_cache(struct _lv_vg_lite_grad_ctx_t * ctx);
+
+/**
  * @brief Draw a gradient
  * @param ctx the gradient context
  * @param buffer the target buffer

--- a/tests/src/test_cases/draw/test_draw_vector.c
+++ b/tests/src/test_cases/draw/test_draw_vector.c
@@ -23,6 +23,12 @@ void setUp(void)
 
 void tearDown(void)
 {
+    /* Test the cleanup of a specified name */
+    lv_draw_unit_send_event("VG_LITE", LV_EVENT_CANCEL, NULL);
+
+    /* Test all cleanup */
+    lv_draw_unit_send_event(NULL, LV_EVENT_CANCEL, NULL);
+
     lv_obj_clean(lv_screen_active());
 }
 


### PR DESCRIPTION
Because VG-Lite will deinitialize the context (including the GPU independent heap), before the GPU goes to sleep, it is necessary to first discard and dereference all caches that depend on the independent heap.

So I added a `lv_draw_unit_send_event(NULL, LV_EVENT_CANCEL, NULL)` to the upper layer to explicitly release the cache before entering low power.

cc @xaowang96 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
