### PR TITLE
fix(drm/egl/gbm): fixes for gbm buffer format and EGL display creation on i.mx95

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -921,7 +921,7 @@ static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t conn
 
     /* Add support to create a surface with modifiers */
     drm_dev->surface = gbm_surface_create(drm_dev->gbm_device,
-                                          drm_dev->width, drm_dev->height, GBM_BO_FORMAT_ARGB8888,
+                                          drm_dev->width, drm_dev->height, GBM_FORMAT_ARGB8888,
                                           GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
     if(!drm_dev->surface) {
         LV_LOG_ERROR("failed to create gbm surface");

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -348,7 +348,19 @@ static lv_result_t lv_egl_init(void)
 
     /* get an EGL display connection */
     if(backend_device) {
-        egl_display = eglGetDisplay(backend_device);
+#ifdef LV_USE_LINUX_DRM_GBM_BUFFERS
+        PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
+            (PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
+        egl_display = EGL_NO_DISPLAY;
+        if(eglGetPlatformDisplayEXT) {
+            egl_display = eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, backend_device, NULL);
+        }
+        /* fallback to generic eglGetDisplay() */
+        if(egl_display == EGL_NO_DISPLAY)
+#endif
+        {
+            egl_display = eglGetDisplay(backend_device);
+        }
     }
     else {
         egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -20,6 +20,7 @@ extern "C" {
 #if LV_USE_EGL
 #include <GLES/gl.h>
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <GLES3/gl3.h>
 #include <GLES/glext.h>
 #include <GLES2/gl2ext.h>


### PR DESCRIPTION
This fixes two encountered issues on the i.MX95 mali (G-310) platform when using the DRM/EGL driver.

First it allows the usage of the extended eglGetPlatformDisplayEXT with explicit platform specifiers. It only uses this if it can load the address of the function and will fall back to the generic eglGetDisplay if the specialized variant fails.
This is required on the i.MX95 mali platform, as calls to the generic eglGetDisplay will fail.

Secondly it changes the selected buffer format passed to the gbm_surface_create function. The new format is in the 'new' four CC variant. It could be that this binary driver does not call gbm_format_canonicalize() on the format, but the end result is that gbm_surface_create fails when the old style _BO_FORMAT_* is passed to it.

