### PR TITLE
chore: fix lv_font_montserrat_14_aligned.c include

### DIFF
--- a/src/font/lv_font_montserrat_14_aligned.c
+++ b/src/font/lv_font_montserrat_14_aligned.c
@@ -15,7 +15,7 @@
 #ifdef LV_LVGL_H_INCLUDE_SIMPLE
     #include "lvgl.h"
 #else
-    #include "lvgl/lvgl.h"
+    #include "../../lvgl.h"
 #endif
 
 #if !LV_VERSION_CHECK(9, 3, 0)


### PR DESCRIPTION
Demo did not compile with old pattern