### PR TITLE
fix(vg_lite): change log level from info to warning for unsupported gradient features

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -166,13 +166,13 @@ bool lv_vg_lite_draw_grad(
     /* check radial gradient is supported */
     if(grad->style == LV_VECTOR_GRADIENT_STYLE_RADIAL) {
         if(!vg_lite_query_feature(gcFEATURE_BIT_VG_RADIAL_GRADIENT)) {
-            LV_LOG_INFO("radial gradient is not supported");
+            LV_LOG_WARN("radial gradient is not supported");
             return false;
         }
 
         /* check if the radius is valid */
         if(grad->cr <= 0) {
-            LV_LOG_INFO("radius: %f is not valid", grad->cr);
+            LV_LOG_WARN("radius: %f is not valid", grad->cr);
             return false;
         }
     }
@@ -180,7 +180,7 @@ bool lv_vg_lite_draw_grad(
     /* check spread mode is supported */
     if(grad->spread == LV_VECTOR_GRADIENT_SPREAD_REPEAT || grad->spread == LV_VECTOR_GRADIENT_SPREAD_REFLECT) {
         if(!vg_lite_query_feature(gcFEATURE_BIT_VG_IM_REPEAT_REFLECT)) {
-            LV_LOG_INFO("repeat/reflect spread(%d) is not supported", grad->spread);
+            LV_LOG_WARN("repeat/reflect spread(%d) is not supported", grad->spread);
             return false;
         }
     }


### PR DESCRIPTION
## Changes

Upgrade log levels for VG-Lite gradient hardware feature checks from `INFO` to `WARN` to improve debugging visibility.

## Modified Files
- `src/draw/vg_lite/lv_vg_lite_grad.c`

## Specific Changes
1. **Radial gradient not supported** (line 169)
   - Changed from `LV_LOG_INFO` to `LV_LOG_WARN` when hardware doesn't support radial gradients

2. **Invalid radius warning** (line 175)  
   - Changed from `LV_LOG_INFO` to `LV_LOG_WARN` when radial gradient radius is invalid

3. **Spread mode not supported** (line 183)
   - Changed from `LV_LOG_INFO` to `LV_LOG_WARN` when hardware doesn't support repeat/reflect spread modes

## Rationale
- These conditions cause gradient rendering to fail and should be treated as warnings rather than informational messages
- Upgrading log levels helps developers quickly identify and troubleshoot gradient functionality issues
- Users need clear visibility when requested gradient effects cannot be displayed due to hardware limitations

## Testing Impact
- No functional logic changes, only affects log output levels
- Improves debugging and issue identification capabilities
- No performance impact