### PR TITLE
fix(profiler): remove macro for external usage

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -73,9 +73,7 @@ struct _snippet_stack;
 struct _lv_freetype_context_t;
 #endif
 
-#if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 struct _lv_profiler_builtin_ctx_t;
-#endif
 
 #if LV_USE_NUTTX
 struct _lv_nuttx_ctx_t;
@@ -207,9 +205,12 @@ typedef struct _lv_global_t {
     struct _snippet_stack * span_snippet_stack;
 #endif
 
-#if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
+    /**
+     * Since LV_USE_PROFILER is an option that needs to be turned on and off
+     * frequently, this pointer is always reserved as a placeholder to prevent the
+     * lv_global_t size mismatch affecting the static library.
+     */
     struct _lv_profiler_builtin_ctx_t * profiler_context;
-#endif
 
 #if LV_USE_FILE_EXPLORER != 0
     lv_style_t fe_list_button_style;


### PR DESCRIPTION
This macro may switch very often, we should reserved this placeholder in case LVGL or relevant codes are used as static library.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
