### PR TITLE
docs(xml/events): rename page to avoid confusion when searching documentation

### DIFF
--- a/docs/src/details/xml/ui_elements/events.rst
+++ b/docs/src/details/xml/ui_elements/events.rst
@@ -1,8 +1,8 @@
 .. _xml_events:
 
-======
-Events
-======
+============
+Events - XML
+============
 
 Overview
 ********

--- a/docs/src/details/xml/ui_elements/events.rst
+++ b/docs/src/details/xml/ui_elements/events.rst
@@ -1,8 +1,8 @@
 .. _xml_events:
 
-============
-Events - XML
-============
+=============
+Events in XML
+=============
 
 Overview
 ********


### PR DESCRIPTION
When searching the documentation for "events" I noticed that it's really not obvious what is the generic event documentation and the XML documentation, this is title proposal but i'm open to other ideas if there are 

<img width="1889" height="498" alt="image" src="https://github.com/user-attachments/assets/b2027a92-553b-45ef-b860-19db0cbbb07f" />

Mostly need @kisvegabor's opinion on this

