### PR TITLE
fix(fbdev): fix stride, bounds checking, and partial flushes in direct render mode in flush callback

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -321,9 +321,10 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
             src_stride = lv_draw_buf_width_to_stride(lv_area_get_width(area), cf);
             rotated_area = *area;
         }
+
         lv_display_rotate_area(disp, &rotated_area);
         const uint32_t dest_stride = lv_draw_buf_width_to_stride(lv_area_get_width(&rotated_area), cf);
-        const size_t buf_size = lv_area_get_width(&rotated_area) * lv_area_get_height(&rotated_area) * px_size;
+        const size_t buf_size = dest_stride * lv_area_get_height(&rotated_area);
         if(!dsc->rotated_buf || dsc->rotated_buf_size != buf_size) {
             dsc->rotated_buf = lv_realloc(dsc->rotated_buf, buf_size);
             LV_ASSERT_MALLOC(dsc->rotated_buf);

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -28,6 +28,7 @@
 
 #include "../../../display/lv_display_private.h"
 #include "../../../draw/sw/lv_draw_sw.h"
+#include "../../../misc/lv_area_private.h"
 
 /*********************
  *      DEFINES
@@ -335,8 +336,12 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         color_p = dsc->rotated_buf;
     }
 
-    /* Ensure that we're within the framebuffer's bounds */
-    if(area->x2 < 0 || area->y2 < 0 || area->x1 > (int32_t)dsc->vinfo.xres - 1 || area->y1 > (int32_t)dsc->vinfo.yres - 1) {
+    lv_area_t display_area;
+    /* vinfo.xres and vinfo.yres will already be 1 less than the actual resolution. i.e: 1023x767 on a 1024x768 screen */
+    lv_area_set(&display_area, 0, 0, dsc->vinfo.xres, dsc->vinfo.yres);
+
+    /* TODO: Consider rendering the clipped area*/
+    if(!lv_area_is_in(area, &display_area, 0)) {
         lv_display_flush_ready(disp);
         return;
     }

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -346,10 +346,11 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         (area->y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
 
     const int32_t w = lv_area_get_width(area);
+    const int32_t stride = lv_draw_buf_width_to_stride(w, cf);
     for(int32_t y = area->y1; y <= area->y2; y++) {
         write_to_fb(dsc, fb_pos, color_p, w * px_size);
         fb_pos += dsc->finfo.line_length;
-        color_p += w * px_size;
+        color_p += stride;
     }
 
     if(dsc->force_refresh) {


### PR DESCRIPTION
Fixes #8390 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
