### PR TITLE
feat(EVE): support fonts with a stride alignment

### DIFF
--- a/docs/src/details/integration/external_display_controllers/eve/gpu.rst
+++ b/docs/src/details/integration/external_display_controllers/eve/gpu.rst
@@ -23,6 +23,7 @@ Limitations
 
 - Image format, size, and count limit.
 - Font format, size, and count limit.
+- Only 4 bpp fonts are supported for now.
 - The total number of tasks rendered per refresh has an upper limit.
 - Layers are not supported.
 
@@ -193,6 +194,23 @@ It can be called multiple times with different strings.
     lv_draw_eve_pre_upload_font_text(disp, &lv_font_montserrat_48, "The current time is");
     lv_draw_eve_pre_upload_font_range(disp, &lv_font_montserrat_48, '0', '9');
     lv_draw_eve_pre_upload_font_range(disp, &lv_font_montserrat_48, ':', ':');
+
+
+Supported Asset Formats
+-----------------------
+
+The supported image color formats are RGB565, RGB565A8, ARGB8888, and L8. It's good to
+note that RGB565A8 and ARGB8888 are converted to ARGB4444 before being uploaded to EVE. The
+implication of this is that a reduced color depth will be realized on the display compared
+to the original asset. The initial asset upload time may also be longer.
+
+The only supported font format is 4 bpp. The stride is converted to 1 before it's
+uploaded to EVE. If a provided font has a stride of 1, the font will be uploaded
+directly without being converted. It can improve the asset upload time. To generate a font
+with a specific stride like 1, you should use the
+`offline font converter <https://github.com/lvgl/lv_font_conv>`__ and specify a stride
+argument on the command line, e.g. ``--stride 1``. A stride of 0 is the default. This means
+that the bits are packed even across rows. EVE cannot use fonts that are packed across rows.
 
 
 .. _eve register access:

--- a/docs/src/details/integration/external_display_controllers/eve/gpu.rst
+++ b/docs/src/details/integration/external_display_controllers/eve/gpu.rst
@@ -204,13 +204,14 @@ note that RGB565A8 and ARGB8888 are converted to ARGB4444 before being uploaded 
 implication of this is that a reduced color depth will be realized on the display compared
 to the original asset. The initial asset upload time may also be longer.
 
-The only supported font format is 4 bpp. The stride is converted to 1 before it's
-uploaded to EVE. If a provided font has a stride of 1, the font will be uploaded
-directly without being converted. It can improve the asset upload time. To generate a font
-with a specific stride like 1, you should use the
+The only supported font format is 4 bpp. If the font's stride is not 1, it will be converted
+to stride 1 before being uploaded to EVE. If the font already has a stride of 1, it will be
+uploaded directly without conversion, which can improve asset upload time.
+
+To generate a font with a specific stride (such as 1), you should use the
 `offline font converter <https://github.com/lvgl/lv_font_conv>`__ and specify a stride
 argument on the command line, e.g. ``--stride 1``. A stride of 0 is the default. This means
-that the bits are packed even across rows. EVE cannot use fonts that are packed across rows.
+that the bits are packed even across rows, but EVE cannot use fonts that are packed across rows.
 
 
 .. _eve register access:


### PR DESCRIPTION
Made possible by https://github.com/lvgl/lv_font_conv/pull/144 and #8887

No longer assumes the bits are packed across rows.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
