### PR TITLE
fix(draw_buf): check range for draw buffer when accessing pixel

### DIFF
--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -379,6 +379,12 @@ void * lv_draw_buf_goto_xy(const lv_draw_buf_t * buf, uint32_t x, uint32_t y)
     LV_ASSERT_NULL(buf);
     if(buf == NULL) return NULL;
 
+    if(x >= buf->header.w || y >= buf->header.h) {
+        LV_LOG_ERROR("coordinates out of range, x: %" LV_PRIu32 ", y: %"LV_PRIu32", w: %"LV_PRIu32", h: %"LV_PRIu32, x, y,
+                     (uint32_t)buf->header.w, (uint32_t)buf->header.h);
+        return NULL;
+    }
+
     uint8_t * data = buf->data;
 
     /*Skip palette*/

--- a/tests/src/test_cases/test_draw_buf.c
+++ b/tests/src/test_cases/test_draw_buf.c
@@ -114,4 +114,17 @@ void test_draw_buf_stride_adjust(void)
 #endif
 }
 
+void test_draw_buf_xy_access(void)
+{
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, 100, 100, LV_COLOR_FORMAT_RGB565);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
+
+    uint8_t * ret = lv_draw_buf_goto_xy(&draw_buf, 50, 50);
+    TEST_ASSERT_NOT_NULL(ret);
+    ret = lv_draw_buf_goto_xy(&draw_buf, 100, 100);
+    TEST_ASSERT_NULL(ret);
+    ret = lv_draw_buf_goto_xy(&draw_buf, -10, -10);
+    TEST_ASSERT_NULL(ret);
+}
+
 #endif


### PR DESCRIPTION
API like lv_draw_layer_go_to_xy ask for int32_t input. Need to add check in case users give a negative input.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
