### PR TITLE
feat(event): add ability to delete display and indev on event

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -384,7 +384,12 @@ void lv_display_refr_timer(lv_timer_t * tmr)
         return;
     }
 
-    lv_display_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
+    lv_result_t res = lv_display_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
+    if(res == LV_RESULT_INVALID) {
+        LV_TRACE_REFR("deleted");
+        LV_PROFILER_REFR_END;
+        return;
+    }
 
     /*Refresh the screen's layout if required*/
     LV_PROFILER_LAYOUT_BEGIN_TAG("layout");

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -178,6 +178,7 @@ void lv_display_delete(lv_display_t * disp)
     if(disp == lv_refr_get_disp_refreshing()) was_refr = true;
 
     lv_display_send_event(disp, LV_EVENT_DELETE, NULL);
+    lv_event_mark_deleted(disp);
     lv_event_remove_all(&(disp->event_list));
 
     /*Detach the input devices*/
@@ -914,21 +915,7 @@ uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event
 
 lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, void * param)
 {
-
-    lv_event_t e;
-    lv_memzero(&e, sizeof(e));
-    e.code = code;
-    e.current_target = disp;
-    e.original_target = disp;
-    e.param = param;
-    lv_result_t res;
-    res = lv_event_send(&disp->event_list, &e, true);
-    if(res != LV_RESULT_OK) return res;
-
-    res = lv_event_send(&disp->event_list, &e, false);
-    if(res != LV_RESULT_OK) return res;
-
-    return res;
+    return lv_event_push_and_send(&disp->event_list, code, disp, param);
 }
 
 lv_area_t * lv_event_get_invalidated_area(lv_event_t * e)

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -154,6 +154,7 @@ void lv_indev_delete(lv_indev_t * indev)
     LV_ASSERT_NULL(indev);
 
     lv_indev_send_event(indev, LV_EVENT_DELETE, NULL);
+    lv_event_mark_deleted(indev);
     lv_event_remove_all(&(indev->event_list));
 
     /*Clean up the read timer first*/
@@ -671,21 +672,7 @@ uint32_t lv_indev_remove_event_cb_with_user_data(lv_indev_t * indev, lv_event_cb
 
 lv_result_t lv_indev_send_event(lv_indev_t * indev, lv_event_code_t code, void * param)
 {
-
-    lv_event_t e;
-    lv_memzero(&e, sizeof(e));
-    e.code = code;
-    e.current_target = indev;
-    e.original_target = indev;
-    e.param = param;
-    lv_result_t res;
-    res = lv_event_send(&indev->event_list, &e, true);
-    if(res != LV_RESULT_OK) return res;
-
-    res = lv_event_send(&indev->event_list, &e, false);
-    if(res != LV_RESULT_OK) return res;
-
-    return res;
+    return lv_event_push_and_send(&indev->event_list, code, indev, param);
 }
 
 /**********************

--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -69,6 +69,29 @@ void lv_event_pop(lv_event_t * e)
     event_head = e->prev;
 }
 
+lv_result_t lv_event_push_and_send(lv_event_list_t * event_list, lv_event_code_t code, void * original_target,
+                                   void * param)
+{
+    LV_ASSERT_NULL(event_list);
+    lv_event_t e;
+    lv_memzero(&e, sizeof(e));
+    e.code = code;
+    e.current_target = original_target;
+    e.original_target = original_target;
+    e.param = param;
+
+    lv_event_push(&e);
+    lv_result_t res = lv_event_send(event_list, &e, true);
+    if(res != LV_RESULT_OK) goto ret;
+
+    res = lv_event_send(event_list, &e, false);
+    if(res != LV_RESULT_OK) goto ret;
+
+ret:
+    lv_event_pop(&e);
+    return res;
+}
+
 lv_result_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preprocess)
 {
     if(list == NULL) return LV_RESULT_OK;

--- a/src/misc/lv_event_private.h
+++ b/src/misc/lv_event_private.h
@@ -56,6 +56,10 @@ void lv_event_push(lv_event_t * e);
 
 void lv_event_pop(lv_event_t * e);
 
+
+lv_result_t lv_event_push_and_send(lv_event_list_t * event_list, lv_event_code_t code, void * original_target,
+                                   void * param);
+
 /**
  * Nested events can be called and one of them might belong to an object that is being deleted.
  * Mark this object's `event_temp_data` deleted to know that its `lv_obj_send_event` should return `LV_RESULT_INVALID`


### PR DESCRIPTION
While trying to use the `REFR_START` event to handle the wayland window, I noticed that I would get a segfault when closing the window because the display would be destroyed during the event handler, the two main fixes here are:

Calling `lv_event_push` before sending the event and then marking the display as deleted in the display delete function, similar to how it's done with objects.
Checking for LV_RESULT_INVALID after sending the event so that we can quit the refresh timer callback early

Noticed the same thing was happening to indev so I also added the same code to it

The wayland patch still needs more testing and will be pushed in a separate PR