### PR TITLE
docs(style): update banner JSON URL to use static domain

### DIFF
--- a/docs/src/_static/js/custom.js
+++ b/docs/src/_static/js/custom.js
@@ -178,7 +178,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
   <div class="page">
     ...page content...
    *---------------------------------------------------------------------*/
-  let bannerJsonUrl = "https://lvgl.io/data/banner.json";
+  let bannerJsonUrl = "https://static.lvgl.io/data/banner.json";
   let bannerContainerClass = "lv-custom-banner-list";
   let bannerClass = "lv-custom-banner";
   /* Note:  banner priority property can have only one of these values:


### PR DESCRIPTION
Changed the docs' top banner data source to a static server (static.lvgl.io).
