### PR TITLE
fix(vg_lite): replace FLT_MIN to -FLT_MAX

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -359,8 +359,8 @@ static void lv_path_to_vg(lv_vg_lite_path_t * dest, const lv_vector_path_t * src
 
     float min_x = FLT_MAX;
     float min_y = FLT_MAX;
-    float max_x = FLT_MIN;
-    float max_y = FLT_MIN;
+    float max_x = -FLT_MAX;
+    float max_y = -FLT_MAX;
 
 #define CMP_BOUNDS(point)                           \
     do {                                            \

--- a/src/draw/vg_lite/lv_vg_lite_path.c
+++ b/src/draw/vg_lite/lv_vg_lite_path.c
@@ -228,8 +228,8 @@ bool lv_vg_lite_path_update_bounding_box(lv_vg_lite_path_t * path)
     /* init bounds */
     bounds.min_x = FLT_MAX;
     bounds.min_y = FLT_MAX;
-    bounds.max_x = FLT_MIN;
-    bounds.max_y = FLT_MIN;
+    bounds.max_x = -FLT_MAX;
+    bounds.max_y = -FLT_MAX;
 
     /* calc bounds */
     lv_vg_lite_path_for_each_data(lv_vg_lite_path_get_path(path), path_bounds_iter_cb, &bounds);

--- a/src/others/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/others/vg_lite_tvg/vg_lite_tvg.cpp
@@ -2476,7 +2476,7 @@ static Result shape_append_path(std::unique_ptr<Shape> & shape, vg_lite_path_t *
     float x_max = path->bounding_box[2];
     float y_max = path->bounding_box[3];
 
-    if(math_equal(x_min, FLT_MIN) && math_equal(y_min, FLT_MIN)
+    if(math_equal(x_min, -FLT_MAX) && math_equal(y_min, -FLT_MAX)
        && math_equal(x_max, FLT_MAX) && math_equal(y_max, FLT_MAX)) {
         return Result::Success;
     }


### PR DESCRIPTION
`FLT_MIN` is not a negative number, it represents the smallest positive number that can be represented. If we want to represent the smallest negative number, we should use `-FLT_MAX`.

See: https://cplusplus.com/reference/cfloat/

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
