### PR TITLE
fix(opengles): add missing variable declaration

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -330,6 +330,7 @@ static void lv_opengles_index_buffer_unbind(void)
 
 static void lv_opengles_shader_manager_init(void)
 {
+    lv_opengl_shader_portions_t portions;
     lv_opengles_standard_shader_get_src(&portions);
     char * vertex_shader = lv_opengles_standard_shader_get_vertex();
     char * frag_shader = lv_opengles_standard_shader_get_fragment();


### PR DESCRIPTION
Fixes current CI failure in master

Fix is also present in #8966 but since that one will take sometime to review this is a hotfix
