### PR TITLE
fix(vg_lite): fix build break after LV_USE_VECTOR_GRAPHIC is turned off

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -310,6 +310,7 @@ static void draw_event_cb(lv_event_t * e)
 
     switch(code) {
         case LV_EVENT_CANCEL: {
+#if LV_USE_VECTOR_GRAPHIC
                 /**
                  * Because VG-Lite will deinitialize the context (including the GPU independent heap)
                  * before the GPU goes to sleep, it is necessary to first discard and dereference
@@ -319,6 +320,7 @@ static void draw_event_cb(lv_event_t * e)
                 lv_cache_drop_all(lv_vg_lite_grad_ctx_get_cache(unit->grad_ctx), NULL);
                 lv_cache_drop_all(unit->stroke_cache, NULL);
                 LV_LOG_INFO("dropt all cache");
+#endif
             }
             break;
         default:


### PR DESCRIPTION
Grad and stroke related functions need to rely on `LV_USE_VECTOR_GRAPHIC` configuration.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
