### PR TITLE
fix(gdb/draw_buf): validate and correct expected data size for pixel buffer

### DIFF
--- a/scripts/gdb/lvglgdb/lvgl/draw/lv_draw_buf.py
+++ b/scripts/gdb/lvglgdb/lvgl/draw/lv_draw_buf.py
@@ -99,6 +99,7 @@ class LVDrawBuf(Value):
             data_ptr = self.super_value("data")
             data_size = int(self.super_value("data_size"))
             width = (stride * 8) // cf_info["bpp"] if cf_info["bpp"] else 0
+            expected_data_size = stride * height
 
             # Validate buffer data
             if not data_ptr:
@@ -107,10 +108,14 @@ class LVDrawBuf(Value):
                 raise ValueError(f"Invalid dimensions: {width}x{height}")
             if data_size <= 0:
                 raise ValueError(f"Invalid data size: {data_size}")
+            if data_size < expected_data_size:
+                raise ValueError(f"Data size mismatch: expected {expected_data_size}, got {data_size}")
+            elif data_size > expected_data_size:
+                gdb.write(f"\033[93mData size mismatch: expected {expected_data_size}, got {data_size}\033[0m\n")
 
             # Read pixel data
             pixel_data = (
-                gdb.selected_inferior().read_memory(int(data_ptr), data_size).tobytes()
+                gdb.selected_inferior().read_memory(int(data_ptr), expected_data_size).tobytes()
             )
             if not pixel_data:
                 raise ValueError("Failed to read pixel data")


### PR DESCRIPTION
Most of the time it's correct, but the draw buffer size used by lvgl's test cases is larger than the actual size because:

<img width="1276" height="220" alt="image" src="https://github.com/user-attachments/assets/d32ffa31-5f9a-4c17-97ec-5b6c9286ed70" />


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
